### PR TITLE
GRADLE-2034 - handle missing artifacts in mavenLocal cache.

### DIFF
--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultBuildableModuleVersionMetaDataResolveResult.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultBuildableModuleVersionMetaDataResolveResult.java
@@ -30,6 +30,7 @@ public class DefaultBuildableModuleVersionMetaDataResolveResult implements Build
 
     private ModuleDescriptor moduleDescriptor;
     private boolean changing;
+    private boolean metaDataOnly;
     private State state = State.Unknown;
     private ModuleSource moduleSource;
     private List<DependencyMetaData> dependencies;
@@ -158,6 +159,11 @@ public class DefaultBuildableModuleVersionMetaDataResolveResult implements Build
         return changing;
     }
 
+    public boolean isMetaDataOnly() {
+        assertResolved();
+        return metaDataOnly;
+    }
+
     public ModuleSource getModuleSource() {
         assertResolved();
         return moduleSource;
@@ -181,6 +187,11 @@ public class DefaultBuildableModuleVersionMetaDataResolveResult implements Build
     public void setChanging(boolean changing) {
         assertResolved();
         this.changing = changing;
+    }
+
+    public void setMetaDataOnly(boolean metaDataOnly) {
+        assertResolved();
+        this.metaDataOnly = metaDataOnly;
     }
 
     public void setStatus(String status) {

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleVersionMetaData.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleVersionMetaData.java
@@ -36,6 +36,8 @@ public interface ModuleVersionMetaData {
 
     boolean isChanging();
 
+    boolean isMetaDataOnly();
+
     String getStatus();
 
     List<String> getStatusScheme();

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -196,7 +196,11 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
         }
 
         DefaultModuleDescriptor moduleDescriptor = mdBuilder.getModuleDescriptor();
-        return new ModuleDescriptorAdapter(moduleDescriptor.getModuleRevisionId(), moduleDescriptor);
+        ModuleDescriptorAdapter adapter = new ModuleDescriptorAdapter(moduleDescriptor.getModuleRevisionId(), moduleDescriptor);
+        if ("pom".equals(pomReader.getPackaging())) {
+            adapter.setMetaDataOnly(true);
+        }
+        return adapter;
     }
 
     private ModuleDescriptor parseOtherPom(DescriptorParseContext ivySettings,

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleDescriptorAdapter.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleDescriptorAdapter.java
@@ -33,6 +33,7 @@ public class ModuleDescriptorAdapter implements MutableModuleVersionMetaData {
     private final ModuleVersionIdentifier moduleVersionIdentifier;
     private final ModuleDescriptor moduleDescriptor;
     private boolean changing;
+    private boolean metaDataOnly;
     private String status;
     private List<String> statusScheme = DEFAULT_STATUS_SCHEME;
 
@@ -54,6 +55,10 @@ public class ModuleDescriptorAdapter implements MutableModuleVersionMetaData {
         return changing;
     }
 
+    public boolean isMetaDataOnly() {
+        return metaDataOnly;
+    }
+
     public String getStatus() {
         return status;
     }
@@ -64,6 +69,10 @@ public class ModuleDescriptorAdapter implements MutableModuleVersionMetaData {
 
     public void setChanging(boolean changing) {
         this.changing = changing;
+    }
+
+    public void setMetaDataOnly(boolean metaDataOnly) {
+        this.metaDataOnly = metaDataOnly;
     }
 
     public void setStatus(String status) {

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -87,7 +87,8 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     }
 
     public MavenArtifactRepository createMavenLocalRepository() {
-        MavenArtifactRepository mavenRepository = createMavenRepository();
+        MavenArtifactRepository mavenRepository = instantiator.newInstance(DefaultMavenLocalArtifactRepository.class, fileResolver, createPasswordCredentials(), transportFactory,
+                locallyAvailableResourceFinder, metadataProcessor);
         final File localMavenRepository = localMavenRepositoryLocator.getLocalMavenRepository();
         mavenRepository.setUrl(localMavenRepository);
         return mavenRepository;

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -104,12 +104,20 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         return resolver;
     }
 
-    private RepositoryTransport getTransport(String scheme) {
+    protected RepositoryTransport getTransport(String scheme) {
         if (scheme.equalsIgnoreCase("file")) {
             return transportFactory.createFileTransport(getName());
         } else {
             return transportFactory.createHttpTransport(getName(), getCredentials());
         }
+    }
+
+    protected LocallyAvailableResourceFinder<ArtifactRevisionId> getLocallyAvailableResourceFinder() {
+        return locallyAvailableResourceFinder;
+    }
+
+    protected ModuleMetadataProcessor getMetadataProcessor() {
+        return metadataProcessor;
     }
 
 }

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.groovy
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories
+
+import org.apache.ivy.core.module.id.ArtifactRevisionId
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.internal.artifacts.ModuleMetadataProcessor
+import org.gradle.api.internal.artifacts.repositories.resolver.MavenLocalResolver
+import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
+import org.gradle.api.internal.externalresource.local.LocallyAvailableResourceFinder
+import org.gradle.api.internal.file.FileResolver
+
+class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRepository implements MavenArtifactRepository {
+    DefaultMavenLocalArtifactRepository(FileResolver fileResolver, PasswordCredentials credentials, RepositoryTransportFactory transportFactory,
+                                        LocallyAvailableResourceFinder<ArtifactRevisionId> locallyAvailableResourceFinder, ModuleMetadataProcessor metadataProcessor) {
+        super(fileResolver, credentials, transportFactory, locallyAvailableResourceFinder, metadataProcessor)
+    }
+
+    protected MavenResolver createRealResolver() {
+        URI rootUri = getUrl();
+        if (rootUri == null) {
+            throw new InvalidUserDataException("You must specify a URL for a Maven repository.");
+        }
+
+        MavenResolver resolver = new MavenLocalResolver(getName(), rootUri, getTransport(rootUri.getScheme()), getLocallyAvailableResourceFinder(), getMetadataProcessor());
+        for (URI repoUrl : getArtifactUrls()) {
+            resolver.addArtifactLocation(repoUrl, null);
+        }
+        return resolver;
+    }
+}

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenLocalResolver.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenLocalResolver.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor;
+import org.apache.ivy.core.module.descriptor.DependencyDescriptor;
+import org.apache.ivy.core.module.id.ArtifactRevisionId;
+import org.apache.ivy.core.module.id.ModuleRevisionId;
+import org.gradle.api.internal.artifacts.ModuleMetadataProcessor;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.BuildableModuleVersionMetaDataResolveResult;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleVersionMetaData;
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
+import org.gradle.api.internal.externalresource.local.LocallyAvailableResourceFinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+
+public class MavenLocalResolver extends MavenResolver {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenResolver.class);
+
+    public MavenLocalResolver(String name, URI rootUri, RepositoryTransport transport,
+                              LocallyAvailableResourceFinder<ArtifactRevisionId> locallyAvailableResourceFinder,
+                              ModuleMetadataProcessor metadataProcessor
+    ) {
+        super(name, rootUri, transport, locallyAvailableResourceFinder, metadataProcessor);
+    }
+
+    protected void getDependency(DependencyDescriptor dd, BuildableModuleVersionMetaDataResolveResult result) {
+        if (isSnapshotVersion(dd)) {
+            getSnapshotDependency(dd, result);
+        } else {
+            resolveIfArtifactPresent(dd, result);
+        }
+    }
+
+    protected void getSnapshotDependency(DependencyDescriptor dd, BuildableModuleVersionMetaDataResolveResult result) {
+        final ModuleRevisionId dependencyRevisionId = dd.getDependencyRevisionId();
+        final String uniqueSnapshotVersion = findUniqueSnapshotVersion(dependencyRevisionId);
+        if (uniqueSnapshotVersion != null) {
+            DependencyDescriptor enrichedDependencyDescriptor = enrichDependencyDescriptorWithSnapshotVersionInfo(dd, dependencyRevisionId, uniqueSnapshotVersion);
+            resolveIfArtifactPresent(enrichedDependencyDescriptor, result);
+            if (result.getState() == BuildableModuleVersionMetaDataResolveResult.State.Resolved) {
+                result.setModuleSource(new TimestampedModuleSource(uniqueSnapshotVersion));
+            }
+        } else {
+            resolveIfArtifactPresent(dd, result);
+        }
+    }
+
+    protected void resolveIfArtifactPresent(DependencyDescriptor dependencyDescriptor, BuildableModuleVersionMetaDataResolveResult result) {
+        ModuleRevisionId moduleRevisionId = dependencyDescriptor.getDependencyRevisionId();
+        ResolvedArtifact ivyRef = findIvyFileRef(dependencyDescriptor);
+
+        // get module descriptor
+        if (ivyRef == null) {
+            super.getDependency(dependencyDescriptor, result);
+        } else {
+            ModuleVersionMetaData metaData = getArtifactMetadata(ivyRef.getArtifact(), ivyRef.getResource());
+            if (!metaData.isMetaDataOnly()) {
+                DefaultModuleDescriptor generatedModuleDescriptor = DefaultModuleDescriptor.newDefaultInstance(moduleRevisionId, dependencyDescriptor.getAllDependencyArtifacts());
+                ResolvedArtifact artifactRef = findAnyArtifact(generatedModuleDescriptor);
+                if (artifactRef != null) {
+                    super.getDependency(dependencyDescriptor, result);
+                } else {
+                    LOGGER.debug("Ivy file found for module '{}' in repository '{}' but no artifact found. Checking next repository.", moduleRevisionId, getName());
+                }
+            } else {
+                super.getDependency(dependencyDescriptor, result);
+            }
+        }
+    }
+}

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -83,7 +83,7 @@ public class MavenResolver extends ExternalResourceResolver implements PatternBa
         }
     }
 
-    private void getSnapshotDependency(DependencyDescriptor dd, BuildableModuleVersionMetaDataResolveResult result) {
+    protected void getSnapshotDependency(DependencyDescriptor dd, BuildableModuleVersionMetaDataResolveResult result) {
         final ModuleRevisionId dependencyRevisionId = dd.getDependencyRevisionId();
         final String uniqueSnapshotVersion = findUniqueSnapshotVersion(dependencyRevisionId);
         if (uniqueSnapshotVersion != null) {
@@ -97,14 +97,14 @@ public class MavenResolver extends ExternalResourceResolver implements PatternBa
         }
     }
 
-    private DependencyDescriptor enrichDependencyDescriptorWithSnapshotVersionInfo(DependencyDescriptor dd, ModuleRevisionId dependencyRevisionId, String uniqueSnapshotVersion) {
+    protected DependencyDescriptor enrichDependencyDescriptorWithSnapshotVersionInfo(DependencyDescriptor dd, ModuleRevisionId dependencyRevisionId, String uniqueSnapshotVersion) {
         Map<String, String> extraAttributes = new HashMap<String, String>(1);
         extraAttributes.put("timestamp", uniqueSnapshotVersion);
         final ModuleRevisionId newModuleRevisionId = ModuleRevisionId.newInstance(dependencyRevisionId.getOrganisation(), dependencyRevisionId.getName(), dependencyRevisionId.getRevision(), extraAttributes);
         return dd.clone(newModuleRevisionId);
     }
 
-    private boolean isSnapshotVersion(DependencyDescriptor dd) {
+    protected boolean isSnapshotVersion(DependencyDescriptor dd) {
         return dd.getDependencyRevisionId().getRevision().endsWith("SNAPSHOT");
     }
 
@@ -171,7 +171,7 @@ public class MavenResolver extends ExternalResourceResolver implements PatternBa
         return null;
     }
 
-    private String findUniqueSnapshotVersion(ModuleRevisionId moduleRevisionId) {
+    protected String findUniqueSnapshotVersion(ModuleRevisionId moduleRevisionId) {
         Artifact pomArtifact = DefaultArtifact.newPomArtifact(moduleRevisionId, new Date());
         String metadataLocation = toResourcePattern(getWholePattern()).toModuleVersionPath(pomArtifact) + "/maven-metadata.xml";
         MavenMetadata mavenMetadata = parseMavenMetadata(metadataLocation);

--- a/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -124,7 +124,7 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
 
         then:
         def repo = factory.createMavenLocalRepository()
-        repo instanceof DefaultMavenArtifactRepository
+        repo instanceof DefaultMavenLocalArtifactRepository
         repo.url == repoDir.toURI()
     }
 

--- a/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories
+
+import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.internal.artifacts.ModuleMetadataProcessor
+import org.gradle.api.internal.artifacts.repositories.resolver.MavenLocalResolver
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
+import org.gradle.api.internal.externalresource.local.LocallyAvailableResourceFinder
+import org.gradle.api.internal.externalresource.transport.ExternalResourceRepository
+import org.gradle.api.internal.file.FileResolver
+import org.gradle.logging.ProgressLoggerFactory
+import spock.lang.Specification
+
+class DefaultMavenLocalRepositoryTest extends Specification {
+    final FileResolver resolver = Mock()
+    final PasswordCredentials credentials = Mock()
+    final RepositoryTransportFactory transportFactory = Mock()
+    final LocallyAvailableResourceFinder locallyAvailableResourceFinder = Mock()
+    final ExternalResourceRepository resourceRepository = Mock()
+    final ModuleMetadataProcessor metadataProcessor = Mock()
+
+    final DefaultMavenArtifactRepository repository = new DefaultMavenLocalArtifactRepository(
+            resolver, credentials, transportFactory, locallyAvailableResourceFinder, metadataProcessor)
+    final ProgressLoggerFactory progressLoggerFactory = Mock();
+
+    def "creates local repository"() {
+        given:
+        def file = new File('repo')
+        def uri = file.toURI()
+        _ * resolver.resolveUri('repo-dir') >> uri
+        transportFactory.createFileTransport('repo') >> transport()
+
+        and:
+        repository.name = 'repo'
+        repository.url = 'repo-dir'
+
+        when:
+        def repo = repository.createRealResolver()
+
+        then:
+        repo instanceof MavenLocalResolver
+        repo.root == "${uri}/"
+    }
+
+    private RepositoryTransport transport() {
+        return Mock(RepositoryTransport) {
+            getRepository() >> resourceRepository
+            convertToPath(_) >> { URI uri ->
+                def result = uri.toString()
+                return result.endsWith('/') ? result : result + '/'
+            }
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileModule.groovy
@@ -219,7 +219,7 @@ class MavenFileModule extends AbstractModule implements MavenModule {
         return new Date(updateFormat.parse("20100101120000").time + publishCount * 1000)
     }
 
-    MavenModule publish() {
+    MavenModule publishPom() {
         moduleDir.createDir()
         def rootMavenMetaData = getRootMetaDataFile()
 
@@ -283,7 +283,12 @@ class MavenFileModule extends AbstractModule implements MavenModule {
 
             writer << "\n</project>"
         }
+        return this
+    }
 
+    MavenModule publish() {
+
+        publishPom()
         artifacts.each { artifact ->
             publishArtifact(artifact)
         }


### PR DESCRIPTION
Implement a new MavenLocalResolver which checks for artifact
existance in the maven cache before resolving the artifact
from the cache. This is to work around the issue on
systems that are using Gradle and Maven where Maven
builds will resolve an artifact POM but not the artifact
itself.
