### PR TITLE
docs for default distributionUrl should use Groovy strings

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.wrapper.Wrapper.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.wrapper.Wrapper.xml
@@ -38,9 +38,9 @@
             </tr>
             <tr>
                 <td>distributionUrl</td>
-                <td><literal>'http\://services.gradle.org/distributions/gradle-${gradleVersion}-bin.zip'</literal>
+                <td><literal>"http\://services.gradle.org/distributions/gradle-${gradleVersion}-bin.zip"</literal>
                     (or
-                    <literal>'http\://services.gradle.org/distributions-snapshots/gradle-${gradleVersion}-bin.zip'</literal>
+                    <literal>"http\://services.gradle.org/distributions-snapshots/gradle-${gradleVersion}-bin.zip"</literal>
                     for snapshot versions).
                 </td>
             </tr>


### PR DESCRIPTION
Simple fix for a typo that I ran into today.
