### PR TITLE
Support to run tests in jar files and other class folders

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/Test.java
@@ -120,6 +120,7 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
     private TestExecuter testExecuter;
     private List<File> testSrcDirs = new ArrayList<File>();
     private File testClassesDir;
+    private FileCollection additionalTests;
     private File binResultsDir;
     private PatternFilterable patternSet = new PatternSet();
     private boolean ignoreFailures;
@@ -686,6 +687,25 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
     }
 
     /**
+     * Returns the additional tests. Must be either jar files or class folders.
+     *
+     * @return All the additional tests to be used.
+     */
+    @InputFiles
+    public FileCollection getAdditionalTests() {
+        return additionalTests;
+    }
+
+    /**
+     * Sets the additional tests to use.
+     *
+     * @param additionalTests The additional tests
+     */
+    public void setAdditionalTests(FileCollection additionalTests) {
+        this.additionalTests = additionalTests;
+    }
+
+    /**
      * Returns the root folder for the test results in XML format.
      *
      * @return the test result directory, containing the test results in XML format.
@@ -1027,7 +1047,20 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
     @InputFiles
     @Input
     public FileTree getCandidateClassFiles() {
-        return getProject().fileTree(getTestClassesDir()).matching(patternSet);
+        FileTree result = getProject().fileTree(getTestClassesDir());
+        FileCollection fc = getAdditionalTests();
+        if (fc != null) {
+            for (File file : fc.getFiles()) {
+                if (file.isDirectory()) {
+                    result = result.plus(getProject().fileTree(file));
+                }
+                if (file.isFile() && file.getName().endsWith(".jar")) {    
+                    result = result.plus(getProject().zipTree(file));
+                }
+                // else ignore
+            }
+        }
+        return result.matching(patternSet);
     }
 
     /**


### PR DESCRIPTION
The following patch is a proposal for http://issues.gradle.org//browse/GRADLE-2654

The test task can be configured with the property **additionalTests** which is a FileCollection of additional jars or class folders to be used when searching test classes.

A typical example looks as follows:

```
apply plugin: 'java'

repositories {
    mavenCentral()
}

configurations {
    testsJar
}

dependencies {
    testRuntime 'org.apache.commons:commons-lang3:3.1'
    testRuntime 'junit:junit:4.10'
    testsJar 'org.apache.commons:commons-lang3:3.1:tests@jar'
}

test {
    additionalTests = configurations.testsJar
    classpath += configurations.testsJar
    exclude 'org/apache/commons/lang3/concurrent/**'
}
```