### PR TITLE
Update subprojects/docs/src/samples/userguide/tutorial/properties/gradle...

### DIFF
--- a/subprojects/docs/src/samples/userguide/tutorial/properties/gradle.properties
+++ b/subprojects/docs/src/samples/userguide/tutorial/properties/gradle.properties
@@ -1,4 +1,4 @@
 gradlePropertiesProp=gradlePropertiesValue
 systemPropertiesProp=shouldBeOverWrittenBySystemProp
-envPropertiesProp=shouldBeOverWrittenByEnvProp
+envProjectProp=shouldBeOverWrittenByEnvProp
 systemProp.system=systemValue


### PR DESCRIPTION
....properties

This will fix an error, as the property is different spelled on build.gradle (envProjectProp instead of envPropertiesProp)
