### PR TITLE
AbstractTask.setActions has no effect due to scoping

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/AbstractTask.java
@@ -178,11 +178,11 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         return observableActionList;
     }
 
-    public void setActions(final List<Action<? super Task>> actions) {
+    public void setActions(final List<Action<? super Task>> replacements) {
         taskMutator.mutate("Task.setActions(List<Action>)", new Runnable() {
             public void run() {
                 actions.clear();
-                for (Action<? super Task> action : actions) {
+                for (Action<? super Task> action : replacements) {
                     doLast(action);
                 }
             }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
@@ -144,6 +144,18 @@ public abstract class AbstractSpockTaskTest extends Specification {
         new ArrayList() ==  getTask().getActions()
     }
 
+    def testSetActions() {
+        when:
+        Action action1 = Actions.doNothing();
+        getTask().actions = [action1]
+
+        Action action2 = Actions.doNothing();
+        getTask().actions = [action2]
+
+        then:
+        [new AbstractTask.TaskActionWrapper(action2)] ==  getTask().actions
+    }
+
     def testAddActionWithNull() {
         when:
         getTask().doLast((Closure) null)


### PR DESCRIPTION
I think there is a scope-related issue when setting the actions of an AbstractTask.

The list of actions supplied as a parameter is cleared, rather than the current actions of the task. 
