### PR TITLE
Basic support for PMD 5.0+. 

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins.quality
+
+import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetVersions
+import org.junit.Test
+
+@TargetVersions(['4.3', '5.0.0'])
+class PmdPluginVersionIntegrationTest extends MultiVersionIntegrationSpec {
+
+    @Test
+    public void canRunPmdWithDifferentToolVersions() {
+        given:
+        buildFile << """
+        apply plugin: "java"
+        apply plugin: "pmd"
+
+        repositories {
+            mavenCentral()
+        }
+        pmd {
+            toolVersion = '$version'
+            ignoreFailures = true
+        }"""
+        createTestFiles();
+        when:
+        succeeds('pmdMain', 'pmdTest')
+        then:
+        output.contains("2 PMD rule violations were found. See the report at:")
+    }
+
+    private void createTestFiles() {
+        file("src/main/java/org/gradle/Class1.java") <<
+                "package org.gradle; class Class1 { public boolean isFoo(Object arg) { return true; } }"
+        file("src/test/java/org/gradle/Class1Test.java") <<
+                "package org.gradle; class Class1Test { {} public boolean equals(Object arg) { return true; } }"
+    }
+}

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.groovy
@@ -15,15 +15,14 @@
  */
 package org.gradle.api.plugins.quality
 
+import org.gradle.api.GradleException
 import org.gradle.api.file.FileCollection
-import org.gradle.internal.reflect.Instantiator
 import org.gradle.api.internal.project.IsolatedAntBuilder
 import org.gradle.api.plugins.quality.internal.PmdReportsImpl
 import org.gradle.api.reporting.Reporting
 import org.gradle.api.tasks.*
+import org.gradle.internal.reflect.Instantiator
 import org.gradle.logging.ConsoleRenderer
-import org.gradle.api.GradleException
-import org.gradle.util.VersionNumber
 
 import javax.inject.Inject
 
@@ -69,54 +68,42 @@ class Pmd extends SourceTask implements VerificationTask, Reporting<PmdReports> 
      */
     boolean ignoreFailures
 
-    String toolVersion
-
-    @Inject Pmd(Instantiator instantiator, IsolatedAntBuilder antBuilder) {
+    @Inject
+    Pmd(Instantiator instantiator, IsolatedAntBuilder antBuilder) {
         reports = instantiator.newInstance(PmdReportsImpl, this)
         this.antBuilder = antBuilder
     }
 
     @TaskAction
     void run() {
-        VersionNumber latestBranch = VersionNumber.parse("5.0.0")
-        VersionNumber convertedToolVersion = VersionNumber.parse(getToolVersion())
+        boolean oldBranch = getPmdClasspath().find {
+            it.name ==~ /pmd-([1-4]\.[0-9\.]+)\.jar/
+        }
         antBuilder.withClasspath(getPmdClasspath()).execute {
             ant.taskdef(name: 'pmd', classname: 'net.sourceforge.pmd.ant.PMDTask')
-            if (convertedToolVersion.compareTo(latestBranch) < 0) {
-                ant.pmd(failOnRuleViolation: false, failuresPropertyName: "pmdFailureCount") {
-                    getSource().addToAntBuilder(ant, 'fileset', FileCollection.AntType.FileSet)
-                    getRuleSets().each {
-                        ruleset(it)
-                    }
-                    getRuleSetFiles().each {
-                        ruleset(it)
-                    }
 
-                    if (reports.html.enabled) {
-                        assert reports.html.destination.parentFile.exists()
-                        formatter(type: 'betterhtml', toFile: reports.html.destination)
-                    }
-                    if (reports.xml.enabled) {
-                        formatter(type: 'xml', toFile: reports.xml.destination)
+            ant.pmd(failOnRuleViolation: false, failuresPropertyName: "pmdFailureCount") {
+                getSource().addToAntBuilder(ant, 'fileset', FileCollection.AntType.FileSet)
+                if (getRuleSets().isEmpty()) {
+                    if (oldBranch) {
+                        setRuleSets(["basic"])
+                    } else {
+                        setRuleSets(["java-basic"])
                     }
                 }
-            } else {
-                ant.pmd(failOnRuleViolation: false, failuresPropertyName: "pmdFailureCount") {
-                    getSource().addToAntBuilder(ant, 'fileset', FileCollection.AntType.FileSet)
-                    getRuleSets().each {
-                        ruleset(it)
-                    }
-                    getRuleSetFiles().each {
-                        ruleset(it)
-                    }
+                getRuleSets().each {
+                    ruleset(it)
+                }
+                getRuleSetFiles().each {
+                    ruleset(it)
+                }
 
-                    if (reports.html.enabled) {
-                        assert reports.html.destination.parentFile.exists()
-                        formatter(type: 'html', toFile: reports.html.destination)
-                    }
-                    if (reports.xml.enabled) {
-                        formatter(type: 'xml', toFile: reports.xml.destination)
-                    }
+                if (reports.html.enabled) {
+                    assert reports.html.destination.parentFile.exists()
+                    formatter(type: oldBranch ? 'betterhtml' : 'html', toFile: reports.html.destination)
+                }
+                if (reports.xml.enabled) {
+                    formatter(type: 'xml', toFile: reports.xml.destination)
                 }
             }
             def failureCount = ant.project.properties["pmdFailureCount"]

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.groovy
@@ -50,7 +50,7 @@ class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         extension = project.extensions.create("pmd", PmdExtension, project)
         extension.with {
             toolVersion = "4.3"
-            ruleSets = ["basic"]
+            ruleSets = []
             ruleSetFiles = project.files()
         }
         return extension
@@ -60,7 +60,6 @@ class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
     protected void configureTaskDefaults(Pmd task, String baseName) {
 
         task.conventionMapping.with {
-            toolVersion = { extension.toolVersion }
             pmdClasspath = {
                 def config = project.configurations['pmd']
                 if (config.dependencies.empty) {

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -50,7 +50,7 @@ class PmdPluginTest extends Specification {
     def "configures pmd extension"() {
         expect:
         PmdExtension extension = project.extensions.pmd
-        extension.ruleSets == ["basic"]
+        extension.ruleSets == []
         extension.ruleSetFiles.empty
         extension.reportsDir == project.file("build/reports/pmd")
         !extension.ignoreFailures
@@ -77,7 +77,7 @@ class PmdPluginTest extends Specification {
             assert description == "Run PMD analysis for ${sourceSet.name} classes"
             source as List == sourceSet.allJava as List
             assert pmdClasspath == project.configurations.pmd
-            assert ruleSets == ["basic"]
+            assert ruleSets == []
             assert ruleSetFiles.empty
             assert reports.xml.destination == project.file("build/reports/pmd/${sourceSet.name}.xml")
             assert reports.html.destination == project.file("build/reports/pmd/${sourceSet.name}.html")
@@ -92,7 +92,7 @@ class PmdPluginTest extends Specification {
         task.description == null
         task.source.empty
         task.pmdClasspath == project.configurations.pmd
-        task.ruleSets == ["basic"]
+        task.ruleSets == []
         task.ruleSetFiles.empty
         task.reports.xml.destination == project.file("build/reports/pmd/custom.xml")
         task.reports.html.destination == project.file("build/reports/pmd/custom.html")

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
@@ -18,7 +18,7 @@
             </tr>
             <tr>
                 <td>ruleSets</td>
-                <td><literal>["basic"]</literal></td>
+                <td><literal>["basic"] or ["java-basic"]</literal> depending on the PMD version used</td>
             </tr>
             <tr>
                 <td>ruleSetFiles</td>


### PR DESCRIPTION
Highly dependent on the toolVersion since the ant tasks have changed between 4.3 and 5.0, targetJdk not present in 5.0 nor is the betterhtml xslt script.

Default values is still on 4.3 level since ruleset names have changed etc.
