### PR TITLE
Added closure syntax for configuration of security roles in ear files.

### DIFF
--- a/subprojects/docs/src/samples/ear/earCustomized/ear/build.gradle
+++ b/subprojects/docs/src/samples/ear/earCustomized/ear/build.gradle
@@ -27,6 +27,10 @@ ear {
 //      webModule("my.war", "/")  // wouldn't deploy since my.war isn't a deploy dependency
         securityRole "admin"
         securityRole "superadmin"
+        securityRole {
+            roleName = 'supersuperadmin'
+            description = 'Super Super Administrator'
+        }
         withXml { provider -> // add a custom node to the XML
             provider.asNode().appendNode("data-source", "my/data/source")
         }

--- a/subprojects/ear/src/main/groovy/org/gradle/plugins/ear/descriptor/DeploymentDescriptor.java
+++ b/subprojects/ear/src/main/groovy/org/gradle/plugins/ear/descriptor/DeploymentDescriptor.java
@@ -149,6 +149,15 @@ public interface DeploymentDescriptor {
     public DeploymentDescriptor securityRole(String role);
 
     /**
+     * Add a security role to the deployment descriptor by applying the closure.
+     *
+     * @param closure The closure that contains the definition for <code>EarSecurityRole</code>
+     *  that should be added.
+     * @return this.
+     */
+    public DeploymentDescriptor securityRole(Closure closure);
+
+    /**
      * Mapping of module paths to module types. Non-null by default. For example, to specify that a module is a java
      * module, set <code>moduleTypeMappings["myJavaModule.jar"] = "java"</code>.
      */

--- a/subprojects/ear/src/main/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.groovy
+++ b/subprojects/ear/src/main/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.groovy
@@ -26,6 +26,7 @@ import org.gradle.plugins.ear.descriptor.DeploymentDescriptor
 import org.gradle.plugins.ear.descriptor.EarModule
 import org.gradle.plugins.ear.descriptor.EarSecurityRole
 import org.gradle.plugins.ear.descriptor.EarWebModule
+import org.gradle.util.ConfigureUtil
 
 /**
  * @author David Gileadi
@@ -91,6 +92,13 @@ class DefaultDeploymentDescriptor implements DeploymentDescriptor {
 
     public DeploymentDescriptor securityRole(String role) {
         securityRoles.add(new DefaultEarSecurityRole(role))
+        return this
+    }
+
+    DeploymentDescriptor securityRole(Closure closure) {
+        def newRole = new DefaultEarSecurityRole()
+        ConfigureUtil.configure(closure, newRole)
+        securityRoles.add(newRole)
         return this
     }
 

--- a/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
+++ b/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
@@ -75,6 +75,10 @@ class DefaultDeploymentDescriptorTest extends Specification {
         descriptor.webModule("my.war", "/")
         descriptor.securityRole "admin"
         descriptor.securityRole "superadmin"
+        descriptor.securityRole {
+            roleName = 'supersuperadmin'
+            description = 'Super Super Admin Description'
+        }
         descriptor.withXml { it.asNode().appendNode("data-source", "my/data/source") }
 
         when:
@@ -102,6 +106,10 @@ class DefaultDeploymentDescriptorTest extends Specification {
   </security-role>
   <security-role>
     <role-name>superadmin</role-name>
+  </security-role>
+  <security-role>
+    <description>Super Super Admin Description</description>
+    <role-name>supersuperadmin</role-name>
   </security-role>
   <library-directory>APP-INF/lib</library-directory>
   <data-source>my/data/source</data-source>


### PR DESCRIPTION
Patch for the ear plugin, that allows to set role name and description together inside the deploymentDescriptor configuration by closure syntax. The closure is mapped to a EarSecurityRole instance.
