### PR TITLE
Now proxy is not set when http.proxyHost or http.proxyPort are blank instead of null

### DIFF
--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/externalresource/transport/http/JavaSystemPropertiesHttpProxySettings.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/externalresource/transport/http/JavaSystemPropertiesHttpProxySettings.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.externalresource.transport.http;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class JavaSystemPropertiesHttpProxySettings implements HttpProxySettings 
     }
 
     JavaSystemPropertiesHttpProxySettings(String proxyHost, String proxyPortString, String proxyUser, String proxyPassword, String nonProxyHostsString) {
-        if (proxyHost == null) {
+        if (StringUtils.isBlank(proxyHost)) {
             this.proxy = null;
         } else {
             this.proxy = new HttpProxy(proxyHost, initProxyPort(proxyPortString), proxyUser, proxyPassword);
@@ -46,7 +47,7 @@ public class JavaSystemPropertiesHttpProxySettings implements HttpProxySettings 
     }
 
     private int initProxyPort(String proxyPortString) {
-        if (proxyPortString == null) {
+        if (StringUtils.isBlank(proxyPortString)) {
             return DEFAULT_PROXY_PORT;
         }
         
@@ -59,7 +60,7 @@ public class JavaSystemPropertiesHttpProxySettings implements HttpProxySettings 
     }
 
     private List<Pattern> initNonProxyHosts(String nonProxyHostsString) {
-        if (nonProxyHostsString == null) {
+        if (StringUtils.isBlank(nonProxyHostsString)) {
             return Collections.emptyList();
         }
 

--- a/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/externalresource/transport/http/JavaSystemPropertiesHttpProxySettingsTest.groovy
+++ b/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/externalresource/transport/http/JavaSystemPropertiesHttpProxySettingsTest.groovy
@@ -21,15 +21,18 @@ import spock.lang.Specification
 class JavaSystemPropertiesHttpProxySettingsTest extends Specification {
     def "proxy is not configured when proxyHost property not set"() {
         expect:
-        def settings = settings(null, proxyPort, nonProxyHosts)
+        def settings = settings(proxyHost, proxyPort, nonProxyHosts)
         settings.getProxy(requestHost) == null
 
         where:
-        proxyPort | nonProxyHosts | requestHost
-        null      | null          | null
-        null      | null          | "foo"
-        "111"     | null          | "foo"
-        null      | "foo|bar|baz" | "foo"
+        proxyHost | proxyPort | nonProxyHosts | requestHost
+        null      | null      | null          | null
+        null      | null      | null          | "foo"
+        null      | "111"     | null          | "foo"
+        null      | null      | "foo|bar|baz" | "foo"
+        ""        | null      | null          | null
+        ""        | ""        | null          | null
+        null      | ""        | null          | null
     }
 
     private JavaSystemPropertiesHttpProxySettings settings(host, proxyPort, nonProxyHosts) {


### PR DESCRIPTION
Currently there is a bug due to checking if proxy related system properties are null. In some cases (for example when launching from IntelliJ) those properties can be empty strings instead of null:
12:04:16.515 [DEBUG] [org.gradle.api.internal.artifacts.ivyservice.IvyLoggingAdaper] setting 'http.proxyPort' to ''
