### PR TITLE
Allow sonatypeSnapshot() to be specified in a repositories block

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -175,6 +175,23 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
     MavenArtifactRepository mavenCentral();
 
     /**
+     * Adds a repository which looks in the Sonatype snapshots repository for dependencies. The URL used to access this repository is
+     * {@value org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler#SONATYPE_SNAPSHOT_URL}. The name of the repository is
+     * {@value org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler#DEFAULT_SONATYPE_SNAPSHOT_REPO_NAME}.
+     *
+     * <p>Examples:
+     * <pre autoTested="">
+     * repositories {
+     *     sonatypeSnapshot()
+     * }
+     * </pre>
+     * </p>
+     *
+     * @return the added resolver
+     */
+    MavenArtifactRepository sonatypeSnapshot();
+
+    /**
      * Adds a repository which looks in the local Maven cache for dependencies. The name of the repository is
      * {@value org.gradle.api.artifacts.ArtifactRepositoryContainer#DEFAULT_MAVEN_LOCAL_REPO_NAME}.
      *

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/BaseRepositoryFactory.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/BaseRepositoryFactory.java
@@ -31,6 +31,8 @@ public interface BaseRepositoryFactory {
 
     MavenArtifactRepository createMavenCentralRepository();
 
+    MavenArtifactRepository createSonatypeSnapshotRepository();
+
     IvyArtifactRepository createIvyRepository();
 
     MavenArtifactRepository createMavenRepository();

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -37,6 +37,9 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
     public static final String DEFAULT_BINTRAY_JCENTER_REPO_NAME = "BintrayJCenter";
     public static final String BINTRAY_JCENTER_URL = "https://jcenter.bintray.com/";
 
+    public static final String DEFAULT_SONATYPE_SNAPSHOT_REPO_NAME = "Sonatype Snapshot";
+    public static final String SONATYPE_SNAPSHOT_URL = "https://oss.sonatype.org/content/repositories/snapshots/";
+
     public static final String FLAT_DIR_DEFAULT_NAME = "flatDir";
     private static final String MAVEN_REPO_DEFAULT_NAME = "maven";
     private static final String IVY_REPO_DEFAULT_NAME = "ivy";
@@ -79,6 +82,11 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
     public MavenArtifactRepository mavenCentral(Map<String, ?> args) {
         Map<String, Object> modifiedArgs = new HashMap<String, Object>(args);
         return addRepository(repositoryFactory.createMavenCentralRepository(), DEFAULT_MAVEN_CENTRAL_REPO_NAME, new ConfigureByMapAction<MavenArtifactRepository>(modifiedArgs));
+    }
+
+    @Override
+    public MavenArtifactRepository sonatypeSnapshot() {
+        return addRepository(repositoryFactory.createSonatypeSnapshotRepository(), DEFAULT_SONATYPE_SNAPSHOT_REPO_NAME);
     }
 
     public MavenArtifactRepository mavenLocal() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandlerTest.groovy
@@ -79,6 +79,16 @@ class DefaultRepositoryHandlerTest extends DefaultArtifactRepositoryContainerTes
         handler.mavenCentral(artifactUrls: ["abc"]).is(repository)
     }
 
+    public void testSonatypeSnapshot() {
+        when:
+        MavenArtifactRepository repository = Mock(TestMavenArtifactRepository)
+        1 * repositoryFactory.createSonatypeSnapshotRepository() >> repository
+        repository.getName() >> "name"
+
+        then:
+        handler.sonatypeSnapshot().is(repository)
+    }
+
     def testMavenLocalWithNoArgs() {
         when:
         MavenArtifactRepository repository = Mock(TestMavenArtifactRepository)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -86,6 +86,13 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
         return mavenRepository;
     }
 
+    @Override
+    public MavenArtifactRepository createSonatypeSnapshotRepository() {
+        MavenArtifactRepository mavenRepository = createMavenRepository();
+        mavenRepository.setUrl(DefaultRepositoryHandler.SONATYPE_SNAPSHOT_URL);
+        return mavenRepository;
+    }
+
     public IvyArtifactRepository createIvyRepository() {
         return instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory,
                 locallyAvailableResourceFinder, instantiator, resolverStrategy, artifactFileStore);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -90,6 +90,19 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
         repo.url == centralUrl
     }
 
+    def testCreateSonatypeSnapshotRepo() {
+        given:
+        def snapshotUrl = new URI(DefaultRepositoryHandler.SONATYPE_SNAPSHOT_URL)
+
+        when:
+        fileResolver.resolveUri(DefaultRepositoryHandler.SONATYPE_SNAPSHOT_URL) >> snapshotUrl
+
+        then:
+        def repo = factory.createSonatypeSnapshotRepository()
+        repo instanceof DefaultMavenArtifactRepository
+        repo.url == snapshotUrl
+    }
+
     def createIvyRepository() {
         expect:
         def repo = factory.createIvyRepository()


### PR DESCRIPTION
This allows for easier addition of the Sonatype Snapshots repository, which, from my experience, is used quite a bit in some cases.