### PR TITLE
Updated the intro paragraph of the README.md. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <img src="http://gradle.org/img/gradle_logo.gif" />
 
-Gradle is build automation *evolved*. Gradle can automate the building, testing, publishing, deployment and more of software packages or other types of projects such as generated static websites, generated documentation or indeed anything else.
+Gradle is a build tool with a focus on build automation and support for multi-language development. If you are building, testing, publishing, and deploying software on any platform, Gradle offers a flexible model that can support the entire development lifecycle from compiling and packaging code to publishing web sites. Gradle has been designed to support build automation across multiple languages and platforms including Java, Scala, Android, C/C++, and Groovy, and is closely integrated with development tools and continuous integration servers including Eclipse, IntelliJ, and Jenkins.
 
-For more information about Gradle, please visit http://gradle.org.
+For more information about Gradle, please visit: http://gradle.org
 
 ## Downloading
 
-You can download released versions and nightly build artifacts from http://gradle.org/downloads.
+You can download released versions and nightly build artifacts from: http://gradle.org/downloads
 
 ## Building
 


### PR DESCRIPTION
'Gradle is build automation evolved' is to say nothing of meaning to new users.  When I was talking to people at Google I/O people were very confused about what Gradle _is_.  Many had already come to the independent conclusion that Gradle was a replacement for Jenkins.

We should be specific, Gradle is a build tool that happens to focus on build automation.  We should also make sure to list the languages and major software tools Gradle is designed to work with.
