### PR TITLE
Possibility to apply plugin by instance, not only by id/type

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/plugins/DefaultPluginContainer.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/plugins/DefaultPluginContainer.java
@@ -41,6 +41,12 @@ public class DefaultPluginContainer<T extends PluginAware> extends DefaultPlugin
         return addPluginInternal(type);
     }
 
+    public <T extends Plugin> T apply(T plugin) {
+        add(plugin);
+
+        return plugin;
+    }
+
     public boolean hasPlugin(String id) {
         return findPlugin(id) != null;
     }

--- a/subprojects/core/src/main/groovy/org/gradle/api/plugins/PluginContainer.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/plugins/PluginContainer.java
@@ -48,6 +48,16 @@ public interface PluginContainer extends PluginCollection<Plugin> {
     <T extends Plugin> T apply(Class<T> type);
 
     /**
+     * Applies a plugin to the project. This usually means that the plugin uses the project API to add and modify the
+     * state of the project. This method can be called an arbitrary number of times for a particular plugin type. The
+     * plugin will be actually used only the first time this method is called.
+     *
+     * @param plugin The plugin instance of the plugin to be used
+     * @return The plugin which has been used against the project.
+     */
+    <T extends Plugin> T apply(T plugin);
+
+    /**
      * Returns true if the container has a plugin with the given id, false otherwise.
      *
      * @param id The id of the plugin

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.java
@@ -128,4 +128,17 @@ public class DefaultPluginContainerTest {
     public void getNonUsedPluginByType() {
         container.getPlugin(TestPlugin1.class);
     }
+
+    @Test
+    public void applyPluginByInstance() {
+        Plugin addedPlugin = container.apply(pluginWithIdMock);
+
+        assertThat(pluginWithIdMock, sameInstance(addedPlugin));
+
+        assertThat(container.apply(pluginWithIdMock), sameInstance(addedPlugin));
+        assertThat(container.apply(pluginId), sameInstance(addedPlugin));
+
+        assertThat(container.findPlugin(pluginWithIdMock.getClass()), sameInstance(addedPlugin));
+        assertThat(container.findPlugin(pluginId), sameInstance(addedPlugin));
+    }
 }


### PR DESCRIPTION
This pull requests adds possibility to apply plugin by instance, not only by id/type.
This is important, when building more complicated plugins (like our Ameba - mobile builds support), with potential dependency injection, that makes us using the internal API (example: https://github.com/apphance/Apphance-MobilE-Build-Automation/blob/master/src/main/groovy/com/apphance/ameba/plugins/PluginMaster.groovy ).

Ameba: http://ameba.apphance.com/
