### PR TITLE
Always pass -sourcepath to javac, allow to configure it in CompileOption..s

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -29,6 +29,7 @@ import org.codehaus.groovy.tools.javac.JavaAwareCompilationUnit;
 import org.codehaus.groovy.tools.javac.JavaCompiler;
 import org.codehaus.groovy.tools.javac.JavaCompilerFactory;
 import org.gradle.api.GradleException;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
 import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.specs.Spec;
@@ -127,8 +128,11 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
                         } else {
                             // When annotation processing isn't required, it's better to add the Groovy stubs as part of the source path.
                             // This allows compilations to complete faster, because only the Groovy stubs that are needed by the java source are compiled.
-                            spec.getCompileOptions().getCompilerArgs().add("-sourcepath");
-                            spec.getCompileOptions().getCompilerArgs().add(stubDir.getAbsolutePath());
+                            FileCollection sourcepath = new SimpleFileCollection(stubDir);
+                            if (spec.getCompileOptions().getSourcepath() != null) {
+                                sourcepath = spec.getCompileOptions().getSourcepath().plus(sourcepath);
+                            }
+                            spec.getCompileOptions().setSourcepath(sourcepath);
                         }
 
                         spec.setSource(spec.getSource().filter(new Spec<File>() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -55,4 +55,34 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         then:
         file("build/classes/main/Foo.class").exists()
     }
+
+    def "don't implicitly compile source files from classpath"() {
+        settingsFile << "include 'a', 'b'"
+        buildFile << """
+            subprojects {
+                apply plugin: 'java'
+            }
+            project(':b') {
+                dependencies {
+                    compile project(':a')
+                }
+            }
+"""
+
+        file("a/src/main/resources/Foo.java") << "public class Foo {}"
+
+        file("b/src/main/java/Bar.java") << "public class Bar extends Foo {}"
+
+        expect:
+        fails("compileJava")
+        failure.assertHasDescription("Execution failed for task ':b:compileJava'.")
+
+        // This makes sure the test above is correct AND you can get back javac's default behavior if needed
+        when:
+        buildFile << "project(':b').compileJava { options.sourcepath = classpath }"
+        run("compileJava")
+        then:
+        file("b/build/classes/main/Bar.class").exists()
+        file("b/build/classes/main/Foo.class").exists()
+    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -136,6 +136,12 @@ public class JavaCompilerArgumentsBuilder {
             args.add("-extdirs");
             args.add(compileOptions.getExtensionDirs());
         }
+        FileCollection sourcepath = compileOptions.getSourcepath();
+        Iterable<File> classpath = spec.getClasspath();
+        if ((sourcepath != null && !sourcepath.isEmpty()) || !includeClasspath || (classpath != null && classpath.iterator().hasNext())) {
+            args.add("-sourcepath");
+            args.add(sourcepath == null ? "" : sourcepath.getAsPath());
+        }
         if (compileOptions.getCompilerArgs() != null) {
             args.addAll(compileOptions.getCompilerArgs());
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.compile;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.Incubating;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
@@ -67,6 +68,8 @@ public class CompileOptions extends AbstractOptions {
     private List<String> compilerArgs = Lists.newArrayList();
 
     private boolean incremental;
+
+    private FileCollection sourcepath;
 
     /**
      * Tells whether to fail the build when compilation fails. Defaults to {@code true}.
@@ -388,6 +391,26 @@ public class CompileOptions extends AbstractOptions {
     @Incubating
     public boolean isIncremental() {
         return incremental;
+    }
+
+    /**
+     * Returns the sourcepath to use to compile the source files.
+     *
+     * @return The sourcepath.
+     */
+    @Input
+    @Optional
+    public FileCollection getSourcepath() {
+        return sourcepath;
+    }
+
+    /**
+     * Sets the sourcepath to use to compile the source files.
+     *
+     * @param sourcepath The sourcepath. Must not be null, but may be empty.
+     */
+    public void setSourcepath(FileCollection sourcepath) {
+        this.sourcepath = sourcepath;
     }
 }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CommandLineJavaCompilerArgumentsGeneratorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CommandLineJavaCompilerArgumentsGeneratorTest.groovy
@@ -34,7 +34,7 @@ class CommandLineJavaCompilerArgumentsGeneratorTest extends Specification {
         def args = argsGenerator.generate(spec)
 
         then:
-        Lists.newArrayList(args) == ["-J-Xmx256m", "-g", "-classpath", spec.classpath.asPath, *spec.source*.path]
+        Lists.newArrayList(args) == ["-J-Xmx256m", "-g", "-sourcepath", "", "-classpath", spec.classpath.asPath, *spec.source*.path]
     }
 
     def "creates arguments file if arguments get too long"() {
@@ -48,7 +48,7 @@ class CommandLineJavaCompilerArgumentsGeneratorTest extends Specification {
         Lists.newArrayList(args) == ["-J-Xmx256m", "@$argsFile"]
 
         and: "args file contains remaining arguments (one per line, quoted)"
-        argsFile.readLines() == ["-g", "-classpath", quote("$spec.classpath.asPath"), *(spec.source*.path.collect { quote(it) })]
+        argsFile.readLines() == ["-g", "-sourcepath", "", "-classpath", quote("$spec.classpath.asPath"), *(spec.source*.path.collect { quote(it) })]
     }
 
     def createCompileSpec(numFiles) {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -158,7 +158,7 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         spec.classpath = [file1, file2]
 
         expect:
-        builder.build() == ["-g", "-classpath", "$file1$File.pathSeparator$file2"]
+        builder.build() == ["-g", "-sourcepath", "", "-classpath", "$file1$File.pathSeparator$file2"]
     }
 
     def "adds custom compiler args"() {
@@ -200,13 +200,13 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         builder.includeClasspath(true)
 
         then:
-        builder.build() == ["-g", "-classpath", "$file1$File.pathSeparator$file2"]
+        builder.build() == ["-g", "-sourcepath", "", "-classpath", "$file1$File.pathSeparator$file2"]
 
         when:
         builder.includeClasspath(false)
 
         then:
-        builder.build() == ["-g"]
+        builder.build() == ["-g", "-sourcepath", ""]
     }
 
     def "includes classpath by default"() {
@@ -215,7 +215,7 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         spec.classpath = [file1, file2]
 
         expect:
-        builder.build() == ["-g", "-classpath", "$file1$File.pathSeparator$file2"]
+        builder.build() == ["-g", "-sourcepath", "", "-classpath", "$file1$File.pathSeparator$file2"]
     }
 
     def "can include/exclude launcher options"() {
@@ -272,5 +272,14 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
 
         expect:
         builder.build() == ["-g"]
+    }
+
+    def "generates -sourcepath option"() {
+        def file1 = new File("/lib/lib1.jar")
+        def file2 = new File("/lib/lib2.jar")
+        spec.compileOptions.sourcepath = new SimpleFileCollection(file1, file2)
+
+        expect:
+        builder.build() == ["-g", "-sourcepath", "/lib/lib1.jar:/lib/lib2.jar"]
     }
 }


### PR DESCRIPTION
By default, pass an empty sourcepath to avoid implicitly compiling
sources included as resources in dependencies on the classpath.

To get back to the default behavior of javac, one can use:

    compileJava.options.sourcepath = compileJava.classpath