### PR TITLE
fixing deamon/daemon typos in userguide

### DIFF
--- a/subprojects/docs/src/docs/userguide/gradleDaemon.xml
+++ b/subprojects/docs/src/docs/userguide/gradleDaemon.xml
@@ -82,10 +82,10 @@
             <itemizedlist>
                 <listitem>If the daemon process is currently busy running some job, a brand new daemon process will be started.</listitem>
                 <listitem>We fork a separate daemon process per java home. So even if there is some idle daemon waiting
-                    for build requests but you happen to run build with a different java home then a brand new deamon will be forked.</listitem>
+                    for build requests but you happen to run build with a different java home then a brand new daemon will be forked.</listitem>
                 <listitem>At the moment daemon is coupled with particular version of gradle.
                     This means that even if some daemon is idle but you are running the build
-                    with a different version of Gradle, a new deamon will be started.
+                    with a different version of Gradle, a new daemon will be started.
                     This also have a consequence for the <literal>--stop</literal> command line instruction:
                     You can only stop daemons that were started with the gradle version you use when running <literal>--stop</literal>.
                 </listitem>

--- a/subprojects/docs/src/docs/userguide/thisAndThat.xml
+++ b/subprojects/docs/src/docs/userguide/thisAndThat.xml
@@ -105,7 +105,7 @@
 
     <section id="sec:gradle_configuration_properties">
         <title>Configuring gradle via gradle.properties</title>
-        <para>The idea is that certain settings like jvm memory settings, java home, deamon on/off
+        <para>The idea is that certain settings like jvm memory settings, java home, daemon on/off
             are best useful if they can versioned with the project in your VCS so that
             the entire team can work with consistent environment.
             You can place those settings in the <filename>gradle.properties</filename>.


### PR DESCRIPTION
Just three simple changes.
