### PR TITLE
jna directory is created in user.home and not in gradle.user.home

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/logging/LoggingServiceRegistry.java
+++ b/subprojects/core/src/main/groovy/org/gradle/logging/LoggingServiceRegistry.java
@@ -72,7 +72,7 @@ public class LoggingServiceRegistry extends DefaultServiceRegistry {
     protected TimeProvider createTimeProvider() {
         return new TrueTimeProvider();
     }
-    
+
     protected StdOutLoggingSystem createStdOutLoggingSystem() {
         return new StdOutLoggingSystem(stdoutListener, get(TimeProvider.class));
     }
@@ -88,7 +88,7 @@ public class LoggingServiceRegistry extends DefaultServiceRegistry {
     protected ProgressLoggerFactory createProgressLoggerFactory() {
         return new DefaultProgressLoggerFactory(new ProgressLoggingBridge(get(OutputEventListener.class)), get(TimeProvider.class));
     }
-    
+
     protected Factory<LoggingManagerInternal> createLoggingManagerFactory() {
         OutputEventRenderer renderer = get(OutputEventRenderer.class);
         Slf4jLoggingConfigurer slf4jConfigurer = new Slf4jLoggingConfigurer(renderer);
@@ -107,7 +107,8 @@ public class LoggingServiceRegistry extends DefaultServiceRegistry {
     protected OutputEventRenderer createOutputEventRenderer() {
         Spec<FileDescriptor> terminalDetector;
         if (detectConsole) {
-            terminalDetector = new TerminalDetector(StartParameter.DEFAULT_GRADLE_USER_HOME);
+            StartParameter startParameter = new StartParameter();
+            terminalDetector = new TerminalDetector(startParameter.getGradleUserHomeDir());
         } else {
             terminalDetector = Specs.satisfyNone();
         }


### PR DESCRIPTION
I use gradle as tomcat user having a read-only home. Therefore, all data needs to go to another directory, set by the gradle.user.home property. But gradle still tries to create the file ${TOMCAT_HOME}/.gradle/jna/libjnidispatch.so which results in the following exception:

org.gradle.api.UncheckedIOException: java.io.FileNotFoundException: /usr/share/tomcat6/.gradle/jna/libjnidispatch.so (No such file or directory)
    at org.gradle.logging.internal.TerminalDetector.<init>(TerminalDetector.java:54)
    at org.gradle.logging.LoggingServiceRegistry.createOutputEventRenderer(LoggingServiceRegistry.java:84)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.gradle.api.internal.project.DefaultServiceRegistry.invoke(DefaultServiceRegistry.java:179)
    at org.gradle.api.internal.project.DefaultServiceRegistry.access$100(DefaultServiceRegistry.java:52)
    at org.gradle.api.internal.project.DefaultServiceRegistry$FactoryMethodService.create(DefaultServiceRegistry.java:284)
    at org.gradle.api.internal.project.DefaultServiceRegistry$Service.getService(DefaultServiceRegistry.java:207)
    at org.gradle.api.internal.project.DefaultServiceRegistry.get(DefaultServiceRegistry.java:123)
    at org.gradle.logging.LoggingServiceRegistry.<init>(LoggingServiceRegistry.java:47)
    at org.gradle.logging.LoggingServiceRegistry.<init>(LoggingServiceRegistry.java:39)
    at org.gradle.launcher.CommandLineActionFactory.createLoggingServices(CommandLineActionFactory.java:93)
    at org.gradle.launcher.CommandLineActionFactory.convert(CommandLineActionFactory.java:73)
    at org.gradle.launcher.Main.execute(Main.java:54)
    at org.gradle.launcher.Main.main(Main.java:40)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.gradle.launcher.ProcessBootstrap.runNoExit(ProcessBootstrap.java:46)
    at org.gradle.launcher.ProcessBootstrap.run(ProcessBootstrap.java:28)
    at org.gradle.launcher.GradleMain.main(GradleMain.java:24)
Caused by: java.io.FileNotFoundException: /usr/share/tomcat6/.gradle/jna/libjnidispatch.so (No such file or directory)
    at java.io.FileOutputStream.open(Native Method)
    at java.io.FileOutputStream.<init>(FileOutputStream.java:179)
    at java.io.FileOutputStream.<init>(FileOutputStream.java:131)
    at org.gradle.logging.internal.TerminalDetector.<init>(TerminalDetector.java:44)
    ... 23 more

This patch fixes this by using the gradle.user.home.
