### PR TITLE
application plugin: support running the application from the build directory

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/plugins/StartScriptGenerator.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/plugins/StartScriptGenerator.groovy
@@ -45,6 +45,11 @@ class StartScriptGenerator {
     Iterable<String> classpath
 
     /**
+     * The classpath, relative to build directory.
+     */
+    Iterable<String> inPlaceClasspath
+
+    /**
      * The path of the script, relative to the application home directory.
      */
     String scriptRelPath
@@ -64,12 +69,14 @@ class StartScriptGenerator {
 
     String generateUnixScriptContent() {
         def unixClassPath = classpath.collect { "\$APP_HOME/${it.replace('\\', '/')}" }.join(":")
+        def inPlaceUnixClassPath = inPlaceClasspath.collect { "\$APP_HOME/${it.replace('\\', '/')}" }.join(":")
         def binding = [applicationName: applicationName,
                 optsEnvironmentVar: optsEnvironmentVar,
                 mainClassName: mainClassName,
                 appNameSystemProperty: appNameSystemProperty,
                 appHomeRelativePath: appHomeRelativePath,
-                classpath: unixClassPath]
+                classpath: unixClassPath,
+                inPlaceClasspath: inPlaceUnixClassPath]
         return generateNativeOutput('unixStartScript.txt', binding, TextUtil.unixLineSeparator)
     }
 
@@ -80,6 +87,7 @@ class StartScriptGenerator {
 
     String generateWindowsScriptContent() {
         def windowsClassPath = classpath.collect { "%APP_HOME%\\${it.replace('/', '\\')}" }.join(";")
+        def inPlaceWindowsClassPath = classpath.collect { "%APP_HOME%\\${it.replace('/', '\\')}" }.join(";")
         def appHome = appHomeRelativePath.replace('/', '\\')
         def binding = [applicationName: applicationName,
                 optsEnvironmentVar: optsEnvironmentVar,
@@ -87,7 +95,8 @@ class StartScriptGenerator {
                 mainClassName: mainClassName,
                 appNameSystemProperty: appNameSystemProperty,
                 appHomeRelativePath: appHome,
-                classpath: windowsClassPath]
+                classpath: windowsClassPath,
+                inPlaceClasspath: inPlaceWindowsClassPath]
         return generateNativeOutput('windowsStartScript.txt', binding, TextUtil.windowsLineSeparator)
 
     }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/application/CreateStartScripts.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/application/CreateStartScripts.groovy
@@ -101,6 +101,7 @@ public class CreateStartScripts extends ConventionTask {
         generator.optsEnvironmentVar = getOptsEnvironmentVar()
         generator.exitEnvironmentVar = getExitEnvironmentVar()
         generator.classpath = getClasspath().collect { "lib/${it.name}" }
+        generator.inPlaceClasspath = getClasspath().collect { "libs/${it.name}" }
         generator.scriptRelPath = "bin/${getUnixScript().name}"
         generator.generateUnixScript(getUnixScript())
         generator.generateWindowsScript(getWindowsScript())

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -65,7 +65,11 @@ cd "`dirname \"\$PRG\"`/${appHomeRelativePath}" >&-
 APP_HOME="`pwd -P`"
 cd "\$SAVED" >&-
 
-CLASSPATH=$classpath
+if [ -d "\$APP_HOME/libs" ] ; then
+    CLASSPATH=$inPlaceClasspath
+else
+    CLASSPATH=$classpath
+fi
 
 # Determine the Java command to use to start the JVM.
 if [ -n "\$JAVA_HOME" ] ; then


### PR DESCRIPTION
With application plugin, you cannot run the generated script right after "gradle startScripts" because the classpath uses 'lib' subdirectory and that directory only exists after the 'installApp' task is run.

This computes 2 classpaths, one using lib, the other using libs and the generated script sets the CLASSPATH variable accordingly at run-time based on the presence (or not) of APP_HOME/libs directory.

Note: the 'windowsStartScript.txt' will have to be adapted for this feature to work on windows machine also, it is just that I don't know how to program correctly BAT files.
