### PR TITLE
Handle 'dot' in ACL from ls when SELinux is enabled

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
@@ -115,7 +115,7 @@ class TestFileHelper {
             throw new RuntimeException("Could not list permissions for '$file': $error")
         }
         def perms = result.split()[0]
-        assert perms.matches("[d\\-][rwx\\-]{9}[@\\+]?")
+        assert perms.matches("[d\\-][rwx\\-]{9}[@\\.\\+]?")
         return perms.substring(1, 10)
     }
 


### PR DESCRIPTION
When running the tests locally, TestFileHelper was failing for me.  I tracked this back to selinux adding '.' to file permissions.   The test already looked for @ (extended attributes) and + (ACL), so I expanded the regex to include '.' (SELinux context). 
