### PR TITLE
GRADLE-3080 Exclude SNAPSHOTs from version ranges

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
@@ -29,7 +29,8 @@ import java.util.regex.Pattern;
  * none is set, it uses the default one of the ivy instance set through setIvy(). If neither a
  * latest strategy nor a ivy instance is set, an IllegalStateException will be thrown when calling
  * accept(). Note that it can't work with latest time strategy, cause no time is known for the
- * limits of the range. Therefore only purely revision based LatestStrategy can be used.
+ * limits of the range. Therefore only purely revision based LatestStrategy can be used.  All
+ * maven SNAPSHOT revisions are rejected in keeping with maven behavior.
  */
 public class VersionRangeSelector extends AbstractVersionSelector {
     private static final String OPEN_INC = "[";
@@ -140,6 +141,9 @@ public class VersionRangeSelector extends AbstractVersionSelector {
     }
 
     public boolean accept(String candidate) {
+        if (candidate.endsWith("SNAPSHOT")) {
+            return false;
+        }
         if (lowerBound != null && !isHigher(candidate, lowerBound, lowerInclusive)) {
             return false;
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
@@ -113,6 +113,9 @@ public class VersionRangeSelectorTest extends AbstractVersionSelectorTest {
 
         !accept("(,2.0[", "2.0")
         !accept("(,2.0[", "42")
+        
+        !accept("(1.0,2.0)", "1.0")
+        !accept("(1.0,2.0)", "2.0")
     }
 
     def "rejects candidate versions that don't fall into the selector's range (adding qualifiers to the mix)"() {
@@ -124,6 +127,10 @@ public class VersionRangeSelectorTest extends AbstractVersionSelectorTest {
         !accept("[1.0-dev-2,2.0[", "1.0-dev-1")
         !accept("[1.0,2.0-rc-2[", "2.0-rc-2")
         !accept("[1.0,2.0-final[", "2.0")
+        
+        !accept("[1.0,2.0)", "2.0-SNAPSHOT")
+        !accept("[1.0,2.0)", "1.0-SNAPSHOT")
+        !accept("[1.0,2.0)", "1.5-SNAPSHOT")
 
         !accept("]1.0-dev-1,2.0]", "1.0-dev-1")
         !accept("]1.0-rc-2,2.0]", "1.0-dev-3")


### PR DESCRIPTION
- Exclude SNAPSHOT versions from ranges, e.g. "[1.0,2.0)"
