### PR TITLE
Add appDirName to EclipseWtpComponent.sourceDirs when EarPlugin applied, but JavaPlugin not

### DIFF
--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
@@ -105,6 +105,7 @@ class EclipseWtpPlugin extends IdePlugin {
                     component.minusConfigurations = []
                     component.classesDeployPath = "/"
                     component.libDeployPath = "/lib"
+                    component.conventionMapping.sourceDirs = { [project.file { project.appDirName }] as Set }
                     project.plugins.withType(JavaPlugin) {
                         component.conventionMapping.sourceDirs = { getMainSourceDirs(project) }
                     }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -174,4 +174,12 @@ class EclipseWtpPluginTest extends Specification {
         GenerateEclipseClasspath eclipseClasspath = project.tasks.eclipseClasspath
         assert eclipseClasspath.plusConfigurations == configurations
     }
+
+    def applyToEarProjectWithoutJavaPlugin_shouldUseAppDirInWtpComponentSource() {
+        when:
+        project.apply(plugin: 'ear')
+        wtpPlugin.apply(project)
+        then:
+        project.eclipseWtpComponent.sourceDirs == [project.file(project.appDirName)] as Set
+    }
 }


### PR DESCRIPTION
This is a fix for GRADLE-2018.

http://issues.gradle.org/browse/GRADLE-2018
