### PR TITLE
Update subprojects/plugins/src/main/groovy/org/gradle/api/tasks/applicat...

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/application/CreateStartScripts.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/application/CreateStartScripts.groovy
@@ -59,6 +59,12 @@ class CreateStartScripts extends ConventionTask {
     FileCollection classpath
 
     /**
+     * Additional class path for the application (useful for external properties file).
+     */
+    @InputFiles
+    FileCollection additionalClasspath
+
+    /**
      * Returns the name of the application's OPTS environment variable.
      */
     @Input
@@ -102,7 +108,8 @@ class CreateStartScripts extends ConventionTask {
         generator.mainClassName = getMainClassName()
         generator.optsEnvironmentVar = getOptsEnvironmentVar()
         generator.exitEnvironmentVar = getExitEnvironmentVar()
-        generator.classpath = getClasspath().collect { "lib/${it.name}" }
+        generator.classpath = getClasspath().collect { "lib/${it.name}" }        
+        generator.additionalClasspath = getAdditionalClasspath().collect { "${it.name}" }
         generator.scriptRelPath = "bin/${getUnixScript().name}"
         generator.generateUnixScript(getUnixScript())
         generator.generateWindowsScript(getWindowsScript())


### PR DESCRIPTION
...ion/CreateStartScripts.groovy

Added another classpath option, useful for creating conf directories (which shouldn't be in lib!)

for example:
startScripts.classpath.add(files('conf'))

adds conf dir in lib

startScripts.additionalClasspath.add(files('conf'))

adds conf in $APP_HOME
