### PR TITLE
Use standard ivy layout pattern in ivy support

### DIFF
--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -59,7 +59,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         this.locallyAvailableResourceFinder = locallyAvailableResourceFinder;
         this.resolverStrategy = resolverStrategy;
         this.additionalPatternsLayout = new AdditionalPatternsRepositoryLayout(fileResolver);
-        this.layout = new GradleRepositoryLayout();
+        this.layout = new IvyRepositoryLayout();
         this.metaDataProvider = new MetaDataProvider();
         this.instantiator = instantiator;
     }

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/layout/IvyRepositoryLayout.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/layout/IvyRepositoryLayout.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories.layout;
+
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.resolver.PatternBasedResolver;
+
+import java.net.URI;
+
+/**
+ * A Repository Layout that applies the following patterns:
+ * <ul>
+ *     <li>Artifacts: $baseUri/{@value IvyArtifactRepository#IVY_ARTIFACT_PATTERN}</li>
+ *     <li>Ivy: $baseUri/{@value IvyArtifactRepository#IVY_IVY_PATTERN}</li>
+ * </ul>
+ */
+public class IvyRepositoryLayout extends RepositoryLayout {
+
+    public void apply(URI baseUri, PatternBasedResolver resolver) {
+        if (baseUri == null) {
+            return;
+        }
+
+        resolver.addArtifactLocation(baseUri, IvyArtifactRepository.IVY_ARTIFACT_PATTERN);
+        resolver.addDescriptorLocation(baseUri, IvyArtifactRepository.IVY_IVY_PATTERN);
+    }
+}

--- a/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -124,9 +124,31 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         repo.is(wrapper.resolver)
     }
 
+    def "uses ivy patterns with specified url and default layout"() {
+        repository.name = 'name'
+        repository.url = 'http://host'
+
+        given:
+        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        transportFactory.createTransport({ it == ['http'] as Set}, 'name', credentials) >> transport()
+
+        when:
+        def resolver = repository.createResolver()
+
+        then:
+        with(resolver) {
+            it instanceof IvyResolver
+            repository instanceof ExternalResourceRepository
+            name == 'name'
+            artifactPatterns == ['http://host/[organisation]/[module]/[revision]/[ext]s/[artifact](.[ext])']
+            ivyPatterns == ["http://host/[organisation]/[module]/[revision]/[artifact]s/[artifact](.[ext])"]
+        }
+    }
+
     def "uses gradle patterns with specified url and default layout"() {
         repository.name = 'name'
         repository.url = 'http://host'
+        repository.layout 'gradle'
 
         given:
         fileResolver.resolveUri('http://host') >> new URI('http://host/')
@@ -239,8 +261,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
             it instanceof IvyResolver
             repository instanceof ExternalResourceRepository
             name == 'name'
-            artifactPatterns == ['http://host/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])', 'http://host/[other]/artifact']
-            ivyPatterns == ["http://host/[organisation]/[module]/[revision]/ivy-[revision].xml", 'http://host/[other]/ivy']
+            artifactPatterns == ['http://host/[organisation]/[module]/[revision]/[ext]s/[artifact](.[ext])', 'http://host/[other]/artifact']
+            ivyPatterns == ["http://host/[organisation]/[module]/[revision]/[artifact]s/[artifact](.[ext])", 'http://host/[other]/ivy']
         }
     }
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -34,6 +34,9 @@ import java.net.URI;
  */
 public interface IvyArtifactRepository extends ArtifactRepository, AuthenticationSupported {
 
+    String IVY_ARTIFACT_PATTERN = "[organisation]/[module]/[revision]/[ext]s/[artifact](.[ext])";
+    String IVY_IVY_PATTERN = "[organisation]/[module]/[revision]/[artifact]s/[artifact](.[ext])";
+
     String GRADLE_ARTIFACT_PATTERN = "[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])";
     String GRADLE_IVY_PATTERN = "[organisation]/[module]/[revision]/ivy-[revision].xml";
 


### PR DESCRIPTION
Gradle's ivy-publish plugin uses a non-standard ivy layout pattern. I found a [mailing list post](http://gradle.1045684.n5.nabble.com/Standard-patterns-for-ivy-repositories-td4793222.html) where this feature was implemented and the developer asked if anyone knew if there was a standard layout. They weren't sure what the default ivy layout was and so used the maven layout. However, there is indeed a default ivy layout and it is different than the Maven layout. You can see the default ivy layout defined in [ivysettings-local.xml](http://grepcode.com/file/repository.springsource.com/org.apache.ant/com.springsource.org.apache.ivy/2.1.0/org/apache/ivy/core/settings/ivysettings-local.xml) except ivy has a [type] which gradle does not support so I had to replace it with [ext] and [artifact] in order to get the same result.

```
<property name="ivy.local.default.ivy.pattern"      value="[organisation]/[module]/[revision]/[type]s/[artifact].[ext]" override="false"/>
<property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact].[ext]" override="false"/>
```

The fact that Gradle does not properly implement this makes it very difficult to interoperate with other tools. I can fix it by specifying my own layout in my build file, but I've been frustrated having to specify this in all of my build files in order to get Gradle to work properly with other tools.
