### PR TITLE
Fix GRADLE-2695: ClassFormatError introduced in 1.3

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/AbstractClassGenerator.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/AbstractClassGenerator.java
@@ -193,12 +193,18 @@ public abstract class AbstractClassGenerator implements ClassGenerator {
 
             for (MetaBeanProperty property : settableProperties) {
                 Collection<MetaMethod> methodsForProperty = methods.get(property.getName());
-                if (methodsForProperty.isEmpty()) {
-                    builder.addSetMethod(property);
-                } else if (conventionProperties.contains(property)) {
+                boolean anyOverridden = false;
+                if (conventionProperties.contains(property)) {
                     for (MetaMethod method : methodsForProperty) {
-                        builder.overrideSetMethod(property, method);
+                        if (method.getParameterTypes().length == 1) {
+                            builder.overrideSetMethod(property, method);
+                            anyOverridden = true;
+                        }
                     }
+                }
+
+                if (!anyOverridden) {
+                    builder.addSetMethod(property);
                 }
             }
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/AsmBackedClassGenerator.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/AsmBackedClassGenerator.java
@@ -784,7 +784,9 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         }
 
         public void overrideSetMethod(MetaBeanProperty property, MetaMethod metaMethod) throws Exception {
-            if (!extensible || metaMethod.getParameterTypes().length != 1) {
+            if (metaMethod.getParameterTypes().length != 1) {
+                throw new IllegalArgumentException("Can only override set methods that take one argument: " + metaMethod.toString());
+            } else if (!extensible) {
                 return;
             }
             Type paramType = Type.getType(metaMethod.getParameterTypes()[0].getTheClass());

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AsmBackedClassGeneratorTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AsmBackedClassGeneratorTest.java
@@ -645,10 +645,12 @@ public class AsmBackedClassGeneratorTest {
         //assertThat(bean.getFiles(), sameInstance(files));
     }
 
-    @Test(expected=MissingMethodException.class)
-    public void doesNotAddSetValueMethodIfOnlyMultiArgMethods() throws Exception {
+    @Test
+    public void addsInsteadOfOverridesSetValueMethodIfOnlyMultiArgMethods() throws Exception {
         BeanWithMultiArgDslMethods bean = generator.generate(BeanWithMultiArgDslMethods.class).newInstance();
-        call("{ it.prop('value') }", bean);
+        // this method should have been added to the class
+        call("{ it.prop 'value'}", bean);
+        assertThat(bean.getProp(), equalTo("value"));
     }
 
     @Test


### PR DESCRIPTION
AsmBackedClassGenerator currently "overrides" the set method for any method
with the same name as the property, regardless of how many arguments it has.
The set method is intended to be an alias for the setter without starting with
"set" (e.g. instead of setProp(String), it would be prop(String)).

By accepting any method with the property's name, it is generating more set
methods than intended. If there is a prop(String, String) and a prop(String,
String, String) it will generate two prop(String) methods, resulting in a
ClassFormatError (as noted in GRADLE-2695).

This commit changes the overrideSetMethod() method to only perform the
override if the passed metaMethod is a one arg method.

See additional information in the [issue](http://issues.gradle.org/browse/GRADLE-2695).
