### PR TITLE
[maven-aws] Adds support for AWS S3 backed maven repositories (resolutio...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-sudo: false
-cache:
-  directories:
-  - $HOME/.m2
-  - $HOME/.gradle/wrapper
 language: java
 jdk:
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+sudo: false
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.gradle/wrapper
 language: java
 jdk:
   - oraclejdk7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ If you're not sure where to start, ask on the developer list. There's likely a n
 
 Try to ensure that your code & tests will run successfully on Java 6, and on both *nix and Windows platforms.
 The [Gradle CI](http://builds.gradle.org/) will verify this, but it helps if things work first time.
+Pull requests are verified on [Travis CI] (https://travis-ci.org/gradle/gradle/pull_requests).
 
 1. Avoid using features introduced in Java 1.7 or later
 2. Be careful to normalise file paths in tests. The `org.gradle.util.TextUtil` class has some useful utility functions for this purpose.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -163,6 +163,16 @@ libraries.bouncycastle_pgp = dependencies.module("org.bouncycastle:bcpg-jdk15on:
     dependency libraries.bouncycastle_provider
 }
 
+libraries.joda = 'joda-time:joda-time:2.4@jar'
+
+libraries.aws = [
+        'com.amazonaws:aws-java-sdk:1.7.13@jar',
+        'commons-logging:commons-logging:1.1.1@jar',
+        'com.fasterxml.jackson.core:jackson-core:2.1.1@jar',
+        'com.fasterxml.jackson.core:jackson-databind:2.1.1@jar',
+        'com.fasterxml.jackson.core:jackson-annotations:2.1.1@jar',
+] + libraries.commons_httpclient + libraries.joda
+
 allprojects {
     configurations.all {
         resolutionStrategy.eachDependency { details ->

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
@@ -17,6 +17,7 @@ package org.gradle.api.artifacts.repositories;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.credentials.Credentials;
 
 /**
  * An artifact repository which supports username/password authentication.
@@ -24,10 +25,17 @@ import org.gradle.api.Action;
 public interface AuthenticationSupported {
 
     /**
-     * Returns the credentials used to authenticate to this repository.
-     * @return The credentials
+     * Returns the standard username and password credentials used to authenticate to this repository.
+     * @return The PasswordCredentials
      */
     PasswordCredentials getCredentials();
+
+    /**
+     * Returns the alternative credentials used to authenticate with this repository.
+     * Alternative credentials are used for non username/password credentials.
+     * @return The Credentials
+     */
+    Credentials getAlternativeCredentials();
 
     /**
      * Configure the credentials for this repository using the supplied Closure.
@@ -60,4 +68,20 @@ public interface AuthenticationSupported {
      * </pre>
      */
     void credentials(Action<? super PasswordCredentials> action);
+
+    /**
+     * Configures strongly typed credentials for this repository using the supplied action.
+     *
+     * repositories {
+     *    maven {
+     *        url "${url}"
+     *        credentials(AwsCredentials) {
+     *            accessKey "myAccessKey"
+     *            secretKey "mySecret"
+     *        }
+     *    }
+     *  }
+     *
+     */
+    <T extends Credentials> void credentials(Class<T> clazz, Action<? super Credentials> action);
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/AwsCredentials.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/AwsCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.resource.transport.http;
 
+package org.gradle.api.artifacts.repositories;
 
-import spock.lang.Specification
+import org.gradle.credentials.Credentials;
 
-class JavaSystemPropertiesHttpProxySettingsTest extends Specification {
+/**
+ * Represents credentials used to authenticate with Amazon Web Services.
+ */
+public interface AwsCredentials extends Credentials {
 
-    def "should use default HTTP prefix and port"() {
-        JavaSystemPropertiesProxySettings settings = new JavaSystemPropertiesHttpProxySettings()
-        expect:
-        settings.propertyPrefix == 'http'
-        settings.defaultPort == 80
-    }
+    public String getAccessKey();
+
+    public void setAccessKey(String accessKey);
+
+    public String getSecretKey();
+
+    public void setSecretKey(String secretKey);
+
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/PasswordCredentials.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/PasswordCredentials.java
@@ -15,10 +15,12 @@
  */
 package org.gradle.api.artifacts.repositories;
 
+import org.gradle.credentials.Credentials;
+
 /**
  * A username/password credentials that can be used to login to password-protected remote repository.
  */
-public interface PasswordCredentials {
+public interface PasswordCredentials extends Credentials {
     /**
      * Returns the user name to use when authenticating to this repository.
      *

--- a/subprojects/core/src/main/groovy/org/gradle/credentials/Credentials.java
+++ b/subprojects/core/src/main/groovy/org/gradle/credentials/Credentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.resource.transport.http;
 
+package org.gradle.credentials;
 
-import spock.lang.Specification
-
-class JavaSystemPropertiesHttpProxySettingsTest extends Specification {
-
-    def "should use default HTTP prefix and port"() {
-        JavaSystemPropertiesProxySettings settings = new JavaSystemPropertiesHttpProxySettings()
-        expect:
-        settings.propertyPrefix == 'http'
-        settings.defaultPort == 80
-    }
+public interface Credentials {
 }

--- a/subprojects/core/src/main/groovy/org/gradle/internal/credentials/DefaultAwsCredentials.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/credentials/DefaultAwsCredentials.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.credentials;
+
+import org.gradle.api.artifacts.repositories.AwsCredentials;
+
+public class DefaultAwsCredentials implements AwsCredentials {
+
+    private String accessKey;
+    private String secretKey;
+
+    public DefaultAwsCredentials() {
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultAwsCredentials that = (DefaultAwsCredentials) o;
+
+        if (accessKey != null ? !accessKey.equals(that.accessKey) : that.accessKey != null) {
+            return false;
+        }
+        if (secretKey != null ? !secretKey.equals(that.secretKey) : that.secretKey != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = accessKey != null ? accessKey.hashCode() : 0;
+        result = 31 * result + (secretKey != null ? secretKey.hashCode() : 0);
+        return result;
+    }
+}

--- a/subprojects/dependency-management/dependency-management.gradle
+++ b/subprojects/dependency-management/dependency-management.gradle
@@ -1,9 +1,14 @@
 apply plugin: "groovy"
 
-import org.gradle.build.*
+import org.gradle.build.JarJar
 
 configurations {
     mvn3Input
+}
+
+repositories {
+    jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -16,6 +21,8 @@ dependencies {
     compile libraries.slf4j_api
     compile libraries.maven_ant_tasks
     compile libraries.jsch
+    compile libraries.gson
+    compile libraries.aws
     runtime libraries.xbean //maven3 classes dependency
     runtime libraries.bouncycastle_provider
 
@@ -49,8 +56,8 @@ task jarJarMaven3(type: JarJar) {
     avoidConflictingPlexusComponents(it)
 }
 
-if(isWindows && javaVersion.java5){
-    compileTestGroovy.options.fork (memoryMaximumSize: '512m')
+if (isWindows && javaVersion.java5) {
+    compileTestGroovy.options.fork(memoryMaximumSize: '512m')
 }
 
 classpathManifest.dependsOn jarJarMaven3 //see GRADLE-2521

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CredentialsDslIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CredentialsDslIntegrationTest.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.resolve.support.RepositoryDslSupport
+import spock.lang.Unroll
+
+@Mixin(RepositoryDslSupport)
+class CredentialsDslIntegrationTest extends AbstractIntegrationSpec {
+
+    @Unroll
+    def "can configure repositories with [#scenario] DSL "() {
+        expect:
+        buildFile << dsl
+        succeeds 'help'
+
+        where:
+        scenario          | dsl
+        'simple'          | simplestDsl()
+        'awsCredentials'  | awsCredentials()
+        'ivyWithPassword' | ivyPasswordCredentials()
+        'passwordTyped'   | passwordCredentialsTyped()
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/AbstractS3DependencyResolutionTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/AbstractS3DependencyResolutionTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.aws.s3
+
+import groovy.io.FileType
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.internal.resource.transport.aws.s3.S3ConnectionProperties
+import org.gradle.test.fixtures.server.s3.MavenS3Repository
+import org.gradle.test.fixtures.server.s3.S3Resource
+import org.gradle.test.fixtures.server.s3.S3StubServer
+import org.gradle.test.fixtures.server.s3.S3StubSupport
+import org.junit.Rule
+
+abstract class AbstractS3DependencyResolutionTest extends AbstractDependencyResolutionTest {
+
+    @Rule
+    public final S3StubServer server = new S3StubServer()
+    final S3StubSupport s3StubSupport = new S3StubSupport(server)
+
+    def setup() {
+        executer.withArgument('-i')
+        executer.withArgument("-D${S3ConnectionProperties.S3_ENDPOINT_PROPERTY}=${s3StubSupport.endpoint.toString()}")
+    }
+
+    abstract String getBucket()
+
+    abstract String getRepositoryPath()
+
+
+    MavenS3Repository getMavenS3Repo() {
+        new MavenS3Repository(server, file(getTestDirectory()), getRepositoryPath(), getBucket())
+    }
+
+    def assertLocallyAvailableLogged(S3Resource... resources) {
+        resources.each {
+            assert output.contains("Found locally available resource with matching checksum: [s3:/${it.relativeFilePath()}")
+        }
+    }
+
+    def listDirs = {
+        def list = []
+        getTestDirectory().eachFileRecurse(FileType.ANY) { file ->
+            list << file
+        }
+        println "Contents of test directory are:"
+        list.each {
+            println it
+        }
+    }
+
+    String mavenAwsRepoDsl(){
+        """
+        repositories {
+            maven {
+                url "s3://${getBucket()}${getRepositoryPath()}"
+                credentials(AwsCredentials) {
+                    accessKey "someKey"
+                    secretKey "someSecret"
+                }
+            }
+        }
+        """
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/MavenS3RepoErrorsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/MavenS3RepoErrorsIntegrationTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.gradle.integtests.resolve.aws.s3
+
+class MavenS3RepoErrorsIntegrationTest extends AbstractS3DependencyResolutionTest {
+    final String artifactVersion = "1.85"
+
+    @Override
+    String getBucket() {
+        return 'tests3bucket'
+    }
+
+    @Override
+    String getRepositoryPath() {
+        return '/maven/release/'
+    }
+
+    def "should fail with an AWS S3 authentication error"() {
+        setup:
+        buildFile << mavenAwsRepoDsl()
+        buildFile << """
+configurations { compile }
+
+dependencies{
+    compile 'org.gradle:test:$artifactVersion'
+}
+
+task retrieve(type: Sync) {
+    from configurations.compile
+    into 'libs'
+}
+"""
+        when:
+        s3StubSupport.stubGetFileAuthFailure('/tests3bucket/maven/release/org/gradle/test/1.85/test-1.85.pom')
+
+        then:
+        fails 'retrieve'
+
+
+        and:
+        failure.assertHasDescription("Could not resolve all dependencies for configuration ':compile'.")
+                .assertHasCause('Could not resolve org.gradle:test:1.85')
+                .assertHasCause("The AWS Access Key Id you provided does not exist in our records. " +
+                "(Service: Amazon S3; Status Code: 403; Error Code: InvalidAccessKeyId; Request ID: stubbedAuthFailureRequestId")
+
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/MavenS3RepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/MavenS3RepoResolveIntegrationTest.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.aws.s3
+
+import org.gradle.test.fixtures.server.s3.MavenS3Module
+
+class MavenS3RepoResolveIntegrationTest extends AbstractS3DependencyResolutionTest {
+
+    @Override
+    String getBucket() {
+        return 'tests3bucket'
+    }
+
+    @Override
+    String getRepositoryPath() {
+        return '/maven/release/'
+    }
+
+    def "should not download artifacts when already present in maven home"() {
+        setup:
+        String artifactVersion = "1.85"
+        MavenS3Module remoteModule = getMavenS3Repo().module("org.gradle", "test", artifactVersion)
+        remoteModule.publish()
+
+        m2Installation.generateGlobalSettingsFile()
+        def localModule = m2Installation.mavenRepo().module("org.gradle", "test", artifactVersion).publish()
+
+        buildFile << mavenAwsRepoDsl()
+        buildFile << """
+configurations { compile }
+
+dependencies{
+    compile 'org.gradle:test:$artifactVersion'
+}
+
+task retrieve(type: Sync) {
+    from configurations.compile
+    into 'libs'
+}
+"""
+        and:
+        remoteModule.pom.expectMetadataRetrieve()
+        remoteModule.pomSha1.expectDownload()
+        remoteModule.artifact.expectMetadataRetrieve()
+        remoteModule.artifactSha1.expectDownload()
+
+        when:
+        using m2Installation
+
+        then:
+        succeeds 'retrieve'
+
+        and:
+        localModule.artifactFile.assertIsCopyOf(remoteModule.artifactFile)
+        localModule.pomFile.assertIsCopyOf(remoteModule.pomFile)
+        file('libs/test-1.85.jar').assertIsCopyOf(remoteModule.artifactFile)
+
+        and:
+        assertLocallyAvailableLogged(remoteModule.pom, remoteModule.artifact)
+    }
+
+
+    def "should download artifacts when maven local artifacts are different to remote "() {
+        setup:
+        String artifactVersion = "1.85"
+        MavenS3Module remoteModule = getMavenS3Repo().module("org.gradle", "test", artifactVersion)
+        remoteModule.publish()
+
+        m2Installation.generateGlobalSettingsFile()
+        def localModule = m2Installation.mavenRepo().module("org.gradle", "test", artifactVersion).publishWithChangedContent()
+
+        buildFile << mavenAwsRepoDsl()
+        buildFile << """
+configurations { compile }
+
+dependencies{
+    compile 'org.gradle:test:$artifactVersion'
+}
+
+task retrieve(type: Sync) {
+    from configurations.compile
+    into 'libs'
+}
+"""
+        and:
+        remoteModule.pom.expectMetadataRetrieve()
+        remoteModule.pomSha1.expectDownload()
+        remoteModule.pom.expectDownload()
+        remoteModule.artifact.expectMetadataRetrieve()
+        remoteModule.artifactSha1.expectDownload()
+        remoteModule.artifact.expectDownload()
+
+        when:
+        using m2Installation
+        run 'retrieve'
+
+        then:
+        succeeds 'retrieve'
+
+        and:
+        localModule.artifactFile.assertIsDifferentFrom(remoteModule.artifactFile)
+        localModule.pomFile.assertIsDifferentFrom(remoteModule.pomFile)
+        file('libs/test-1.85.jar').assertIsCopyOf(remoteModule.artifactFile)
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/MavenS3SnapshotRepoIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/MavenS3SnapshotRepoIntegrationTest.groovy
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.aws.s3
+
+import org.gradle.test.fixtures.server.s3.MavenS3Module
+
+class MavenS3SnapshotRepoIntegrationTest extends AbstractS3DependencyResolutionTest {
+
+    @Override
+    String getBucket() {
+        return 'tests3bucket'
+    }
+
+    @Override
+    String getRepositoryPath() {
+        return '/maven/snapshot/'
+    }
+
+    def "resolves a maven snapshot module stored in S3"() {
+        setup:
+        MavenS3Module module = getMavenS3Repo().module("org.gradle", "test", "1.45-SNAPSHOT")
+        module.publish()
+
+        buildFile << mavenAwsRepoDsl()
+        buildFile << """
+configurations { compile }
+
+dependencies{
+    compile 'org.gradle:test:1.45-SNAPSHOT'
+}
+
+task retrieve(type: Sync) {
+    from configurations.compile
+    into 'libs'
+}
+"""
+
+        expect:
+        module.pom.expectDownload()
+        module.metaData.expectDownload()
+        module.artifact.expectDownload()
+
+        and:
+        succeeds 'retrieve'
+
+        and:
+        file('libs').assertHasDescendants('test-1.45-SNAPSHOT.jar')
+    }
+
+    def "resolves a dynamic maven snapshot module stored in S3"() {
+        setup:
+        MavenS3Module remoteModule = getMavenS3Repo().module("org.gradle", "test", "1.45-SNAPSHOT")
+        remoteModule.publish()
+
+        and:
+        buildFile << mavenAwsRepoDsl()
+        buildFile << """
+configurations { compile }
+
+
+dependencies{
+    compile 'org.gradle:test:1.45-SNAPSHOT+'
+}
+
+task retrieve(type: Sync) {
+    from configurations.compile
+    into 'libs'
+}
+"""
+
+        expect:
+        remoteModule.mavenRootMetaData.expectDownload()
+        remoteModule.metaData.expectDownload()
+        remoteModule.pom.expectDownload()
+        remoteModule.artifact.expectDownload()
+
+        and:
+        succeeds 'retrieve'
+
+        and:
+        file('libs').assertHasDescendants('test-1.45-SNAPSHOT.jar')
+    }
+
+    def "should download snapshot artifacts when maven local artifacts are different to remote"() {
+        setup:
+        String artifactVersion = "1.45-SNAPSHOT"
+        MavenS3Module remoteModule = getMavenS3Repo().module("org.gradle", "test", artifactVersion)
+        remoteModule.publishWithChangedContent()
+
+        m2Installation.generateGlobalSettingsFile()
+        def localModule = m2Installation.mavenRepo().module("org.gradle", "test", artifactVersion).publish()
+
+        buildFile << mavenAwsRepoDsl()
+        buildFile << """
+configurations { compile }
+
+dependencies{
+    compile 'org.gradle:test:$artifactVersion'
+}
+
+task retrieve(type: Sync) {
+    from configurations.compile
+    into 'libs'
+}
+"""
+        and:
+        remoteModule.metaData.expectDownload()
+        remoteModule.pom.expectDownload()
+        remoteModule.artifact.expectDownload()
+
+        when:
+        using m2Installation
+        run 'retrieve'
+
+        then:
+        succeeds 'retrieve'
+
+        and:
+        localModule.artifactFile.assertIsDifferentFrom(remoteModule.artifactFile)
+        localModule.pomFile.assertIsDifferentFrom(remoteModule.pomFile)
+        file("libs/test-${artifactVersion}.jar").assertIsCopyOf(remoteModule.artifactFile)
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/S3ClientIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/S3ClientIntegrationTest.groovy
@@ -18,14 +18,14 @@ package org.gradle.integtests.resolve.aws.s3
 
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.S3Object
+import com.google.common.base.Optional
 import org.apache.commons.io.IOUtils
-import org.gradle.internal.resource.transport.http.JavaSystemPropertiesSecureHttpProxySettings
-import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.test.fixtures.server.s3.S3StubServer
-import org.gradle.test.fixtures.server.s3.S3StubSupport
 import org.gradle.internal.credentials.DefaultAwsCredentials
 import org.gradle.internal.resource.transport.aws.s3.S3Client
 import org.gradle.internal.resource.transport.aws.s3.S3ConnectionProperties
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.test.fixtures.server.s3.S3StubServer
+import org.gradle.test.fixtures.server.s3.S3StubSupport
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -62,8 +62,8 @@ class S3ClientIntegrationTest extends Specification {
         }
 
         S3ConnectionProperties s3SystemProperties = Mock {
-            getEndpoint() >> s3StubSupport.endpoint.toString()
-            getProxySettings() >> Mock(JavaSystemPropertiesSecureHttpProxySettings)
+            getEndpoint() >> Optional.of(s3StubSupport.endpoint)
+            getProxy() >> Optional.fromNullable(null)
         }
 
         S3Client s3Client = new S3Client(awsCredentials, s3SystemProperties)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/S3ClientIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/aws/s3/S3ClientIntegrationTest.groovy
@@ -26,8 +26,8 @@ import org.gradle.internal.resource.transport.aws.s3.S3ConnectionProperties
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.fixtures.server.s3.S3StubServer
 import org.gradle.test.fixtures.server.s3.S3StubSupport
-import org.junit.Ignore
 import org.junit.Rule
+import spock.lang.Ignore
 import spock.lang.Specification
 
 class S3ClientIntegrationTest extends Specification {
@@ -94,10 +94,10 @@ class S3ClientIntegrationTest extends Specification {
         }
     }
 
-    @Ignore
     /**
      * Allows for quickly making real aws requests during development
      */
+    @Ignore
     def "should interact with real S3"() {
         DefaultAwsCredentials credentials = new DefaultAwsCredentials()
         String bucketName = System.getenv('G_S3_BUCKET')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/support/RepositoryDslSupport.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/support/RepositoryDslSupport.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.support
+
+class RepositoryDslSupport {
+
+    def url = "http://somerepo"
+    def s3Url = "s3://somerepo"
+
+    def simplestDsl() {
+        """
+        repositories {
+            maven {
+                url "${url}"
+            }
+        }
+        """
+    }
+
+    def passwordCredentialsTyped() {
+        """
+        repositories {
+            maven {
+                url "${url}"
+                credentials(PasswordCredentials) {
+                    username "myUsername"
+                    password "myPassword"
+                }
+            }
+        }
+        """
+    }
+
+    def awsCredentials() {
+        """
+        repositories {
+            maven {
+                url "${s3Url}"
+                credentials(AwsCredentials) {
+                    accessKey "myAccessKey"
+                    secretKey "mySecret"
+                }
+            }
+        }
+        """
+
+    }
+
+    def ivyPasswordCredentials(){
+        """
+repositories {
+    ivy {
+        url "${url}"
+        credentials {
+            username 'targetUser'
+            password 'targetPassword'
+        }
+    }
+}
+"""
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepository.java
@@ -18,17 +18,30 @@ package org.gradle.api.internal.artifacts.repositories;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.AuthenticationSupported;
+import org.gradle.api.artifacts.repositories.AwsCredentials;
 import org.gradle.api.artifacts.repositories.PasswordCredentials;
 import org.gradle.api.internal.ClosureBackedAction;
+import org.gradle.credentials.Credentials;
+import org.gradle.internal.credentials.DefaultAwsCredentials;
+import org.gradle.internal.reflect.Instantiator;
 
 public abstract class AbstractAuthenticationSupportedRepository extends AbstractArtifactRepository implements AuthenticationSupported {
-    private final PasswordCredentials passwordCredentials;
+    private PasswordCredentials passwordCredentials;
+    private Credentials alternativeCredentials;
+    private final Instantiator instantiator;
 
-    AbstractAuthenticationSupportedRepository(PasswordCredentials credentials) {
-        this.passwordCredentials = credentials;
+    AbstractAuthenticationSupportedRepository(PasswordCredentials passwordCredentials, Instantiator instantiator) {
+        this.passwordCredentials = passwordCredentials;
+        this.alternativeCredentials = passwordCredentials;
+        this.instantiator = instantiator;
     }
 
     public PasswordCredentials getCredentials() {
+        if (passwordCredentials == null && alternativeCredentials != null) {
+            throw new IllegalStateException("Password credentials has been overridden by a specific credentials of type ["
+                    + alternativeCredentials.getClass().getName()
+                    + "] Credentials should be accessed using 'getAlternativeCredentials()'");
+        }
         return passwordCredentials;
     }
 
@@ -37,6 +50,37 @@ public abstract class AbstractAuthenticationSupportedRepository extends Abstract
     }
 
     public void credentials(Action<? super PasswordCredentials> action) {
+        if (passwordCredentials == null) {
+            throw new IllegalStateException("Password credentials is null, most likely an alternative "
+                    + "credentials type has been configured for this repository");
+        }
         action.execute(passwordCredentials);
+    }
+
+    public <T extends Credentials> void credentials(Class<T> clazz, Action<? super Credentials> action) {
+        Credentials instance = null;
+        if (clazz == AwsCredentials.class) {
+            instance = instantiator.newInstance(DefaultAwsCredentials.class);
+        } else if (clazz == PasswordCredentials.class) {
+            instance = instantiator.newInstance(DefaultPasswordCredentials.class);
+        }
+        overrideDefaultCredentials(instance);
+        action.execute(instance);
+    }
+
+    /**
+     * Implies the user has configured the DSL with a specific type: { credentials(PasswordCredentials){ ... }
+     */
+    private void overrideDefaultCredentials(Credentials instance) {
+        alternativeCredentials = instance;
+        passwordCredentials = null;
+    }
+
+    public Credentials getAlternativeCredentials() {
+        if (null == alternativeCredentials) {
+            throw new IllegalStateException("This repository has not been configured a specific credentials type "
+                    + "e.g. (credentials(PasswordCredentials){ ... })");
+        }
+        return alternativeCredentials;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -69,7 +69,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
 
     public MavenArtifactRepository createMavenLocalRepository() {
         MavenArtifactRepository mavenRepository = instantiator.newInstance(DefaultMavenLocalArtifactRepository.class, fileResolver, createPasswordCredentials(), transportFactory,
-                locallyAvailableResourceFinder, artifactFileStore, pomParser);
+                locallyAvailableResourceFinder, instantiator, artifactFileStore, pomParser);
         final File localMavenRepository = localMavenRepositoryLocator.getLocalMavenRepository();
         mavenRepository.setUrl(localMavenRepository);
         return mavenRepository;
@@ -94,7 +94,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
 
     public MavenArtifactRepository createMavenRepository() {
         return instantiator.newInstance(DefaultMavenArtifactRepository.class, fileResolver, createPasswordCredentials(), transportFactory,
-                locallyAvailableResourceFinder, artifactFileStore, pomParser);
+                locallyAvailableResourceFinder, instantiator, artifactFileStore, pomParser);
     }
 
     private PasswordCredentials createPasswordCredentials() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -56,7 +56,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
     public DefaultIvyArtifactRepository(FileResolver fileResolver, PasswordCredentials credentials, RepositoryTransportFactory transportFactory,
                                         LocallyAvailableResourceFinder<ModuleComponentArtifactMetaData> locallyAvailableResourceFinder, Instantiator instantiator,
                                         ResolverStrategy resolverStrategy, FileStore<ModuleComponentArtifactMetaData> artifactFileStore) {
-        super(credentials);
+        super(credentials, instantiator);
         this.fileResolver = fileResolver;
         this.transportFactory = transportFactory;
         this.locallyAvailableResourceFinder = locallyAvailableResourceFinder;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.local.FileStore;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 
@@ -47,8 +48,9 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     public DefaultMavenArtifactRepository(FileResolver fileResolver, PasswordCredentials credentials, RepositoryTransportFactory transportFactory,
                                           LocallyAvailableResourceFinder<ModuleComponentArtifactMetaData> locallyAvailableResourceFinder,
+                                          Instantiator instantiator,
                                           FileStore<ModuleComponentArtifactMetaData> artifactFileStore, MetaDataParser pomParser) {
-        super(credentials);
+        super(credentials, instantiator);
         this.fileResolver = fileResolver;
         this.transportFactory = transportFactory;
         this.locallyAvailableResourceFinder = locallyAvailableResourceFinder;
@@ -116,7 +118,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     }
 
     protected RepositoryTransport getTransport(String scheme) {
-        return transportFactory.createTransport(scheme, getName(), getCredentials());
+        return transportFactory.createTransport(scheme, getName(), getAlternativeCredentials());
     }
 
     protected LocallyAvailableResourceFinder<ModuleComponentArtifactMetaData> getLocallyAvailableResourceFinder() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.MavenLocalResolve
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.local.FileStore;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 
@@ -31,9 +32,9 @@ import java.net.URI;
 
 public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRepository implements MavenArtifactRepository {
     public DefaultMavenLocalArtifactRepository(FileResolver fileResolver, PasswordCredentials credentials, RepositoryTransportFactory transportFactory,
-                                        LocallyAvailableResourceFinder<ModuleComponentArtifactMetaData> locallyAvailableResourceFinder,
+                                        LocallyAvailableResourceFinder<ModuleComponentArtifactMetaData> locallyAvailableResourceFinder, Instantiator instantiator,
                                         FileStore<ModuleComponentArtifactMetaData> artifactFileStore, MetaDataParser pomParser) {
-        super(fileResolver, credentials, transportFactory, locallyAvailableResourceFinder, artifactFileStore, pomParser);
+        super(fileResolver, credentials, transportFactory, locallyAvailableResourceFinder, instantiator, artifactFileStore, pomParser);
     }
 
     protected MavenResolver createRealResolver() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
@@ -16,14 +16,17 @@
 package org.gradle.api.internal.artifacts.repositories.transport;
 
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.artifacts.repositories.AwsCredentials;
 import org.gradle.api.artifacts.repositories.PasswordCredentials;
 import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.file.TemporaryFileProvider;
+import org.gradle.credentials.Credentials;
 import org.gradle.internal.resource.cached.CachedExternalResourceIndex;
+import org.gradle.internal.resource.transport.aws.s3.S3TransportBuilder;
 import org.gradle.internal.resource.transport.file.FileTransport;
 import org.gradle.internal.resource.transport.http.HttpTransport;
 import org.gradle.internal.resource.transport.sftp.SftpClientFactory;
 import org.gradle.internal.resource.transport.sftp.SftpTransport;
-import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.logging.ProgressLoggerFactory;
 import org.gradle.util.BuildCommencedTimeProvider;
 import org.gradle.util.WrapUtil;
@@ -32,6 +35,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class RepositoryTransportFactory {
+    private static final String[] SUPPORTED_SCHEMES = new String[]{"http", "https", "file", "sftp", "s3"};
     private final TemporaryFileProvider temporaryFileProvider;
     private final CachedExternalResourceIndex<String> cachedExternalResourceIndex;
     private final ProgressLoggerFactory progressLoggerFactory;
@@ -53,7 +57,7 @@ public class RepositoryTransportFactory {
         this.cacheLockingManager = cacheLockingManager;
     }
 
-    private RepositoryTransport createHttpTransport(String name, PasswordCredentials credentials) {
+    private RepositoryTransport createHttpTransport(String name, Credentials credentials) {
         return new HttpTransport(name, convertPasswordCredentials(credentials), progressLoggerFactory, temporaryFileProvider, cachedExternalResourceIndex, timeProvider, cacheLockingManager);
     }
 
@@ -61,24 +65,38 @@ public class RepositoryTransportFactory {
         return new FileTransport(name);
     }
 
-    private RepositoryTransport createSftpTransport(String name, PasswordCredentials credentials) {
+    private RepositoryTransport createSftpTransport(String name, Credentials credentials) {
         return new SftpTransport(name, convertPasswordCredentials(credentials), progressLoggerFactory, temporaryFileProvider, cachedExternalResourceIndex, timeProvider, sftpClientFactory, cacheLockingManager);
     }
 
-    public RepositoryTransport createTransport(String scheme, String name, PasswordCredentials credentials) {
+    public RepositoryTransport createTransport(String scheme, String name, Credentials credentials) {
         Set<String> schemes = new HashSet<String>();
         schemes.add(scheme);
         return createTransport(schemes, name, credentials);
     }
 
-    private org.gradle.internal.resource.PasswordCredentials convertPasswordCredentials(PasswordCredentials credentials) {
-        return new org.gradle.internal.resource.PasswordCredentials(credentials.getUsername(), credentials.getPassword());
+    private org.gradle.internal.resource.PasswordCredentials convertPasswordCredentials(Credentials credentials) {
+        if (!(credentials instanceof PasswordCredentials)) {
+            throw new IllegalArgumentException(String.format("Credentials must be an instance of: %s", PasswordCredentials.class.getCanonicalName()));
+        }
+        PasswordCredentials passwordCredentials = (PasswordCredentials) credentials;
+        return new org.gradle.internal.resource.PasswordCredentials(passwordCredentials.getUsername(), passwordCredentials.getPassword());
     }
 
-    public RepositoryTransport createTransport(Set<String> schemes, String name, PasswordCredentials credentials) {
-        if (!WrapUtil.toSet("http", "https", "file", "sftp").containsAll(schemes)) {
-            throw new InvalidUserDataException("You may only specify 'file', 'http', 'https' and 'sftp' URLs for a repository.");
-        }
+    private RepositoryTransport createS3Transport(String name, Credentials credentials) {
+        return new S3TransportBuilder()
+                .awsCredentials((AwsCredentials) credentials)
+                .cacheLockingManager(cacheLockingManager)
+                .cachedExternalResourceIndex(cachedExternalResourceIndex)
+                .name(name)
+                .progressLoggerFactory(progressLoggerFactory)
+                .temporaryFileProvider(temporaryFileProvider)
+                .timeProvider(timeProvider)
+                .build();
+    }
+
+    public RepositoryTransport createTransport(Set<String> schemes, String name, Credentials credentials) {
+        validateSchemes(schemes);
         if (WrapUtil.toSet("http", "https").containsAll(schemes)) {
             return createHttpTransport(name, credentials);
         }
@@ -88,6 +106,15 @@ public class RepositoryTransportFactory {
         if (WrapUtil.toSet("sftp").containsAll(schemes)) {
             return createSftpTransport(name, credentials);
         }
+        if (WrapUtil.toSet("s3").containsAll(schemes)) {
+            return createS3Transport(name, credentials);
+        }
         throw new InvalidUserDataException("You cannot mix different URL schemes for a single repository. Please declare separate repositories.");
+    }
+
+    private void validateSchemes(Set<String> schemes) {
+        if (!WrapUtil.toSet(SUPPORTED_SCHEMES).containsAll(schemes)) {
+            throw new InvalidUserDataException("You may only specify 'file', 'http', 'https', 'sftp' and 's3' URLs for a repository.");
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
+import com.amazonaws.services.s3.model.*;
+import org.apache.commons.lang.StringUtils;
+import org.gradle.api.artifacts.repositories.AwsCredentials;
+import org.gradle.internal.resource.PasswordCredentials;
+import org.gradle.internal.resource.transport.http.HttpProxySettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class S3Client {
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3Client.class);
+    private static final Pattern FILENAME_PATTERN = Pattern.compile("[^\\/]+\\.*$");
+    private final AmazonS3Client amazonS3Client;
+    private final S3ConnectionProperties s3ConnectionProperties;
+
+    public S3Client(AmazonS3Client amazonS3Client, S3ConnectionProperties s3ConnectionProperties) {
+        this.s3ConnectionProperties = s3ConnectionProperties;
+        this.amazonS3Client = amazonS3Client;
+    }
+
+    public S3Client(AwsCredentials awsCredentials, S3ConnectionProperties s3ConnectionProperties) {
+        S3CredentialsProvider s3CredentialsProvider = new S3CredentialsProvider(awsCredentials.getAccessKey(), awsCredentials.getSecretKey());
+        this.s3ConnectionProperties = s3ConnectionProperties;
+        amazonS3Client = createClient(s3CredentialsProvider);
+    }
+
+    private AmazonS3Client createClient(S3CredentialsProvider s3CredentialsProvider) {
+        AmazonS3Client client = new AmazonS3Client(s3CredentialsProvider.getChain(), getClientConfiguration());
+        String endPoint = s3ConnectionProperties.getEndpoint();
+        if (StringUtils.isNotBlank(endPoint)) {
+            client.setEndpoint(endPoint);
+            client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true));
+        }
+        return client;
+    }
+
+    private ClientConfiguration getClientConfiguration() {
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        HttpProxySettings.HttpProxy proxy = s3ConnectionProperties.getProxySettings().getProxy();
+        if (proxy != null) {
+            clientConfiguration.setProxyHost(proxy.host);
+            clientConfiguration.setProxyPort(proxy.port);
+            PasswordCredentials credentials = proxy.credentials;
+            if (credentials != null) {
+                clientConfiguration.setProxyUsername(credentials.getUsername());
+                clientConfiguration.setProxyPassword(credentials.getPassword());
+            }
+        }
+        return clientConfiguration;
+    }
+
+    public void put(InputStream inputStream, Long contentLength, URI destination) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(contentLength);
+        String bucketName = getBucketName(destination);
+        String s3Key = getS3BucketKey(destination);
+        LOGGER.debug("Attempting to put resource:[{}] into s3 bucket [{}]", s3Key, bucketName);
+        amazonS3Client.putObject(bucketName, s3Key, inputStream, objectMetadata);
+    }
+
+    public ObjectMetadata getMetaData(URI uri) {
+        String bucketName = getBucketName(uri);
+        String s3Key = getS3BucketKey(uri);
+        ObjectMetadata objectMetadata = amazonS3Client.getObjectMetadata(bucketName, s3Key);
+        return objectMetadata;
+    }
+
+    public S3Object getResource(URI uri) {
+        LOGGER.debug("Attempting to get s3 resource: [{}]", uri.toString());
+        S3Object object = amazonS3Client.getObject(getBucketName(uri), getS3BucketKey(uri));
+        return object;
+    }
+
+    private String getS3BucketKey(URI destination) {
+        String path = destination.getPath();
+        return path.startsWith("/") ? path.substring(1) : path;
+    }
+
+    private String getBucketName(URI uri) {
+        return uri.getHost();
+    }
+
+    public List<String> list(URI parent) {
+        List<String> results = new ArrayList<String>();
+        String bucketName = getBucketName(parent);
+        String s3Key = getS3BucketKey(parent);
+        ListObjectsRequest listObjectsRequest = new ListObjectsRequest()
+                .withBucketName(bucketName)
+                .withPrefix(s3Key)
+                .withDelimiter("/");
+        ObjectListing objectListing = amazonS3Client.listObjects(listObjectsRequest);
+        results.addAll(resolveResourceNames(objectListing));
+
+        while (objectListing.isTruncated()) {
+            objectListing = amazonS3Client.listNextBatchOfObjects(objectListing);
+            results.addAll(resolveResourceNames(objectListing));
+        }
+        return results;
+    }
+
+    private List<String> resolveResourceNames(ObjectListing objectListing) {
+        List<String> results = new ArrayList<String>();
+        List<S3ObjectSummary> objectSummaries = objectListing.getObjectSummaries();
+        if (null != objectSummaries) {
+            for (S3ObjectSummary objectSummary : objectSummaries) {
+                String key = objectSummary.getKey();
+                String fileName = extractResourceName(key);
+                if (null != fileName) {
+                    results.add(fileName);
+                }
+            }
+        }
+        return results;
+    }
+
+    private String extractResourceName(String key) {
+        Matcher matcher = FILENAME_PATTERN.matcher(key);
+        if (matcher.find()) {
+            String group = matcher.group(0);
+            return group.contains(".") ? group : null;
+        }
+        return null;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectionProperties.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectionProperties.java
@@ -16,26 +16,69 @@
 
 package org.gradle.internal.resource.transport.aws.s3;
 
+import com.google.common.base.Optional;
+import org.apache.commons.lang.StringUtils;
 import org.gradle.internal.resource.transport.http.HttpProxySettings;
+import org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpProxySettings;
 import org.gradle.internal.resource.transport.http.JavaSystemPropertiesSecureHttpProxySettings;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+import static com.amazonaws.services.s3.internal.Constants.S3_HOSTNAME;
+import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.System.getProperty;
+import static org.apache.commons.lang.StringUtils.isBlank;
 
 public class S3ConnectionProperties {
     public static final String S3_ENDPOINT_PROPERTY = "org.gradle.s3.endpoint";
-    private final String endpoint;
+    private static final Set<String> SUPPORTED_SCHEMES = newHashSet("HTTP", "HTTPS");
+
+    private final Optional<URI> endpoint;
     private final HttpProxySettings proxySettings;
+    private final HttpProxySettings secureProxySettings;
 
     public S3ConnectionProperties() {
-        endpoint = getProperty(S3_ENDPOINT_PROPERTY);
-        proxySettings = new JavaSystemPropertiesSecureHttpProxySettings();
+        endpoint = configureEndpoint(getProperty(S3_ENDPOINT_PROPERTY));
+        proxySettings = new JavaSystemPropertiesHttpProxySettings();
+        secureProxySettings = new JavaSystemPropertiesSecureHttpProxySettings();
     }
 
-    public String getEndpoint() {
+    public S3ConnectionProperties(HttpProxySettings proxySettings, HttpProxySettings secureProxySettings, URI endpoint) {
+        this.endpoint = Optional.fromNullable(endpoint);
+        this.proxySettings = proxySettings;
+        this.secureProxySettings = secureProxySettings;
+    }
+
+    private Optional<URI> configureEndpoint(String property) {
+        URI uri = null;
+        if (StringUtils.isNotBlank(property)) {
+            try {
+                uri = new URI(property);
+                if (isBlank(uri.getScheme()) || !SUPPORTED_SCHEMES.contains(uri.getScheme().toUpperCase())) {
+                    throw new IllegalArgumentException("System property [" + S3_ENDPOINT_PROPERTY + "=" + property + "] must have a scheme of 'http' or 'https'");
+                }
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException("System property [" + S3_ENDPOINT_PROPERTY + "=" + property + "]  must be a valid URI");
+            }
+        }
+        return Optional.fromNullable(uri);
+    }
+
+    public Optional<URI> getEndpoint() {
         return endpoint;
     }
 
-    public HttpProxySettings getProxySettings() {
-        return proxySettings;
+    public Optional<HttpProxySettings.HttpProxy> getProxy() {
+        if (endpoint.isPresent()) {
+            String host = endpoint.get().getHost();
+            if (endpoint.get().getScheme().toUpperCase().equals("HTTP")) {
+                return Optional.fromNullable(proxySettings.getProxy(host));
+            } else {
+                return Optional.fromNullable(secureProxySettings.getProxy(host));
+            }
+        }
+        return Optional.fromNullable(secureProxySettings.getProxy(S3_HOSTNAME));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectionProperties.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectionProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+import org.gradle.internal.resource.transport.http.HttpProxySettings;
+import org.gradle.internal.resource.transport.http.JavaSystemPropertiesSecureHttpProxySettings;
+
+import static java.lang.System.getProperty;
+
+public class S3ConnectionProperties {
+    public static final String S3_ENDPOINT_PROPERTY = "org.gradle.s3.endpoint";
+    private final String endpoint;
+    private final HttpProxySettings proxySettings;
+
+    public S3ConnectionProperties() {
+        endpoint = getProperty(S3_ENDPOINT_PROPERTY);
+        proxySettings = new JavaSystemPropertiesSecureHttpProxySettings();
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public HttpProxySettings getProxySettings() {
+        return proxySettings;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3CredentialsProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3CredentialsProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+import com.amazonaws.auth.*;
+
+public class S3CredentialsProvider implements AWSCredentialsProvider {
+
+    private BasicAWSCredentials credentials;
+
+    public S3CredentialsProvider(String key, String secret) {
+        this.credentials = new BasicAWSCredentials(key, secret);
+    }
+
+    public AWSCredentials getCredentials() {
+        return credentials;
+    }
+
+    public AWSCredentialsProviderChain getChain() {
+        return new AWSCredentialsProviderChain(this, new InstanceProfileCredentialsProvider());
+    }
+
+    public void refresh() {
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Exception.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Exception.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+public class S3Exception extends RuntimeException {
+
+    public S3Exception(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Resource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Resource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import org.gradle.internal.resource.AbstractExternalResource;
+import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData;
+import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Date;
+
+public class S3Resource extends AbstractExternalResource {
+
+    private final S3Object s3Object;
+    private final ObjectMetadata objectMetadata;
+    private final URI uri;
+
+    public S3Resource(S3Object s3Object, URI uri) {
+        this.s3Object = s3Object;
+        objectMetadata = s3Object.getObjectMetadata();
+        this.uri = uri;
+    }
+
+    @Override
+    protected InputStream openStream() throws IOException {
+        return s3Object.getObjectContent();
+    }
+
+    public URI getURI() {
+        return uri;
+    }
+
+    public long getContentLength() {
+        return objectMetadata.getContentLength();
+    }
+
+    public boolean isLocal() {
+        return false;
+    }
+
+    public ExternalResourceMetaData getMetaData() {
+        ObjectMetadata objectMetadata = s3Object.getObjectMetadata();
+        Date lastModified = objectMetadata.getLastModified();
+        DefaultExternalResourceMetaData defaultExternalResourceMetaData = new DefaultExternalResourceMetaData(uri,
+                lastModified.getTime(),
+                getContentLength(),
+                objectMetadata.getETag(),
+                null); // Passing null for sha1 - TODO - consider using the etag which is an MD5 hash of the file (when less than 5Gb)
+        return defaultExternalResourceMetaData;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnector.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import org.apache.commons.io.IOUtils;
+import org.gradle.internal.Factory;
+import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.resource.ExternalResource;
+import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData;
+import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
+import org.gradle.internal.resource.transfer.ExternalResourceAccessor;
+import org.gradle.internal.resource.transfer.ExternalResourceLister;
+import org.gradle.internal.resource.transfer.ExternalResourceUploader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+public class S3ResourceConnector implements ExternalResourceLister, ExternalResourceAccessor, ExternalResourceUploader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3ResourceConnector.class);
+    private final S3Client s3Client;
+
+    public S3ResourceConnector(S3Client s3Client) {
+        this.s3Client = s3Client;
+    }
+
+    public List<String> list(URI parent) throws IOException {
+        LOGGER.debug("Listing parent resources: {}", parent);
+        List<String> list = s3Client.list(parent);
+        return list;
+    }
+
+    public ExternalResource getResource(URI location) throws IOException {
+        LOGGER.debug("Attempting to get resource: {}", location);
+        S3Object s3Object = s3Client.getResource(location);
+        return new S3Resource(s3Object, location);
+    }
+
+    public HashValue getResourceSha1(URI location) {
+        try {
+            S3Object resource = s3Client.getResource(new URI(location.toString() + ".sha1"));
+            S3ObjectInputStream objectContent = resource.getObjectContent();
+            String sha = IOUtils.toString(objectContent);
+            return HashValue.parse(sha);
+        } catch (IOException e) {
+            LOGGER.error("Could not get contents of resource sha", e);
+        } catch (URISyntaxException e) {
+            LOGGER.error("Could not create URI for sha resource", e);
+        }
+        return null;
+    }
+
+    public ExternalResourceMetaData getMetaData(URI location) throws IOException {
+        LOGGER.debug("Attempting to get resource metadata: {}", location);
+        ObjectMetadata metaData = s3Client.getMetaData(location);
+        DefaultExternalResourceMetaData defaultExternalResourceMetaData = new DefaultExternalResourceMetaData(location,
+                metaData.getLastModified().getTime(),
+                metaData.getContentLength(),
+                metaData.getETag(),
+                null); // Passing null for sha1 - TODO - consider using the etag which is an MD5 hash of the file (when less than 5Gb)
+        return defaultExternalResourceMetaData;
+    }
+
+    public void upload(Factory<InputStream> sourceFactory, Long contentLength, URI destination) throws IOException {
+        LOGGER.debug("Attempting to upload stream to : {}", destination);
+        InputStream inputStream = sourceFactory.create();
+        s3Client.put(inputStream, contentLength, destination);
+        inputStream.close();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Transport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Transport.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+import org.gradle.api.artifacts.repositories.AwsCredentials;
+import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.file.TemporaryFileProvider;
+import org.gradle.internal.resource.cached.CachedExternalResourceIndex;
+import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor;
+import org.gradle.internal.resource.transfer.DefaultCacheAwareExternalResourceAccessor;
+import org.gradle.internal.resource.transfer.ProgressLoggingExternalResourceAccessor;
+import org.gradle.internal.resource.transfer.ProgressLoggingExternalResourceUploader;
+import org.gradle.internal.resource.transport.AbstractRepositoryTransport;
+import org.gradle.internal.resource.transport.DefaultExternalResourceRepository;
+import org.gradle.internal.resource.transport.ExternalResourceRepository;
+import org.gradle.logging.ProgressLoggerFactory;
+import org.gradle.util.BuildCommencedTimeProvider;
+
+public class S3Transport extends AbstractRepositoryTransport {
+    private final ExternalResourceRepository repository;
+    private final DefaultCacheAwareExternalResourceAccessor resourceAccessor;
+
+
+    protected S3Transport(String name, AwsCredentials awsCredentials,
+                          ProgressLoggerFactory progressLoggerFactory,
+                          TemporaryFileProvider temporaryFileProvider,
+                          CachedExternalResourceIndex<String> cachedExternalResourceIndex,
+                          BuildCommencedTimeProvider timeProvider,
+                          CacheLockingManager cacheLockingManager) {
+        super(name);
+        S3ResourceConnector connector = new S3ResourceConnector(new S3Client(awsCredentials, new S3ConnectionProperties()));
+        ProgressLoggingExternalResourceUploader uploader = new ProgressLoggingExternalResourceUploader(connector, progressLoggerFactory);
+        ProgressLoggingExternalResourceAccessor loggingAccessor = new ProgressLoggingExternalResourceAccessor(connector, progressLoggerFactory);
+        resourceAccessor = new DefaultCacheAwareExternalResourceAccessor(loggingAccessor, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, cacheLockingManager);
+        repository = new DefaultExternalResourceRepository(name, connector, uploader, connector);
+    }
+
+    public ExternalResourceRepository getRepository() {
+        return repository;
+    }
+
+    public CacheAwareExternalResourceAccessor getResourceAccessor() {
+        return resourceAccessor;
+    }
+
+    public boolean isLocal() {
+        return false;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3TransportBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3TransportBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+import org.gradle.api.artifacts.repositories.AwsCredentials;
+import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.file.TemporaryFileProvider;
+import org.gradle.internal.resource.cached.CachedExternalResourceIndex;
+import org.gradle.logging.ProgressLoggerFactory;
+import org.gradle.util.BuildCommencedTimeProvider;
+
+public class S3TransportBuilder {
+    private String name;
+    private AwsCredentials awsCredentials;
+    private ProgressLoggerFactory progressLoggerFactory;
+    private TemporaryFileProvider temporaryFileProvider;
+    private CachedExternalResourceIndex<String> cachedExternalResourceIndex;
+    private BuildCommencedTimeProvider timeProvider;
+    private CacheLockingManager cacheLockingManager;
+
+    public S3TransportBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public S3TransportBuilder awsCredentials(AwsCredentials awsCredentials) {
+        this.awsCredentials = awsCredentials;
+        return this;
+    }
+
+    public S3TransportBuilder progressLoggerFactory(ProgressLoggerFactory progressLoggerFactory) {
+        this.progressLoggerFactory = progressLoggerFactory;
+        return this;
+    }
+
+    public S3TransportBuilder temporaryFileProvider(TemporaryFileProvider temporaryFileProvider) {
+        this.temporaryFileProvider = temporaryFileProvider;
+        return this;
+    }
+
+    public S3TransportBuilder cachedExternalResourceIndex(CachedExternalResourceIndex<String> cachedExternalResourceIndex) {
+        this.cachedExternalResourceIndex = cachedExternalResourceIndex;
+        return this;
+    }
+
+    public S3TransportBuilder timeProvider(BuildCommencedTimeProvider timeProvider) {
+        this.timeProvider = timeProvider;
+        return this;
+    }
+
+    public S3TransportBuilder cacheLockingManager(CacheLockingManager cacheLockingManager) {
+        this.cacheLockingManager = cacheLockingManager;
+        return this;
+    }
+
+    public S3Transport build() {
+        return new S3Transport(name,
+                awsCredentials,
+                progressLoggerFactory,
+                temporaryFileProvider,
+                cachedExternalResourceIndex,
+                timeProvider,
+                cacheLockingManager);
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepositoryTest.groovy
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories
+
+import org.gradle.api.Action
+import org.gradle.api.artifacts.repositories.AwsCredentials
+import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.internal.ClosureBackedAction
+import org.gradle.credentials.Credentials
+import org.gradle.internal.credentials.DefaultAwsCredentials
+import org.gradle.internal.reflect.DirectInstantiator
+import org.gradle.internal.reflect.Instantiator
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class AbstractAuthenticationSupportedRepositoryTest extends Specification {
+
+    final AbstractAuthenticationSupportedRepository repository = new AuthSupportedRepository(null, new DirectInstantiator())
+
+    def "should configure default password credentials using a closure only"() {
+        setup:
+        DefaultPasswordCredentials passwordCredentials = new DefaultPasswordCredentials()
+        enhanceCredentials(passwordCredentials, 'username', 'password')
+
+        Instantiator instantiator = Mock()
+        instantiator.newInstance(DefaultPasswordCredentials) >> passwordCredentials
+
+        AuthSupportedRepository repo = new AuthSupportedRepository(passwordCredentials, instantiator)
+
+        Closure cls = {
+            username "myUsername"
+            password "myPassword"
+        }
+
+        when:
+        repo.credentials(cls)
+
+        then:
+        repo.credentials
+        repo.credentials.username == 'myUsername'
+        repo.credentials.password == 'myPassword'
+    }
+
+    def "should configure alternative credentials"() {
+        setup:
+        DefaultAwsCredentials enhancedCredentials = new DefaultAwsCredentials()
+        enhanceCredentials(enhancedCredentials, 'accessKey', 'secretKey')
+
+        Instantiator instantiator = Mock()
+        instantiator.newInstance(DefaultAwsCredentials) >> enhancedCredentials
+
+        AuthSupportedRepository repo = new AuthSupportedRepository(null, instantiator)
+
+        def action = new ClosureBackedAction<DefaultAwsCredentials>({
+            accessKey = 'key'
+            secretKey = 'secret'
+        })
+
+        when:
+        repo.credentials(AwsCredentials.class, action)
+        def credentials = repo.getAlternativeCredentials()
+
+        then:
+        credentials.accessKey == 'key'
+        credentials.secretKey == 'secret'
+
+    }
+
+    @Unroll
+    def "should instantiate the correct default credential types "() {
+        Instantiator instantiator = Mock()
+        Action action = Mock()
+        AuthSupportedRepository repo = new AuthSupportedRepository(null, instantiator)
+
+        when:
+        repo.credentials(credentialType, action) == credentials
+
+        then:
+        1 * instantiator.newInstance(_) >> credentials
+        1 * action.execute(credentials)
+
+        where:
+        credentialType      | credentials
+        AwsCredentials      | Mock(AwsCredentials)
+        PasswordCredentials | Mock(PasswordCredentials)
+    }
+
+    def "should throw when credentials have been pre-configured with a specific type"() {
+        Instantiator instantiator = Mock()
+        Action action = Mock()
+        AuthSupportedRepository repo = new AuthSupportedRepository(null, instantiator)
+        1 * instantiator.newInstance(_) >> credentials
+        1 * action.execute(credentials)
+
+        when:
+        repo.credentials(credentialType, action)
+        repo.getCredentials()
+
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.message.startsWith("Password credentials has been overridden by a specific credentials of type [")
+
+        where:
+        credentialType      | credentials
+        AwsCredentials      | Mock(AwsCredentials)
+        PasswordCredentials | Mock(PasswordCredentials)
+    }
+
+    def "should configure aws credentials"() {
+        Instantiator instantiator = Mock()
+        AuthSupportedRepository repo = new AuthSupportedRepository(null, instantiator)
+        def alternative = Mock(AwsCredentials)
+        Action action = Mock()
+        1 * instantiator.newInstance(DefaultAwsCredentials) >> alternative
+        repo.credentials(AwsCredentials, action)
+
+        when:
+        def credentials = repo.getAlternativeCredentials()
+
+        then:
+        credentials == alternative
+    }
+
+    def "should default both credentials to PasswordCredentials"() {
+        setup:
+        PasswordCredentials pCredentials = Mock()
+        when:
+        def repo = new AuthSupportedRepository(pCredentials, null)
+        then:
+        repo.getCredentials() == pCredentials
+        repo.getAlternativeCredentials() == pCredentials
+    }
+
+    def "Should throw on configuring and password credentials is null"() {
+        setup:
+        def repo = new AuthSupportedRepository(null, new DirectInstantiator())
+        def action = new ClosureBackedAction<DefaultPasswordCredentials>({
+            username = 'key'
+            password = 'secret'
+        })
+
+        when:
+        repo.credentials(action)
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.message == "Password credentials is null, most likely an alternative credentials type has been configured for this repository"
+    }
+
+    private void enhanceCredentials(Credentials credentials, String... props) {
+        props.each { prop ->
+            credentials.metaClass."$prop" = { String val ->
+                delegate."set${prop.capitalize()}"(val)
+            }
+        }
+    }
+
+    class AuthSupportedRepository extends AbstractAuthenticationSupportedRepository {
+        AuthSupportedRepository(Credentials credentials, Instantiator instantiator) {
+            super(credentials, instantiator)
+        }
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransp
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
+import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
 import org.gradle.internal.resource.transport.ExternalResourceRepository
 import org.gradle.logging.ProgressLoggerFactory
@@ -37,7 +38,7 @@ class DefaultMavenLocalRepositoryTest extends Specification {
     final MetaDataParser pomParser = Stub()
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenLocalArtifactRepository(
-            resolver, credentials, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, pomParser)
+            resolver, credentials, transportFactory, locallyAvailableResourceFinder, new DirectInstantiator(), artifactIdentifierFileStore, pomParser)
     final ProgressLoggerFactory progressLoggerFactory = Mock()
 
     def "creates local repository"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.ObjectListing
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import org.gradle.internal.credentials.DefaultAwsCredentials
+import org.gradle.internal.resource.transport.http.HttpProxySettings
+import org.gradle.internal.resource.transport.http.JavaSystemPropertiesSecureHttpProxySettings
+import spock.lang.Specification
+
+class S3ClientTest extends Specification {
+
+    final S3ConnectionProperties s3SystemProperties = Mock()
+
+    def "should resolve bucket name from uri"() {
+        given:
+        URI uri = new URI(uriStr)
+        def client = new S3Client(Mock(AmazonS3Client), s3SystemProperties)
+
+        expect:
+        client.getBucketName(uri) == expected
+
+        where:
+        uriStr                                              || expected
+        "s3://localhost"                                    || "localhost"
+        "s3://localhost.com/somePath/somePath/filename.txt" || "localhost.com"
+        "s3://myaws.com.au"                                 || "myaws.com.au"
+        "http://myaws.com.au"                               || "myaws.com.au"
+        "https://myaws.com.au"                              || "myaws.com.au"
+    }
+
+    def "should resolve s3 bucket key from uri"() {
+        given:
+        URI uri = new URI(uriStr)
+        def client = new S3Client(Mock(AmazonS3Client), s3SystemProperties)
+
+        expect:
+        client.getS3BucketKey(uri) == expected
+
+        where:
+        uriStr                                     || expected
+        's3://localhost/maven/release/myFile.txt'  || 'maven/release/myFile.txt'
+        's3://localhost/maven/snapshot/myFile.txt' || 'maven/snapshot/myFile.txt'
+        's3://localhost/maven/'                    || 'maven/'
+
+    }
+
+    def "Should upload to s3"() {
+        given:
+        AmazonS3Client amazonS3Client = Mock()
+        S3Client client = new S3Client(amazonS3Client, s3SystemProperties)
+        URI uri = new URI("s3://localhost/maven/snapshot/myFile.txt")
+
+        when:
+        client.put(Mock(InputStream), 12L, uri)
+
+        then:
+        1 * amazonS3Client.putObject(*_) >> { args ->
+            assert args[0] == 'localhost'
+            assert args[1] == 'maven/snapshot/myFile.txt'
+            assert args[3].contentLength == 12
+        }
+    }
+
+    def "should extract file name from s3 listing"() {
+        S3Client s3Client = new S3Client(Mock(AmazonS3Client), s3SystemProperties)
+
+        expect:
+        s3Client.extractResourceName(listing) == expected
+
+        where:
+        listing         | expected
+        '/a/b/file.pom' | 'file.pom'
+        '/file.pom'     | 'file.pom'
+        '/file.pom'     | 'file.pom'
+        '/SNAPSHOT/'    | null
+        '/SNAPSHOT/bin' | null
+        '/'             | null
+    }
+
+    def "should resolve resource names from an AWS objectlisting"() {
+        setup:
+        S3Client s3Client = new S3Client(Mock(AmazonS3Client), s3SystemProperties)
+        ObjectListing objectListing = Mock()
+        S3ObjectSummary objectSummary = Mock()
+        objectSummary.getKey() >> '/SNAPSHOT/some.jar'
+        objectListing.getObjectSummaries() >> [objectSummary]
+
+        when:
+        def results = s3Client.resolveResourceNames(objectListing)
+
+        then:
+        results == ['some.jar']
+    }
+
+    def "should make batch call when more than one object listing exists"() {
+        def amazonS3Client = Mock(AmazonS3Client)
+        S3Client s3Client = new S3Client(amazonS3Client, s3SystemProperties)
+        def uri = new URI("s3://mybucket.com.au/maven/release/")
+        ObjectListing firstListing = Mock()
+        firstListing.isTruncated() >> true
+
+        ObjectListing secondListing = Mock()
+        secondListing.isTruncated() >> false
+
+        when:
+        s3Client.list(uri)
+
+        then:
+        1 * amazonS3Client.listObjects(_) >> firstListing
+        1 * amazonS3Client.listNextBatchOfObjects(_) >> secondListing
+    }
+
+    def "should apply endpoint override with path style access"() {
+        setup:
+        String someEndpoint = "someEndpoint"
+        S3ConnectionProperties s3Properties = Stub()
+        s3Properties.getEndpoint() >> someEndpoint
+
+        def credentials = new DefaultAwsCredentials()
+        credentials.setAccessKey("AKey")
+        credentials.setSecretKey("ASecret")
+
+        when:
+        S3Client s3Client = new S3Client(credentials, s3Properties)
+
+        then:
+        s3Client.amazonS3Client.clientOptions.pathStyleAccess == true
+        s3Client.amazonS3Client.endpoint == new URI("https://${someEndpoint}")
+    }
+
+    def "should configure https proxy"() {
+        setup:
+        JavaSystemPropertiesSecureHttpProxySettings proxySettings = Mock(JavaSystemPropertiesSecureHttpProxySettings)
+        proxySettings.getProxy() >> new HttpProxySettings.HttpProxy("localhost", 443, 'username', 'password')
+
+        S3ConnectionProperties s3Properties = Mock()
+        s3Properties.getProxySettings() >> proxySettings
+
+        def credentials = new DefaultAwsCredentials()
+        credentials.setAccessKey("AKey")
+        credentials.setSecretKey("ASecret")
+
+        when:
+        S3Client s3Client = new S3Client(credentials, s3Properties)
+
+        then:
+        s3Client.amazonS3Client.clientConfiguration.proxyHost == 'localhost'
+        s3Client.amazonS3Client.clientConfiguration.proxyPort == 443
+        s3Client.amazonS3Client.clientConfiguration.proxyPassword == 'password'
+        s3Client.amazonS3Client.clientConfiguration.proxyUsername == 'username'
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ConnectionPropertiesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ConnectionPropertiesTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3
+
+import com.amazonaws.services.s3.internal.Constants
+import org.gradle.internal.resource.transport.http.HttpProxySettings
+import spock.lang.Specification
+
+class S3ConnectionPropertiesTest extends Specification {
+
+    final S3ConnectionProperties s3ConnectionProperties = new S3ConnectionProperties()
+
+    def "should report invalid scheme"() {
+        when:
+        s3ConnectionProperties.configureEndpoint(endpoint)
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == "System property [org.gradle.s3.endpoint=$endpoint] must have a scheme of 'http' or 'https'"
+
+        where:
+        endpoint << ['httpd//somewhere', 'httpd://somewhere', 's3://somewhere']
+    }
+
+    def "should report invalid uri"() {
+        when:
+        s3ConnectionProperties.configureEndpoint('httpdasd%:/ads')
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == "System property [org.gradle.s3.endpoint=httpdasd%:/ads]  must be a valid URI"
+    }
+
+    def "should allow case insensitive schemes"() {
+        expect:
+        endpoint == s3ConnectionProperties.configureEndpoint(endpoint).get().toString()
+        where:
+        endpoint << ['http://some', 'httP://some', 'httpS://some', 'HTTpS://some']
+    }
+
+    def "should get secure proxy for default s3 host when no endpoint override present"() {
+        HttpProxySettings.HttpProxy secureProxy = Mock()
+        HttpProxySettings secureHttpProxySettings = Mock()
+
+        1 * secureHttpProxySettings.getProxy(Constants.S3_HOSTNAME) >> secureProxy
+
+        when:
+        S3ConnectionProperties properties = new S3ConnectionProperties(Mock(HttpProxySettings), secureHttpProxySettings, null)
+
+        then:
+        properties.getProxy().get() == secureProxy
+    }
+
+    def "should get non-secure http proxy for override host"() {
+        String endpoint = "http://someproxy"
+        HttpProxySettings.HttpProxy proxy = Mock()
+        HttpProxySettings httpProxySettings = Mock()
+
+        1 * httpProxySettings.getProxy(_) >> proxy
+
+        when:
+        S3ConnectionProperties properties = new S3ConnectionProperties(httpProxySettings, Mock(HttpProxySettings), new URI(endpoint))
+
+        then:
+        properties.getProxy().get() == proxy
+    }
+
+    def "should get secure http proxy for override host"() {
+        String endpoint = "https://someproxy"
+        HttpProxySettings.HttpProxy secureProxy = Mock()
+        HttpProxySettings secureHttpProxySettings = Mock()
+
+        1 * secureHttpProxySettings.getProxy(_) >> secureProxy
+
+        when:
+        S3ConnectionProperties properties = new S3ConnectionProperties(Mock(HttpProxySettings), secureHttpProxySettings, new URI(endpoint))
+
+        then:
+        properties.getProxy().get() == secureProxy
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3CredentialsProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3CredentialsProviderTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.resource.transport.http;
 
+package org.gradle.internal.resource.transport.aws.s3
 
+import com.amazonaws.auth.InstanceProfileCredentialsProvider
 import spock.lang.Specification
 
-class JavaSystemPropertiesHttpProxySettingsTest extends Specification {
+class S3CredentialsProviderTest extends Specification {
 
-    def "should use default HTTP prefix and port"() {
-        JavaSystemPropertiesProxySettings settings = new JavaSystemPropertiesHttpProxySettings()
-        expect:
-        settings.propertyPrefix == 'http'
-        settings.defaultPort == 80
+    def "should create with basic credentials first "() {
+        S3CredentialsProvider credentialsProvider = new S3CredentialsProvider('key', 'secret')
+
+        when:
+        def chain = credentialsProvider.getChain()
+
+        then:
+        chain.credentialsProviders[0] in S3CredentialsProvider
+        chain.credentialsProviders[1] in InstanceProfileCredentialsProvider
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnectorTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3
+
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.S3Object
+import com.amazonaws.services.s3.model.S3ObjectInputStream
+import org.apache.commons.io.IOUtils
+import org.gradle.internal.hash.HashValue
+import spock.lang.Specification
+
+class S3ResourceConnectorTest extends Specification {
+
+    public static final String SHA1_STRING = "06e7d22787ee800ce4c9a2b5e94805aee4d7f1f9"
+    URI uri = new URI("http://somewhere")
+
+    def "should list resources"() {
+        S3Client s3Client = Mock()
+        when:
+        new S3ResourceConnector(s3Client).list(uri)
+        then:
+        1 * s3Client.list(uri)
+    }
+
+    def "should get a resource"() {
+        ObjectMetadata objectMetadata = Mock()
+        S3Client s3Client = Mock {
+            1 * getResource(uri) >> Mock(S3Object) {
+                getObjectMetadata() >> objectMetadata
+            }
+        }
+        when:
+        S3Resource s3Resource = new S3ResourceConnector(s3Client).getResource(uri)
+        then:
+        s3Resource.getURI() == uri
+    }
+
+    def "should get a resource sha1"() {
+        given:
+        URI shaUri = new URI(uri.toString() + ".sha1")
+        S3Object s3Object = Mock()
+        S3ObjectInputStream s3ObjectInputStream = new S3ObjectInputStream(IOUtils.toInputStream(SHA1_STRING), null)
+        s3Object.getObjectContent() >> s3ObjectInputStream
+
+        S3Client s3Client = Mock()
+        1 * s3Client.getResource(_) >> { URI u ->
+            assert u == shaUri
+            return s3Object
+        }
+
+        when:
+        S3ResourceConnector connector = new S3ResourceConnector(s3Client)
+        HashValue sha1 = connector.getResourceSha1(uri)
+
+        then:
+        sha1.asHexString() == SHA1_STRING.substring(1, SHA1_STRING.length())
+    }
+
+    def "should return a null resource sha1 when sha cannot be read from input stream"() {
+        given:
+        S3Object s3Object = Mock()
+        s3Object.getObjectContent() >> Mock(S3ObjectInputStream)
+
+        S3Client s3Client = Mock()
+        1 * s3Client.getResource(_) >> s3Object
+
+        when:
+        S3ResourceConnector connector = new S3ResourceConnector(s3Client)
+        HashValue sha1 = connector.getResourceSha1(uri)
+
+        then:
+        sha1 == null
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3TransportBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3TransportBuilderTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3
+
+import org.gradle.api.artifacts.repositories.AwsCredentials
+import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager
+import org.gradle.api.internal.file.TemporaryFileProvider
+import org.gradle.internal.resource.cached.CachedExternalResourceIndex
+import org.gradle.logging.ProgressLoggerFactory
+import org.gradle.util.BuildCommencedTimeProvider
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class S3TransportBuilderTest extends Specification {
+
+    @Unroll
+    def "should set #property property"() {
+        S3TransportBuilder builder = new S3TransportBuilder()
+        expect:
+        builder."${property}"(value)."${property}" == value
+
+        where:
+        property                      | value
+        'name'                        | 'test'
+        'awsCredentials'              | Mock(AwsCredentials)
+        'progressLoggerFactory'       | Mock(ProgressLoggerFactory)
+        'temporaryFileProvider'       | Mock(TemporaryFileProvider)
+        'cachedExternalResourceIndex' | Mock(CachedExternalResourceIndex)
+        'timeProvider'                | Mock(BuildCommencedTimeProvider)
+        'cacheLockingManager'         | Mock(CacheLockingManager)
+    }
+}

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle
@@ -26,6 +26,7 @@ dependencies {
     }
     compile libraries.sshd
     compile libraries.gson
+    compile libraries.joda
     compile libraries.jsch
 }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
@@ -592,6 +592,10 @@ class HttpServer extends ServerWithExpectations {
         })
     }
 
+    void addHandler(Handler handler){
+        collection.addHandler(handler)
+    }
+
     int getPort() {
         return server.connectors[0].localPort
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/MavenS3Module.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/MavenS3Module.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.gradle.test.fixtures.server.s3
+
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.maven.MavenFileModule
+import org.gradle.test.fixtures.maven.MavenMetaData
+import org.gradle.test.fixtures.maven.MavenModule
+import org.gradle.test.fixtures.maven.MavenPom
+
+class MavenS3Module implements MavenModule {
+    MavenFileModule backingModule
+    S3StubServer server
+    String bucket
+    String repositoryPath
+
+    MavenS3Module(S3StubServer server, MavenFileModule backingModule, String repositoryPath, String bucket) {
+        this.bucket = bucket
+        this.server = server
+        this.backingModule = backingModule
+        this.repositoryPath = repositoryPath
+    }
+
+    MavenModule publish() {
+        backingModule.publish()
+    }
+
+    MavenModule publishPom() {
+        backingModule.publishPom()
+    }
+
+    MavenModule publishWithChangedContent() {
+        backingModule.publishWithChangedContent()
+    }
+
+    MavenModule withNonUniqueSnapshots() {
+        backingModule.withNonUniqueSnapshots()
+    }
+
+    MavenModule parent(String group, String artifactId, String version) {
+        backingModule.parent(group, artifactId, version)
+    }
+
+    MavenModule dependsOn(String group, String artifactId, String version) {
+        backingModule.dependsOn(group, artifactId, version)
+    }
+
+    MavenModule dependsOn(String group, String artifactId, String version, String type) {
+        backingModule.dependsOn(group, artifactId, version, type)
+    }
+
+    MavenModule hasPackaging(String packaging) {
+        backingModule.hasPackaging(packaging)
+    }
+
+    MavenModule hasType(String type) {
+        backingModule.hasPackaging(type)
+    }
+
+    TestFile getPomFile() {
+        backingModule.getPomFile()
+    }
+
+    TestFile getArtifactFile() {
+        backingModule.getArtifactFile()
+    }
+
+    TestFile getMetaDataFile() {
+        backingModule.getMetaDataFile()
+    }
+
+    MavenPom getParsedPom() {
+        backingModule.getParsedPom()
+    }
+
+    MavenMetaData getRootMetaData() {
+        backingModule.getRootMetaData()
+    }
+
+    S3Resource getPom() {
+        new S3Resource(server, pomFile, repositoryPath, bucket)
+    }
+
+    S3Resource getArtifact() {
+        new S3Resource(server, artifactFile, repositoryPath, bucket)
+    }
+
+    S3Resource getMetaData() {
+        new S3Resource(server, backingModule.metaDataFile, repositoryPath, bucket)
+    }
+
+    S3Resource getArtifactSha1() {
+        new S3Resource(server, backingModule.sha1File(artifactFile), repositoryPath, bucket)
+    }
+
+    S3Resource getPomSha1() {
+        new S3Resource(server, backingModule.sha1File(pomFile), repositoryPath, bucket)
+    }
+
+    S3Resource getMavenRootMetaData() {
+        new S3Resource(server, backingModule.rootMetaDataFile, repositoryPath, bucket)
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/MavenS3Repository.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/MavenS3Repository.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.gradle.test.fixtures.server.s3
+
+import org.gradle.test.fixtures.maven.MavenFileRepository
+import org.gradle.test.fixtures.maven.MavenRepository
+
+class MavenS3Repository implements MavenRepository {
+    private final S3StubServer server
+    private final MavenFileRepository backingRepository
+    private final String bucket
+    private final String repositoryPath
+
+    MavenS3Repository(S3StubServer server, File repoDir, String repositoryPath, String bucket) {
+        assert !bucket.startsWith('/')
+        this.server = server
+        this.bucket = bucket
+        this.backingRepository = new MavenFileRepository(repoDir.file(bucket + repositoryPath))
+        this.repositoryPath = repositoryPath
+    }
+
+    URI getUri() {
+        new URI("s3://${bucket}${repositoryPath}")
+    }
+
+    MavenS3Module module(String organisation, String module, Object revision = "1.0") {
+        new MavenS3Module(server, backingRepository.module(organisation, module, revision), repositoryPath, bucket)
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/S3Resource.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/S3Resource.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.server.s3
+
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.resource.RemoteResource
+
+class S3Resource implements RemoteResource {
+    S3StubServer server
+    TestFile file
+    S3StubSupport s3StubSupport
+    String bucket
+    String repositoryPath
+
+    S3Resource(S3StubServer server, TestFile file, String repositoryPath, String bucket) {
+        this.repositoryPath = repositoryPath
+        this.bucket = bucket
+        this.server = server
+        this.s3StubSupport = new S3StubSupport(server)
+        this.file = file
+    }
+
+    @Override
+    URI getUri() {
+        return new URI(relativeFilePath())
+    }
+
+    @Override
+    void expectDownload() {
+        s3StubSupport.stubGetFile(file, relativeFilePath())
+    }
+
+    @Override
+    void expectDownloadMissing() {
+
+    }
+
+    @Override
+    void expectMetadataRetrieve() {
+        s3StubSupport.stubMetaData(file, relativeFilePath())
+    }
+
+    @Override
+    void expectMetadataRetrieveMissing() {
+
+    }
+
+    @Override
+    void expectDownloadBroken() {
+
+    }
+
+    @Override
+    void expectMetadataRetrieveBroken() {
+
+    }
+
+    def relativeFilePath() {
+        String absolute = file.absolutePath
+        String base = "/${bucket}$repositoryPath"
+        absolute.substring(absolute.indexOf(base), absolute.length())
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/S3StubServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/S3StubServer.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.server.s3
+
+import org.gradle.test.fixtures.server.http.HttpServer
+import org.gradle.test.fixtures.server.stub.HttpStub
+import org.gradle.test.fixtures.server.stub.StubRequest
+import org.mortbay.jetty.handler.AbstractHandler
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class S3StubServer extends HttpServer {
+
+    S3StubServer() {
+        super()
+    }
+
+    def expect(HttpStub httpStub) {
+        add(httpStub, stubAction(httpStub))
+    }
+
+
+    HttpServer.ActionSupport stubAction(HttpStub httpStub) {
+        new HttpServer.ActionSupport("Generic stub handler") {
+            void handle(HttpServletRequest request, HttpServletResponse response) {
+                httpStub.response?.headers?.each {
+                    response.addHeader(it.key, it.value)
+                }
+                response.setStatus(httpStub.response.status)
+                if (httpStub.response?.body) {
+                    response.outputStream.bytes = httpStub.response.body
+                }
+            }
+        }
+    }
+
+    private void add(HttpStub httpStub, HttpServer.ActionSupport action) {
+        HttpExpectOne expectation = new HttpExpectOne(action, [httpStub.request.method], httpStub.request.path)
+        expectations << expectation
+        addHandler(new AbstractHandler() {
+            void handle(String target, HttpServletRequest request, HttpServletResponse response, int dispatch) {
+                if (requestMatches(httpStub, request)) {
+                    assertRequest(httpStub, request)
+                    if (expectation.run) {
+                        return
+                    }
+                    expectation.run = true
+                    action.handle(request, response)
+                    request.handled = true
+                }
+            }
+        })
+    }
+
+    void assertRequest(HttpStub httpStub, HttpServletRequest request) {
+        StubRequest stubRequest = httpStub.request
+        String path = stubRequest.path
+        assert path.startsWith('/')
+        assert path == request.pathInfo
+        assert stubRequest.method == request.method
+        if (stubRequest.body) {
+            assert stubRequest.body == request.getInputStream().bytes
+        }
+        assert stubRequest.params.every { request.getParameterMap()[it.key] == it.value }
+    }
+
+    boolean requestMatches(HttpStub httpStub, HttpServletRequest request) {
+        StubRequest stubRequest = httpStub.request
+        String path = stubRequest.path
+        assert path.startsWith('/')
+        path == request.pathInfo && stubRequest.method == request.method
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/S3StubSupport.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/S3StubSupport.groovy
@@ -228,6 +228,41 @@ class S3StubSupport {
         server.expect(httpStub)
     }
 
+    def stubFileNotFound(String url) {
+        def xml = new StreamingMarkupBuilder().bind {
+            Error() {
+                Code("NoSuchKey")
+                Message("The specified key does not exist.")
+                Key(url)
+                RequestId("stubbedRequestId")
+                HostId("stubbedHostId")
+            }
+
+        }
+
+        HttpStub httpStub = HttpStub.stubInteraction {
+            request {
+                method = 'GET'
+                path = url
+                headers = [
+                        'Content-Type': 'application/octet-stream',
+                        'Connection'  : 'Keep-Alive'
+                ]
+            }
+            response {
+                status = 404
+                headers = [
+                        'x-amz-id-2'      : X_AMZ_ID_2,
+                        'x-amz-request-id': X_AMZ_REQUEST_ID,
+                        'Date'            : DATE_HEADER,
+                        'Server'          : SERVER_AMAZON_S3,
+                        'Content-Type'    : 'application/xml',
+                ]
+                body = xml.toString()
+            }
+        }
+        server.expect(httpStub)
+    }
 
     def calculateEtag(File file) {
         MessageDigest digest = MessageDigest.getInstance("MD5")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/S3StubSupport.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/s3/S3StubSupport.groovy
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.server.s3
+
+import groovy.xml.StreamingMarkupBuilder
+import org.gradle.test.fixtures.server.stub.HttpStub
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
+import org.joda.time.tz.FixedDateTimeZone
+
+import java.security.MessageDigest
+
+class S3StubSupport {
+    private static final DateTimeZone GMT = new FixedDateTimeZone("GMT", "GMT", 0, 0)
+    protected static final DateTimeFormatter RCF_822_DATE_FORMAT = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss z")
+                    .withLocale(Locale.US)
+                    .withZone(GMT);
+
+    public static final String ETAG = 'd41d8cd98f00b204e9800998ecf8427e'
+    public static final String X_AMZ_REQUEST_ID = '0A398F9A1BAD4027'
+    public static final String X_AMZ_ID_2 = 'nwUZ/n/F2/ZFRTZhtzjYe7mcXkxCaRjfrJSWirV50lN7HuvhF60JpphwoiX/sMnh'
+    public static final String DATE_HEADER = 'Mon, 29 Sep 2014 11:04:27 GMT'
+    public static final String SERVER_AMAZON_S3 = 'AmazonS3'
+    final URI endpoint
+    final S3StubServer server
+
+    S3StubSupport(S3StubServer server) {
+        this.server = server
+        this.endpoint = new URI(server.address)
+    }
+
+    def stubPutFile(File file, String url) {
+        HttpStub httpStub = HttpStub.stubInteraction {
+            request {
+                method = 'PUT'
+                path = url
+                headers = [
+                        'Content-Type': 'application/octet-stream',
+                        'Connection'  : 'Keep-Alive'
+                ]
+                body = file.getBytes()
+
+            }
+            response {
+                status = 200
+                headers = [
+                        'x-amz-id-2'      : X_AMZ_ID_2,
+                        'x-amz-request-id': X_AMZ_REQUEST_ID,
+                        'Date'            : DATE_HEADER,
+                        "ETag"            : calculateEtag(file),
+                        'Server'          : SERVER_AMAZON_S3
+                ]
+            }
+        }
+        server.expect(httpStub)
+    }
+
+    def stubMetaData(File file, String url) {
+        HttpStub httpStub = HttpStub.stubInteraction {
+            request {
+                method = 'HEAD'
+                path = url
+                headers = [
+                        'Content-Type': "application/x-www-form-urlencoded; charset=utf-8",
+                        'Connection'  : 'Keep-Alive'
+                ]
+            }
+            response {
+                status = 200
+                headers = [
+                        'x-amz-id-2'      : X_AMZ_ID_2,
+                        'x-amz-request-id': X_AMZ_REQUEST_ID,
+                        'Date'            : DATE_HEADER,
+                        'ETag'            : calculateEtag(file),
+                        'Server'          : SERVER_AMAZON_S3,
+                        'Accept-Ranges'   : 'bytes',
+                        'Content-Type'    : 'application/octet-stream',
+                        'Content-Length'  : "${file.length()}",
+                        'Last-Modified'   : RCF_822_DATE_FORMAT.print(new Date().getTime())
+                ]
+            }
+        }
+        server.expect(httpStub)
+    }
+
+    def stubGetFile(File file, String url) {
+        HttpStub httpStub = HttpStub.stubInteraction {
+            request {
+                method = 'GET'
+                path = url
+                headers = [
+                        'Content-Type': "application/x-www-form-urlencoded; charset=utf-8",
+                        'Connection'  : 'Keep-Alive'
+                ]
+            }
+            response {
+                status = 200
+                headers = [
+                        'x-amz-id-2'      : X_AMZ_ID_2,
+                        'x-amz-request-id': X_AMZ_REQUEST_ID,
+                        'Date'            : DATE_HEADER,
+                        'ETag'            : calculateEtag(file),
+                        'Server'          : SERVER_AMAZON_S3,
+                        'Accept-Ranges'   : 'bytes',
+                        'Content-Type'    : 'application/octet-stream',
+                        'Content-Length'  : "${file.length()}",
+                        'Last-Modified'   : RCF_822_DATE_FORMAT.print(new Date().getTime())
+                ]
+                body = file.getBytes()
+            }
+        }
+        server.expect(httpStub)
+    }
+
+    def stubListFile(File file, String bucketName, prefix = 'maven/release/', delimiter = '/') {
+        def xml = new StreamingMarkupBuilder().bind {
+            ListBucketResult(xmlns: "http://s3.amazonaws.com/doc/2006-03-01/") {
+                Name(bucketName)
+                Prefix(prefix)
+                Marker()
+                MaxKeys('1000')
+                Delimiter(delimiter)
+                IsTruncated('false')
+                Contents {
+                    Key(prefix)
+                    LastModified('2014-09-21T06:44:09.000Z')
+                    ETag(ETAG)
+                    Size('0')
+                    Owner {
+                        ID("${(1..57).collect { 'a' }.join()}")
+                        DisplayName('me')
+                    }
+                    StorageClass('STANDARD')
+                }
+                Contents {
+                    Key(prefix + file.name)
+                    LastModified('2014-10-01T13:03:29.000Z')
+                    ETag(ETAG)
+                    Size('19')
+                    Owner {
+                        ID("${(1..57).collect { 'a' }.join()}")
+                        DisplayName('me')
+                    }
+                    StorageClass('STANDARD')
+                }
+                CommonPrefixes {
+                    Prefix("${prefix}com/")
+                }
+            }
+        }
+
+        HttpStub httpStub = HttpStub.stubInteraction {
+            request {
+                method = 'GET'
+                path = "/${bucketName}/"
+                headers = [
+                        'Content-Type': "application/x-www-form-urlencoded; charset=utf-8",
+                        'Connection'  : 'Keep-Alive'
+                ]
+                params = [
+                        'prefix'   : ["${prefix}"],
+                        'delimiter': ["${delimiter}"]
+                ]
+            }
+            response {
+                status = 200
+                headers = [
+                        'x-amz-id-2'      : X_AMZ_ID_2,
+                        'x-amz-request-id': X_AMZ_REQUEST_ID,
+                        'Date'            : DATE_HEADER,
+                        'Server'          : SERVER_AMAZON_S3,
+                        'Content-Type'    : 'application/xml',
+                ]
+                body = xml.toString()
+            }
+        }
+        server.expect(httpStub)
+    }
+
+    def calculateEtag(File file) {
+        MessageDigest digest = MessageDigest.getInstance("MD5")
+        digest.update(file.bytes);
+        new BigInteger(1, digest.digest()).toString(16).padLeft(32, '0')
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/stub/HttpMessage.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/stub/HttpMessage.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.resource.transport.http;
 
+package org.gradle.test.fixtures.server.stub
 
-import spock.lang.Specification
+import groovy.transform.ToString
 
-class JavaSystemPropertiesHttpProxySettingsTest extends Specification {
-
-    def "should use default HTTP prefix and port"() {
-        JavaSystemPropertiesProxySettings settings = new JavaSystemPropertiesHttpProxySettings()
-        expect:
-        settings.propertyPrefix == 'http'
-        settings.defaultPort == 80
-    }
+@ToString(includeNames = true)
+class HttpMessage {
+    Map<String, String> headers = [:]
+    def body
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/stub/HttpStub.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/stub/HttpStub.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.server.stub
+
+import groovy.transform.ToString
+
+@ToString
+class HttpStub {
+    StubRequest request
+    StubResponse response
+
+    static stubInteraction(Closure closure) {
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        HttpStub stub = new HttpStub()
+        closure.delegate = stub
+        closure()
+        stub
+    }
+
+    def request(Closure closure){
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        StubRequest stubRequest = new StubRequest()
+        closure.delegate = stubRequest
+        closure()
+        request = stubRequest
+    }
+
+    def response(Closure closure){
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        StubResponse stubResponse= new StubResponse()
+        closure.delegate = stubResponse
+        closure()
+        response = stubResponse
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/stub/StubRequest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/stub/StubRequest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.resource.transport.http;
 
+package org.gradle.test.fixtures.server.stub
 
-import spock.lang.Specification
+import groovy.transform.ToString
 
-class JavaSystemPropertiesHttpProxySettingsTest extends Specification {
-
-    def "should use default HTTP prefix and port"() {
-        JavaSystemPropertiesProxySettings settings = new JavaSystemPropertiesHttpProxySettings()
-        expect:
-        settings.propertyPrefix == 'http'
-        settings.defaultPort == 80
-    }
+@ToString(includeNames = true, includeSuper = true)
+class StubRequest extends HttpMessage {
+    String method
+    String path
+    Map<String, List<String>> params = [:]
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/stub/StubResponse.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/stub/StubResponse.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.resource.transport.http;
 
+package org.gradle.test.fixtures.server.stub
 
-import spock.lang.Specification
+import groovy.transform.ToString
 
-class JavaSystemPropertiesHttpProxySettingsTest extends Specification {
-
-    def "should use default HTTP prefix and port"() {
-        JavaSystemPropertiesProxySettings settings = new JavaSystemPropertiesHttpProxySettings()
-        expect:
-        settings.propertyPrefix == 'http'
-        settings.defaultPort == 80
-    }
+@ToString(includeNames = true, includeSuper = true)
+class StubResponse extends HttpMessage {
+    int status
 }

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesHttpProxySettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesHttpProxySettings.java
@@ -15,90 +15,11 @@
  */
 package org.gradle.internal.resource.transport.http;
 
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Pattern;
-
-public class JavaSystemPropertiesHttpProxySettings implements HttpProxySettings {
-    private static final Logger LOGGER = LoggerFactory.getLogger(JavaSystemPropertiesHttpProxySettings.class);
+public class JavaSystemPropertiesHttpProxySettings extends JavaSystemPropertiesProxySettings {
     private static final int DEFAULT_PROXY_PORT = 80;
-
-    private final HttpProxy proxy;
-    private final List<Pattern> nonProxyHosts;
+    private static final String PROPERTY_PREFIX = "http";
 
     public JavaSystemPropertiesHttpProxySettings() {
-        this(System.getProperty("http.proxyHost"), System.getProperty("http.proxyPort"), 
-                System.getProperty("http.proxyUser"), System.getProperty("http.proxyPassword"), 
-                System.getProperty("http.nonProxyHosts"));
-    }
-
-    JavaSystemPropertiesHttpProxySettings(String proxyHost, String proxyPortString, String proxyUser, String proxyPassword, String nonProxyHostsString) {
-        if (StringUtils.isBlank(proxyHost)) {
-            this.proxy = null;
-        } else {
-            this.proxy = new HttpProxy(proxyHost, initProxyPort(proxyPortString), proxyUser, proxyPassword);
-        }
-        this.nonProxyHosts = initNonProxyHosts(nonProxyHostsString);
-    }
-
-    private int initProxyPort(String proxyPortString) {
-        if (StringUtils.isBlank(proxyPortString)) {
-            return DEFAULT_PROXY_PORT;
-        }
-        
-        try {
-            return Integer.parseInt(proxyPortString);
-        } catch (NumberFormatException e) {
-            LOGGER.warn("Invalid value for java system property 'http.proxyPort': {}. Default port '{}' will be used.", System.getProperty("http.proxyPort"), DEFAULT_PROXY_PORT);
-            return DEFAULT_PROXY_PORT;
-        }
-    }
-
-    private List<Pattern> initNonProxyHosts(String nonProxyHostsString) {
-        if (StringUtils.isBlank(nonProxyHostsString)) {
-            return Collections.emptyList();
-        }
-
-        LOGGER.debug("Found java system property 'http.nonProxyHosts': {}. Will ignore proxy settings for these hosts.", nonProxyHostsString);
-        List<Pattern> patterns = new ArrayList<Pattern>();
-        for (String nonProxyHost : nonProxyHostsString.split("\\|")) {
-            patterns.add(createHostMatcher(nonProxyHost));
-        }
-        return patterns;
-    }
-
-    private Pattern createHostMatcher(String nonProxyHost) {
-        if (nonProxyHost.startsWith("*")) {
-            return Pattern.compile(".*" + Pattern.quote(nonProxyHost.substring(1)));
-        }
-        if (nonProxyHost.endsWith("*")) {
-            return Pattern.compile(Pattern.quote(nonProxyHost.substring(0, nonProxyHost.length() - 1)) + ".*");
-        }
-        return Pattern.compile(Pattern.quote(nonProxyHost));
-    }
-
-    public HttpProxy getProxy() {
-        return proxy;
-    }
-
-    public HttpProxy getProxy(String host) {
-        if (proxy == null || isNonProxyHost(host)) {
-            return null;
-        }
-        return proxy;
-    }
-
-    private boolean isNonProxyHost(String host) {        
-        for (Pattern nonProxyHost : nonProxyHosts) {
-            if (nonProxyHost.matcher(host).matches()) {
-                return true;
-            }
-        }
-        return false;
+        super(PROPERTY_PREFIX, DEFAULT_PROXY_PORT);
     }
 }

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettings.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public abstract class JavaSystemPropertiesProxySettings implements HttpProxySettings {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaSystemPropertiesProxySettings.class);
+
+    private final HttpProxy proxy;
+    private final List<Pattern> nonProxyHosts;
+    private final String propertyPrefix;
+    private final int defaultPort;
+
+    public JavaSystemPropertiesProxySettings(String propertyPrefix, int defaultPort) {
+        this(propertyPrefix, defaultPort,
+                System.getProperty(propertyPrefix + ".proxyHost"),
+                System.getProperty(propertyPrefix + ".proxyPort"),
+                System.getProperty(propertyPrefix + ".proxyUser"),
+                System.getProperty(propertyPrefix + ".proxyPassword"),
+                System.getProperty(propertyPrefix + ".nonProxyHosts"));
+    }
+
+    JavaSystemPropertiesProxySettings(String propertyPrefix, int defaultPort, String proxyHost, String proxyPortString, String proxyUser, String proxyPassword, String nonProxyHostsString) {
+        this.propertyPrefix = propertyPrefix;
+        this.defaultPort = defaultPort;
+        if (StringUtils.isBlank(proxyHost)) {
+            this.proxy = null;
+        } else {
+            this.proxy = new HttpProxy(proxyHost, initProxyPort(proxyPortString), proxyUser, proxyPassword);
+        }
+        this.nonProxyHosts = initNonProxyHosts(nonProxyHostsString);
+    }
+
+    private int initProxyPort(String proxyPortString) {
+        if (StringUtils.isBlank(proxyPortString)) {
+            return defaultPort;
+        }
+        try {
+            return Integer.parseInt(proxyPortString);
+        } catch (NumberFormatException e) {
+            String key = propertyPrefix + ".proxyPort";
+            LOGGER.warn("Invalid value for java system property '{}': {}. Default port '{}' will be used.",
+                    key, System.getProperty(key), defaultPort);
+            return defaultPort;
+        }
+    }
+
+    private List<Pattern> initNonProxyHosts(String nonProxyHostsString) {
+        if (StringUtils.isBlank(nonProxyHostsString)) {
+            return Collections.emptyList();
+        }
+
+        LOGGER.debug("Found java system property 'http.nonProxyHosts': {}. Will ignore proxy settings for these hosts.", nonProxyHostsString);
+        List<Pattern> patterns = new ArrayList<Pattern>();
+        for (String nonProxyHost : nonProxyHostsString.split("\\|")) {
+            patterns.add(createHostMatcher(nonProxyHost));
+        }
+        return patterns;
+    }
+
+    private Pattern createHostMatcher(String nonProxyHost) {
+        if (nonProxyHost.startsWith("*")) {
+            return Pattern.compile(".*" + Pattern.quote(nonProxyHost.substring(1)));
+        }
+        if (nonProxyHost.endsWith("*")) {
+            return Pattern.compile(Pattern.quote(nonProxyHost.substring(0, nonProxyHost.length() - 1)) + ".*");
+        }
+        return Pattern.compile(Pattern.quote(nonProxyHost));
+    }
+
+    public HttpProxySettings.HttpProxy getProxy() {
+        return proxy;
+    }
+
+    public HttpProxySettings.HttpProxy getProxy(String host) {
+        if (proxy == null || isNonProxyHost(host)) {
+            return null;
+        }
+        return proxy;
+    }
+
+    private boolean isNonProxyHost(String host) {
+        for (Pattern nonProxyHost : nonProxyHosts) {
+            if (nonProxyHost.matcher(host).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public String getPropertyPrefix() {
+        return propertyPrefix;
+    }
+
+    public int getDefaultPort() {
+        return defaultPort;
+    }
+}

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesSecureHttpProxySettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesSecureHttpProxySettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.internal.resource.transport.http;
 
+    public class JavaSystemPropertiesSecureHttpProxySettings extends JavaSystemPropertiesProxySettings {
+    private static final int DEFAULT_PROXY_PORT = 443;
+    private static final String PROPERTY_PREFIX = "https";
 
-import spock.lang.Specification
-
-class JavaSystemPropertiesHttpProxySettingsTest extends Specification {
-
-    def "should use default HTTP prefix and port"() {
-        JavaSystemPropertiesProxySettings settings = new JavaSystemPropertiesHttpProxySettings()
-        expect:
-        settings.propertyPrefix == 'http'
-        settings.defaultPort == 80
+    public JavaSystemPropertiesSecureHttpProxySettings() {
+        super(PROPERTY_PREFIX, DEFAULT_PROXY_PORT);
     }
 }

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettingsTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettingsTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http
+
+import spock.lang.Specification
+
+class JavaSystemPropertiesProxySettingsTest extends Specification {
+
+    def "proxy is not configured when proxyHost property not set"() {
+        expect:
+        def settings = settings(proxyHost, proxyPort, nonProxyHosts)
+        settings.getProxy(requestHost) == null
+
+        where:
+        proxyHost | proxyPort | nonProxyHosts | requestHost
+        null      | null      | null          | null
+        null      | null      | null          | "foo"
+        null      | "111"     | null          | "foo"
+        null      | null      | "foo|bar|baz" | "foo"
+        ""        | null      | null          | null
+        ""        | ""        | null          | null
+        null      | ""        | null          | null
+    }
+
+    private JavaSystemPropertiesProxySettings settings(host, proxyPort, nonProxyHosts) {
+        return new TestSystemProperties(host, proxyPort, null, null, nonProxyHosts)
+    }
+
+    def "proxy is not configured when host is in list of nonproxy hosts"() {
+        expect:
+        settings("proxyHost", "111", nonProxyHosts).getProxy(host)?.host == proxyHost
+
+        where:
+        nonProxyHosts | host      | proxyHost
+        null          | "foo"     | "proxyHost"
+        ""            | "foo"     | "proxyHost"
+        "bar"         | "foo"     | "proxyHost"
+        "foo"         | "foo"     | null
+        "fo"          | "foo"     | "proxyHost"
+        "foo|bar|baz" | "foo"     | null
+        "foo.*"       | "foo.bar" | null
+        "*.bar"       | "foo.bar" | null
+        "*.ba"        | "foo.bar" | "proxyHost"
+        "*"           | "foo"     | null
+        "*"           | "foo"     | null
+        "foo.*|baz"   | "foo.bar" | null
+    }
+
+    def "uses specified port property and default port when port property not set or invalid"() {
+        expect:
+        settings("proxyHost", prop, null).getProxy("host").port == value
+
+        where:
+        prop     | value
+        null     | 80
+        ""       | 80
+        "notInt" | 80
+        "0"      | 0
+        "111"    | 111
+    }
+
+    def "uses specified proxy user and password"() {
+        expect:
+        def proxy = new TestSystemProperties("proxyHost", null, user, password, null).getProxy("host")
+        proxy.credentials?.username == proxyUser
+        proxy.credentials?.password == proxyPassword
+
+        where:
+        user   | password   | proxyUser | proxyPassword
+        "user" | "password" | "user"    | "password"
+        "user" | ""         | "user"    | ""
+        ""     | "password" | null      | null
+        null   | "anything" | null      | null
+    }
+
+    class TestSystemProperties extends JavaSystemPropertiesProxySettings {
+        TestSystemProperties(String proxyHost, String proxyPortString, String proxyUser, String proxyPassword, String nonProxyHostsString) {
+            super('http', 80, proxyHost, proxyPortString, proxyUser, proxyPassword, nonProxyHostsString);
+        }
+    }
+}

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesSecureHttpProxySettingsTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesSecureHttpProxySettingsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.resource.transport.http;
 
+package org.gradle.internal.resource.transport.http
 
 import spock.lang.Specification
 
-class JavaSystemPropertiesHttpProxySettingsTest extends Specification {
+class JavaSystemPropertiesSecureHttpProxySettingsTest extends Specification {
 
-    def "should use default HTTP prefix and port"() {
-        JavaSystemPropertiesProxySettings settings = new JavaSystemPropertiesHttpProxySettings()
+    def "should use default HTTPS prefix and port"() {
+        JavaSystemPropertiesProxySettings settings = new JavaSystemPropertiesSecureHttpProxySettings()
         expect:
-        settings.propertyPrefix == 'http'
-        settings.defaultPort == 80
+        settings.propertyPrefix == 'https'
+        settings.defaultPort == 443
     }
 }


### PR DESCRIPTION
...n not publishing).

[maven-aws] Adds skeleton S3 transport classes and uses transport scheme to determine credentials type.

[maven-aws] Wiring in AWS sdk and implementing S3 resource accessor

[maven-aws] Code review cleanup

[maven-aws] Sets default credentials to null when specific type has been specified via DSL

[maven-aws] Validates the PasswordCredentials type