### PR TITLE
Trivial documentation update

### DIFF
--- a/subprojects/docs/src/docs/userguide/multiproject.xml
+++ b/subprojects/docs/src/docs/userguide/multiproject.xml
@@ -465,7 +465,7 @@
                 distribution out of them.
                 <footnote>
                     <para>The real use case we had, was using <ulink url='http://lucene.apache.org/solr'/>, where you
-                        need a separate war for each index your are accessing. That was one reason why we have created a
+                        need a separate war for each index you are accessing. That was one reason why we have created a
                         distribution of webapps. The Resin servlet container allows us, to let such a distribution point
                         to a base installation of the servlet container.
                     </para>


### PR DESCRIPTION
In footnote number 21 on this documentation page: http://www.gradle.org/docs/nightly/userguide/multi_project_builds.html#sec:decoupled_projects

"your are" should be "you are"
