### PR TITLE
GRADLE-3133 Limit ssh authentication methods to password

### DIFF
--- a/subprojects/core-impl/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvySftpRepoErrorsIntegrationTest.groovy
+++ b/subprojects/core-impl/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvySftpRepoErrorsIntegrationTest.groovy
@@ -106,7 +106,7 @@ class IvySftpRepoErrorsIntegrationTest extends AbstractSftpDependencyResolutionT
         then:
         failure.assertHasDescription("Could not resolve all dependencies for configuration ':compile'.")
                 .assertHasCause('Could not resolve org.group.name:projectA:1.2')
-                .assertHasCause("Invalid credentials for SFTP server at ${ivySftpRepo.serverUri}")
+                .assertHasCause("Password authentication not supported or invalid credentials for SFTP server at ${ivySftpRepo.serverUri}")
     }
 
     void "resolve dependencies from an unreachable SFTP Ivy repository"() {


### PR DESCRIPTION
Gradle JSch was configured by default to support "gssapi-with-mic,publickey,keyboard-interactive,password" authentication. But "password" is the only one that works at the moment.
A server that allows "publickey,keyboard-interactive" returns "Auth Cancel" by the "keyboard-interactive" method. This is fixed by the pull request.
Additionally, the exception message is changed to let the user know that that one failure cause is that the server is not configured to use "password" authentication.
