### PR TITLE
Updated built in MavenCentral to use https url and update some docs

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ArtifactRepositoryContainer.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ArtifactRepositoryContainer.java
@@ -47,7 +47,7 @@ import org.gradle.util.Configurable;
 public interface ArtifactRepositoryContainer extends NamedDomainObjectList<ArtifactRepository>, Configurable<ArtifactRepositoryContainer> {
     String DEFAULT_MAVEN_CENTRAL_REPO_NAME = "MavenRepo";
     String DEFAULT_MAVEN_LOCAL_REPO_NAME = "MavenLocal";
-    String MAVEN_CENTRAL_URL = "http://repo1.maven.org/maven2/";
+    String MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2/";
 
     /**
      * Adds a repository to this container, at the end of the repository sequence.

--- a/subprojects/docs/src/docs/userguide/depMngmt.xml
+++ b/subprojects/docs/src/docs/userguide/depMngmt.xml
@@ -728,7 +728,7 @@
 
         <section id='sub:maven_central'>
             <title>Maven central repository</title>
-            <para>To add the central Maven 2 repository (<ulink url='http://repo1.maven.org/maven2'/>) simply add this to your build script:
+            <para>To add the central Maven 2 repository (<ulink url='https://repo1.maven.org/maven2'/>) simply add this to your build script:
             </para>
             <sample id="mavenCentral" dir="userguide/artifacts/defineRepository" title="Adding central Maven repository">
                 <sourcefile file="build.gradle" snippet="maven-central"/>
@@ -1251,7 +1251,7 @@ someroot/[artifact]-[revision].[ext]
     </section>
     <section id='sec:strategies_of_transitive_dependency_management'>
         <title>Strategies for transitive dependency management</title>
-        <para>Many projects rely on the <ulink url='http://repo1.maven.org/maven2'>Maven Central repository</ulink>. This is not without problems.
+        <para>Many projects rely on the <ulink url='https://repo1.maven.org/maven2'>Maven Central repository</ulink>. This is not without problems.
         </para>
         <itemizedlist>
             <listitem>


### PR DESCRIPTION
I did not change the tests that are using the http url. Documentation on how to use https on central without this patch is on http://central.sonatype.org/pages/consumers.html#gradle but the default should probably use https now that it is available.
