### PR TITLE
PatternSet.getAsExcludeSpec: don't exclude everything if there are no patterns

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/util/PatternSet.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/util/PatternSet.java
@@ -107,7 +107,7 @@ public class PatternSet implements AntBuilderAware, PatternFilterable {
         }
 
         public Spec<FileTreeElement> getAsSpec() {
-            return new AndSpec<FileTreeElement>(super.getAsSpec(), other.getAsSpec());
+            return Specs.and(super.getAsSpec(), other.getAsSpec());
         }
 
         public Object addToAntBuilder(Object node, String childNodeName) {
@@ -121,7 +121,7 @@ public class PatternSet implements AntBuilderAware, PatternFilterable {
     }
 
     public Spec<FileTreeElement> getAsSpec() {
-        return new AndSpec<FileTreeElement>(getAsIncludeSpec(), new NotSpec<FileTreeElement>(getAsExcludeSpec()));
+        return Specs.and(getAsIncludeSpec(), Specs.not(getAsExcludeSpec()));
     }
 
     public Spec<FileTreeElement> getAsIncludeSpec() {
@@ -132,7 +132,7 @@ public class PatternSet implements AntBuilderAware, PatternFilterable {
         }
 
         matchers.addAll(includeSpecs);
-        return new OrSpec<FileTreeElement>(matchers);
+        return Specs.or(matchers);
     }
 
     public Spec<FileTreeElement> getAsExcludeSpec() {
@@ -146,7 +146,7 @@ public class PatternSet implements AntBuilderAware, PatternFilterable {
         }
 
         matchers.addAll(excludeSpecs);
-        return new OrSpec<FileTreeElement>(matchers);
+        return Specs.or(matchers);
     }
 
     public Set<String> getIncludes() {

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/util/PatternSet.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/util/PatternSet.java
@@ -146,7 +146,7 @@ public class PatternSet implements AntBuilderAware, PatternFilterable {
         }
 
         matchers.addAll(excludeSpecs);
-        return Specs.or(matchers);
+        return Specs.or(false, matchers);
     }
 
     public Set<String> getIncludes() {


### PR DESCRIPTION
It is normally impossible to have no exclude patterns, because `DirectoryScanner.getDefaultExcludes()` is always added to their list. However, it can happen if Ant's global exclude list is emptied by the user beforehand.

In GRADLE-1883, the workaround by Björn Kautler contains this rather unnatural part:

```groovy
DirectoryScanner.addDefaultExclude 'something has to be in here or everything gets excluded'
```

This PR removes the need for that.