### PR TITLE
Added manifest & metaInf to Jar DSL

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.Jar.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.Jar.xml
@@ -8,6 +8,10 @@
                     <td>Default with <literal>java</literal> plugin</td>
                 </tr>
             </thead>
+                <tr>
+                    <td>manifest</td>
+                    <td/>
+                </tr>
         </table>
     </section>
     <section>
@@ -18,6 +22,9 @@
                     <td>Name</td>
                 </tr>
             </thead>
+            <tr>
+                <td>metaInf</td>
+            </tr>
         </table>
     </section>
 </section>


### PR DESCRIPTION
As per forum conversation - http://forums.gradle.org/gradle/topics/metainf-is-missing-from-documentation
