### PR TITLE
Ide plugins respect substituted projects

### DIFF
--- a/design-docs/dependency-substitution.md
+++ b/design-docs/dependency-substitution.md
@@ -140,6 +140,12 @@ external dependency, the correct tasks are included for execution:
 
 ## Story: IDE plugins include correct set of projects based on dependency substitution
 
+### Test coverage
+
+- For both IDEA and Eclipse plugins:
+    - external dependency replaced with subproject is shown as project dependency in IDE
+    - subproject replaced with external dependency is shown as external dependency in IDE
+
 # Feature: Improve the dependency substitution rule DSL
 
 ## Story: Declare substitution rules that apply to all resolution for a project

--- a/design-docs/dependency-substitution.md
+++ b/design-docs/dependency-substitution.md
@@ -140,6 +140,14 @@ external dependency, the correct tasks are included for execution:
 
 ## Story: IDE plugins include correct set of projects based on dependency substitution
 
+Newly introduced dependency substitutions should work in both IntelliJ and Eclipse. The IDEs
+should be able to recognize when an external dependency is replaced with a local project or
+vice versa.
+
+### Implementation
+
+No need to add new functionality, this should already work due to the changes in other stories.
+
 ### Test coverage
 
 - For both IDEA and Eclipse plugins:

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -364,6 +364,17 @@ idea.project {
         hasProjectLibrary("root.ipr", "someLib", ["someClasses.jar"], ["someJavadoc.jar"], ["someSources.jar"])
     }
 
+    @Test
+    void canDetectSubstitutedProjectDependency() {
+        executer.withTasks('idea').run()
+
+        assertHasExpectedContents('root.ipr')
+        assertHasExpectedContents('root.iws')
+        assertHasExpectedContents('root.iml')
+        assertHasExpectedContents('api/api.iml')
+        assertHasExpectedContents('impl/impl.iml')
+    }
+
     private void assertHasExpectedContents(String path) {
         TestFile file = testDirectory.file(path).assertIsFile()
         TestFile expectedFile = testDirectory.file("expectedFiles/${path}.xml").assertIsFile()

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -368,10 +368,13 @@ idea.project {
     void canDetectSubstitutedProjectDependency() {
         executer.withTasks('idea').run()
 
-        assertHasExpectedContents('root.ipr')
-        assertHasExpectedContents('root.iws')
-        assertHasExpectedContents('root.iml')
-        assertHasExpectedContents('api/api.iml')
+        assertHasExpectedContents('impl/impl.iml')
+    }
+
+    @Test
+    void canDetectSubstitutedExternalDependency() {
+        executer.withTasks('idea').run()
+
         assertHasExpectedContents('impl/impl.iml')
     }
 

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedExternalDependency/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedExternalDependency/build.gradle
@@ -1,0 +1,22 @@
+allprojects {
+	apply plugin: "java"
+	apply plugin: "idea"
+}
+
+project(":impl") {
+	repositories {
+		mavenCentral()
+	}
+
+	dependencies {
+		compile project(":api")
+	}
+
+	configurations.all {
+		resolutionStrategy.eachDependency {
+			if (it.requested.name == 'api') {
+				it.useTarget "junit:junit:4.7"
+			}
+		}
+	}
+}

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedExternalDependency/expectedFiles/impl/impl.iml.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedExternalDependency/expectedFiles/impl/impl.iml.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module relativePaths="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output/>
+    <orderEntry type="inheritedJdk"/>
+    <content url="file://$MODULE_DIR$/">
+      <excludeFolder url="file://$MODULE_DIR$/build"/>
+      <excludeFolder url="file://$MODULE_DIR$/.gradle"/>
+    </content>
+    <orderEntry type="sourceFolder" forTests="false"/>
+    <orderEntry type="module-library" exported="">
+      <library>
+        <CLASSES>
+          <root url="jar://@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar!/"/>
+        </CLASSES>
+        <JAVADOC/>
+        <SOURCES>
+          <root url="jar://@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar!/"/>
+        </SOURCES>
+      </library>
+    </orderEntry>
+  </component>
+  <component name="ModuleRootManager"/>
+</module>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedExternalDependency/settings.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedExternalDependency/settings.gradle
@@ -1,0 +1,3 @@
+include "api", "impl"
+
+rootProject.name = 'root'

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedProjectDependency/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedProjectDependency/build.gradle
@@ -1,0 +1,20 @@
+allprojects {
+	apply plugin: "java"
+	apply plugin: "idea"
+	group "org.utils"
+	version = "1.6"
+}
+
+project(":impl") {
+	dependencies {
+		compile group: "org.utils", name: "api", version: "1.5"
+	}
+
+	configurations.all {
+		resolutionStrategy.eachDependency {
+			if (it.requested.name == 'api') {
+				it.useTarget project(":api")
+			}
+		}
+	}
+}

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedProjectDependency/expectedFiles/impl/impl.iml.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedProjectDependency/expectedFiles/impl/impl.iml.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module relativePaths="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output/>
+    <orderEntry type="inheritedJdk"/>
+    <content url="file://$MODULE_DIR$/">
+      <excludeFolder url="file://$MODULE_DIR$/build"/>
+      <excludeFolder url="file://$MODULE_DIR$/.gradle"/>
+    </content>
+    <orderEntry type="sourceFolder" forTests="false"/>
+    <orderEntry type="module" module-name="api" exported=""/>
+  </component>
+  <component name="ModuleRootManager"/>
+</module>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedProjectDependency/settings.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canDetectSubstitutedProjectDependency/settings.gradle
@@ -1,0 +1,3 @@
+include "api", "impl"
+
+rootProject.name = 'root'


### PR DESCRIPTION
This is a piece of the PR #403 that contains only the tests for IDE integration regarding substituted project dependencies. This should already work with master, and can thus be merged independently.

- IDEA
    - [x] external dependency replaced with subproject is shown as project dependency in IDE
    - [ ] transitive external dependency replaced with subproject is shown as project dependency in IDE
    - [x] subproject replaced with external dependency is shown as external dependency in IDE
- Eclipse
    - [x] external dependency replaced with subproject is shown as project dependency in IDE
    - [ ] transitive external dependency replaced with subproject is shown as project dependency in IDE
    - [x] subproject replaced with external dependency is shown as external dependency in IDE
- [ ] update spec with transitive replacement test case