### PR TITLE
GRADLE-2123: remove dependencies from wtp component which are already in classpath (eclipse-wtp)

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
@@ -16,6 +16,7 @@
 package org.gradle.plugins.ide.eclipse
 
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
+import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry
 import org.gradle.test.fixtures.file.TestFile
 
 import java.util.regex.Pattern
@@ -56,7 +57,7 @@ class EclipseClasspathFixture {
     }
 
     void assertHasLibs(String... jarNames) {
-        assert libs*.jarName == jarNames as List
+        assert libs*.jarName as Set == jarNames as Set
     }
 
     EclipseLibrary lib(String jarName) {
@@ -146,13 +147,13 @@ class EclipseClasspathFixture {
 
         void assertIsDeployedTo(String path) {
             assert entry.attributes
-            assert entry.attributes[0].attribute[0].@name == 'org.eclipse.jst.component.dependency'
+            assert entry.attributes[0].attribute[0].@name == AbstractClasspathEntry.COMPONENT_DEPENDENCY_ATTRIBUTE
             assert entry.attributes[0].attribute[0].@value == path
         }
 
         void assertIsExcludedFromDeployment() {
             assert entry.attributes
-            assert entry.attributes[0].attribute[0].@name == 'org.eclipse.jst.component.nondependency'
+            assert entry.attributes[0].attribute[0].@name == AbstractClasspathEntry.COMPONENT_NON_DEPENDENCY_ATTRIBUTE
             assert entry.attributes[0].attribute[0].@value == ''
         }
 

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
@@ -507,15 +507,10 @@ project(':contrib') {
         executer.withTasks("eclipse").run()
 
         //then
-        def classpath = classpath
-        def component = wtpComponent
-
-        //the jar dependency is configured in the WTP component file and in the classpath
-        classpath.lib('commons-io-1.4.jar').assertIsExcludedFromDeployment()
-        component.lib('commons-io-1.4.jar').assertDeployedAt('/WEB-INF/lib')
-
-        classpath.lib('myFoo.jar').assertIsExcludedFromDeployment()
-        component.lib('myFoo.jar').assertDeployedAt('/WEB-INF/lib')
+        //the jar dependencies are configured in the classpath and not in the WTP component file
+        classpath.lib('commons-io-1.4.jar').assertIsDeployedTo('/WEB-INF/lib')
+        classpath.lib('myFoo.jar').assertIsDeployedTo('/WEB-INF/lib')
+        assert wtpComponent.modules.size() == 0
     }
 
     @Test

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
@@ -80,7 +80,7 @@ project(':java') {
 
         def webClasspath = classpath('web')
         webClasspath.assertHasLibs('commons-lang3-3.0.jar', 'javax.servlet-api-3.1.0.jar', 'junit-4.12.jar', "guava-18.0.jar", 'hamcrest-core-1.3.jar')
-        webClasspath.lib('commons-lang3-3.0.jar').assertIsExcludedFromDeployment()
+        webClasspath.lib('commons-lang3-3.0.jar').assertIsDeployedTo('/WEB-INF/lib')
         webClasspath.lib('javax.servlet-api-3.1.0.jar').assertIsExcludedFromDeployment()
         webClasspath.lib('junit-4.12.jar').assertIsExcludedFromDeployment()
         webClasspath.lib('hamcrest-core-1.3.jar').assertIsExcludedFromDeployment()
@@ -106,8 +106,7 @@ project(':java') {
         webComponent.resources.size() == 2
         webComponent.sourceDirectory('src/main/java').assertDeployedAt('/WEB-INF/classes')
         webComponent.sourceDirectory('src/main/webapp').assertDeployedAt('/')
-        webComponent.modules.size() == 3
-        webComponent.lib('commons-lang3-3.0.jar').assertDeployedAt('/WEB-INF/lib')
+        webComponent.modules.size() == 1
         webComponent.project('java').assertDeployedAt('/WEB-INF/lib')
     }
 }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
@@ -109,4 +109,74 @@ project(':java') {
         webComponent.modules.size() == 1
         webComponent.project('java').assertDeployedAt('/WEB-INF/lib')
     }
+
+    def "correctly adds different versions of dependencies to web project and java project it depends on"() {
+        settingsFile << "include 'web', 'java'"
+
+        file('java/src/main/java').mkdirs()
+        file('web/src/main/java').mkdirs()
+        file('web/src/main/webapp').mkdirs()
+
+        buildFile << """
+subprojects {
+    apply plugin: 'eclipse-wtp'
+
+    repositories {
+        jcenter()
+    }
+}
+project(':web') {
+    apply plugin: 'war'
+
+    dependencies {
+        compile 'com.google.guava:guava:19.0'
+        compile project(':java')
+    }
+}
+project(':java') {
+    apply plugin: 'java'
+
+    dependencies {
+        compile 'com.google.guava:guava:18.0'
+    }
+}
+"""
+
+        when:
+        run "eclipse"
+
+        then:
+        // Builders and natures
+        def javaProject = project('java')
+        javaProject.assertHasJavaFacetNatures()
+        javaProject.assertHasJavaFacetBuilders()
+
+        def webProject = project('web')
+        webProject.assertHasJavaFacetNatures()
+        webProject.assertHasJavaFacetBuilders()
+
+        // Classpath
+        def javaClasspath = classpath('java')
+        javaClasspath.assertHasLibs('guava-18.0.jar')
+        javaClasspath.lib('guava-18.0.jar').assertIsDeployedTo('../')
+
+        def webClasspath = classpath('web')
+        webClasspath.assertHasLibs('guava-19.0.jar')
+        webClasspath.lib('guava-19.0.jar').assertIsDeployedTo('/WEB-INF/lib')
+
+        // Deployment
+        def javaComponent = wtpComponent('java')
+        javaComponent.deployName == 'java'
+        javaComponent.resources.size() == 1
+        javaComponent.sourceDirectory('src/main/java').assertDeployedAt('/')
+        javaComponent.modules.isEmpty()
+
+        def webComponent = wtpComponent('web')
+        webComponent.deployName == 'web'
+        webComponent.resources.size() == 2
+        webComponent.sourceDirectory('src/main/java').assertDeployedAt('/WEB-INF/classes')
+        webComponent.sourceDirectory('src/main/webapp').assertDeployedAt('/')
+        webComponent.modules.size() == 1
+        webComponent.project('java').assertDeployedAt('/WEB-INF/lib')
+    }
 }

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/api/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/api/build.gradle
@@ -6,7 +6,5 @@ dependencies {
 }
 
 sourceSets {
-    integTest {
-        java.srcDirs = ['src/integTest/java']
-    }
+    integTest
 }

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
@@ -8,6 +8,7 @@
 	<classpathentry sourcepath="@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-sources.jar" kind="lib" path="@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-javadoc.jar!/"/>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-sources.jar" kind="lib" path="@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5.jar">

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
@@ -13,7 +13,12 @@
 	<classpathentry sourcepath="@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-sources.jar" kind="lib" path="@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-javadoc.jar!/"/>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar"/>
+	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar">
+		<attributes>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+		</attributes>
+	</classpathentry>
 </classpath>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6WtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6WtpComponent.xml
@@ -10,14 +10,5 @@
 		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/resource/api/api">
 			<dependency-type>uses</dependency-type>
 		</dependent-module>
-		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17.jar">
-			<dependency-type>uses</dependency-type>
-		</dependent-module>
-		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5.jar">
-			<dependency-type>uses</dependency-type>
-		</dependent-module>
-		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar">
-			<dependency-type>uses</dependency-type>
-		</dependent-module>
 	</wb-module>
 </project-modules>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
@@ -7,6 +7,7 @@
 					path="GRADLE_USER_HOME/@CACHE@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-javadoc.jar!/"/>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/junit/junit/4.7/@SHA1@/junit-4.7.jar"/>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsWtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsWtpComponent.xml
@@ -2,7 +2,7 @@
 	<wb-module deploy-name="webAppWithVars">
 		<property name="context-root" value="webAppWithVars"/>
 		<wb-resource deploy-path="/WEB-INF/classes" source-path="src/main/java"/>
-		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/var/GRADLE_USER_HOME/@CACHE@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">
+		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/var/GRADLE_USER_HOME/@CACHE@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2.jar">
 			<dependency-type>uses</dependency-type>
 		</dependent-module>
 	</wb-module>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
@@ -9,14 +9,18 @@
 	<classpathentry sourcepath="@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-javadoc.jar!/"/>
-			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-sources.jar" kind="lib" path="@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-javadoc.jar!/"/>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar"/>
-	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar"/>
+	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar">
+		<attributes>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+		</attributes>
+	</classpathentry>
 </classpath>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
@@ -9,6 +9,7 @@
 	<classpathentry sourcepath="@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-javadoc.jar!/"/>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-sources.jar" kind="lib" path="@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceWtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceWtpComponent.xml
@@ -6,11 +6,8 @@
 		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/resource/api/api">
 			<dependency-type>uses</dependency-type>
 		</dependent-module>
-		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">
 			<dependency-type>uses</dependency-type>
 		</dependent-module>
 		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar">
-			<dependency-type>uses</dependency-type>
-		</dependent-module>
 	</wb-module>
 </project-modules>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceWtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceWtpComponent.xml
@@ -6,8 +6,5 @@
 		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/resource/api/api">
 			<dependency-type>uses</dependency-type>
 		</dependent-module>
-			<dependency-type>uses</dependency-type>
-		</dependent-module>
-		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar">
 	</wb-module>
 </project-modules>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/webAppWithVars/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/webAppWithVars/build.gradle
@@ -1,10 +1,19 @@
 apply plugin: 'war'
 
+configurations {
+    someInterestingConfiguration
+}
+
 dependencies {
+    someInterestingConfiguration 'commons-io:commons-io:1.2'
     runtime "commons-lang:commons-lang:2.5"
     testCompile 'junit:junit:4.7'
 }
 
 eclipse {
     pathVariables GRADLE_USER_HOME: file("${gradle.gradleUserHomeDir}/caches")
+
+    wtp.component {
+        plusConfigurations += [ configurations.someInterestingConfiguration ]
+    }
 }

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
@@ -24,6 +24,8 @@ import org.gradle.internal.reflect.Instantiator
 import org.gradle.plugins.ear.EarPlugin
 import org.gradle.plugins.ide.eclipse.model.*
 import org.gradle.plugins.ide.eclipse.model.Facet.FacetType
+import org.gradle.plugins.ide.eclipse.model.internal.ClasspathFactory
+import org.gradle.plugins.ide.eclipse.model.internal.WtpComponentFactory
 import org.gradle.plugins.ide.internal.IdePlugin
 
 import javax.inject.Inject
@@ -67,53 +69,60 @@ class EclipseWtpPlugin extends IdePlugin {
     }
 
     private void configureEclipseClasspath(Project project, EclipseModel eclipseModel) {
+
+        def adjustClasspath = { Classpath classpath ->
+            def libDeployPath = eclipseModel.wtp.component.libDeployPath
+            def depFiles = WtpComponentFactory.resolveDependenciesFor(eclipseModel.wtp.component.plusConfigurations,
+                    eclipseModel.wtp.component.minusConfigurations)*.file
+
+            for (entry in classpath.entries) {
+                if (!(entry instanceof AbstractLibrary)) {
+                    continue;
+                }
+                if (depFiles.contains(entry.library.file)) {
+                    // '../' and '/WEB-INF/lib' both seem to be correct (and equivalent) values here
+                    //this is necessary so that the depended upon projects will have their dependencies
+                    // deployed to WEB-INF/lib of the main project.
+                    entry.entryAttributes[AbstractClasspathEntry.COMPONENT_DEPENDENCY_ATTRIBUTE] = libDeployPath
+                } else {
+                    // Mark this library as not required for deployment
+                    entry.entryAttributes[AbstractClasspathEntry.COMPONENT_NON_DEPENDENCY_ATTRIBUTE] = ''
+                }
+            }
+        }
+
+        def adjustWtpComponent = { WtpComponent wtpComponent ->
+            def depPaths = ClasspathFactory.resolveDependenciesFrom(eclipseModel.classpath).collect { dependency ->
+                eclipseModel.classpath.fileReferenceFactory.fromFile(dependency.file).path
+            }
+            wtpComponent.wbModuleEntries.removeAll{ wbModule ->
+                wbModule instanceof WbDependentModule && depPaths.any{ path -> wbModule.handle.endsWith(path) }
+            }
+        }
+
         project.plugins.withType(JavaPlugin) {
-            def deleteWtpDependentModule = []
             eclipseModel.classpath.file.whenMerged { Classpath classpath ->
                 if (hasWarOrEarPlugin(project)) {
                     return
                 }
-
-                def minusFiles = eclipseModel.wtp.component.minusConfigurations*.files?.flatten() ?: project.files()
-                def libFiles = eclipseModel.wtp.component.libConfigurations*.files?.flatten() ?: project.files()
-                for (entry in classpath.entries) {
-                    if (!(entry instanceof AbstractLibrary)) {
-                        continue;
-                    }
-                    if (minusFiles.contains(entry.library.file) || !libFiles.contains(entry.library.file)) {
-                        // Mark this library as not required for deployment
-                        entry.entryAttributes[AbstractClasspathEntry.COMPONENT_NON_DEPENDENCY_ATTRIBUTE] = ''
-                    } else {
-                        // '../' and '/WEB-INF/lib' both seem to be correct (and equivalent) values here
-                        //this is necessary so that the depended upon projects will have their dependencies
-                        // deployed to WEB-INF/lib of the main project.
-                        entry.entryAttributes[AbstractClasspathEntry.COMPONENT_DEPENDENCY_ATTRIBUTE] = '../'
-                        deleteWtpDependentModule << entry.path
-                    }
-                }
+                adjustClasspath(classpath)
             }
             eclipseModel.wtp.component.file.whenMerged { WtpComponent wtpComponent ->
                 if (hasWarOrEarPlugin(project)) {
                     return
                 }
-                wtpComponent.wbModuleEntries.removeAll { wbModule ->
-                    wbModule instanceof WbDependentModule && deleteWtpDependentModule.any { lib -> wbModule.handle.contains(lib) }
-                }
+                adjustWtpComponent(wtpComponent)
             }
         }
 
         project.plugins.withType(WarPlugin) {
             eclipseModel.classpath.containers WEB_LIBS_CONTAINER
 
-            eclipseModel.classpath.file.whenMerged { Classpath classpath ->
-                for (entry in classpath.entries) {
-                    if (entry instanceof AbstractLibrary) {
-                        //this is necessary to avoid annoying warnings upon import to Eclipse
-                        //the .classpath entries can be marked all as non-deployable dependencies
-                        //because the wtp component file declares the deployable dependencies
-                        entry.entryAttributes[AbstractClasspathEntry.COMPONENT_NON_DEPENDENCY_ATTRIBUTE] = ''
-                    }
-                }
+            project.eclipse.classpath.file.whenMerged { Classpath classpath ->
+                adjustClasspath(classpath)
+            }
+            project.eclipse.wtp.component.file.whenMerged { WtpComponent wtpComponent ->
+                adjustWtpComponent(wtpComponent)
             }
         }
     }

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
@@ -81,7 +81,7 @@ class EclipseWtpPlugin extends IdePlugin {
                 }
                 def libDeployPath = eclipseModel.wtp.component.libDeployPath
                 def depFiles = WtpComponentFactory.resolveDependenciesFor(eclipseModel.wtp.component.plusConfigurations,
-                        eclipseModel.wtp.component.minusConfigurations, true)*.file
+                        eclipseModel.wtp.component.minusConfigurations, false)*.file
 
                 for (entry in classpath.entries) {
                     if (!(entry instanceof AbstractLibrary)) {

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
@@ -89,7 +89,7 @@ class EclipseWtpPlugin extends IdePlugin {
                     }
                     if (depFiles.contains(entry.library.file)) {
                         // '../' and '/WEB-INF/lib' both seem to be correct (and equivalent) values here
-                        //this is necessary so that the depended upon projects will have their dependencies
+                        // this is necessary so that the depended upon projects will have their dependencies
                         // deployed to WEB-INF/lib of the main project.
                         entry.entryAttributes[AbstractClasspathEntry.COMPONENT_DEPENDENCY_ATTRIBUTE] = libDeployPath
                     } else {

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.groovy
@@ -81,7 +81,7 @@ class EclipseWtpPlugin extends IdePlugin {
                 }
                 def libDeployPath = eclipseModel.wtp.component.libDeployPath
                 def depFiles = WtpComponentFactory.resolveDependenciesFor(eclipseModel.wtp.component.plusConfigurations,
-                        eclipseModel.wtp.component.minusConfigurations)*.file
+                        eclipseModel.wtp.component.minusConfigurations, true)*.file
 
                 for (entry in classpath.entries) {
                     if (!(entry instanceof AbstractLibrary)) {

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.groovy
@@ -89,7 +89,7 @@ class ClasspathFactory {
     }
 
     Collection<UnresolvedIdeRepoFileDependency> getUnresolvedDependencies(EclipseClasspath classpath) {
-        return dependenciesExtractor.unresolvedExternalDependencies(classpath.plusConfigurations, classpath.minusConfigurations);
+        return DEPENDENCIES_EXTRACTOR.unresolvedExternalDependencies(classpath.plusConfigurations, classpath.minusConfigurations);
     }
 
     private AbstractLibrary createLibraryEntry(

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.groovy
@@ -26,6 +26,8 @@ import org.gradle.util.DeprecationLogger
 
 class ClasspathFactory {
 
+    private static final IdeDependenciesExtractor DEPENDENCIES_EXTRACTOR = new IdeDependenciesExtractor()
+
     private final ClasspathEntryBuilder outputCreator = new ClasspathEntryBuilder() {
         void update(List<ClasspathEntry> entries, EclipseClasspath eclipseClasspath) {
             entries.add(new Output(eclipseClasspath.project.relativePath(eclipseClasspath.defaultOutputDir)))
@@ -43,28 +45,31 @@ class ClasspathFactory {
 
     private final ClasspathEntryBuilder projectDependenciesCreator = new ClasspathEntryBuilder() {
         void update(List<ClasspathEntry> entries, EclipseClasspath eclipseClasspath) {
-            entries.addAll(dependenciesExtractor.extractProjectDependencies(eclipseClasspath.project, eclipseClasspath.plusConfigurations, eclipseClasspath.minusConfigurations)
+            entries.addAll(DEPENDENCIES_EXTRACTOR.extractProjectDependencies(eclipseClasspath.project, eclipseClasspath.plusConfigurations, eclipseClasspath.minusConfigurations)
                 .collect { IdeProjectDependency it -> new ProjectDependencyBuilder().build(it.project, it.declaredConfiguration.name) })
         }
     }
 
+    public static Collection resolveDependenciesFrom(EclipseClasspath classpath) {
+        def externals = DEPENDENCIES_EXTRACTOR.extractRepoFileDependencies(classpath.project.dependencies, classpath.plusConfigurations, classpath.minusConfigurations, classpath.downloadSources, classpath.downloadJavadoc)
+        def locals = DEPENDENCIES_EXTRACTOR.extractLocalFileDependencies(classpath.plusConfigurations, classpath.minusConfigurations)
+        return externals + locals
+    }
+
     private final ClasspathEntryBuilder librariesCreator = new ClasspathEntryBuilder() {
         void update(List<ClasspathEntry> entries, EclipseClasspath classpath) {
-            dependenciesExtractor.extractRepoFileDependencies(
-                    classpath.project.dependencies, classpath.plusConfigurations, classpath.minusConfigurations, classpath.downloadSources, classpath.downloadJavadoc)
-            .each { IdeExtendedRepoFileDependency it ->
-                entries << createLibraryEntry(it.file, it.sourceFile, it.javadocFile, it.declaredConfiguration.name, classpath, it.id)
-            }
-
-            dependenciesExtractor.extractLocalFileDependencies(classpath.plusConfigurations, classpath.minusConfigurations)
-            .each { IdeLocalFileDependency it ->
-                entries << createLibraryEntry(it.file, null, null, it.declaredConfiguration.name, classpath, null)
+            resolveDependenciesFrom(classpath).each { dep ->
+                if (dep instanceof IdeExtendedRepoFileDependency) {
+                    entries << createLibraryEntry(dep.file, dep.sourceFile, dep.javadocFile, dep.declaredConfiguration.name, classpath, dep.id)
+                }
+                if (dep instanceof IdeLocalFileDependency) {
+                    entries << createLibraryEntry(dep.file, null, null, dep.declaredConfiguration.name, classpath, null)
+                }
             }
         }
     }
 
     private final sourceFoldersCreator = new SourceFoldersCreator()
-    private final IdeDependenciesExtractor dependenciesExtractor = new IdeDependenciesExtractor()
     private final classFoldersCreator = new ClassFoldersCreator()
 
     List<ClasspathEntry> createEntries(EclipseClasspath classpath) {

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.groovy
@@ -81,17 +81,18 @@ class WtpComponentFactory {
     }
 
     // must NOT include transitive library dependencies
-    private Set getEntriesFromLibraries(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations, EclipseWtpComponent wtp, String deployPath) {
+    public static Collection resolveDependenciesFor(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations) {
         def extractor = new IdeDependenciesExtractor()
         //below is not perfect because we're skipping the unresolved dependencies completely
         //however, it should be better anyway. Sometime soon we will hopefully change the wtp component stuff
         def externals = extractor.resolvedExternalDependencies(plusConfigurations, minusConfigurations)
         def locals = extractor.extractLocalFileDependencies(plusConfigurations, minusConfigurations)
+        return externals + locals
+    }
 
-        def libFiles = (externals + locals)*.file
-
-        libFiles.collect { file ->
-            createWbDependentModuleEntry(file, wtp.fileReferenceFactory, deployPath)
+    private Set getEntriesFromLibraries(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations, EclipseWtpComponent wtp, String deployPath) {
+        resolveDependenciesFor(plusConfigurations, minusConfigurations).collect { dep ->
+            createWbDependentModuleEntry(dep.file, wtp.fileReferenceFactory, deployPath)
         }
     }
 

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.groovy
@@ -15,8 +15,11 @@
  */
 package org.gradle.plugins.ide.eclipse.model.internal
 
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
+import org.gradle.plugins.ide.eclipse.EclipseWtpPlugin
 import org.gradle.plugins.ide.eclipse.model.EclipseWtpComponent
 import org.gradle.plugins.ide.eclipse.model.WbDependentModule
 import org.gradle.plugins.ide.eclipse.model.WbResource
@@ -45,33 +48,35 @@ class WtpComponentFactory {
 
     private List<WbDependentModule> getEntriesFromConfigurations(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations, EclipseWtpComponent wtp, String deployPath, boolean transitive) {
         (getEntriesFromProjectDependencies(plusConfigurations, minusConfigurations, deployPath, transitive) as List) +
-                (getEntriesFromLibraries(plusConfigurations, minusConfigurations, wtp, deployPath) as List)
+                (getEntriesFromLibraries(plusConfigurations, minusConfigurations, wtp, deployPath, transitive) as List)
     }
 
-    // must include transitive project dependencies
     private Set getEntriesFromProjectDependencies(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations, String deployPath, boolean transitive) {
-        def dependencies = getDependencies(plusConfigurations, minusConfigurations,
-                { it instanceof org.gradle.api.artifacts.ProjectDependency })
-
-        def projects = dependencies*.dependencyProject
-
-        def allProjects = [] as LinkedHashSet
-        allProjects.addAll(projects)
-        if (transitive) {
-            projects.each { collectDependedUponProjects(it, allProjects) }
-        }
-
+        LinkedHashSet allProjects = getProjectDependencies(plusConfigurations, minusConfigurations, transitive)
         allProjects.collect { project ->
             def moduleName = project.plugins.hasPlugin(EclipsePlugin) ? project.eclipse.project.name : project.name
             new WbDependentModule(deployPath, "module:/resource/" + moduleName + "/" + moduleName)
         }
     }
 
+    private static LinkedHashSet getProjectDependencies(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations, boolean transitive) {
+        def dependencies = getDependencies(plusConfigurations, minusConfigurations, { it instanceof ProjectDependency })
+
+        def projects = dependencies*.dependencyProject
+
+        def result = [ ] as LinkedHashSet
+        result.addAll(projects)
+        if (transitive) {
+            projects.each{ collectDependedUponProjects(it, result) }
+        }
+        return result
+    }
+
     // TODO: might have to search all class paths of all source sets for project dependencies, not just runtime configuration
-    private void collectDependedUponProjects(org.gradle.api.Project project, Set<org.gradle.api.Project> result) {
+    private static void collectDependedUponProjects(Project project, Set<Project> result) {
         def runtimeConfig = project.configurations.findByName("runtime")
         if (runtimeConfig) {
-            def projectDeps = runtimeConfig.allDependencies.withType(org.gradle.api.artifacts.ProjectDependency)
+            def projectDeps = runtimeConfig.allDependencies.withType(ProjectDependency)
             def dependedUponProjects = projectDeps*.dependencyProject
             result.addAll(dependedUponProjects)
             for (dependedUponProject in dependedUponProjects) {
@@ -80,9 +85,18 @@ class WtpComponentFactory {
         }
     }
 
-    // must NOT include transitive library dependencies
-    public static Collection resolveDependenciesFor(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations) {
+    public static Collection resolveDependenciesFor(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations, boolean transitive) {
         def extractor = new IdeDependenciesExtractor()
+
+        if (transitive) {
+            def projects = getProjectDependencies(plusConfigurations, minusConfigurations, transitive)
+            projects.findAll{ it.plugins.hasPlugin(EclipseWtpPlugin) }.each{ project ->
+                def wtp = project.eclipse.wtp.component
+                plusConfigurations += wtp.plusConfigurations
+                minusConfigurations += wtp.minusConfigurations
+            }
+        }
+
         //below is not perfect because we're skipping the unresolved dependencies completely
         //however, it should be better anyway. Sometime soon we will hopefully change the wtp component stuff
         def externals = extractor.resolvedExternalDependencies(plusConfigurations, minusConfigurations)
@@ -90,8 +104,8 @@ class WtpComponentFactory {
         return externals + locals
     }
 
-    private Set getEntriesFromLibraries(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations, EclipseWtpComponent wtp, String deployPath) {
-        resolveDependenciesFor(plusConfigurations, minusConfigurations).collect { dep ->
+    private Set getEntriesFromLibraries(Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations, EclipseWtpComponent wtp, String deployPath, boolean transitive) {
+        resolveDependenciesFor(plusConfigurations, minusConfigurations, transitive).collect { dep ->
             createWbDependentModuleEntry(dep.file, wtp.fileReferenceFactory, deployPath)
         }
     }
@@ -107,7 +121,7 @@ class WtpComponentFactory {
         return new WbDependentModule(deployPath, "module:/classpath/$handleSnippet")
     }
 
-    private LinkedHashSet getDependencies(Set plusConfigurations, Set minusConfigurations, Closure filter) {
+    private static LinkedHashSet getDependencies(Set plusConfigurations, Set minusConfigurations, Closure filter) {
         def declaredDependencies = new LinkedHashSet()
         plusConfigurations.each { Configuration configuration ->
             declaredDependencies.addAll(configuration.allDependencies.matching(filter))


### PR DESCRIPTION
I have implemented the behavior as discussed and confirmed with @adammurdoch in https://issues.gradle.org/browse/GRADLE-2123. Please also have a look at my last comment about the implementation in the issue!
The only thing which is still open/missing is if 'ear' is used together with 'java' or even 'war' plugin. I am not sure about it, yet. Any suggestions?

As @adammurdoch has already started changing some parts of the 'eclipse-wtp' plugin, I am looking forward to a discussion :-)
I would be glad to help more, however I think to get a clear implementation the 'classpath' and 'wtp component' has to know about each others dependencies to not even add incorrect values!

If you have any questions, don't hesitate to ask.