### PR TITLE
Remove Groovy jars duplication in generated project

### DIFF
--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/groovylibrary/build.gradle.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/groovylibrary/build.gradle.template
@@ -17,10 +17,21 @@ repositories {
     mavenCentral()
 }
 
+// In this section you declare the dependency configurations for your project
+configurations {
+    // To prevent an accidental usage of groovy-all.jar and groovy.jar in different versions
+    // all modularized Groovy jars are replaced with groovy-all.jar by default.
+    resolutionStrategy.eachDependency { dependency ->
+        if (dependency.requested.group == 'org.codehaus.groovy') {
+            useTarget("org.codehaus.groovy:groovy-all:${dependency.requested.version}")
+        }
+    }
+}
+
 // In this section you declare the dependencies for your production and test code
 dependencies {
     // We use the latest groovy 2.x version for building this library
-    compile 'org.codehaus.groovy:groovy:${groovyVersion.groovyString}'
+    compile 'org.codehaus.groovy:groovy-all:${groovyVersion.groovyString}'
 
     // We use the awesome Spock testing and specification framework
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'


### PR DESCRIPTION
Generated sample Groovy project (`gradle init --type groovy-library`) uses groovy-2.x.jar (core) while some dependencies (here Spock, but in general many others) have groovy-all-2.x.jar as a transitive dependency. Gradle treats them as different libraries and there is a warning about duplicated classes (like AST transformations) during compilation which can cause the wrong Groovy version to be used in the project. This commit adds global (for all configurations) exclude for groovy-all artifact.

```
Warning:Groovyc: The global transform for class groovy.grape.GrabAnnotationTransformation is defined in both
jar:file:/home/foo/.gradle/caches/modules-2/files-2.1/org.codehaus.groovy/groovy/2.2.1/cf35c6e15fff24309538541783ef0d7a4e330030/groovy-2.2.1.jar!/META-INF/services/org.codehaus.groovy.transform.ASTTransformation and
jar:file:/home/foo/.gradle/caches/modules-2/files-2.1/org.codehaus.groovy/groovy-all/2.2.1/7ae565d50d24167c4e5d74b96f4126d4c56f16f/groovy-all-2.2.1.jar!/META-INF/services/org.codehaus.groovy.transform.ASTTransformation
 - the former definition will be used and the latter ignored.
```

Btw, I know it is harder to read by the newcomers to Gradle, so maybe `configurations` could be placed below dependency section (which is less logical order on the other side).
