### PR TITLE
Documented need to check IncrementalTaskInputs.incremental

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/incremental/IncrementalTaskInputs.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/incremental/IncrementalTaskInputs.java
@@ -37,6 +37,9 @@ import org.gradle.api.NonExtensible;
  *
  *      @TaskAction
  *      void execute(IncrementalTaskInputs inputs) {
+ *          if (!inputs.incremental)
+ *              outputDir.deleteDir()
+ *
  *          inputs.outOfDate { change ->
  *              def targetFile = project.file("$outputDir/${change.file.name}")
  *              targetFile.text = change.file.text.reverse()

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/incremental/IncrementalTaskInputs.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/incremental/IncrementalTaskInputs.java
@@ -38,7 +38,7 @@ import org.gradle.api.NonExtensible;
  *      @TaskAction
  *      void execute(IncrementalTaskInputs inputs) {
  *          if (!inputs.incremental)
- *              outputDir.deleteDir()
+ *              project.delete(outputDir.listFiles())
  *
  *          inputs.outOfDate { change ->
  *              def targetFile = project.file("$outputDir/${change.file.name}")

--- a/subprojects/docs/src/docs/userguide/customTasks.xml
+++ b/subprojects/docs/src/docs/userguide/customTasks.xml
@@ -196,6 +196,11 @@
                 <sourcefile file="build.gradle" snippet="incremental-task" />
             </sample>
             <para>
+                If for some reason the task is not run incremental, e.g. by running with --rerun-tasks, only the
+                outOfDate action is executed, even if there where deleted input files. You should consider handling this
+                case at the beginning, as is done in the example above.
+            </para>
+            <para>
                 For a simple transformer task like this, the task action simply needs to generate output files for any out-of-date inputs,
                 and delete output files for any removed inputs.
             </para>

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/build.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/build.gradle
@@ -47,6 +47,11 @@ class IncrementalReverseTask extends DefaultTask {
     void execute(IncrementalTaskInputs inputs) {
         println inputs.incremental ? "CHANGED inputs considered out of date"
                                    : "ALL inputs considered out of date"
+        // START SNIPPET handle-non-incremental-inputs
+        if (!inputs.incremental)
+            outputDir.deleteDir()
+        // END SNIPPET handle-non-incremental-inputs
+
         // START SNIPPET out-of-date-inputs
         inputs.outOfDate { change ->
             println "out of date: ${change.file.name}"

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/build.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/build.gradle
@@ -49,7 +49,7 @@ class IncrementalReverseTask extends DefaultTask {
                                    : "ALL inputs considered out of date"
         // START SNIPPET handle-non-incremental-inputs
         if (!inputs.incremental)
-            outputDir.deleteDir()
+            project.delete(outputDir.listFiles())
         // END SNIPPET handle-non-incremental-inputs
 
         // START SNIPPET out-of-date-inputs


### PR DESCRIPTION
I use IncrementalTaskInputs a lot, but until recently did never check for
inputs.incremental to cleanup before doing any work. This resulted in stale
files still laying around in the output dir, because I thought
inputs.removed() would take care of this. This is wrong. The documentation
just did not state clearly enough this is necessary.