### PR TITLE
fix gradle-wrapper ignoring -g / --gradle-user-home switches

### DIFF
--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperSetup.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperSetup.groovy
@@ -23,7 +23,6 @@ class WrapperSetup implements Action<GradleExecuter> {
     void execute(GradleExecuter executer) {
         executer.requireOwnGradleUserHomeDir()
         executer.requireIsolatedDaemons()
-        // Wrapper doesn't handle -g or -Dgradle.user.home, have to use an environment variable
         executer.withEnvironmentVars(GRADLE_USER_HOME: executer.gradleUserHomeDir)
     }
 }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperUserHomeIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperUserHomeIntegrationTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2007 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests
+
+import org.gradle.api.Action
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.wrapper.PathAssembler
+import org.gradle.wrapper.WrapperConfiguration
+import spock.lang.Issue
+
+class WrapperUserHomeIntegrationTest extends AbstractIntegrationSpec {
+    void setup() {
+        assert distribution.binDistribution.exists(): "bin distribution must exist to run this test, you need to run the :distributions:binZip task"
+        executer.beforeExecute { it.requireIsolatedDaemons() } as Action
+    }
+
+    private prepareWrapper() {
+        file("build.gradle") << """
+    wrapper {
+        distributionUrl = '${distribution.binDistribution.toURI()}'
+    }
+"""
+        executer.withTasks('wrapper').run()
+        executer.usingExecutable('gradlew').inDirectory(testDirectory).withGradleUserHomeDir(null)
+    }
+
+    private installationIn(String gradleUserHomePath) {
+        def config = new WrapperConfiguration(distribution: distribution.binDistribution.toURI())
+        File distDir = new PathAssembler(new File(gradleUserHomePath)).getDistribution(config).distributionDir
+        new File(distDir, "gradle-$distribution.version.version/bin/gradle")
+    }
+
+    void 'uses gradle user home set by -Dgradle.user.home'() {
+        given:
+        prepareWrapper()
+        def gradleUserHomePath = testDirectory.file('user-home').absolutePath
+
+        when:
+        args "-Dgradle.user.home=$gradleUserHomePath"
+        succeeds()
+
+        then:
+        installationIn gradleUserHomePath exists()
+    }
+
+    @Issue('http://issues.gradle.org/browse/GRADLE-2802')
+    void 'uses gradle user home set by -g'() {
+        given:
+        prepareWrapper()
+        def gradleUserHomePath = testDirectory.file('user-home').absolutePath
+
+        when:
+        args '-g', gradleUserHomePath
+        succeeds()
+
+        then:
+        installationIn gradleUserHomePath exists()
+    }
+}


### PR DESCRIPTION
Hi. My first attempt to fix an issue I mentioned in the forums. The change adds the -g / --gradle-user-home options to the parser and uses that in the home-searching method if specified on the command line.
I inlined some code out of a helper method directly to main as this method would have to return 2 things (the home and properties, or ParsedCommandLine and properties) or I would have to create a parser and parse twice. Of course, there might be a better way still.
I also optimize a tiny little bit in that I call the home-searching method only once.

wujek
