### PR TITLE
Add ; escaping on java/jvm opts

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -158,7 +158,7 @@ fi
 function splitJvmOpts() {
     JVM_OPTS=("$@")
 }
-eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
+eval splitJvmOpts '$DEFAULT_JVM_OPTS' '$JAVA_OPTS' '$GRADLE_OPTS'
 JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
 
 exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"


### PR DESCRIPTION
This add escaping on ; character inside enviroment properties $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS. Without single quotes ; character inside options parameters will be dropped. 
Example:
$JAVA_OPTS = "-Dhttp.proxy.password=;jgfjcmvbyjuf" become 
"-Dhttp.proxy.password=<newline>jgfjcmvbyjuf" with resulting error on gradle invocation
