### PR TITLE
announce plugin: Don't run AppleScript if headless

### DIFF
--- a/subprojects/announce/src/integTest/groovy/org/gradle/api/plugins/announce/AnnouncePluginIntegrationTest.groovy
+++ b/subprojects/announce/src/integTest/groovy/org/gradle/api/plugins/announce/AnnouncePluginIntegrationTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins.announce
+
+import org.gradle.integtests.fixtures.WellBehavedPluginTest
+
+class AnnouncePluginIntegrationTest extends WellBehavedPluginTest {
+    private static String isHeadlessProperty
+
+    @Override
+    String getPluginId() {
+        return "announce"
+    }
+
+    @Override
+    String getMainTask() {
+        return "tasks"
+    }
+
+    void setupSpec() {
+        isHeadlessProperty = System.getProperty("java.awt.headless", "false")
+        System.setProperty("java.awt.headless", "true")
+    }
+
+    void cleanupSpec() {
+        System.setProperty("java.awt.headless", isHeadlessProperty)
+    }
+
+    def "does not blow up in headless mode when a local notification mechanism is not available"() {
+        buildFile << """
+apply plugin: 'java'
+apply plugin: 'build-announcements'
+"""
+
+        expect:
+        succeeds 'assemble'
+    }
+}

--- a/subprojects/announce/src/main/groovy/org/gradle/api/plugins/announce/internal/DefaultAnnouncerFactory.groovy
+++ b/subprojects/announce/src/main/groovy/org/gradle/api/plugins/announce/internal/DefaultAnnouncerFactory.groovy
@@ -57,7 +57,7 @@ class DefaultAnnouncerFactory implements AnnouncerFactory {
             case "snarl":
                 return new Snarl(iconProvider)
             case "growl":
-                if (JavaVersion.current().java6Compatible) {
+                if (JavaVersion.current().java6Compatible && !java.awt.GraphicsEnvironment.isHeadless()) {
                     try {
                         return getClass().getClassLoader().loadClass("org.gradle.api.plugins.announce.internal.jdk6.AppleScriptBackedGrowlAnnouncer").newInstance(iconProvider)
                     }


### PR DESCRIPTION
As discussed in [gradle-dev](http://gradle.1045684.n5.nabble.com/Announce-Plugin-amp-java-awt-headless-td5712593.html), running AppleScript with `java.awt.headless=true` causes build errors when using the announce plugin. This pull request makes us fall back to `GrowlNotifyBackedAnnouncer` when we're in headless mode and the `growl` announcer is requested.

I've just signed and sent the CLA. Let me know if I can do anything else to help! :)
