### PR TITLE
Minor English rephrasings

### DIFF
--- a/subprojects/docs/src/docs/userguide/buildLifecycle.xml
+++ b/subprojects/docs/src/docs/userguide/buildLifecycle.xml
@@ -118,9 +118,9 @@
                 </sample>
                 <para>The <literal>include</literal> method takes project paths as arguments.
                     The project path is assumed to be equal to the relative physical file system path.
-                    For example a path 'services:api' by default is mapped to a folder 'services/api'
-                    (relative from the project root). You only need to specify the leafs of the tree.
-                    This means that the inclusion of path 'services:hotels:api' will result in creating 3 projects:
+                    For example, a path 'services:api' is mapped by default to a folder 'services/api'
+                    (relative from the project root). You only need to specify the leaves of the tree.
+                    This means that the inclusion of the path 'services:hotels:api' will result in creating 3 projects:
                     'services', 'services:hotels' and 'services:hotels:api'.
                 </para>
             </section>

--- a/subprojects/docs/src/docs/userguide/buildScriptsTutorial.xml
+++ b/subprojects/docs/src/docs/userguide/buildScriptsTutorial.xml
@@ -114,7 +114,8 @@
             <literal>taskY</literal> is defined. This is very important for multi-project builds. Task dependencies are
             discussed in more detail in <xref linkend='sec:adding_dependencies_to_tasks'/>.
         </para>
-        <para>Please notice, that you can't use a shortcut notation (see <xref linkend='sec:shortcut_notations' />) when referring to task, which is not defined yet.</para>
+        <para>Please notice that you can't use shortcut notation (see <xref linkend='sec:shortcut_notations' />)
+        when referring to a task that is not yet defined.</para>
     </section>
     <section>
         <title>Dynamic tasks</title>
@@ -172,10 +173,10 @@
     </section>
     <section>
         <title>Using Ant Tasks</title>
-        <para>Ant tasks are first-class citizens in Gradle. Gradle provides excellent integration for Ant tasks simply
-            by relying on Groovy. Groovy is shipped with the fantastic <literal>AntBuilder</literal>. Using Ant tasks
+        <para>Ant tasks are first-class citizens in Gradle. Gradle provides excellent integration for Ant tasks by simply
+            relying on Groovy. Groovy is shipped with the fantastic <literal>AntBuilder</literal>. Using Ant tasks
             from Gradle is as convenient and more powerful than using Ant tasks from a <filename>build.xml</filename>
-            file. From below example you can learn how to execute ant tasks and how to access ant properties:
+            file. From the example below, you can learn how to execute ant tasks and how to access ant properties:
         </para>
         <sample id="antLoadfile" dir="userguide/tutorial/antLoadfile" title="Using AntBuilder to execute ant.loadfile target">
             <sourcefile file="build.gradle"/>
@@ -213,21 +214,20 @@
     </section>
     <section id="configure-by-dag">
         <title>Configure by DAG</title>
-        <para>As we describe in full detail later (See <xref linkend='build_lifecycle'/>) Gradle has a
-            configuration phase and an execution phase. After the configuration phase Gradle knows all tasks that should
+        <para>As we later describe in full detail (see <xref linkend='build_lifecycle'/>), Gradle has a
+            configuration phase and an execution phase. After the configuration phase, Gradle knows all tasks that should
             be executed. Gradle offers you a hook to make use of this information. A use-case for this would be to check
-            if the release task is part of the tasks to be executed. Depending on this you can assign different values
+            if the release task is among the tasks to be executed. Depending on this, you can assign different values
             to some variables.
         </para>
-        <para>In the following example, execution of <literal>distribution</literal> and <literal>release</literal> tasks results in different value of <literal>version</literal> variable.</para>
+        <para>In the following example, execution of the <literal>distribution</literal> and <literal>release</literal> tasks results in different value of the <literal>version</literal> variable.</para>
         <sample id="configByDagNoRelease" dir="userguide/tutorial/configByDag" title="Different outcomes of build depending on chosen tasks">
             <sourcefile file="build.gradle"/>
             <output args="-q distribution"/>
             <output args="-q release" outputFile="configByDag.out"/>
         </sample>
-        <para>The important thing is, that the fact that the release task has been chosen, has an effect
-            <emphasis>before</emphasis> the release task gets executed. Nor has the release task to be the
-            <emphasis>primary</emphasis> task (i.e. the task passed to the <command>gradle</command> command).
+        <para>The important thing is that <literal>whenReady</literal> affects the release task <emphasis>before</emphasis> the release task is executed.
+        This works even when the release task is not the <emphasis>primary</emphasis> task (i.e., the task passed to the <command>gradle</command> command).
         </para>
     </section>
     <section>

--- a/subprojects/docs/src/docs/userguide/comparingBuilds.xml
+++ b/subprojects/docs/src/docs/userguide/comparingBuilds.xml
@@ -179,7 +179,7 @@
 }
         </programlisting>
         <para>
-            The above example configures a comparison between two different projects using two different Gradle versions.
+            The example above configures a comparison between two different projects using two different Gradle versions.
         </para>
         <section>
             <title>Trying Gradle upgrades</title>

--- a/subprojects/docs/src/docs/userguide/customPlugins.xml
+++ b/subprojects/docs/src/docs/userguide/customPlugins.xml
@@ -130,7 +130,7 @@
         <para>
             In this example, we configure the <literal>greet</literal> task <literal>destination</literal> property as a closure, which is evaluated with
             the <apilink class="org.gradle.api.Project" method="file(java.lang.Object)"/> method to turn the return value of the closure into a file object
-            at the last minute. You will notice that in the above example we specify the <literal>greetingFile</literal> property value after we have 
+            at the last minute. You will notice that in the example above we specify the <literal>greetingFile</literal> property value after we have 
             configured to use it for the task. This kind of lazy evaluation is a key benefit of accepting any value when setting a file property, then 
             resolving that value when reading the property.
         </para>

--- a/subprojects/docs/src/docs/userguide/distributionPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/distributionPlugin.xml
@@ -187,7 +187,7 @@
             <sourcefile file="build.gradle" snippet="configure-distribution"/>
         </sample>
         <para>
-            In the above example, the content of the "<literal>src/readme</literal>" directory will be included in the distribution
+            In the example above, the content of the "<literal>src/readme</literal>" directory will be included in the distribution
             (along with the files in the "<literal>src/dist/main</literal>" directory which are added by default).
         </para>
         <para>

--- a/subprojects/docs/src/docs/userguide/nativeBinaries.xml
+++ b/subprojects/docs/src/docs/userguide/nativeBinaries.xml
@@ -274,7 +274,7 @@
             <sourcefile file="build.gradle" snippet="assembler-args"/>
         </sample>
         <para>
-            The above example will apply the supplied configuration to all <literal>executable</literal> binaries built.
+            The example above will apply the supplied configuration to all <literal>executable</literal> binaries built.
         </para>
         <para>
             Similarly, settings can be specified to target binaries for a component that are of a particular type:
@@ -314,7 +314,7 @@
             <sourcefile file="build-resource-only-dll.gradle" snippet="resource-only-library"/>
         </sample>
         <para>
-            The above example also demonstrates the mechanism of passing extra command-line arguments to the resource compiler.
+            The example above also demonstrates the mechanism of passing extra command-line arguments to the resource compiler.
             The <literal>rcCompiler</literal> extension is of type <apilink class="org.gradle.nativebinaries.language.PreprocessingTool"/>.
         </para>
     </section>
@@ -437,7 +437,7 @@
                 <sourcefile file="build.gradle" snippet="flavors"/>
             </sample>
             <para>
-                In the above example, a library is defined with a 'english' and 'french' flavor. When compiling the 'french'
+                In the example above, a library is defined with a 'english' and 'french' flavor. When compiling the 'french'
                 variant, a separate macro is defined which leads to a different binary being produced.
             </para>
             <para>

--- a/subprojects/docs/src/docs/userguide/plugins.xml
+++ b/subprojects/docs/src/docs/userguide/plugins.xml
@@ -123,7 +123,7 @@
             <output args="-q show"/>
         </sample>
         <para>
-            In the above example, we applied the Java plugin which, among other things, did the following:
+            In the example above, we applied the Java plugin which, among other things, did the following:
         </para>
         <itemizedlist>
             <listitem>Added a new domain object type: <apilink class="org.gradle.api.tasks.SourceSet" /></listitem>
@@ -131,7 +131,7 @@
             <listitem>Configured supporting tasks to use these properties to perform work</listitem>
         </itemizedlist>
         <para>
-            All of this happened during the <literal>apply plugin: "java"</literal> step. In the example above we <emphasis>changed</emphasis>
+            All of this happened during the <literal>apply plugin: "java"</literal> step. In the example above, we <emphasis>changed</emphasis>
             the desired location of the class files after this conventional configuration had been performed. Notice by the output with the example
             that the value for <literal>compileJava.destinationDir</literal> also changed to reflect the configuration change.
         </para>
@@ -143,7 +143,7 @@
         <para>
             This ability to configure properties of objects to reflect the value of another object's task at all times (i.e. even when it changes) is
             known as “<emphasis>convention mapping</emphasis>”. It allows Gradle to provide conciseness through convention-over-configuration and
-            sensible defaults yet not require complete reconfiguration if a conventional default needs to be changed. Without this, in the above example
+            sensible defaults yet not require complete reconfiguration if a conventional default needs to be changed. Without this, in the example above,
             we would have had to reconfigure every object that needs to work with the class files.
         </para>
     </section>

--- a/subprojects/docs/src/docs/userguide/publishingIvy.xml
+++ b/subprojects/docs/src/docs/userguide/publishingIvy.xml
@@ -264,7 +264,7 @@
             The “<literal>ivy-publish</literal>” plugin automatically wires in one <apilink class="org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor" /> task
             for each registered <apilink class="org.gradle.api.publish.ivy.IvyPublication" />.
             This task is given a name based on the name of the publication:  "<literal>generateDescriptorFileFor«<emphasis>NAME OF PUBLICATION</emphasis>»Publication</literal>".
-            So in the above example where the publication is named "<literal>ivyJava</literal>", the task will be named "<literal>generateDescriptorFileForIvyJavaPublication</literal>".
+            So in the example above where the publication is named "<literal>ivyJava</literal>", the task will be named "<literal>generateDescriptorFileForIvyJavaPublication</literal>".
         </para>
         <para>
             You can specify where the generated Ivy file will be located by setting the <literal>destination</literal> property on the generate task.
@@ -279,7 +279,7 @@
                 The “<literal>ivy-publish</literal>” plugin leverages some experimental support for late plugin configuration,
                 and the <literal>GenerateIvyDescriptor</literal> task will not be constructed until the publishing extension is configured.
                 The simplest way to ensure that the publishing plugin is configured when you attempt to access the <literal>GenerateIvyDescriptor</literal> task
-                is to place the access inside a <literal>publishing</literal> block, as the above example demonstrates.
+                is to place the access inside a <literal>publishing</literal> block, as the example above demonstrates.
             </para>
             <para>
                 The same applies to any attempt to access publication-specific tasks like <apilink class="org.gradle.api.publish.ivy.tasks.PublishToIvyRepository" />.

--- a/subprojects/docs/src/docs/userguide/publishingMaven.xml
+++ b/subprojects/docs/src/docs/userguide/publishingMaven.xml
@@ -276,8 +276,8 @@
         </para>
         <para>
             The task for generating the POM file is of type <apilink class="org.gradle.api.publish.maven.tasks.GenerateMavenPom"/>, and it is given a name based on the name
-            of the publication: "<literal>generatePomFileFor«<emphasis>NAME OF PUBLICATION</emphasis>»Publication</literal>". So in the below example where the publication is named
-            "<literal>mavenCustom</literal>",
+            of the publication: "<literal>generatePomFileFor«<emphasis>NAME OF PUBLICATION</emphasis>»Publication</literal>". So in the example below,
+            where the publication is named "<literal>mavenCustom</literal>",
             the task will be named "<literal>generatePomFileForMavenCustomPublication</literal>".
         </para>
         <sample dir="maven-publish/pomCustomization" id="publishingMavenGeneratePom" title="Generate a POM file without publishing">
@@ -293,7 +293,7 @@
                 The “<literal>maven-publish</literal>” plugin leverages some experimental support for late plugin configuration,
                 and any <literal>GenerateMavenPom</literal> tasks will not be constructed until the publishing extension is configured.
                 The simplest way to ensure that the publishing plugin is configured when you attempt to access the <literal>GenerateMavenPom</literal> task
-                is to place the access inside a <literal>publishing</literal> block, as the above example demonstrates.
+                is to place the access inside a <literal>publishing</literal> block, as the example above demonstrates.
             </para>
             <para>
                 The same applies to any attempt to access publication-specific tasks like <apilink class="org.gradle.api.publish.maven.tasks.PublishToMavenRepository"/>.


### PR DESCRIPTION
As I'm reading the Gradle tutorial (which is great, by the way), I'm running into a few language usage things that I think could be improved. For example, for some reason, "the above example", "the preceding example" and "the following example" all sound fine in American English, but "the below example" sounds really weird. No idea why. (And "the example preceding" and "the example following", while not strictly correct, sound archaic, so I left those alone.)  But I ran it by a couple of people, and they agreed, giggled, and shook their heads. English is odd, what can I say.

If you like, I can continue to suggest edits. Or reject the pull request and I'll leave you alone.
