### PR TITLE
cleanup

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleReports.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleReports.java
@@ -20,7 +20,7 @@ import org.gradle.api.reporting.ReportContainer;
 import org.gradle.api.reporting.SingleFileReport;
 
 /**
- * The reporting configuration for the the {@link Checkstyle} test.
+ * The reporting configuration for the {@link Checkstyle} test.
  */
 public interface CheckstyleReports extends ReportContainer<SingleFileReport> {
 
@@ -30,5 +30,4 @@ public interface CheckstyleReports extends ReportContainer<SingleFileReport> {
      * @return The checkstyle XML report
      */
     SingleFileReport getXml();
-
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarc.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarc.groovy
@@ -168,6 +168,4 @@ class CodeNarc extends SourceTask implements VerificationTask, Reporting<CodeNar
     CodeNarcReports reports(Closure closure) {
         reports.configure(closure)
     }
-
-
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcExtension.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcExtension.groovy
@@ -38,7 +38,6 @@ class CodeNarcExtension extends CodeQualityExtension {
      */
     int maxPriority3Violations
 
-
     /**
      * The format type of the CodeNarc report. One of <tt>html</tt>, <tt>xml</tt>, <tt>text</tt>, <tt>console</tt>.
      */

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcPlugin.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcPlugin.groovy
@@ -86,6 +86,6 @@ class CodeNarcPlugin extends AbstractCodeQualityPlugin<CodeNarc> {
         task.with {
             description = "Run CodeNarc analysis for $sourceSet.name classes"
         }
-        task.setSource( sourceSet.allGroovy )
+        task.setSource(sourceSet.allGroovy)
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcReports.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcReports.java
@@ -20,7 +20,7 @@ import org.gradle.api.reporting.ReportContainer;
 import org.gradle.api.reporting.SingleFileReport;
 
 /**
- * The reporting configuration for the the {@link CodeNarc} test.
+ * The reporting configuration for the {@link CodeNarc} test.
  */
 public interface CodeNarcReports extends ReportContainer<SingleFileReport> {
 
@@ -44,5 +44,4 @@ public interface CodeNarcReports extends ReportContainer<SingleFileReport> {
      * @return The codenarc text report
      */
     SingleFileReport getText();
-
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsReports.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsReports.java
@@ -20,7 +20,7 @@ import org.gradle.api.reporting.ReportContainer;
 import org.gradle.api.reporting.SingleFileReport;
 
 /**
- * The reporting configuration for the the {@link FindBugs} task.
+ * The reporting configuration for the {@link FindBugs} task.
  *
  * Only one of the XML or HTML reports can be enabled when the task executes. If more than one is enabled, an {@link org.gradle.api.InvalidUserDataException}
  * will be thrown.
@@ -40,5 +40,4 @@ public interface FindBugsReports extends ReportContainer<SingleFileReport> {
      * @return The findbugs HTML report
      */
     SingleFileReport getHtml();
-    
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/JDependReports.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/JDependReports.java
@@ -20,7 +20,7 @@ import org.gradle.api.reporting.ReportContainer;
 import org.gradle.api.reporting.SingleFileReport;
 
 /**
- * The reporting configuration for the the {@link JDepend} task.
+ * The reporting configuration for the {@link JDepend} task.
  *
  * Exactly one of the XML or HTML reports can be enabled when the task executes. If more than one or none is enabled, an {@link org.gradle.api.InvalidUserDataException}
  * will be thrown.
@@ -40,5 +40,4 @@ public interface JDependReports extends ReportContainer<SingleFileReport> {
      * @return The jdepend text report
      */
     SingleFileReport getText();
-     
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.groovy
@@ -51,6 +51,7 @@ class PmdExtension extends CodeQualityExtension {
     void setTargetJdk(def value) {
         targetJdk = TargetJdk.toVersion(value)
     }
+
     /**
      * Convenience method for adding rule sets.
      *

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdReports.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdReports.java
@@ -20,7 +20,7 @@ import org.gradle.api.reporting.ReportContainer;
 import org.gradle.api.reporting.SingleFileReport;
 
 /**
- * The reporting configuration for the the {@link Pmd} task.
+ * The reporting configuration for the {@link Pmd} task.
  */
 public interface PmdReports extends ReportContainer<SingleFileReport> {
 


### PR DESCRIPTION
- fixed duplicate words in Javadoc
- removed/added empty lines to make source consistent
