### PR TITLE
Fix charset declaration in the TabbedPageRenderer. Replace 'httpEquiv' attribute name with 'http-equiv'

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/reporting/TabbedPageRenderer.java
+++ b/subprojects/core/src/main/groovy/org/gradle/reporting/TabbedPageRenderer.java
@@ -43,7 +43,7 @@ public abstract class TabbedPageRenderer<T> extends ReportRenderer<T, SimpleHtml
     public void render(final T model, SimpleHtmlWriter htmlWriter) throws IOException {
         this.model = model;
         htmlWriter.startElement("head")
-            .startElement("meta").attribute("httpEquiv", "Content-Type").attribute("content", "text/html; charset=utf-8").endElement()
+            .startElement("meta").attribute("http-equiv", "Content-Type").attribute("content", "text/html; charset=utf-8").endElement()
             .startElement("title").characters(getPageTitle()).endElement()
             .startElement("link").attribute("href", "css/base-style.css").attribute("rel", "stylesheet").attribute("type", "text/css").endElement()
             .startElement("link").attribute("href", "css/style.css").attribute("rel", "stylesheet").attribute("type", "text/css").endElement()

--- a/subprojects/core/src/test/groovy/org/gradle/profile/ProfileReportRendererTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/profile/ProfileReportRendererTest.groovy
@@ -65,7 +65,7 @@ class ProfileReportRendererTest extends Specification {
         file.text.contains(toPlatformLineSeparators("""<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
-<meta httpEquiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <title>Profile report</title>
 <link href="css/base-style.css" rel="stylesheet" type="text/css"/>
 <link href="css/style.css" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
Hi!

Found this typo today, and here is a patch to fix it, but, sorry, I'm to lazy to print, sign, scan and send back your CLA for such a minor issue.
