### PR TITLE
Fix Success Rate display in overview page.

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/OverviewPageRenderer.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/OverviewPageRenderer.java
@@ -64,7 +64,7 @@ class OverviewPageRenderer extends PageRenderer<AllTestResults> {
             htmlWriter.startElement("td").characters(Integer.toString(testPackage.getTestCount())).endElement();
             htmlWriter.startElement("td").characters(Integer.toString(testPackage.getFailureCount())).endElement();
             htmlWriter.startElement("td").characters(testPackage.getFormattedDuration()).endElement();
-            htmlWriter.startElement("td").attribute("class", testPackage.getStatusClass()).characters(testPackage.getFormattedDuration()).endElement();
+            htmlWriter.startElement("td").attribute("class", testPackage.getStatusClass()).characters(testPackage.getFormattedSuccessRate()).endElement();
             htmlWriter.endElement();
         }
         htmlWriter.endElement();


### PR DESCRIPTION
In the package section the success rate value displayed
was actually the test duration.
