### PR TITLE
Prevent tests from invoking System#exit by installing NoExitSecurityManager

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -57,6 +57,30 @@ class TestingIntegrationTest extends AbstractIntegrationSpec {
         ":test" in nonSkippedTasks
     }
 
+    def "fails cleanly if the test class calls System#exit(int)"() {
+        given:
+        file('src/test/java/CallsSystemExitTest.java') << """
+            import org.junit.*;
+            public class CallsSystemExitTest {
+                @Test
+                public void testSystemExit() {
+                    System.exit(0);
+                }
+            }
+        """
+        file('build.gradle') << """
+            apply plugin: 'java'
+            repositories { mavenCentral() }
+            dependencies { testCompile 'junit:junit:4.10' }
+        """
+
+        when:
+        runAndFail "test"
+
+        then:
+        failureHasCause "There were failing tests"
+    }
+
     @IgnoreIf({ OperatingSystem.current().isWindows() })
     def "can use long paths for working directory"() {
         given:

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.worker;
 
+import org.apache.tools.ant.util.optional.NoExitSecurityManager;
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
@@ -99,11 +100,18 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
 
     public void processTestClass(final TestClassRunInfo testClass) {
         Thread.currentThread().setName("Test worker");
+        boolean setSecurityManager = System.getSecurityManager() == null;
+        if (setSecurityManager) {
+            System.setSecurityManager(new NoExitSecurityManager());
+        }
         try {
             processor.processTestClass(testClass);
         } finally {
             // Clean the interrupted status
             Thread.interrupted();
+            if (setSecurityManager) {
+                System.setSecurityManager(null);
+            }
         }
     }
 


### PR DESCRIPTION
Calling `System#exit` causes an unexpected exception reading from the worker process. The tests do not fail cleanly and subsequent tests that should have run in in the same worker VM are not run. This change prevents calling `System#exit` by installing a custom security manager. In the unlikely event of another security manager already installed, we don't do anything because the installed `NoExitSecurityManager` (from ant-optional) doesn't support nesting another `SecurityManager`.
