### PR TITLE
Use hostname command as fallback way of getting build host name

### DIFF
--- a/gradle/buildReceipt.gradle
+++ b/gradle/buildReceipt.gradle
@@ -109,7 +109,17 @@ task createBuildReceipt(dependsOn: determineCommitId) {
         try {
             hostName = InetAddress.localHost.hostName
         } catch (UnknownHostException e) {
-            hostName = "unknown"
+            def baos = new ByteArrayOutputStream()
+            def execResult = exec {
+                ignoreExitValue = true
+                commandLine = ["hostname"]
+                standardOutput = baos
+            }
+            if (execResult.exitValue == 0) {
+                hostName = new String(baos.toByteArray(), "utf8").trim()
+            } else {
+                hostName = "unknown"
+            }
         }
         def data = [
                 commitId: determineCommitId.commitId,


### PR DESCRIPTION
- getHostName() may fail for number of reasons, for example when
  networking is disabled or network is down.
- hostname command is a portable way of determining host name,
  which doesn't depend on networking to be available.

For more details, see: http://stackoverflow.com/a/7800008

For example, Fedora build servers don't have networking available, not even local loopback interface (localhost). As a result host name in Gradle build is always set to "unknown". This patch fixes the problem.