### PR TITLE
Default classname to suite name when testcase's classname is missing

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
@@ -78,6 +78,9 @@ public class DefaultTestReport implements TestReporter {
             for (int i = 0; i < testCases.getLength(); i++) {
                 Element testCase = (Element) testCases.item(i);
                 String className = testCase.getAttribute("classname");
+                if("".equals(className)) {
+                    className = ((Element)testCase.getParentNode()).getAttribute("name");
+                }
                 String testName = testCase.getAttribute("name");
                 LocaleSafeDecimalFormat format = new LocaleSafeDecimalFormat();
                 BigDecimal duration = format.parse(testCase.getAttribute("time"));

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
@@ -197,6 +197,29 @@ message">this is a failure.</failure></testcase>
         packageFile.assertHasLinkTo('Test')
     }
 
+    def reportsOnTestCasesWithoutClassname() {
+        resultsDir.file('TEST-someClass.xml') << '''
+<testsuite name="Test">
+    <testcase name="test1" time="0">
+    </testcase>
+</testsuite>
+'''
+
+        when:
+        report.generateReport()
+
+        then:
+        def index = results(indexFile)
+        index.assertHasLinkTo('default-package')
+        index.assertHasLinkTo('Test', 'Test')
+
+        def packageFile = results(reportDir.file('default-package.html'))
+        packageFile.assertHasLinkTo('Test', 'Test')
+
+        def testFile = results(reportDir.file('Test.html'))
+        testFile.assertHasTest("test1")
+    }
+
     def escapesHtmlContentInReport() {
         resultsDir.file('TEST-someClass.xml') << '''
 <testsuite name="org.gradle.Test">


### PR DESCRIPTION
I'm using [ci_reporter](https://github.com/nicksieger/ci_reporter) to generate some test results and the DefaultTestReport creates some strange results. It turns out that ci_reporter isn't setting the classname attribute on testcase elements and gradle gave those tests the classname of empty string. This ends up creating an odd combination of an anchor tag with no content and a file named ".html"

This patch defaults the testcase's classname to the testsuite's name if the classname attribute is missing.
