### PR TITLE
Update defaults to match Sonar 3.3

### DIFF
--- a/subprojects/sonar/src/main/groovy/org/gradle/api/plugins/sonar/SonarPlugin.groovy
+++ b/subprojects/sonar/src/main/groovy/org/gradle/api/plugins/sonar/SonarPlugin.groovy
@@ -85,8 +85,8 @@ class SonarPlugin implements Plugin<ProjectInternal> {
 
     private SonarDatabase configureSonarDatabase() {
         def database = instantiator.newInstance(SonarDatabase)
-        database.url = "jdbc:derby://localhost:1527/sonar"
-        database.driverClassName = "org.apache.derby.jdbc.ClientDriver"
+        database.url = "jdbc:h2:tcp://localhost:9092/sonar"
+        database.driverClassName = "org.h2.Driver"
         database.username = "sonar"
         database.password = "sonar"
         database


### PR DESCRIPTION
Sonar 3.3 updated their database from derby to H2. Updated the defaults to match.
