### PR TITLE
Allow annotation processors to be run against groovy stubs during a joint compile

### DIFF
--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileBadCodeWithAnnotationProcessor/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileBadCodeWithAnnotationProcessor/build.gradle
@@ -1,0 +1,16 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':SimpleAnnotationProcessor')
+}
+
+compileGroovy {
+    groovyOptions.with {
+        stubDir = file([buildDir, 'classes', 'stub'].join(File.separator))
+        keepStubs = true
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileBadCodeWithAnnotationProcessor/settings.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileBadCodeWithAnnotationProcessor/settings.gradle
@@ -1,0 +1,2 @@
+include ':'
+include ':SimpleAnnotationProcessor'

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileBadCodeWithAnnotationProcessor/src/main/groovy/Person.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileBadCodeWithAnnotationProcessor/src/main/groovy/Person.groovy
@@ -1,0 +1,12 @@
+import com.test.SimpleAnnotation
+
+@SimpleAnnotation
+class Person {
+    String name
+    int age
+
+    void sing() {
+        Bad code = new thatDoesntAffectStubGeneration()
+        println "tra-la-la"
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileWithAnnotationProcessor/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileWithAnnotationProcessor/build.gradle
@@ -1,0 +1,9 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':SimpleAnnotationProcessor')
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileWithAnnotationProcessor/settings.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileWithAnnotationProcessor/settings.gradle
@@ -1,0 +1,2 @@
+include ':'
+include ':SimpleAnnotationProcessor'

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileWithAnnotationProcessor/src/main/groovy/Person.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileWithAnnotationProcessor/src/main/groovy/Person.groovy
@@ -1,0 +1,11 @@
+import com.test.SimpleAnnotation
+
+@SimpleAnnotation
+class Person {
+    String name
+    int age
+
+    void sing() {
+        println "tra-la-la"
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCode/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCode/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}
+
+compileGroovy {
+    groovyOptions.with {
+        stubDir = file([buildDir, 'classes', 'stub'].join(File.separator))
+        keepStubs = true
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCode/src/main/groovy/Address.java
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCode/src/main/groovy/Address.java
@@ -1,0 +1,2 @@
+public class Address {
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCode/src/main/groovy/Person.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCode/src/main/groovy/Person.groovy
@@ -1,0 +1,10 @@
+class Person {
+    String name
+    int age
+    Address address
+
+    void sing() {
+        Bad code = new thatDoesntAffectStubGeneration()
+        println "tra-la-la"
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessor/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessor/build.gradle
@@ -1,0 +1,16 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':SimpleAnnotationProcessor')
+}
+
+compileGroovy {
+    groovyOptions.with {
+        stubDir = file([buildDir, 'classes', 'stub'].join(File.separator))
+        keepStubs = true
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessor/settings.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessor/settings.gradle
@@ -1,0 +1,2 @@
+include ':'
+include ':SimpleAnnotationProcessor'

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessor/src/main/groovy/Address.java
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessor/src/main/groovy/Address.java
@@ -1,0 +1,5 @@
+import com.test.SimpleAnnotation;
+
+@SimpleAnnotation
+public class Address {
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessor/src/main/groovy/Person.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessor/src/main/groovy/Person.groovy
@@ -1,0 +1,13 @@
+import com.test.SimpleAnnotation
+
+@SimpleAnnotation
+class Person {
+    String name
+    int age
+    Address address
+
+    void sing() {
+        Bad code = new thatDoesntAffectStubGeneration()
+        println "tra-la-la"
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessorDisabled/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessorDisabled/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':SimpleAnnotationProcessor')
+}
+
+compileGroovy {
+    options.compilerArgs << '-proc:none'
+    groovyOptions.with {
+        stubDir = file([buildDir, 'classes', 'stub'].join(File.separator))
+        keepStubs = true
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessorDisabled/settings.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessorDisabled/settings.gradle
@@ -1,0 +1,2 @@
+include ':'
+include ':SimpleAnnotationProcessor'

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessorDisabled/src/main/groovy/Address.java
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessorDisabled/src/main/groovy/Address.java
@@ -1,0 +1,5 @@
+import com.test.SimpleAnnotation;
+
+@SimpleAnnotation
+public class Address {
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessorDisabled/src/main/groovy/Person.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileBadCodeWithAnnotationProcessorDisabled/src/main/groovy/Person.groovy
@@ -1,0 +1,13 @@
+import com.test.SimpleAnnotation
+
+@SimpleAnnotation
+class Person {
+    String name
+    int age
+    Address address
+
+    void sing() {
+        Bad code = new thatDoesntAffectStubGeneration()
+        println "tra-la-la"
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessor/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessor/build.gradle
@@ -1,0 +1,9 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':SimpleAnnotationProcessor')
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessor/settings.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessor/settings.gradle
@@ -1,0 +1,2 @@
+include ':'
+include ':SimpleAnnotationProcessor'

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessor/src/main/groovy/Address.java
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessor/src/main/groovy/Address.java
@@ -1,0 +1,5 @@
+import com.test.SimpleAnnotation;
+
+@SimpleAnnotation
+public class Address {
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessor/src/main/groovy/Person.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessor/src/main/groovy/Person.groovy
@@ -1,0 +1,12 @@
+import com.test.SimpleAnnotation
+
+@SimpleAnnotation
+class Person {
+    String name
+    int age
+    Address address
+
+    void sing() {
+        println "tra-la-la"
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessorDisabled/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessorDisabled/build.gradle
@@ -1,0 +1,13 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':SimpleAnnotationProcessor')
+}
+
+compileGroovy {
+    options.compilerArgs << '-proc:none'
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessorDisabled/settings.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessorDisabled/settings.gradle
@@ -1,0 +1,2 @@
+include ':'
+include ':SimpleAnnotationProcessor'

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessorDisabled/src/main/groovy/Address.java
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessorDisabled/src/main/groovy/Address.java
@@ -1,0 +1,5 @@
+import com.test.SimpleAnnotation;
+
+@SimpleAnnotation
+public class Address {
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessorDisabled/src/main/groovy/Person.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/jointCompileWithAnnotationProcessorDisabled/src/main/groovy/Person.groovy
@@ -1,0 +1,12 @@
+import com.test.SimpleAnnotation
+
+@SimpleAnnotation
+class Person {
+    String name
+    int age
+    Address address
+
+    void sing() {
+        println "tra-la-la"
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/shared/SimpleAnnotationProcessor/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/shared/SimpleAnnotationProcessor/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: "java"

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/shared/SimpleAnnotationProcessor/src/main/java/com/test/SimpleAnnotation.java
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/shared/SimpleAnnotationProcessor/src/main/java/com/test/SimpleAnnotation.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface SimpleAnnotation {
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/shared/SimpleAnnotationProcessor/src/main/java/com/test/SimpleAnnotationProcessor.java
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/shared/SimpleAnnotationProcessor/src/main/java/com/test/SimpleAnnotationProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.test;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.SourceVersion;
+import javax.tools.JavaFileObject;
+
+@SupportedAnnotationTypes("com.test.SimpleAnnotation")
+public class SimpleAnnotationProcessor extends AbstractProcessor {
+    @Override
+    public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+        for (final Element classElement : roundEnv.getElementsAnnotatedWith(SimpleAnnotation.class)) {
+            final String className = String.format("%s$$Generated", classElement.getSimpleName().toString());
+
+            Writer writer = null;
+            try {
+                final JavaFileObject file = processingEnv.getFiler().createSourceFile(className);
+
+                writer = new BufferedWriter(file.openWriter());
+                writer.append(String.format("public class %s {\n", className));
+                writer.append("}");
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            } finally {
+                if (writer != null) {
+                    try {
+                        writer.close();
+                    } catch (final IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/shared/SimpleAnnotationProcessor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/shared/SimpleAnnotationProcessor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.test.SimpleAnnotationProcessor


### PR DESCRIPTION
I've posted a [description this problem](https://groups.google.com/d/msg/gradle-dev/CvkFHRve3Sk/EkOU4liL7X8J) to gradle-dev earlier this week.