### PR TITLE
ApplicationPlugin configurability

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class ApplicationPluginIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        file("settings.gradle").text = "rootProject.name='AppPluginTestProject'"
+        file("src/dist/read.me").createFile()
+        file("src/main/resources/config.xml").createFile()
+        file("src/main/resources/scripts/myscript").with {
+            createFile()
+            withWriter { itWriter ->
+                itWriter.println """
+                echo \$defaultJvmOpts
+                echo \${classpath}
+                echo \$myprop
+                """
+            }
+        }
+        file("src/main/resources/scripts/myscript.bat").with {
+            createFile()
+            withWriter { itWriter ->
+                itWriter.println """
+                echo \$defaultJvmOpts
+                echo \${classpath}
+                echo \$myprop
+                """
+            }
+        }
+
+        file("src/main/java/Ok.java").with {
+            createFile()
+            withWriter { itWriter ->
+                itWriter.println """
+                public class Ok {
+                    public static void main(String[] args) {
+                        System.out.println("Ok!");
+                    }
+                }
+                """
+            }
+        }
+    }
+
+    def checkDefaultDistribution() {
+        when:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'application'
+
+            mainClassName = 'Ok'
+            applicationDistribution.with {
+                into('config') {
+                    from(processResources) {
+                        includeEmptyDirs = false
+                    }
+                    exclude('scripts')
+                }
+            }
+
+            """
+        then:
+        succeeds('distZip')
+        and:
+        file('build/distributions/AppPluginTestProject.zip').usingNativeTools().unzipTo(file("unzip"))
+        file("unzip/AppPluginTestProject/bin/AppPluginTestProject.bat").assertIsFile()
+        file("unzip/AppPluginTestProject/bin/AppPluginTestProject").assertIsFile()
+        file("unzip/AppPluginTestProject/lib/AppPluginTestProject.jar").assertIsFile()
+        file("unzip/AppPluginTestProject/config/config.xml").assertIsFile()
+        file("unzip/AppPluginTestProject/read.me").assertIsFile()
+    }
+
+    def checkAlteredDistribution() {
+        when:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin:'application'
+
+            applicationBinDir = '.'
+            applicationDistribution.with {
+                into('config') {
+                    from(processResources) {
+                        includeEmptyDirs = false
+                    }
+                }
+                exclude('scripts')
+            }
+
+            startScripts {
+                mainClassName = 'Ok'
+                classpath += files('config')
+            }
+
+            """
+        then:
+        succeeds('distZip')
+        and:
+        file('build/distributions/AppPluginTestProject.zip').usingNativeTools().unzipTo(file("unzip"))
+        def winScript = file("unzip/AppPluginTestProject/AppPluginTestProject.bat")
+        winScript.assertIsFile()
+        winScript.text =~ /(?m)CLASSPATH=.*?%APP_HOME%\\config/
+        def nixScript = file("unzip/AppPluginTestProject/AppPluginTestProject")
+        nixScript.assertIsFile()
+        nixScript.text =~ /(?m)CLASSPATH=.*?APP_HOME\/config/
+        file("unzip/AppPluginTestProject/lib/AppPluginTestProject.jar").assertIsFile()
+        file("unzip/AppPluginTestProject/config/config.xml").assertIsFile()
+        file("unzip/AppPluginTestProject/read.me").assertIsFile()
+    }
+
+    def checkCustomScriptDistribution() {
+        when:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin:'application'
+
+            applicationBinDir = '.'
+            applicationDistribution.with {
+                into('config') {
+                    from(processResources) {
+                        includeEmptyDirs = false
+                    }
+                }
+                exclude('scripts')
+            }
+
+            startScripts {
+                mainClassName = 'Ok'
+                classpath += files('config')
+                token 'myprop', 'myvalue'
+                unixStartScripts.from('src/main/resources/scripts') {
+                    exclude('myscript.bat')
+                }
+            }
+
+            """
+        then:
+        succeeds('distZip')
+        and:
+        file('build/distributions/AppPluginTestProject.zip').usingNativeTools().unzipTo(file("unzip"))
+        def winScript = file("unzip/AppPluginTestProject/AppPluginTestProject.bat")
+        winScript.assertIsFile()
+        winScript.text =~ /(?m)CLASSPATH=.*?%APP_HOME%\\config/
+        def nixScript = file("unzip/AppPluginTestProject/AppPluginTestProject")
+        nixScript.assertIsFile()
+        nixScript.text =~ /(?m)CLASSPATH=.*?APP_HOME\/config/
+        file("unzip/AppPluginTestProject/myscript.bat").assertDoesNotExist()
+        def nixMyScript = file("unzip/AppPluginTestProject/myscript")
+        nixMyScript.assertIsFile()
+        nixMyScript.text =~ /echo myvalue/
+        file("unzip/AppPluginTestProject/lib/AppPluginTestProject.jar").assertIsFile()
+        file("unzip/AppPluginTestProject/config/config.xml").assertIsFile()
+        file("unzip/AppPluginTestProject/config/scripts/myscript").assertDoesNotExist()
+        file("unzip/AppPluginTestProject/read.me").assertIsFile()
+    }
+
+    def checkCustomTokenNotFound() {
+        when:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin:'application'
+
+            applicationBinDir = '.'
+            applicationDistribution.with {
+                into('config') {
+                    from(processResources) {
+                        includeEmptyDirs = false
+                    }
+                }
+                exclude('scripts')
+            }
+
+            startScripts {
+                mainClassName = 'Ok'
+                classpath += files('config')
+                //token 'myprop', 'myvalue' //myprop is expected but not given
+                unixStartScripts.from('src/main/resources/scripts') {
+                    exclude('myscript.bat')
+                }
+            }
+
+            """
+        then:
+        fails('distZip')
+    }
+
+    def checkNotEscapingDistribution() {
+        when:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin:'application'
+
+            applicationBinDir = '.'
+            applicationDistribution.with {
+                into('config') {
+                    from(processResources) {
+                        includeEmptyDirs = false
+                    }
+                }
+                exclude('scripts')
+            }
+
+            startScripts {
+                mainClassName = 'Ok'
+                defaultJvmOpts = ['-Dmyopt=']
+                quoteJvmOpts { system, jvmOpt ->
+                    switch(jvmOpt) {
+                        case '-Dmyopt=': return system.equals('nix') ? (jvmOpt + '\$MY_ENV_VAR') : (jvmOpt + '%MY_ENV_VAR%')
+                        default: return jvmOpt
+                    }
+                }
+                token 'myprop', 'myvalue'
+                classpath += files('config')
+                windowsStartScripts.from('src/main/resources/scripts') {
+                    exclude('myscript')
+                }
+                unixStartScripts.from('src/main/resources/scripts') {
+                    exclude('myscript.bat')
+                }
+            }
+
+            """
+        then:
+        succeeds('distZip')
+        and:
+        file('build/distributions/AppPluginTestProject.zip').usingNativeTools().unzipTo(file("unzip"))
+        def winScript = file("unzip/AppPluginTestProject/AppPluginTestProject.bat")
+        winScript.assertIsFile()
+        winScript.text =~ /(?m)CLASSPATH=.*?%APP_HOME%\\config/
+        def nixScript = file("unzip/AppPluginTestProject/AppPluginTestProject")
+        nixScript.assertIsFile()
+        nixScript.text =~ /(?m)CLASSPATH=.*?APP_HOME\/config/
+        def nixMyScript = file("unzip/AppPluginTestProject/myscript")
+        nixMyScript.assertIsFile()
+        nixMyScript.text =~ '-Dmyopt=\\$MY_ENV_VAR'
+        def winMyScript = file("unzip/AppPluginTestProject/myscript.bat")
+        winMyScript.assertIsFile()
+        winMyScript.text =~ /-Dmyopt=%MY_ENV_VAR%/
+        file("unzip/AppPluginTestProject/lib/AppPluginTestProject.jar").assertIsFile()
+        file("unzip/AppPluginTestProject/config/config.xml").assertIsFile()
+        file("unzip/AppPluginTestProject/config/scripts/myscript").assertDoesNotExist()
+        file("unzip/AppPluginTestProject/read.me").assertIsFile()
+    }
+
+    def checkExcludeDefaultScripts() {
+        when:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin:'application'
+
+            applicationBinDir = '.'
+            applicationDistribution.with {
+                into('config') {
+                    from(processResources) {
+                        includeEmptyDirs = false
+                    }
+                }
+                exclude('scripts')
+            }
+
+            startScripts {
+                mainClassName = 'Ok'
+                defaultJvmOpts = ['-Dmyopt=']
+                quoteJvmOpts { system, jvmOpt ->
+                    switch(jvmOpt) {
+                        case '-Dmyopt=': return system.equals('nix') ? (jvmOpt + '\$MY_ENV_VAR') : (jvmOpt + '%MY_ENV_VAR%')
+                        default: return jvmOpt
+                    }
+                }
+                token 'myprop', 'myvalue'
+                classpath += files('config')
+                windowsStartScripts.from('src/main/resources/scripts') {
+                    exclude('myscript')
+                }
+                windowsStartScripts.exclude('**/windowsStartScript.txt')
+                unixStartScripts.from('src/main/resources/scripts') {
+                    exclude('myscript.bat')
+                }
+                unixStartScripts.exclude('**/unixStartScript.txt')
+            }
+
+            """
+        then:
+        succeeds('distZip')
+        and:
+        file('build/distributions/AppPluginTestProject.zip').usingNativeTools().unzipTo(file("unzip"))
+        file("unzip/AppPluginTestProject/AppPluginTestProject.bat").assertDoesNotExist()
+        file("unzip/AppPluginTestProject/AppPluginTestProject").assertDoesNotExist()
+        def nixMyScript = file("unzip/AppPluginTestProject/myscript")
+        nixMyScript.assertIsFile()
+        nixMyScript.text =~ '-Dmyopt=\\$MY_ENV_VAR'
+        def winMyScript = file("unzip/AppPluginTestProject/myscript.bat")
+        winMyScript.assertIsFile()
+        winMyScript.text =~ /-Dmyopt=%MY_ENV_VAR%/
+        file("unzip/AppPluginTestProject/lib/AppPluginTestProject.jar").assertIsFile()
+        file("unzip/AppPluginTestProject/config/config.xml").assertIsFile()
+        file("unzip/AppPluginTestProject/config/scripts/myscript").assertDoesNotExist()
+        file("unzip/AppPluginTestProject/read.me").assertIsFile()
+    }
+
+}

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/ApplicationPlugin.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/ApplicationPlugin.groovy
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.plugins
 
+import org.apache.commons.lang.StringUtils
+import org.apache.tools.ant.filters.BaseFilterReader
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -22,10 +24,13 @@ import org.gradle.api.Task
 import org.gradle.api.distribution.Distribution
 import org.gradle.api.distribution.plugins.DistributionPlugin
 import org.gradle.api.file.CopySpec
+import org.gradle.api.internal.plugins.StartScriptGenerator
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.application.CreateStartScripts
 import org.gradle.util.DeprecationLogger
+import org.gradle.util.TextUtil
 
 /**
  * <p>A {@link Plugin} which runs a project as a Java Application.</p>
@@ -40,6 +45,12 @@ class ApplicationPlugin implements Plugin<Project> {
     static final String TASK_INSTALL_NAME = "installApp"
     static final String TASK_DIST_ZIP_NAME = "distZip"
     static final String TASK_DIST_TAR_NAME = "distTar"
+
+    /**
+     * The name of the application.
+     */
+    public static final String DEFAULT_UNIX_TEMPLATE = 'unixStartScript.txt'
+    public static final String DEFAULT_WINDOWS_TEMPLATE = 'windowsStartScript.txt'
 
     private Project project
     private ApplicationPluginConvention pluginConvention
@@ -63,9 +74,11 @@ class ApplicationPlugin implements Plugin<Project> {
     void configureInstallTasks(Task... installTasks) {
         installTasks.each { installTask ->
             installTask.doFirst {
+                String resolvedBinDir = pluginConvention.applicationBinDir
+                String resolvedLibDir = pluginConvention.applicationLibDir
                 if (destinationDir.directory) {
-                    if (!new File(destinationDir, 'lib').directory || !new File(destinationDir, 'bin').directory) {
-                        throw new GradleException("The specified installation directory '${destinationDir}' is neither empty nor does it contain an installation for '${pluginConvention.applicationName}'.\n" +
+                    if (!new File(destinationDir, resolvedLibDir).directory || !new File(destinationDir, resolvedBinDir).directory) {
+                        throw new StopExecutionException("The specified installation directory '${destinationDir}' is neither empty nor does it contain an installation for '${pluginConvention.applicationName}'.\n" +
                                 "If you really want to install to this directory, delete it and run the install task again.\n" +
                                 "Alternatively, choose a different installation directory."
                         )
@@ -73,7 +86,8 @@ class ApplicationPlugin implements Plugin<Project> {
                 }
             }
             installTask.doLast {
-                project.ant.chmod(file: "${destinationDir.absolutePath}/bin/${pluginConvention.applicationName}", perm: 'ugo+x')
+                String resolvedBinDir = pluginConvention.applicationBinDir
+                project.ant.chmod(file: "${destinationDir.absolutePath}/${StringUtils.isBlank(resolvedBinDir) || ".".equals(resolvedBinDir) ? '' : resolvedBinDir + '/'}${pluginConvention.applicationName}", perm: 'ugo+x')
             }
         }
     }
@@ -93,7 +107,6 @@ class ApplicationPlugin implements Plugin<Project> {
         run.conventionMapping.jvmArgs = { pluginConvention.applicationDefaultJvmArgs }
     }
 
-    // @Todo: refactor this task configuration to extend a copy task and use replace tokens
     private void addCreateScriptsTask() {
         def startScripts = project.tasks.create(TASK_START_SCRIPTS_NAME, CreateStartScripts)
         startScripts.description = "Creates OS specific scripts to run the project as a JVM application."
@@ -102,6 +115,31 @@ class ApplicationPlugin implements Plugin<Project> {
         startScripts.conventionMapping.applicationName = { pluginConvention.applicationName }
         startScripts.conventionMapping.outputDir = { new File(project.buildDir, 'scripts') }
         startScripts.conventionMapping.defaultJvmOpts = { pluginConvention.applicationDefaultJvmArgs }
+
+        startScripts.into({startScripts.getOutputDir()})
+        startScripts.unixStartScripts = project.copySpec {
+            from([StartScriptGenerator.getResource(DEFAULT_UNIX_TEMPLATE).getFile()] as Object[])
+        }
+
+        startScripts.unixStartScripts.filter([createStartScripts: startScripts] /*it's important to pass the task itself, to allow parameter customization; parameter name complies with setCreateStartScripts method of the filter class*/, LazyNixStartScriptGeneratorAdapter)
+        startScripts.unixStartScripts.rename { filename ->
+            DEFAULT_UNIX_TEMPLATE.equals(filename) ? pluginConvention.applicationName : filename
+        }
+
+        startScripts.with(startScripts.unixStartScripts)
+
+
+        startScripts.windowsStartScripts = project.copySpec {
+            from([StartScriptGenerator.getResource(DEFAULT_WINDOWS_TEMPLATE).getFile()] as Object[])
+        }
+
+        startScripts.windowsStartScripts.filter([createStartScripts: startScripts] /*it's important to pass the task itself, to allow parameter customization; parameter name complies with setCreateStartScripts method of the filter class*/, LazyWindowsStartScriptGeneratorAdapter)
+        startScripts.windowsStartScripts.rename { filename ->
+            DEFAULT_WINDOWS_TEMPLATE.equals(filename) ? "${pluginConvention.applicationName}.bat" : filename
+        }
+
+        startScripts.with(startScripts.windowsStartScripts)
+
     }
 
     private Task addInstallAppTask(Distribution distribution) {
@@ -123,17 +161,133 @@ class ApplicationPlugin implements Plugin<Project> {
         distSpec.with {
             from(project.file("src/dist"))
 
-            into("lib") {
+            into({
+                String resolvedLibDir = pluginConvention.applicationLibDir
+                StringUtils.isBlank(resolvedLibDir) || ".".equals(resolvedLibDir) ? '' : resolvedLibDir //enabling lib dir renaming and complete omitting
+            }) {
                 from(jar)
                 from(project.configurations.runtime)
             }
-            into("bin") {
+
+            into({
+                String resolvedBinDir = pluginConvention.applicationBinDir
+                StringUtils.isBlank(resolvedBinDir) || ".".equals(resolvedBinDir) ? '' : resolvedBinDir //enabling bin dir renaming and complete omitting
+            }) {
                 from(startScripts)
                 fileMode = 0755
             }
         }
+
         distSpec.with(pluginConvention.applicationDistribution)
 
         distSpec
+    }
+
+    static class LazyWindowsStartScriptGeneratorAdapter extends LazyNixStartScriptGeneratorAdapter {
+
+        /**
+         * Creates a new filtered reader.
+         *
+         * @param enclosing @param reader a Reader object providing the underlying stream.
+         * @throws NullPointerException if <code>in</code> is <code>null</code>
+         */
+        public LazyWindowsStartScriptGeneratorAdapter(Reader reader) {
+            super(reader)
+            lineSeparator = TextUtil.windowsLineSeparator
+        }
+
+        @Override
+        protected Map<String, String> makeTokens() {
+            generator.getWindowsScriptBindings(quoteJvmOptsClosure != null ? generator.defaultJvmOpts.collect{ quoteJvmOptsClosure('win', it) } : generator.getWindowsQuotedJvmOpts())
+        }
+    }
+
+    static class LazyNixStartScriptGeneratorAdapter extends BaseFilterReader {
+
+        private static final int EOF = -1;
+
+        private char[] buffer;
+        private int index;
+        protected final generator = new StartScriptGenerator()
+
+        protected Map<String, String> tokens
+        protected Closure<String> quoteJvmOptsClosure
+
+        protected String lineSeparator
+
+        /**
+         * Creates a new filtered reader.
+         *
+         * @param reader a Reader object providing the underlying stream.
+         * @throws NullPointerException if <code>in</code> is <code>null</code>
+         */
+        public LazyNixStartScriptGeneratorAdapter(Reader reader) {
+            super(reader);
+            lineSeparator = TextUtil.unixLineSeparator
+        }
+
+        public void setCreateStartScripts(CreateStartScripts startScripts) {
+            def pluginCovnention = startScripts.project.convention.plugins.application
+            def resolvedBinDir = pluginCovnention.applicationBinDir
+            def resolvedLibDir = pluginCovnention.applicationLibDir
+            generator.applicationName = startScripts.getApplicationName()
+            generator.scriptRelPath = "${getRelPath(resolvedBinDir)}$generator.applicationName"
+            generator.classpath = startScripts.classpath.getFiles().collect { it.name =~ /\.jar/ ? "${getRelPath(resolvedLibDir)}${it.name}" : "${it.name}" } //allowing non-jar classpath entries to be added as is (e.g. directories)
+            generator.optsEnvironmentVar = startScripts.getOptsEnvironmentVar()
+            generator.exitEnvironmentVar = startScripts.getExitEnvironmentVar()
+            generator.mainClassName = startScripts.getMainClassName()
+            generator.defaultJvmOpts = startScripts.getDefaultJvmOpts()
+            if (startScripts.quoteJvmOptsClosure) {
+                this.quoteJvmOptsClosure = startScripts.quoteJvmOptsClosure
+            }
+
+            this.tokens = startScripts.tokens
+            if (tokens != null && !tokens.isEmpty()) {
+                tokens.putAll(makeTokens()) //overriding in case someone chosen some token names we already use
+            } else {
+                this.tokens = makeTokens()
+            }
+        }
+
+        String getRelPath(String aDir) {
+            return !StringUtils.isBlank(aDir) && !aDir.equals(".") ? "$aDir/" : ""
+        }
+
+
+        protected Map<String, String> makeTokens() {
+            generator.getUnixScriptBindings(quoteJvmOptsClosure != null ? /*passing into a given closure*/ generator.defaultJvmOpts.collect{ quoteJvmOptsClosure('nix', it) } : generator.getUnixQuotedJvmOpts())
+        }
+
+        /**
+         * Returns the next character in the filtered stream. The original
+         * stream is first read in fully, and the tokens are expanded via SimpleTemplateEngine
+         * The results of this expansion are then queued so they can be read
+         * character-by-character.
+         *
+         * @return the next character in the resulting stream, or -1
+         * if the end of the resulting stream has been reached
+         *
+         * @exception IOException if the underlying stream throws an IOException
+         * during reading
+         */
+        public int read() throws IOException {
+            if (index > EOF) {
+                if (buffer == null) {
+                    String data = readFully();
+                    try {
+                        def nativeOutput = generator.generateNativeOutputFromText(data, tokens, lineSeparator)
+                        buffer = nativeOutput == null ? new char[0]
+                                : nativeOutput.toString().toCharArray();
+                    } catch (MissingPropertyException mpe) {
+                        throw new GradleException("Property ${mpe.property} is expected but not supplied for current template", mpe)
+                    }
+                }
+                if (index < buffer.length) {
+                    return buffer[index++];
+                }
+                index = EOF;
+            }
+            return EOF;
+        }
     }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/ApplicationPluginConvention.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/ApplicationPluginConvention.groovy
@@ -22,9 +22,12 @@ import org.gradle.api.file.CopySpec
  * <p>A {@link Convention} used for the ApplicationPlugin.</p>
  */
 class ApplicationPluginConvention {
+
     /**
-     * The name of the application.
+     * Application name to use in generated run scripts
+     * Defaults to project.name
      */
+
     String applicationName
 
     /**
@@ -54,6 +57,21 @@ class ApplicationPluginConvention {
      * into the "{@code lib}" directory.
      */
     CopySpec applicationDistribution
+
+    /**
+     * Allows you to customize name of the lib directory inside the distribution
+     * Making it blank or '.' will mean to put them under root of the distribution
+     *
+     */
+
+    String applicationLibDir = 'lib'
+
+    /**
+     * Allows you to customize name of the bin directory inside the distribution
+     * Making it blank or '.' will mean to put them under root of the distribution
+     *
+     */
+    String applicationBinDir = 'bin'
 
     final Project project
 

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/application/CreateStartScripts.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/application/CreateStartScripts.groovy
@@ -15,16 +15,15 @@
  */
 package org.gradle.api.tasks.application
 
+import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.ConventionTask
-import org.gradle.api.internal.plugins.StartScriptGenerator
 import org.gradle.api.tasks.*
 import org.gradle.util.GUtil
 
 /**
  * <p>A {@link org.gradle.api.Task} for creating OS dependent start scripts.</p>
  */
-public class CreateStartScripts extends ConventionTask {
+public class CreateStartScripts extends Copy {
 
     /**
      * The directory to write the scripts into.
@@ -61,6 +60,82 @@ public class CreateStartScripts extends ConventionTask {
     FileCollection classpath
 
     /**
+     * A spec for making unix scripts
+     * By default contains 'unixStartScript.txt' template, which you can exclude if you wish
+     * By default a StartScriptGenerator-based filter is applied for all of the templates
+     * You can add your custom templates via CopySpec.from
+     * You can add your own filters (they won't get same parameters as the default one though) and stuff like in usual CopySpec
+     *
+     * <p> Examples
+     * <pre autoTested='true'>
+     *  startScripts {
+     *      unixStartScripts.from('src/main/resources/scripts') {
+     *          exclude('myscript.bat')
+     *      }
+     *      unixStartScripts.exclude('**&#47unixStartScript.txt')
+     *  }
+     * </pre>
+     */
+    CopySpec unixStartScripts
+
+    /**
+     * A spec for making windows scripts
+     * By default contains 'windowsStartScript.txt' template, which you can exclude if you wish
+     * By default a StartScriptGenerator-based filter is applied for all of the templates
+     * You can add your custom templates via CopySpec.from
+     * You can add your own filters (they won't get same parameters as the default one though) and stuff like in usual CopySpec
+     *
+     * <p> Examples
+     * <pre autoTested='true'>
+     *  startScripts {
+     *      windowsStartScripts.from('src/main/resources/scripts') {
+     *          exclude('myscript')
+     *      }
+     *      windowsStartScripts.exclude('**&#windowsStartScript.txt')
+     *  }
+     * </pre>
+     */
+    CopySpec windowsStartScripts
+
+    Closure quoteJvmOptsClosure
+
+    Map<String, String> tokens = [:]
+
+    /**
+     *
+     * A convenient method for adding extra tokens for the ReplaceToken filter (in case if you need some extras in your custom template)
+     *
+     * @param name
+     * @param value
+     */
+    public void token(String name, String value) {
+        tokens.put(name, value)
+    }
+
+    /**
+     *
+     * This method allows you to specify your own quoting for the JVM opts.
+     * You might need this if you want to pass an environment variable as a value for some JVM option
+     * Would be called on each JVM opt specified
+     * <p> Examples:
+     * <pre autoTested='true'>
+     * startScripts {
+     *  defaultJvmOpts = ['-Dmyopt=']
+     *  quoteJvmOpts { system, jvmOpt ->
+     *     switch(jvmOpt) {
+     *      case '-Dmyopt=': return system.equals('nix') ? (jvmOpt + '\$MY_ENV_VAR') : (jvmOpt + '%MY_ENV_VAR%')
+     *      default: return jvmOpt
+     *     }
+     *  }
+     * }
+     * < /pre>
+     * @param closure system (one of 'nix' or 'win') and a current jvm opt would be passed into
+     */
+    public void quoteJvmOpts(Closure closure) {
+        this.quoteJvmOptsClosure = closure //keeping original delegate
+    }
+
+    /**
      * Returns the name of the application's OPTS environment variable.
      */
     @Input
@@ -85,27 +160,4 @@ public class CreateStartScripts extends ConventionTask {
         return "${GUtil.toConstant(getApplicationName())}_EXIT_CONSOLE"
     }
 
-    @OutputFile
-    File getUnixScript() {
-        return new File(getOutputDir(), getApplicationName())
-    }
-
-    @OutputFile
-    File getWindowsScript() {
-        return new File(getOutputDir(), "${getApplicationName()}.bat")
-    }
-
-    @TaskAction
-    void generate() {
-        def generator = new StartScriptGenerator()
-        generator.applicationName = getApplicationName()
-        generator.mainClassName = getMainClassName()
-        generator.defaultJvmOpts = getDefaultJvmOpts()
-        generator.optsEnvironmentVar = getOptsEnvironmentVar()
-        generator.exitEnvironmentVar = getExitEnvironmentVar()
-        generator.classpath = getClasspath().collect { "lib/${it.name}" }
-        generator.scriptRelPath = "bin/${getUnixScript().name}"
-        generator.generateUnixScript(getUnixScript())
-        generator.generateWindowsScript(getWindowsScript())
-    }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
@@ -65,6 +65,9 @@ class ApplicationPluginTest extends Specification {
         task.applicationName == project.applicationName
         task.outputDir == project.file('build/scripts')
         task.defaultJvmOpts == []
+        task.windowsStartScripts != null
+        task.unixStartScripts != null
+        task.quoteJvmOptsClosure == null
     }
 
     public void "adds installApp task to project with default target"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/StartScriptGeneratorAdapterTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/StartScriptGeneratorAdapterTest.groovy
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.gradle.api.plugins
+
+import org.gradle.api.Project
+import org.gradle.api.internal.plugins.StartScriptGenerator
+import org.gradle.api.tasks.application.CreateStartScripts
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+import org.gradle.util.TextUtil
+
+class StartScriptGeneratorAdapterTest extends Specification {
+
+    public static final String WINDOWS_TEMPLATE_TEXT = StartScriptGenerator.getResource(ApplicationPlugin.DEFAULT_WINDOWS_TEMPLATE).getText()
+    public static final String NIX_TEMPLATE_TEXT = StartScriptGenerator.getResource(ApplicationPlugin.DEFAULT_UNIX_TEMPLATE).getText()
+
+    def "classpath for unix script uses slashes as path separator"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.setClasspath(project.files("Jar.jar"))
+        ApplicationPlugin.LazyNixStartScriptGeneratorAdapter nixAdapter = new ApplicationPlugin.LazyNixStartScriptGeneratorAdapter(new StringReader(NIX_TEMPLATE_TEXT))
+        nixAdapter.setCreateStartScripts(startScripts)
+        when:
+        String unixScriptContent = nixAdapter.getText()
+        then:
+        unixScriptContent.contains("CLASSPATH=\$APP_HOME/lib/Jar.jar")
+    }
+
+
+    def "unix script uses unix line separator"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        ApplicationPlugin.LazyNixStartScriptGeneratorAdapter nixAdapter = new ApplicationPlugin.LazyNixStartScriptGeneratorAdapter(new StringReader(NIX_TEMPLATE_TEXT))
+        nixAdapter.setCreateStartScripts(startScripts)
+        when:
+        String unixScriptContent = nixAdapter.getText()
+        then:
+        unixScriptContent.split(TextUtil.windowsLineSeparator).length == 1
+        unixScriptContent.split(TextUtil.unixLineSeparator).length == 164
+    }
+
+    def "classpath for windows script uses backslash as path separator and windows line separator"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.setClasspath(project.files("Jar.jar"))
+        ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter winAdapter = new ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter(new StringReader(WINDOWS_TEMPLATE_TEXT))
+        winAdapter.setCreateStartScripts(startScripts)
+        when:
+        String windowsScriptContent = winAdapter.getText()
+        then:
+        windowsScriptContent.contains("set CLASSPATH=%APP_HOME%\\lib\\Jar.jar")
+        windowsScriptContent.split(TextUtil.windowsLineSeparator).length == 90
+    }
+
+    def "windows script uses windows line separator"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter winAdapter = new ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter(new StringReader(WINDOWS_TEMPLATE_TEXT))
+        winAdapter.setCreateStartScripts(startScripts)
+        when:
+        String windowsScriptContent = winAdapter.getText()
+        then:
+        windowsScriptContent.split(TextUtil.windowsLineSeparator).length == 90
+    }
+
+    def "defaultJvmOpts is expanded properly in windows script"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.defaultJvmOpts = ['-Dfoo=bar', '-Xint']
+        ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter winAdapter = new ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter(new StringReader(WINDOWS_TEMPLATE_TEXT))
+        winAdapter.setCreateStartScripts(startScripts)
+        when:
+        String windowsScriptContent = winAdapter.getText()
+        then:
+        windowsScriptContent.contains('set DEFAULT_JVM_OPTS="-Dfoo=bar" "-Xint"')
+    }
+
+    def "defaultJvmOpts is expanded properly in windows script -- spaces"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.defaultJvmOpts = ['-Dfoo=bar baz', '-Xint']
+        ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter winAdapter = new ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter(new StringReader(WINDOWS_TEMPLATE_TEXT))
+        winAdapter.setCreateStartScripts(startScripts)
+        when:
+        String windowsScriptContent = winAdapter.getText()
+        then:
+        windowsScriptContent.contains(/set DEFAULT_JVM_OPTS="-Dfoo=bar baz" "-Xint"/)
+    }
+
+    def "defaultJvmOpts is expanded properly in windows script -- double quotes"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.defaultJvmOpts = ['-Dfoo=b"ar baz', '-Xi""nt', '-Xpatho\\"logical']
+        ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter winAdapter = new ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter(new StringReader(WINDOWS_TEMPLATE_TEXT))
+        winAdapter.setCreateStartScripts(startScripts)
+        when:
+        String windowsScriptContent = winAdapter.getText()
+        then:
+        windowsScriptContent.contains(/set DEFAULT_JVM_OPTS="-Dfoo=b\"ar baz" "-Xi\"\"nt" "-Xpatho\\\"logical"/)
+    }
+
+    def "defaultJvmOpts is expanded properly in windows script -- backslashes and shell metacharacters"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.defaultJvmOpts = ['-Dfoo=b\\ar baz', '-Xint%PATH%']
+        ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter winAdapter = new ApplicationPlugin.LazyWindowsStartScriptGeneratorAdapter(new StringReader(WINDOWS_TEMPLATE_TEXT))
+        winAdapter.setCreateStartScripts(startScripts)
+        when:
+        String windowsScriptContent = winAdapter.getText()
+        then:
+        windowsScriptContent.contains(/set DEFAULT_JVM_OPTS="-Dfoo=b\ar baz" "-Xint%%PATH%%"/)
+    }
+
+    def "defaultJvmOpts is expanded properly in unix script"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.defaultJvmOpts = ['-Dfoo=bar', '-Xint']
+        ApplicationPlugin.LazyNixStartScriptGeneratorAdapter nixAdapter = new ApplicationPlugin.LazyNixStartScriptGeneratorAdapter(new StringReader(NIX_TEMPLATE_TEXT))
+        nixAdapter.setCreateStartScripts(startScripts)
+        when:
+        String unixScriptContent = nixAdapter.getText()
+        then:
+        unixScriptContent.contains('DEFAULT_JVM_OPTS=\'"-Dfoo=bar" "-Xint"\'')
+    }
+
+    def "defaultJvmOpts is expanded properly in unix script -- spaces"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.defaultJvmOpts = ['-Dfoo=bar baz', '-Xint']
+        ApplicationPlugin.LazyNixStartScriptGeneratorAdapter nixAdapter = new ApplicationPlugin.LazyNixStartScriptGeneratorAdapter(new StringReader(NIX_TEMPLATE_TEXT))
+        nixAdapter.setCreateStartScripts(startScripts)
+        when:
+        String unixScriptContent = nixAdapter.getText()
+        then:
+        unixScriptContent.contains(/DEFAULT_JVM_OPTS='"-Dfoo=bar baz" "-Xint"'/)
+    }
+
+    def "defaultJvmOpts is expanded properly in unix script -- double quotes"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.defaultJvmOpts = ['-Dfoo=b"ar baz', '-Xi""nt']
+        ApplicationPlugin.LazyNixStartScriptGeneratorAdapter nixAdapter = new ApplicationPlugin.LazyNixStartScriptGeneratorAdapter(new StringReader(NIX_TEMPLATE_TEXT))
+        nixAdapter.setCreateStartScripts(startScripts)
+        when:
+        String unixScriptContent = nixAdapter.getText()
+        then:
+        unixScriptContent.contains(/DEFAULT_JVM_OPTS='"-Dfoo=b\"ar baz" "-Xi\"\"nt"'/)
+    }
+
+    def "defaultJvmOpts is expanded properly in unix script -- single quotes"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.defaultJvmOpts = ['-Dfoo=b\'ar baz', '-Xi\'\'n`t']
+        ApplicationPlugin.LazyNixStartScriptGeneratorAdapter nixAdapter = new ApplicationPlugin.LazyNixStartScriptGeneratorAdapter(new StringReader(NIX_TEMPLATE_TEXT))
+        nixAdapter.setCreateStartScripts(startScripts)
+        when:
+        String unixScriptContent = nixAdapter.getText()
+        then:
+        unixScriptContent.contains(/DEFAULT_JVM_OPTS='"-Dfoo=b'"'"'ar baz" "-Xi'"'"''"'"'n'"`"'t"'/)
+    }
+
+    def "defaultJvmOpts is expanded properly in unix script -- backslashes and shell metacharacters"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        startScripts.defaultJvmOpts = ['-Dfoo=b\\ar baz', '-Xint$PATH']
+        ApplicationPlugin.LazyNixStartScriptGeneratorAdapter nixAdapter = new ApplicationPlugin.LazyNixStartScriptGeneratorAdapter(new StringReader(NIX_TEMPLATE_TEXT))
+        nixAdapter.setCreateStartScripts(startScripts)
+        when:
+        String unixScriptContent = nixAdapter.getText()
+        then:
+        unixScriptContent.contains(/DEFAULT_JVM_OPTS='"-Dfoo=b\\ar baz" "-Xint/ + '\\$PATH' + /"'/)
+    }
+
+    def "defaultJvmOpts is expanded properly in unix script -- empty list"() {
+        given:
+        Project project = TestUtil.createRootProject()
+        ApplicationPlugin plugin = new ApplicationPlugin()
+        plugin.apply(project)
+        ApplicationPluginConvention pluginConvention = project.convention.plugins.application
+        CreateStartScripts startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        pluginConvention.applicationName = "TestApp"
+        ApplicationPlugin.LazyNixStartScriptGeneratorAdapter nixAdapter = new ApplicationPlugin.LazyNixStartScriptGeneratorAdapter(new StringReader(NIX_TEMPLATE_TEXT))
+        nixAdapter.setCreateStartScripts(startScripts)
+        when:
+        String unixScriptContent = nixAdapter.getText()
+        then:
+        unixScriptContent.contains(/DEFAULT_JVM_OPTS=""/)
+    }
+}

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/application/CreateStartScriptsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/application/CreateStartScriptsTest.groovy
@@ -21,16 +21,6 @@ import org.gradle.util.TestUtil
 class CreateStartScriptsTest extends Specification {
     final CreateStartScripts task = TestUtil.createTask(CreateStartScripts.class)
 
-    def scriptNameDefaultsToApplicationName() {
-        task.outputDir = new File('output')
-
-        when:
-        task.applicationName = "myApp"
-
-        then:
-        task.unixScript == new File(task.outputDir, 'myApp')
-        task.windowsScript == new File(task.outputDir, 'myApp.bat')
-    }
     
     def optsEnvironmentVariableNameDefaultsToApplicationName() {
         when:


### PR DESCRIPTION
Hello,
Just thought it might be useful to make ApplicationPlugin configuration a bit easier. Basically, it's hard because the root spec in CopySpec is immutable in terms of the child specs manipulation. Say, if I want to have an application plugin structure other than 
````
/whatever
|-- /bin
|-- /lib
````
I can't do that without full replacement of installApp, distZip/Tar task and createStartScripts too due to hardcoded default applicationDistribution CopySpec. I've implemented another task which will take care of that re-configuration if it's configure closure is triggered. If the task is not there, then it falls back to the defaults like before the change.

E.g. the script before the proposed change (which is ok as a work around for installApp, but something like that would need to be done to distZip too):
````groovy
installApp {
	applicationDistribution.with copySpec {
		from(processResources) {
			includeEmptyDirs = false
		}
		from(startScripts) {
			fileMode = 0755
		}
	}

	if(project.hasProperty('installDir')) {
		destinationDir = new File(installDir)
		cleanInstallDir.delete destinationDir.getAbsolutePath()
		clean.dependsOn(':cleanInstallDir')
	}

	doLast {
		new File("${destinationDir.getAbsolutePath()}/bin").deleteDir()
	}

}

startScripts {
	mainClassName = "bla.bla.bla.Main"
	classpath += files('/config')

	doLast {
		def windowsScriptFile = file getWindowsScript()
		def unixScriptFile = file getUnixScript()
	 	windowsScriptFile.text = windowsScriptFile.text.replace('%APP_HOME%\\lib\\config', '%APP_HOME%\\config').replace('set APP_HOME=%DIRNAME%..','set APP_HOME=%DIRNAME%')
	 	unixScriptFile.text = unixScriptFile.text.replace('$APP_HOME/lib/config', '$APP_HOME/config').replace('cd "`dirname \\"$PRG\\"`/.." >&-','cd "`dirname \\"$PRG\\"`" >&-')
	}
}
````
And after:
````groovy
configureDist {
	applicationBinDir = "."
	applicationDistribution.with {
		from(processResources) {
			includeEmptyDirs = false

		}
	}
}

installApp {
	if(project.hasProperty('installDir')) {
		destinationDir = new File(installDir)
		cleanInstallDir.delete destinationDir.getAbsolutePath()
		clean.dependsOn(':cleanInstallDir')
	}
}

startScripts {
	mainClassName = "bla.bla.bla.Main"
	classpath += files('config')
}
````
The last bit with 'config' dir to classpath addition relates to GRADLE-2333