### PR TITLE
Use configurations from target dependency when resolving conf="x->*"

### DIFF
--- a/subprojects/core-impl/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
+++ b/subprojects/core-impl/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
@@ -68,6 +68,12 @@ class ArtifactDependenciesIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    public void canUseWildcardVersions() throws IOException {
+        File buildFile = testFile("projectWithWildcardVersions.gradle");
+        usingBuildFile(buildFile).run();
+    }
+
+    @Test
     public void resolutionFailsWhenProjectHasNoRepositoriesEvenWhenArtifactIsCachedLocally() {
         testFile('settings.gradle') << 'include "a", "b"'
         testFile('build.gradle') << """

--- a/subprojects/core-impl/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canUseWildcardVersions/projectA-1.2-ivy.xml
+++ b/subprojects/core-impl/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canUseWildcardVersions/projectA-1.2-ivy.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivy-module version="1.0">
+	<info organisation="test"
+		module="projectA"
+		revision="1.2"
+	/>
+	<configurations>
+		<conf name="parent" visibility="public"/>
+		<conf name="runtime" visibility="public"/>
+		<conf name="default" visibility="public" extends="runtime"/>
+	</configurations>
+	<publications>
+		<artifact name="projectA" type="jar" ext="jar" conf="*"/>
+	</publications>
+    <dependencies>
+        <dependency org="test" name="projectB" rev="latest.release" conf="runtime->*"/>
+    </dependencies>
+</ivy-module>

--- a/subprojects/core-impl/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canUseWildcardVersions/projectB-1.5-ivy.xml
+++ b/subprojects/core-impl/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canUseWildcardVersions/projectB-1.5-ivy.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivy-module version="1.0">
+    <info organisation="test" module="projectB" revision="1.5" status="release"/>
+    <configurations>
+        <conf name="runtime" visibility="public"/>
+        <conf name="default" visibility="public" extends="runtime"/>
+        <conf name="child" visibility="public"/>
+    </configurations>
+    <publications>
+        <artifact name="projectB" type="jar" ext="jar" conf="runtime"/>
+        <artifact name="projectB-child" type="jar" ext="jar" conf="child"/>
+    </publications>
+</ivy-module>

--- a/subprojects/core-impl/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canUseWildcardVersions/projectWithWildcardVersions.gradle
+++ b/subprojects/core-impl/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canUseWildcardVersions/projectWithWildcardVersions.gradle
@@ -1,0 +1,34 @@
+configurations {
+    compile
+}
+dependencies {
+    repositories {
+        ivy {
+            artifactPattern projectDir.absolutePath + '/[artifact]-[revision].jar'
+            ivyPattern projectDir.absolutePath + '/[module]-[revision]-ivy.xml'
+        }
+    }
+    compile group: 'test', name: 'projectA', version: '1.+'
+}
+
+file("projectA-1.2.jar").text = ''
+file("projectB-1.5.jar").text = ''
+file("projectB-child-1.5.jar").text = ''
+
+defaultTasks 'listJars'
+
+task listJars << {
+    def compile = configurations.compile
+
+    def jars = compile.collect { it.name }
+    assert ['projectA-1.2.jar', 'projectB-1.5.jar', 'projectB-child-1.5.jar'] == jars
+
+    def artifacts = compile.resolvedConfiguration.resolvedArtifacts.collect { "$it.name-$it.moduleVersion.id.version.$it.extension" }
+    assert ['projectA-1.2.jar', 'projectB-1.5.jar', 'projectB-child-1.5.jar'] == artifacts
+
+    def projectA = compile.resolvedConfiguration.firstLevelModuleDependencies.find { it.moduleName == 'projectA' }
+    assert '1.2' == projectA.moduleVersion
+
+    def projectB = projectA.children.find { it.moduleName == 'projectB' }
+    assert '1.5' == projectB.moduleVersion
+}

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilder.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilder.java
@@ -793,7 +793,10 @@ public class DependencyGraphBuilder {
                 if (moduleConfiguration.equals("*") || heirarchy.contains(moduleConfiguration)) {
                     for (String targetConfiguration : dependencyDescriptor.getDependencyConfigurations(moduleConfiguration)) {
                         if (targetConfiguration.equals("*")) {
-                            Collections.addAll(targetConfigurations, descriptor.getPublicConfigurationsNames());
+                            DefaultModuleRevisionResolveState dependencyRevision = resolveState.getSelector(dependencyDescriptor).resolveModuleRevisionId();
+                            if (dependencyRevision != null) {
+                              Collections.addAll(targetConfigurations, dependencyRevision.getDescriptor().getPublicConfigurationsNames());
+                            }
                         } else {
                             targetConfigurations.add(targetConfiguration);
                         }


### PR DESCRIPTION
Hey guys,

Looks like there is a bug in how conf="anything->*" is being interpreted.  Currently, the configurations from the parent are used when evaluating the \* wildcard on the target side, rather than the configurations from the target.  

For example, if the master has configurations _compile_ and _runtime_, and the target has configurations _compile_ and _archive_, then conf="compile->*" is being interpreted as conf="compile->compile,runtime" instead of conf="compile->compile,archive".

See the canUseWildcardVersions integration test for an example.

Cheers!
