### PR TITLE
Added documentation for the META-INF/gradle-plugins properties file

### DIFF
--- a/subprojects/docs/src/docs/userguide/customPlugins.xml
+++ b/subprojects/docs/src/docs/userguide/customPlugins.xml
@@ -147,7 +147,19 @@
             <sourcefile file="build.gradle" snippet="use-plugin"/>
         </sample>
 
-        <para>We just follow the convention for where the source for the plugin class should go.</para>
+	<para>
+            So how does Gradle find the <apilink class="org.gradle.api.Plugin"/> implementation? The answer is you need to provide a properties file in the jar's
+	    META-INF/gradle-plugins directory that matches the name of your plugin.  	    
+	</para>
+
+        <sample id="customPluginStandalone" dir="customPlugin" title="Wiring for a custom plugin">
+            <sourcefile file="src/main/resources/META-INF/gradle-plugins/greeting.properties"/>
+        </sample>	
+
+	<para>
+	    Notice that the properties filename matches the plugin's name and is placed in the resources folder, and
+	    that the <literal>implementation-class</literal> property identifies the <apilink class="org.gradle.api.Plugin"/> implementation class.
+	</para>
 
         <section>
             <title>Using your plugin in another project</title>


### PR DESCRIPTION
This is a minor addition to the documentation for the Writing Custom Plugins section. No new sample code was added. I've simply referenced a sample that already existed, and included a brief explanation.

My verification steps for this were limited to checking the :docs:userguideHtml output.
