### PR TITLE
Pull request related to eclipse-wtp ignoring excludes by configuration (see http://goo.gl/5a3wc)

### DIFF
--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.groovy
@@ -16,7 +16,6 @@
 package org.gradle.plugins.ide.eclipse.model.internal
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
@@ -24,6 +23,8 @@ import org.gradle.plugins.ide.eclipse.model.EclipseWtpComponent
 import org.gradle.plugins.ide.eclipse.model.WbDependentModule
 import org.gradle.plugins.ide.eclipse.model.WbResource
 import org.gradle.plugins.ide.eclipse.model.WtpComponent
+import org.gradle.plugins.ide.internal.IdeDependenciesExtractor
+import org.gradle.plugins.ide.internal.IdeDependenciesExtractor.IdeRepoFileDependency
 
 /**
  * @author Hans Dockter
@@ -89,7 +90,11 @@ class WtpComponentFactory {
         Set declaredDependencies = getDependencies(plusConfigurations, minusConfigurations,
                 { it instanceof ExternalDependency})
 
-        Set libFiles = wtp.project.configurations.detachedConfiguration((declaredDependencies as Dependency[])).files +
+        //Just like in ClasspathFactory this considers excludes by configuration:
+        List<IdeRepoFileDependency> deps = new IdeDependenciesExtractor().extractRepoFileDependencies(wtp.project.configurations, plusConfigurations, minusConfigurations, false, false)
+        Set libFiles = deps.collect { IdeRepoFileDependency dep -> dep.file }
+
+        libFiles = libFiles +
                 getSelfResolvingFiles(getDependencies(plusConfigurations, minusConfigurations,
                         { it instanceof SelfResolvingDependency && !(it instanceof org.gradle.api.artifacts.ProjectDependency)}))
 


### PR DESCRIPTION
Hello,

As Szczepan requested in thread http://goo.gl/5a3wc I am now providing a pull request instead of a patch.
Please check if it is reasonable to do this.
It fixes the problem I described, and it seems reasonable to me that a common DependenciesExtractor be used wherever the list of depended-on artifacts is required for a direct/declared dependency.

All tests triggered by target ide:check passed.

Cheers,
illusioni
