### PR TITLE
The properties example for system properties did not work as expected

### DIFF
--- a/subprojects/docs/src/samples/userguide/tutorial/properties/gradle.properties
+++ b/subprojects/docs/src/samples/userguide/tutorial/properties/gradle.properties
@@ -1,4 +1,4 @@
 gradlePropertiesProp=gradlePropertiesValue
-systemPropertiesProp=shouldBeOverWrittenBySystemProp
+systemProjectProp=shouldBeOverWrittenBySystemProp
 envProjectProp=shouldBeOverWrittenByEnvProp
 systemProp.system=systemValue


### PR DESCRIPTION
Renamed variable systemPropertiesProp to systemProjectProp in gradle.properties to match the idea of overridden properties and the given command line parameters. Now removing -Dorg.gradle.project.systemProjectProp=systemPropertyValue from the command line gives the expected result of the fallback to the gradle.properties variable.

See http://www.gradle.org/docs/current/userguide/userguide_single.html#sec:gradle_properties_and_system_properties
