### PR TITLE
add --ansi command line option and remove system property

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/logging/LoggingConfiguration.java
+++ b/subprojects/core/src/main/groovy/org/gradle/logging/LoggingConfiguration.java
@@ -23,6 +23,7 @@ public class LoggingConfiguration implements Serializable {
     private LogLevel logLevel = LogLevel.LIFECYCLE;
     private ShowStacktrace showStacktrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private boolean colorOutput = true;
+    private boolean ansiConsole;
 
     public LogLevel getLogLevel() {
         return logLevel;
@@ -50,6 +51,21 @@ public class LoggingConfiguration implements Serializable {
     public void setColorOutput(boolean colorOutput) {
         this.colorOutput = colorOutput;
     }
+
+    /**
+     * Returns true if native terminal detection should be disabled and ANSI escape encoding should be always enabled for logging output.
+     * The default value is false.
+     *
+     * @return true if logging output should be displayed in color.
+     */
+    public boolean isAnsiConsole() { return ansiConsole; }
+
+    /**
+     * Specifies whether native terminal detection should be disabled and ANSI escape encoding should be always enabled for logging output.
+     *
+     * @param ansiConsole true if terminal detection should be disabled and ANSI escape encoding output enabled for logging output.
+     */
+    public void setAnsiConsole(boolean ansiConsole) { this.ansiConsole = ansiConsole; }
 
     public ShowStacktrace getShowStacktrace() {
         return showStacktrace;

--- a/subprojects/core/src/main/groovy/org/gradle/logging/LoggingServiceRegistry.java
+++ b/subprojects/core/src/main/groovy/org/gradle/logging/LoggingServiceRegistry.java
@@ -50,7 +50,7 @@ public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
      *
      * <p>Does nothing until started.</p>
      *
-     * <p>Allows dynamic and colored output to be written to the console. Use {@link LoggingManagerInternal#attachProcessConsole(boolean)} to enable this.</p>
+     * <p>Allows dynamic and colored output to be written to the console. Use {@link LoggingManagerInternal#attachProcessConsole(boolean,boolean)} to enable this.</p>
      */
     public static LoggingServiceRegistry newCommandLineProcessLogging() {
         return new CommandLineLogging();

--- a/subprojects/core/src/main/groovy/org/gradle/logging/internal/ConsoleConfigureAction.java
+++ b/subprojects/core/src/main/groovy/org/gradle/logging/internal/ConsoleConfigureAction.java
@@ -26,10 +26,10 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 
 public class ConsoleConfigureAction implements Action<OutputEventRenderer> {
-    private static boolean useAnsiOutput = "true".equalsIgnoreCase(System.getProperty("org.gradle.ansi", "false"));
 
     public void execute(OutputEventRenderer renderer) {
         ConsoleMetaData consoleMetaData;
+        boolean useAnsiOutput = renderer.isUseAnsiConsole();
         if (useAnsiOutput) {
             consoleMetaData = new FallbackConsoleMetaData();
         } else {

--- a/subprojects/core/src/main/groovy/org/gradle/logging/internal/DefaultLoggingManager.java
+++ b/subprojects/core/src/main/groovy/org/gradle/logging/internal/DefaultLoggingManager.java
@@ -158,8 +158,8 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
 
     public void removeAllOutputEventListeners() { loggingOutput.removeAllOutputEventListeners(); }
 
-    public void attachProcessConsole(boolean colorOutput) {
-        loggingOutput.attachProcessConsole(colorOutput);
+    public void attachProcessConsole(boolean colorOutput, boolean useAnsiConsole) {
+        loggingOutput.attachProcessConsole(colorOutput, useAnsiConsole);
     }
 
     public void attachAnsiConsole(OutputStream outputStream) {

--- a/subprojects/core/src/main/groovy/org/gradle/logging/internal/LoggingCommandLineConverter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/logging/internal/LoggingCommandLineConverter.java
@@ -38,6 +38,7 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
     public static final String QUIET = "q";
     public static final String QUIET_LONG = "quiet";
     public static final String NO_COLOR = "no-color";
+    public static final String ANSI_CONSOLE = "ansi";
     public static final String FULL_STACKTRACE = "S";
     public static final String FULL_STACKTRACE_LONG = "full-stacktrace";
     public static final String STACKTRACE = "s";
@@ -70,6 +71,10 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
             loggingConfiguration.setColorOutput(false);
         }
 
+        if (commandLine.hasOption(ANSI_CONSOLE)) {
+            loggingConfiguration.setAnsiConsole(true);
+        }
+
         return loggingConfiguration;
     }
 
@@ -80,6 +85,7 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
         parser.allowOneOf(DEBUG, QUIET, INFO);
 
         parser.option(NO_COLOR).hasDescription("Do not use color in the console output.");
+        parser.option(ANSI_CONSOLE).hasDescription("Disable native terminal detection and enable ANSI escape encoding in the console output.");
 
         parser.option(STACKTRACE, STACKTRACE_LONG).hasDescription("Print out the stacktrace for all exceptions.");
         parser.option(FULL_STACKTRACE, FULL_STACKTRACE_LONG).hasDescription("Print out the full (very verbose) stacktrace for all exceptions.");

--- a/subprojects/core/src/main/groovy/org/gradle/logging/internal/LoggingOutputInternal.java
+++ b/subprojects/core/src/main/groovy/org/gradle/logging/internal/LoggingOutputInternal.java
@@ -31,7 +31,7 @@ public interface LoggingOutputInternal extends LoggingOutput {
      *
      * <p>Removes standard output and/or error as a side-effect.
      */
-    void attachProcessConsole(boolean colorOutput);
+    void attachProcessConsole(boolean colorOutput, boolean useAnsiConsole);
 
     /**
      * Adds the given {@link java.io.OutputStream} as a logging destination. The stream receives stdout and stderr logging formatted according to the current logging settings

--- a/subprojects/core/src/main/groovy/org/gradle/logging/internal/OutputEventRenderer.java
+++ b/subprojects/core/src/main/groovy/org/gradle/logging/internal/OutputEventRenderer.java
@@ -44,6 +44,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingConfigur
     private OutputStream originalStdErr;
     private StreamBackedStandardOutputListener stdOutListener;
     private StreamBackedStandardOutputListener stdErrListener;
+    private boolean useAnsiConsole;
 
     public OutputEventRenderer(Action<? super OutputEventRenderer> consoleConfigureAction) {
         OutputEventListener stdOutChain = onNonError(new ProgressLogEventGenerator(new StyledTextOutputBackedRenderer(new StreamingStyledTextOutput(stdoutListeners.getSource())), false));
@@ -57,6 +58,8 @@ public class OutputEventRenderer implements OutputEventListener, LoggingConfigur
         return colourMap;
     }
 
+    public boolean isUseAnsiConsole() { return useAnsiConsole; }
+
     public OutputStream getOriginalStdOut() {
         return originalStdOut;
     }
@@ -65,9 +68,10 @@ public class OutputEventRenderer implements OutputEventListener, LoggingConfigur
         return originalStdErr;
     }
 
-    public void attachProcessConsole(boolean colorOutput) {
+    public void attachProcessConsole(boolean colorOutput, boolean useAnsiConsole) {
         synchronized (lock) {
             colourMap.setUseColor(colorOutput);
+            this.useAnsiConsole = useAnsiConsole;
             consoleConfigureAction.execute(this);
         }
     }

--- a/subprojects/core/src/main/groovy/org/gradle/testfixtures/internal/NoOpLoggingManager.java
+++ b/subprojects/core/src/main/groovy/org/gradle/testfixtures/internal/NoOpLoggingManager.java
@@ -82,7 +82,7 @@ public class NoOpLoggingManager implements LoggingManagerInternal {
 
     }
 
-    public void attachProcessConsole(boolean colorOutput) {
+    public void attachProcessConsole(boolean colorOutput, boolean useAnsiConsole) {
     }
 
     public void attachAnsiConsole(OutputStream outputStream) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
@@ -55,6 +55,7 @@ public class DefaultCommandLineConverterTest {
     private ShowStacktrace expectedShowStackTrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private LogLevel expectedLogLevel = LogLevel.LIFECYCLE;
     private boolean expectedColorOutput = true;
+    private boolean expectedAnsiConsole;
     private StartParameter actualStartParameter;
     private boolean expectedProfile;
     private File expectedProjectCacheDir;
@@ -92,6 +93,7 @@ public class DefaultCommandLineConverterTest {
         assertEquals(expectedGradleUserHome.getAbsoluteFile(), startParameter.getGradleUserHomeDir().getAbsoluteFile());
         assertEquals(expectedLogLevel, startParameter.getLogLevel());
         assertEquals(expectedColorOutput, startParameter.isColorOutput());
+        assertEquals(expectedAnsiConsole, startParameter.isAnsiConsole());
         assertEquals(expectedDryRun, startParameter.isDryRun());
         assertEquals(expectedShowStackTrace, startParameter.getShowStacktrace());
         assertEquals(expectedExcludedTasks, startParameter.getExcludedTaskNames());
@@ -304,6 +306,12 @@ public class DefaultCommandLineConverterTest {
     public void withNoColor() {
         expectedColorOutput = false;
         checkConversion("--no-color");
+    }
+
+    @Test
+    public void withAnsiConsole() {
+        expectedAnsiConsole = true;
+        checkConversion("--ansi");
     }
 
     @Test(expected = CommandLineArgumentException.class)

--- a/subprojects/core/src/test/groovy/org/gradle/logging/internal/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/logging/internal/LoggingCommandLineConverterTest.groovy
@@ -60,6 +60,13 @@ class LoggingCommandLineConverterTest extends Specification {
         checkConversion(['--no-color'])
     }
 
+    def convertsAnsi() {
+        expectedConfig.ansiConsole = true
+
+        expect:
+        checkConversion(['--ansi'])
+    }
+
     def convertsShowStacktrace() {
         expectedConfig.showStacktrace = ShowStacktrace.ALWAYS
 

--- a/subprojects/docs/src/docs/userguide/commandLine.xml
+++ b/subprojects/docs/src/docs/userguide/commandLine.xml
@@ -140,6 +140,14 @@
         </varlistentry>
         <varlistentry>
             <term>
+                <option>--ansi</option>
+            </term>
+            <listitem>
+                <para>Disable native terminal detection and enable ANSI escape encoding in the console output.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term>
                 <option>--offline</option>
             </term>
             <listitem>

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -201,7 +201,7 @@ public class CommandLineActionFactory {
             loggingManager.start();
 
             NativeServices.initialize(buildLayout.getGradleUserHomeDir());
-            loggingManager.attachProcessConsole(loggingConfiguration.isColorOutput());
+            loggingManager.attachProcessConsole(loggingConfiguration.isColorOutput(), loggingConfiguration.isAnsiConsole());
 
             action.execute(executionListener);
         }


### PR DESCRIPTION
improves #340 
- --ansi command line option disables native terminal detection and enables ANSI escape encoding in the console output
- remove "org.gradle.ansi" system property usage that was added as part of #340
