### PR TITLE
Use Pattern.DOTALL to ensure that newlines are handled in options.

### DIFF
--- a/subprojects/cli/src/main/java/org/gradle/cli/CommandLineParser.java
+++ b/subprojects/cli/src/main/java/org/gradle/cli/CommandLineParser.java
@@ -94,15 +94,15 @@ public class CommandLineParser {
                 } else if (arg.matches("--[^=]+")) {
                     OptionParserState parsedOption = parseState.onStartOption(arg, arg.substring(2));
                     parseState = parsedOption.onStartNextArg();
-                } else if (arg.matches("--[^=]+=.*")) {
+                } else if (arg.matches("(?s)--[^=]+=.*")) {
                     int endArg = arg.indexOf('=');
                     OptionParserState parsedOption = parseState.onStartOption(arg, arg.substring(2, endArg));
                     parseState = parsedOption.onArgument(arg.substring(endArg + 1));
-                } else if (arg.matches("-[^=]=.*")) {
+                } else if (arg.matches("(?s)-[^=]=.*")) {
                     OptionParserState parsedOption = parseState.onStartOption(arg, arg.substring(1, 2));
                     parseState = parsedOption.onArgument(arg.substring(3));
                 } else {
-                    assert arg.matches("-[^-].*");
+                    assert arg.matches("(?s)-[^-].*");
                     String option = arg.substring(1);
                     if (optionsByString.containsKey(option)) {
                         OptionParserState parsedOption = parseState.onStartOption(arg, option);
@@ -277,7 +277,7 @@ public class CommandLineParser {
         public abstract boolean maybeStartOption(String arg);
 
         boolean isOption(String arg) {
-            return arg.matches("-.+");
+            return arg.matches("(?s)-.+");
         }
 
         public abstract OptionParserState onStartOption(String arg, String option);

--- a/subprojects/core/src/main/groovy/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/groovy/org/gradle/process/internal/JvmOptions.java
@@ -30,7 +30,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class JvmOptions {
-    private static final Pattern SYS_PROP_PATTERN = Pattern.compile("-D(.+?)=(.*)");
+    private static final Pattern SYS_PROP_PATTERN = Pattern.compile("(?s)-D(.+?)=(.*)");
     private static final Pattern NO_ARG_SYS_PROP_PATTERN = Pattern.compile("-D([^=]+)");
     private static final Pattern MIN_HEAP_PATTERN = Pattern.compile("-Xms(.+)");
     private static final Pattern MAX_HEAP_PATTERN = Pattern.compile("-Xmx(.+)");


### PR DESCRIPTION
Without this patch, if you run e.g.

```
gradle -Dprop=a:1\nb:2\nc:3 task
```

(where whatever shell you use to invoke Gradle is passing an actual newline where I wrote `\n`) Gradle gets very confused and emits a baffling error message. For example, it will complain that there is no subproject named `-Dprop=a`.

While the `bin/gradle` wrapper miraculously preserves all the newlines intact for the Java argv, command-line parsers use the regexp element `.` in various places where what is really meant is “any character”. You need to use `DOTALL` or the inline `(?s)`.
