### PR TITLE
Output per test case in HTML test report

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/internal/html/SimpleHtmlWriter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/html/SimpleHtmlWriter.java
@@ -26,16 +26,32 @@ import java.io.Writer;
  */
 public class SimpleHtmlWriter extends SimpleMarkupWriter {
 
+    private final Writer output;
+    
     public SimpleHtmlWriter(Writer writer) throws IOException {
         this(writer, null);
     }
 
     public SimpleHtmlWriter(Writer writer, String indent) throws IOException {
+        this(writer, indent, true);
+    }
+    
+    private SimpleHtmlWriter(Writer writer, String indent, boolean beginHeader) throws IOException {
         super(writer, indent);
-        writeHtmlHeader();
+        this.output = writer;
+        if (beginHeader) {
+            writeHtmlHeader();
+        }
     }
 
     private void writeHtmlHeader() throws IOException {
         writeRaw("<!DOCTYPE html>");
+    }
+    
+    /**
+     * Return writer based on same output stream but with custom indentation
+     */
+    public SimpleHtmlWriter getSubWriter(String indent) throws IOException {
+        return new SimpleHtmlWriter(this.output, indent, false);
     }
 }

--- a/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
+++ b/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
@@ -159,3 +159,7 @@ span.code pre {
     width: auto !important;
     width: 700px;
 }
+
+span.code pre span.stderr {
+  color: red;
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -423,6 +423,7 @@ public class JUnitIntegrationTest extends AbstractIntegrationTest {
 
         def junitResult = new DefaultTestExecutionResult(testDirectory)
         def testClass = junitResult.testClass("org.gradle.SystemOutTest")
+        testClass.assertStderr(containsText(""))
         testClass.assertStdout(containsText("thread 0 out"))
         testClass.assertStdout(containsText("thread 1 out"))
         testClass.assertStdout(containsText("thread 2 out"))
@@ -437,6 +438,7 @@ public class JUnitIntegrationTest extends AbstractIntegrationTest {
 
         def junitResult = new DefaultTestExecutionResult(testDirectory)
         def testClass = junitResult.testClass("org.gradle.SystemErrTest")
+        testClass.assertStdout(containsText(""))
         testClass.assertStderr(containsText("thread 0 err"))
         testClass.assertStderr(containsText("thread 1 err"))
         testClass.assertStderr(containsText("thread 2 err"))

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/AllTestResults.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/AllTestResults.java
@@ -43,9 +43,9 @@ public class AllTestResults extends CompositeTestResults {
         return packages.values();
     }
 
-    public TestResult addTest(long classId, String className, String testName, long duration) {
+    public TestResult addTest(long classId, String className, long testId, String testName, long duration) {
         PackageTestResults packageResults = addPackageForClass(className);
-        return addTest(packageResults.addTest(classId, className, testName, duration));
+        return addTest(packageResults.addTest(classId, className, testId, testName, duration));
     }
 
     public ClassTestResults addTestClass(long classId, String className) {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassTestResults.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassTestResults.java
@@ -72,8 +72,8 @@ public class ClassTestResults extends CompositeTestResults {
         return results;
     }
 
-    public TestResult addTest(String testName, long duration) {
-        TestResult test = new TestResult(testName, duration, this);
+    public TestResult addTest(long testId, String testName, long duration) {
+        TestResult test = new TestResult(testId, testName, duration, this);
         results.add(test);
         return addTest(test);
     }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
@@ -53,7 +53,7 @@ public class DefaultTestReport implements TestReporter {
                 model.addTestClass(classResult.getId(), classResult.getClassName());
                 List<TestMethodResult> collectedResults = classResult.getResults();
                 for (TestMethodResult collectedResult : collectedResults) {
-                    final TestResult testResult = model.addTest(classResult.getId(), classResult.getClassName(), collectedResult.getName(), collectedResult.getDuration());
+                    final TestResult testResult = model.addTest(classResult.getId(), classResult.getClassName(), collectedResult.getId(), collectedResult.getName(), collectedResult.getDuration());
                     if (collectedResult.getResultType() == SKIPPED) {
                         testResult.setIgnored();
                     } else {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/PackageTestResults.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/PackageTestResults.java
@@ -49,9 +49,9 @@ public class PackageTestResults extends CompositeTestResults {
         return classes.values();
     }
 
-    public TestResult addTest(long classId, String className, String testName, long duration) {
+    public TestResult addTest(long classId, String className, long testId, String testName, long duration) {
         ClassTestResults classResults = addClass(classId, className);
-        return addTest(classResults.addTest(testName, duration));
+        return addTest(classResults.addTest(testId, testName, duration));
     }
 
     public ClassTestResults addClass(long classId, String className) {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/TestResult.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/TestResult.java
@@ -24,19 +24,21 @@ import static org.gradle.api.tasks.testing.TestResult.ResultType;
 
 public class TestResult extends TestResultModel implements Comparable<TestResult> {
     private final long duration;
+    final long id;
     final ClassTestResults classResults;
     final List<TestFailure> failures = new ArrayList<TestFailure>();
     final String name;
     boolean ignored;
 
-    public TestResult(String name, long duration, ClassTestResults classResults) {
+    public TestResult(long id, String name, long duration, ClassTestResults classResults) {
+        this.id = id;
         this.name = name;
         this.duration = duration;
         this.classResults = classResults;
     }
 
-    public Object getId() {
-        return name;
+    public long getId() {
+        return id;
     }
 
     public String getName() {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
@@ -21,7 +21,9 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
+
 import org.gradle.api.Action;
+import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider.WriterOutputEnricher;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.internal.concurrent.CompositeStoppable;
@@ -105,10 +107,26 @@ public class AggregateTestResultsProvider implements TestResultsProvider {
                     }
                 });
     }
+    
+    public boolean hasOutput(long id) {
+        return Iterables.any(
+                classOutputProviders.get(id),
+                new Predicate<DelegateProvider>() {
+                    public boolean apply(DelegateProvider delegateProvider) {
+                        return delegateProvider.provider.hasOutput(delegateProvider.id);
+                    }
+                });
+    }
 
     public void writeAllOutput(long id, TestOutputEvent.Destination destination, Writer writer) {
         for (DelegateProvider delegateProvider : classOutputProviders.get(id)) {
             delegateProvider.provider.writeAllOutput(delegateProvider.id, destination, writer);
+        }
+    }
+    
+    public void writeAllOutput(long id, WriterOutputEnricher enricher, Writer writer) {
+        for (DelegateProvider delegateProvider : classOutputProviders.get(id)) {
+            delegateProvider.provider.writeAllOutput(delegateProvider.id, enricher, writer);
         }
     }
 
@@ -125,10 +143,22 @@ public class AggregateTestResultsProvider implements TestResultsProvider {
             delegateProvider.provider.writeNonTestOutput(delegateProvider.id, destination, writer);
         }
     }
+    
+    public void writeNonTestOutput(long id, WriterOutputEnricher enricher, Writer writer) {
+        for (DelegateProvider delegateProvider : classOutputProviders.get(id)) {
+            delegateProvider.provider.writeNonTestOutput(delegateProvider.id, enricher, writer);
+        }
+    }
 
     public void writeTestOutput(long classId, long testId, TestOutputEvent.Destination destination, Writer writer) {
         for (DelegateProvider delegateProvider : classOutputProviders.get(classId)) {
             delegateProvider.provider.writeTestOutput(delegateProvider.id, testId, destination, writer);
+        }
+    }
+    
+    public void writeTestOutput(long classId, long testId, WriterOutputEnricher enricher, Writer writer) {
+        for (DelegateProvider delegateProvider : classOutputProviders.get(classId)) {
+            delegateProvider.provider.writeTestOutput(delegateProvider.id, testId, enricher, writer);
         }
     }
 

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/BinaryResultBackedTestResultsProvider.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/BinaryResultBackedTestResultsProvider.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.junit.result;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider.WriterOutputEnricher;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 
 import java.io.File;
@@ -35,9 +36,17 @@ public class BinaryResultBackedTestResultsProvider implements TestResultsProvide
     public boolean hasOutput(long id, TestOutputEvent.Destination destination) {
         return outputReader.hasOutput(id, destination);
     }
+    
+    public boolean hasOutput(long id) {
+        return outputReader.hasOutput(id);
+    }
 
     public void writeAllOutput(long id, TestOutputEvent.Destination destination, Writer writer) {
         outputReader.writeAllOutput(id, destination, writer);
+    }
+    
+    public void writeAllOutput(long id, WriterOutputEnricher enricher, Writer writer) {
+        outputReader.writeAllOutput(id, enricher, writer);
     }
     
     public boolean isHasResults() {
@@ -47,9 +56,17 @@ public class BinaryResultBackedTestResultsProvider implements TestResultsProvide
     public void writeNonTestOutput(long id, TestOutputEvent.Destination destination, Writer writer) {
         outputReader.writeNonTestOutput(id, destination, writer);
     }
+    
+    public void writeNonTestOutput(long id, WriterOutputEnricher enricher, Writer writer) {
+        outputReader.writeNonTestOutput(id, enricher, writer);
+    }
 
     public void writeTestOutput(long classId, long testId, TestOutputEvent.Destination destination, Writer writer) {
         outputReader.writeTestOutput(classId, testId, destination, writer);
+    }
+    
+    public void writeTestOutput(long classId, long testId, WriterOutputEnricher enricher, Writer writer) {
+        outputReader.writeTestOutput(classId, testId, enricher, writer);
     }
 
     public void visitClasses(final Action<? super TestClassResult> visitor) {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/InMemoryTestResultsProvider.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/InMemoryTestResultsProvider.java
@@ -34,17 +34,33 @@ public class InMemoryTestResultsProvider implements TestResultsProvider {
     public boolean hasOutput(long id, TestOutputEvent.Destination destination) {
         return outputReader.hasOutput(id, destination);
     }
+    
+    public boolean hasOutput(long id) {
+        return outputReader.hasOutput(id);
+    }
 
     public void writeAllOutput(long id, TestOutputEvent.Destination destination, Writer writer) {
         outputReader.writeAllOutput(id, destination, writer);
+    }
+    
+    public void writeAllOutput(long id, WriterOutputEnricher enricher, Writer writer) {
+        outputReader.writeAllOutput(id, enricher, writer);
     }
 
     public void writeNonTestOutput(long id, TestOutputEvent.Destination destination, Writer writer) {
         outputReader.writeNonTestOutput(id, destination, writer);
     }
+    
+    public void writeNonTestOutput(long id, WriterOutputEnricher enricher, Writer writer) {
+        outputReader.writeNonTestOutput(id, enricher, writer);
+    }
 
     public void writeTestOutput(long classId, long testId, TestOutputEvent.Destination destination, Writer writer) {
         outputReader.writeTestOutput(classId, testId, destination, writer);
+    }
+    
+    public void writeTestOutput(long classId, long testId, WriterOutputEnricher enricher, Writer writer) {
+        outputReader.writeTestOutput(classId, testId, enricher, writer);
     }
 
     public void visitClasses(final Action<? super TestClassResult> visitor) {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestResultsProvider.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestResultsProvider.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.Writer;
 
 public interface TestResultsProvider extends Closeable {
@@ -29,8 +30,17 @@ public interface TestResultsProvider extends Closeable {
      * Writes all output for the test class.
      */
     void writeAllOutput(long id, TestOutputEvent.Destination destination, Writer writer);
+    
+    /**
+     * Writes all output for the test class with enricher (allows to write some pre or post data)
+     * 
+     * @see #writeAllOutput(long, org.gradle.api.tasks.testing.TestOutputEvent.Destination, Writer)
+     */
+    void writeAllOutput(long id, WriterOutputEnricher enricher, Writer writer);
 
     void writeNonTestOutput(long id, TestOutputEvent.Destination destination, Writer writer);
+    
+    void writeNonTestOutput(long id, WriterOutputEnricher enricher, Writer writer);
 
     /**
      * Writes the output of the given test to the given writer. This method must be called only after {@link #visitClasses(org.gradle.api.Action)}.
@@ -38,13 +48,44 @@ public interface TestResultsProvider extends Closeable {
      * Write all output for the given test case name of the test class.
      */
     void writeTestOutput(long classId, long testId, TestOutputEvent.Destination destination, Writer writer);
+    
+    void writeTestOutput(long classId, long testId, WriterOutputEnricher enricher, Writer writer);
 
     /**
      * Visits the results of each test class, in no specific order. Each class is visited exactly once.
      */
     void visitClasses(Action<? super TestClassResult> visitor);
 
+
     boolean hasOutput(long id, TestOutputEvent.Destination destination);
 
+    /**
+     * Check if we have any output available (out or err)
+     */
+    boolean hasOutput(long id);
+
     boolean isHasResults();
+
+    /**
+     * Interface for handling pre and post conditions during writing test output
+     */
+    interface WriterOutputEnricher {
+
+        /**
+         * testId > 0 means this is test
+         * 
+         * @return true if message must be filtered (skipped)
+         */
+        void enrichPre(long testId, TestOutputEvent.Destination destination) throws IOException;
+
+        /**
+         * see {@link #filterPre(long, org.gradle.api.tasks.testing.TestOutputEvent.Destination)}
+         */
+        void enrichPost(long testId, TestOutputEvent.Destination destination) throws IOException;
+        
+        /**
+         * Will be called after complete of writing data
+         */
+        void complete() throws IOException;
+    }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/AllTestResultsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/AllTestResultsTest.groovy
@@ -22,7 +22,7 @@ class AllTestResultsTest extends Specification {
 
     def addsTest() {
         when:
-        def test = results.addTest(1, 'org.gradle.Test', 'test', 90)
+        def test = results.addTest(1, 'org.gradle.Test', 1, 'test', 90)
 
         then:
         test.name == 'test'
@@ -33,7 +33,7 @@ class AllTestResultsTest extends Specification {
     
     def addsTestInDefaultPackage() {
         when:
-        def test = results.addTest(1, 'Test', 'test', 90)
+        def test = results.addTest(1, 'Test', 1, 'test', 90)
 
         then:
         test.name == 'test'

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/CompositeTestResultsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/CompositeTestResultsTest.groovy
@@ -145,6 +145,6 @@ class CompositeTestResultsTest extends Specification {
     }
 
     private TestResult test() {
-        return new TestResult('test', 45, new ClassTestResults(1, 'test', null))
+        return new TestResult(1, 'test', 45, new ClassTestResults(1, 'test', null))
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/TestResultModelTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/TestResultModelTest.groovy
@@ -35,6 +35,6 @@ class TestResultModelTest extends Specification {
     }
 
     def test(long duration) {
-        return new TestResult('test', duration, null)
+        return new TestResult(1, 'test', duration, null)
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/TestResultTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/TestResultTest.groovy
@@ -26,11 +26,11 @@ class TestResultTest extends Specification {
         ClassTestResults class3 = Mock()
         _ * class3.name >> 'z'
 
-        TestResult result = new TestResult('name', 0, class1)
-        TestResult smallerClass = new TestResult('name', 0, class2)
-        TestResult largerClass = new TestResult('name', 0, class3)
-        TestResult smallerName = new TestResult('a', 0, class1)
-        TestResult largerName = new TestResult('z', 0, class1)
+        TestResult result = new TestResult(1, 'name', 0, class1)
+        TestResult smallerClass = new TestResult(1, 'name', 0, class2)
+        TestResult largerClass = new TestResult(2, 'name', 0, class3)
+        TestResult smallerName = new TestResult(3, 'a', 0, class1)
+        TestResult largerName = new TestResult(4, 'z', 0, class1)
 
         expect:
         [result, largerName, smallerClass, largerClass, smallerName].sort() == [smallerClass, smallerName, result, largerName, largerClass]
@@ -40,8 +40,8 @@ class TestResultTest extends Specification {
         ClassTestResults class1 = Mock()
         _ * class1.name >> 'name'
 
-        TestResult result = new TestResult('name', 0, class1)
-        TestResult equalResult = new TestResult('name', 0, class1)
+        TestResult result = new TestResult(1, 'name', 0, class1)
+        TestResult equalResult = new TestResult(1, 'name', 0, class1)
 
         expect:
         def r = [result, equalResult] as SortedSet

--- a/subprojects/plugins/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/junit/report/HtmlTestResultsFixture.groovy
+++ b/subprojects/plugins/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/junit/report/HtmlTestResultsFixture.groovy
@@ -180,17 +180,24 @@ class HtmlTestResultsFixture {
         def anchor = tab.select("TD").find { it.text() == className }
         return anchor?.parent()
     }
-
-    void assertHasStandardOutput(String stdout) {
-        def tab = findTab('Standard output')
+    
+    void assertHasOutput(String testName, String testOutput) {
+        def tab = findTab('Output')
         assert tab != null
-        assert tab.select("SPAN > PRE").find { it.text() == stdout.trim() }
+            
+        def name = tab.select("SPAN > H3").find { it.text() == testName }
+        assert name
+            
+        def pre = name.nextElementSibling()
+        assert pre
+        
+        assert pre.text() == testOutput.trim()
     }
-
-    void assertHasStandardError(String stderr) {
-        def tab = findTab('Standard error')
+    
+    void assertHasClassOutput(String output) {
+        def tab = findTab('Class output')
         assert tab != null
-        assert tab.select("SPAN > PRE").find { it.text() == stderr.trim() }
+        assert tab.select("SPAN > PRE").find { it.text() == output.trim() }
     }
 
     private def findTab(String title) {


### PR DESCRIPTION
This is initial commit for task described at this thread: https://groups.google.com/forum/#!topic/gradle-dev/2FDZ6MQNPJQ

Here some changes in Javascript we may need to implement:
1. add reference (a) to test names and able to scroll into specific test output position on page
2. add expand/collapse button to each test in test output to collapse all other test outputs except current. This is useful if I want to investigate issues in exact test (and don't care about many others).