### PR TITLE
GRADLE-2313 Lazily get temporary directory, calling back to AbstractTask...

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -46,7 +46,7 @@ public class JUnitTestFramework implements TestFramework {
         this.testTask = testTask;
         reporter = new DefaultTestReport();
         options = new JUnitOptions();
-        detector = new JUnitDetector(testTask.getTestClassesDir(), testTask.getClasspath(), new ClassFileExtractionManager(testTask.getTemporaryDir()));
+        detector = new JUnitDetector(testTask.getTestClassesDir(), testTask.getClasspath(), new ClassFileExtractionManager(testTask.getTemporaryDirFactory()));
     }
 
     public WorkerTestClassProcessorFactory getProcessorFactory() {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
@@ -46,7 +46,7 @@ public class TestNGTestFramework implements TestFramework {
         this.testTask = testTask;
         options = new TestNGOptions(testTask.getProject().getProjectDir());
         options.setAnnotationsOnSourceCompatibility(JavaVersion.toVersion(testTask.getProject().property("sourceCompatibility")));
-        detector = new TestNGDetector(testTask.getTestClassesDir(), testTask.getClasspath(), new ClassFileExtractionManager(testTask.getTemporaryDir()));
+        detector = new TestNGDetector(testTask.getTestClassesDir(), testTask.getClasspath(), new ClassFileExtractionManager(testTask.getTemporaryDirFactory()));
     }
 
     public WorkerTestClassProcessorFactory getProcessorFactory() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestFrameworkTest.java
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestFrameworkTest.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.junit;
 
 import org.gradle.api.AntBuilder;
+import org.gradle.internal.Factory;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.api.internal.tasks.testing.AbstractTestFrameworkTest;
@@ -26,6 +27,8 @@ import org.gradle.api.tasks.testing.junit.JUnitOptions;
 import org.gradle.messaging.actor.ActorFactory;
 import org.jmock.Expectations;
 import org.junit.Before;
+
+import java.io.File;
 
 import static junit.framework.Assert.assertNotNull;
 import static org.hamcrest.Matchers.instanceOf;
@@ -49,12 +52,16 @@ public class JUnitTestFrameworkTest extends AbstractTestFrameworkTest {
         jUnitOptionsMock = context.mock(JUnitOptions.class);
         idGenerator = context.mock(IdGenerator.class);
         serviceRegistry = context.mock(ServiceRegistry.class);
-
+        final Factory<File> temporaryDirFactory = new Factory<File>() {
+            public File create() {
+                return temporaryDir;
+            }
+        };
         context.checking(new Expectations(){{
             allowing(testMock).getTestClassesDir(); will(returnValue(testClassesDir));
             allowing(testMock).getClasspath(); will(returnValue(classpathMock));
             allowing(testMock).getAnt(); will(returnValue(context.mock(AntBuilder.class)));
-            allowing(testMock).getTemporaryDir(); will(returnValue(temporaryDir));
+            allowing(testMock).getTemporaryDirFactory(); will(returnValue(temporaryDirFactory));
         }});
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFrameworkTest.java
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFrameworkTest.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.testng;
 
 import org.gradle.api.JavaVersion;
+import org.gradle.internal.Factory;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.api.internal.tasks.testing.AbstractTestFrameworkTest;
@@ -47,6 +48,11 @@ public class TestNGTestFrameworkTest extends AbstractTestFrameworkTest {
         testngOptionsMock = context.mock(TestNGOptions.class);
         idGeneratorMock = context.mock(IdGenerator.class);
         serviceRegistry = context.mock(ServiceRegistry.class);
+        final Factory<File> temporaryDirFactory = new Factory<File>() {
+            public File create() {
+                return temporaryDir;
+            }
+        };
 
         final JavaVersion sourceCompatibility = JavaVersion.VERSION_1_5;
         context.checking(new Expectations() {{
@@ -55,6 +61,7 @@ public class TestNGTestFrameworkTest extends AbstractTestFrameworkTest {
             allowing(testMock).getTestClassesDir(); will(returnValue(testClassesDir));
             allowing(testMock).getClasspath(); will(returnValue(classpathMock));
             allowing(testMock).getTemporaryDir(); will(returnValue(temporaryDir));
+            allowing(testMock).getTemporaryDirFactory(); will(returnValue(temporaryDirFactory));
         }});
     }
 


### PR DESCRIPTION
....getTemporaryDir() which will call mkdirs() to ensure the directory exists when it is being asked for.
