### PR TITLE
TestNGOptions parallel property javadoc fix

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/testng/TestNGOptions.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/testng/TestNGOptions.groovy
@@ -85,7 +85,7 @@ class TestNGOptions extends TestFrameworkOptions {
     Set<String> listeners = new LinkedHashSet<String>()
 
     /**
-     * The parallel mode to use for running the tests - either methods or tests.
+     * The parallel mode to use for running the tests - one of the following modes: methods, tests, classes or instances.
      *
      * Not required.
      *


### PR DESCRIPTION
Added missing parallel run modes according to [TestNG DTD](http://testng.org/testng-1.0.dtd.php)
