### PR TITLE
Expose Test.setTestExecutor

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/Test.java
@@ -123,7 +123,7 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
         testLogging = instantiator.newInstance(DefaultTestLoggingContainer.class, instantiator);
     }
 
-    void setTestExecuter(TestExecuter testExecuter) {
+    public void setTestExecuter(TestExecuter testExecuter) {
         this.testExecuter = testExecuter;
     }
 


### PR DESCRIPTION
This is so that we can hook in distributed test executor.
