### PR TITLE
GRADLE-3023 Fixed return type of ScalaDoc.getClasspath()

### DIFF
--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -61,7 +61,7 @@ public class ScalaDoc extends SourceTask {
      * @return The classpath.
      */
     @InputFiles
-    public Iterable<File> getClasspath() {
+    public FileCollection getClasspath() {
         return classpath;
     }
 


### PR DESCRIPTION
- When running with Java 8, the scala plugin couldn't be used because the
  property type of the setters must be assignable from the property type
  of the getters (as per the code in PropertyDescriptor.findPropertyType()).

Unfortunately, I'm not able to write an automated test to make sure this works, as it involves Groovy meta classes and ASM generated code which I'm not that familiar with. It's very simple to test, though: simply create a build.gradle file with this line:

```
 apply plugin: 'scala'
```

And then try `gradle tasks` using Java 8
