### PR TITLE
Set wrapper version on command-line

### DIFF
--- a/subprojects/build-init/src/main/groovy/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/groovy/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -21,6 +21,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.plugins.StartScriptGenerator;
+import org.gradle.api.internal.tasks.options.Option;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -203,6 +204,7 @@ public class Wrapper extends DefaultTask {
      * The version of the gradle distribution required by the wrapper. This is usually the same version of Gradle you
      * use for building your project.
      */
+    @Option(option = "gradle-version", description = "The version of the Gradle distribution required by the wrapper.")
     public void setGradleVersion(String gradleVersion) {
         this.gradleVersion = GradleVersion.version(gradleVersion);
     }
@@ -230,6 +232,7 @@ public class Wrapper extends DefaultTask {
         }
     }
 
+    @Option(option = "gradle-distribution-url", description = "The URL to download the gradle distribution from.")
     public void setDistributionUrl(String url) {
         this.distributionUrl = url;
     }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -138,6 +138,24 @@ The `useVersion()` method is also deprecated. You can use the `useTarget()` meth
 
 Note that `ModuleComponentSelector` has a `module` property to return the module's name, while `ModuleVersionSelector` had a `name` property.
 
+### Generate wrapper with specific version from command-line
+
+Previously to generate a Gradle wrapper with a specific version, or a custom distribution URL,
+you had to add a task in `build.gradle`:
+
+    task wrapper (type: Wrapper) {
+        gradleVersion = "2.3"
+    }
+
+Now you can specify the version or the distribution URL from the command-line, without having
+to add the task in `build.gradle`:
+
+    gradle wrapper --gradle-version 2.3
+
+And with a distribution URL:
+
+    gradle wrapper --gradle-distribution-url https://services.gradle.org/distributions/gradle-2.3-bin.zip
+
 ## Potential breaking changes
 
 ### Model DSL changes
@@ -197,7 +215,8 @@ We would like to thank the following community members for making contributions 
 * [Daniel Siwiec](https://github.com/danielsiwiec) - update `README.md`
 * [Andreas Schmid](https://github.com/aaschmid) - add test coverage for facet type configuration in `GenerateEclipseWtpFacet`
 * [Roman Donchenko](https://github.com/SpecLad) - fix a bug in `org.gradle.api.specs.OrSpecTest`
-* [Lorant Pinter](https://github.com/lptr), [Daniel Vigovszky](https://github.com/vigoo) and [Mark Vujevits](https://github.com/vujevits),  - implement dependency substitution for projects
+* [Lorant Pinter](https://github.com/lptr), [Daniel Vigovszky](https://github.com/vigoo) and [Mark Vujevits](https://github.com/vujevits) - implement dependency substitution for projects
+* [Lorant Pinter](https://github.com/lptr) - add setting wrapper version on command-line
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](http://gradle.org/contribute).
 

--- a/subprojects/docs/src/docs/userguide/gradleWrapper.xml
+++ b/subprojects/docs/src/docs/userguide/gradleWrapper.xml
@@ -28,7 +28,15 @@
         build your project) as it requires no configuration on the server.
     </para>
     <para>
-        You install the wrapper into your project by adding and configuring a <apilink class="org.gradle.api.tasks.wrapper.Wrapper"/> 
+        You install the wrapper into your project by running the <literal>wrapper</literal> task. (This task is always available, even if
+        you don't add it to your build.) To specify a Gradle version use <literal>--gradle-version</literal> on the command-line.
+        You can also set the URL to download Gradle from directly via <literal>--gradle-distribution-url</literal>.
+    </para>
+    <sample id="wrapperCommandLine" dir="userguide/wrapper/simple" title="Running the wrapper task">
+        <output args="wrapper --gradle-version 2.0"/>
+    </sample>
+    <para>
+        The wrapper can be further customized by adding and configuring a <apilink class="org.gradle.api.tasks.wrapper.Wrapper"/>
         task in your build script, and then executing it.
     </para>
     <sample id="wrapperSimple" dir="userguide/wrapper/simple" title="Wrapper task">

--- a/subprojects/docs/src/samples/userguideOutput/wrapperCommandLine.out
+++ b/subprojects/docs/src/samples/userguideOutput/wrapperCommandLine.out
@@ -1,0 +1,5 @@
+:wrapper
+
+BUILD SUCCESSFUL
+
+Total time: 1 secs

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -20,15 +20,13 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.TextUtil
 
 class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
-    def setup() {
+    def "generated wrapper scripts use correct line separators"() {
         buildFile << """
             wrapper {
                 distributionUrl = 'http://localhost:8080/gradlew/dist'
             }
         """
-    }
 
-    def "generated wrapper scripts use correct line separators"() {
         when:
         run "wrapper"
 
@@ -39,11 +37,33 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "wrapper jar is small"() {
+        buildFile << """
+            wrapper {
+                distributionUrl = 'http://localhost:8080/gradlew/dist'
+            }
+        """
+
         when:
         run "wrapper"
 
         then:
         // wrapper needs to be small. Let's check it's smaller than some arbitrary 'small' limit
         file("gradle/wrapper/gradle-wrapper.jar").length() < 52 * 1024
+    }
+
+    def "generated wrapper scripts for given version from command-line"() {
+        when:
+        run "wrapper", "--gradle-version", "2.2.1"
+
+        then:
+        file("gradle/wrapper/gradle-wrapper.properties").text.split(TextUtil.unixLineSeparator).contains("distributionUrl=https\\://services.gradle.org/distributions/gradle-2.2.1-bin.zip")
+    }
+
+    def "generated wrapper scripts for given distribution URL from command-line"() {
+        when:
+        run "wrapper", "--gradle-distribution-url", "http://localhost:8080/gradlew/dist"
+
+        then:
+        file("gradle/wrapper/gradle-wrapper.properties").text.split(TextUtil.unixLineSeparator).contains("distributionUrl=http\\://localhost\\:8080/gradlew/dist")
     }
 }


### PR DESCRIPTION
Can now do:

    gradle wrapper --gradle-version 2.0

...without having a `Wrapper` task in `build.gradle`.