### PR TITLE
Added /nologo to rc.exe

### DIFF
--- a/subprojects/cpp/src/main/groovy/org/gradle/nativebinaries/toolchain/internal/msvcpp/WindowsResourceCompiler.java
+++ b/subprojects/cpp/src/main/groovy/org/gradle/nativebinaries/toolchain/internal/msvcpp/WindowsResourceCompiler.java
@@ -55,6 +55,7 @@ public class WindowsResourceCompiler implements Compiler<WindowsResourceCompileS
 
         public List<String> transform(WindowsResourceCompileSpec spec) {
             List<String> args = new ArrayList<String>();
+            args.add("/nologo");
             args.add("/fo");
             args.add(getOutputFile(spec).getAbsolutePath());
             for (String macroArg : new MacroArgsConverter().transform(spec.getMacros())) {


### PR DESCRIPTION
This might be the simplest pull request ever... It removes the version/copyright information from the output when using the resource compiler.

But in order to possibly make this pull request more interesting, I was wondering:
- .rc files generally include resource.h (which defines most of your resource constants)
- said resource.h is then used from your C or C++ code to reference the resources

Right now, if I put resource.h in src/main/rc, it seems wrong to include "../rc/resource.h" from src/main/cpp.
Something like exportedHeaders would sort of make sense but then it's just shared with another sourceset, not really exported from that particular component.
How could this be made to work nicely?
