### PR TITLE
Don't specify Groovy version in the title.

### DIFF
--- a/subprojects/docs/src/docs/userguide/groovyTutorial.xml
+++ b/subprojects/docs/src/docs/userguide/groovyTutorial.xml
@@ -40,7 +40,7 @@
             The <literal>compile</literal> configuration inherits this dependency, so the groovy libraries will
             be included in classpath when compiling Groovy and Java source.  For our sample, we will use Groovy 2.2.0
             from the public Maven repository:</para>
-        <sample id="groovyQuickstart" dir="groovy/quickstart" title="Dependency on Groovy 2.2.0">
+        <sample id="groovyQuickstart" dir="groovy/quickstart" title="Dependency on Groovy">
             <sourcefile file="build.gradle" snippet="groovy-dependency"/>
         </sample>
         <para>Here is our complete build file:</para>


### PR DESCRIPTION
It gets out of sync with the code file and it's too easy to forget to sync them: right now the docs say 2.2.0 but the example uses 2.3.x.
Equally importantly, the exact version in the title doesn't really matter to the reader.
