### PR TITLE
Move to HTTPS

### DIFF
--- a/gradle/wrapper.gradle
+++ b/gradle/wrapper.gradle
@@ -21,7 +21,7 @@ def wrapperUpdateTask = { name, label ->
     task "$configureWrapperTaskName" {
         doLast {
             configure(tasks."$wrapperTaskName") {
-                def version = new groovy.json.JsonSlurper().parseText(new URL("http://services.gradle.org/versions/$label").text)
+                def version = new groovy.json.JsonSlurper().parseText(new URL("https://services.gradle.org/versions/$label").text)
                 if (version.empty) {
                     throw new GradleException("Cannot update wrapper to '${label}' version as there is currently no version of that label")
                 }

--- a/subprojects/core/src/main/groovy/org/gradle/util/DistributionLocator.java
+++ b/subprojects/core/src/main/groovy/org/gradle/util/DistributionLocator.java
@@ -21,8 +21,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class DistributionLocator {
-    private static final String RELEASE_REPOSITORY = "http://services.gradle.org/distributions";
-    private static final String SNAPSHOT_REPOSITORY = "http://services.gradle.org/distributions-snapshots";
+    private static final String RELEASE_REPOSITORY = "https://services.gradle.org/distributions";
+    private static final String SNAPSHOT_REPOSITORY = "https://services.gradle.org/distributions-snapshots";
 
     public URI getDistributionFor(GradleVersion version) {
         return getDistribution(getDistributionRepository(version), version, "gradle", "bin");


### PR DESCRIPTION
You guys! All of the communication with Gradle servers is done over unencrypted http!

This means that anybody installing gradle on a hostile network has a high risk of installing malicious software via trivial attacks!

This is a big security vulnerability which should be fixed immediately.. shouldn't cost you more than sixty bucks to do it properly.

This patch will _currently_ break gradle, but once you have your SSL certificates installed properly, it'll work just fine.

Please fix and merge ASAP! 
