### PR TITLE
Update bnd to the 2.1.0 version

### DIFF
--- a/subprojects/osgi/osgi.gradle
+++ b/subprojects/osgi/osgi.gradle
@@ -21,7 +21,7 @@ dependencies {
     compile project(':plugins')
     compile libraries.slf4j_api
 
-    compile module('biz.aQute:bndlib:1.50.0')
+    compile module('biz.aQute.bnd:bndlib:2.1.0')
 }
 
 useTestFixtures()

--- a/subprojects/osgi/src/main/groovy/org/gradle/api/internal/plugins/osgi/ContainedVersionAnalyzer.java
+++ b/subprojects/osgi/src/main/groovy/org/gradle/api/internal/plugins/osgi/ContainedVersionAnalyzer.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.plugins.osgi;
 
-import aQute.lib.osgi.Analyzer;
+import aQute.bnd.osgi.Analyzer;
 
 public class ContainedVersionAnalyzer extends Analyzer {
 }

--- a/subprojects/osgi/src/main/groovy/org/gradle/api/internal/plugins/osgi/DefaultOsgiManifest.java
+++ b/subprojects/osgi/src/main/groovy/org/gradle/api/internal/plugins/osgi/DefaultOsgiManifest.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.plugins.osgi;
 
-import aQute.lib.osgi.Analyzer;
+import aQute.bnd.osgi.Analyzer;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.java.archives.Attributes;

--- a/subprojects/osgi/src/test/groovy/org/gradle/api/internal/plugins/osgi/DefaultOsgiManifestTest.groovy
+++ b/subprojects/osgi/src/test/groovy/org/gradle/api/internal/plugins/osgi/DefaultOsgiManifestTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.plugins.osgi
 
-import aQute.lib.osgi.Analyzer
+import aQute.bnd.osgi.Analyzer
 import java.util.jar.Manifest
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.FileResolver


### PR DESCRIPTION
The old bnd version used had problems with working with JDK 7 and JDK 8 bytecode, in particular with the _invoke dynamic_ support. 

It's been problematic for the Groovy project, as we haven't been able to osgi-fy the Groovy artifacts with the invoke dynamic compiled classes.

http://issues.gradle.org/browse/GRADLE-2806
