### PR TITLE
Method to add default facets because manually adding facets removes default facets

### DIFF
--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
@@ -160,23 +160,28 @@ class EclipseWtpPlugin extends IdePlugin {
             project.plugins.withType(JavaPlugin) {
                 if (hasWarOrEarPlugin(project)) { return }
 
-                facet.conventionMapping.facets = {
+                configureFacets({
                     [new Facet(FacetType.fixed, "jst.java", null), new Facet(FacetType.installed, "jst.utility", "1.0"),
                       new Facet(FacetType.installed, "jst.java", toJavaFacetVersion(project.sourceCompatibility))]
-                }
+                })
             }
             project.plugins.withType(WarPlugin) {
-                facet.conventionMapping.facets = {
+                configureFacets({
                     [new Facet(FacetType.fixed, "jst.java", null), new Facet(FacetType.fixed, "jst.web", null),
                       new Facet(FacetType.installed, "jst.web", "2.4"), new Facet(FacetType.installed, "jst.java", toJavaFacetVersion(project.sourceCompatibility))]
-                }
+                })
             }
             project.plugins.withType(EarPlugin) {
-                facet.conventionMapping.facets = {
+                configureFacets({
                     [new Facet(FacetType.fixed, "jst.ear", null), new Facet(FacetType.installed, "jst.ear", "5.0")]
-                }
+                })
             }
         }
+    }
+
+    private void configureFacets(Closure facets) {
+        eclipseWtpModel.facet.defaults = facets
+        eclipseWtpModel.facet.conventionMapping.facets = facets
     }
 
     private void maybeAddTask(Project project, IdePlugin plugin, String taskName, Class taskType, Closure action) {

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.groovy
@@ -32,8 +32,10 @@ import org.gradle.util.ConfigureUtil
  * eclipse {
  *   wtp {
  *     facet {
- *       //you can add some extra wtp facets; mandatory keys: 'name', 'version':
+ *       //manually adding wtp facets => default facets are not applied; mandatory keys: 'name', 'version':
  *       facet name: 'someCoolFacet', version: '1.3'
+ *       //additionally add all the default facets (only available with "java", "war" or "ear" plugin)
+ *       defaultFacets()
  *
  *       file {
  *         //if you want to mess with the resulting XML in whatever way you fancy
@@ -74,6 +76,13 @@ class EclipseWtpFacet {
     // TODO: What's the difference between fixed and installed facets? Why do we only model the latter?
 
     /**
+     * {@link Closure} which returns all the default facets to be added by {@link #defaultFacets()} to {@link #facets}.
+     * <p>
+     * For examples see docs for {@link EclipseWtpFacet}
+     */
+    Closure defaults = { [] }
+
+    /**
      * Adds a facet.
      * <p>
      * For examples see docs for {@link EclipseWtpFacet}
@@ -82,6 +91,15 @@ class EclipseWtpFacet {
      */
     void facet(Map<String, ?> args) {
         facets << ConfigureUtil.configureByMap(args, new Facet())
+    }
+
+    /**
+     * Adds the default facets.
+     * <p>
+     * For examples see docs for {@link EclipseWtpFacet}
+     */
+    void defaultFacets() {
+        facets += defaults()
     }
 
     /**

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -92,6 +92,27 @@ class EclipseWtpPluginTest extends Specification {
                 new Facet(FacetType.installed, 'jst.java', '1.7')])
     }
 
+    def applyToJavaProject_shouldAllowToAddDefaultFacetsManually() {
+        when:
+        project.apply(plugin: 'java')
+        wtpPlugin.apply(project)
+        project.sourceCompatibility = 1.3
+
+        project.eclipse.wtp {
+            facet {
+                facet name: 'someCoolFacet', version: '1.3'
+                defaultFacets()
+            }
+        }
+
+        then:
+        checkEclipseWtpFacet([
+                new Facet(FacetType.fixed, 'jst.java', null),
+                new Facet(FacetType.installed, 'jst.utility', '1.0'),
+                new Facet(FacetType.installed, 'jst.java', '1.3'),
+                new Facet(FacetType.installed, 'someCoolFacet', '1.3')])
+    }
+
     def applyToWarProject_shouldHaveWebProjectAndClasspathTask() {
         when:
         project.apply(plugin: 'war')
@@ -130,6 +151,28 @@ class EclipseWtpPluginTest extends Specification {
                 new Facet(FacetType.fixed, "jst.web", null),
                 new Facet(FacetType.installed, "jst.web", "2.4"),
                 new Facet(FacetType.installed, "jst.java", "1.8")])
+    }
+
+    def applyToWarProject_shouldAllowToAddDefaultFacetsManually() {
+        when:
+        project.apply(plugin: 'war')
+        wtpPlugin.apply(project)
+        project.sourceCompatibility = 1.4
+
+        project.eclipse.wtp {
+            facet {
+                defaultFacets()
+                facet name: 'someCoolFacet', version: '1.4'
+            }
+        }
+
+        then:
+        checkEclipseWtpFacet([
+                new Facet(FacetType.fixed, "jst.java", null),
+                new Facet(FacetType.fixed, "jst.web", null),
+                new Facet(FacetType.installed, "jst.web", "2.4"),
+                new Facet(FacetType.installed, "jst.java", "1.4"),
+                new Facet(FacetType.installed, 'someCoolFacet', '1.4')])
     }
 
     @Issue("GRADLE-1770")
@@ -183,6 +226,25 @@ class EclipseWtpPluginTest extends Specification {
 
                 ['eclipse-wtp', 'java', 'ear'],
                 ['eclipse-wtp', 'ear', 'java']]
+    }
+
+    def applyToEarProject_shouldAllowToAddDefaultFacetsManually() {
+        when:
+        project.apply(plugin: 'ear')
+        wtpPlugin.apply(project)
+
+        project.eclipse.wtp {
+            facet {
+                defaultFacets()
+                facet name: 'someFancyFacet', version: '2.0'
+            }
+        }
+
+        then:
+        checkEclipseWtpFacet([
+                new Facet(FacetType.fixed, "jst.ear", null),
+                new Facet(FacetType.installed, "jst.ear", "5.0"),
+                new Facet(FacetType.installed, 'someFancyFacet', '2.0')])
     }
 
     @Issue(['GRADLE-2186', 'GRADLE-2221'])


### PR DESCRIPTION
Hi @radimk, 

thanks to your comment on http://forums.gradle.org/gradle/topics/additional_eclipse_wtp_facet_overwrites_default_facets. I have fixed the behavior. Please tell me if this satisfies your needs and feel free to change/enhance the changed documentation or give me same feedback such that I can do!

Cheers,
Andreas
