### PR TITLE
Fix: Quotes around $JVM_OPTS fail with multi-args

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -161,4 +161,4 @@ function splitJvmOpts() {
 eval splitJvmOpts \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar}
 <% if ( appNameSystemProperty ) { %>JVM_OPTS[\${#JVM_OPTS[*]}]="-D${appNameSystemProperty}=\$APP_BASE_NAME"<% } %>
 
-exec "\$JAVACMD" "\${JVM_OPTS[@]}" -classpath "\$CLASSPATH" ${mainClassName} "\$@"
+exec "\$JAVACMD" \${JVM_OPTS[@]} -classpath "\$CLASSPATH" ${mainClassName} "\$@"


### PR DESCRIPTION
Quotes around $JVM_OPTS make java fail when multiple JVM-args are provided.

Java sees all arguments as a single argument failing with an error such as:
  Unrecognized VM option 'HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/server-standalone.hprof'

Sorry for not providing any tests to back up my statement.. :-)
Did manual testing by modifying the script after "gradle installApp".
Failed with surrounding quotes - worked without quotes.
