### PR TITLE
Distributions Plugin install*Dist cannot be re-run

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
@@ -27,6 +27,7 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
         "distribution"
     }
 
+    @Override
     String getMainTask() {
         return "distZip"
     }
@@ -326,6 +327,29 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
                 'dir/file2.txt',
                 'docs/file3.txt',
                 'docs/dir2/file4.txt')
+    }
+
+    def installDistCanBeRerun() {
+        when:
+        buildFile << """
+            apply plugin:'distribution'
+
+            distributions {
+                custom{
+                    contents {
+                        from { "someFile" }
+                    }
+                }
+            }
+
+            """
+        succeeds('installCustomDist')
+        // update the file so that when it re-runs it is not UP-TO-DATE
+        file("someFile") << "updated"
+        then:
+        succeeds('installCustomDist')
+        and:
+        file('build/install/TestProject-custom/someFile').assertIsCopyOf(file("someFile"))
     }
 
     def createTarTaskForCustomDistribution() {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/distribution/plugins/DistributionPlugin.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/distribution/plugins/DistributionPlugin.groovy
@@ -106,22 +106,12 @@ class DistributionPlugin implements Plugin<Project> {
     private void addInstallTask(Project project, Distribution distribution) {
         def taskName = TASK_INSTALL_NAME
         if (MAIN_DISTRIBUTION_NAME != distribution.name) {
-            taskName = "install"+ distribution.name.capitalize() + "Dist"
+            taskName = "install" + distribution.name.capitalize() + "Dist"
         }
         def installTask = project.tasks.create(taskName, Sync)
-        installTask.description = "Installs the project as a JVM application along with libs and OS specific scripts."
+        installTask.description = "Installs the project as a distribution as-is."
         installTask.group = DISTRIBUTION_GROUP
         installTask.with distribution.contents
         installTask.into { project.file("${project.buildDir}/install/${distribution.baseName}") }
-        installTask.doFirst {
-            if (destinationDir.directory) {
-                if (!new File(destinationDir, 'lib').directory || !new File(destinationDir, 'bin').directory) {
-                    throw new GradleException("The specified installation directory '${destinationDir}' is neither empty nor does it contain an installation for '${distribution.name}'.\n" +
-                            "If you really want to install to this directory, delete it and run the install task again.\n" +
-                            "Alternatively, choose a different installation directory."
-                    )
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
This removes some code copied from the `application` plugin that prevented distribution installations to be re-run without providing a `lib` and `bin` directory within the installation. Also added an integration test to ensure the rerunnable behavior.
