### PR TITLE
Make notify-send notifications transient

### DIFF
--- a/subprojects/announce/src/main/groovy/org/gradle/api/plugins/announce/internal/NotifySend.groovy
+++ b/subprojects/announce/src/main/groovy/org/gradle/api/plugins/announce/internal/NotifySend.groovy
@@ -47,6 +47,7 @@ class NotifySend implements Announcer {
             if (icon) {
                 args '-i', icon.absolutePath
             }
+            args '--hint=int:transient:1'
             args title, message
         }
     }


### PR DESCRIPTION
In contrast to Ubuntu Shell in Gnome Shell notifications are persistent by default. This change adds a hint for notify-send to make notifications emitted by gradle transient. Without that notifications clutter the notification panel in Gnome Shell.

![Workspace 1_023](https://f.cloud.github.com/assets/205451/43794/f7d1f842-5698-11e2-946e-2523fa7c4edc.png)
