### PR TITLE
Disables the default travisci gradle assemble task to reduce build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 jdk:
   - oraclejdk7
+install:
+  - true
 script:
   - ./gradlew pullRequestValidation
 env:


### PR DESCRIPTION
I tried out travisci cached-container builds and at one point I got a successful build taking ~7mins. For some reason, container builds aren't stable and intermittently hang.

Disabling travisci's default gradle assemble tasks does make a difference though: builds 19, 20 and 21 here https://travis-ci.org/adrianbk/gradle/builds come in at approx 10mins. Don't want to speak too soon but looks like half the current build time. 
