### PR TITLE
Fix dependsOn in webDist userguide example.

### DIFF
--- a/subprojects/docs/src/samples/userguide/multiproject/dependencies/webDist/build.gradle
+++ b/subprojects/docs/src/samples/userguide/multiproject/dependencies/webDist/build.gradle
@@ -14,7 +14,7 @@ subprojects {
     }
 }
 
-task explodedDist(dependsOn: assemble) << {
+task explodedDist(dependsOn: subprojects*.assemble) << {
     File explodedDist = mkdir("$buildDir/explodedDist")
     subprojects.each {project ->
         project.tasks.withType(Jar).each {archiveTask ->


### PR DESCRIPTION
Before, running `gradle clean explodedDist` resulted in an empty `build/explodedDist` directory. This change fixes it by making `explodedDist` depend on all subprojects' `assemble` task.