### PR TITLE
Improve robustness of MavenProjectXmlWriter

### DIFF
--- a/subprojects/maven/src/main/groovy/org/gradle/api/plugins/maven/internal/MavenProjectXmlWriter.java
+++ b/subprojects/maven/src/main/groovy/org/gradle/api/plugins/maven/internal/MavenProjectXmlWriter.java
@@ -53,6 +53,6 @@ public class MavenProjectXmlWriter {
         } catch (IOException e) {
             throw new RuntimeException("Unable to serialize maven model to xml. Maven project: " + project, e);
         }
-        return out.toString().replace("<?xml version=\"1.0\"?>", "");
+        return out.toString().replaceFirst("^<\\?xml.+?\\?>", "");
     }
 }


### PR DESCRIPTION
Using the [bootstrap plugin](http://gradle.org/docs/current/userguide/bootstrap_plugin.html), I kept getting this error:

`[Fatal Error] :346:6: The processing instruction target matching "[xX][mM][lL]" is not allowed.
:maven2Gradle FAILED`

Turns out the reason was that my pom.xml had this at the top:
`<?xml version="1.0" encoding="UTF-8"?>`

instead of what the plugin was expecting. 
`<?xml version="1.0"?>`

This changes makes the search and replace more robust using a regex expression to 
identify to the XML declaration.
