### PR TITLE
GRADLE-2731 JUnit AssumptionViolationException is not described properly in XML

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
@@ -148,13 +148,21 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
             checked = true
         }
         Map testMethods = [:]
-        testClassNode.testcase.each { testMethods[it.@name.text()] = it }
+        testClassNode.testcase.each {
+            if (it.skipped.size()==0) {
+                testMethods[it.@name.text()] = it
+            }
+        }
         return testMethods
     }
 
     private def findIgnoredTests() {
         Map testMethods = [:]
-        testClassNode."ignored-testcase".each { testMethods[it.@name.text()] = it }
+        testClassNode."testcase".each { 
+            if (it.skipped.size()!=0) {
+                testMethods[it.@name.text()] = it 
+            }
+        }
         return testMethods
     }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -51,6 +51,7 @@ public class JUnitXmlResultWriter {
                     .attribute("tests", String.valueOf(result.getTestsCount()))
                     .attribute("failures", String.valueOf(result.getFailuresCount()))
                     .attribute("errors", "0")
+                    .attribute("skipped", String.valueOf(result.getSkippedTestCount()))
                     .attribute("timestamp", DateUtils.format(result.getStartTime(), DateUtils.ISO8601_DATETIME_PATTERN))
                     .attribute("hostname", hostName)
                     .attribute("time", String.valueOf(result.getDuration() / 1000.0));
@@ -91,11 +92,15 @@ public class JUnitXmlResultWriter {
 
     private void writeTests(SimpleXmlWriter writer, Iterable<TestMethodResult> methodResults, String className, long classId) throws IOException {
         for (TestMethodResult methodResult : methodResults) {
-            String testCase = methodResult.getResultType() == TestResult.ResultType.SKIPPED ? "ignored-testcase" : "testcase";
-            writer.startElement(testCase)
+            writer.startElement("testcase")
                     .attribute("name", methodResult.getName())
                     .attribute("classname", className)
                     .attribute("time", String.valueOf(methodResult.getDuration() / 1000.0));
+
+            if (methodResult.getResultType() == TestResult.ResultType.SKIPPED) {
+                writer.startElement("skipped");
+                writer.endElement();
+            }
 
             for (Throwable failure : methodResult.getExceptions()) {
                 writer.startElement("failure")

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
@@ -26,6 +26,7 @@ public class TestClassResult {
     private final String className;
     private final long startTime;
     private int failuresCount;
+    private int skippedCount;
     private long id;
 
     public TestClassResult(long id, String className, long startTime) {
@@ -49,6 +50,9 @@ public class TestClassResult {
         if (methodResult.getResultType() == TestResult.ResultType.FAILURE) {
             failuresCount++;
         }
+        if (methodResult.getResultType() == TestResult.ResultType.SKIPPED) {
+            skippedCount++;
+        }
         methodResults.add(methodResult);
         return this;
     }
@@ -69,6 +73,10 @@ public class TestClassResult {
         return failuresCount;
     }
 
+    public int getSkippedTestCount() {
+        return skippedCount;
+    }
+
     public long getDuration() {
         long end = startTime;
         for (TestMethodResult m : methodResults) {
@@ -79,3 +87,5 @@ public class TestClassResult {
         return end - startTime;
     }
 }
+
+

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
@@ -69,7 +69,7 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         and:
         xml.startsWith """<?xml version="1.1" encoding="UTF-8"?>
-<testsuite name="com.foo.FooTest" tests="4" failures="1" errors="0" timestamp="2012-11-19T17:09:28" hostname="localhost" time="0.045">
+<testsuite name="com.foo.FooTest" tests="4" failures="1" errors="0" skipped="1" timestamp="2012-11-19T17:09:28" hostname="localhost" time="0.045">
   <properties/>
   <testcase name="some test" classname="com.foo.FooTest" time="0.015"/>
   <testcase name="some test two" classname="com.foo.FooTest" time="0.015"/>
@@ -78,7 +78,9 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         xml.endsWith """</failure>
   </testcase>
-  <ignored-testcase name="some skipped test" classname="com.foo.FooTest" time="0.01"/>
+  <testcase name="some skipped test" classname="com.foo.FooTest" time="0.01">
+    <skipped/>
+  </testcase>
   <system-out><![CDATA[1st output message
 2nd output message
 ]]></system-out>
@@ -97,7 +99,7 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         then:
         xml == """<?xml version="1.1" encoding="UTF-8"?>
-<testsuite name="com.foo.FooTest" tests="1" failures="0" errors="0" timestamp="2012-11-19T17:09:28" hostname="localhost" time="0.3">
+<testsuite name="com.foo.FooTest" tests="1" failures="0" errors="0" skipped="0" timestamp="2012-11-19T17:09:28" hostname="localhost" time="0.3">
   <properties/>
   <testcase name="some test" classname="com.foo.FooTest" time="0.2"/>
   <system-out><![CDATA[]]></system-out>
@@ -131,7 +133,7 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         then:
         xml == """<?xml version="1.1" encoding="UTF-8"?>
-<testsuite name="com.foo.IgnoredTest" tests="0" failures="0" errors="0" timestamp="2012-11-19T17:09:28" hostname="localhost" time="0.0">
+<testsuite name="com.foo.IgnoredTest" tests="0" failures="0" errors="0" skipped="0" timestamp="2012-11-19T17:09:28" hostname="localhost" time="0.0">
   <properties/>
   <system-out><![CDATA[]]></system-out>
   <system-err><![CDATA[]]></system-err>
@@ -165,7 +167,7 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         then:
         getXml(testClass) == """<?xml version="1.1" encoding="UTF-8"?>
-<testsuite name="com.Foo" tests="2" failures="0" errors="0" timestamp="1970-01-01T00:00:00" hostname="localhost" time="1.0">
+<testsuite name="com.Foo" tests="2" failures="0" errors="0" skipped="0" timestamp="1970-01-01T00:00:00" hostname="localhost" time="1.0">
   <properties/>
   <testcase name="m1" classname="com.Foo" time="0.1">
     <system-out><![CDATA[ m1-out-1 m1-out-2]]></system-out>


### PR DESCRIPTION
This patch fixes JUnit XMLs generated by Gradle. 
