### PR TITLE
Test class BuildEnvironmentIntegrationTest fails on linux without jdk5

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
@@ -154,17 +154,24 @@ abstract public class AvailableJavaHomes {
         public List<JvmInstallation> findJvms() {
             List<JvmInstallation> jvms = new ArrayList<JvmInstallation>();
             if (OperatingSystem.current().isLinux()) {
-                jvms.add(new JvmInstallation(JavaVersion.VERSION_1_5, "1.5.0", fileCanonicalizer.canonicalize(new File("/opt/jdk/sun-jdk-5")), true, JvmInstallation.Arch.i386));
-                jvms.add(new JvmInstallation(JavaVersion.VERSION_1_6, "1.6.0", fileCanonicalizer.canonicalize(new File("/opt/jdk/sun-jdk-6")), true, JvmInstallation.Arch.x86_64));
-                jvms.add(new JvmInstallation(JavaVersion.VERSION_1_6, "1.6.0", fileCanonicalizer.canonicalize(new File("/opt/jdk/ibm-jdk-6")), true, JvmInstallation.Arch.x86_64));
-                jvms.add(new JvmInstallation(JavaVersion.VERSION_1_7, "1.7.0", fileCanonicalizer.canonicalize(new File("/opt/jdk/oracle-jdk-7")), true, JvmInstallation.Arch.x86_64));
-                jvms.add(new JvmInstallation(JavaVersion.VERSION_1_8, "1.8.0", fileCanonicalizer.canonicalize(new File("/opt/jdk/oracle-jdk-8")), true, JvmInstallation.Arch.x86_64));
+                jvms = addJvm(jvms, JavaVersion.VERSION_1_5, "1.5.0", new File("/opt/jdk/sun-jdk-5"), true, JvmInstallation.Arch.i386);
+                jvms = addJvm(jvms, JavaVersion.VERSION_1_6, "1.6.0", new File("/opt/jdk/sun-jdk-6"), true, JvmInstallation.Arch.x86_64);
+                jvms = addJvm(jvms, JavaVersion.VERSION_1_6, "1.6.0", new File("/opt/jdk/ibm-jdk-6"), true, JvmInstallation.Arch.x86_64);
+                jvms = addJvm(jvms, JavaVersion.VERSION_1_7, "1.7.0", new File("/opt/jdk/oracle-jdk-7"), true, JvmInstallation.Arch.x86_64);
+                jvms = addJvm(jvms, JavaVersion.VERSION_1_8, "1.8.0", new File("/opt/jdk/oracle-jdk-8"), true, JvmInstallation.Arch.x86_64);
             }
             return CollectionUtils.filter(jvms, new Spec<JvmInstallation>() {
                 public boolean isSatisfiedBy(JvmInstallation element) {
                     return element.getJavaHome().isDirectory();
                 }
             });
+        }
+
+        private List<JvmInstallation> addJvm(List<JvmInstallation> jvms, JavaVersion javaVersion, String versionString, File javaHome, boolean jdk, JvmInstallation.Arch arch) {
+            if(javaHome.exists()) {
+                jvms.add(new JvmInstallation(javaVersion, versionString, fileCanonicalizer.canonicalize(javaHome), jdk, arch));
+            }
+            return jvms;
         }
     }
 


### PR DESCRIPTION
Building :integTest:integTest on a linux system with jdk7 without one of
the following paths existing fails
/opt/jdk/sun-jdk-5, /opt/jdk/sun-jdk-6, /opt/jdk/ibm-jdk-6,
/opt/jdk/oracle-jdk-7, /opt/jdk/oracle-jdk-7
The @IgnoreIf({ AvailableJavaHomes.differentJdk == null}) in the test class
gives an expeption because of Jdk7FileCanonicalizer throwing an exception
if the file to canonicalize does not exist.
