### PR TITLE
Support for Sonar 3.2

### DIFF
--- a/subprojects/sonar/src/main/groovy/org/gradle/api/plugins/sonar/SonarAnalyze.groovy
+++ b/subprojects/sonar/src/main/groovy/org/gradle/api/plugins/sonar/SonarAnalyze.groovy
@@ -40,7 +40,7 @@ class SonarAnalyze extends ConventionTask {
         def classLoader = bootstrapper.createClassLoader(
                 [findGradleSonarJar()] as URL[], SonarAnalyze.classLoader,
                         "groovy", "org.codehaus.groovy", "org.slf4j", "org.apache.log4j", "org.apache.commons.logging",
-                                "org.gradle.api.plugins.sonar.model")
+                                "org.gradle.api.plugins.sonar.model", "ch.qos.logback")
 
         def analyzerClass = classLoader.loadClass("org.gradle.api.plugins.sonar.internal.SonarCodeAnalyzer")
         def analyzer = analyzerClass.newInstance()


### PR DESCRIPTION
Passing classes from ch.qos.logback through the Sonar classloader to avoid
ClassCastException that started with Sonar 3.2.  This fixes [GRADLE-2424](http://issues.gradle.org/browse/GRADLE-2424).

Tested against local 3.2 and 3.1.1 installations.
