### PR TITLE
Update to JNR (JRuby Native Extensions) 1.1.8

### DIFF
--- a/subprojects/native/native.gradle
+++ b/subprojects/native/native.gradle
@@ -10,7 +10,10 @@ dependencies {
     compile libraries.commons_io
     compile libraries.slf4j_api
     compile libraries.jna
-    compile module('org.jruby.ext.posix:jna-posix:1.0.3') {
+    compile module('org.jruby.ext.posix:jnr-posix:1.1.8') {
+        dependency libraries.jna
+    }
+    compile module('org.jruby.extras:constantine:0.7') {
         dependency libraries.jna
     }
     compile module('org.fusesource.jansi:jansi:1.2.1') {

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeplatform/PosixWrapper.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeplatform/PosixWrapper.java
@@ -28,9 +28,10 @@ import java.io.IOException;
 public class PosixWrapper {
 
     public static POSIX wrap(POSIX posix) {
-        if (posix instanceof JavaPOSIX) {
+        String name = posix.getClass().getSimpleName();
+        if ("JavaPOSIX".equals(name)) {
             return new ChmodDisabledFallbackPOSIX(posix);
-        } else if (posix instanceof WindowsPOSIX) {
+        } else if ("WindowsPOSIX".equals("name")) {
             return new FilePermissionFallbackPOSIX(posix);
         } else {
             return posix;
@@ -263,6 +264,46 @@ public class PosixWrapper {
 
         public void errno(int value) {
             delegate.errno(value);
+        }
+
+        public LibC libc() {
+            return delegate.libc();
+        }
+
+        public boolean isNative() {
+            return delegate.isNative();
+        }
+
+        public String getenv(String name) {
+            return delegate.getenv(name);
+        }
+
+        public int setenv(String name, String value, int i) {
+            return delegate.setenv(name, value, i);
+        }
+
+        public int unsetenv(String name) {
+            return delegate.unsetenv(name);
+        }
+
+        public int exec(String cmd, String... args) {
+            return delegate.exec(cmd, args);
+        }
+
+        public int exec(String cmd, String[] args, String[] env) {
+            return delegate.exec(cmd, args, env);
+        }
+
+        public int execv(String cmd, String[] args) {
+            return delegate.execv(cmd, args);
+        }
+
+        public int execve(String cmd, String[] args, String[] env) {
+            return delegate.execve(cmd, args, env);
+        }
+
+        public FileStat allocateStat() {
+            return delegate.allocateStat();
         }
     }
 

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeplatform/filesystem/PosixUtil.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeplatform/filesystem/PosixUtil.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.nativeplatform.filesystem;
 
+import com.kenai.constantine.platform.Errno;
+
 import org.jruby.ext.posix.POSIX;
 import org.jruby.ext.posix.POSIXFactory;
 import org.jruby.ext.posix.POSIXHandler;
@@ -32,7 +34,7 @@ public class PosixUtil {
     }
 
     private static class POSIXHandlerImpl implements POSIXHandler {
-        public void error(POSIX.ERRORS error, String message) {
+        public void error(Errno error, String message) {
             throw new UnsupportedOperationException(error + " - " + message);
         }
 

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeplatform/filesystem/PosixWrapper.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeplatform/filesystem/PosixWrapper.java
@@ -27,9 +27,10 @@ import java.io.IOException;
 public class PosixWrapper {
 
     public static POSIX wrap(POSIX posix) {
-        if (posix instanceof JavaPOSIX) {
+        String name = posix.getClass().getSimpleName();
+        if ("JavaPOSIX".equals(name)) {
             return new ChmodDisabledFallbackPOSIX(posix);
-        } else if (posix instanceof WindowsPOSIX) {
+        } else if ("WindowsPOSIX".equals(name)) {
             return new FilePermissionFallbackPOSIX(posix);
         } else {
             return posix;
@@ -262,6 +263,46 @@ public class PosixWrapper {
 
         public void errno(int value) {
             delegate.errno(value);
+        }
+
+        public LibC libc() {
+            return delegate.libc();
+        }
+
+        public boolean isNative() {
+            return delegate.isNative();
+        }
+
+        public String getenv(String name) {
+            return delegate.getenv(name);
+        }
+
+        public int setenv(String name, String value, int i) {
+            return delegate.setenv(name, value, i);
+        }
+
+        public int unsetenv(String name) {
+            return delegate.unsetenv(name);
+        }
+
+        public int exec(String cmd, String... args) {
+            return delegate.exec(cmd, args);
+        }
+
+        public int exec(String cmd, String[] args, String[] env) {
+            return delegate.exec(cmd, args, env);
+        }
+
+        public int execv(String cmd, String[] args) {
+            return delegate.execv(cmd, args);
+        }
+
+        public int execve(String cmd, String[] args, String[] env) {
+            return delegate.execve(cmd, args, env);
+        }
+
+        public FileStat allocateStat() {
+            return delegate.allocateStat();
         }
     }
 


### PR DESCRIPTION
We are in the process of packaging Gradle for Fedora (http://fedoraproject.org) and we found an small issue with the JNR libraries. Fedora already has newer versions of those libraries, 1.1.8 to be precise, and the native sub-package doesn't build correctly.

This patch updates the dependencies and the Java code to use those newer versions.

Having this in the gradle code base would simplify the packaging effort in Fedora.

Hope this helps!
