### PR TITLE
Added Hibernate to projects using Gradle on home page

### DIFF
--- a/website/src/content/index.php
+++ b/website/src/content/index.php
@@ -66,7 +66,7 @@
             <li><a href="http://www.corp.carrier.com">Carrier</a></li>
             <li><a href="http://www.fcc-fac.ca/">FCC</a></li>
             <li><a href="http://www.zeppelin.com">Zeppelin</a></li>
-            <li style="color:white"><a href="http://www.gradle.org" style="color:white">Dummy</a></li>
+            <li><a href="http://www.hibernate.org">Hibernate</a></li>
             <li style="color:white"><a href="http://www.gradle.org" style="color:white">Dummy</a></li>
         </ul>
     </div>


### PR DESCRIPTION
Pretty much what the subject says. Was looking through the Gradle site after meeting Hans at NFJS conference in Minneapolis. Saw that Hibernate wasn't listed yet under "projects using Gradle" - easy enough to fix. That's the only change in this pull request.

Cheers,
Brice Ruth
