### PR TITLE
GRADLE-2171: Added fail and warn strategies to DuplicatesStrategy.

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/file/DuplicateFileCopyingException.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/file/DuplicateFileCopyingException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.file;
+
+import org.gradle.api.GradleException;
+
+/**
+ * Thrown when more than one file with the same relative path name is to be copied
+ * and the {@link DuplicatesStrategy} is set to DuplicatesStrategy.FAIL
+ */
+public class DuplicateFileCopyingException extends GradleException {
+
+    public DuplicateFileCopyingException() {
+
+    }
+
+    public DuplicateFileCopyingException(String desc) {
+        super(desc);
+    }
+
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/file/DuplicatesStrategy.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/file/DuplicatesStrategy.java
@@ -38,6 +38,22 @@ public enum DuplicatesStrategy {
      * If an attempt is made to create a duplicate file/entry during an operation, ignore the item.
      * This will leave the file/entry that was first copied/created in place.
      */
-    EXCLUDE
+    EXCLUDE,
+
+    /**
+     * Do not attempt to prevent duplicates, but log a warning message when multiple items 
+     * are to be created at the same path.
+     * <p>
+     * This behaves exactly as INCLUDE otherwise.
+     */
+    WARN,
+
+    /**
+     * Throw a {@link DuplicateFileCopyingException} when subsequent items are to be created at the same path.
+     * <p> 
+     * Use this strategy when duplicates are an error condition that should cause the build to fail.
+     */
+    FAIL
+
 
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionDecorator.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionDecorator.java
@@ -17,8 +17,11 @@
 package org.gradle.api.internal.file.copy;
 
 import org.gradle.api.Action;
+import org.gradle.api.file.DuplicateFileCopyingException;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.RelativePath;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
 
 import java.util.HashSet;
@@ -26,6 +29,7 @@ import java.util.Set;
 
 public class DuplicateHandlingCopyActionDecorator implements CopyAction {
 
+    private final static Logger LOGGER = Logging.getLogger(DuplicateHandlingCopyActionDecorator.class);
     private final CopyAction delegate;
 
     public DuplicateHandlingCopyActionDecorator(CopyAction delegate) {
@@ -45,6 +49,10 @@ public class DuplicateHandlingCopyActionDecorator implements CopyAction {
                             if (!visitedFiles.add(details.getRelativePath())) {
                                 if (strategy == DuplicatesStrategy.EXCLUDE) {
                                     return;
+                                } else if (strategy == DuplicatesStrategy.FAIL) {
+                                    throw new DuplicateFileCopyingException(String.format("Encountered duplicate path \"%s\" during copy operation configured with DuplicatesStrategy.FAIL", details.getRelativePath()));
+                                } else if (strategy == DuplicatesStrategy.WARN) {
+                                    LOGGER.warn("Encountered duplicate path \"{}\" during copy operation configured with DuplicatesStrategy.WARN", details.getRelativePath());
                                 }
                             }
                         }


### PR DESCRIPTION
- WARN will log a warning message for each duplicate file that is encountered.
- FAIL will throw a DuplicateFileCopyingException.
- Updated documentation and unit tests to reflect these new behaviors.

This PR addresses ["Story: User specifies that copy operation should fail when duplicate files are present"](https://github.com/gradle/gradle/blob/master/design-docs/duplicate-entries-in-archives.md).

(I know you guys are in the middle of the 1.7 release; no worries about not reviewing this right away)
