### PR TITLE
Configure the scala compile classpath from a project extension

### DIFF
--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaProjectIntegrationTest.java
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaProjectIntegrationTest.java
@@ -32,4 +32,14 @@ public class ScalaProjectIntegrationTest extends AbstractIntegrationTest {
         inTestDirectory().withTasks("build").run();
         testFile("build/libs/javaOnly.jar").assertExists();
     }
+
+    @Test
+    public void supportsScalaVersionConfiguration() {
+        testFile("src/main/scala/somepackage/SomeClass.scala").writelns("class SomeClass { }");
+        testFile("build.gradle").writelns("apply plugin: 'scala'", "scala { version = '2.11.5' }");
+        testFile("settings.gradle").write("rootProject.name='scala'");
+        inTestDirectory().withTasks("build").run();
+        testFile("build/libs/scala_2.11.jar").assertExists();
+    }
+
 }

--- a/subprojects/scala/src/main/groovy/org/gradle/api/plugins/scala/ScalaLibraryExtension.groovy
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/plugins/scala/ScalaLibraryExtension.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradle.api.plugins.scala
 
 import org.gradle.api.Project

--- a/subprojects/scala/src/main/groovy/org/gradle/api/plugins/scala/ScalaLibraryExtension.groovy
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/plugins/scala/ScalaLibraryExtension.groovy
@@ -1,0 +1,67 @@
+package org.gradle.api.plugins.scala
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+
+import java.util.regex.Pattern
+
+/**
+ * Alternative mechanism to configure the scala runtime version, rather than deriving it from the compile configuration.
+ * This crystallises existing conventions into a standard mechanism, providing the scala binary version for other dependencies.
+ * It does not necessarily supersede the existing ScalaRuntime extension.
+ *
+ * <p>Example usage:
+ *
+ * <pre autoTested="">
+ *     apply plugin: "scala"
+ *
+ *     repositories {*         mavenCentral()
+ *}*
+ *     scala {*         version = '2.11.5'
+ *}*
+ *     dependencies {*         compile "org.scalatest:scalatest_${scala.binaryVersion}:2.2.4"
+ *}* </pre>
+ */
+class ScalaLibraryExtension {
+
+    static String scalaVersionProperty = 'scalaVersion'
+    static String scalaComponentsProperty = 'scalaComponents'
+    private static Pattern scalaVersionPattern = ~/(\d+\.\d+)\.\d+/
+
+    String version = ""
+    Boolean publishVersion = true
+    List<String> additionalComponents = []
+
+    ScalaLibraryExtension(Project project) {
+        if (project.hasProperty(scalaVersionProperty)) {
+            version = project.property(scalaVersionProperty) as String
+        }
+        if (project.hasProperty(scalaComponentsProperty)) {
+            additionalComponents = project.property(scalaComponentsProperty) as List<String>
+        }
+        project.afterEvaluate { p ->
+            def scala = p.scala
+            if (scala.version) {
+                p.dependencies.add(JavaPlugin.COMPILE_CONFIGURATION_NAME, [group: 'org.scala-lang', name:'scala-library', version: scala.version])
+                if (additionalComponents) {
+                    scala.additionalComponents.each { component ->
+                        p.dependencies.add(JavaPlugin.COMPILE_CONFIGURATION_NAME, [group: 'org.scala-lang', name: "scala-$component", version: scala.version])
+                    }
+                }
+                if (publishVersion) {
+                    p.archivesBaseName += "_${scala.binaryVersion}"
+                }
+            }
+        }
+    }
+
+    def getBinaryVersion() {
+        def match = (version =~ scalaVersionPattern)
+        if (match.matches()) {
+            match.group(1)
+        } else {
+            ""
+        }
+    }
+
+}

--- a/subprojects/scala/src/main/groovy/org/gradle/api/plugins/scala/ScalaPlugin.groovy
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/plugins/scala/ScalaPlugin.groovy
@@ -22,6 +22,9 @@ import org.gradle.api.tasks.scala.ScalaDoc
 import org.gradle.api.plugins.JavaBasePlugin
 
 public class ScalaPlugin implements Plugin<Project> {
+
+    public static final String SCALA_LIBRARY_EXTENSION_NAME = "scala"
+
     // tasks
     public static final String SCALA_DOC_TASK_NAME = "scaladoc";
 
@@ -30,6 +33,7 @@ public class ScalaPlugin implements Plugin<Project> {
         project.pluginManager.apply(JavaPlugin);
 
         configureScaladoc(project);
+        configureScalaLibraryExtension(project);
     }
 
     private void configureScaladoc(final Project project) {
@@ -40,5 +44,9 @@ public class ScalaPlugin implements Plugin<Project> {
         ScalaDoc scalaDoc = project.tasks.create(SCALA_DOC_TASK_NAME, ScalaDoc.class)
         scalaDoc.description = "Generates Scaladoc for the main source code.";
         scalaDoc.group = JavaBasePlugin.DOCUMENTATION_GROUP
+    }
+
+    private void configureScalaLibraryExtension(final Project project) {
+        project.extensions.create(SCALA_LIBRARY_EXTENSION_NAME, ScalaLibraryExtension, project)
     }
 }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaLibraryExtensionTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaLibraryExtensionTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradle.api.plugins.scala
 
 import org.gradle.jvm.tasks.Jar

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaLibraryExtensionTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaLibraryExtensionTest.groovy
@@ -1,0 +1,68 @@
+package org.gradle.api.plugins.scala
+
+import org.gradle.jvm.tasks.Jar
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ScalaLibraryExtensionTest extends Specification {
+
+    def project = TestUtil.createRootProject()
+
+    def setup() {
+        project.pluginManager.apply(ScalaPlugin)
+    }
+
+    @Unroll
+    def "determines the binary version #binaryVersion from library #libraryVersion"(String libraryVersion, String binaryVersion) {
+        when:
+        project.scala.version = libraryVersion
+        then:
+        project.scala.binaryVersion == binaryVersion
+        where:
+        libraryVersion << [ '2.10.4', '2.10.5', '2.11.0', '2.12.0' ]
+        binaryVersion  << [ '2.10',   '2.10',   '2.11',   '2.12' ]
+    }
+
+    def "additional components are added as compile dependencies"() {
+        given:
+        project.scala.version = '2.10.5'
+        project.scala.additionalComponents = ['xml']
+        when:
+        project.evaluate()
+        then:
+        project.configurations.compile.dependencies.matching { it.group == 'org.scala-lang' && it.name == 'scala-xml' && it.version == '2.10.5' }
+    }
+
+    def "scala-library is added as a compile dependency"() {
+        given:
+        project.scala.version = '2.10.5'
+        when:
+        project.evaluate()
+        then:
+        project.configurations.compile.dependencies.matching { it.group == 'org.scala-lang' && it.name == 'scala-library' && it.version == '2.10.5' }
+    }
+
+    def "scala binary version is appended to artifact name"() {
+        given:
+        project.scala.version = '2.11.0'
+        when:
+        project.evaluate()
+        then:
+        project.tasks.withType(Jar) {
+            assert(it.baseName.endsWith('_2.11'))
+        }
+    }
+
+    def "publishVersion prevents appending of scala binary version to artifact name"() {
+        given:
+        project.scala.version = '2.11.0'
+        project.scala.publishVersion = false
+        when:
+        project.evaluate()
+        then:
+        project.tasks.withType(Jar) {
+            assert(it.baseName == project.name)
+        }
+    }
+}

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
@@ -26,6 +26,7 @@ import org.junit.Test
 
 import static org.gradle.api.tasks.TaskDependencyMatchers.dependsOn
 import static org.gradle.util.WrapUtil.toLinkedSet
+import static org.gradle.util.WrapUtil.toList
 import static org.hamcrest.Matchers.*
 import static org.junit.Assert.assertThat
 import static org.junit.Assert.assertTrue
@@ -37,6 +38,14 @@ class ScalaPluginTest {
     @Test void appliesTheJavaPluginToTheProject() {
         scalaPlugin.apply(project)
         assertTrue(project.getPlugins().hasPlugin(JavaPlugin))
+    }
+
+    @Test void addsScalaLibraryExtensionToTheProject() {
+        scalaPlugin.apply(project)
+        def extension = project.extensions.getByName(ScalaPlugin.SCALA_LIBRARY_EXTENSION_NAME) as ScalaLibraryExtension
+        assertThat(extension.version, equalTo(""))
+        assertThat(extension.binaryVersion, equalTo(""))
+        assertThat(extension.additionalComponents, equalTo(toList()))
     }
 
     @Test void addsScalaConventionToEachSourceSetAndAppliesMappings() {


### PR DESCRIPTION
Hi,

Scala projects generally need to know their 'binary-compatible' version, so that they can define the other scala libraries that they depend on.

This typically leads to a couple of project properties being defined, or a property and a method.

```
ext {
  scalaVersion = '2.11.5'
  scalaBinaryVersion = '2.11'
}

 archivesBaseName = "scalaproject_${scalaBinaryVersion}"

dependencies {
   compile 'org.scala-lang:scala-library:$scalaVersion'
   testCompile 'org.scalatest:scalatest_$scalaBinaryVersion:3.0.0-SNAP4'
}
```

This extension aims to formalise this mechanism, with the following being a direct equivalent:

```
scala {
  version = '2.11.5'
}
dependencies {
   testCompile 'org.scalatest:scalatest_${scala.binaryVersion}:3.0.0-SNAP4'
}
```

I think for backwards compatibility the extension should have no effect until a user explicitly states a scala version.

Does this sound like a useful extension to the existing ScalaPlugin?

Thanks,
Stu.