### PR TITLE
GRADLE-3107 Fix for resource missing problem in master.

### DIFF
--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -153,10 +153,6 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
                 return;
             }
             if (cachedMetaData.isMissing()) {
-                if (cachePolicy.mustRefreshMissingModule(moduleComponentIdentifier, cachedMetaData.getAgeMillis())) {
-                    LOGGER.debug("Cached meta-data for missing module is expired: will perform fresh resolve of '{}' in '{}'", moduleComponentIdentifier, delegate.getName());
-                    return;
-                }
                 LOGGER.debug("Detected non-existence of module '{}' in resolver cache '{}'", moduleComponentIdentifier, delegate.getName());
                 if (cachedMetaData.getAgeMillis() == 0) {
                     // Verified since the start of this build, assume still missing
@@ -241,7 +237,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         private void resolveArtifactFromCache(ComponentArtifactMetaData artifact, CachingModuleSource moduleSource, BuildableArtifactResolveResult result) {
             CachedArtifact cached = artifactAtRepositoryCachedResolutionIndex.lookup(artifactCacheKey(artifact));
             final BigInteger descriptorHash = moduleSource.getDescriptorHash();
-           if (cached != null) {
+            if (cached != null) {
                long age = timeProvider.getCurrentTime() - cached.getCachedAt();
                final boolean isChangingModule = moduleSource.isChangingModule();
                ArtifactIdentifier artifactIdentifier = ((ModuleVersionArtifactMetaData) artifact).toArtifactIdentifier();

--- a/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
+++ b/subprojects/core-impl/src/main/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
@@ -46,7 +46,7 @@ public class DefaultCachePolicy implements CachePolicy, ResolutionRules {
 
         cacheDynamicVersionsFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
         cacheChangingModulesFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
-        cacheMissingModulesAndArtifactsFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
+        cacheMissingArtifactsFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
     }
 
     DefaultCachePolicy(DefaultCachePolicy policy) {
@@ -92,14 +92,7 @@ public class DefaultCachePolicy implements CachePolicy, ResolutionRules {
         });
     }
 
-    private void cacheMissingModulesAndArtifactsFor(final int value, final TimeUnit units) {
-        eachModule(new Action<ModuleResolutionControl>() {
-            public void execute(ModuleResolutionControl moduleResolutionControl) {
-                if (moduleResolutionControl.getCachedResult() == null) {
-                    moduleResolutionControl.cacheFor(value, units);
-                }
-            }
-        });
+    public void cacheMissingArtifactsFor(final int value, final TimeUnit units) {
         eachArtifact(new Action<ArtifactResolutionControl>() {
             public void execute(ArtifactResolutionControl artifactResolutionControl) {
                 if (artifactResolutionControl.getCachedResult() == null) {
@@ -120,10 +113,6 @@ public class DefaultCachePolicy implements CachePolicy, ResolutionRules {
         }
 
         return false;
-    }
-
-    public boolean mustRefreshMissingModule(ModuleComponentIdentifier component, long ageMillis) {
-        return mustRefreshModule(component, null, ageMillis, false);
     }
 
     public boolean mustRefreshModule(ModuleComponentIdentifier component, ResolvedModuleVersion resolvedModuleVersion, long ageMillis) {

--- a/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
+++ b/subprojects/core-impl/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
@@ -46,7 +46,6 @@ public class DefaultCachePolicySpec extends Specification {
         hasChangingModuleTimeout(DAY)
         hasModuleTimeout(FOREVER)
         hasMissingArtifactTimeout(DAY)
-        hasMissingModuleTimeout(DAY)
     }
 
     def "uses changing module timeout for changing modules"() {
@@ -57,7 +56,6 @@ public class DefaultCachePolicySpec extends Specification {
         hasDynamicVersionTimeout(DAY);
         hasChangingModuleTimeout(10 * SECOND)
         hasModuleTimeout(FOREVER)
-        hasMissingModuleTimeout(DAY)
         hasChangingArtifactTimeout(DAY)
     }
 
@@ -68,7 +66,6 @@ public class DefaultCachePolicySpec extends Specification {
         then:
         hasDynamicVersionTimeout(10 * SECOND)
         hasChangingModuleTimeout(DAY)
-        hasMissingModuleTimeout(DAY)
         hasMissingArtifactTimeout(DAY)
         hasModuleTimeout(FOREVER)
     }

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/configurations/dynamicversion/CachePolicy.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/configurations/dynamicversion/CachePolicy.java
@@ -27,8 +27,6 @@ import java.util.Set;
 public interface CachePolicy {
     boolean mustRefreshVersionList(ModuleIdentifier selector, Set<ModuleVersionIdentifier> moduleVersions, long ageMillis);
 
-    boolean mustRefreshMissingModule(ModuleComponentIdentifier component, long ageMillis);
-
     boolean mustRefreshModule(ModuleComponentIdentifier component, ResolvedModuleVersion resolvedModuleVersion, long ageMillis);
 
     boolean mustRefreshChangingModule(ModuleComponentIdentifier component, ResolvedModuleVersion resolvedModuleVersion, long ageMillis);


### PR DESCRIPTION
- This fix makes it so that if a dependency can be found in the cache of any repository, the cached dependency will always be used.
  - If a dependency cannot be found in the cache of _any_ repository, the actual repositories will be queried, possibly over the network.
- This will fix an issue where after 24h Gradle would do remote checks even if an artifact exists (cached) in a repository further down the chain.
  - In order to test this, we've made the cacheMissingArtifactsFor timeout (which defaults to 24h) configurable.

Credit for this fix goes to Graham Dennis.
