### PR TITLE
GRADLE-2372

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
@@ -48,10 +48,15 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
         return delegateAndHandleErrors(spec);
     }
 
-    private void resolveAndFilterSourceFiles(GroovyJavaJointCompileSpec spec) {
+    private void resolveAndFilterSourceFiles(final GroovyJavaJointCompileSpec spec) {
         FileCollection groovyJavaOnly = spec.getSource().filter(new Spec<File>() {
             public boolean isSatisfiedBy(File element) {
-                return element.getName().endsWith(".groovy") || element.getName().endsWith(".java");
+                for (String fileExtension : spec.getGroovyCompileOptions().getFileExtensions()) {
+                    if (element.getName().endsWith("." + fileExtension)) {
+                        return true;
+                    }
+                }
+                return false;
             }
         });
 

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/compile/GroovyCompileOptions.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/compile/GroovyCompileOptions.java
@@ -44,6 +44,8 @@ public class GroovyCompileOptions extends AbstractOptions {
 
     private boolean keepStubs;
 
+    private List<String> fileExtensions = ImmutableList.of("java", "groovy");
+
     private GroovyForkOptions forkOptions = new GroovyForkOptions();
 
     private Map<String, Boolean> optimizationOptions = Maps.newHashMap();
@@ -237,6 +239,23 @@ public class GroovyCompileOptions extends AbstractOptions {
     }
 
     /**
+     * Returns the list of acceptable source file extensions.
+     * Defaults to {@code ImmutableList.of("java", "groovy")}.
+     */
+    @Input
+    public List<String> getFileExtensions() {
+        return fileExtensions;
+    }
+
+    /**
+     * Sets the list of acceptable source file extenssions.
+     * Defaults to {@code ImmutableList.of("java", "groovy")}.
+     */
+    public void setFileExtensions(List<String> fileExtensions) {
+        this.fileExtensions = fileExtensions;
+    }
+
+    /**
      * Tells whether Java stubs for Groovy classes generated during Java/Groovy joint compilation
      * should be kept after compilation has completed. Useful for joint compilation debugging purposes.
      * Defaults to {@code false}.
@@ -268,7 +287,7 @@ public class GroovyCompileOptions extends AbstractOptions {
      * Internal method.
      */
     protected List<String> excludedFieldsFromOptionMap() {
-        return ImmutableList.of("forkOptions", "optimizationOptions", "useAnt", "stubDir", "keepStubs");
+        return ImmutableList.of("forkOptions", "optimizationOptions", "useAnt", "stubDir", "keepStubs", "fileExtensions");
     }
 
     /**

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks.compile
+
+import org.gradle.api.internal.file.collections.SimpleFileCollection
+
+import groovy.transform.InheritConstructors
+
+import spock.lang.Specification
+
+class NormalizingGroovyCompilerTest extends Specification { 
+    Compiler<GroovyJavaJointCompileSpec> target = Mock()
+    GroovyJavaJointCompileSpec spec = new DefaultGroovyJavaJointCompileSpec()
+    NormalizingGroovyCompiler compiler = new NormalizingGroovyCompiler(target)
+    
+    def setup() {
+        spec.classpath = files('Dep1.jar', 'Dep2.jar', 'Dep3.jar')
+        spec.groovyClasspath = spec.classpath
+        spec.source = files('House.scala', 'Person1.java', 'package.html', 'Person2.groovy')
+    }
+
+    def "silently excludes source files not ending in .java or .groovy by default"() {
+        when:
+        compiler.execute(spec)
+
+        then:
+        1 * target.execute(spec) >> {
+            assert spec.source.files == files('Person1.java', 'Person2.groovy').files
+        }
+    }
+
+    def "excludes source files that have extension different from specified by fileExtensions option"() {
+        spec.groovyCompileOptions.fileExtensions = ['html']
+
+        when:
+        compiler.execute(spec)
+
+        then:
+        1 * target.execute(spec) >> {
+            assert spec.source.files == files('package.html').files
+        }
+    }
+
+    static private files(String... paths) {
+        new TestFileCollection(paths.collect { new File(it) })
+    }
+
+    // file collection whose type is distinguishable from SimpleFileCollection
+    @InheritConstructors
+    static class TestFileCollection extends SimpleFileCollection {} 
+}

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/compile/GroovyCompileOptionsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/compile/GroovyCompileOptionsTest.groovy
@@ -40,6 +40,7 @@ class GroovyCompileOptionsTest {
         assertFalse(compileOptions.listFiles)
         assertFalse(compileOptions.verbose)
         assertTrue(compileOptions.fork)
+        assertEquals(['java', 'groovy'], compileOptions.fileExtensions)
         assertEquals('UTF-8', compileOptions.encoding)
         assertNotNull(compileOptions.forkOptions)
     }


### PR DESCRIPTION
Added fileExtensions to GroovyCompileOptions. Usage example:

compileDslGroovy.groovyOptions.fileExtensions = ['dsl']
