### PR TITLE
Capability to allow additional Resources to be rendered within a Testreport

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassPageRenderer.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassPageRenderer.java
@@ -32,7 +32,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ClassPageRenderer extends PageRenderer<ClassTestResults> {
+class ClassPageRenderer extends PageRenderer<ClassTestResults> {
     private final CodePanelRenderer codePanelRenderer = new CodePanelRenderer();
     private final TestResultsProvider resultsProvider;
     private File classesBaseUrl;
@@ -145,7 +145,7 @@ public class ClassPageRenderer extends PageRenderer<ClassTestResults> {
         }
     }
 
-    public void addAdditionalResourceListeners(IAdditionalTestResultResource additionalResourceListeners) {
-        this.additionalResourceListeners.add(additionalResourceListeners);
+    public void addAdditionalResourceListeners(List<IAdditionalTestResultResource> additionalResourceListeners) {
+        this.additionalResourceListeners.addAll(additionalResourceListeners);
     }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassPageRenderer.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassPageRenderer.java
@@ -37,7 +37,7 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
     private final TestResultsProvider resultsProvider;
     private File classesBaseUrl;
 
-    private List<IAdditionalTestResultResource> additionalResourceListeners = new ArrayList<IAdditionalTestResultResource>();
+    private List<IAdditionalTestResultResource> additionalResources = new ArrayList<IAdditionalTestResultResource>();
 
     public ClassPageRenderer(TestResultsProvider provider, File classesBaseUrl) {
         this.resultsProvider = provider;
@@ -71,8 +71,8 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
                     .startElement("td").attribute("class", test.getStatusClass()).characters(test.getFormattedResultType()).endElement()
                     .endElement();
             List<File> additionalFiles = new ArrayList<File>();
-            for (IAdditionalTestResultResource additionalResourceListener : additionalResourceListeners) {
-                additionalFiles.addAll(additionalResourceListener.findResources(test));
+            for (IAdditionalTestResultResource additionalResource : additionalResources) {
+                additionalFiles.addAll(additionalResource.findResources(test));
             }
             if (!additionalFiles.isEmpty()) {
                 htmlWriter.startElement("tr").startElement("td").attribute("colspan", "3").startElement("table");
@@ -145,7 +145,7 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
         }
     }
 
-    public void addAdditionalResourceListeners(List<IAdditionalTestResultResource> additionalResourceListeners) {
-        this.additionalResourceListeners.addAll(additionalResourceListeners);
+    public void addAdditionalResources(List<IAdditionalTestResultResource> additionalResources) {
+        this.additionalResources.addAll(additionalResources);
     }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassPageRenderer.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassPageRenderer.java
@@ -24,14 +24,24 @@ import org.gradle.internal.SystemProperties;
 import org.gradle.reporting.CodePanelRenderer;
 import org.gradle.util.GUtil;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
 
-class ClassPageRenderer extends PageRenderer<ClassTestResults> {
+public class ClassPageRenderer extends PageRenderer<ClassTestResults> {
     private final CodePanelRenderer codePanelRenderer = new CodePanelRenderer();
     private final TestResultsProvider resultsProvider;
+    private File classesBaseUrl;
 
-    public ClassPageRenderer(TestResultsProvider provider) {
+    private List<IAdditionalTestResultResource> additionalResourceListeners = new ArrayList<IAdditionalTestResultResource>();
+
+    public ClassPageRenderer(TestResultsProvider provider, File classesBaseUrl) {
         this.resultsProvider = provider;
+        this.classesBaseUrl = classesBaseUrl;
     }
 
     @Override
@@ -56,10 +66,25 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
 
         for (TestResult test : getResults().getTestResults()) {
             htmlWriter.startElement("tr")
-                .startElement("td").attribute("class", test.getStatusClass()).characters(test.getName()).endElement()
-                .startElement("td").characters(test.getFormattedDuration()).endElement()
-                .startElement("td").attribute("class", test.getStatusClass()).characters(test.getFormattedResultType()).endElement()
-            .endElement();
+                    .startElement("td").attribute("class", test.getStatusClass()).characters(test.getName()).endElement()
+                    .startElement("td").characters(test.getFormattedDuration()).endElement()
+                    .startElement("td").attribute("class", test.getStatusClass()).characters(test.getFormattedResultType()).endElement()
+                    .endElement();
+            List<File> additionalFiles = new ArrayList<File>();
+            for (IAdditionalTestResultResource additionalResourceListener : additionalResourceListeners) {
+                additionalFiles.addAll(additionalResourceListener.findResources(test));
+            }
+            if (!additionalFiles.isEmpty()) {
+                htmlWriter.startElement("tr").startElement("td").attribute("colspan", "3").startElement("table");
+                for (File additionalFile : additionalFiles) {
+                    Files.copy(additionalFile.toPath(), Paths.get(classesBaseUrl.getAbsolutePath(), additionalFile.getName()), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+                    htmlWriter.startElement("tr");
+                    htmlWriter.startElement("td");
+                    htmlWriter.startElement("a").attribute("href", additionalFile.getName()).attribute("style", "font-size:small").characters(additionalFile.getName()).endElement();
+                    htmlWriter.endElement();
+                    htmlWriter.endElement();
+                }
+            }
         }
         htmlWriter.endElement();
     }
@@ -118,5 +143,9 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
                 }
             });
         }
+    }
+
+    public void addAdditionalResourceListeners(IAdditionalTestResultResource additionalResourceListeners) {
+        this.additionalResourceListeners.add(additionalResourceListeners);
     }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
@@ -68,15 +68,15 @@ public class DefaultTestReport implements TestReporter {
         return model;
     }
 
-    private void generateFiles(AllTestResults model, final TestResultsProvider resultsProvider, File reportDir) {
+    private void generateFiles(AllTestResults model, final TestResultsProvider resultsProvider, final File reportDir) {
         try {
             HtmlReportRenderer htmlRenderer = new HtmlReportRenderer();
             htmlRenderer.render(model, new ReportRenderer<AllTestResults, HtmlReportBuilder>() {
                 @Override
                 public void render(AllTestResults model, HtmlReportBuilder output) throws IOException {
                     PackagePageRenderer packagePageRenderer = new PackagePageRenderer();
-                    ClassPageRenderer classPageRenderer = new ClassPageRenderer(resultsProvider);
-
+                    ClassPageRenderer classPageRenderer = new ClassPageRenderer(resultsProvider, new File(reportDir,"classes"));
+                    addAdditionalResourceListeners(classPageRenderer);
                     output.renderHtmlPage("index.html", model, new OverviewPageRenderer());
                     for (PackageTestResults packageResults : model.getPackages()) {
                         output.renderHtmlPage(packageResults.getBaseUrl(), packageResults, packagePageRenderer);
@@ -90,4 +90,6 @@ public class DefaultTestReport implements TestReporter {
             throw new GradleException(String.format("Could not generate test report to '%s'.", reportDir), e);
         }
     }
+
+    protected void addAdditionalResourceListeners(ClassPageRenderer classPageRenderer) {}
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
@@ -77,7 +77,7 @@ public class DefaultTestReport implements TestReporter {
                 public void render(AllTestResults model, HtmlReportBuilder output) throws IOException {
                     PackagePageRenderer packagePageRenderer = new PackagePageRenderer();
                     ClassPageRenderer classPageRenderer = new ClassPageRenderer(resultsProvider, new File(reportDir,"classes"));
-                    classPageRenderer.addAdditionalResourceListeners(additionalResourceListeners());
+                    classPageRenderer.addAdditionalResources(additionalResources());
                     output.renderHtmlPage("index.html", model, new OverviewPageRenderer());
                     for (PackageTestResults packageResults : model.getPackages()) {
                         output.renderHtmlPage(packageResults.getBaseUrl(), packageResults, packagePageRenderer);
@@ -92,7 +92,7 @@ public class DefaultTestReport implements TestReporter {
         }
     }
 
-    protected List<IAdditionalTestResultResource> additionalResourceListeners() {
+    protected List<IAdditionalTestResultResource> additionalResources() {
         return new ArrayList<IAdditionalTestResultResource>();
     }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
@@ -76,7 +76,7 @@ public class DefaultTestReport implements TestReporter {
                 @Override
                 public void render(AllTestResults model, HtmlReportBuilder output) throws IOException {
                     PackagePageRenderer packagePageRenderer = new PackagePageRenderer();
-                    ClassPageRenderer classPageRenderer = new ClassPageRenderer(resultsProvider, new File(reportDir,"classes"));
+                    ClassPageRenderer classPageRenderer = new ClassPageRenderer(resultsProvider, new File(reportDir, "classes"));
                     classPageRenderer.addAdditionalResources(additionalResources());
                     output.renderHtmlPage("index.html", model, new OverviewPageRenderer());
                     for (PackageTestResults packageResults : model.getPackages()) {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReport.java
@@ -30,6 +30,7 @@ import org.gradle.util.Clock;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.gradle.api.tasks.testing.TestResult.ResultType.SKIPPED;
@@ -76,7 +77,7 @@ public class DefaultTestReport implements TestReporter {
                 public void render(AllTestResults model, HtmlReportBuilder output) throws IOException {
                     PackagePageRenderer packagePageRenderer = new PackagePageRenderer();
                     ClassPageRenderer classPageRenderer = new ClassPageRenderer(resultsProvider, new File(reportDir,"classes"));
-                    addAdditionalResourceListeners(classPageRenderer);
+                    classPageRenderer.addAdditionalResourceListeners(additionalResourceListeners());
                     output.renderHtmlPage("index.html", model, new OverviewPageRenderer());
                     for (PackageTestResults packageResults : model.getPackages()) {
                         output.renderHtmlPage(packageResults.getBaseUrl(), packageResults, packagePageRenderer);
@@ -91,5 +92,7 @@ public class DefaultTestReport implements TestReporter {
         }
     }
 
-    protected void addAdditionalResourceListeners(ClassPageRenderer classPageRenderer) {}
+    protected List<IAdditionalTestResultResource> additionalResourceListeners() {
+        return new ArrayList<IAdditionalTestResultResource>();
+    }
 }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/IAdditionalTestResultResource.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/IAdditionalTestResultResource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradle.api.internal.tasks.testing.junit.report;
 
 import java.io.File;

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/IAdditionalTestResultResource.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/IAdditionalTestResultResource.java
@@ -1,0 +1,13 @@
+package org.gradle.api.internal.tasks.testing.junit.report;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * This interface is inteded to be used in case a Testreport implementation allows to have additional Resources to be
+ * rendered within the Test report.
+ * @see org.gradle.api.internal.tasks.testing.junit.report.DefaultTestReport
+ */
+public interface IAdditionalTestResultResource {
+    List<File> findResources(TestResult test);
+}

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/AdditionalResourcesTestReportTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/AdditionalResourcesTestReportTest.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks.testing.junit.report
+
+import org.gradle.api.internal.tasks.testing.BuildableTestResultsProvider
+import org.gradle.api.internal.tasks.testing.junit.result.AggregateTestResultsProvider
+import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.ConfigureUtil
+import org.junit.Rule
+import spock.lang.Specification
+
+class AdditionalResourcesTestReportTest extends Specification {
+    @Rule
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestFile reportDir = tmpDir.file('report')
+    final File resourceFile1 = File.createTempFile('additionalResource', '.txt')
+    final File resourceFile2 = File.createTempFile('additionalResource', '.txt')
+    final DefaultTestReport report = new AdditionalResourcesTestReport(resourceFile1, resourceFile2)
+
+    def additionalResourcesProcessing() {
+        given:
+        def firstTestResults = aggregatedBuildResultsRun1()
+        when:
+        report.generateReport(new AggregateTestResultsProvider([firstTestResults]), reportDir)
+
+        then:
+        def passedClassFile = new HtmlTestResultsFixture(reportDir.file('classes/org.gradle.aggregation.FooTest.html'))
+        passedClassFile.assertHasTests(1)
+        assert passedClassFile.content.select("a[href=${resourceFile1.name}]").find { it.text() == resourceFile1.name }
+        assert passedClassFile.content.select("a[href=${resourceFile2.name}]").find { it.text() == resourceFile2.name }
+    }
+
+
+    TestResultsProvider buildResults(Closure closure) {
+        ConfigureUtil.configure(closure, new BuildableTestResultsProvider())
+    }
+
+    TestResultsProvider aggregatedBuildResultsRun1() {
+        buildResults {
+            testClassResult("org.gradle.aggregation.FooTest") {
+                testcase("first") {
+                    duration = 1000;
+                }
+            }
+        }
+    }
+
+}
+
+class AdditionalResourcesTestReport extends DefaultTestReport {
+    File[] resources
+
+    AdditionalResourcesTestReport(File... resources) {
+        this.resources = resources
+
+    }
+
+    @Override
+    protected List<IAdditionalTestResultResource> additionalResources() {
+        return [new IAdditionalTestResultResource() {
+            @Override
+            List<File> findResources(TestResult test) {
+                resources
+            }
+        }]
+    }
+}
+
+


### PR DESCRIPTION
Beeing able to render additional test results within a Testreport, could give users the chance to include other resources that have been created into one test report.
My for this is when running Geb functional UI Tests, the results that Geb can produce are the screenshots of the Application. 
Also downloaded files generated by the WebPage i.e. documents, XML files and others can be included in the Testreport.

Howto use:
- extend the DefaultTestReport and overwrite 'additionalResource' method
- within the test configuration of your build.gradle set your testReporter to be used
- run your task and see the outcome in the testreport.
Here is an example of the generated testreport.

![testreport](https://cloud.githubusercontent.com/assets/3175859/5936652/e62ee7e4-a6e6-11e4-8713-dbce7e0ddc9b.png)

Here is the GebTestReport that I wrote to complete my modification:

<pre>
package ch.prospective.njc

import org.gradle.api.internal.tasks.testing.junit.report.DefaultTestReport
import org.gradle.api.internal.tasks.testing.junit.report.IAdditionalTestResultResource
import org.gradle.api.internal.tasks.testing.junit.report.TestResult

class GebTestReport extends DefaultTestReport {

    @Override
    protected List<IAdditionalTestResultResource> additionalResourceListeners() {
        return [new IAdditionalTestResultResource() {
            @Override
            List<File> findResources(TestResult test) {
                File classResultFolder = new File("build/geb-reports/${test.classResults.name.replaceAll('\\.', '/')}")
                List<File> result = []
                def testRFile = classResultFolder.listFiles().find {
                    it.name.contains(test.name.replaceAll("[^\\w\\s-]", "_"))
                }
                if (testRFile) {
                    String testResultFilePrefix = testRFile.name.substring(0, 3)
                    result = classResultFolder.listFiles(new FilenameFilter() {
                        @Override
                        boolean accept(File dir, String name) {
                            name.startsWith(testResultFilePrefix)
                        }
                    })
                }
                return result.sort { it.name }
            }
        }]
    }
}
</pre>

Would be nice to see this hook become part of gradle in the near future.


Thanks,
Detlef