### PR TITLE
Right URL in console running on Jetty

### DIFF
--- a/subprojects/jetty/src/main/java/org/gradle/api/plugins/jetty/AbstractJettyRunTask.java
+++ b/subprojects/jetty/src/main/java/org/gradle/api/plugins/jetty/AbstractJettyRunTask.java
@@ -269,8 +269,8 @@ public abstract class AbstractJettyRunTask extends ConventionTask {
         }
 
         progressLogger = progressLoggerFactory.newOperation(AbstractJettyRunTask.class);
-        progressLogger.setDescription(String.format("Run Jetty at http://localhost:%d/%s", getHttpPort(), getContextPath()));
-        progressLogger.setShortDescription(String.format("Running at http://localhost:%d/%s", getHttpPort(), getContextPath()));
+        progressLogger.setDescription(String.format("Run Jetty at http://localhost:%d%s", getHttpPort(), getContextPath()));
+        progressLogger.setShortDescription(String.format("Running at http://localhost:%d%s", getHttpPort(), getContextPath()));
         progressLogger.started();
         try {
             // keep the thread going if not in daemon mode


### PR DESCRIPTION
Since the method getContextPath() already starts with slash, the progress logger doesn't need to add it when generates the message.

For instance, for us, running [LMF](http://lmf.googlecode.com), we are getting:

```
> Building > :jettyRun > Running at http://localhost:8080//LMF
```

This naive patch should solve the issue.
