### PR TITLE
GRADLE-1653: Added github method to RepositoryHandler

### DIFF
--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultResolverFactory.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultResolverFactory.java
@@ -152,6 +152,13 @@ public class DefaultResolverFactory implements ResolverFactory {
         return new DefaultIvyArtifactRepository(resolver);
     }
 
+    public DependencyResolver createGitHubResolver() {
+        URLResolver github = new URLResolver();
+        github.setName("GitHub");
+        github.addArtifactPattern("http://cloud.github.com/downloads/[organisation]/[module]/[module]-[revision].[ext]");
+        return github;
+    }
+
     private PomFilterContainer createPomFilterContainer(Factory<MavenPom> mavenPomFactory) {
         return new BasePomFilterContainer(mavenPomFactory);
     }

--- a/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultResolverFactoryTest.groovy
+++ b/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultResolverFactoryTest.groovy
@@ -124,4 +124,13 @@ class DefaultResolverFactoryTest {
         def repo = factory.createIvyRepository()
         assert repo instanceof DefaultIvyArtifactRepository
     }
+
+    @Test public void createGitHubResolver() {
+        DependencyResolver actual = factory.createGitHubResolver();
+        def expectedPatterns = [
+                'http://cloud.github.com/downloads/[organisation]/[module]/[module]-[revision].[ext]'
+        ]
+        assert expectedPatterns == actual.artifactPatterns
+        assert actual.name != null
+    }
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -257,6 +257,8 @@ public interface RepositoryHandler extends ResolverContainer, ResolverProvider {
      */
     MavenResolver mavenInstaller(Map<String, ?> args, Closure configureClosure);
 
+    DependencyResolver github();
+
     /**
      * Adds and configures an Ivy repository.
      *

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -19,6 +19,7 @@ import groovy.lang.Closure;
 import org.apache.ivy.plugins.resolver.AbstractResolver;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 import org.apache.ivy.plugins.resolver.FileSystemResolver;
+import org.apache.ivy.plugins.resolver.URLResolver;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.dsl.ArtifactRepository;
@@ -158,6 +159,10 @@ public class DefaultRepositoryHandler extends DefaultResolverContainer implement
 
     public MavenResolver mavenInstaller(Closure configureClosure) {
         return mavenInstaller(Collections.emptyMap(), configureClosure);
+    }
+
+    public DependencyResolver github() {
+        return add(getResolverFactory().createGitHubResolver());
     }
 
     public MavenResolver mavenInstaller(Map args) {

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ResolverFactory.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ResolverFactory.java
@@ -47,4 +47,6 @@ public interface ResolverFactory {
                                        Conf2ScopeMappingContainer scopeMapping, FileResolver fileResolver);
 
     IvyArtifactRepository createIvyRepository(FileResolver resolver);
+
+    DependencyResolver createGitHubResolver();
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandlerTest.groovy
@@ -38,6 +38,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertSame
+import org.apache.ivy.plugins.resolver.URLResolver
 
 /**
  * @author Hans Dockter
@@ -120,6 +121,17 @@ class DefaultRepositoryHandlerTest extends DefaultResolverContainerTest {
         }
         prepareResolverFactoryToTakeAndReturnExpectedResolver()
         assert repositoryHandler.mavenLocal().is(expectedResolver)
+        assertEquals([expectedResolver], repositoryHandler.resolvers)
+    }
+
+    @Test
+    public void testGithub() {
+        context.checking {
+            one(resolverFactoryMock).createGitHubResolver()
+            will(returnValue(expectedResolver))
+        }
+        prepareResolverFactoryToTakeAndReturnExpectedResolver()
+        assert repositoryHandler.github().is(expectedResolver)
         assertEquals([expectedResolver], repositoryHandler.resolvers)
     }
 


### PR DESCRIPTION
Straight-forward code plus tests for http://issues.gradle.org/browse/GRADLE-1653.
