### PR TITLE
Add shouldRunAfter ordering to Ant target dependencies

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/AntProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/AntProjectIntegrationTest.groovy
@@ -156,4 +156,25 @@ ant.importBuild('build.xml')
         failure.assertHasDescription('Execution failed for task \':target1\'.')
         failure.assertHasCause('broken')
     }
+
+    @Test
+    public void targetDependenciesAreOrderedBasedOnDeclarationSequence() {
+        testFile('build.xml') << """
+<project>
+    <target name='a' depends='d,c,b'/>
+    <target name='b'/>
+    <target name='c'/>
+    <target name='d'/>
+    <target name='e' depends='g,f'/>
+    <target name='f'/>
+    <target name='g'/>
+    <target name='h' depends='i'/>
+    <target name='i'/>
+</project>
+"""
+        testFile('build.gradle') << """
+ant.importBuild('build.xml')
+"""
+        inTestDirectory().withTasks('a', 'e', 'h').run().assertTasksExecuted(':d', ':c', ':b', ':a', ':g', ':f', ':e', ':i', ':h')
+    }
 }


### PR DESCRIPTION
Dependencies of Ant targets imported into Gradle using `ant.importBuild()` are ordered as declared using `shouldRunAfter`. This is to help people with use cases like the ones in [GRADLE-474](http://issues.gradle.org/browse/GRADLE-427) and [GRADLE-1102](http://issues.gradle.org/browse/GRADLE-1102).
