### PR TITLE
Add parameter configURL to CheckStyleTask (GRADLE-932)

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.groovy
@@ -20,6 +20,11 @@ class CheckstyleExtension extends CodeQualityExtension {
      * The Checkstyle configuration file to use.
      */
     File configFile
+
+    /**
+     * The Checkstyle configuration URL to use.
+     */
+    String configURL
     
     /**
      * The properties available for use in the configuration file. These are substituted into the configuration

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.groovy
@@ -37,7 +37,6 @@ class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
 
         extension.with {
             toolVersion = "5.6"
-            configFile = project.file("config/checkstyle/checkstyle.xml")
         }
 
         return extension
@@ -56,6 +55,7 @@ class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
                 config
             }
             configFile = { extension.configFile }
+            configURL = { extension.configURL }
             configProperties = { extension.configProperties }
             ignoreFailures = { extension.ignoreFailures }
             showViolations = { extension.showViolations }

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
@@ -80,6 +80,7 @@ class CheckstylePluginTest extends Specification {
             assert checkstyleClasspath == project.configurations["checkstyle"]
             assert classpath == sourceSet.output
             assert configFile == project.file("config/checkstyle/checkstyle.xml")
+            assert configURL == null
             assert configProperties == [:]
             assert resultFile == project.file("build/reports/checkstyle/${sourceSet.name}.xml")
             assert !ignoreFailures
@@ -95,6 +96,7 @@ class CheckstylePluginTest extends Specification {
         task.source.isEmpty()
         task.checkstyleClasspath == project.configurations.checkstyle
         task.configFile == project.file("config/checkstyle/checkstyle.xml")
+        task.configURL == null
         task.configProperties == [:]
         task.resultFile == project.file("build/reports/checkstyle/custom.xml")
         !task.ignoreFailures
@@ -145,6 +147,7 @@ class CheckstylePluginTest extends Specification {
             assert source as List == sourceSet.allJava as List
             assert checkstyleClasspath == project.configurations["checkstyle"]
             assert configFile == project.file("checkstyle-config")
+            assert configURL == null
             assert configProperties == [foo: "foo"]
             assert resultFile == project.file("checkstyle-reports/${sourceSet.name}.xml")
             assert ignoreFailures
@@ -156,6 +159,7 @@ class CheckstylePluginTest extends Specification {
         def task = project.tasks.add("checkstyleCustom", Checkstyle)
         project.checkstyle {
             configFile = project.file("checkstyle-config")
+            configURL = 'http://www.example.com/'
             configProperties = [foo: "foo"]
             reportsDir = project.file("checkstyle-reports")
             ignoreFailures = true
@@ -166,6 +170,7 @@ class CheckstylePluginTest extends Specification {
         task.source.isEmpty()
         task.checkstyleClasspath == project.configurations.checkstyle
         task.configFile == project.file("checkstyle-config")
+        task.configURL == 'http://www.example.com/'
         task.configProperties == [foo: "foo"]
         task.resultFile == project.file("checkstyle-reports/custom.xml")
         task.ignoreFailures

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstyleTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstyleTest.groovy
@@ -30,6 +30,7 @@ class CheckstyleTest extends Specification {
             checkstyleClasspath == null
             classpath == null
             configFile == null
+            configURL == null
             configProperties == [:]
             !reports.xml.enabled
             reports.xml.destination == null


### PR DESCRIPTION
This pull request adds the parameter `configURL` to Gradle's CheckStyle plugin which defines a URL (HTTP or HTTPS) from which CheckStyle will fetch its configuration (see [GRADLE-932](http://issues.gradle.org/browse/GRADLE-932)).

I'm not quite happy yet with the [fallback check for `configFile` and `configURL`](https://github.com/smarchive/gradle/blob/ed2a19bffdc900de36df4392894240ac548884e6/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.groovy#L168-170). Maybe you have an advice how to do this better.
