### PR TITLE
JavaFX Groovy classpath fix

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -88,6 +88,9 @@ enum TestPrecondition {
     JDK6_OR_LATER({
         JavaVersion.current() >= JavaVersion.VERSION_1_6
     }),
+    JDK7({
+        JavaVersion.current() == JavaVersion.VERSION_1_7
+    }),
     JDK7_OR_LATER({
         JavaVersion.current() >= JavaVersion.VERSION_1_7
     }),
@@ -105,6 +108,15 @@ enum TestPrecondition {
     }),
     NOT_JDK_IBM({
         System.getProperty('java.vm.vendor') != 'IBM Corporation'
+    }),
+    JVM_ORACLE({
+        System.getProperty('java.vm.name').startsWith('Java HotSpot(TM)')
+    }),
+    JVM_OPENJDK({
+        System.getProperty('java.vm.name').startsWith('OpenJDK')
+    }),
+    JVM_IBM({
+        System.getProperty('java.vm.name').startsWith('IBM J9')
     }),
     ONLINE({
         try {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -69,7 +69,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
         jointCompilationOptions.put("keepStubs", spec.getGroovyCompileOptions().isKeepStubs());
         configuration.setJointCompilationOptions(jointCompilationOptions);
 
-        URLClassLoader classPathLoader = new GroovyCompileTransformingClassLoader(new DefaultClassPath(spec.getClasspath()));
+        URLClassLoader classPathLoader = new GroovyCompileTransformingClassLoader(getExtClassLoader(), new DefaultClassPath(spec.getClasspath()));
         GroovyClassLoader compileClasspathClassLoader = new GroovyClassLoader(classPathLoader, null);
 
         FilteringClassLoader groovyCompilerClassLoader = new FilteringClassLoader(GroovyClassLoader.class.getClassLoader());
@@ -178,4 +178,17 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
         }
     }
 
+    // returns the Extension Classloader needed to compile JavaFX programs
+    // or null on platforms where JavaFX must be explicitly added to the classpath.
+    private ClassLoader getExtClassLoader() {
+        try {
+            // javafx.application.Application is the most visible class available the ExtClassLoader
+            Class<?> jfxClass = Class.forName("javafx.application.Application");
+            return jfxClass.getClassLoader();
+        } catch (Exception ignored) {
+            // This can happen on Oracle JDK 7 and OpenJDK builds without OpenJFX
+            // In these cases jfxrt.jar must be added manually to the compile classpath
+        }
+        return null;
+    }
 }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompileTransformingClassLoader.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompileTransformingClassLoader.java
@@ -32,7 +32,11 @@ class GroovyCompileTransformingClassLoader extends TransformingClassLoader {
     private static final String ANNOTATION_DESCRIPTOR = Type.getType(GroovyASTTransformationClass.class).getDescriptor();
 
     public GroovyCompileTransformingClassLoader(ClassPath classpath) {
-        super(null, classpath);
+        this(null, classpath);
+    }
+
+    public GroovyCompileTransformingClassLoader(ClassLoader parent, ClassPath classPath) {
+        super(parent, classPath);
     }
 
     @Override

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -21,6 +21,8 @@ import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
 @TargetVersions(['1.5.8', '1.6.9', '1.7.11', '1.8.8', '2.0.5', '2.1.9', '2.2.2', '2.3.6', '2.4.0-beta-2'])
@@ -140,6 +142,34 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         expect:
         fails("compileGroovy")
         failure.assertHasCause("Could not execute Groovy compiler configuration script: ${file('groovycompilerconfig.groovy')}")
+    }
+
+    @Requires([TestPrecondition.JVM_ORACLE, TestPrecondition.JDK8_OR_LATER])
+    def "compileJavaFx8Code"() {
+        if (versionLowerThan("2.0")) {
+            return
+        }
+
+        expect:
+        succeeds("compileGroovy")
+    }
+
+    @Requires([TestPrecondition.JVM_ORACLE, TestPrecondition.JDK7])
+    def "compileJavaFx2Code"() {
+        if (versionLowerThan("2.0")) {
+            return
+        }
+
+        expect:
+        fails("compileGroovy")
+        errorOutput.contains('unable to resolve class javafx.application.Application')
+
+        when:
+        buildFile << "dependencies { compile files( \"${System.properties['java.home']}/lib/jfxrt.jar\" ) }"
+
+        then:
+        succeeds("compileGroovy")
+        !errorOutput
     }
 
     protected ExecutionResult run(String... tasks) {

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx2Code/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx2Code/build.gradle
@@ -1,0 +1,7 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}
+
+// jfxrt.jar added here as dependency during test execution

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx2Code/src/main/groovy/FxApp.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx2Code/src/main/groovy/FxApp.groovy
@@ -1,0 +1,9 @@
+import javafx.application.Application
+import javafx.stage.Stage
+
+class FxApp extends Application {
+
+    @Override
+    void start(Stage stage) {
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/src/main/groovy/FxApp.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/src/main/groovy/FxApp.groovy
@@ -1,0 +1,9 @@
+import javafx.application.Application
+import javafx.stage.Stage
+
+class FxApp extends Application {
+
+    @Override
+    void start(Stage stage) {
+    }
+}


### PR DESCRIPTION
This PR fixes a problem when compiling Groovy programs using the JavaFX technology from Oracle.
When using the Oracle JVM, Groovy code was being compiled without adding the Extension Classloader to the compile classpath.
The problem is described in [a post](https://groups.google.com/forum/#!topic/gradle-dev/q3u-T09km2s) on the gradle-dev Google group.

Integration tests are included.