### PR TITLE
GRADLE-2171 Duplicate entries in archives -- per-file configuration

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Test
 
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.startsWith
-import static org.junit.Assert.assertThat
+import static org.junit.Assert.*
 
 public class CopyTaskIntegrationTest extends AbstractIntegrationTest {
     @Rule
@@ -434,5 +434,51 @@ public class CopyTaskIntegrationTest extends AbstractIntegrationTest {
 
         assert !file("dest", "emptyDir").exists()
         assert !file("dest", "yet", "another", "veryEmptyDir").exists()
+    }
+
+
+    @Test
+    public void testCopyIncludeDuplicatesWithWarning() {
+
+        file('dir1', 'path', 'file.txt').createFile()
+        file('dir2', 'path', 'file.txt').createFile()
+
+
+        def buildFile = testFile('build.gradle') <<
+        '''
+            task copy(type: Copy) {
+                from 'dir1'
+                from 'dir2'
+                into 'dest'
+            }
+
+        '''
+
+        def result = usingBuildFile(buildFile).withDeprecationChecksDisabled().withTasks("copy").run()
+        assertTrue(file('dest/path/file.txt').exists())
+        assertTrue(result.output.contains('Including duplicate file path/file.txt. This behaviour has been deprecated and is scheduled to be removed'))
+    }
+
+    @Test
+    public void testCopyExcludeDuplicates() {
+        file('dir1', 'path', 'file.txt').createFile()
+        file('dir2', 'path', 'file.txt').createFile()
+
+
+        def buildFile = testFile('build.gradle') <<
+                '''
+            task copy(type: Copy) {
+                from 'dir1'
+                from 'dir2'
+                into 'dest'
+
+                eachFile { it.duplicatesStrategy = 'exclude' }
+            }
+
+        '''
+
+        def result = usingBuildFile(buildFile).withTasks("copy").run()
+        assertTrue(file('dest/path/file.txt').exists())
+        assertFalse(result.output.contains('deprecated'))
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ZipIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ZipIntegrationTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.bundling
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+import java.util.zip.ZipFile
+
+import static org.junit.Assert.assertEquals;
+
+class ZipIntegrationTest  extends AbstractIntegrationSpec {
+
+    def ensureDuplicatesIncludedWithoutWarning() {
+        given:
+        createDir('dir1', {
+            file 'file1.txt'
+        })
+        createDir('dir2', {
+            file 'file2.txt'
+        })
+        createDir('dir3', {
+            file 'file1.txt'
+        })
+        buildFile << '''
+            task zip(type: Zip) {
+                from 'dir1'
+                from 'dir2'
+                from 'dir3'
+                destinationDir = buildDir
+                archiveName = 'test.zip'
+            }
+            '''
+        when:
+        run 'zip'
+
+        then:
+        assertZipContains('build/test.zip', [ 'file1.txt', 'file1.txt', 'file2.txt' ])
+    }
+
+    def ensureDuplicatesCanBeExcluded() {
+        given:
+        createDir('dir1', {
+            file 'file1.txt'
+        })
+        createDir('dir2', {
+            file 'file2.txt'
+        })
+        createDir('dir3', {
+            file 'file1.txt'
+        })
+        buildFile << '''
+            task zip(type: Zip) {
+                from 'dir1'
+                from 'dir2'
+                from 'dir3'
+                destinationDir = buildDir
+                archiveName = 'test.zip'
+                eachFile { it.duplicatesStrategy = 'exclude' }
+            }
+            '''
+        when:
+        run 'zip'
+
+        then:
+        assertZipContains('build/test.zip', [ 'file1.txt', 'file2.txt' ])
+    }
+
+
+
+    def assertZipContains(zipfile, files) {
+        def entries = new ZipFile(file(zipfile)).entries();
+        def list = []
+        while (entries.hasMoreElements()) {
+            def entry = entries.nextElement()
+            list += entry.getName();
+        }
+        assertEquals(files.sort(), list.sort())
+        return this
+    }
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/file/DuplicatesStrategy.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/file/DuplicatesStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.file;
+
+/**
+ * The possible strategies for handling files with the same relative
+ * path during a copy (or archive) operation.
+ *
+ * @author Kyle Mahan
+ */
+public enum DuplicatesStrategy {
+
+    /**
+     * Files with the same relative path should be included. For Copy
+     * operations this will generate a warning.
+     */
+    INCLUDE,
+
+    /**
+     * Only the first file with a given relative path will be
+     * included.
+     */
+    EXCLUDE;
+
+    /**
+     * Convert a string in the form 'include'/'exclude' to a DuplicatesStrategy
+     * @param str the string to convert
+     * @return a DuplicatesStrategy
+     */
+    public static DuplicatesStrategy fromString(String str) {
+        return valueOf(str.toUpperCase());
+    }
+
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/file/FileCopyDetails.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/file/FileCopyDetails.java
@@ -55,4 +55,22 @@ public interface FileCopyDetails extends FileTreeElement, ContentFilterable {
      * @param mode the Unix permissions, e.g. {@code 0644}.
      */
     void setMode(int mode);
+
+    /**
+     * Sets the strategy for handling duplicates.
+     *
+     * @param strategy the strategy used when a duplicate file is encountered.
+     *  Either 'include' or 'exclude'
+     */
+    void setDuplicatesStrategy(String strategy);
+    
+    /**
+     * Get the strategy for handling duplicates, either
+     * DuplicatesStrategy.INCLUDE if duplicate files of this type
+     * should be retained or DuplicatesStrategy.EXCLUDE otherwise.
+     *
+     * @return the duplicates strategy for this file
+     */
+    DuplicatesStrategy getDuplicatesStrategy();
+
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/CopyActionImpl.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/CopyActionImpl.java
@@ -42,7 +42,14 @@ public class CopyActionImpl implements CopyAction, CopySpecSource {
         this.resolver = resolver;
         root = new CopySpecImpl(resolver);
         mainContent = root.addChild();
-        this.visitor = new MappingCopySpecVisitor(new NormalizingCopySpecVisitor(visitor), FileSystems.getDefault());
+        this.visitor = new MappingCopySpecVisitor(
+                           new DuplicateHandlingCopySpecVisitor(
+                               new NormalizingCopySpecVisitor(visitor)),
+                           FileSystems.getDefault());
+    }
+
+    public boolean isWarnOnIncludeDuplicates() {
+        return true;
     }
 
     public FileResolver getResolver() {

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopySpecVisitor.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopySpecVisitor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.copy;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.gradle.api.file.DuplicatesStrategy;
+import org.gradle.api.file.FileCopyDetails;
+import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.file.RelativePath;
+import org.gradle.util.DeprecationLogger;
+
+/**
+ * Maintains a set of relative paths that has been seen and optionally
+ * excludes duplicates (based on that path).
+ * @author Kyle Mahan
+ */
+public class DuplicateHandlingCopySpecVisitor extends DelegatingCopySpecVisitor {
+
+    private final Set<RelativePath> visitedFiles = new HashSet<RelativePath>();
+    private ReadableCopySpec spec;
+    private boolean warnOnIncludeDuplicate;
+
+    public DuplicateHandlingCopySpecVisitor(CopySpecVisitor visitor) {
+        super(visitor);
+        this.warnOnIncludeDuplicate = false;
+    }
+
+    public void startVisit(CopyAction action) {
+        CopyActionImpl actionImpl = (CopyActionImpl) action;
+        warnOnIncludeDuplicate = actionImpl.isWarnOnIncludeDuplicates();
+        super.startVisit(action);
+    }
+
+
+    public void visitSpec(ReadableCopySpec spec) {
+        this.spec = spec;
+        super.visitSpec(spec);
+    }
+
+    public void visitFile(FileVisitDetails fileDetails) {
+        FileCopyDetails details = (FileCopyDetails) fileDetails;
+
+        if (!visitedFiles.add(details.getRelativePath())) {
+            if (details.getDuplicatesStrategy() == DuplicatesStrategy.EXCLUDE) {
+                return;
+            }
+            if (warnOnIncludeDuplicate) {
+                DeprecationLogger.nagUserOfDeprecatedBehaviour(
+                        String.format("Including duplicate file %s", details.getRelativePath()));
+            }
+        }
+        getVisitor().visitFile(fileDetails);
+    }
+
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/MappingCopySpecVisitor.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/MappingCopySpecVisitor.java
@@ -18,10 +18,7 @@ package org.gradle.api.internal.file.copy;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
-import org.gradle.api.file.ContentFilterable;
-import org.gradle.api.file.FileCopyDetails;
-import org.gradle.api.file.FileVisitDetails;
-import org.gradle.api.file.RelativePath;
+import org.gradle.api.file.*;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 
@@ -65,11 +62,13 @@ public class MappingCopySpecVisitor extends DelegatingCopySpecVisitor {
         private RelativePath relativePath;
         private boolean excluded;
         private Integer mode;
+        private DuplicatesStrategy duplicatesStrategy;
 
         public FileVisitDetailsImpl(FileVisitDetails fileDetails, ReadableCopySpec spec, FileSystem fileSystem) {
             this.fileDetails = fileDetails;
             this.spec = spec;
             this.fileSystem = fileSystem;
+            this.duplicatesStrategy = DuplicatesStrategy.INCLUDE;
         }
 
         public String getDisplayName() {
@@ -206,6 +205,14 @@ public class MappingCopySpecVisitor extends DelegatingCopySpecVisitor {
         public ContentFilterable expand(Map<String, ?> properties) {
             filterChain.expand(properties);
             return this;
+        }
+
+        public void setDuplicatesStrategy(String strategy) {
+            this.duplicatesStrategy = DuplicatesStrategy.fromString(strategy);
+        }
+
+        public DuplicatesStrategy getDuplicatesStrategy() {
+            return this.duplicatesStrategy;
         }
     }
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/Tar.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/Tar.java
@@ -84,5 +84,9 @@ public class Tar extends AbstractArchiveTask {
                 default:    return new SimpleCompressor();
             }
         }
+
+        public boolean isWarnOnIncludeDuplicates() {
+            return false;
+        }
     }
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/Zip.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/Zip.java
@@ -88,5 +88,9 @@ public class Zip extends AbstractArchiveTask {
                     throw new IllegalArgumentException(String.format("Unknown Compression type %s", entryCompression));
             }
         }
+
+        public boolean isWarnOnIncludeDuplicates() {
+            return false;
+        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopySpecVisitorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopySpecVisitorTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.file.copy
+
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileVisitDetails
+import org.gradle.api.file.RelativePath
+import spock.lang.Specification
+
+class DuplicateHandlingCopySpecVisitorTest extends Specification {
+
+    private static interface MyCopySpec extends CopySpec, ReadableCopySpec { }
+
+    FileCopySpecVisitor delegate = Mock()
+    org.gradle.internal.nativeplatform.filesystem.FileSystem fileSystem = Mock()
+    MyCopySpec copySpec = Mock()
+    FileTree fileTree = Mock()
+    def visitor = new MappingCopySpecVisitor(
+            new DuplicateHandlingCopySpecVisitor(delegate), fileSystem)
+
+    
+    def duplicatesIncludedByDefault() {
+        FileVisitDetails file1 = Mock()
+        FileVisitDetails file2 = Mock()
+        FileVisitDetails file3 = Mock()
+
+        given:
+        file1.relativePath >> new RelativePath(true, 'path/file1.txt')
+        file2.relativePath >> new RelativePath(true, 'path/file2.txt')
+        file3.relativePath >> new RelativePath(true, 'path/file1.txt')
+
+        fileTree.files >> [ file1, file2, file3 ]
+        copySpec.destPath >> new RelativePath(false, '/root')
+        copySpec.allCopyActions >> []
+        copySpec.source >> fileTree
+
+        when:
+        visitor.visitSpec(copySpec)
+        fileTree.files.each { visitor.visitFile it }
+
+        then:
+        1 * delegate.visitSpec(copySpec)
+        2 * delegate.visitFile({ it.relativePath.pathString ==  '/root/path/file1.txt' })
+        1 * delegate.visitFile({ it.relativePath.pathString ==  '/root/path/file2.txt' })
+
+    }
+
+    def duplicatesExcludedByConfiguration() {
+        FileVisitDetails file1 = Mock()
+        FileVisitDetails file2 = Mock()
+        FileVisitDetails file3 = Mock()
+
+        given:
+        file1.relativePath >> new RelativePath(true, 'path/file1.txt')
+        file2.relativePath >> new RelativePath(true, 'path/file2.txt')
+        file3.relativePath >> new RelativePath(true, 'path/file1.txt')
+
+        fileTree.files >> [ file1, file2, file3 ]
+        copySpec.destPath >> new RelativePath(false, '/root')
+        copySpec.allCopyActions >> [ {it.setDuplicatesStrategy('exclude')} as org.gradle.api.Action ]
+        copySpec.source >> fileTree
+
+        when:
+        visitor.visitSpec(copySpec)
+        fileTree.files.each { visitor.visitFile it }
+
+        then:
+        1 * delegate.visitSpec(copySpec)
+        1 * delegate.visitFile({ it.relativePath.pathString ==  '/root/path/file1.txt' })
+        1 * delegate.visitFile({ it.relativePath.pathString ==  '/root/path/file2.txt' })
+
+    }
+
+
+    def duplicatesExcludedEvenWhenRenamed() {
+        FileVisitDetails file1 = Mock()
+        FileVisitDetails file2 = Mock()
+        FileVisitDetails file3 = Mock()
+
+        given:
+        file1.relativePath >> new RelativePath(true, 'module1/path/file1.txt')
+        file2.relativePath >> new RelativePath(true, 'module1/path/file2.txt')
+        file3.relativePath >> new RelativePath(true, 'module2/path/file1.txt')
+
+        fileTree.files >> [ file1, file2, file3 ]
+        copySpec.destPath >> new RelativePath(false, '/root')
+
+        copySpec.allCopyActions >> [
+                {it.name = it.name.replaceAll('module[0-9]+/', '')} as org.gradle.api.Action,
+                {it.setDuplicatesStrategy('exclude')} as org.gradle.api.Action ]
+        copySpec.source >> fileTree
+
+        when:
+        visitor.visitSpec(copySpec)
+        fileTree.files.each { visitor.visitFile it }
+
+        then:
+        1 * delegate.visitSpec(copySpec)
+        1 * delegate.visitFile({ it.relativePath.pathString ==  '/root/path/file1.txt' })
+        1 * delegate.visitFile({ it.relativePath.pathString ==  '/root/path/file2.txt' })
+
+    }
+}


### PR DESCRIPTION
Added DuplicatesStrategy allowing duplicate files (based on their path) to be included or excluded on a per-file basis

This addresses story #1: [User declares strategy for dealing with duplicates](https://github.com/gradle/gradle/blob/master/design-docs/duplicate-entries-in-archives.md) and discussed in [this email thread](http://gradle.1045684.n5.nabble.com/Avoid-duplicates-when-creating-a-zip-file-td5711308.html)

One note in particular: I was a little unsure of the cleanest way to implement the slightly different behavior for Copy tasks vs. Archive tasks (copy tasks issue a warning when including duplicates). CopyActionImpl has a method boolean isWarnOnIncludeDuplicates() that is overridden by ZipCopyActionImpl and TarCopyActionImpl. Please let me know if there is a better solution.
