### PR TITLE
Add origin to stacktrace lines

### DIFF
--- a/subprojects/internal-integ-testing/src/main/resources/logback.xml
+++ b/subprojects/internal-integ-testing/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
         <!-- encoders are assigned the type
      ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%xEx</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Logback has this nifty feature which can be very useful for debugging:

http://logback.qos.ch/manual/layouts.html#xThrowable

It essentially prints the JAR that the problem came from, like this:

```text
java.lang.NullPointerException
  at com.xyz.Wombat(Wombat.java:57) ~[wombat-1.3.jar:1.3]
  at  com.xyz.Wombat(Wombat.java:76) ~[wombat-1.3.jar:1.3]
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.5.0_06]
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39) ~[na:1.5.0_06]
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25) ~[na:1.5.0_06]
  at java.lang.reflect.Method.invoke(Method.java:585) ~[na:1.5.0_06]
  at org.junit.internal.runners.TestMethod.invoke(TestMethod.java:59) [junit-4.4.jar:na]
  at org.junit.internal.runners.MethodRoadie.runTestMethod(MethodRoadie.java:98) [junit-4.4.jar:na]
```

This makes it a lot easier to track down problems where the developer expects one version of a dependency to be used, but in reality another one is present on the classpath.