### PR TITLE
Add gzip/bzip support to TarFileTree (GRADLE-947)

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
@@ -54,6 +54,26 @@ public class TarFileTreeTest {
     }
 
     @Test
+    public void readsGzippedTarFile() {
+        rootDir.file("subdir/file1.txt").write("content");
+        rootDir.file("subdir2/file2.txt").write("content");
+        rootDir.tgzTo(tarFile);
+
+        assertVisits(tree, toList("subdir/file1.txt", "subdir2/file2.txt"), toList("subdir", "subdir2"));
+        assertSetContainsForAllTypes(tree, toList("subdir/file1.txt", "subdir2/file2.txt"));
+    }
+
+    @Test
+    public void readsBzippedTarFile() {
+        rootDir.file("subdir/file1.txt").write("content");
+        rootDir.file("subdir2/file2.txt").write("content");
+        rootDir.tbzTo(tarFile);
+
+        assertVisits(tree, toList("subdir/file1.txt", "subdir2/file2.txt"), toList("subdir", "subdir2"));
+        assertSetContainsForAllTypes(tree, toList("subdir/file1.txt", "subdir2/file2.txt"));
+    }
+
+    @Test
     public void canStopVisitingFiles() {
         rootDir.file("subdir/file1.txt").write("content");
         rootDir.file("subdir/other/file2.txt").write("content");

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestFile.java
@@ -20,6 +20,7 @@ import groovy.lang.Closure;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.taskdefs.Tar;
 import org.apache.tools.ant.taskdefs.Zip;
+import org.apache.tools.ant.types.EnumeratedAttribute;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.DeleteAction;
@@ -448,6 +449,24 @@ public class TestFile extends File implements TestFileContext {
         Tar tar = new Tar();
         tar.setBasedir(this);
         tar.setDestFile(zipFile);
+        AntUtil.execute(tar);
+        return this;
+    }
+
+    public TestFile tgzTo(TestFile tarFile) {
+        Tar tar = new Tar();
+        tar.setBasedir(this);
+        tar.setDestFile(tarFile);
+        tar.setCompression((Tar.TarCompressionMethod) EnumeratedAttribute.getInstance(Tar.TarCompressionMethod.class, "gzip"));
+        AntUtil.execute(tar);
+        return this;
+    }
+
+    public TestFile tbzTo(TestFile tarFile) {
+        Tar tar = new Tar();
+        tar.setBasedir(this);
+        tar.setDestFile(tarFile);
+        tar.setCompression((Tar.TarCompressionMethod) EnumeratedAttribute.getInstance(Tar.TarCompressionMethod.class, "bzip2"));
         AntUtil.execute(tar);
         return this;
     }


### PR DESCRIPTION
This implements http://issues.gradle.org/browse/GRADLE-947

We had need of this at Tripwire, so I implemented it (+ bzip2). I'm hoping this can be integrated so we can switch back to using official releases.
