### PR TITLE
Adds a restoreJar() method to the War Task

### DIFF
--- a/subprojects/docs/src/docs/userguide/warPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/warPlugin.xml
@@ -185,5 +185,8 @@
         <sample id="customisedWebApplication" dir="webApplication/customised" title="Generation of JAR archive in addition to WAR archive">
             <sourcefile file="build.gradle" snippet="enable-jar"/>
         </sample>
+        <sample id="restoredJar" dir="webApplication/customised" title="Restores the JAR archive as default artifact for project">
+            <sourcefile file="build.gradle" snippet="restore-jar"/>
+        </sample>
     </section>
 </chapter>

--- a/subprojects/docs/src/samples/webApplication/customised/build.gradle
+++ b/subprojects/docs/src/samples/webApplication/customised/build.gradle
@@ -39,6 +39,12 @@ war {
 jar.enabled = true
 // END SNIPPET enable-jar
 
+// START SNIPPET restore-jar
+war {
+    restoreJar()
+}
+// END SNIPPET restore-jar
+
 [jettyRun, jettyRunWar]*.daemon = true
 stopKey = 'foo'
 stopPort = 9451

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/WarPlugin.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Callable;
 public class WarPlugin implements Plugin<Project> {
     public static final String PROVIDED_COMPILE_CONFIGURATION_NAME = "providedCompile";
     public static final String PROVIDED_RUNTIME_CONFIGURATION_NAME = "providedRuntime";
+    public static final String WARS_CONFIGURATION_NAME = "wars";
     public static final String WAR_TASK_NAME = "war";
     public static final String WEB_APP_GROUP = "web application";
 
@@ -80,6 +81,10 @@ public class WarPlugin implements Plugin<Project> {
         disableJarTaskAndRemoveFromArchivesConfiguration(project, archivesConfiguration);
         archivesConfiguration.getArtifacts().add(new ArchivePublishArtifact(war));
         configureConfigurations(project.getConfigurations());
+
+        Configuration warsConfiguration = project.getConfigurations().getByName(WARS_CONFIGURATION_NAME);
+
+        warsConfiguration.getArtifacts().add(new ArchivePublishArtifact(war));
     }
 
     private void disableJarTaskAndRemoveFromArchivesConfiguration(Project project, Configuration archivesConfiguration) {
@@ -108,5 +113,9 @@ public class WarPlugin implements Plugin<Project> {
                 setDescription("Additional runtime classpath for libraries that should not be part of the WAR archive.");
         configurationContainer.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME).extendsFrom(provideCompileConfiguration);
         configurationContainer.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
+
+        Configuration warsConfiguration = configurationContainer.
+                add(WARS_CONFIGURATION_NAME).
+                setDescription("WAR archive destination instead of archives");
     }
 }


### PR DESCRIPTION
Adds a "wars" configuration when applying the War Plugin
Re-adds the JAR artifact to archives configuration
Removes the WAR artifact from the archives configuration
Makes the war include the generated jar instead of classes
Adds the WAR artifact to the wars configuration

Could not quite figure out how to get the DSL to pick up the
groovydoc, even though the restoreJar() method shows up
just fine in the generated groovydoc.

It is also missing automated test cases.

Wanted to get this out there for review/incorporation so that
this long standing issue can be mitigated.
