### PR TITLE
Create the static builder in ModuleVersionSelectorParsers only once

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsers.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsers.java
@@ -28,6 +28,11 @@ import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.new
 
 public class ModuleVersionSelectorParsers {
 
+    private static final NotationParserBuilder<ModuleVersionSelector> BUILDER = NotationParserBuilder
+            .toType(ModuleVersionSelector.class)
+            .fromCharSequence(new StringParser())
+            .parser(new MapParser());
+
     public static NotationParser<Object, Set<ModuleVersionSelector>> multiParser() {
         return builder().toFlatteningComposite();
     }
@@ -37,10 +42,7 @@ public class ModuleVersionSelectorParsers {
     }
 
     private static NotationParserBuilder<ModuleVersionSelector> builder() {
-        return NotationParserBuilder
-                .toType(ModuleVersionSelector.class)
-                .fromCharSequence(new StringParser())
-                .parser(new MapParser());
+        return BUILDER;
     }
 
     static class MapParser extends MapNotationParser<ModuleVersionSelector> {


### PR DESCRIPTION
... instead of doing the costly reflection every time
The builder is stateless so there should be no problem to create only one instance of it. The main performance problem is in the creation of `MapParser` which does a reflection on itself (in `MapNotationParser` constructor) detecting annotations on parameters of `parseMap`. In our project (~250 modules with dependencies) this method is called almost 43,000 times making the total overhead substantial.
