### PR TITLE
Fixes GRADLE-3150: Accept DOCTYPE declaration in pre-existing application descriptor

### DIFF
--- a/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
+++ b/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
@@ -167,6 +167,29 @@ ear {
         ear.assertFileContent("META-INF/application.xml", applicationXml)
     }
 
+
+    @Test
+    void "works with existing descriptor containing a doctype declaration"() {
+        def applicationXml = """<?xml version="1.0"?>
+<!DOCTYPE application PUBLIC "-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN" "http://java.sun.com/dtd/application_1_3.dtd">
+<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_6.xsd" version="6">
+  <application-name>customear</application-name>
+</application>
+"""
+
+        file('src/main/application/META-INF/application.xml').createFile().write(applicationXml)
+        file("build.gradle").write("""
+apply plugin: 'ear'
+""")
+
+        //when
+        executer.withTasks('assemble').run()
+
+        //then
+        def ear = new JarTestFixture(file('build/libs/root.ear'))
+        ear.assertFileContent("META-INF/application.xml", applicationXml)
+    }
+
     @Test @Ignore
     void "exclude duplicates: deploymentDescriptor has priority over metaInf"() {
         file('bad-meta-inf/application.xml').createFile().write('bad descriptor')

--- a/subprojects/ear/src/main/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.groovy
+++ b/subprojects/ear/src/main/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.groovy
@@ -136,7 +136,7 @@ class DefaultDeploymentDescriptor implements DeploymentDescriptor {
 
     DeploymentDescriptor readFrom(Reader reader) {
         try {
-            def appNode = new XmlParser().parse(reader)
+            def appNode = new XmlParser(false, true, true).parse(reader)
             version = appNode.@version
 
             appNode.children().each { child ->


### PR DESCRIPTION
Groovy changed the behavior of `XmlParser` and `XmlSlurper` as of 2.0. In essence, a new constructor has been added that allows enabling or disabling support for `DOCTYPE` declarations. The problem, however, is that they made it so that the default constructor (which most of us were using) is set to not allowing it.

I added an integration test that reproduces the error and changed from the default constructor to the 3-arguments one, with enabled `DOCTYPE`, which reestablishes the pre-Groovy2 behavior.
