### PR TITLE
Fix for Gradle-1656 The Checkstyle plugin doesn't support omitting the console output

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.groovy
@@ -15,10 +15,10 @@
  */
 package org.gradle.api.plugins.quality
 
-import org.gradle.api.file.FileCollection
-import org.gradle.api.tasks.*
 import org.gradle.api.GradleException
+import org.gradle.api.file.FileCollection
 import org.gradle.util.DeprecationLogger
+import org.gradle.api.tasks.*
 
 /**
  * Runs Checkstyle against some source files.
@@ -103,6 +103,11 @@ class Checkstyle extends SourceTask implements VerificationTask {
      */
     boolean ignoreFailures
 
+    /**
+     * Whether or not the build should display violations on the console or not.
+     */
+    boolean displayViolations
+
     @TaskAction
     public void run() {
         def propertyName = "org.gradle.checkstyle.violations"
@@ -112,7 +117,9 @@ class Checkstyle extends SourceTask implements VerificationTask {
         ant.checkstyle(config: getConfigFile(), failOnViolation: false, failureProperty: propertyName) {
             getSource().addToAntBuilder(ant, 'fileset', FileCollection.AntType.FileSet)
             getClasspath().addToAntBuilder(ant, 'classpath')
-            formatter(type: 'plain', useFile: false)
+            if (displayViolations) {
+                formatter(type: 'plain', useFile: false)
+            }
             formatter(type: 'xml', toFile: getReportFile())
             getConfigProperties().each { key, value ->
                 property(key: key, value: value.toString())

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.groovy
@@ -37,4 +37,14 @@ class CheckstyleExtension extends CodeQualityExtension {
      * file. Defaults to the empty map.
      */
     Map<String, Object> configProperties
+
+    /**
+     * Specifies whether the build should display violations on the console or not. Defaults to true
+     */
+    /**
+     * Whether or not the build should display violations on the console or not. Defaults to <tt>true</tt>.
+     *
+     * Example: displayViolations = false
+     */
+    boolean displayViolations = true
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.groovy
@@ -18,9 +18,9 @@ package org.gradle.api.plugins.quality
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.Instantiator
-import org.gradle.api.tasks.SourceSet
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.reporting.ReportingExtension
+import org.gradle.api.tasks.SourceSet
 
 class CheckstylePlugin implements Plugin<Project> {
     private Project project
@@ -85,6 +85,7 @@ class CheckstylePlugin implements Plugin<Project> {
                 configProperties = { extension.configProperties }
                 reportFile = { new File(extension.reportsDir, "${sourceSet.name}.xml") }
                 ignoreFailures = { extension.ignoreFailures }
+                displayViolations = { extension.displayViolations }
             }
         }
     }

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
@@ -16,18 +16,13 @@
 package org.gradle.api.plugins.quality
 
 import org.gradle.api.Project
-
-import org.gradle.api.tasks.SourceSet
 import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.tasks.SourceSet
 import org.gradle.util.HelperUtil
-
 import spock.lang.Specification
-
-import static spock.util.matcher.HamcrestSupport.*
 import static org.gradle.util.Matchers.dependsOn
-import static org.hamcrest.Matchers.hasItem
-import static org.hamcrest.Matchers.hasItems
-import static org.hamcrest.Matchers.not
+import static org.hamcrest.Matchers.*
+import static spock.util.matcher.HamcrestSupport.that
 
 class CheckstylePluginTest extends Specification {
     Project project = HelperUtil.createRootProject()
@@ -85,6 +80,7 @@ class CheckstylePluginTest extends Specification {
             assert configProperties == [:]
             assert reportFile == project.file("build/reports/checkstyle/${sourceSet.name}.xml")
             assert ignoreFailures == false
+            assert displayViolations == true
         }
     }
     
@@ -122,6 +118,23 @@ class CheckstylePluginTest extends Specification {
         that(project.check, dependsOn(not(hasItems('checkstyleTest', 'checkstyleOther'))))
     }
 
+    def "can suppress std out display of violations via displayViolations=false"() {
+        project.sourceSets {
+            main
+            test
+            other
+        }
+
+        project.checkstyle {
+            displayViolations = false
+        }
+
+        expect:
+        def task = project.tasks.findByName("checkstyleMain")
+        assert task instanceof Checkstyle
+        assert task.displayViolations == false
+    }
+
     private void hasCustomizedSettings(String taskName, SourceSet sourceSet) {
         def task = project.tasks.findByName(taskName)
         assert task instanceof Checkstyle
@@ -133,6 +146,7 @@ class CheckstylePluginTest extends Specification {
             assert configProperties == [foo: "foo"]
             assert reportFile == project.file("checkstyle-reports/${sourceSet.name}.xml")
             assert ignoreFailures == true
+            assert displayViolations == true
         }
     }
 }

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Checkstyle.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Checkstyle.xml
@@ -11,6 +11,7 @@
             <tr><td>classpath</td><td><literal><replaceable>sourceSet</replaceable>.compileClasspath</literal></td></tr>
             <tr><td>configFile</td><td><literal>project.checkstyleConfigFile</literal></td></tr>
             <tr><td>ignoreFailures</td><td><literal>false</literal></td></tr>
+            <tr><td>displayViolations</td><td><literal>true</literal></td></tr>
             <tr><td>configProperties</td><td><literal>project.checkstyleProperties</literal></td></tr>
             <tr>
                 <td>reportFile</td>


### PR DESCRIPTION
Added displayViolations attribute to allow suppression of Checkstyle violations on the console.

Only added to Checkstyle as other code quality plugins do not appear to output violations to the console by default.
