### PR TITLE
Adds the ability to specify xml:withMessages, text, or emacs for the FindBugs report.

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/FindBugsPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/FindBugsPluginIntegrationTest.groovy
@@ -146,6 +146,26 @@ class FindBugsPluginIntegrationTest extends WellBehavedPluginTest {
         then:
         file("build/reports/findbugs/main.html").exists()
     }
+    
+    def "can generate xml with messages reports"() {
+        given:
+        buildFile << """
+            findbugsMain.reports {
+                xml.enabled true
+                xml.withMessages true
+                html.enabled false
+            }
+        """
+
+        and:
+        goodCode()
+
+        when:
+        run "findbugsMain"
+
+        then:
+        file("build/reports/findbugs/main.xml").exists()
+    }
 
     def "can generate no reports"() {
         given:

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsReports.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsReports.java
@@ -22,7 +22,7 @@ import org.gradle.api.reporting.SingleFileReport;
 /**
  * The reporting configuration for the {@link FindBugs} task.
  *
- * Only one of the XML or HTML reports can be enabled when the task executes. If more than one is enabled, an {@link org.gradle.api.InvalidUserDataException}
+ * Only one of the reports can be enabled when the task executes. If more than one is enabled, an {@link org.gradle.api.InvalidUserDataException}
  * will be thrown.
  */
 public interface FindBugsReports extends ReportContainer<SingleFileReport> {
@@ -32,7 +32,7 @@ public interface FindBugsReports extends ReportContainer<SingleFileReport> {
      *
      * @return The findbugs XML report
      */
-    SingleFileReport getXml();
+    FindBugsXmlReport getXml();
 
     /**
      * The findbugs HTML report
@@ -40,4 +40,18 @@ public interface FindBugsReports extends ReportContainer<SingleFileReport> {
      * @return The findbugs HTML report
      */
     SingleFileReport getHtml();
+    
+    /**
+     * The findbugs Text report
+     *
+     * @return The findbugs Text report
+     */
+    SingleFileReport getText();
+    
+    /**
+     * The findbugs Emacs report
+     *
+     * @return The findbugs Emacs report
+     */
+    SingleFileReport getEmacs();
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsXmlReport.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsXmlReport.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.quality;
+
+import org.gradle.api.reporting.SingleFileReport;
+
+/**
+ * The single file XML report for FindBugs.
+ */
+public interface FindBugsXmlReport extends SingleFileReport {
+
+    /**
+     * Whether or not FindBugs should generate XML augmented with human-readable messages.
+     * You should use this format if you plan to generate a report using an XSL stylesheet. 
+     * <p>
+     * If {@code true}, FindBugs will augment the XML with human-readable messages.
+     * If {@code false}, FindBugs will not augment the XML with human-readable messages.
+     *
+     * @return Whether or not FindBugs should generate XML augmented with human-readable messages.
+     */
+    boolean isWithMessages();
+
+    /**
+     * Whether or not FindBugs should generate XML augmented with human-readable messages.
+     *
+     * @see #isWithMessages()
+     * @param withMessages Whether or not FindBugs should generate XML augmented with human-readable messages.
+     */
+    void setWithMessages(boolean withMessages);
+    
+}

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsImpl.java
@@ -18,6 +18,8 @@ package org.gradle.api.plugins.quality.internal;
 
 import org.gradle.api.Task;
 import org.gradle.api.plugins.quality.FindBugsReports;
+import org.gradle.api.plugins.quality.FindBugsXmlReport;
+import org.gradle.api.plugins.quality.internal.findbugs.FindBugsXmlReportImpl;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
 import org.gradle.api.reporting.internal.TaskReportContainer;
@@ -27,15 +29,25 @@ public class FindBugsReportsImpl extends TaskReportContainer<SingleFileReport> i
     public FindBugsReportsImpl(Task task) {
         super(SingleFileReport.class, task);
 
-        add(TaskGeneratedSingleFileReport.class, "xml", task);
+        add(FindBugsXmlReportImpl.class, "xml", task);
         add(TaskGeneratedSingleFileReport.class, "html", task);
+        add(TaskGeneratedSingleFileReport.class, "text", task);
+        add(TaskGeneratedSingleFileReport.class, "emacs", task);
     }
 
-    public SingleFileReport getXml() {
-        return getByName("xml");
+    public FindBugsXmlReport getXml() {
+        return (FindBugsXmlReport) getByName("xml");
     }
 
     public SingleFileReport getHtml() {
         return getByName("html");
+    }
+    
+    public SingleFileReport getText() {
+        return getByName("text");
+    }
+    
+    public SingleFileReport getEmacs() {
+        return getByName("emacs");
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsSpecBuilder.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsSpecBuilder.java
@@ -16,7 +16,11 @@
 
 package org.gradle.api.plugins.quality.internal.findbugs;
 
-import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.quality.FindBugsReports;
@@ -24,10 +28,7 @@ import org.gradle.api.plugins.quality.internal.FindBugsReportsImpl;
 import org.gradle.api.specs.Spec;
 import org.gradle.util.CollectionUtils;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Set;
+import com.google.common.collect.ImmutableSet;
 
 public class FindBugsSpecBuilder {
     private static final Set<String> VALID_EFFORTS = ImmutableSet.of("min", "default", "max");
@@ -143,11 +144,18 @@ public class FindBugsSpecBuilder {
         if (reports != null && !reports.getEnabled().isEmpty()) {
             if (reports.getEnabled().size() == 1) {
                 FindBugsReportsImpl reportsImpl = (FindBugsReportsImpl) reports;
-                args.add("-" + reportsImpl.getFirstEnabled().getName());
+                String outputArg = "-" + reportsImpl.getFirstEnabled().getName();
+                if (reportsImpl.getFirstEnabled() instanceof FindBugsXmlReportImpl) {
+                    FindBugsXmlReportImpl r = (FindBugsXmlReportImpl)reportsImpl.getFirstEnabled();
+                    if (r.isWithMessages()) {
+                        outputArg += ":withMessages";
+                    }
+                }
+                args.add(outputArg);
                 args.add("-outputFile");
                 args.add(reportsImpl.getFirstEnabled().getDestination().getAbsolutePath());
             } else {
-                throw new InvalidUserDataException("FindBugs tasks can only have one report enabled, however both the XML and HTML report are enabled. You need to disable one of them.");
+                throw new InvalidUserDataException("FindBugs tasks can only have one report enabled, however more than one report was enabled. You need to disable all but one of them.");
             }
         }
 

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsXmlReportImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsXmlReportImpl.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.quality.internal.findbugs;
+
+import org.gradle.api.Task;
+import org.gradle.api.plugins.quality.FindBugsXmlReport;
+import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
+
+public class FindBugsXmlReportImpl extends TaskGeneratedSingleFileReport implements FindBugsXmlReport {
+
+    private boolean withMessages;
+    
+    public FindBugsXmlReportImpl(String name, Task task) {
+        super(name, task);
+    }
+
+    public boolean isWithMessages() {
+        return withMessages;
+    }
+
+    public void setWithMessages(boolean withMessages) {
+        this.withMessages = withMessages;
+    }
+
+}


### PR DESCRIPTION
I wasn't sure if extending SingleFileReport was the way to go, but it seemed to make the most sense.  If this does, I can update this pull request to also add the ability to specify the stylesheet used when generating the HTML report.
