### PR TITLE
Change the way the the gcc linker works so it doesn't link to an absolut...

### DIFF
--- a/subprojects/cpp/src/main/groovy/org/gradle/nativebinaries/toolchain/internal/gcc/GccLinker.java
+++ b/subprojects/cpp/src/main/groovy/org/gradle/nativebinaries/toolchain/internal/gcc/GccLinker.java
@@ -80,12 +80,12 @@ class GccLinker implements Compiler<LinkerSpec> {
     }
 
     public static String getLibraryName(final String fileName) {
-	Pattern pattern = Pattern.compile("^lib(.+)\\.so$");
-	Matcher matcher = pattern.matcher(fileName);
-	if (matcher.find()) {
-	    return matcher.group(1);
-	} else {
-	    return fileName;
-	}
+        Pattern pattern = Pattern.compile("^lib(.+)\\.so$");
+        Matcher matcher = pattern.matcher(fileName);
+        if (matcher.find()) {
+            return matcher.group(1);
+        } else {
+            return fileName;
+        }
     }
 }

--- a/subprojects/cpp/src/test/groovy/org/gradle/nativebinaries/toolchain/internal/gcc/GccLinkerTest.java
+++ b/subprojects/cpp/src/test/groovy/org/gradle/nativebinaries/toolchain/internal/gcc/GccLinkerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gradle.nativebinaries.toolchain.internal.gcc;
 
 import static org.junit.Assert.*;
@@ -6,8 +22,8 @@ import org.junit.Test;
 
 public class GccLinkerTest {
 
-	@Test
-	public void test() {
-		assertEquals("somelib", GccLinker.getLibraryName("libsomelib.so"));
-	}
+    @Test
+    public void test() {
+        assertEquals("somelib", GccLinker.getLibraryName("libsomelib.so"));
+    }
 }


### PR DESCRIPTION
Could we change the gcc linker to create a relative link instead of an absolute path.  The existing implementation works for testing on your development box but creates non-portable shared libraries because the shared library will point to dependencies in the gradle cache.
