### PR TITLE
Add ScalaIDE container to the Eclipse classpath for Scala projects

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -104,6 +104,10 @@ Groovy: [`ScalaCompile.fork = true`](dsl/org.gradle.api.tasks.scala.ScalaCompile
 activates external compilation, and [`ScalaCompile.forkOptions`](dsl/org.gradle.api.tasks.scala.ScalaCompile.html#org.gradle.api.tasks.scala.ScalaCompile:forkOptions)
 allows to adjust memory settings.
 
+### ScalaIDE integration
+
+The [Eclipse Plugin](http://gradle.org/docs/current/userguide/eclipse_plugin.html) has improved Scala support by generating classpath entries for the [Scala IDE](http://scala-ide.org).
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to our backwards compatibility policy.
@@ -210,5 +214,6 @@ We would like to thank the following community members for making contributions 
 * Gerd Aschemann - fixes for `application` plugins generated shell scripts (GRADLE-2501)
 * Cruz Fernandez - fixes to the properties sample project
 * Fadeev Alexandr - fixes for Gradle Daemon on Win 7 when `PATH` env var is not set (GRADLE-2461)
+* Ben Manes - ScalaIDE integration
 
 We love getting contributions from the Gradle community. For information on contributing, please see (gradle.org/contribute)[http://gradle.org/contribute]

--- a/subprojects/docs/src/docs/userguide/eclipsePlugin.xml
+++ b/subprojects/docs/src/docs/userguide/eclipsePlugin.xml
@@ -44,7 +44,7 @@
             <td><link linkend="groovy_plugin">Groovy</link></td><td>Adds Groovy configuration to <filename>.project</filename> file.</td>
         </tr>
         <tr>
-                <td><link linkend="scala_plugin">Scala</link></td><td>Adds Scala support to <filename>.project</filename> file.</td>
+            <td><link linkend="scala_plugin">Scala</link></td><td>Adds Scala support to <filename>.project</filename> and <filename>.classpath</filename> files.</td>
         </tr>
         <tr>
             <td><link linkend="war_plugin">War</link></td><td>Adds web application support to <filename>.project</filename> file.

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
@@ -631,4 +631,47 @@ dependencies {
         libraries[1].assertHasJar(file('unresolved dependency - i.dont Exist 1.0'))
         libraries[2].assertHasJar(localJar)
     }
+
+    @Test
+    void classpathIsConfiguredForScalaIDE() {
+        //given
+        def scalaCompilerJar = mavenRepo.module('org.scala-lang', 'scala-compiler', '2.9.2').publish().artifactFile
+        def scalaLibraryJar = mavenRepo.module('org.scala-lang', 'scala-library', '2.9.2').publish().artifactFile
+        def scalaSwingJar = mavenRepo.module('org.scala-lang', 'scala-swing', '2.9.2').publish().artifactFile
+        def scalaDbcJar = mavenRepo.module('org.scala-lang', 'scala-dbc', '2.9.2').publish().artifactFile
+        def scalaJlineJar = mavenRepo.module('org.scala-lang', 'jline', '2.9.2').publish().artifactFile
+
+        //when
+        runEclipseTask """
+apply plugin: 'scala'
+apply plugin: 'eclipse'
+
+repositories {
+    maven { url "${mavenRepo.uri}" }
+    mavenCentral()
+}
+
+dependencies {
+    def libraries = [
+        scala_compiler: "org.scala-lang:scala-compiler:2.9.2",
+        scala_library: "org.scala-lang:scala-library:2.9.2",
+        scala_swing: "org.scala-lang:scala-swing:2.9.2",
+        scala_dbc: "org.scala-lang:scala-dbc:2.9.2",
+        scala_jline: "org.scala-lang:jline:2.9.2",
+    ]
+
+    scalaTools libraries.scala_compiler
+    scalaTools libraries.scala_library
+    scalaTools libraries.scala_jline
+
+    compile libraries.scala_library
+    compile libraries.scala_swing
+    compile libraries.scala_dbc
+}
+"""
+
+        //then
+        assert classpath.libs.isEmpty()
+        assert classpath.containers == ['org.eclipse.jdt.launching.JRE_CONTAINER', 'org.scala-ide.sdt.launching.SCALA_CONTAINER']
+    }
 }


### PR DESCRIPTION
The [ScalaIDE plugin](http://scala-ide.org) is the standard approach for developing Scala projects in Eclipse. Previously an import of a Scala gradle project would initially fail to build due to the error 'Cannot find Scala library on the classpath. Verify your build path!'. This had to be resolved manually so that the ScalaIDE verifier could be run successfully.

The ScalaIDE is now added as a classpath container. In addition to the unit test, the change was verified on a private project. The container was added to Scala projects only (and not Java projects).

Further background details is provided in the forum post, [Generate ScalaIDE Eclipse metadata for Scala projects](http://forums.gradle.org/gradle/topics/generate_scalaide_eclipse_metadata_for_scala_projects).
