### PR TITLE
Support Play 2.3.7 instead of Play 2.3.5

### DIFF
--- a/design-docs/play-support.md
+++ b/design-docs/play-support.md
@@ -78,7 +78,7 @@ When running `gradle assemble`, a Jar file will be built for the default templat
     - Locations of routes file
     - Locations of templates files
     - Scala version
-    - Dependencies of Play ("com.typesafe.play:play_2.11:2.3.5")
+    - Dependencies of Play ("com.typesafe.play:play_2.11:2.3.7")
     - Dependency of template compiler ("com.typesafe.play:twirl-compiler_2.11:1.0.2)
     - Dependency of routes compiler
 - resolve different play dependencies from user-configured repositories
@@ -109,7 +109,7 @@ At this stage, only the default generated Play application is supported, with a 
           
 #### Test cases
 
-- verify that play app can be built and executed with play version 2.3.5 and 2.2.3
+- verify that play app can be built and executed with play version 2.3.7 and 2.2.3
 - Can configure port for launched PlayApp: default is 9000
 
 #### Open issue
@@ -137,11 +137,11 @@ At this stage, only the default generated Play application is supported, with a 
 
 ### Story: Developer builds, runs and tests a basic application for a specified version of Play
 
-- Can build play application with Play 2.2.3 on Scala 2.10, and Play 2.3.5 on Scala 2.11
+- Can build play application with Play 2.2.3 on Scala 2.10, and Play 2.3.7 on Scala 2.11
 
 #### Test cases
 
-- Verify building and running the 'activator new' app with Play 2.2.3 and Play 2.3.5
+- Verify building and running the 'activator new' app with Play 2.2.3 and Play 2.3.7
 
 #### Open issues
 
@@ -411,7 +411,7 @@ Play plugin:
     model {
         components {
             play(PlayApplicationSpec) {
-                platform play: "2.3.6"
+                platform play: "2.3.7"
                 platform play: "2.2.3"
             }
         }
@@ -419,7 +419,7 @@ Play plugin:
 
 #### Test cases
 
-- For each supported Play version: 2.2.3, 2.3.5, 2.3.6
+- For each supported Play version: 2.2.3, 2.3.7
     - Can assemble Play application
     - Can run Play application
     - Can test Play application
@@ -434,7 +434,7 @@ Play plugin:
     model {
         components {
             play(PlayApplicationSpec) {
-                platform play: "2.3.5", scala: "2.11"
+                platform play: "2.3.7", scala: "2.11"
             }
         }
     }
@@ -445,7 +445,7 @@ Play plugin:
     model {
         components {
             play(PlayApplicationSpec) {
-                platform play: "2.3.5", scala: "2.11", java: "1.8"
+                platform play: "2.3.7", scala: "2.11", java: "1.8"
             }
         }
     }

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/fixtures/PlayCoverage.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/fixtures/PlayCoverage.groovy
@@ -17,5 +17,5 @@
 package org.gradle.play.integtest.fixtures
 
 class PlayCoverage {
-    static final String[] DEFAULT = ["2.2.3", "2.3.5"]
+    static final String[] DEFAULT = ["2.2.3", "2.3.7"]
 }

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/plugins/PlayApplicationPluginIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/plugins/PlayApplicationPluginIntegrationTest.groovy
@@ -61,7 +61,7 @@ Source sets
 Binaries
     Play Application Jar 'playBinary'
         build using task: :playBinary
-        platform: PlayPlatform2.3.5
+        platform: PlayPlatform2.3.7
         tool chain: Default Play Toolchain"""))
     }
 

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayApplicationPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayApplicationPlugin.java
@@ -61,7 +61,7 @@ import java.util.List;
  */
 @Incubating
 public class PlayApplicationPlugin implements Plugin<ProjectInternal> {
-    private final static String DEFAULT_PLAY_VERSION = "2.3.5";
+    private final static String DEFAULT_PLAY_VERSION = "2.3.7";
     public static final int DEFAULT_HTTP_PORT = 9000;
 
     public void apply(final ProjectInternal project) {


### PR DESCRIPTION
I added a commit to Play for @breskeby so that it no longer says you're running SBT when you're really starting it from Gradle :-)

https://github.com/playframework/playframework/commit/01a73b24652e5c181948fb6e538ad0f00a773636
https://github.com/gradle/gradle/commit/1de14e43728bde17ffef466fb148e3440b951564#commitcomment-8764498

I'm not sure how to test out the Play support to see if there's anything else I could do for you guys. Is there a way I can build Gradle from source and use that version instead of the version I currently have on my path? Or will there be a version of Gradle released soon that will have some of the Play support stuff in it?
