### PR TITLE
fix javadoc of classpath and groovyClasspath property in Groovydoc Task; 

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.javadoc.Groovydoc.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.javadoc.Groovydoc.xml
@@ -17,6 +17,10 @@
                 <td><literal>project.configurations.groovy</literal></td>
             </tr>
             <tr>
+                <td>classpath</td>
+                <td><literal>sourceSets.main.output + sourceSets.main.compileClasspath</literal></td>
+            </tr>
+            <tr>
                 <td>use</td>
                 <td><literal>false</literal></td>
             </tr>

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -100,34 +100,34 @@ public class Groovydoc extends SourceTask {
     }
 
     /**
-     * Returns the classpath used to locate classes referenced by the documented sources.
+     * Returns the classpath containing the Groovy library to be used.
      *
-     * @return The classpath used to locate classes referenced by the documented sources
-     */
+     * @return The classpath containing the Groovy library to be used
+     */   
     @InputFiles
     public FileCollection getGroovyClasspath() {
         return groovyClasspath;
     }
 
     /**
-     * Sets the classpath used to locate classes referenced by the documented sources.
+     * Sets the classpath containing the Groovy library to be used.
      */
     public void setGroovyClasspath(FileCollection groovyClasspath) {
         this.groovyClasspath = groovyClasspath;
     }
 
     /**
-     * Returns the classpath containing the Groovy library to be used.
-     *
-     * @return The classpath containing the Groovy library to be used
-     */
+      * Returns the classpath used to locate classes referenced by the documented sources.
+      *
+      * @return The classpath used to locate classes referenced by the documented sources
+      */
     @InputFiles
     public FileCollection getClasspath() {
         return classpath;
     }
 
     /**
-     * Sets the classpath containing the Groovy library to be used.
+     * Sets the classpath used to locate classes referenced by the documented sources.
      */
     public void setClasspath(FileCollection classpath) {
         this.classpath = classpath;


### PR DESCRIPTION
I've fixed the wrong DSL reference of Groovydoc. The javadoc for classpath and groovyclasspath attribute was mixed. This issue was discussed on the gradle mailinglist. see http://gradle.1045684.n5.nabble.com/groovydoc-value-of-the-default-cp-td4432618.html
