### PR TITLE
Adding ignore for Sublime Text 2 project files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 .textmate
 /incoming-distributions
 .idea
+*.sublime-*


### PR DESCRIPTION
I added an ignore pattern to the `.gitignore` to handle Sublime Text 2 project files. These would be named:
- <project name>.sublime-project
- <project name>.sublime-workspace
