### PR TITLE
Removes extension of archives by default and ensures that jar/war product

### DIFF
--- a/subprojects/docs/src/samples/java/base/prod/build.gradle
+++ b/subprojects/docs/src/samples/java/base/prod/build.gradle
@@ -12,6 +12,6 @@ task jar(type: Jar) {
 }
 
 artifacts {
-    archives jar
+    'default' jar
 }
 

--- a/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
+++ b/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
@@ -56,6 +56,21 @@ dependencies {
     }
 
     @Test
+    void "ear and war and java plugins"() {
+        file("build.gradle").write("""
+apply plugin: 'java'
+apply plugin: 'war'
+apply plugin: 'ear'
+""")
+
+        executer.withTasks('assemble').run()
+
+        file("build/libs/root.jar").assertExists()
+        file("build/libs/root.war").assertExists()
+        file("build/libs/root.ear").assertExists()
+    }
+
+    @Test
     void "customizes ear archive"() {
         file("build.gradle").write("""
 apply plugin: 'ear'

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SamplesJavaMultiProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SamplesJavaMultiProjectIntegrationTest.groovy
@@ -210,7 +210,7 @@ class SamplesJavaMultiProjectIntegrationTest {
         assertExists(javaprojectDir, SHARED_NAME, testPackagePrefix, SHARED_NAME, 'PersonTest.class')
         assertExists(javaprojectDir, "$SERVICES_NAME/$WEBAPP_NAME" as String, packagePrefix, WEBAPP_NAME, 'TestTest.class')
         assertExists(javaprojectDir, "$SERVICES_NAME/$WEBAPP_NAME" as String, 'build', 'libs', 'webservice-2.5.war')
-        assertDoesNotExist(javaprojectDir, false, "$SERVICES_NAME/$WEBAPP_NAME" as String, 'build', 'libs', 'webservice-2.5.jar')
+        assertExists(javaprojectDir, "$SERVICES_NAME/$WEBAPP_NAME" as String, 'build', 'libs', 'webservice-2.5.jar')
     }
 
     private static void assertExists(TestFile baseDir, Object... path) {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/BasePlugin.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/BasePlugin.groovy
@@ -167,9 +167,9 @@ class BasePlugin implements Plugin<Project> {
         project.setProperty("status", "integration");
 
         Configuration archivesConfiguration = configurations.add(Dependency.ARCHIVES_CONFIGURATION).
-                setDescription("Configuration for the default artifacts.");
+                setDescription("Configuration for archive artifacts.");
 
-        configurations.add(Dependency.DEFAULT_CONFIGURATION).extendsFrom(archivesConfiguration).
-                setDescription("Configuration for the default artifacts and their dependencies.");
+        configurations.add(Dependency.DEFAULT_CONFIGURATION).
+                setDescription("Configuration for default artifacts.");
     }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/JavaPlugin.java
@@ -120,6 +120,7 @@ public class JavaPlugin implements Plugin<Project> {
         });
 
         project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getArtifacts().add(new ArchivePublishArtifact(jar));
+        project.getConfigurations().getByName(RUNTIME_CONFIGURATION_NAME).getArtifacts().add(new ArchivePublishArtifact(jar));
     }
 
     private void configureBuild(Project project) {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/WarPlugin.java
@@ -77,14 +77,13 @@ public class WarPlugin implements Plugin<Project> {
         war.setDescription("Generates a war archive with all the compiled classes, the web-app content and the libraries.");
         war.setGroup(BasePlugin.BUILD_GROUP);
         Configuration archivesConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION);
-        disableJarTaskAndRemoveFromArchivesConfiguration(project, archivesConfiguration);
+        removeJarTaskFromArchivesConfiguration(project, archivesConfiguration);
         archivesConfiguration.getArtifacts().add(new ArchivePublishArtifact(war));
         configureConfigurations(project.getConfigurations());
     }
 
-    private void disableJarTaskAndRemoveFromArchivesConfiguration(Project project, Configuration archivesConfiguration) {
+    private void removeJarTaskFromArchivesConfiguration(Project project, Configuration archivesConfiguration) {
         Jar jarTask = (Jar) project.getTasks().getByName(JavaPlugin.JAR_TASK_NAME);
-        jarTask.setEnabled(false);
         removeJarTaskFromArchivesConfiguration(archivesConfiguration, jarTask);
     }
 


### PR DESCRIPTION
Removes extension of archives by default configuration and ensures that jar/war products are built by default

Jar is added to runtime configuration, so picked up by dependent products, and jar/war tasks can remain enabled all the time.  Jar and War products are still not added to archives by default, but these changes make that more readily possible in the future.  Ear now removes any war file from archives if war and ear plugins both applied.
