### PR TITLE
Allow installing gradle into an empty target directory.

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/build/Install.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/Install.groovy
@@ -41,9 +41,11 @@ class Install extends Sync {
                     throw new RuntimeException("Install directory $installDir does not look like a Gradle installation. Cannot delete it to install.")
                 }
                 if (installDir.directory) {
-                    File libDir = new File(installDir, "lib")
-                    if (!libDir.directory || !libDir.list().findAll { it.matches('gradle.*\\.jar')}) {
-                        throw new RuntimeException("Install directory $installDir does not look like a Gradle installation. Cannot delete it to install.")
+                    if (!(installDir.list() as List).empty) {
+                        File libDir = new File(installDir, "lib")
+                        if (!libDir.directory || !libDir.list().findAll { it.matches('gradle.*\\.jar')}) {
+                            throw new RuntimeException("Install directory $installDir does not look like a Gradle installation. Cannot delete it to install.")
+                        }
                     }
                 }
                 into installDir


### PR DESCRIPTION
- list()'s the contents of the directory to check if empty
- if !empty then existing logic is applied (check if the directory has a prior gradle install)
- if empty then no checks are applied and the directory may be used for install
