### PR TITLE
Fix of ```test.testLogging.showStandardStreams = false```

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
@@ -119,7 +119,12 @@ public class DefaultTestLogging implements TestLogging {
     }
 
     public TestLogging setShowStandardStreams(boolean flag) {
-        events.addAll(EnumSet.of(TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR));
+        boolean showingStandardStreams = getShowStandardStreams();
+        if (showingStandardStreams && !flag) {
+            events.removeAll(EnumSet.of(TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR));
+        } else if (!showingStandardStreams && flag) {
+            events.addAll(EnumSet.of(TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR));
+        }
         return this;
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingTest.groovy
@@ -63,4 +63,20 @@ class DefaultTestLoggingTest extends Specification {
         then:
         logging.stackTraceFilters == [TRUNCATE, GROOVY] as Set
     }
+
+    def "allows standardStreams to be turned off"() {
+        when:
+        logging.showStandardStreams = false
+
+        then:
+        logging.showStandardStreams == false
+    }
+
+    def "allows standardStreams to be turned on"() {
+        when:
+        logging.showStandardStreams = true
+
+        then:
+        logging.showStandardStreams == true
+    }
 }


### PR DESCRIPTION
The setter was ignoring the flag, so it wasn't possible
to disable standardStreams using this setter.

The following sample easily demonstrates the problem with Gradle 2.2.1+:

``` groovy
test {
    testLogging {
        showStandardStreams = false
    }

    // this prints true no matter what value you actually will use in assignment
    println("In-tests logging configured: ${project.test.testLogging.showStandardStreams}")
}
```
