### PR TITLE
Fix some inconsistencies between Ant and Zinc scala compilers

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.scala.ScalaCompileOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.scala.ScalaCompileOptions.xml
@@ -58,7 +58,7 @@
             </tr>
             <tr>
                 <td>force</td>
-                <td><literal>never</literal></td>
+                <td><literal>false</literal></td>
             </tr>
             <tr>
                 <td>additionalParameters</td>

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
@@ -27,6 +27,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.util.GFileUtils;
 import scala.Option;
 import xsbti.F0;
 
@@ -63,6 +64,10 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec>, S
                     scalacOptions, javacOptions, spec.getScalaCompileOptions().getIncrementalOptions().getAnalysisFile(), spec.getAnalysisMap(), "mixed", getIncOptions(), true);
             if (LOGGER.isDebugEnabled()) {
                 Inputs.debug(inputs, logger);
+            }
+
+            if (spec.getScalaCompileOptions().isForce()) {
+                GFileUtils.deleteDirectory(spec.getDestinationDir());
             }
 
             try {

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -44,7 +44,7 @@ public class BaseScalaCompileOptions extends AbstractOptions {
 
     private String encoding;
 
-    private String force = "never";
+    private boolean force;
 
     private List<String> additionalParameters;
 
@@ -132,15 +132,14 @@ public class BaseScalaCompileOptions extends AbstractOptions {
     /**
      * Whether to force the compilation of all files.
      * Legal values:
-     * - never (only compile modified files)
-     * - changed (compile all files when at least one file is modified)
-     * - always (always recompile all files)
+     * - false (only compile modified files)
+     * - true (always recompile all files)
      */
-    public String getForce() {
+    public boolean isForce() {
         return force;
     }
 
-    public void setForce(String force) {
+    public void setForce(boolean force) {
         this.force = force;
     }
 

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest.groovy
@@ -60,8 +60,8 @@ class IncrementalScalaCompileIntegrationTest extends AbstractIntegrationSpec {
         run("compileScala")
 
         when:
-        file("src/main/scala/uk/Person.scala").delete()
-        file("src/main/scala/uk/Person.scala") << "package uk\n\nclass Person"
+        file("src/main/scala/Person.scala").delete()
+        file("src/main/scala/Person.scala") << "class Person"
         args("-i")
         run("compileScala")
 

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest.groovy
@@ -52,6 +52,25 @@ class IncrementalScalaCompileIntegrationTest extends AbstractIntegrationSpec {
         runAndFail("classes").assertHasDescription("Execution failed for task ':compileScala'.")
     }
 
+    def compilesAllScalaCodeWhenForced() {
+        setup:
+        def person = file("build/classes/main/Person.class")
+        def house = file("build/classes/main/House.class")
+        def other = file("build/classes/main/Other.class")
+        run("compileScala")
+
+        when:
+        file("src/main/scala/uk/Person.scala").delete()
+        file("src/main/scala/uk/Person.scala") << "package uk\n\nclass Person"
+        args("-i")
+        run("compileScala")
+
+        then:
+        person.lastModified() != old(person.lastModified())
+        house.lastModified() != old(house.lastModified())
+        other.lastModified() != old(other.lastModified())
+    }
+
     @Issue("GRADLE-2548")
     @Ignore
     def recompilesScalaWhenJavaChanges() {

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
@@ -105,7 +105,7 @@ compileScala.scalaCompileOptions.with {
 
         when:
         file("src/main/scala/Person.scala").delete()
-        file("src/main/scala/Person.scala") << "package uk\n\nclass Person"
+        file("src/main/scala/Person.scala") << "class Person"
         args("-i", "-PscalaVersion=$version") // each run clears args (argh!)
         run("compileScala")
 

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
@@ -95,4 +95,23 @@ compileScala.scalaCompileOptions.with {
         house.lastModified() != old(house.lastModified())
         other.lastModified() == old(other.lastModified())
     }
+
+    def compilesAllScalaCodeWhenForced() {
+        setup:
+        def person = file("build/classes/main/Person.class")
+        def house = file("build/classes/main/House.class")
+        def other = file("build/classes/main/Other.class")
+        run("compileScala")
+
+        when:
+        file("src/main/scala/Person.scala").delete()
+        file("src/main/scala/Person.scala") << "package uk\n\nclass Person"
+        args("-i", "-PscalaVersion=$version") // each run clears args (argh!)
+        run("compileScala")
+
+        then:
+        person.lastModified() != old(person.lastModified())
+        house.lastModified() != old(house.lastModified())
+        other.lastModified() != old(other.lastModified())
+    }
 }

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest/compilesAllScalaCodeWhenForced/build.gradle
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest/compilesAllScalaCodeWhenForced/build.gradle
@@ -1,0 +1,16 @@
+apply plugin: "scala"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.scala-lang:scala-library:2.11.1"
+}
+
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.with {
+        force = true
+    }
+}
+

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/House.scala
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/House.scala
@@ -1,0 +1,1 @@
+class House(val owner: Person)

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Other.scala
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Other.scala
@@ -1,0 +1,1 @@
+class Other

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Person.scala
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Person.scala
@@ -1,0 +1,1 @@
+class Person(val name: String, val age: Int)

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/build.gradle
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/build.gradle
@@ -1,0 +1,18 @@
+apply plugin: "scala"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.scala-lang:scala-library:$scalaVersion"
+}
+
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.with {
+        useAnt = false
+        force = true
+        fork = true
+    }
+}
+

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/House.scala
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/House.scala
@@ -1,0 +1,3 @@
+package uk
+
+class House(val owner: Person)

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/House.scala
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/House.scala
@@ -1,3 +1,1 @@
-package uk
-
 class House(val owner: Person)

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Other.scala
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Other.scala
@@ -1,3 +1,1 @@
-package uk
-
 class Other

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Other.scala
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Other.scala
@@ -1,0 +1,3 @@
+package uk
+
+class Other

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Person.scala
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Person.scala
@@ -1,0 +1,3 @@
+package uk
+
+class Person(val name: String, val age: Int)

--- a/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Person.scala
+++ b/subprojects/scala/src/integTest/resources/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest/compilesAllScalaCodeWhenForced/src/main/scala/Person.scala
@@ -1,3 +1,1 @@
-package uk
-
 class Person(val name: String, val age: Int)

--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/AntScalaCommandLineWriter.groovy
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/AntScalaCommandLineWriter.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.scala
+
+import org.gradle.api.Transformer
+import org.gradle.util.CollectionUtils
+
+import java.util.regex.Pattern
+
+class AntScalaCommandLineWriter {
+
+    static String toCommandLineArg(List<String> arguments) {
+        arguments.isEmpty() ? " " : CollectionUtils.collect(arguments, toEscapedString).join(' ')
+    }
+
+    static String toCommaSeparatedArg(List<String> arguments) {
+        arguments.isEmpty() ? " " : arguments.join(',')
+    }
+
+    // there appears to be a bug in the groovy compiler that prevents these being local to the Transformer
+    private static def singleQuoted = Pattern.compile("^\".*\"\$")
+    private static def doubleQuoted = Pattern.compile("^'.*'\$")
+    private static def aSingleQuote = Pattern.compile("'")
+
+    private static def toEscapedString = new Transformer<String, String>() {
+
+        @Override
+        String transform(String input) {
+            if (singleQuoted.matcher(input).matches() || doubleQuoted.matcher(input).matches() || !input.contains(' ')) {
+                input
+            } else {
+                wrapWithSingleQuotes(input)
+            }
+        }
+
+        def wrapWithSingleQuotes(String input) {
+            String.format("'%1\$s'", escapeSingleQuotes(input))
+        }
+
+        def escapeSingleQuotes(String input) {
+            aSingleQuote.matcher(input).replaceAll("\\\\'")
+        }
+    }
+
+
+
+
+}

--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
@@ -15,13 +15,8 @@
  */
 package org.gradle.api.tasks.scala;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import org.gradle.api.Transformer;
-import org.gradle.util.CollectionUtils;
 import org.gradle.language.scala.tasks.BaseScalaCompileOptions;
-
-import java.util.regex.Pattern;
 
 /**
  * Options for Scala compilation, including the use of the Ant-backed compiler.
@@ -129,10 +124,10 @@ public class ScalaCompileOptions extends BaseScalaCompileOptions {
             return toOnOffString(isOptimize());
         }
         if (fieldName.equals("loggingPhases")) {
-            return getLoggingPhases().isEmpty() ? " " : Joiner.on(',').join(getLoggingPhases());
+            return AntScalaCommandLineWriter.toCommaSeparatedArg(getLoggingPhases());
         }
         if (fieldName.equals("additionalParameters")) {
-            return getAdditionalParameters().isEmpty() ? " " : Joiner.on(' ').join(CollectionUtils.collect(getAdditionalParameters(), TO_ESCAPED_STRING));
+            return AntScalaCommandLineWriter.toCommandLineArg(getAdditionalParameters());
         }
         return value;
     }
@@ -140,32 +135,6 @@ public class ScalaCompileOptions extends BaseScalaCompileOptions {
     private String toOnOffString(boolean flag) {
         return flag ? "on" : "off";
     }
-
-    protected static final Transformer<String, String> TO_ESCAPED_STRING = new Transformer<String, String>() {
-
-        private final Pattern singleQuoted = Pattern.compile("^\".*\"$");
-        private final Pattern doubleQuoted = Pattern.compile("^'.*'$");
-        private final Pattern aSingleQuote = Pattern.compile("'");
-
-        @Override
-        public String transform(String input) {
-            if (singleQuoted.matcher(input).matches() || doubleQuoted.matcher(input).matches()) {
-                return input;
-            } else if(input.contains(" ")) {
-                return wrapWithSingleQuotes(input);
-            } else {
-                return input;
-            }
-        }
-
-        private String wrapWithSingleQuotes(String input) {
-            return String.format("'%1$s'", escapeSingleQuotes(input));
-        }
-
-        private String escapeSingleQuotes(String input) {
-            return aSingleQuote.matcher(input).replaceAll("\\\\'");
-        }
-    };
 
 
 }

--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
@@ -141,7 +141,7 @@ public class ScalaCompileOptions extends BaseScalaCompileOptions {
         return flag ? "on" : "off";
     }
 
-    private static final Transformer<String, String> TO_ESCAPED_STRING = new Transformer<String, String>() {
+    protected static final Transformer<String, String> TO_ESCAPED_STRING = new Transformer<String, String>() {
 
         private final Pattern singleQuoted = Pattern.compile("^\".*\"$");
         private final Pattern doubleQuoted = Pattern.compile("^'.*'$");

--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
@@ -15,10 +15,10 @@
  */
 package org.gradle.api.tasks.scala;
 
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
+import org.gradle.api.Transformer;
+import org.gradle.util.CollectionUtils;
 import org.gradle.language.scala.tasks.BaseScalaCompileOptions;
 
 import java.util.regex.Pattern;
@@ -132,7 +132,7 @@ public class ScalaCompileOptions extends BaseScalaCompileOptions {
             return getLoggingPhases().isEmpty() ? " " : Joiner.on(',').join(getLoggingPhases());
         }
         if (fieldName.equals("additionalParameters")) {
-            return getAdditionalParameters().isEmpty() ? " " : Joiner.on(' ').join(Iterables.transform(getAdditionalParameters(), TO_ESCAPED_STRING));
+            return getAdditionalParameters().isEmpty() ? " " : Joiner.on(' ').join(CollectionUtils.collect(getAdditionalParameters(), TO_ESCAPED_STRING));
         }
         return value;
     }
@@ -141,13 +141,13 @@ public class ScalaCompileOptions extends BaseScalaCompileOptions {
         return flag ? "on" : "off";
     }
 
-    private static final Function<String, String> TO_ESCAPED_STRING = new Function<String, String>() {
+    private static final Transformer<String, String> TO_ESCAPED_STRING = new Transformer<String, String>() {
 
         private final Pattern singleQuoted = Pattern.compile("^\".*\"$");
         private final Pattern doubleQuoted = Pattern.compile("^'.*'$");
 
         @Override
-        public String apply(String input) {
+        public String transform(String input) {
             if (singleQuoted.matcher(input).matches() || doubleQuoted.matcher(input).matches()) {
                 return input;
             } else if(input.contains(" ")) {

--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
@@ -143,12 +143,12 @@ public class ScalaCompileOptions extends BaseScalaCompileOptions {
 
     private static final Function<String, String> TO_ESCAPED_STRING = new Function<String, String>() {
 
-        private final Pattern SINGLE_QUOTED = Pattern.compile("^\".*\"$");
-        private final Pattern DOUBLE_QUOTED = Pattern.compile("^'.*'$");
+        private final Pattern singleQuoted = Pattern.compile("^\".*\"$");
+        private final Pattern doubleQuoted = Pattern.compile("^'.*'$");
 
         @Override
         public String apply(String input) {
-            if (SINGLE_QUOTED.matcher(input).matches() || DOUBLE_QUOTED.matcher(input).matches()) {
+            if (singleQuoted.matcher(input).matches() || doubleQuoted.matcher(input).matches()) {
                 return input;
             } else if(input.contains(" ")) {
                 return String.format("'%1$s'", input.replaceAll("'", "\\'"));

--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
@@ -15,9 +15,13 @@
  */
 package org.gradle.api.tasks.scala;
 
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import org.gradle.language.scala.tasks.BaseScalaCompileOptions;
+
+import java.util.regex.Pattern;
 
 /**
  * Options for Scala compilation, including the use of the Ant-backed compiler.
@@ -128,7 +132,7 @@ public class ScalaCompileOptions extends BaseScalaCompileOptions {
             return getLoggingPhases().isEmpty() ? " " : Joiner.on(',').join(getLoggingPhases());
         }
         if (fieldName.equals("additionalParameters")) {
-            return getAdditionalParameters().isEmpty() ? " " : Joiner.on(' ').join(getAdditionalParameters());
+            return getAdditionalParameters().isEmpty() ? " " : Joiner.on(' ').join(Iterables.transform(getAdditionalParameters(), TO_ESCAPED_STRING));
         }
         return value;
     }
@@ -136,6 +140,23 @@ public class ScalaCompileOptions extends BaseScalaCompileOptions {
     private String toOnOffString(boolean flag) {
         return flag ? "on" : "off";
     }
+
+    private static final Function<String, String> TO_ESCAPED_STRING = new Function<String, String>() {
+
+        private final Pattern SINGLE_QUOTED = Pattern.compile("^\".*\"$");
+        private final Pattern DOUBLE_QUOTED = Pattern.compile("^'.*'$");
+
+        @Override
+        public String apply(String input) {
+            if (SINGLE_QUOTED.matcher(input).matches() || DOUBLE_QUOTED.matcher(input).matches()) {
+                return input;
+            } else if(input.contains(" ")) {
+                return String.format("'%1$s'", input.replaceAll("'", "\\'"));
+            } else {
+                return input;
+            }
+        }
+    };
 
 
 }

--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaCompileOptions.java
@@ -145,16 +145,25 @@ public class ScalaCompileOptions extends BaseScalaCompileOptions {
 
         private final Pattern singleQuoted = Pattern.compile("^\".*\"$");
         private final Pattern doubleQuoted = Pattern.compile("^'.*'$");
+        private final Pattern aSingleQuote = Pattern.compile("'");
 
         @Override
         public String transform(String input) {
             if (singleQuoted.matcher(input).matches() || doubleQuoted.matcher(input).matches()) {
                 return input;
             } else if(input.contains(" ")) {
-                return String.format("'%1$s'", input.replaceAll("'", "\\'"));
+                return wrapWithSingleQuotes(input);
             } else {
                 return input;
             }
+        }
+
+        private String wrapWithSingleQuotes(String input) {
+            return String.format("'%1$s'", escapeSingleQuotes(input));
+        }
+
+        private String escapeSingleQuotes(String input) {
+            return aSingleQuote.matcher(input).replaceAll("\\\\'");
         }
     };
 

--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaDocOptions.java
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaDocOptions.java
@@ -15,12 +15,10 @@
  */
 package org.gradle.api.tasks.scala;
 
-import com.google.common.base.Joiner;
-import org.gradle.api.tasks.compile.AbstractOptions;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.InputFile;
-import org.gradle.util.CollectionUtils;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.compile.AbstractOptions;
 
 import java.io.File;
 import java.util.List;
@@ -209,7 +207,7 @@ public class ScalaDocOptions extends AbstractOptions {
             return toOnOffString(unchecked);
         }
         if (fieldName.equals("additionalParameters")) {
-            return additionalParameters.isEmpty() ? ' ' : Joiner.on(' ').join(CollectionUtils.collect(getAdditionalParameters(), ScalaCompileOptions.TO_ESCAPED_STRING));
+            return AntScalaCommandLineWriter.toCommandLineArg(getAdditionalParameters());
         }
         return value;
     }

--- a/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaDocOptions.java
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/tasks/scala/ScalaDocOptions.java
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.compile.AbstractOptions;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.util.CollectionUtils;
 
 import java.io.File;
 import java.util.List;
@@ -194,7 +195,7 @@ public class ScalaDocOptions extends AbstractOptions {
     @Override
     protected String getAntPropertyName(String fieldName) {
         if (fieldName.equals("additionalParameters")) {
-            return "addParams";
+            return "addparams";
         }
         return fieldName;
     }
@@ -208,7 +209,7 @@ public class ScalaDocOptions extends AbstractOptions {
             return toOnOffString(unchecked);
         }
         if (fieldName.equals("additionalParameters")) {
-            return additionalParameters.isEmpty() ? ' ' : Joiner.on(' ').join(additionalParameters);
+            return additionalParameters.isEmpty() ? ' ' : Joiner.on(' ').join(CollectionUtils.collect(getAdditionalParameters(), ScalaCompileOptions.TO_ESCAPED_STRING));
         }
         return value;
     }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/BaseScalaOptionTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/BaseScalaOptionTest.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.scala
+
+import org.gradle.api.tasks.compile.AbstractOptions
+import spock.lang.Specification
+
+abstract class BaseScalaOptionTest<T extends AbstractOptions> extends Specification {
+
+    protected T compileOptions
+
+    abstract T testObject()
+
+    def setup() {
+        compileOptions = testObject()
+    }
+
+    def contains(String key) {
+        compileOptions.optionMap().containsKey(key)
+    }
+
+    def doesNotContain(String key) {
+        !contains(key)
+    }
+
+    def value(String key) {
+        compileOptions.optionMap().get(key)
+    }
+
+
+}

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/BaseScalaOptionTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/BaseScalaOptionTest.groovy
@@ -17,12 +17,70 @@ package org.gradle.api.tasks.scala
 
 import org.gradle.api.tasks.compile.AbstractOptions
 import spock.lang.Specification
+import spock.lang.Unroll
 
 abstract class BaseScalaOptionTest<T extends AbstractOptions> extends Specification {
 
     protected T testObject
 
     abstract T newTestObject()
+
+    abstract List<Map<String, String>> stringProperties()
+
+    abstract List<Map<String, String>> onOffProperties()
+
+    abstract List<Map<String, String>> listProperties()
+
+    @Unroll("String #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
+    def "string values"(Map<String, String> fixture) {
+        given:
+        assert testObject."${fixture.fieldName}" == fixture.defaultValue
+        if (fixture.defaultValue == null) {
+            assert doesNotContain(fixture.antProperty)
+        } else {
+            assert value(fixture.antProperty) == fixture.defaultValue
+        }
+        when:
+        testObject."${fixture.fieldName}" = fixture.testValue
+        then:
+        value(fixture.antProperty) == fixture.testValue
+        where:
+        fixture << stringProperties()
+    }
+
+    @Unroll("OnOff #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
+    def "onOff values"(Map<String, String> fixture) {
+        given:
+        assert testObject."${fixture.fieldName}" == fixture.defaultValue
+
+        when:
+        testObject."${fixture.fieldName}" = true
+        then:
+        value(fixture.antProperty) == 'on'
+
+        when:
+        testObject."${fixture.fieldName}" = false
+        then:
+        value(fixture.antProperty) == 'off'
+
+        where:
+        fixture << onOffProperties()
+    }
+
+    @Unroll("List #fixture.fieldName with value #fixture.args maps to #fixture.antProperty with value #fixture.expected")
+    def "list values"(Map<String, Object> fixture) {
+        given:
+        assert testObject."${fixture.fieldName}" == null
+        assert value(fixture.antProperty as String) == null
+
+        when:
+        testObject."${fixture.fieldName}" = fixture.args as List<String>
+        then:
+        value(fixture.antProperty as String) == fixture.expected
+
+        where:
+        fixture << listProperties()
+    }
 
     def setup() {
         testObject = newTestObject()

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/BaseScalaOptionTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/BaseScalaOptionTest.groovy
@@ -20,16 +20,16 @@ import spock.lang.Specification
 
 abstract class BaseScalaOptionTest<T extends AbstractOptions> extends Specification {
 
-    protected T compileOptions
+    protected T testObject
 
-    abstract T testObject()
+    abstract T newTestObject()
 
     def setup() {
-        compileOptions = testObject()
+        testObject = newTestObject()
     }
 
     def contains(String key) {
-        compileOptions.optionMap().containsKey(key)
+        testObject.optionMap().containsKey(key)
     }
 
     def doesNotContain(String key) {
@@ -37,8 +37,7 @@ abstract class BaseScalaOptionTest<T extends AbstractOptions> extends Specificat
     }
 
     def value(String key) {
-        compileOptions.optionMap().get(key)
+        testObject.optionMap().get(key)
     }
-
 
 }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
@@ -69,7 +69,7 @@ class ScalaCompileOptionsTest {
     }
 
     @Test void testOptionMapContainsForce() {
-        assertSimpleStringValue('force', 'force', 'never', 'changed')
+        assertBooleanValue('force', 'force', false)
     }
 
     @Test void testOptionMapDoesNotContainTargetCompatibility() {

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
@@ -24,35 +24,34 @@ class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
         return new ScalaCompileOptions()
     }
 
-    def "optionMap never contains useCompileDaemon"(boolean compileDaemonIsEnabled) {
-        setup:
-        testObject.useCompileDaemon = compileDaemonIsEnabled
-        expect:
-        doesNotContain('useCompileDaemon')
-        where:
-        compileDaemonIsEnabled << [true, false]
+    @Override
+    List<Map<String, String>> stringProperties() {
+        [
+                [fieldName: 'daemonServer', antProperty: 'server', defaultValue: null, testValue: 'host:9000'],
+                [fieldName: 'encoding', antProperty: 'encoding', defaultValue: null, testValue: 'utf8'],
+                [fieldName: 'debugLevel', antProperty: 'debuginfo', defaultValue: null, testValue: 'line'],
+                [fieldName: 'loggingLevel', antProperty: 'logging', defaultValue: null, testValue: 'verbose']
+        ]
     }
 
-    @Unroll("String #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
-    def "simple string values"(Map<String, String> fixture) {
-        given:
-        assert testObject."${fixture.fieldName}" == fixture.defaultValue
-        if (fixture.defaultValue == null) {
-            assert doesNotContain(fixture.antProperty)
-        } else {
-            assert value(fixture.antProperty) == fixture.defaultValue
-        }
-        when:
-        testObject."${fixture.fieldName}" = fixture.testValue
-        then:
-        value(fixture.antProperty) == fixture.testValue
-        where:
-        fixture << [
-                    [fieldName: 'daemonServer', antProperty: 'server', defaultValue: null, testValue: 'host:9000'],
-                    [fieldName: 'encoding', antProperty: 'encoding', defaultValue: null, testValue: 'utf8'],
-                    [fieldName: 'debugLevel', antProperty: 'debuginfo', defaultValue: null, testValue: 'line'],
-                    [fieldName: 'loggingLevel', antProperty: 'logging', defaultValue: null, testValue: 'verbose']
-            ]
+    @Override
+    List<Map<String, String>> onOffProperties() {
+        [
+                [fieldName: 'deprecation', antProperty: 'deprecation', defaultValue: true],
+                [fieldName: 'unchecked', antProperty: 'unchecked', defaultValue: true]
+        ]
+    }
+
+    @Override
+    List<Map<String, String>> listProperties() {
+        [
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['-opt1', '-opt2'], expected: '-opt1 -opt2'],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with spaces'], expected: '\'arg with spaces\''],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with \' and spaces'], expected: '\'arg with \\\' and spaces\''],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['\'arg with spaces\''], expected: '\'arg with spaces\''],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['"arg with spaces"'], expected: '"arg with spaces"'],
+                [fieldName: 'loggingPhases', antProperty: 'logphase', args: ['pickler', 'tailcalls'], expected: 'pickler,tailcalls']
+        ]
     }
 
     @Unroll("Boolean #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
@@ -74,51 +73,17 @@ class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
         fixture << [
                 [fieldName: 'failOnError', antProperty: 'failOnError', defaultValue: true],
                 [fieldName: 'force', antProperty: 'force', defaultValue: false],
-                [fieldName: 'listFiles', antProperty: 'scalacdebugging', defaultValue: false]        ]
-    }
-
-    @Unroll("OnOff #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
-    def "onOff values"(Map<String, String> fixture) {
-        given:
-        assert testObject."${fixture.fieldName}" == fixture.defaultValue
-
-        when:
-        testObject."${fixture.fieldName}" = true
-        then:
-        value(fixture.antProperty) == 'on'
-
-        when:
-        testObject."${fixture.fieldName}" = false
-        then:
-        value(fixture.antProperty) == 'off'
-
-        where:
-        fixture << [
-                [fieldName: 'deprecation', antProperty: 'deprecation', defaultValue: true],
-                [fieldName: 'unchecked', antProperty: 'unchecked', defaultValue: true]
+                [fieldName: 'listFiles', antProperty: 'scalacdebugging', defaultValue: false]
         ]
     }
 
-    @Unroll("List #fixture.fieldName with value #fixture.args maps to #fixture.antProperty with value #fixture.expected")
-    def "list values"(Map<String, Object> fixture) {
-        given:
-        assert testObject."${fixture.fieldName}" == null
-        assert value(fixture.antProperty as String) == null
-
-        when:
-        testObject."${fixture.fieldName}" = fixture.args as List<String>
-        then:
-        value(fixture.antProperty as String) == fixture.expected
-
+    def "optionMap never contains useCompileDaemon"(boolean compileDaemonIsEnabled) {
+        setup:
+        testObject.useCompileDaemon = compileDaemonIsEnabled
+        expect:
+        doesNotContain('useCompileDaemon')
         where:
-        fixture << [
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['-opt1', '-opt2'], expected: '-opt1 -opt2'],
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with spaces'], expected: '\'arg with spaces\''],
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with \' and spaces'], expected: '\'arg with \\\' and spaces\''],
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['\'arg with spaces\''], expected: '\'arg with spaces\''],
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['"arg with spaces"'], expected: '"arg with spaces"'],
-                [fieldName: 'loggingPhases', antProperty: 'logphase', args: ['pickler', 'tailcalls'], expected: 'pickler,tailcalls']
-        ]
+        compileDaemonIsEnabled << [true, false]
     }
 
     def "optionMap contains optimise when set"() {

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
@@ -20,13 +20,13 @@ import spock.lang.Unroll
 class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
 
     @Override
-    ScalaCompileOptions testObject() {
+    ScalaCompileOptions newTestObject() {
         return new ScalaCompileOptions()
     }
 
     def "optionMap never contains useCompileDaemon"(boolean compileDaemonIsEnabled) {
         setup:
-        compileOptions.useCompileDaemon = compileDaemonIsEnabled
+        testObject.useCompileDaemon = compileDaemonIsEnabled
         expect:
         doesNotContain('useCompileDaemon')
         where:
@@ -36,14 +36,14 @@ class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
     @Unroll("String #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
     def "simple string values"(Map<String, String> fixture) {
         given:
-        assert compileOptions."${fixture.fieldName}" == fixture.defaultValue
+        assert testObject."${fixture.fieldName}" == fixture.defaultValue
         if (fixture.defaultValue == null) {
             assert doesNotContain(fixture.antProperty)
         } else {
             assert value(fixture.antProperty) == fixture.defaultValue
         }
         when:
-        compileOptions."${fixture.fieldName}" = fixture.testValue
+        testObject."${fixture.fieldName}" = fixture.testValue
         then:
         value(fixture.antProperty) == fixture.testValue
         where:
@@ -58,15 +58,15 @@ class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
     @Unroll("Boolean #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
     def "boolean values"(Map<String, String> fixture) {
         given:
-        assert compileOptions."${fixture.fieldName}" == fixture.defaultValue
+        assert testObject."${fixture.fieldName}" == fixture.defaultValue
 
         when:
-        compileOptions."${fixture.fieldName}" = true
+        testObject."${fixture.fieldName}" = true
         then:
         value(fixture.antProperty) as String == 'true'
 
         when:
-        compileOptions."${fixture.fieldName}" = false
+        testObject."${fixture.fieldName}" = false
         then:
         value(fixture.antProperty) as String == 'false'
 
@@ -80,15 +80,15 @@ class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
     @Unroll("OnOff #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
     def "onOff values"(Map<String, String> fixture) {
         given:
-        assert compileOptions."${fixture.fieldName}" == fixture.defaultValue
+        assert testObject."${fixture.fieldName}" == fixture.defaultValue
 
         when:
-        compileOptions."${fixture.fieldName}" = true
+        testObject."${fixture.fieldName}" = true
         then:
         value(fixture.antProperty) == 'on'
 
         when:
-        compileOptions."${fixture.fieldName}" = false
+        testObject."${fixture.fieldName}" = false
         then:
         value(fixture.antProperty) == 'off'
 
@@ -100,13 +100,13 @@ class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
     }
 
     @Unroll("List #fixture.fieldName with value #fixture.args maps to #fixture.antProperty with value #fixture.expected")
-    def "addParams"(Map<String, Object> fixture) {
+    def "list values"(Map<String, Object> fixture) {
         given:
-        assert compileOptions."${fixture.fieldName}" == null
+        assert testObject."${fixture.fieldName}" == null
         assert value(fixture.antProperty as String) == null
 
         when:
-        compileOptions."${fixture.fieldName}" = fixture.args as List<String>
+        testObject."${fixture.fieldName}" = fixture.args as List<String>
         then:
         value(fixture.antProperty as String) == fixture.expected
 
@@ -125,7 +125,7 @@ class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
         given:
         assert doesNotContain('optimise')
         when:
-        compileOptions.optimize = true
+        testObject.optimize = true
         then:
         value('optimise') == 'on'
     }
@@ -137,11 +137,11 @@ class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
 
     def "disabling UseAnt enables Fork"() {
         given:
-        assert !compileOptions.fork
+        assert !testObject.fork
         when:
-        compileOptions.useAnt = false
+        testObject.useAnt = false
         then:
-        compileOptions.fork == true
+        testObject.fork == true
     }
 
 

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
@@ -15,27 +15,13 @@
  */
 package org.gradle.api.tasks.scala
 
-import spock.lang.Specification
 import spock.lang.Unroll
 
-class ScalaCompileOptionsTest extends Specification {
+class ScalaCompileOptionsTest extends BaseScalaOptionTest<ScalaCompileOptions> {
 
-    private ScalaCompileOptions compileOptions
-
-    def setup() {
-        compileOptions = new ScalaCompileOptions()
-    }
-
-    def contains(String key) {
-        compileOptions.optionMap().containsKey(key)
-    }
-
-    def doesNotContain(String key) {
-        !contains(key)
-    }
-
-    def value(String key) {
-        compileOptions.optionMap().get(key)
+    @Override
+    ScalaCompileOptions testObject() {
+        return new ScalaCompileOptions()
     }
 
     def "optionMap never contains useCompileDaemon"(boolean compileDaemonIsEnabled) {

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileOptionsTest.groovy
@@ -76,13 +76,33 @@ class ScalaCompileOptionsTest {
         assert !compileOptions.optionMap().containsKey("target")
     }
 
-    @Test void testOptionMapContainsValuesForAdditionalParameters() {
+    String addParams(List<String> inputs) {
         String antProperty = 'addparams'
         assertNull(compileOptions.additionalParameters)
         assertFalse(compileOptions.optionMap().containsKey(antProperty))
 
-        compileOptions.additionalParameters = ['-opt1', '-opt2']
-        assertThat(compileOptions.optionMap()[antProperty] as String, equalTo('-opt1 -opt2' as String))
+        compileOptions.additionalParameters = inputs
+        return compileOptions.optionMap()[antProperty] as String
+    }
+
+    @Test void testOptionMapContainsValuesForAdditionalParameters() {
+        assertThat(addParams(['-opt1', '-opt2']), equalTo('-opt1 -opt2'))
+    }
+
+    @Test void testOptionMapEscapesValuesForAdditionalParameters() {
+        assertThat(addParams(['arg with spaces']), equalTo('\'arg with spaces\''))
+    }
+
+    @Test void testOptionMapEscapesQuoteInValuesForAdditionalParameters() {
+        assertThat(addParams(['arg with \' and spaces']), equalTo('\'arg \\\' with spaces\''))
+    }
+
+    @Test void testOptionMapDoesNotEscapeSingleQuotedValuesAdditionalParameters() {
+        assertThat(addParams(['\'arg with spaces\'']), equalTo('\'arg with spaces\''))
+    }
+
+    @Test void testOptionMapDoesNotEscapeDoubleQuotedValuesAdditionalParameters() {
+        assertThat(addParams(['"arg with spaces"']), equalTo('"arg with spaces"'))
     }
 
     @Test void testOptionMapContainsListFiles() {

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaDocOptionsTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaDocOptionsTest.groovy
@@ -15,84 +15,94 @@
  */
 package org.gradle.api.tasks.scala
 
-import org.junit.Test
+import spock.lang.Unroll
 
-import static org.hamcrest.Matchers.equalTo
-import static org.junit.Assert.*
+public class ScalaDocOptionsTest extends BaseScalaOptionTest<ScalaDocOptions> {
 
-public class ScalaDocOptionsTest {
-
-    private ScalaDocOptions docOptions = new ScalaDocOptions()
-
-    @Test public void testOptionMapContainsDeprecation() {
-        assertOnOffValue('deprecation', 'deprecation', true)
+    @Override
+    ScalaDocOptions newTestObject() {
+        return new ScalaDocOptions()
     }
 
-    @Test public void testOptionMapContainsUnchecked() {
-        assertOnOffValue('unchecked', 'unchecked', true)
+    @Unroll("OnOff #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
+    def "onOff values"(Map<String, String> fixture) {
+        given:
+        assert testObject."${fixture.fieldName}" == fixture.defaultValue
+
+        when:
+        testObject."${fixture.fieldName}" = true
+        then:
+        value(fixture.antProperty) == 'on'
+
+        when:
+        testObject."${fixture.fieldName}" = false
+        then:
+        value(fixture.antProperty) == 'off'
+
+        where:
+        fixture << [
+                [fieldName: 'deprecation', antProperty: 'deprecation', defaultValue: true],
+                [fieldName: 'unchecked', antProperty: 'unchecked', defaultValue: true]
+        ]
     }
 
-    @Test public void testOptionMapContainsWindowTitleIfSpecified() {
-        assertSimpleStringValue('windowTitle', 'windowTitle', null, 'title-value')
-    }
-
-    @Test public void testOptionMapContainsDocTitleIfSpecified() {
-        assertSimpleStringValue('docTitle', 'docTitle', null, 'title-value')
-    }
-
-    @Test public void testOptionMapContainsHeaderIfSpecified() {
-        assertSimpleStringValue('header', 'header', null, 'header-value')
-    }
-
-    @Test public void testOptionMapContainsFooterIfSpecified() {
-        assertSimpleStringValue('footer', 'footer', null, 'footer-value')
-    }
-
-    @Test public void testOptionMapContainsTopIfSpecified() {
-        assertSimpleStringValue('top', 'top', null, 'top-value')
-    }
-
-    @Test public void testOptionMapContainsBottomIfSpecified() {
-        assertSimpleStringValue('bottom', 'bottom', null, 'bottom-value')
-    }
-
-    @Test public void testOptionMapContainsStyleSheetIfSpecified() {
-        String antProperty = 'styleSheet'
-        assertNull(docOptions.styleSheet)
-        assertFalse(docOptions.optionMap().containsKey(antProperty))
-        File file = new File('abc')
-        docOptions.styleSheet = file
-        assertThat(docOptions.optionMap()[antProperty] as File, equalTo(file))
-    }
-
-    @Test public void testOptionMapContainsValuesForAdditionalParameters() {
-        String antProperty = 'addParams'
-        assertNull(docOptions.additionalParameters)
-        assertFalse(docOptions.optionMap().containsKey(antProperty))
-
-        docOptions.additionalParameters = ['-opt1', '-opt2']
-        assertThat(docOptions.optionMap()[antProperty] as String, equalTo('-opt1 -opt2' as String))
-    }
-
-    private assertOnOffValue(String fieldName, String antProperty, boolean defaultValue) {
-        assertThat(docOptions."$fieldName" as boolean, equalTo(defaultValue))
-
-        docOptions."$fieldName" = true
-        assertThat(docOptions.optionMap()[antProperty] as String, equalTo('on'))
-
-        docOptions."$fieldName" = false
-        assertThat(docOptions.optionMap()[antProperty] as String, equalTo('off'))
-    }
-
-    private assertSimpleStringValue(String fieldName, String antProperty, String defaultValue, String testValue) {
-        assertThat(docOptions."${fieldName}" as String, equalTo(defaultValue))
-        if (defaultValue == null) {
-            assertFalse(docOptions.optionMap().containsKey(antProperty))
+    @Unroll("String #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
+    def "simple string values"(Map<String, String> fixture) {
+        given:
+        assert testObject."${fixture.fieldName}" == fixture.defaultValue
+        if (fixture.defaultValue == null) {
+            assert doesNotContain(fixture.antProperty)
         } else {
-            assertThat(docOptions.optionMap()[antProperty] as String, equalTo(defaultValue))
+            assert value(fixture.antProperty) == fixture.defaultValue
         }
-        docOptions."${fieldName}" = testValue
-        assertThat(docOptions.optionMap()[antProperty] as String, equalTo(testValue))
+        when:
+        testObject."${fixture.fieldName}" = fixture.testValue
+        then:
+        value(fixture.antProperty) == fixture.testValue
+        where:
+        fixture << [
+                [fieldName: 'windowTitle', antProperty: 'windowTitle', defaultValue: null, testValue: 'title-value'],
+                [fieldName: 'docTitle', antProperty: 'docTitle', defaultValue: null, testValue: 'doc-title-value'],
+                [fieldName: 'header', antProperty: 'header', defaultValue: null, testValue: 'header-value'],
+                [fieldName: 'footer', antProperty: 'footer', defaultValue: null, testValue: 'footer-value'],
+                [fieldName: 'top', antProperty: 'top', defaultValue: null, testValue: 'top-value'],
+                [fieldName: 'bottom', antProperty: 'bottom', defaultValue: null, testValue: 'bottom-value'],
+                [fieldName: 'footer', antProperty: 'footer', defaultValue: null, testValue: 'footer-value']
+        ]
     }
+
+    def testOptionMapContainsStyleSheetIfSpecified() {
+        String antProperty = 'styleSheet'
+        given:
+        assert testObject.styleSheet == null
+        assert doesNotContain(antProperty)
+        when:
+        File file = new File('abc')
+        testObject.styleSheet = file
+        then:
+        value(antProperty) == file
+    }
+
+    @Unroll("List #fixture.fieldName with value #fixture.args maps to #fixture.antProperty with value #fixture.expected")
+    def "addParams"(Map<String, Object> fixture) {
+        given:
+        assert testObject."${fixture.fieldName}" == null
+        assert value(fixture.antProperty as String) == null
+
+        when:
+        testObject."${fixture.fieldName}" = fixture.args as List<String>
+        then:
+        value(fixture.antProperty as String) == fixture.expected
+
+        where:
+        fixture << [
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['-opt1', '-opt2'], expected: '-opt1 -opt2'],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with spaces'], expected: '\'arg with spaces\''],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with \' and spaces'], expected: '\'arg with \\\' and spaces\''],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['\'arg with spaces\''], expected: '\'arg with spaces\''],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['"arg with spaces"'], expected: '"arg with spaces"'],
+        ]
+    }
+
 
 }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaDocOptionsTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaDocOptionsTest.groovy
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.tasks.scala
 
-import spock.lang.Unroll
-
 public class ScalaDocOptionsTest extends BaseScalaOptionTest<ScalaDocOptions> {
 
     @Override
@@ -24,43 +22,9 @@ public class ScalaDocOptionsTest extends BaseScalaOptionTest<ScalaDocOptions> {
         return new ScalaDocOptions()
     }
 
-    @Unroll("OnOff #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
-    def "onOff values"(Map<String, String> fixture) {
-        given:
-        assert testObject."${fixture.fieldName}" == fixture.defaultValue
-
-        when:
-        testObject."${fixture.fieldName}" = true
-        then:
-        value(fixture.antProperty) == 'on'
-
-        when:
-        testObject."${fixture.fieldName}" = false
-        then:
-        value(fixture.antProperty) == 'off'
-
-        where:
-        fixture << [
-                [fieldName: 'deprecation', antProperty: 'deprecation', defaultValue: true],
-                [fieldName: 'unchecked', antProperty: 'unchecked', defaultValue: true]
-        ]
-    }
-
-    @Unroll("String #fixture.fieldName maps to #fixture.antProperty with a default value of #fixture.defaultValue")
-    def "simple string values"(Map<String, String> fixture) {
-        given:
-        assert testObject."${fixture.fieldName}" == fixture.defaultValue
-        if (fixture.defaultValue == null) {
-            assert doesNotContain(fixture.antProperty)
-        } else {
-            assert value(fixture.antProperty) == fixture.defaultValue
-        }
-        when:
-        testObject."${fixture.fieldName}" = fixture.testValue
-        then:
-        value(fixture.antProperty) == fixture.testValue
-        where:
-        fixture << [
+    @Override
+    List<Map<String, String>> stringProperties() {
+        [
                 [fieldName: 'windowTitle', antProperty: 'windowTitle', defaultValue: null, testValue: 'title-value'],
                 [fieldName: 'docTitle', antProperty: 'docTitle', defaultValue: null, testValue: 'doc-title-value'],
                 [fieldName: 'header', antProperty: 'header', defaultValue: null, testValue: 'header-value'],
@@ -71,7 +35,26 @@ public class ScalaDocOptionsTest extends BaseScalaOptionTest<ScalaDocOptions> {
         ]
     }
 
-    def testOptionMapContainsStyleSheetIfSpecified() {
+    @Override
+    List<Map<String, String>> onOffProperties() {
+        [
+                [fieldName: 'deprecation', antProperty: 'deprecation', defaultValue: true],
+                [fieldName: 'unchecked', antProperty: 'unchecked', defaultValue: true]
+        ]
+    }
+
+    @Override
+    List<Map<String, String>> listProperties() {
+        [
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['-opt1', '-opt2'], expected: '-opt1 -opt2'],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with spaces'], expected: '\'arg with spaces\''],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with \' and spaces'], expected: '\'arg with \\\' and spaces\''],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['\'arg with spaces\''], expected: '\'arg with spaces\''],
+                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['"arg with spaces"'], expected: '"arg with spaces"'],
+        ]
+    }
+
+    def "optionMap contains stylesheet when set"() {
         String antProperty = 'styleSheet'
         given:
         assert testObject.styleSheet == null
@@ -81,27 +64,6 @@ public class ScalaDocOptionsTest extends BaseScalaOptionTest<ScalaDocOptions> {
         testObject.styleSheet = file
         then:
         value(antProperty) == file
-    }
-
-    @Unroll("List #fixture.fieldName with value #fixture.args maps to #fixture.antProperty with value #fixture.expected")
-    def "addParams"(Map<String, Object> fixture) {
-        given:
-        assert testObject."${fixture.fieldName}" == null
-        assert value(fixture.antProperty as String) == null
-
-        when:
-        testObject."${fixture.fieldName}" = fixture.args as List<String>
-        then:
-        value(fixture.antProperty as String) == fixture.expected
-
-        where:
-        fixture << [
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['-opt1', '-opt2'], expected: '-opt1 -opt2'],
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with spaces'], expected: '\'arg with spaces\''],
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['arg with \' and spaces'], expected: '\'arg with \\\' and spaces\''],
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['\'arg with spaces\''], expected: '\'arg with spaces\''],
-                [fieldName: 'additionalParameters', antProperty: 'addparams', args: ['"arg with spaces"'], expected: '"arg with spaces"'],
-        ]
     }
 
 


### PR DESCRIPTION
Hi,

`scalaCompileOptions.force` currently appears to have no effect for the Zinc compiler. This PR tries to implement a clean compilation mode for both Ant and Zinc compilers when `force` is set to true.

Also, the Ant compiler currently requires the client to handle whitespace in any arguments, yet the Zinc compiler requires that the client does not handle whitespace escaping. This PR therefore tries to handle any unescaped whitespace when the Ant compiler is used and standardises the behaviour to match the Zinc compiler.