### PR TITLE
Use the APP_NAME to set process title on unix systems

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -161,4 +161,4 @@ function splitJvmOpts() {
 eval splitJvmOpts \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar}
 <% if ( appNameSystemProperty ) { %>JVM_OPTS[\${#JVM_OPTS[*]}]="-D${appNameSystemProperty}=\$APP_BASE_NAME"<% } %>
 
-exec "\$JAVACMD" "\${JVM_OPTS[@]}" -classpath "\$CLASSPATH" ${mainClassName} "\$@"
+exec -a ${APP_NAME} "\$JAVACMD" "\${JVM_OPTS[@]}" -classpath "\$CLASSPATH" ${mainClassName} "\$@"


### PR DESCRIPTION
This makes easy to use pidof to find the process.
Additionally, it enables searching for all network connections
for any application using 'netstat -tanp |grep <appname>'.

Testing done: Verified that 'pidof <appname>'
and 'netstat -tanp | grep <appname>' works.
