### PR TITLE
Update gradle version in wraper task sample

### DIFF
--- a/subprojects/docs/src/samples/userguide/wrapper/simple/build.gradle
+++ b/subprojects/docs/src/samples/userguide/wrapper/simple/build.gradle
@@ -1,3 +1,3 @@
 task wrapper(type: Wrapper) {
-    gradleVersion = '1.4'
+    gradleVersion = '2.0'
 }


### PR DESCRIPTION
Updated gradle version from 1.4 to 2.0 in wraper task of userguide's simple gradle wrapper sample.
People tend to just copy-paste the example from docs without checking if there is newer version.
It would be nice if this version information would be dynamically computed, from current build version.
