### PR TITLE
Add ivy layout which uses standard ivy layout

### DIFF
--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -123,7 +123,9 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
     }
 
     public void layout(String layoutName) {
-        if ("maven".equals(layoutName)) {
+        if ("ivy".equals(layoutName)) {
+            layout = instantiator.newInstance(IvyRepositoryLayout.class);
+        } else if ("maven".equals(layoutName)) {
             layout = instantiator.newInstance(MavenRepositoryLayout.class);
         } else if ("pattern".equals(layoutName)) {
             layout = instantiator.newInstance(PatternRepositoryLayout.class);

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/layout/IvyRepositoryLayout.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/repositories/layout/IvyRepositoryLayout.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories.layout;
+
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.resolver.PatternBasedResolver;
+
+import java.net.URI;
+
+/**
+ * A Repository Layout that applies the following patterns:
+ * <ul>
+ *     <li>Artifacts: $baseUri/{@value IvyArtifactRepository#IVY_ARTIFACT_PATTERN}</li>
+ *     <li>Ivy: $baseUri/{@value IvyArtifactRepository#IVY_IVY_PATTERN}</li>
+ * </ul>
+ */
+public class IvyRepositoryLayout extends RepositoryLayout {
+
+    public void apply(URI baseUri, PatternBasedResolver resolver) {
+        if (baseUri == null) {
+            return;
+        }
+
+        resolver.addArtifactLocation(baseUri, IvyArtifactRepository.IVY_ARTIFACT_PATTERN);
+        resolver.addDescriptorLocation(baseUri, IvyArtifactRepository.IVY_IVY_PATTERN);
+    }
+}

--- a/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -124,6 +124,28 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         repo.is(wrapper.resolver)
     }
 
+    def "uses ivy patterns with specified url and default layout"() {
+        repository.name = 'name'
+        repository.url = 'http://host'
+        repository.layout 'ivy'
+
+        given:
+        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        transportFactory.createTransport({ it == ['http'] as Set}, 'name', credentials) >> transport()
+
+        when:
+        def resolver = repository.createResolver()
+
+        then:
+        with(resolver) {
+            it instanceof IvyResolver
+            repository instanceof ExternalResourceRepository
+            name == 'name'
+            artifactPatterns == ['http://host/[organisation]/[module]/[revision]/[ext]s/[artifact](.[ext])']
+            ivyPatterns == ["http://host/[organisation]/[module]/[revision]/[artifact]s/[artifact](.[ext])"]
+        }
+    }
+
     def "uses gradle patterns with specified url and default layout"() {
         repository.name = 'name'
         repository.url = 'http://host'

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -34,6 +34,9 @@ import java.net.URI;
  */
 public interface IvyArtifactRepository extends ArtifactRepository, AuthenticationSupported {
 
+    String IVY_ARTIFACT_PATTERN = "[organisation]/[module]/[revision]/[ext]s/[artifact](.[ext])";
+    String IVY_IVY_PATTERN = "[organisation]/[module]/[revision]/[artifact]s/[artifact](.[ext])";
+
     String GRADLE_ARTIFACT_PATTERN = "[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])";
     String GRADLE_IVY_PATTERN = "[organisation]/[module]/[revision]/ivy-[revision].xml";
 


### PR DESCRIPTION
Backwards compatible version of https://github.com/gradle/gradle/pull/265. Left the default as non-standard gradle layout for backwards compatibility, but highly recommend the default be changed for the next major version of gradle released as it's still very broken
