### PR TITLE
Recognize JDK 9

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
  * An enumeration of Java versions.
  */
 public enum JavaVersion {
-    VERSION_1_1(false), VERSION_1_2(false), VERSION_1_3(false), VERSION_1_4(false), VERSION_1_5(true), VERSION_1_6(true), VERSION_1_7(true), VERSION_1_8(true);
+    VERSION_1_1(false), VERSION_1_2(false), VERSION_1_3(false), VERSION_1_4(false), VERSION_1_5(true), VERSION_1_6(true), VERSION_1_7(true), VERSION_1_8(true), VERSION_1_9(true);
 
     private final boolean hasMajorVersion;
 
@@ -88,6 +88,10 @@ public enum JavaVersion {
         return this == VERSION_1_8;
     }
 
+    private boolean isJava9() {
+        return this == VERSION_1_9;
+    }
+
     public boolean isJava5Compatible() {
         return this.compareTo(VERSION_1_5) >= 0;
     }
@@ -102,6 +106,10 @@ public enum JavaVersion {
 
     public boolean isJava8Compatible() {
         return this.compareTo(VERSION_1_8) >= 0;
+    }
+
+    public boolean isJava9Compatible() {
+        return this.compareTo(VERSION_1_9) >= 0;
     }
 
     @Override

--- a/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
@@ -32,6 +32,7 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.VERSION_1_6.toString() == "1.6"
         JavaVersion.VERSION_1_7.toString() == "1.7"
         JavaVersion.VERSION_1_8.toString() == "1.8"
+        JavaVersion.VERSION_1_9.toString() == "1.9"
     }
 
     def convertsStringToVersion() {
@@ -46,6 +47,8 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.toVersion("6") == JavaVersion.VERSION_1_6
         JavaVersion.toVersion("7") == JavaVersion.VERSION_1_7
         JavaVersion.toVersion("8") == JavaVersion.VERSION_1_8
+        JavaVersion.toVersion("9") == JavaVersion.VERSION_1_9
+        JavaVersion.toVersion("1.9.0-internal") == JavaVersion.VERSION_1_9
     }
 
     def failsToConvertStringToVersionForUnknownVersion() {
@@ -60,7 +63,6 @@ public class JavaVersionSpec extends Specification {
         conversionFails("  ");
 
         conversionFails("1.54");
-        conversionFails("1.9");
         conversionFails("1.10");
         conversionFails("2.0");
         conversionFails("1_4");
@@ -80,6 +82,7 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.toVersion(7) == JavaVersion.VERSION_1_7
         JavaVersion.toVersion(1.7) == JavaVersion.VERSION_1_7
         JavaVersion.toVersion(1.8) == JavaVersion.VERSION_1_8
+        JavaVersion.toVersion(1.9) == JavaVersion.VERSION_1_9
     }
     
     def failsToConvertNumberToVersionForUnknownVersion() {
@@ -173,5 +176,23 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.current().java6Compatible
         JavaVersion.current().java7Compatible
         JavaVersion.current().java8Compatible
+    }
+
+    def "uses system property to determine if compatible with Java 9"() {
+        System.properties['java.version'] = '1.9'
+
+        expect:
+        !JavaVersion.current().java5
+        !JavaVersion.current().java6
+        !JavaVersion.current().java7
+        !JavaVersion.current().java8
+        JavaVersion.current().java9
+
+        and:
+        JavaVersion.current().java5Compatible
+        JavaVersion.current().java6Compatible
+        JavaVersion.current().java7Compatible
+        JavaVersion.current().java8Compatible
+        JavaVersion.current().java9Compatible
     }
 }


### PR DESCRIPTION
This patch fixes `JavaVersion` so that it recognizes if the current JDK is JDK 9.

This would be helpful for Groovy where we setup a build against the latest JDK9 sources, but Gradle fails recognizing the JDK.
