### PR TITLE
The 'gradle init' task should output files with sample buildscript

### DIFF
--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/build.gradle.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/build.gradle.template
@@ -11,6 +11,15 @@
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
 
+buildscript {
+    repositories {
+        mavenCentral() 
+    }
+
+    dependencies {
+    }
+}
+
 // In this section you declare where to find the dependencies of your project
 repositories {
     // Use 'maven central' for resolving your dependencies.

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javalibrary/build.gradle.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javalibrary/build.gradle.template
@@ -10,6 +10,15 @@
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
 
+buildscript {
+    repositories {
+        mavenCentral() 
+    }
+
+    dependencies {
+    }
+}
+
 // In this section you declare where to find the dependencies of your project
 repositories {
     // Use 'maven central' for resolving your dependencies.


### PR DESCRIPTION
This will speed up new project configuration by enabling developers to drop in dependencies with as little busy-work as possible.
