### PR TITLE
NotationParser to NotationConverter

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/DefaultExcludeRuleContainer.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/DefaultExcludeRuleContainer.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ExcludeRuleContainer;
-import org.gradle.internal.typeconversion.NotationParser;
 
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -26,7 +25,6 @@ import java.util.Set;
 
 public class DefaultExcludeRuleContainer implements ExcludeRuleContainer {
     private Set<ExcludeRule> addedRules = new LinkedHashSet<ExcludeRule>();
-    private final NotationParser<Object, ExcludeRule> notationParser = new ExcludeRuleNotationParser();
 
     public DefaultExcludeRuleContainer() {}
 
@@ -35,7 +33,7 @@ public class DefaultExcludeRuleContainer implements ExcludeRuleContainer {
     }
 
     public void add(Map<String, String> args) {
-        addedRules.add(notationParser.parseNotation(args));
+        addedRules.add(ExcludeRuleNotationConverter.parser().parseNotation(args));
     }
 
     public Set<ExcludeRule> getRules() {

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/ExcludeRuleNotationConverter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/ExcludeRuleNotationConverter.java
@@ -20,11 +20,20 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.tasks.Optional;
 import org.gradle.internal.typeconversion.MapKey;
-import org.gradle.internal.typeconversion.MapNotationParser;
+import org.gradle.internal.typeconversion.MapNotationConverter;
+import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.internal.typeconversion.NotationParserBuilder;
 
 import java.util.Collection;
 
-public class ExcludeRuleNotationParser extends MapNotationParser<ExcludeRule> {
+public class ExcludeRuleNotationConverter extends MapNotationConverter<ExcludeRule> {
+
+    private static final NotationParser<Object, ExcludeRule> PARSER =
+            NotationParserBuilder.toType(ExcludeRule.class).converter(new ExcludeRuleNotationConverter()).toComposite();
+
+    public static NotationParser<Object, ExcludeRule> parser() {
+        return PARSER;
+    }
 
     @Override
     public void describe(Collection<String> candidateFormats) {

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/AbstractFileResolver.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/AbstractFileResolver.java
@@ -45,7 +45,7 @@ public abstract class AbstractFileResolver implements FileResolver {
 
     protected AbstractFileResolver(FileSystem fileSystem) {
         this.fileSystem = fileSystem;
-        this.fileNotationParser = FileOrUriNotationParser.create(fileSystem);
+        this.fileNotationParser = FileOrUriNotationConverter.create(fileSystem);
     }
 
     public FileSystem getFileSystem() {

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/FileOrUriNotationConverter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/FileOrUriNotationConverter.java
@@ -28,13 +28,13 @@ import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class FileOrUriNotationParser implements NotationConverter<Object, Object> {
+public class FileOrUriNotationConverter implements NotationConverter<Object, Object> {
 
     private static final Pattern URI_SCHEME = Pattern.compile("[a-zA-Z][a-zA-Z0-9+-\\.]*:.+");
     private static final Pattern ENCODED_URI = Pattern.compile("%([0-9a-fA-F]{2})");
     private final FileSystem fileSystem;
 
-    public FileOrUriNotationParser(FileSystem fileSystem) {
+    public FileOrUriNotationConverter(FileSystem fileSystem) {
         this.fileSystem = fileSystem;
     }
 
@@ -42,7 +42,7 @@ public class FileOrUriNotationParser implements NotationConverter<Object, Object
         return NotationParserBuilder
                 .toType(Object.class)
                 .typeDisplayName("a File or URI")
-                .converter(new FileOrUriNotationParser(fileSystem))
+                .converter(new FileOrUriNotationConverter(fileSystem))
                 .toComposite();
     }
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/DefaultCopySpec.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/DefaultCopySpec.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
 
 @NonExtensible
 public class DefaultCopySpec implements CopySpecInternal {
-    private static final NotationParser<Object, String> PATH_NOTATION_PARSER = PathNotationParser.create();
+    private static final NotationParser<Object, String> PATH_NOTATION_PARSER = PathNotationConverter.create();
     protected final FileResolver fileResolver;
     private final Set<Object> sourcePaths;
     private Object destDir;

--- a/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/ClosureToSpecNotationConverter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/ClosureToSpecNotationConverter.java
@@ -22,10 +22,10 @@ import org.gradle.api.specs.Specs;
 
 import java.util.Collection;
 
-public class ClosureToSpecNotationParser<T> implements NotationConverter<Closure, Spec<T>> {
+public class ClosureToSpecNotationConverter<T> implements NotationConverter<Closure, Spec<T>> {
     private final Class<T> type;
 
-    public ClosureToSpecNotationParser(Class<T> type) {
+    public ClosureToSpecNotationConverter(Class<T> type) {
         this.type = type;
     }
 

--- a/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/JustReturningConverter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/JustReturningConverter.java
@@ -13,37 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.internal.typeconversion;
 
+import java.util.Collection;
 
-import spock.lang.Specification
+public class JustReturningConverter<N, T> implements NotationConverter<N, T> {
 
-public class TypedNotationParserTest extends Specification {
+    private final Class<? extends T> passThroughType;
 
-    def parser = new DummyParser();
-
-    def "parses object of source type"(){
-        expect:
-        parser.parseNotation("100") == 100
+    public JustReturningConverter(Class<? extends T> passThroughType) {
+        this.passThroughType = passThroughType;
     }
 
-    def "throws meaningful exception on parse attempt"(){
-        when:
-        parser.parseNotation(new Object())
-
-        then:
-        thrown(UnsupportedNotationException)
+    public void describe(Collection<String> candidateFormats) {
+        candidateFormats.add(String.format("Instances of %s.", passThroughType.getSimpleName()));
     }
 
-    class DummyParser extends TypedNotationParser<String, Integer> {
-
-        DummyParser() {
-            super(String.class)
-        }
-
-        Integer parseType(String notation) {
-            return Integer.valueOf(notation);
+    @Override
+    public void convert(N notation, NotationConvertResult<? super T> result) throws TypeConversionException {
+        if (passThroughType.isInstance(notation)) {
+            result.converted(passThroughType.cast(notation));
         }
     }
 }

--- a/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/MapNotationConverter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/MapNotationConverter.java
@@ -30,12 +30,12 @@ import java.util.*;
  * for each key value required from the source map. Each parameter should be annotated with a {@code @MapKey} annotation, and can also
  * be annotated with a {@code @optional} annotation.
  */
-public abstract class MapNotationParser<T> extends TypedNotationParser<Map, T> {
+public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map, T> {
     private final Method convertMethod;
     private final String[] keyNames;
     private final boolean[] optional;
 
-    public MapNotationParser() {
+    public MapNotationConverter() {
         super(Map.class);
         convertMethod = findConvertMethod();
         keyNames = new String[convertMethod.getParameterAnnotations().length];

--- a/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/NotationConverterToNotationParserAdapter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/NotationConverterToNotationParserAdapter.java
@@ -18,7 +18,7 @@ package org.gradle.internal.typeconversion;
 
 import java.util.Collection;
 
-class NotationConverterToNotationParserAdapter<N, T> implements NotationParser<N, T> {
+public class NotationConverterToNotationParserAdapter<N, T> implements NotationParser<N, T> {
     private final NotationConverter<N, ? extends T> converter;
 
     public NotationConverterToNotationParserAdapter(NotationConverter<N, ? extends T> converter) {

--- a/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/NotationParserBuilder.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/NotationParserBuilder.java
@@ -42,11 +42,6 @@ public class NotationParserBuilder<T> {
         typeDisplayName = resultingType.getTargetType().equals(String.class) ? "a String" : String.format("an object of type %s", resultingType.getTargetType().getSimpleName());
     }
 
-    public NotationParserBuilder<T> parser(NotationParser<Object, ? extends T> parser) {
-        this.notationParsers.add(new NotationParserToNotationConverterAdapter<Object, T>(parser));
-        return this;
-    }
-
     /**
      * Specifies the display name for the target type, to use in error messages. By default the target type's simple name is used.
      */
@@ -116,13 +111,6 @@ public class NotationParserBuilder<T> {
         return this;
     }
 
-    public NotationParserBuilder<T> parsers(Iterable<? extends NotationParser<Object, ? extends T>> notationParsers) {
-        for (NotationParser<Object, ? extends T> parser : notationParsers) {
-            parser(parser);
-        }
-        return this;
-    }
-
     public NotationParser<Object, Set<T>> toFlatteningComposite() {
         return wrapInErrorHandling(new FlatteningNotationParser<T>(create()));
     }
@@ -138,7 +126,7 @@ public class NotationParserBuilder<T> {
     private NotationParser<Object, T> create() {
         List<NotationConverter<Object, ? extends T>> composites = new LinkedList<NotationConverter<Object, ? extends T>>();
         if (!resultingType.getTargetType().equals(Object.class) && implicitConverters) {
-            composites.add(new NotationParserToNotationConverterAdapter<Object, T>(new JustReturningParser<Object, T>(resultingType.getTargetType())));
+            composites.add(new JustReturningConverter<Object, T>(resultingType.getTargetType()));
         }
         composites.addAll(this.notationParsers);
 

--- a/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/TypedNotationConverter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/typeconversion/TypedNotationConverter.java
@@ -18,16 +18,16 @@ package org.gradle.internal.typeconversion;
 
 import java.util.Collection;
 
-public abstract class TypedNotationParser<N, T> implements NotationParser<Object, T> {
+public abstract class TypedNotationConverter<N, T> implements NotationConverter<Object, T> {
 
     private final Class<N> typeToken;
 
-    public TypedNotationParser(Class<N> typeToken) {
+    public TypedNotationConverter(Class<N> typeToken) {
         assert typeToken != null : "typeToken cannot be null";
         this.typeToken = typeToken;
     }
 
-    public TypedNotationParser(TypeInfo<N> typeToken) {
+    public TypedNotationConverter(TypeInfo<N> typeToken) {
         assert typeToken != null : "typeToken cannot be null";
         this.typeToken = typeToken.getTargetType();
     }
@@ -36,11 +36,11 @@ public abstract class TypedNotationParser<N, T> implements NotationParser<Object
         candidateFormats.add(String.format("Instances of %s.", typeToken.getSimpleName()));
     }
 
-    public T parseNotation(Object notation) {
-        if (!typeToken.isInstance(notation)) {
-            throw new UnsupportedNotationException(notation);
+    @Override
+    public void convert(Object notation, NotationConvertResult<? super T> result) throws TypeConversionException {
+        if (typeToken.isInstance(notation)) {
+            result.converted(parseType(typeToken.cast(notation)));
         }
-        return parseType(typeToken.cast(notation));
     }
 
     abstract protected T parseType(N notation);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/ExcludeRuleNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/ExcludeRuleNotationConverterTest.groovy
@@ -18,11 +18,12 @@ package org.gradle.api.internal.artifacts
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.ExcludeRule
+import org.gradle.internal.typeconversion.NotationConverterToNotationParserAdapter
 import org.gradle.util.WrapUtil
 import spock.lang.Specification
 
-class ExcludeRuleNotationParserTest extends Specification {
-    def parser = new ExcludeRuleNotationParser();
+class ExcludeRuleNotationConverterTest extends Specification {
+    def parser = new NotationConverterToNotationParserAdapter<>(new ExcludeRuleNotationConverter());
 
     def "with group"() {
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/FileOrUriNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/FileOrUriNotationConverterTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
-class FileOrUriNotationParserTest extends Specification {
+class FileOrUriNotationConverterTest extends Specification {
 
     @Rule public TestNameTestDirectoryProvider folder = new TestNameTestDirectoryProvider();
 
@@ -112,6 +112,6 @@ The following types/formats are supported:
     }
 
     def parse(def value) {
-        return FileOrUriNotationParser.create(TestFiles.fileSystem()).parseNotation(value)
+        return FileOrUriNotationConverter.create(TestFiles.fileSystem()).parseNotation(value)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/PathNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/PathNotationConverterTest.groovy
@@ -23,8 +23,8 @@ import java.util.concurrent.Callable
 import org.gradle.api.internal.artifacts.DefaultExcludeRule
 import spock.lang.Specification
 
-class PathNotationParserTest extends Specification {
-    NotationParser<Object, String> pathNotationParser = PathNotationParser.create();
+class PathNotationConverterTest extends Specification {
+    NotationParser<Object, String> pathNotationParser = PathNotationConverter.create();
 
     def "with null"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/ClosureToSpecNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/ClosureToSpecNotationConverterTest.groovy
@@ -19,8 +19,8 @@ package org.gradle.internal.typeconversion
 import org.gradle.api.specs.Spec
 import spock.lang.Specification
 
-class ClosureToSpecNotationParserTest extends Specification {
-    private ClosureToSpecNotationParser parser = new ClosureToSpecNotationParser(String)
+class ClosureToSpecNotationConverterTest extends Specification {
+    private ClosureToSpecNotationConverter converter = new ClosureToSpecNotationConverter(String)
 
     def "converts closures"() {
         given:
@@ -33,6 +33,6 @@ class ClosureToSpecNotationParserTest extends Specification {
     }
 
     def parse(def value) {
-        return NotationParserBuilder.toType(Spec).fromType(Closure, parser).toComposite().parseNotation(value)
+        return NotationParserBuilder.toType(Spec).fromType(Closure, converter).toComposite().parseNotation(value)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/MapNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/MapNotationConverterTest.groovy
@@ -19,8 +19,8 @@ import spock.lang.Specification
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Optional
 
-class MapNotationParserTest extends Specification {
-    final DummyParser parser = new DummyParser()
+class MapNotationConverterTest extends Specification {
+    final NotationParser parser = new NotationConverterToNotationParserAdapter<>(new DummyConverter())
     
     def "parses map with required keys"() {
         expect:
@@ -94,7 +94,7 @@ class MapNotationParserTest extends Specification {
         thrown(UnsupportedNotationException)
     }
     
-    static class DummyParser extends MapNotationParser<TargetObject> {
+    static class DummyConverter extends MapNotationConverter<TargetObject> {
         protected TargetObject parseMap(@MapKey('name') String name,
                                         @MapKey('version') String version,
                                         @Optional @MapKey('optional') optional) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/NotationParserBuilderSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/NotationParserBuilderSpec.groovy
@@ -76,18 +76,6 @@ class NotationParserBuilderSpec extends Specification {
         parser.parseNotation("12") == "12"
     }
 
-    def "can add a parser"() {
-        def target = Mock(NotationParser)
-        given:
-        target.parseNotation(_) >> { Number n -> return "[${n}]" }
-
-        and:
-        def parser = NotationParserBuilder.toType(String.class).parser(target).toComposite()
-
-        expect:
-        parser.parseNotation(12) == "[12]"
-    }
-
     def "can opt in to allow null as input"() {
         def converter = Mock(NotationConverter)
         def parser = NotationParserBuilder

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/TypedNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/TypedNotationConverterTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.typeconversion;
+
+
+import spock.lang.Specification
+
+public class TypedNotationConverterTest extends Specification {
+
+    def parser = new NotationConverterToNotationParserAdapter<>(new DummyConverter());
+
+    def "parses object of source type"(){
+        expect:
+        parser.parseNotation("100") == 100
+    }
+
+    def "throws meaningful exception on parse attempt"(){
+        when:
+        parser.parseNotation(new Object())
+
+        then:
+        thrown(UnsupportedNotationException)
+    }
+
+    class DummyConverter extends TypedNotationConverter<String, Integer> {
+
+        DummyConverter() {
+            super(String.class)
+        }
+
+        Integer parseType(String notation) {
+            return Integer.valueOf(notation);
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -44,6 +44,7 @@ import java.util.*;
 import static org.apache.ivy.core.module.descriptor.Configuration.Visibility;
 
 public class DefaultConfiguration extends AbstractFileCollection implements ConfigurationInternal {
+
     private final String path;
     private final String name;
 
@@ -303,7 +304,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     public DefaultConfiguration exclude(Map<String, String> excludeRuleArgs) {
         validateMutation();
-        excludeRules.add(new ExcludeRuleNotationParser().parseNotation(excludeRuleArgs)); //TODO SF try using ExcludeRuleContainer
+        excludeRules.add(ExcludeRuleNotationConverter.parser().parseNotation(excludeRuleArgs)); //TODO SF try using ExcludeRuleContainer
         return this;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentModuleMetadataContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentModuleMetadataContainer.java
@@ -20,7 +20,7 @@ import com.google.common.base.Joiner;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ComponentModuleMetadataDetails;
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.internal.notations.ModuleIdentiferNotationParser;
+import org.gradle.api.internal.notations.ModuleIdentiferNotationConverter;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 
@@ -87,7 +87,7 @@ public class ComponentModuleMetadataContainer implements ModuleReplacementsData 
     private static NotationParser<Object, ModuleIdentifier> parser() {
         return NotationParserBuilder
                 .toType(ModuleIdentifier.class)
-                .parser(new ModuleIdentiferNotationParser())
+                .converter(new ModuleIdentiferNotationConverter())
                 .toComposite();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
@@ -27,7 +27,7 @@ import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
-import org.gradle.api.internal.notations.ModuleIdentiferNotationParser;
+import org.gradle.api.internal.notations.ModuleIdentiferNotationConverter;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.component.external.model.IvyModuleResolveMetaData;
@@ -72,7 +72,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
     private static NotationParser<Object, ModuleIdentifier> createModuleIdentifierNotationParser() {
         return NotationParserBuilder
                 .toType(ModuleIdentifier.class)
-                .parser(new ModuleIdentiferNotationParser())
+                .converter(new ModuleIdentiferNotationConverter())
                 .toComposite();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsers.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsers.java
@@ -30,8 +30,8 @@ public class ModuleVersionSelectorParsers {
 
     private static final NotationParserBuilder<ModuleVersionSelector> BUILDER = NotationParserBuilder
             .toType(ModuleVersionSelector.class)
-            .fromCharSequence(new StringParser())
-            .parser(new MapParser());
+            .fromCharSequence(new StringConverter())
+            .converter(new MapConverter());
 
     public static NotationParser<Object, Set<ModuleVersionSelector>> multiParser() {
         return builder().toFlatteningComposite();
@@ -45,7 +45,7 @@ public class ModuleVersionSelectorParsers {
         return BUILDER;
     }
 
-    static class MapParser extends MapNotationParser<ModuleVersionSelector> {
+    static class MapConverter extends MapNotationConverter<ModuleVersionSelector> {
         @Override
         public void describe(Collection<String> candidateFormats) {
             candidateFormats.add("Maps, e.g. [group: 'org.gradle', name:'gradle-core', version: '1.0'].");
@@ -56,7 +56,7 @@ public class ModuleVersionSelectorParsers {
         }
     }
 
-    static class StringParser implements NotationConverter<String, ModuleVersionSelector> {
+    static class StringConverter implements NotationConverter<String, ModuleVersionSelector> {
         public void describe(Collection<String> candidateFormats) {
             candidateFormats.add("String or CharSequence values, e.g. 'org.gradle:gradle-core:1.0'.");
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactory.java
@@ -22,11 +22,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact;
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact;
-import org.gradle.internal.typeconversion.NotationParserBuilder;
-import org.gradle.internal.typeconversion.NotationParser;
-import org.gradle.internal.typeconversion.MapKey;
-import org.gradle.internal.typeconversion.MapNotationParser;
-import org.gradle.internal.typeconversion.TypedNotationParser;
+import org.gradle.internal.typeconversion.*;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.Instantiator;
@@ -44,17 +40,17 @@ public class PublishArtifactNotationParserFactory implements Factory<NotationPar
     }
 
     public NotationParser<Object, PublishArtifact> create() {
-        FileNotationParser fileParser = new FileNotationParser();
+        FileNotationConverter fileConverter = new FileNotationConverter();
         return NotationParserBuilder
                 .toType(PublishArtifact.class)
-                .parser(new ArchiveTaskNotationParser())
-                .parser(new FileMapNotationParser(fileParser))
-                .parser(fileParser)
+                .converter(new ArchiveTaskNotationConverter())
+                .converter(new FileMapNotationConverter(fileConverter))
+                .converter(fileConverter)
                 .toComposite();
     }
 
-    private class ArchiveTaskNotationParser extends TypedNotationParser<AbstractArchiveTask, PublishArtifact> {
-        private ArchiveTaskNotationParser() {
+    private class ArchiveTaskNotationConverter extends TypedNotationConverter<AbstractArchiveTask, PublishArtifact> {
+        private ArchiveTaskNotationConverter() {
             super(AbstractArchiveTask.class);
         }
 
@@ -69,20 +65,20 @@ public class PublishArtifactNotationParserFactory implements Factory<NotationPar
         }
     }
 
-    private class FileMapNotationParser extends MapNotationParser<PublishArtifact> {
-        private final FileNotationParser fileParser;
+    private class FileMapNotationConverter extends MapNotationConverter<PublishArtifact> {
+        private final FileNotationConverter fileConverter;
 
-        private FileMapNotationParser(FileNotationParser fileParser) {
-            this.fileParser = fileParser;
+        private FileMapNotationConverter(FileNotationConverter fileConverter) {
+            this.fileConverter = fileConverter;
         }
 
         protected PublishArtifact parseMap(@MapKey("file") File file) {
-            return fileParser.parseType(file);
+            return fileConverter.parseType(file);
         }
     }
 
-    private class FileNotationParser extends TypedNotationParser<File, PublishArtifact> {
-        private FileNotationParser() {
+    private class FileNotationConverter extends TypedNotationConverter<File, PublishArtifact> {
+        private FileNotationConverter() {
             super(File.class);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRules.java
@@ -25,9 +25,9 @@ import org.gradle.api.artifacts.ComponentSelection;
 import org.gradle.api.artifacts.ComponentSelectionRules;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.internal.notations.ModuleIdentiferNotationConverter;
 import org.gradle.internal.rules.*;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
-import org.gradle.api.internal.notations.ModuleIdentiferNotationParser;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.typeconversion.NotationParser;
@@ -57,7 +57,7 @@ public class DefaultComponentSelectionRules implements ComponentSelectionRulesIn
     private static NotationParser<Object, ModuleIdentifier> createModuleIdentifierNotationParser() {
         return NotationParserBuilder
                 .toType(ModuleIdentifier.class)
-                .parser(new ModuleIdentiferNotationParser())
+                .converter(new ModuleIdentiferNotationConverter())
                 .toComposite();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ClientModuleNotationParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ClientModuleNotationParserFactory.java
@@ -32,8 +32,8 @@ public class ClientModuleNotationParserFactory implements Factory<NotationParser
 
     public NotationParser<Object, ClientModule> create() {
         return NotationParserBuilder.toType(ClientModule.class)
-                .fromCharSequence(new DependencyStringNotationParser<DefaultClientModule>(instantiator, DefaultClientModule.class))
-                .parser(new DependencyMapNotationParser<DefaultClientModule>(instantiator, DefaultClientModule.class))
+                .fromCharSequence(new DependencyStringNotationConverter<DefaultClientModule>(instantiator, DefaultClientModule.class))
+                .converter(new DependencyMapNotationConverter<DefaultClientModule>(instantiator, DefaultClientModule.class))
                 .toComposite();
 
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyClassPathNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyClassPathNotationConverter.java
@@ -29,14 +29,14 @@ import org.gradle.internal.typeconversion.TypeConversionException;
 import java.io.File;
 import java.util.Collection;
 
-public class DependencyClassPathNotationParser implements NotationConverter<DependencyFactory.ClassPathNotation, SelfResolvingDependency> {
+public class DependencyClassPathNotationConverter implements NotationConverter<DependencyFactory.ClassPathNotation, SelfResolvingDependency> {
 
     private final ClassPathRegistry classPathRegistry;
     private final Instantiator instantiator;
     private final FileResolver fileResolver;
 
-    public DependencyClassPathNotationParser(Instantiator instantiator, ClassPathRegistry classPathRegistry,
-                                             FileResolver fileResolver) {
+    public DependencyClassPathNotationConverter(Instantiator instantiator, ClassPathRegistry classPathRegistry,
+                                                FileResolver fileResolver) {
         this.instantiator = instantiator;
         this.classPathRegistry = classPathRegistry;
         this.fileResolver = fileResolver;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyFilesNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyFilesNotationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2009 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,31 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.internal.notations;
 
-import org.gradle.api.Project;
-import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
+import org.gradle.api.artifacts.SelfResolvingDependency;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.artifacts.dependencies.DefaultSelfResolvingDependency;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationConvertResult;
 import org.gradle.internal.typeconversion.NotationConverter;
 import org.gradle.internal.typeconversion.TypeConversionException;
 
 import java.util.Collection;
 
-public class DependencyProjectNotationParser implements NotationConverter<Project, ProjectDependency> {
+public class DependencyFilesNotationConverter implements NotationConverter<FileCollection, SelfResolvingDependency> {
+    private final Instantiator instantiator;
 
-    private final DefaultProjectDependencyFactory factory;
-
-    public DependencyProjectNotationParser(DefaultProjectDependencyFactory factory) {
-        this.factory = factory;
+    public DependencyFilesNotationConverter(Instantiator instantiator) {
+        this.instantiator = instantiator;
     }
 
     public void describe(Collection<String> candidateFormats) {
-        candidateFormats.add("Projects, e.g. project(':some:project:path').");
+        candidateFormats.add("FileCollections, e.g. files('some.jar', 'someOther.jar').");
     }
 
-    public void convert(Project notation, NotationConvertResult<? super ProjectDependency> result) throws TypeConversionException {
-        result.converted(factory.create(notation));
+    public void convert(FileCollection notation, NotationConvertResult<? super SelfResolvingDependency> result) throws TypeConversionException {
+        result.converted(instantiator.newInstance(DefaultSelfResolvingDependency.class, notation));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
@@ -18,18 +18,18 @@ package org.gradle.api.internal.notations;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ModuleFactoryHelper;
 import org.gradle.internal.typeconversion.MapKey;
-import org.gradle.internal.typeconversion.MapNotationParser;
+import org.gradle.internal.typeconversion.MapNotationConverter;
 import org.gradle.api.tasks.Optional;
 import org.gradle.internal.reflect.Instantiator;
 
 import java.util.Collection;
 
-public class DependencyMapNotationParser<T extends ExternalDependency> extends MapNotationParser<T> {
+public class DependencyMapNotationConverter<T extends ExternalDependency> extends MapNotationConverter<T> {
 
     private final Instantiator instantiator;
     private final Class<T> resultingType;
 
-    public DependencyMapNotationParser(Instantiator instantiator, Class<T> resultingType) {
+    public DependencyMapNotationConverter(Instantiator instantiator, Class<T> resultingType) {
         this.instantiator = instantiator;
         this.resultingType = resultingType;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
@@ -32,11 +32,11 @@ public class DependencyNotationParser {
     public static NotationParser<Object, Dependency> parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, ClassPathRegistry classPathRegistry, FileLookup fileLookup) {
         return NotationParserBuilder
                 .toType(Dependency.class)
-                .fromCharSequence(new DependencyStringNotationParser<DefaultExternalModuleDependency>(instantiator, DefaultExternalModuleDependency.class))
-                .parser(new DependencyMapNotationParser<DefaultExternalModuleDependency>(instantiator, DefaultExternalModuleDependency.class))
-                .fromType(FileCollection.class, new DependencyFilesNotationParser(instantiator))
-                .fromType(Project.class, new DependencyProjectNotationParser(dependencyFactory))
-                .fromType(DependencyFactory.ClassPathNotation.class, new DependencyClassPathNotationParser(instantiator, classPathRegistry, fileLookup.getFileResolver()))
+                .fromCharSequence(new DependencyStringNotationConverter<DefaultExternalModuleDependency>(instantiator, DefaultExternalModuleDependency.class))
+                .converter(new DependencyMapNotationConverter<DefaultExternalModuleDependency>(instantiator, DefaultExternalModuleDependency.class))
+                .fromType(FileCollection.class, new DependencyFilesNotationConverter(instantiator))
+                .fromType(Project.class, new DependencyProjectNotationConverter(dependencyFactory))
+                .fromType(DependencyFactory.ClassPathNotation.class, new DependencyClassPathNotationConverter(instantiator, classPathRegistry, fileLookup.getFileResolver()))
                 .invalidNotationMessage("Comprehensive documentation on dependency notations is available in DSL reference for DependencyHandler type.")
                 .toComposite();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyProjectNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyProjectNotationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,30 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.api.internal.notations;
 
-import org.gradle.api.artifacts.SelfResolvingDependency;
-import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.artifacts.dependencies.DefaultSelfResolvingDependency;
-import org.gradle.internal.reflect.Instantiator;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
 import org.gradle.internal.typeconversion.NotationConvertResult;
 import org.gradle.internal.typeconversion.NotationConverter;
 import org.gradle.internal.typeconversion.TypeConversionException;
 
 import java.util.Collection;
 
-public class DependencyFilesNotationParser implements NotationConverter<FileCollection, SelfResolvingDependency> {
-    private final Instantiator instantiator;
+public class DependencyProjectNotationConverter implements NotationConverter<Project, ProjectDependency> {
 
-    public DependencyFilesNotationParser(Instantiator instantiator) {
-        this.instantiator = instantiator;
+    private final DefaultProjectDependencyFactory factory;
+
+    public DependencyProjectNotationConverter(DefaultProjectDependencyFactory factory) {
+        this.factory = factory;
     }
 
     public void describe(Collection<String> candidateFormats) {
-        candidateFormats.add("FileCollections, e.g. files('some.jar', 'someOther.jar').");
+        candidateFormats.add("Projects, e.g. project(':some:project:path').");
     }
 
-    public void convert(FileCollection notation, NotationConvertResult<? super SelfResolvingDependency> result) throws TypeConversionException {
-        result.converted(instantiator.newInstance(DefaultSelfResolvingDependency.class, notation));
+    public void convert(Project notation, NotationConvertResult<? super ProjectDependency> result) throws TypeConversionException {
+        result.converted(factory.create(notation));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyStringNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyStringNotationConverter.java
@@ -30,11 +30,11 @@ import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class DependencyStringNotationParser<T extends ExternalDependency> implements NotationConverter<String, T> {
+public class DependencyStringNotationConverter<T extends ExternalDependency> implements NotationConverter<String, T> {
     private final Instantiator instantiator;
     private final Class<T> wantedType;
 
-    public DependencyStringNotationParser(Instantiator instantiator, Class<T> wantedType) {
+    public DependencyStringNotationConverter(Instantiator instantiator, Class<T> wantedType) {
         this.instantiator = instantiator;
         this.wantedType = wantedType;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ModuleIdentiferNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ModuleIdentiferNotationConverter.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.notations;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.internal.typeconversion.TypedNotationParser;
+import org.gradle.internal.typeconversion.TypedNotationConverter;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 
 import java.util.Collection;
@@ -26,10 +26,10 @@ import java.util.List;
 
 import static org.gradle.api.internal.artifacts.DefaultModuleIdentifier.newId;
 
-public class ModuleIdentiferNotationParser extends TypedNotationParser<String, ModuleIdentifier> {
+public class ModuleIdentiferNotationConverter extends TypedNotationConverter<String, ModuleIdentifier> {
     private final static List<Character> INVALID_SPEC_CHARS = Lists.newArrayList('*', '[', ']', '(', ')', ',', '+');
 
-    public ModuleIdentiferNotationParser() {
+    public ModuleIdentiferNotationConverter() {
         super(String.class);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
@@ -18,8 +18,7 @@ package org.gradle.api.internal.notations;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
-import org.gradle.internal.typeconversion.MapKey;
-import org.gradle.internal.typeconversion.MapNotationParser;
+import org.gradle.internal.typeconversion.*;
 import org.gradle.api.tasks.Optional;
 
 import java.util.Collection;
@@ -32,17 +31,17 @@ public class ProjectDependencyFactory {
         this.factory = factory;
     }
 
-    public ProjectDependency createFromMap(ProjectFinder projectFinder,
-                                           Map<? extends String, ? extends Object> map) {
-        return new ProjectDependencyMapNotationParser(projectFinder, factory).parseNotation(map);
+    public ProjectDependency createFromMap(ProjectFinder projectFinder, Map<? extends String, ?> map) {
+        return NotationParserBuilder.toType(ProjectDependency.class)
+                .converter(new ProjectDependencyMapNotationConverter(projectFinder, factory)).toComposite().parseNotation(map);
     }
 
-    static class ProjectDependencyMapNotationParser extends MapNotationParser<ProjectDependency> {
+    static class ProjectDependencyMapNotationConverter extends MapNotationConverter<ProjectDependency> {
 
         private final ProjectFinder projectFinder;
         private final DefaultProjectDependencyFactory factory;
 
-        public ProjectDependencyMapNotationParser(ProjectFinder projectFinder, DefaultProjectDependencyFactory factory) {
+        public ProjectDependencyMapNotationConverter(ProjectFinder projectFinder, DefaultProjectDependencyFactory factory) {
             this.projectFinder = projectFinder;
             this.factory = factory;
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationConverterFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationConverterFactoryTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 
 import java.awt.*
 
-public class PublishArtifactNotationParserFactoryTest extends Specification {
+public class PublishArtifactNotationConverterFactoryTest extends Specification {
     final DependencyMetaDataProvider provider = Mock()
     final Instantiator instantiator = ThreadGlobalInstantiator.getOrCreate()
     final PublishArtifactNotationParserFactory publishArtifactNotationParserFactory = new PublishArtifactNotationParserFactory(instantiator, provider)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyClassPathNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyClassPathNotationConverterTest.groovy
@@ -27,11 +27,11 @@ import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.typeconversion.NotationParserBuilder
 import spock.lang.Specification
 
-public class DependencyClassPathNotationParserTest extends Specification {
+public class DependencyClassPathNotationConverterTest extends Specification {
     def instantiator = Mock(Instantiator.class)
     def classPathRegistry = Mock(ClassPathRegistry.class)
     def fileResolver = Mock(FileResolver.class)
-    def factory = new DependencyClassPathNotationParser(instantiator, classPathRegistry, fileResolver)
+    def factory = new DependencyClassPathNotationConverter(instantiator, classPathRegistry, fileResolver)
 
     def "parses classpath literals"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyMapNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyMapNotationConverterTest.groovy
@@ -19,11 +19,12 @@ package org.gradle.api.internal.notations
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.internal.reflect.DirectInstantiator
+import org.gradle.internal.typeconversion.NotationConverterToNotationParserAdapter
 import spock.lang.Specification
 
-public class DependencyMapNotationParserTest extends Specification {
+public class DependencyMapNotationConverterTest extends Specification {
 
-    def parser = new DependencyMapNotationParser<DefaultExternalModuleDependency>(new DirectInstantiator(), DefaultExternalModuleDependency.class);
+    def parser = new NotationConverterToNotationParserAdapter(new DependencyMapNotationConverter<DefaultExternalModuleDependency>(new DirectInstantiator(), DefaultExternalModuleDependency.class));
 
     def "with artifact"() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyStringNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyStringNotationConverterTest.groovy
@@ -24,8 +24,8 @@ import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.typeconversion.NotationParserBuilder
 import spock.lang.Specification
 
-public class DependencyStringNotationParserTest extends Specification {
-    def parser = new DependencyStringNotationParser(new DirectInstantiator(), DefaultExternalModuleDependency.class);
+public class DependencyStringNotationConverterTest extends Specification {
+    def parser = new DependencyStringNotationConverter(new DirectInstantiator(), DefaultExternalModuleDependency.class);
 
     def "with artifact"() {
         when:
@@ -138,7 +138,7 @@ public class DependencyStringNotationParserTest extends Specification {
     }
 
     def "can create client module"() {
-        def parser = new DependencyStringNotationParser(new DirectInstantiator(), DefaultClientModule);
+        def parser = new DependencyStringNotationConverter(new DirectInstantiator(), DefaultClientModule);
 
         when:
         def d = parse(parser, 'org.gradle:gradle-core:10')
@@ -154,7 +154,7 @@ public class DependencyStringNotationParserTest extends Specification {
     }
 
     def "client module ignores the artifact only notation"() {
-        def parser = new DependencyStringNotationParser(new DirectInstantiator(), DefaultClientModule);
+        def parser = new DependencyStringNotationConverter(new DirectInstantiator(), DefaultClientModule);
 
         when:
         def d = parse(parser, 'org.gradle:gradle-core:10@jar')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ModuleIdentiferNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ModuleIdentiferNotationConverterTest.groovy
@@ -18,15 +18,16 @@
 
 package org.gradle.api.internal.notations
 
+import org.gradle.internal.typeconversion.NotationConverterToNotationParserAdapter
 import org.gradle.internal.typeconversion.UnsupportedNotationException
 import spock.lang.Specification
 import spock.lang.Subject
 
 import static org.gradle.api.internal.artifacts.DefaultModuleIdentifier.newId
 
-class ModuleIdentiferNotationParserTest extends Specification {
+class ModuleIdentiferNotationConverterTest extends Specification {
 
-    @Subject parser = new ModuleIdentiferNotationParser()
+    @Subject parser = new NotationConverterToNotationParserAdapter(new ModuleIdentiferNotationConverter())
 
     def "parses module identifer notation"() {
         expect:

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.groovy
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionS
 import org.gradle.api.internal.tasks.options.Option
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.diagnostics.internal.dsl.DependencyResultSpecNotationParser
+import org.gradle.api.tasks.diagnostics.internal.dsl.DependencyResultSpecNotationConverter
 import org.gradle.api.tasks.diagnostics.internal.graph.DependencyGraphRenderer
 import org.gradle.api.tasks.diagnostics.internal.graph.NodeRenderer
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependency
@@ -115,7 +115,7 @@ public class DependencyInsightReportTask extends DefaultTask {
      */
     @Option(option = "dependency", description = "Shows the details of given dependency.")
     public void setDependencySpec(Object dependencyInsightNotation) {
-        def parser = DependencyResultSpecNotationParser.create()
+        def parser = DependencyResultSpecNotationConverter.create()
         this.dependencySpec = parser.parseNotation(dependencyInsightNotation)
     }
 

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpecNotationConverter.java
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpecNotationConverter.java
@@ -23,7 +23,7 @@ import org.gradle.internal.typeconversion.*;
 
 import java.util.Collection;
 
-public class DependencyResultSpecNotationParser implements NotationConverter<String, Spec<DependencyResult>> {
+public class DependencyResultSpecNotationConverter implements NotationConverter<String, Spec<DependencyResult>> {
     public void convert(String notation, NotationConvertResult<? super Spec<DependencyResult>> result) throws TypeConversionException {
         final String stringNotation = notation.trim();
         if (stringNotation.length() > 0) {
@@ -39,8 +39,8 @@ public class DependencyResultSpecNotationParser implements NotationConverter<Str
         return NotationParserBuilder
                 .toType(new TypeInfo<Spec<DependencyResult>>(Spec.class))
                 .invalidNotationMessage("Please check the input for the DependencyInsight.dependency element.")
-                .fromType(Closure.class, new ClosureToSpecNotationParser<DependencyResult>(DependencyResult.class))
-                .fromCharSequence(new DependencyResultSpecNotationParser())
+                .fromType(Closure.class, new ClosureToSpecNotationConverter<DependencyResult>(DependencyResult.class))
+                .fromCharSequence(new DependencyResultSpecNotationConverter())
                 .toComposite();
     }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpecNotationParserSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpecNotationParserSpec.groovy
@@ -27,7 +27,7 @@ import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class DependencyResultSpecNotationParserSpec extends Specification {
 
-    NotationParser<Object, Spec<DependencyResult>> parser = DependencyResultSpecNotationParser.create()
+    NotationParser<Object, Spec<DependencyResult>> parser = DependencyResultSpecNotationConverter.create()
 
     def "accepts closures"() {
         given:

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/IvyArtifactNotationParserFactory.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/IvyArtifactNotationParserFactory.java
@@ -43,25 +43,25 @@ public class IvyArtifactNotationParserFactory implements Factory<NotationParser<
     }
 
     public NotationParser<Object, IvyArtifact> create() {
-        FileNotationParser fileNotationParser = new FileNotationParser(fileResolver);
-        ArchiveTaskNotationParser archiveTaskNotationParser = new ArchiveTaskNotationParser();
-        PublishArtifactNotationParser publishArtifactNotationParser = new PublishArtifactNotationParser();
+        FileNotationConverter fileNotationConverter = new FileNotationConverter(fileResolver);
+        ArchiveTaskNotationConverter archiveTaskNotationConverter = new ArchiveTaskNotationConverter();
+        PublishArtifactNotationConverter publishArtifactNotationConverter = new PublishArtifactNotationConverter();
 
         NotationParser<Object, IvyArtifact> sourceNotationParser = NotationParserBuilder
                 .toType(IvyArtifact.class)
-                .parser(archiveTaskNotationParser)
-                .parser(publishArtifactNotationParser)
-                .converter(fileNotationParser)
+                .converter(archiveTaskNotationConverter)
+                .converter(publishArtifactNotationConverter)
+                .converter(fileNotationConverter)
                 .toComposite();
 
-        IvyArtifactMapNotationParser ivyArtifactMapNotationParser = new IvyArtifactMapNotationParser(sourceNotationParser);
+        IvyArtifactMapNotationConverter ivyArtifactMapNotationConverter = new IvyArtifactMapNotationConverter(sourceNotationParser);
 
         NotationParserBuilder<IvyArtifact> parserBuilder = NotationParserBuilder
                 .toType(IvyArtifact.class)
-                .parser(archiveTaskNotationParser)
-                .parser(publishArtifactNotationParser)
-                .parser(ivyArtifactMapNotationParser)
-                .converter(fileNotationParser);
+                .converter(archiveTaskNotationConverter)
+                .converter(publishArtifactNotationConverter)
+                .converter(ivyArtifactMapNotationConverter)
+                .converter(fileNotationConverter);
 
         return parserBuilder.toComposite();
     }
@@ -79,8 +79,8 @@ public class IvyArtifactNotationParserFactory implements Factory<NotationParser<
         return ivyArtifact;
     }
 
-    private class ArchiveTaskNotationParser extends TypedNotationParser<AbstractArchiveTask, IvyArtifact> {
-        private ArchiveTaskNotationParser() {
+    private class ArchiveTaskNotationConverter extends TypedNotationConverter<AbstractArchiveTask, IvyArtifact> {
+        private ArchiveTaskNotationConverter() {
             super(AbstractArchiveTask.class);
         }
 
@@ -93,8 +93,8 @@ public class IvyArtifactNotationParserFactory implements Factory<NotationParser<
         }
     }
 
-    private class PublishArtifactNotationParser extends TypedNotationParser<PublishArtifact, IvyArtifact> {
-        private PublishArtifactNotationParser() {
+    private class PublishArtifactNotationConverter extends TypedNotationConverter<PublishArtifact, IvyArtifact> {
+        private PublishArtifactNotationConverter() {
             super(PublishArtifact.class);
         }
 
@@ -107,10 +107,10 @@ public class IvyArtifactNotationParserFactory implements Factory<NotationParser<
         }
     }
 
-    private class FileNotationParser implements NotationConverter<Object, IvyArtifact> {
+    private class FileNotationConverter implements NotationConverter<Object, IvyArtifact> {
         private final NotationParser<Object, File> fileResolverNotationParser;
 
-        private FileNotationParser(FileResolver fileResolver) {
+        private FileNotationConverter(FileResolver fileResolver) {
             this.fileResolverNotationParser = fileResolver.asNotationParser();
         }
 
@@ -129,10 +129,10 @@ public class IvyArtifactNotationParserFactory implements Factory<NotationParser<
         }
     }
 
-    private class IvyArtifactMapNotationParser extends MapNotationParser<IvyArtifact> {
+    private class IvyArtifactMapNotationConverter extends MapNotationConverter<IvyArtifact> {
         private final NotationParser<Object, IvyArtifact> sourceNotationParser;
 
-        private IvyArtifactMapNotationParser(NotationParser<Object, IvyArtifact> sourceNotationParser) {
+        private IvyArtifactMapNotationConverter(NotationParser<Object, IvyArtifact> sourceNotationParser) {
             this.sourceNotationParser = sourceNotationParser;
         }
 

--- a/subprojects/maven/src/main/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactory.java
+++ b/subprojects/maven/src/main/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactory.java
@@ -38,30 +38,30 @@ public class MavenArtifactNotationParserFactory implements Factory<NotationParse
     }
 
     public NotationParser<Object, MavenArtifact> create() {
-        FileNotationParser fileNotationParser = new FileNotationParser(fileResolver);
-        ArchiveTaskNotationParser archiveTaskNotationParser = new ArchiveTaskNotationParser();
-        PublishArtifactNotationParser publishArtifactNotationParser = new PublishArtifactNotationParser();
+        FileNotationConverter fileNotationConverter = new FileNotationConverter(fileResolver);
+        ArchiveTaskNotationConverter archiveTaskNotationConverter = new ArchiveTaskNotationConverter();
+        PublishArtifactNotationConverter publishArtifactNotationConverter = new PublishArtifactNotationConverter();
 
         NotationParser<Object, MavenArtifact> sourceNotationParser = NotationParserBuilder
                 .toType(MavenArtifact.class)
-                .fromType(AbstractArchiveTask.class, archiveTaskNotationParser)
-                .fromType(PublishArtifact.class, publishArtifactNotationParser)
-                .converter(fileNotationParser)
+                .fromType(AbstractArchiveTask.class, archiveTaskNotationConverter)
+                .fromType(PublishArtifact.class, publishArtifactNotationConverter)
+                .converter(fileNotationConverter)
                 .toComposite();
 
-        MavenArtifactMapNotationParser mavenArtifactMapNotationParser = new MavenArtifactMapNotationParser(sourceNotationParser);
+        MavenArtifactMapNotationConverter mavenArtifactMapNotationConverter = new MavenArtifactMapNotationConverter(sourceNotationParser);
 
         NotationParserBuilder<MavenArtifact> parserBuilder = NotationParserBuilder
                 .toType(MavenArtifact.class)
-                .fromType(AbstractArchiveTask.class, archiveTaskNotationParser)
-                .fromType(PublishArtifact.class, publishArtifactNotationParser)
-                .parser(mavenArtifactMapNotationParser)
-                .converter(fileNotationParser);
+                .fromType(AbstractArchiveTask.class, archiveTaskNotationConverter)
+                .fromType(PublishArtifact.class, publishArtifactNotationConverter)
+                .converter(mavenArtifactMapNotationConverter)
+                .converter(fileNotationConverter);
 
         return parserBuilder.toComposite();
     }
 
-    private class ArchiveTaskNotationParser implements NotationConverter<AbstractArchiveTask, MavenArtifact> {
+    private class ArchiveTaskNotationConverter implements NotationConverter<AbstractArchiveTask, MavenArtifact> {
         public void convert(AbstractArchiveTask archiveTask, NotationConvertResult<? super MavenArtifact> result) throws TypeConversionException {
             DefaultMavenArtifact artifact = instantiator.newInstance(
                     DefaultMavenArtifact.class,
@@ -75,7 +75,7 @@ public class MavenArtifactNotationParserFactory implements Factory<NotationParse
         }
     }
 
-    private class PublishArtifactNotationParser implements NotationConverter<PublishArtifact, MavenArtifact> {
+    private class PublishArtifactNotationConverter implements NotationConverter<PublishArtifact, MavenArtifact> {
         public void convert(PublishArtifact publishArtifact, NotationConvertResult<? super MavenArtifact> result) throws TypeConversionException {
             DefaultMavenArtifact artifact = instantiator.newInstance(
                     DefaultMavenArtifact.class,
@@ -89,10 +89,10 @@ public class MavenArtifactNotationParserFactory implements Factory<NotationParse
         }
     }
 
-    private class FileNotationParser implements NotationConverter<Object, MavenArtifact> {
+    private class FileNotationConverter implements NotationConverter<Object, MavenArtifact> {
         private final NotationParser<Object, File> fileResolverNotationParser;
 
-        private FileNotationParser(FileResolver fileResolver) {
+        private FileNotationConverter(FileResolver fileResolver) {
             this.fileResolverNotationParser = fileResolver.asNotationParser();
         }
 
@@ -111,10 +111,10 @@ public class MavenArtifactNotationParserFactory implements Factory<NotationParse
         }
     }
 
-    private class MavenArtifactMapNotationParser extends MapNotationParser<MavenArtifact> {
+    private class MavenArtifactMapNotationConverter extends MapNotationConverter<MavenArtifact> {
         private final NotationParser<Object, MavenArtifact> sourceNotationParser;
 
-        private MavenArtifactMapNotationParser(NotationParser<Object, MavenArtifact> sourceNotationParser) {
+        private MavenArtifactMapNotationConverter(NotationParser<Object, MavenArtifact> sourceNotationParser) {
             this.sourceNotationParser = sourceNotationParser;
         }
 

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/SourceSetNotationParser.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/SourceSetNotationParser.java
@@ -16,10 +16,7 @@
 
 package org.gradle.language.base.internal;
 
-import org.gradle.internal.typeconversion.NotationParser;
-import org.gradle.internal.typeconversion.NotationParserBuilder;
-import org.gradle.internal.typeconversion.TypeInfo;
-import org.gradle.internal.typeconversion.TypedNotationParser;
+import org.gradle.internal.typeconversion.*;
 import org.gradle.language.base.FunctionalSourceSet;
 import org.gradle.language.base.LanguageSourceSet;
 
@@ -32,13 +29,13 @@ public class SourceSetNotationParser {
     public static NotationParser<Object, Set<LanguageSourceSet>> parser() {
         return NotationParserBuilder
                 .toType(new TypeInfo<Set<LanguageSourceSet>>(Set.class))
-                .parser(new FunctionalSourceSetConverter())
-                .parser(new SingleLanguageSourceSetConverter())
-                .parser(new LanguageSourceSetCollectionConverter())
+                .converter(new FunctionalSourceSetConverter())
+                .converter(new SingleLanguageSourceSetConverter())
+                .converter(new LanguageSourceSetCollectionConverter())
                 .toComposite();
     }
 
-    private static class FunctionalSourceSetConverter extends TypedNotationParser<FunctionalSourceSet, Set<LanguageSourceSet>> {
+    private static class FunctionalSourceSetConverter extends TypedNotationConverter<FunctionalSourceSet, Set<LanguageSourceSet>> {
         private FunctionalSourceSetConverter() {
             super(FunctionalSourceSet.class);
         }
@@ -49,7 +46,7 @@ public class SourceSetNotationParser {
         }
     }
 
-    private static class SingleLanguageSourceSetConverter extends TypedNotationParser<LanguageSourceSet, Set<LanguageSourceSet>> {
+    private static class SingleLanguageSourceSetConverter extends TypedNotationConverter<LanguageSourceSet, Set<LanguageSourceSet>> {
         private SingleLanguageSourceSetConverter() {
             super(LanguageSourceSet.class);
         }
@@ -60,7 +57,7 @@ public class SourceSetNotationParser {
         }
     }
 
-    private static class LanguageSourceSetCollectionConverter extends TypedNotationParser<Collection<LanguageSourceSet>, Set<LanguageSourceSet>> {
+    private static class LanguageSourceSetCollectionConverter extends TypedNotationConverter<Collection<LanguageSourceSet>, Set<LanguageSourceSet>> {
         private LanguageSourceSetCollectionConverter() {
             super(new TypeInfo<Collection<LanguageSourceSet>>(Collection.class));
         }

--- a/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/internal/resolve/NativeDependencyNotationParser.java
+++ b/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/internal/resolve/NativeDependencyNotationParser.java
@@ -28,12 +28,12 @@ class NativeDependencyNotationParser {
     public static NotationParser<Object, NativeLibraryRequirement> parser() {
         return NotationParserBuilder
                 .toType(NativeLibraryRequirement.class)
-                .parser(new LibraryConverter())
-                .parser(new NativeLibraryRequirementMapNotationParser())
+                .converter(new LibraryConverter())
+                .converter(new NativeLibraryRequirementMapNotationConverter())
                 .toComposite();
     }
 
-    private static class LibraryConverter extends TypedNotationParser<NativeLibrarySpec, NativeLibraryRequirement> {
+    private static class LibraryConverter extends TypedNotationConverter<NativeLibrarySpec, NativeLibraryRequirement> {
         private LibraryConverter() {
             super(NativeLibrarySpec.class);
         }
@@ -44,7 +44,7 @@ class NativeDependencyNotationParser {
         }
     }
 
-    private static class NativeLibraryRequirementMapNotationParser extends MapNotationParser<NativeLibraryRequirement> {
+    private static class NativeLibraryRequirementMapNotationConverter extends MapNotationConverter<NativeLibraryRequirement> {
 
         public void describe(Collection<String> candidateFormats) {
             candidateFormats.add("Map with mandatory 'library' and optional 'project' and 'linkage' keys, e.g. [project: ':someProj', library: 'mylib', linkage: 'static']");


### PR DESCRIPTION
- Convert various implementations
- Remove NotationParserBuilder.parser method
- Rename implementations of NotationConverter that had a suffix 'Parser'

@adammurdoch 
@bigdaz 
