### PR TITLE
GRADLE-2447: Usage of -t cmd switch in Gradle daemon docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/gradleDaemon.xml
+++ b/subprojects/docs/src/docs/userguide/gradleDaemon.xml
@@ -29,7 +29,7 @@
             <itemizedlist>
                 <listitem>When using test driven development, where the unit tests are executed many times.</listitem>
                 <listitem>When developing a web application, where the application is assembled many times.</listitem>
-                <listitem>When discovering what a build can do, where gradle -t is executed a number of times.</listitem>
+                <listitem>When discovering what a build can do, where <userinput>gradle tasks</userinput> is executed a number of times.</listitem>
             </itemizedlist>
             For above sorts of workflows, it is important that the startup cost of invoking Gradle is as small as possible.
         </para>


### PR DESCRIPTION
Gradle daemon docs page needs to use gradle tasks help task instead of -t command line switch. This fixes [GRADLE-2447](http://issues.gradle.org/browse/GRADLE-24470).
