### PR TITLE
GRADLE-3149

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
@@ -38,6 +38,7 @@ public class TestNGSpec implements Serializable {
     private final Set<String> excludeGroups;
     private final Set<String> listeners;
     private final Set<String> includedTests;
+    private final String configFailurePolicy;
 
     public TestNGSpec(TestNGOptions options, DefaultTestFilter filter) {
         this.defaultSuiteName = options.getSuiteName();
@@ -52,6 +53,7 @@ public class TestNGSpec implements Serializable {
         this.excludeGroups = options.getExcludeGroups();
         this.listeners = options.getListeners();
         this.includedTests = filter.getIncludePatterns();
+        this.configFailurePolicy = options.getConfigFailurePolicy();
     }
 
     public Set<String> getListeners() {
@@ -100,5 +102,9 @@ public class TestNGSpec implements Serializable {
 
     public Set<String> getIncludedTests() {
         return includedTests;
+    }
+
+    public String getConfigFailurePolicy() {
+        return configFailurePolicy;
     }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -79,6 +79,11 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         testNg.setParallel(options.getParallel());
         testNg.setThreadCount(options.getThreadCount());
         try {
+            JavaReflectionUtil.method(TestNG.class, Object.class, "setConfigFailurePolicy", String.class).invoke(testNg, options.getConfigFailurePolicy());
+        } catch (NoSuchMethodException e) {
+            /* do nothing; method was created in TestNG 6.3 */
+        }
+        try {
             JavaReflectionUtil.method(TestNG.class, Object.class, "setAnnotations").invoke(testNg, options.getAnnotations());
         } catch (NoSuchMethodException e) {
             /* do nothing; method has been removed in TestNG 6.3 */

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/testng/TestNGOptions.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/testing/testng/TestNGOptions.groovy
@@ -66,6 +66,12 @@ class TestNGOptions extends TestFrameworkOptions {
     Set<String> excludeGroups = new HashSet<String>()
 
     /**
+     * Option for what to do for other tests that use a configuration step when that step fails.
+     * Can be "skip" or "continue", defaults to "skip".
+     */
+    String configFailurePolicy = "skip"
+
+    /**
      * Fully qualified classes that are TestNG listeners (instances of org.testng.ITestListener or
      * org.testng.IReporter). By default, the listeners set is empty.
      *
@@ -223,6 +229,11 @@ class TestNGOptions extends TestFrameworkOptions {
 
     TestNGOptions includeGroups(String... includeGroups) {
         this.includeGroups.addAll(Arrays.asList(includeGroups))
+        this
+    }
+
+    TestNGOptions configFailurePolicy(String configFailurePolicy) {
+        this.configFailurePolicy = configFailurePolicy
         this
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/testng/TestNGOptionsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/testng/TestNGOptionsTest.groovy
@@ -60,6 +60,8 @@ public class TestNGOptionsTest extends AbstractTestFrameworkOptionsTest<TestNGTe
         assertEquals('Gradle suite', testngOptions.suiteName)
 
         assertEquals('Gradle test', testngOptions.testName)
+
+        assertEquals('skip', testngOptions.configFailurePolicy)
     }
 
     @Test public void jdk14SourceCompatibilityAnnotationsDefaulting()


### PR DESCRIPTION
Adding support for the property 'configfailurepolicy' in useTestNG(). Added default behavior to test case. Tested that parameter was getting passed down in my own framework.

https://issues.gradle.org/browse/GRADLE-3149
