### PR TITLE
For CucumberJVM Scenarios, the effective test method name will be

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/testing/cucumberjvm/CucumberJVMReportTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/testing/cucumberjvm/CucumberJVMReportTest.groovy
@@ -1,0 +1,79 @@
+package org.gradle.testing.cucumberjvm
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+import spock.lang.Timeout
+
+class CucumberJVMReportTest extends AbstractIntegrationSpec {
+    @Timeout(30)
+    @Issue("http://issues.gradle.org/browse/GRADLE-2739")
+    def "test writing CucumberJVM test result files when step defs contain literal forward slash"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            repositories { mavenCentral() }
+            dependencies {
+               testCompile "junit:junit:4.11"
+               testCompile "info.cukes:cucumber-java:1.1.2"
+               testCompile "info.cukes:cucumber-junit:1.1.2"
+            }
+            test {
+               testLogging.showStandardStreams = true
+               testLogging.events  'started', 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
+               reports.junitXml.enabled = false
+               reports.html.enabled = false
+            }
+        """
+
+        and:
+        file("src/test/java/RunCukesTest.java") << """
+           import cucumber.api.junit.Cucumber;
+           import org.junit.runner.RunWith;
+
+           @RunWith(Cucumber.class)
+           public class RunCukesTest {}
+        """
+
+        and:
+        file("src/test/java/HelloStepdefs.java") << """
+        import cucumber.api.java.en.Given;
+        import cucumber.api.java.en.Then;
+        import cucumber.api.java.en.When;
+
+        public class HelloStepdefs {
+           @Given("^I have a hello app with Howdy and /four")
+           public void I_have_a_hello_app_with() {
+              System.out.println("Given");
+           }
+
+           @When("^I ask it to say hi and /five/six/seven")
+           public void I_ask_it_to_say_hi() {
+              System.out.println("When");
+           }
+
+           @Then("^it should answer with Howdy World")
+           public void it_should_answer_with() {
+              System.out.println("Then");
+           }
+        }
+        """
+
+        and:
+        file("src/test/resources/helloworld.feature") << """
+           Feature: Hello World /one
+
+           @bar
+           Scenario: Say hello /two/three
+           Given I have a hello app with Howdy and /four
+           When I ask it to say hi and /five/six/seven
+           Then it should answer with Howdy World
+        """
+
+        when:
+        run "test"
+
+        then:
+        ":test" in nonSkippedTasks
+    }
+
+}

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
@@ -50,7 +50,7 @@ public class JUnitTestEventAdapter extends RunListener {
 
     @Override
     public void testStarted(Description description) throws Exception {
-        TestDescriptorInternal descriptor = descriptor(idGenerator.generateId(), description);
+        TestDescriptorInternal descriptor = nullSafeDescriptor(idGenerator.generateId(), description);
         synchronized (lock) {
             TestDescriptorInternal oldTest = executing.put(description, descriptor);
             assert oldTest == null : String.format("Unexpected start event for %s", description);
@@ -68,7 +68,7 @@ public class JUnitTestEventAdapter extends RunListener {
         if (testInternal == null) {
             // This can happen when, for example, a @BeforeClass or @AfterClass method fails
             needEndEvent = true;
-            testInternal = failureDescriptor(idGenerator.generateId(), failure.getDescription());
+            testInternal = nullSafeDescriptor(idGenerator.generateId(), failure.getDescription());
             resultProcessor.started(testInternal, startEvent());
         }
         resultProcessor.failure(testInternal.getId(), failure.getException());
@@ -132,7 +132,7 @@ public class JUnitTestEventAdapter extends RunListener {
         return new DefaultTestDescriptor(id, className(description), methodName(description));
     }
 
-    private TestDescriptorInternal failureDescriptor(Object id, Description description) {
+    private TestDescriptorInternal nullSafeDescriptor(Object id, Description description) {
         if (methodName(description) != null) {
             return new DefaultTestDescriptor(id, className(description), methodName(description));
         } else {


### PR DESCRIPTION
For CucumberJVM Scenarios, the effective test method name will be null when the Scenario clause is processed during test event
reporting.

1) This change, made at the suggestion of Adam Murdoch, assigns a
non-null value to the effective method name in the event that it
is found to be null in

org.gradle.api.internal.tasks.testing.junit.JUnitTestEventAdapter#testStarted.

2) This change renames

org.gradle.api.internal.tasks.testing.junit.JUnitTestEventAdapter#failureDescriptor

to

org.gradle.api.internal.tasks.testing.junit.JUnitTestEventAdapter#nullSafeDescriptor

3) This changes adds an int test

org.gradle.testing.cucumberjvm.CucumberJVMReportTest

to test the changes (1) and (2).
