### PR TITLE
Allow openjdk-style version strings.

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/JvmVersionValidator.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/JvmVersionValidator.java
@@ -51,7 +51,7 @@ public class JvmVersionValidator {
         try {
             String versionStr = reader.readLine();
             while (versionStr != null) {
-                Matcher matcher = Pattern.compile("java version \"(.+?)\"").matcher(versionStr);
+                Matcher matcher = Pattern.compile("[a-z]+ version \"(.+?)\"").matcher(versionStr);
                 if (matcher.matches()) {
                     return JavaVersion.toVersion(matcher.group(1));
                 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/JvmVersionValidatorTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/JvmVersionValidatorTest.groovy
@@ -35,6 +35,20 @@ class JvmVersionValidatorTest extends Specification {
         ]
     }
 
+    def "can parse openjdk style version number"() {
+        expect:
+        JvmVersionValidator.parseJavaVersionCommandOutput(new BufferedReader(new StringReader(output))) == JavaVersion.toVersion("1.8")
+
+        where:
+        output << [
+                'openjdk version "1.8.0_11"',
+                'openjdk version "1.8.0_11"\ntrailers',
+                'headers\nopenjdk version "1.8.0_11"',
+                'openjdk version "1.8.0_11"\r\ntrailers',
+                'headers\r\nopenjdk version "1.8.0_11"',
+        ]
+    }
+
     def "fails to parse version number"() {
         when:
         JvmVersionValidator.parseJavaVersionCommandOutput(new BufferedReader(new StringReader(output)))


### PR DESCRIPTION
This fixes http://forums.gradle.org/gradle/topics/gradle-fails-to-detect-the-java-version-when-using-openjdk-8
