### PR TITLE
use the latest jacoco version to be compatible with Java 8

### DIFF
--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.groovy
@@ -35,7 +35,7 @@ class JacocoPluginExtension {
     /**
      * Version of Jacoco JARs to use.
      */
-    String toolVersion = '0.6.2.201302030002'
+    String toolVersion = '0.7.0.201403182114'
 
     protected final Project project
 


### PR DESCRIPTION
Java 8 was released yesterday, and jacoco also released a new version which makes it compatible with Java 8. This pull request only updates the default tool version of jacoco.
