### PR TITLE
Fixed NPEs in the Groovy plugin

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
@@ -63,7 +63,8 @@ public class DefaultTestReport implements TestReporter {
                     } else {
                         List<Throwable> failures = collectedResult.getExceptions();
                         for (Throwable throwable : failures) {
-                            testResult.addFailure(throwable.getMessage(), stackTrace(throwable));
+                            String message = throwable == null ? "(null exception)" : throwable.getMessage();
+                            testResult.addFailure(message, stackTrace(throwable));
                         }
                     }
                 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -88,7 +88,7 @@ public class JUnitXmlResultWriter {
             for (Throwable failure : methodResult.getExceptions()) {
                 writer.startElement("failure")
                         .attribute("message", failureMessage(failure))
-                        .attribute("type", failure.getClass().getName());
+                        .attribute("type", failure == null ? "(null)" : failure.getClass().getName());
 
                 writer.characters(stackTrace(failure));
 
@@ -102,7 +102,14 @@ public class JUnitXmlResultWriter {
         try {
             return throwable.toString();
         } catch (Throwable t) {
-            String exceptionClassName = throwable instanceof PlaceholderException ? ((PlaceholderException)throwable).getExceptionClassName() : throwable.getClass().getName();
+            String exceptionClassName;
+            if (throwable instanceof PlaceholderException) {
+                exceptionClassName = ((PlaceholderException)throwable).getExceptionClassName();
+            } else if (throwable != null) {
+                exceptionClassName = throwable.getClass().getName();
+            } else {
+                exceptionClassName = "(null exception)";
+            }
             return String.format("Could not determine failure message for exception of type %s: %s",
                     exceptionClassName, t);
         }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/logging/ShortExceptionFormatter.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/logging/ShortExceptionFormatter.java
@@ -46,6 +46,10 @@ public class ShortExceptionFormatter implements TestExceptionFormatter {
         if (cause) {
             builder.append("Caused by: ");
         }
+        if(exception == null) {
+            builder.append("(null exception)\n");
+            return;
+        }
         String className = exception instanceof PlaceholderException
                 ? ((PlaceholderException) exception).getExceptionClassName() : exception.getClass().getName();
         builder.append(className);


### PR DESCRIPTION
These occurred whenever a test failed with an unknown (null) Throwable.

For example, look at the root cause exception in the stack trace below. It comes from the Groovy plugin. It hides the actual error--the user's failing test---and prevents test reports from being written.

This is a small change that makes Groovy handle unknown test failures more gracefully.

Reviewers: @ben-manes

<pre>
BUILD FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':Tests:test'.
> Could not write XML test results for com.addepar.integration.api.JsonAPITest to file /home/odin/AMP3/Tests/build/test-results/TEST-com.addepar.integration.api.JsonAPITest.xml.

* Try:
Run with --info or --debug option to get more log output.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':Tests:test'.
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:72)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:49)
        at org.gradle.api.internal.tasks.execution.PostExecutionAnalysisTaskExecuter.execute(PostExecutionAnalysisTaskExecuter.java:34)
        at org.gradle.api.internal.changedetection.CacheLockHandlingTaskExecuter$1.run(CacheLockHandlingTaskExecuter.java:34)
        at org.gradle.internal.Factories$1.create(Factories.java:22)
        at org.gradle.cache.internal.DefaultCacheAccess.longRunningOperation(DefaultCacheAccess.java:179)
        at org.gradle.cache.internal.DefaultCacheAccess.longRunningOperation(DefaultCacheAccess.java:232)
        at org.gradle.cache.internal.DefaultPersistentDirectoryStore.longRunningOperation(DefaultPersistentDirectoryStore.java:142)
        at org.gradle.api.internal.changedetection.DefaultTaskArtifactStateCacheAccess.longRunningOperation(DefaultTaskArtifactStateCacheAccess.java:83)
        at org.gradle.api.internal.changedetection.CacheLockHandlingTaskExecuter.execute(CacheLockHandlingTaskExecuter.java:32)
        at org.gradle.api.internal.tasks.execution.SkipUpToDateTaskExecuter.execute(SkipUpToDateTaskExecuter.java:55)
        at org.gradle.api.internal.tasks.execution.ValidatingTaskExecuter.execute(ValidatingTaskExecuter.java:57)
        at org.gradle.api.internal.tasks.execution.SkipEmptySourceFilesTaskExecuter.execute(SkipEmptySourceFilesTaskExecuter.java:41)
        at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:51)
        at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:52)
        at org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter.execute(ExecuteAtMostOnceTaskExecuter.java:42)
        at org.gradle.api.internal.AbstractTask.executeWithoutThrowingTaskFailure(AbstractTask.java:278)
        at org.gradle.execution.taskgraph.DefaultTaskPlanExecutor.executeTask(DefaultTaskPlanExecutor.java:52)
        at org.gradle.execution.taskgraph.DefaultTaskPlanExecutor.processTask(DefaultTaskPlanExecutor.java:38)
        at org.gradle.execution.taskgraph.ParallelTaskPlanExecutor$TaskExecutorWorker$1.run(ParallelTaskPlanExecutor.java:113)
        at org.gradle.internal.Factories$1.create(Factories.java:22)
        at org.gradle.cache.internal.DefaultCacheAccess.useCache(DefaultCacheAccess.java:124)
        at org.gradle.cache.internal.DefaultCacheAccess.useCache(DefaultCacheAccess.java:112)
        at org.gradle.cache.internal.DefaultPersistentDirectoryStore.useCache(DefaultPersistentDirectoryStore.java:134)
        at org.gradle.api.internal.changedetection.DefaultTaskArtifactStateCacheAccess.useCache(DefaultTaskArtifactStateCacheAccess.java:79)
        at org.gradle.execution.taskgraph.ParallelTaskPlanExecutor$TaskExecutorWorker.executeTaskWithCacheLock(ParallelTaskPlanExecutor.java:110)
        at org.gradle.execution.taskgraph.ParallelTaskPlanExecutor$TaskExecutorWorker.run(ParallelTaskPlanExecutor.java:100)
Caused by: org.gradle.api.GradleException: Could not write XML test results for com.addepar.integration.api.JsonAPITest to file /home/odin/AMP3/Tests/build/test-results/TEST-com.addepar.integration.api.JsonAPITest.xml.
        at org.gradle.api.internal.tasks.testing.junit.result.Binary2JUnitXmlReportGenerator$1.execute(Binary2JUnitXmlReportGenerator.java:57)
        at org.gradle.api.internal.tasks.testing.junit.result.Binary2JUnitXmlReportGenerator$1.execute(Binary2JUnitXmlReportGenerator.java:48)
        at org.gradle.api.internal.tasks.testing.junit.result.TestReportDataCollector.visitClasses(TestReportDataCollector.java:95)
        at org.gradle.api.internal.tasks.testing.junit.result.Binary2JUnitXmlReportGenerator.generate(Binary2JUnitXmlReportGenerator.java:48)
        at org.gradle.api.tasks.testing.Test.executeTests(Test.java:455)
        at org.gradle.api.internal.BeanDynamicObject$MetaClassAdapter.invokeMethod(BeanDynamicObject.java:216)
        at org.gradle.api.internal.BeanDynamicObject.invokeMethod(BeanDynamicObject.java:122)
        at org.gradle.api.internal.CompositeDynamicObject.invokeMethod(CompositeDynamicObject.java:147)
        at org.gradle.api.tasks.testing.Test_Decorated.invokeMethod(Unknown Source)
        at org.gradle.util.ReflectionUtil.invoke(ReflectionUtil.groovy:23)
        at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$4.execute(AnnotationProcessingTaskFactory.java:161)
        at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$4.execute(AnnotationProcessingTaskFactory.java:156)
        at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:513)
        at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:502)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:64)
        ... 26 more
Caused by: java.lang.NullPointerException
        at org.gradle.api.internal.tasks.testing.junit.result.JUnitXmlResultWriter.failureMessage(JUnitXmlResultWriter.java:105)
        at org.gradle.api.internal.tasks.testing.junit.result.JUnitXmlResultWriter.writeTests(JUnitXmlResultWriter.java:89)
        at org.gradle.api.internal.tasks.testing.junit.result.JUnitXmlResultWriter.write(JUnitXmlResultWriter.java:60)
        at org.gradle.api.internal.tasks.testing.junit.result.Binary2JUnitXmlReportGenerator$1.execute(Binary2JUnitXmlReportGenerator.java:54)
            ... 40 more

BUILD FAILED
Total time: 13.776 secs
</pre>
