### PR TITLE
Ensure the application is always started in the APP_HOME directory

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -60,10 +60,10 @@ while [ -h "\$PRG" ] ; do
         PRG=`dirname "\$PRG"`"/\$link"
     fi
 done
-SAVED="`pwd`"
+
+# Set the working directory to $APP_HOME
 cd "`dirname \"\$PRG\"`/${appHomeRelativePath}" >&-
 APP_HOME="`pwd -P`"
-cd "\$SAVED" >&-
 
 CLASSPATH=$classpath
 

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
@@ -17,6 +17,9 @@ if "%DIRNAME%" == "" set DIRNAME=.\
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%${appHomeRelativePath}
 
+@rem Set the working directory to %APP_HOME%
+cd %APP_HOME%
+
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome
 


### PR DESCRIPTION
When using the `application` plugin to build a distribution, the startscripts that are generated should ensure that the application is started from the `$APP_HOME` directory.

It will then make no difference whether the application is started as:

```
APP_HOME %> bin/myapp
```

or

```
APP_HOME/bin %> ./myapp
```

or even

```
/ %> APP_HOME/bin/myapp
```

All relative paths in the application will then work correctly regardless of from where the application is launched.
