### PR TITLE
CodeNarc 0.13 support added

### DIFF
--- a/subprojects/code-quality/code-quality.gradle
+++ b/subprojects/code-quality/code-quality.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile project(':core')
     compile project(':plugins')
 
-    compile "org.codenarc:CodeNarc:0.12@jar"
+    compile "org.codenarc:CodeNarc:0.13@jar"
     compile libraries.slf4j_api
 
     // CodeNarc dependencies


### PR DESCRIPTION
This is the fix for: 
    http://jira.codehaus.org/browse/GRADLE-1428

I bumped the CodeNarc version number from 0.12 to 0.13
