### PR TITLE
GRADLE-3107 - Make it possible to modify cacheMissingModulesAndArtifactsFor

### DIFF
--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
@@ -92,7 +92,7 @@ public class DefaultCachePolicy implements CachePolicy, ResolutionRules {
         });
     }
 
-    private void cacheMissingModulesAndArtifactsFor(final int value, final TimeUnit units) {
+    public void cacheMissingModulesAndArtifactsFor(final int value, final TimeUnit units) {
         eachModule(new Action<ModuleResolutionControl>() {
             public void execute(ModuleResolutionControl moduleResolutionControl) {
                 if (moduleResolutionControl.getCachedResult() == null) {

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -22,10 +22,10 @@ import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.cache.ResolutionRules;
-import org.gradle.internal.Actions;
 import org.gradle.api.internal.artifacts.DependencyResolveDetailsInternal;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.dsl.ModuleVersionSelectorParsers;
+import org.gradle.internal.Actions;
 import org.gradle.internal.typeconversion.NormalizedTimeUnit;
 import org.gradle.internal.typeconversion.TimeUnitsParser;
 
@@ -112,6 +112,15 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
 
     public void cacheChangingModulesFor(int value, TimeUnit units) {
         this.cachePolicy.cacheChangingModulesFor(value, units);
+    }
+
+    public void cacheMissingModulesAndArtifactsFor(int value, TimeUnit units) {
+        this.cachePolicy.cacheMissingModulesAndArtifactsFor(value, units);
+    }
+
+    public void cacheMissingModulesAndArtifactsFor(int value, String units) {
+        NormalizedTimeUnit timeUnit = new TimeUnitsParser().parseNotation(units, value);
+        this.cachePolicy.cacheMissingModulesAndArtifactsFor(timeUnit.getValue(), timeUnit.getTimeUnit());
     }
 
     public DefaultResolutionStrategy copy() {

--- a/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -190,4 +190,12 @@ public class DefaultResolutionStrategySpec extends Specification {
         then:
         1 * cachePolicy.cacheDynamicVersionsFor(1 * 60 * 60 * 1000, TimeUnit.MILLISECONDS)
     }
+
+    def "configures missing version cache with jdk6+ units"() {
+        when:
+        strategy.cacheMissingModulesAndArtifactsFor(1, "hours")
+
+        then:
+        1 * cachePolicy.cacheMissingModulesAndArtifactsFor(1 * 60 * 60 * 1000, TimeUnit.MILLISECONDS)
+    }
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -219,4 +219,28 @@ public interface ResolutionStrategy {
      * @since 1.0-milestone-6
      */
     void cacheChangingModulesFor(int value, TimeUnit units);
+
+    /**
+     * Sets the duration during which information about missing dependencies will be cached.
+     *
+     * <p>Gradle caches the the fact that a dependency does not exist in a repository.
+     * By default, these cached values are kept for 24 hours,
+     * after which the cached entry is expired and the module is resolved again.</p>
+     * <p>Use this method to provide a custom time period to during which Gradle should cache this information about a missing module.</p>
+     * @param value The number of time units
+     * @param units The units
+     * @since ?
+     */
+    void cacheMissingModulesAndArtifactsFor(int value, String units);
+
+    /**
+     * Sets the duration during which information about missing dependencies will be cached.
+     *
+     * <p>A convenience method for {@link #cacheMissingModulesAndArtifactsFor(int, java.util.concurrent.TimeUnit)} with units expressed as a String.
+     * Units are resolved by calling the {@code valueOf(String)} method of {@link java.util.concurrent.TimeUnit} with the upper-cased string value.</p>
+     * @param value The number of time units
+     * @param units The units
+     * @since ?
+     */
+    void cacheMissingModulesAndArtifactsFor(int value, TimeUnit units);
 }


### PR DESCRIPTION
...dules and artifacts

This is a fix for GRADLE-3107 (http://issues.gradle.org/browse/GRADLE-3107), making it possible
to configure the time that Gradle caches the fact that a dependency does not exist in a repository.
The reason for this (as explained in the Jira issue), is that if you have a build with multiple
repositories (and a slow connection to the repositories), a build might take a long time. When
the dependencies are all cached, you'd expect the build to be fast, especially if all the
dependencies are released versions. However, with Gradle's default of re-checking every 24 hours,
the build will take a long time once per 24 hours.

With this change, it's possible to change this default, using:

cacheMissingModulesAndArtifactsFor 500, 'days'
