### PR TITLE
GRADLE-2894: fixed bug that does not recognize the default wb resource if manually changed

### DIFF
--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/EclipseWtpComponent.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/EclipseWtpComponent.groovy
@@ -184,7 +184,7 @@ class EclipseWtpComponent {
      * @param args A map that must contain a deployPath and sourcePath key with corresponding values.
      */
     void resource(Map<String, String> args) {
-        resources.add(new WbResource(args.deployPath, args.sourcePath))
+        resources = getResources() + new WbResource(args.deployPath, args.sourcePath)
     }
 
     /**

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/EclipseWtpComponent.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/EclipseWtpComponent.groovy
@@ -202,7 +202,7 @@ class EclipseWtpComponent {
      * @param args A map that must contain a 'name' and 'value' key with corresponding values.
      */
     void property(Map<String, String> args) {
-        properties.add(new WbProperty(args.name, args.value))
+        properties = getProperties() + new WbProperty(args.name, args.value)
     }
 
    /**

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -186,6 +186,22 @@ class EclipseWtpPluginTest extends Specification {
         project.eclipse.wtp.component.resources == [new WbResource('/', 'foo')]
     }
 
+    def "web app dir should not disappear while manually adding a wb resource"() {
+        when:
+        project.apply(plugin: 'war')
+        wtpPlugin.apply(project)
+        project.webAppDirName = 'foo'
+
+        project.eclipse.wtp {
+            component {
+                resource sourcePath: "common", deployPath: "/common"
+            }
+        }
+
+        then:
+        project.eclipse.wtp.component.resources == [new WbResource('/', 'foo'), new WbResource('/common', 'common')]
+    }
+
     @Unroll
     def 'applyToEarProject in order #plugs should have web project and classpath task'() {
         when:


### PR DESCRIPTION
I have found this bug on Stackoverflow question "http://stackoverflow.com/questions/22957776/gradle-eclipse-wtp-plugin-adding-wb-resource-removes-webappdir-from-deployment" and the documentation says 

```
      //you can add a wb-resource elements; mandatory keys: 'sourcePath', 'deployPath':
      //if sourcePath points to non-existing folder it will *not* be added.
      resource sourcePath: 'extra/resource', deployPath: 'deployment/resource'
```

But this does override all the default entries and adds only the manually added ...
IMHO this is same problem as we have had with facets, see http://forums.gradle.org/gradle/topics/additional_eclipse_wtp_facet_overwrites_default_facets, which René changed a few days ago.