### PR TITLE
Wrapper respects -q/--quiet options

### DIFF
--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
@@ -115,7 +115,7 @@ public class DistributionFactory {
                         File installDir;
                         try {
                             File realUserHomeDir = userHomeDir != null ? userHomeDir : GradleUserHomeLookup.gradleUserHome();
-                            Install install = new Install(new ProgressReportingDownload(progressLoggerFactory), new PathAssembler(realUserHomeDir));
+                            Install install = new Install(new Logger(false), new ProgressReportingDownload(progressLoggerFactory), new PathAssembler(realUserHomeDir));
                             installDir = install.createDist(wrapperConfiguration);
                         } catch (FileNotFoundException e) {
                             throw new IllegalArgumentException(String.format("The specified %s does not exist.", getDisplayName()), e);
@@ -171,7 +171,7 @@ public class DistributionFactory {
             progressLogger.setDescription(String.format("Download %s", address));
             progressLogger.started();
             try {
-                new Download("Gradle Tooling API", GradleVersion.current().getVersion()).download(address, destination);
+                new Download(new Logger(false), "Gradle Tooling API", GradleVersion.current().getVersion()).download(address, destination);
             } finally {
                 progressLogger.completed();
             }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -44,6 +44,6 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         // wrapper needs to be small. Let's check it's smaller than some arbitrary 'small' limit
-        file("gradle/wrapper/gradle-wrapper.jar").length() < 51 * 1024
+        file("gradle/wrapper/gradle-wrapper.jar").length() < 52 * 1024
     }
 }

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
@@ -22,10 +22,12 @@ import java.net.*;
 public class Download implements IDownload {
     private static final int PROGRESS_CHUNK = 20000;
     private static final int BUFFER_SIZE = 10000;
+    private final Logger logger;
     private final String applicationName;
     private final String applicationVersion;
 
-    public Download(String applicationName, String applicationVersion) {
+    public Download(Logger logger, String applicationName, String applicationVersion) {
+        this.logger = logger;
         this.applicationName = applicationName;
         this.applicationVersion = applicationVersion;
         configureProxyAuthentication();
@@ -64,13 +66,13 @@ public class Download implements IDownload {
                 }
                 progressCounter += numRead;
                 if (progressCounter / PROGRESS_CHUNK > 0) {
-                    System.out.print(".");
+                    logger.append(".");
                     progressCounter = progressCounter - PROGRESS_CHUNK;
                 }
                 out.write(buffer, 0, numRead);
             }
         } finally {
-            System.out.println("");
+            logger.log("");
             if (in != null) {
                 in.close();
             }

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
@@ -30,6 +30,8 @@ import java.util.Properties;
 public class GradleWrapperMain {
     public static final String GRADLE_USER_HOME_OPTION = "g";
     public static final String GRADLE_USER_HOME_DETAILED_OPTION = "gradle-user-home";
+    public static final String GRADLE_QUIET_OPTION = "q";
+    public static final String GRADLE_QUIET_DETAILED_OPTION = "quiet";
 
     public static void main(String[] args) throws Exception {
         File wrapperJar = wrapperJar();
@@ -39,6 +41,7 @@ public class GradleWrapperMain {
         CommandLineParser parser = new CommandLineParser();
         parser.allowUnknownOptions();
         parser.option(GRADLE_USER_HOME_OPTION, GRADLE_USER_HOME_DETAILED_OPTION).hasArgument();
+        parser.option(GRADLE_QUIET_OPTION, GRADLE_QUIET_DETAILED_OPTION);
 
         SystemPropertiesCommandLineConverter converter = new SystemPropertiesCommandLineConverter();
         converter.configure(parser);
@@ -49,13 +52,15 @@ public class GradleWrapperMain {
         systemProperties.putAll(converter.convert(options, new HashMap<String, String>()));
 
         File gradleUserHome = gradleUserHome(options);
-
+        
         addSystemProperties(gradleUserHome, rootDir);
+        
+        Logger logger = logger(options);
 
-        WrapperExecutor wrapperExecutor = WrapperExecutor.forWrapperPropertiesFile(propertiesFile, System.out);
+        WrapperExecutor wrapperExecutor = WrapperExecutor.forWrapperPropertiesFile(propertiesFile, logger);
         wrapperExecutor.execute(
                 args,
-                new Install(new Download("gradlew", wrapperVersion()), new PathAssembler(gradleUserHome)),
+                new Install(logger, new Download(logger, "gradlew", wrapperVersion()), new PathAssembler(gradleUserHome)),
                 new BootstrapMainStarter());
     }
 
@@ -112,5 +117,15 @@ public class GradleWrapperMain {
             return new File(options.option(GRADLE_USER_HOME_OPTION).getValue());
         }
         return GradleUserHomeLookup.gradleUserHome();
+    }
+    
+    private static Logger logger(ParsedCommandLine options) {
+        // the workaround with appending -- or - is needed for it to work
+        // when -q flag is set after task name
+        // i.e. ./gradlew tasks -q
+        boolean shouldBeQuiet = options.hasOption(GRADLE_QUIET_OPTION)
+                || options.getExtraArguments().contains("-" + GRADLE_QUIET_OPTION)
+                || options.getExtraArguments().contains("--" + GRADLE_QUIET_DETAILED_OPTION);
+        return new Logger(shouldBeQuiet);
     }
 }

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -25,11 +25,13 @@ import java.util.zip.ZipFile;
 
 public class Install {
     public static final String DEFAULT_DISTRIBUTION_PATH = "wrapper/dists";
+    private final Logger logger;
     private final IDownload download;
     private final PathAssembler pathAssembler;
     private final ExclusiveFileAccessManager exclusiveFileAccessManager = new ExclusiveFileAccessManager(120000, 200);
 
-    public Install(IDownload download, PathAssembler pathAssembler) {
+    public Install(Logger logger, IDownload download, PathAssembler pathAssembler) {
+        this.logger = logger;
         this.download = download;
         this.pathAssembler = pathAssembler;
     }
@@ -53,17 +55,17 @@ public class Install {
                 if (needsDownload) {
                     File tmpZipFile = new File(localZipFile.getParentFile(), localZipFile.getName() + ".part");
                     tmpZipFile.delete();
-                    System.out.println("Downloading " + distributionUrl);
+                    logger.log("Downloading " + distributionUrl);
                     download.download(distributionUrl, tmpZipFile);
                     tmpZipFile.renameTo(localZipFile);
                 }
 
                 List<File> topLevelDirs = listDirs(distDir);
                 for (File dir : topLevelDirs) {
-                    System.out.println("Deleting directory " + dir.getAbsolutePath());
+                    logger.log("Deleting directory " + dir.getAbsolutePath());
                     deleteDir(dir);
                 }
-                System.out.println("Unzipping " + localZipFile.getAbsolutePath() + " to " + distDir.getAbsolutePath());
+                logger.log("Unzipping " + localZipFile.getAbsolutePath() + " to " + distDir.getAbsolutePath());
                 unzip(localZipFile, distDir);
 
                 File root = getDistributionRoot(distDir, distributionUrl.toString());
@@ -108,7 +110,7 @@ public class Install {
             ProcessBuilder pb = new ProcessBuilder("chmod", "755", gradleCommand.getCanonicalPath());
             Process p = pb.start();
             if (p.waitFor() == 0) {
-                System.out.println("Set executable permissions for: " + gradleCommand.getAbsolutePath());
+                logger.log("Set executable permissions for: " + gradleCommand.getAbsolutePath());
             } else {
                 BufferedReader is = new BufferedReader(new InputStreamReader(p.getInputStream()));
                 Formatter stdout = new Formatter();
@@ -124,8 +126,8 @@ public class Install {
             errorMessage = e.getMessage();
         }
         if (errorMessage != null) {
-            System.out.println("Could not set executable permissions for: " + gradleCommand.getAbsolutePath());
-            System.out.println("Please do this manually if you want to use the Gradle UI.");
+            logger.log("Could not set executable permissions for: " + gradleCommand.getAbsolutePath());
+            logger.log("Please do this manually if you want to use the Gradle UI.");
         }
     }
 

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Logger.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Logger.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2007-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.wrapper;
+
+public class Logger implements Appendable {
+
+    private final boolean quiet;
+
+    public Logger(boolean quiet) {
+        this.quiet = quiet;
+    }
+    
+    public Logger log(String message) {
+        if (!quiet) {
+            System.out.println(message);
+        }
+        return this;
+    }
+
+    public Appendable append(CharSequence csq) {
+        if (!quiet) {
+            System.out.append(csq);
+        }
+        return this;
+    }
+
+    public Appendable append(CharSequence csq, int start, int end) {
+        if (!quiet) {
+            System.out.append(csq, start, end);
+        }
+        return this;
+    }
+
+    public Appendable append(char c) {
+        if(!quiet) {
+            System.out.append(c);
+        }
+        return this;
+    }
+}

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/DownloadTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/DownloadTest.groovy
@@ -34,7 +34,7 @@ class DownloadTest {
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
 
     @Before public void setUp() {
-        download = new Download("gradlew", "aVersion")
+        download = new Download(new Logger(true), "gradlew", "aVersion")
         testDir = tmpDir.testDirectory
         rootDir = new File(testDir, 'root')
         downloadFile = new File(rootDir, 'file')

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/InstallTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/InstallTest.groovy
@@ -50,7 +50,7 @@ class InstallTest extends Specification {
         gradleHomeDir = new TestFile(distributionDir, 'gradle-0.9')
         zipStore = new File(testDir, 'zips');
         zipDestination = new TestFile(zipStore, 'gradle-0.9.zip')
-        install = new Install(download, pathAssembler)
+        install = new Install(new Logger(true), download, pathAssembler)
     }
 
     void createTestZip(File zipDestination) {


### PR DESCRIPTION
Gradle wrapper should respect _-q_ and _--quiet_ options.

Use case: when parsing output from gradle, we use _-q_ flag to suppress all gradle messages. On our CI environment we need to download gradle distribution first and since gradlew does not respect _-q_ flag, it prints a lot of noise, which makes parser fail.

This PR was discussed on [mailing list](https://groups.google.com/forum/#!topic/gradle-dev/hwZTkb5OX3A).
