### PR TITLE
Use Pattern.DOTALL to ensure that newlines are handled in options.

### DIFF
--- a/subprojects/cli/src/main/java/org/gradle/cli/CommandLineParser.java
+++ b/subprojects/cli/src/main/java/org/gradle/cli/CommandLineParser.java
@@ -94,15 +94,15 @@ public class CommandLineParser {
                 } else if (arg.matches("--[^=]+")) {
                     OptionParserState parsedOption = parseState.onStartOption(arg, arg.substring(2));
                     parseState = parsedOption.onStartNextArg();
-                } else if (arg.matches("--[^=]+=.*")) {
+                } else if (arg.matches("(?s)--[^=]+=.*")) {
                     int endArg = arg.indexOf('=');
                     OptionParserState parsedOption = parseState.onStartOption(arg, arg.substring(2, endArg));
                     parseState = parsedOption.onArgument(arg.substring(endArg + 1));
-                } else if (arg.matches("-[^=]=.*")) {
+                } else if (arg.matches("(?s)-[^=]=.*")) {
                     OptionParserState parsedOption = parseState.onStartOption(arg, arg.substring(1, 2));
                     parseState = parsedOption.onArgument(arg.substring(3));
                 } else {
-                    assert arg.matches("-[^-].*");
+                    assert arg.matches("(?s)-[^-].*");
                     String option = arg.substring(1);
                     if (optionsByString.containsKey(option)) {
                         OptionParserState parsedOption = parseState.onStartOption(arg, option);
@@ -277,7 +277,7 @@ public class CommandLineParser {
         public abstract boolean maybeStartOption(String arg);
 
         boolean isOption(String arg) {
-            return arg.matches("-.+");
+            return arg.matches("(?s)-.+");
         }
 
         public abstract OptionParserState onStartOption(String arg, String option);

--- a/subprojects/cli/src/test/groovy/org/gradle/cli/CommandLineParserTest.groovy
+++ b/subprojects/cli/src/test/groovy/org/gradle/cli/CommandLineParserTest.groovy
@@ -90,6 +90,16 @@ class CommandLineParserTest extends Specification {
         result.option('a').values == ['arg']
     }
 
+    def parsesShortOptionWithEqualMultilineArgument() {
+        parser.option('a').hasArgument()
+
+        expect:
+        def result = parser.parse(['-a=1\n2\n3'])
+        result.hasOption('a')
+        result.option('a').value == '1\n2\n3'
+        result.option('a').values == ['1\n2\n3']
+    }
+
     def parsesShortOptionWithEqualsCharacterInAttachedArgument() {
         parser.option('a').hasArgument()
 
@@ -522,6 +532,22 @@ class CommandLineParserTest extends Specification {
         then:
         def e = thrown(CommandLineArgumentException)
         e.message == 'An empty argument was provided for command-line option \'-a\'.'
+    }
+
+    def parseAcceptsMultilineArgument() {
+        parser.option('D').hasArgument()
+
+        expect:
+        def result = parser.parse(['-Dprops=a:1\nb:2\nc:3'])
+        result.option('D').values == ['props=a:1\nb:2\nc:3']
+    }
+
+    def parseAcceptsMultilineArgumentForLongOption() {
+        parser.option('a', 'long-option').hasArgument()
+
+        expect:
+        def result = parser.parse(['--long-option=a\nb\nc'])
+        result.option('long-option').values == ['a\nb\nc']
     }
 
     def parseFailsWhenEmptyArgumentIsProvided() {

--- a/subprojects/core/src/main/groovy/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/groovy/org/gradle/process/internal/JvmOptions.java
@@ -30,7 +30,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class JvmOptions {
-    private static final Pattern SYS_PROP_PATTERN = Pattern.compile("-D(.+?)=(.*)");
+    private static final Pattern SYS_PROP_PATTERN = Pattern.compile("(?s)-D(.+?)=(.*)");
     private static final Pattern NO_ARG_SYS_PROP_PATTERN = Pattern.compile("-D([^=]+)");
     private static final Pattern MIN_HEAP_PATTERN = Pattern.compile("-Xms(.+)");
     private static final Pattern MAX_HEAP_PATTERN = Pattern.compile("-Xmx(.+)");

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -183,7 +183,16 @@ class JvmOptionsTest extends Specification {
         opts.allJvmArgs.containsAll(['-Xmx1G', '-Xms1G', '-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'])
     }
 
-    private JvmOptions createOpts() {
+    def "options with newlines are parsed correctly"() {
+        def opts = createOpts()
+        when:
+        opts.jvmArgs('-Dprops=a:1\nb:2\nc:3')
+        then:
+        opts.allJvmArgs.contains('-Dprops=a:1\nb:2\nc:3')
+        opts.systemProperties['props'] == 'a:1\nb:2\nc:3'
+    }
+
+  private JvmOptions createOpts() {
         return new JvmOptions(TestFiles.resolver())
     }
 


### PR DESCRIPTION
Adding unittests to jglick's https://github.com/gradle/gradle/pull/186 that allows multiline property values to be passed to Gradle

```
gradle -Dprop=a:1\nb:2\nc:3 task
```
