### PR TITLE
GRADLE-3219 - cache the location of the local Maven repo

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
@@ -32,6 +32,7 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
     private final Map<String, String> systemProperties;
     private final Map<String, String> environmentVariables;
     private final MavenSettingsProvider settingsProvider;
+    private File localMavenRepository;
 
     public DefaultLocalMavenRepositoryLocator(MavenSettingsProvider settingsProvider, Map<String, String> systemProperties,
                                               Map<String, String> environmentVariables) {
@@ -40,7 +41,15 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
         this.settingsProvider = settingsProvider;
     }
 
-    public File getLocalMavenRepository() throws CannotLocateLocalMavenRepositoryException{
+    public synchronized File getLocalMavenRepository() throws CannotLocateLocalMavenRepositoryException {
+        if (localMavenRepository != null) {
+            return localMavenRepository;
+        }
+        localMavenRepository = determineLocalMavenRepository();
+        return localMavenRepository;
+    }
+
+    private File determineLocalMavenRepository() throws CannotLocateLocalMavenRepositoryException {
         if (systemProperties.containsKey("maven.repo.local")) {
             return new File(systemProperties.get("maven.repo.local"));
         }


### PR DESCRIPTION
In order to determine the local repository location, user's settings.xml file
is read. There's no need to do this every time an instance of the repository
is created. In multi-project builds this happens at least once per project.
@alkemist 