### PR TITLE
GRADLE-2957 Dependent tasks with same finalizer

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -339,7 +339,11 @@ class DefaultTaskExecutionPlan implements TaskExecutionPlan {
             }
         });
         graphWalker.add(entryTasks);
-        final List<TaskInfo> firstCycle = new ArrayList<TaskInfo>(graphWalker.findCycles().get(0));
+        List<Set<TaskInfo>> cycles = graphWalker.findCycles();
+        if (cycles.isEmpty()) {
+            return;
+        }
+        final List<TaskInfo> firstCycle = new ArrayList<TaskInfo>(cycles.get(0));
         Collections.sort(firstCycle);
 
         DirectedGraphRenderer<TaskInfo> graphRenderer = new DirectedGraphRenderer<TaskInfo>(new GraphNodeRenderer<TaskInfo>() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
@@ -358,6 +358,25 @@ public class DefaultTaskExecutionPlanTest extends Specification {
         executes(finalized, f2, d, f1)
     }
 
+    @Issue("GRADLE-2957")
+    def "dependent tasks with the same finalizer"() {
+        // Finalizer task
+        Task finalTask = task('finalTask')
+
+        // Task with this finalizer
+        Task taskOne = task('taskOne', finalizedBy: [finalTask])
+        Task taskTwo = task('taskTwo', finalizedBy: [finalTask])
+
+        // Task to call, with the same finalizer than one of its dependencies
+        Task buggyTask = task('buggyTask', dependsOn: [taskOne], finalizedBy: [taskTwo])
+
+        when:
+        addToGraphAndPopulate([buggyTask])
+
+        then:
+        executes(taskOne, buggyTask, taskTwo, finalTask)
+    }
+
     @Issue("GRADLE-2983")
     def "multiple finalizer tasks with relationships via other tasks scheduled from multiple tasks"() {
         //finalizers with a relationship via a dependency


### PR DESCRIPTION
Based on discussions around the [GRADLE-2957](https://issues.gradle.org/browse/GRADLE-2957) defect, a test can be designed to reproduce the case where a tree of dependent tasks share the same finaliser. In this case, the detection of cycles does not seem to work properly.

In my commit, I have chosen to by-pass the wrong cycle detection and go on with the execution plan creation.
