### PR TITLE
Add support for single test method execution (GRADLE-2865)

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecuter.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecuter.java
@@ -25,6 +25,8 @@ import org.junit.runner.Runner;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 
+import java.util.List;
+
 public class JUnitTestClassExecuter {
     private final ClassLoader applicationClassLoader;
     private final RunListener listener;
@@ -39,12 +41,19 @@ public class JUnitTestClassExecuter {
         this.executionListener = executionListener;
     }
 
-    public void execute(String testClassName) {
+    public void execute(String testClassName, List<String> testNames) {
         executionListener.testClassStarted(testClassName);
 
         Throwable failure = null;
         try {
-            runTestClass(testClassName);
+            if (testNames.isEmpty()) {
+                runTestClass(testClassName, "");    
+            } else {
+                for (String testName : testNames) {
+                    runTestClass(testClassName, testName);
+                }
+            }
+            
         } catch (Throwable throwable) {
             failure = throwable;
         }
@@ -52,9 +61,9 @@ public class JUnitTestClassExecuter {
         executionListener.testClassFinished(failure);
     }
 
-    private void runTestClass(String testClassName) throws ClassNotFoundException {
+    private void runTestClass(String testClassName, String testName) throws ClassNotFoundException {
         final Class<?> testClass = Class.forName(testClassName, true, applicationClassLoader);
-        Request request = Request.aClass(testClass);
+        Request request = (testName == null || testName.isEmpty()) ? Request.aClass(testClass) : Request.method(testClass, testName);
         if (options.hasCategoryConfiguration()) {
             Transformer<Class<?>, String> transformer = new Transformer<Class<?>, String>() {
                 public Class<?> transform(final String original) {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessor.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessor.java
@@ -30,6 +30,8 @@ import org.gradle.messaging.actor.ActorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 public class JUnitTestClassProcessor implements TestClassProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(JUnitTestClassProcessor.class);
     private final IdGenerator<?> idGenerator;
@@ -37,13 +39,15 @@ public class JUnitTestClassProcessor implements TestClassProcessor {
     private final StandardOutputRedirector outputRedirector;
     private final TimeProvider timeProvider = new TrueTimeProvider();
     private final JUnitSpec spec;
+    private final List<String> testNames;
     private JUnitTestClassExecuter executer;
     private Actor resultProcessorActor;
 
-    public JUnitTestClassProcessor(JUnitSpec spec, IdGenerator<?> idGenerator, ActorFactory actorFactory,
+    public JUnitTestClassProcessor(JUnitSpec spec, List<String> testNames, IdGenerator<?> idGenerator, ActorFactory actorFactory,
                                    StandardOutputRedirector standardOutputRedirector) {
         this.idGenerator = idGenerator;
         this.spec = spec;
+        this.testNames = testNames;
         this.actorFactory = actorFactory;
         this.outputRedirector = standardOutputRedirector;
     }
@@ -65,8 +69,8 @@ public class JUnitTestClassProcessor implements TestClassProcessor {
     }
 
     public void processTestClass(TestClassRunInfo testClass) {
-        LOGGER.debug("Executing test class {}", testClass.getTestClassName());
-        executer.execute(testClass.getTestClassName());
+        LOGGER.debug("Executing test class {} (methods: {})", testClass.getTestClassName(), testNames);
+        executer.execute(testClass.getTestClassName(), testNames);
     }
 
     public void stop() {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -32,6 +32,7 @@ import org.gradle.process.internal.WorkerProcessBuilder;
 
 import java.io.Serializable;
 import java.net.URLClassLoader;
+import java.util.List;
 
 public class JUnitTestFramework implements TestFramework {
     private JUnitOptions options;
@@ -46,7 +47,7 @@ public class JUnitTestFramework implements TestFramework {
 
     public WorkerTestClassProcessorFactory getProcessorFactory() {
         verifyJUnitCategorySupport();
-        return new TestClassProcessorFactoryImpl(new JUnitSpec(options));
+        return new TestClassProcessorFactoryImpl(new JUnitSpec(options), testTask.getTestNames());
     }
 
     private void verifyJUnitCategorySupport() {
@@ -84,13 +85,15 @@ public class JUnitTestFramework implements TestFramework {
 
     private static class TestClassProcessorFactoryImpl implements WorkerTestClassProcessorFactory, Serializable {
         private final JUnitSpec spec;
+        private final List<String> testNames;
 
-        public TestClassProcessorFactoryImpl(JUnitSpec spec) {
+        public TestClassProcessorFactoryImpl(JUnitSpec spec, List<String> testNames) {
             this.spec = spec;
+            this.testNames = testNames;
         }
 
         public TestClassProcessor create(ServiceRegistry serviceRegistry) {
-            return new JUnitTestClassProcessor(spec, serviceRegistry.get(IdGenerator.class), serviceRegistry.get(ActorFactory.class), new JULRedirector());
+            return new JUnitTestClassProcessor(spec, testNames, serviceRegistry.get(IdGenerator.class), serviceRegistry.get(ActorFactory.class), new JULRedirector());
         }
     }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
@@ -48,7 +48,7 @@ public class TestNGTestFramework implements TestFramework {
     public WorkerTestClassProcessorFactory getProcessorFactory() {
         options.setTestResources(testTask.getTestSrcDirs());
         List<File> suiteFiles = options.getSuites(testTask.getTemporaryDir());
-        return new TestClassProcessorFactoryImpl(testTask.getReports().getHtml().getDestination(), new TestNGSpec(options), suiteFiles);
+        return new TestClassProcessorFactoryImpl(testTask.getReports().getHtml().getDestination(), new TestNGSpec(options), suiteFiles, testTask.getTestNames());
     }
 
     public Action<WorkerProcessBuilder> getWorkerConfigurationAction() {
@@ -75,15 +75,17 @@ public class TestNGTestFramework implements TestFramework {
         private final File testReportDir;
         private final TestNGSpec options;
         private final List<File> suiteFiles;
+        private final List<String> testNames;
 
-        public TestClassProcessorFactoryImpl(File testReportDir, TestNGSpec options, List<File> suiteFiles) {
+        public TestClassProcessorFactoryImpl(File testReportDir, TestNGSpec options, List<File> suiteFiles, List<String> testNames) {
             this.testReportDir = testReportDir;
             this.options = options;
             this.suiteFiles = suiteFiles;
+            this.testNames = testNames;
         }
 
         public TestClassProcessor create(ServiceRegistry serviceRegistry) {
-            return new TestNGTestClassProcessor(testReportDir, options, suiteFiles,
+            return new TestNGTestClassProcessor(testReportDir, options, suiteFiles, testNames,
                     serviceRegistry.get(IdGenerator.class), new JULRedirector());
         }
     }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/JavaBasePlugin.java
@@ -293,7 +293,17 @@ public class JavaBasePlugin implements Plugin<Project> {
                 test.getLogger().info("Running single tests with pattern: {}", test.getIncludes());
             }
         });
+        String testNames = "";
+        int pos = -1;
+        if ((pos = singleTest.indexOf("#")) > 0) {
+            testNames = singleTest.substring(pos + 1);
+            singleTest = singleTest.substring(0, pos);
+        }
+
         test.setIncludes(WrapUtil.toSet(String.format("**/%s*.class", singleTest)));
+        if (!testNames.trim().isEmpty()) {
+            test.setTestNames(WrapUtil.toList(testNames.split(",")));    
+        }
         failIfNoTestIsExecuted(test, singleTest);
     }
 

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/Test.java
@@ -122,6 +122,7 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
     private File testClassesDir;
     private File binResultsDir;
     private PatternFilterable patternSet = new PatternSet();
+    private List<String> testNames = new ArrayList<String>();
     private boolean ignoreFailures;
     private FileCollection classpath;
     private TestFramework testFramework;
@@ -773,6 +774,24 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
         patternSet.setIncludes(includes);
         return this;
     }
+
+    /**
+     * Returns the names of the tests to run for a single class
+     */
+    public List<String> getTestNames() {
+        return testNames;
+    }
+
+    /**
+     * Sets the names of the tests to run for a single class
+     * 
+     * @param testNames the list of test names
+     */
+    public Test setTestNames(List<String> testNames) {
+        this.testNames = testNames;
+        return this;
+    }
+
 
     /**
      * Returns the exclude patterns for test execution.

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestFrameworkTest.java
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestFrameworkTest.java
@@ -28,6 +28,7 @@ import org.jmock.Expectations;
 import org.junit.Before;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static junit.framework.Assert.assertNotNull;
@@ -85,6 +86,8 @@ public class JUnitTestFrameworkTest extends AbstractTestFrameworkTest {
             will(returnValue(Collections.emptySet()));
             allowing(jUnitOptionsMock).getExcludeCategories();
             will(returnValue(Collections.emptySet()));
+            allowing(testMock).getTestNames();
+            will(returnValue(Arrays.asList("foo")));
             one(serviceRegistry).get(IdGenerator.class);
             will(returnValue(idGenerator));
             one(serviceRegistry).get(ActorFactory.class);

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessorTest.groovy
@@ -41,7 +41,7 @@ class TestNGTestClassProcessorTest extends Specification {
 
     void setup(){
         options = Spy(TestNGSpec, constructorArgs:[new TestNGOptions(reportDir.testDirectory)]);
-        processor = new TestNGTestClassProcessor(reportDir.testDirectory, options, [], new LongIdGenerator(), {} as StandardOutputRedirector);
+        processor = new TestNGTestClassProcessor(reportDir.testDirectory, options, [], [], new LongIdGenerator(), {} as StandardOutputRedirector);
     }
 
     void "executes the test class"() {
@@ -74,6 +74,26 @@ class TestNGTestClassProcessorTest extends Specification {
         1 * resultProcessor.started({ it.name == 'ok' && it.className == ATestNGClass.class.name }, _ as TestStartEvent)
 
         1 * resultProcessor.completed(2, { it.resultType == ResultType.SUCCESS })
+        1 * resultProcessor.completed(1, { it.resultType == null })
+
+        0 * resultProcessor._
+    }
+
+    void "executes test class for only the given test methods"() {
+        when:
+        processor = new TestNGTestClassProcessor(reportDir.testDirectory, options, [], ['another'], new LongIdGenerator(), {} as StandardOutputRedirector);
+        processor.startProcessing(resultProcessor);
+        processor.processTestClass(testClass(ATestNGClassWithManyMethods.class));
+        processor.stop();
+
+        then:
+        1 * resultProcessor.started({ it.id == 1 && it.name == 'Gradle test' && it.className == null }, { it.parentId == null })
+        then:
+        1 * resultProcessor.started({ it.id == 2 && it.name == 'another' && it.className == ATestNGClassWithManyMethods.class.name }, { it.parentId == 1 })
+
+        then:
+        1 * resultProcessor.completed(2, { it.resultType == ResultType.SUCCESS })
+        then:
         1 * resultProcessor.completed(1, { it.resultType == null })
 
         0 * resultProcessor._
@@ -232,6 +252,16 @@ public class ATestNGClassWithExpectedException {
     @org.testng.annotations.Test(expectedExceptions = RuntimeException.class)
     public void ok() {
         throw new RuntimeException()
+    }
+}
+
+public class ATestNGClassWithManyMethods {
+    @org.testng.annotations.Test
+    public void ok() {
+    }
+
+    @org.testng.annotations.Test
+    public void another() {
     }
 }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -231,7 +231,24 @@ class JavaBasePluginTest extends Specification {
 
         then:
         task.includes == ['**/pattern*.class'] as Set
+        task.testNames == []
         task.inputs.getSourceFiles().empty
+    }
+
+    def "configures test task when test.single is used with test method names"() {
+        javaBasePlugin.apply(project)
+        def task = project.tasks.create('test', Test.class)
+        task.include 'ignoreme'
+
+        when:
+        System.setProperty("test.single", "pattern#test1,test2")
+        project.projectEvaluationBroadcaster.afterEvaluate(project, null)
+
+        then:
+        task.includes == ['**/pattern*.class'] as Set
+        task.testNames == ['test1', 'test2']
+        task.inputs.getSourceFiles().empty
+
     }
 
     def "adds functional and language source sets for each source set added to the 'sourceSets' container"() {


### PR DESCRIPTION
Add support to specify list of test method names using `test.single` property, with the (optional) format: `-Dtest.single=TestClassName#method1,method2`.

I show all tests passing on `subprojects/plugins`. Played around with some real testng and junit test code and was able to successfully run only the method(s) specified. Also tested to make sure not specifying any test method names still does indeed run all test methods in the class.
