### PR TITLE
Enable proxy use in gradlew

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -9,6 +9,23 @@
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS="-Xmx1024m -XX:MaxPermSize=256m -Dfile.encoding=UTF-8"
 
+## Add proxy (http/https) setting if present in environment variables (http_proxy/https_proxy)
+SS_HTTP_PROXY_HOST=${http_proxy%:*}
+SS_HTTP_PROXY_HOST=${SS_HTTP_PROXY_HOST##*/}
+SS_HTTP_PROXY_PORT=${http_proxy##*:}
+SS_HTTP_PROXY_PORT=${SS_HTTP_PROXY_PORT%%/*}
+if [ ! -z "$SS_HTTP_PROXY_HOST" ] ; then
+    GRADLE_OPTS=$GRADLE_OPTS" -Dhttp.proxyHost=${SS_HTTP_PROXY_HOST} -Dhttp.proxyPort=${SS_HTTP_PROXY_PORT}"
+fi
+
+SS_HTTPS_PROXY_HOST=${https_proxy%:*}
+SS_HTTPS_PROXY_HOST=${SS_HTTPS_PROXY_HOST##*/}
+SS_HTTPS_PROXY_PORT=${https_proxy##*:}
+SS_HTTPS_PROXY_PORT=${SS_HTTPS_PROXY_PORT%%/*}
+if [ ! -z "$SS_HTTPS_PROXY_HOST" ] ; then
+    GRADLE_OPTS=$GRADLE_OPTS" -Dhttps.proxyHost=${SS_HTTPS_PROXY_HOST} -Dhttps.proxyPort=${SS_HTTPS_PROXY_PORT}"
+fi
+
 APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 


### PR DESCRIPTION
"Little silly improvement" to enable "automatic" use of proxy in gradlew script for enterprise users that work behind a proxy server; that's all.
