### PR TITLE
Removed def from example

### DIFF
--- a/subprojects/docs/src/samples/userguide/tasks/customTaskWithProperty/build.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/customTaskWithProperty/build.gradle
@@ -8,7 +8,7 @@ task greeting(type: GreetingTask) {
 }
 
 class GreetingTask extends DefaultTask {
-    def String greeting = 'hello from GreetingTask'
+    String greeting = 'hello from GreetingTask'
 
     @TaskAction
     def greet() {


### PR DESCRIPTION
Removed def keyword since type was already specified. This is consistent with following example in the guide.
