### PR TITLE
Mention IntelliJ Run Configurations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To open the Gradle project in IDEA, simply run the following task from the root:
 
     ./gradlew idea
 
-This will generate appropriate IDEA metadata so that the project can be opened from within IDEA.
+This will generate appropriate IDEA metadata so that the project can be opened from within IDEA. Also, IntelliJ Run Configurations will be generated, which allow you to run/debug Gradle or run pre-commit tests.
 
 Note that due to an IDEA glitch, the first build of Gradle from IDEA will fail. Launching a second build fixes the compilation error.
 


### PR DESCRIPTION
The documentation doesn't mention the very useful IntelliJ Run Configurations being generated by the idea task for the Gradle source code. This pull request adds one sentence about it in the README.md in the **Opening in your IDE** section.