### PR TITLE
Add m2compatible support to PatternRepositoryLayout

### DIFF
--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/layout/PatternRepositoryLayout.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/layout/PatternRepositoryLayout.java
@@ -24,10 +24,12 @@ import java.util.Set;
 /**
  * A Repository Layout that uses user-supplied patterns. Each pattern will be appended to the base URI for the repository.
  * At least one artifact pattern must be specified. If no ivy patterns are specified, then the artifact patterns will be used.
+ * If maven 2 compatible layout is requested, the '.' characters in 'organisation' value are replaced with '/'.
  */
 public class PatternRepositoryLayout extends RepositoryLayout {
     private final Set<String> artifactPatterns = new LinkedHashSet<String>();
     private final Set<String> ivyPatterns = new LinkedHashSet<String>();
+    private boolean m2compatible = false;
 
     /**
      * Adds an Ivy artifact pattern to define where artifacts are located in this repository.
@@ -45,6 +47,14 @@ public class PatternRepositoryLayout extends RepositoryLayout {
         ivyPatterns.add(pattern);
     }
 
+    /**
+     * Request maven 2 repository compatible 'organisation' processing. It replaces the '.' characters in 'organisation' value with '/'.
+     * @param m2compatible Is m2 compatible 'organisation' value requested. Defaulted to <code>false</code>.
+     */
+    public void m2compatible(boolean m2compatible) {
+        this.m2compatible = m2compatible;
+    }
+
     @Override
     public void apply(URI baseUri, PatternBasedResolver resolver) {
         if (baseUri == null) {
@@ -59,5 +69,7 @@ public class PatternRepositoryLayout extends RepositoryLayout {
         for (String ivyPattern : usedIvyPatterns) {
             resolver.addDescriptorLocation(baseUri, ivyPattern);
         }
+
+        resolver.setM2compatible(m2compatible);
     }
 }

--- a/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -182,6 +182,32 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         resolver.name == 'name'
         resolver.artifactPatterns == ['http://host/[module]/[revision]/[artifact](.[ext])'] as List
         resolver.ivyPatterns == ["http://host/[module]/[revision]/ivy.xml"] as List
+        !resolver.m2compatible
+    }
+
+    def "when requested uses maven patterns with configured pattern layout"() {
+        repository.name = 'name'
+        repository.url = 'http://host'
+        repository.layout 'pattern', {
+            artifact '[module]/[revision]/[artifact](.[ext])'
+            ivy '[module]/[revision]/ivy.xml'
+            m2compatible true
+        }
+
+        given:
+        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        transportFactory.createHttpTransport('name', credentials) >> createHttpTransport("name", credentials)
+
+        when:
+        def resolver = repository.createResolver()
+
+        then:
+        resolver instanceof ExternalResourceResolver
+        resolver.repository instanceof ExternalResourceRepository
+        resolver.name == 'name'
+        resolver.artifactPatterns == ['http://host/[module]/[revision]/[artifact](.[ext])'] as List
+        resolver.ivyPatterns == ["http://host/[module]/[revision]/ivy.xml"] as List
+        resolver.m2compatible
     }
 
     def "combines layout patterns with additionally specified patterns"() {


### PR DESCRIPTION
Hello,

Can you please accept my pull request:

```
Add m2 compatible handling to PatternRepositoryLayout

PatternRepositoryLayout updated so that m2 compatible treatment of
'organisation' value can be requested.
This means that all '.' characters in the value are replaced with '/'
characters.
```

I've done this as part of solving the [issue I've raised on your forum](http://forums.gradle.org/gradle/topics/can_i_use_instead_of_in_organisation_part_of_ivy_layout_pattern). 

I am not too sure about the introduced duplication in the test, but it seemed like an established pattern.
Please let me know if you would prefer me to do something differently.

Thanks,
Dalibor
