### PR TITLE
New DSL for dependency substitution

### DIFF
--- a/design-docs/dependency-substitution.md
+++ b/design-docs/dependency-substitution.md
@@ -35,10 +35,20 @@ configurations.all {
                     }
                 }
             }
-            withModule("org.gradle:mylib") { DependencySubstitution<ModuleComponentSelector> dependency ->
+            eachModule { ModuleDependencySubstitution dependency ->
+                if (dependency.requested.name == ':api') {
+                    dependency.useVersion "1.3"
+                }
+            }
+            withModule("org.gradle:mylib") { ModuleDependencySubstitution dependency ->
                 dependency.useTarget project(":foo")
             }
-            withProject(":bar") { DependencySubstitution<ProjectComponentSelector> dependency ->
+            eachProject { ProjectDependencySubstitution dependency ->
+                if (dependency.requested.projectPath == ':api') {
+                    dependency.useTarget "org.gradle:another:1.+"
+                }
+            }
+            withProject(":bar") { ProjectDependencySubstitution dependency ->
                 dependency.useTarget "org.gradle:another:1.+"
             }
         }

--- a/design-docs/dependency-substitution.md
+++ b/design-docs/dependency-substitution.md
@@ -20,11 +20,18 @@ This is similar to the current situation when a project dependency is added to a
 ### User visible changes
 
 ```
-class DependencySubstitution<T extends ComponentSelector> {
+interface DependencySubstitution<T extends ComponentSelector> {
     T getRequested()
     void useTarget(Object notation)
 }
+
+interface ModuleDependencySubstitution extendsDependencySubstitution<ModuleComponentSelector> {
+    void useVersion(String version)
+}
     
+interface ProjectDependencySubstitution extendsDependencySubstitution<ProjectComponentSelector> {
+}
+
 configurations.all {
     resolutionStrategy {
         dependencySubstitution {
@@ -58,7 +65,11 @@ configurations.all {
 
 ### Implementation
 
-A description of how we plan to implement this.
+Introduce a new DSL that allows applying substitution rules on all dependencies, or only on modules or projects.
+Ability to substitute a single module or project should be provided as well.
+
+This new DSL supersedes `ResolutionStrategy.eachDependency()`, which in turn is deprecated. `DependencyResolveDetails` is
+deprecated, too, and replaced by the `DependencySubstitution` interface family.
 
 A few notes:
 
@@ -79,10 +90,12 @@ A few notes:
 - Additional dependency details (configuration, transitive, etc) are retained in substituted dependency
 - Real resolution of dependency files: pre-build the substituted project. (This test would later be modified to remove the pre-build step).
 - Dependency reports provide information on dependency substitution
+- Deprecation warnings are shown when `ResolutionStrategy.eachDependency` is used
+- New DSL works together with `ResolutionStrategy.force()` and the deprecated `ResolutionStrategy.eachDependency`
 
 ### Open issues
 
-This section is to keep track of assumptions and things we haven't figured out yet.
+- What happens if `DependencySubstitution.withModule()` is called with a module that is not a dependency? Same with `withProject()`.
 
 ## Story: Option to re-resolve Configuration when modified after resolution
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/DependencyResolveDetails.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/DependencyResolveDetails.java
@@ -23,62 +23,52 @@ import org.gradle.api.artifacts.component.ComponentSelector;
  * Provides details about a dependency when it is resolved.
  * Provides means to manipulate dependency metadata when it is resolved.
  *
- * @param <T> Component selector type.
  * @since 1.4
  */
+@Deprecated
 @Incubating
-public interface DependencyResolveDetails<T extends ComponentSelector> {
-
-    /**
-     * The component selector, before it is resolved.
-     * The requested component selector does not change even if there are multiple dependency resolve rules
-     * that manipulate the dependency metadata.
-     *
-     * @since 2.4
-     */
-    T getSelector();
+public interface DependencyResolveDetails {
 
     /**
      * The module, before it is resolved.
      * The requested module does not change even if there are multiple dependency resolve rules
      * that manipulate the dependency metadata.
-     *
-     * @deprecated Use {@link #getSelector()} instead.
      */
-    @Deprecated
     ModuleVersionSelector getRequested();
 
     /**
      * Allows to override the version when the dependency {@link #getRequested()} is resolved.
      * Can be used to select a version that is different than requested.
-     * Forcing modules via {@link org.gradle.api.artifacts.ResolutionStrategy#force(Object...)} uses this capability.
+     * Configuring a version different than requested will cause {@link #getTarget()} method
+     * return a target module with updated target version.
      * <p>
      * If you need to change not only the version but also group or name please use the {@link #useTarget(Object)} method.
      *
      * @param version to use when resolving this dependency, cannot be null.
      * It is valid to configure the same version as requested.
-     *
-     * @deprecated Use {@link #useTarget(Object)} instead.
      */
-    @Deprecated
     void useVersion(String version);
 
     /**
+     * Allows to override the details of the dependency (see {@link #getTarget()})
+     * when it is resolved (see {@link #getRequested()}).
      * This method can be used to change the dependency before it is resolved,
      * e.g. change group, name or version (or all three of them).
      * In many cases users are interested in changing the version.
      * For such scenario you can use the {@link #useVersion(String)} method.
      *
-     * @param notation the notation that gets parsed into an instance of {@link ComponentSelector}.
-     * You can pass:
-     * <ul>
-     *     <li>Strings like <code>"org.gradle:gradle-core:1.4"</code></li>
-     *     <li>Maps like <code>[group: 'org.gradle', name: 'gradle-core', version: '1.4']</code></li>
-     *     <li>instances of <code>ComponentSelector</code></li>
-     *     <li>{@link org.gradle.api.Project} instances with <code>project(":path")</code></li>
-     * </ul>
+     * @param notation the notation that gets parsed into an instance of {@link ModuleVersionSelector}.
+     * You can pass Strings like 'org.gradle:gradle-core:1.4',
+     * Maps like [group: 'org.gradle', name: 'gradle-core', version: '1.4'],
+     * or instances of ModuleVersionSelector.
      *
      * @since 1.5
      */
     void useTarget(Object notation);
+
+    /**
+     * The target module selector used to resolve the dependency.
+     * Never returns null. Target module is updated when methods like {@link #useVersion(String)} are used.
+     */
+    ComponentSelector getTarget();
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/DependencySubstitution.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/DependencySubstitution.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * Provides means to substitute a different dependency during resolution.
+ *
+ * @param <T> the type of the requested component.
+ *
+ * @since 2.4
+ */
+@Incubating
+@HasInternalProtocol
+public interface DependencySubstitution<T extends ComponentSelector> {
+    /**
+     * The dependency, before it is resolved.
+     * The requested dependency does not change even if there are multiple dependency substitution rules
+     * that manipulate the dependency metadata.
+     */
+    T getRequested();
+
+    /**
+     * This method can be used to replace a dependency before it is resolved,
+     * e.g. change group, name or version (or all three of them), or replace it
+     * with a project dependency.
+     *
+     * @param notation the notation that gets parsed into an instance of {@link ComponentSelector}.
+     * You can pass Strings like 'org.gradle:gradle-core:2.4',
+     * Maps like [group: 'org.gradle', name: 'gradle-core', version: '2.4'],
+     * Projects like <code>project(":api")</code>,
+     * or instances of <code>ModuleComponentSelector</code>.
+     */
+    void useTarget(Object notation);
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/DependencySubstitutions.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/DependencySubstitutions.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * Allows replacing dependencies with other dependencies.
+ *
+ * <pre>
+ * // add dependency substitution rules
+ * dependencySubstitution {
+ *   //specifying a fixed version for all libraries with 'org.gradle' group
+ *   eachModule { ModuleDependencySubstitution details ->
+ *     if (details.requested.group == 'org.gradle') {
+ *       details.useVersion '2.4'
+ *     }
+ *     //changing 'groovy-all' into 'groovy':
+ *     if (details.requested.name == 'groovy-all') {
+ *       details.useTarget group: details.requested.group, name: 'groovy', version: details.requested.version
+ *     }
+ *   }
+ * }
+ * </pre>
+ */
+@HasInternalProtocol
+@Incubating
+public interface DependencySubstitutions {
+    /**
+     * Adds a dependency substitution rule that is triggered for every dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link DependencySubstitution<ComponentSelector>}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    // TODO:PREZI Perhaps we should call this eachDependency(), as we do it for example in ResolutionRules?
+    DependencySubstitutions all(Action<? super DependencySubstitution<? super ComponentSelector>> rule);
+
+    /**
+     * Adds a dependency substitution rule that is triggered for every dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link DependencySubstitution<ComponentSelector>}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    DependencySubstitutions all(Closure<?> rule);
+
+    /**
+     * Adds a dependency substitution rule that is triggered for every module dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link ModuleDependencySubstitution}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    DependencySubstitutions eachModule(Action<? super ModuleDependencySubstitution> rule);
+
+    /**
+     * Adds a dependency substitution rule that is triggered for every module dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link ModuleDependencySubstitution}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    DependencySubstitutions eachModule(Closure<?> rule);
+
+    /**
+     * Adds a dependency substitution rule that is triggered for a given module dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link ModuleDependencySubstitution}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    DependencySubstitutions withModule(Object id, Action<? super ModuleDependencySubstitution> rule);
+
+    /**
+     * Adds a dependency substitution rule that is triggered for a given module dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link ModuleDependencySubstitution}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    DependencySubstitutions withModule(Object id, Closure<?> rule);
+
+    /**
+     * Adds a dependency substitution rule that is triggered for every project dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link ProjectDependencySubstitution}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    DependencySubstitutions eachProject(Action<? super ProjectDependencySubstitution> rule);
+
+    /**
+     * Adds a dependency substitution rule that is triggered for every project dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link ProjectDependencySubstitution}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    DependencySubstitutions eachProject(Closure<?> rule);
+
+    /**
+     * Adds a dependency substitution rule that is triggered for a given project dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link ProjectDependencySubstitution}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    DependencySubstitutions withProject(Object id, Action<? super ProjectDependencySubstitution> rule);
+
+    /**
+     * Adds a dependency substitution rule that is triggered for a given project dependency (including transitive)
+     * when the configuration is being resolved. The action receives an instance of {@link ProjectDependencySubstitution}
+     * that can be used to find out what dependency is being resolved and to influence the resolution process.
+     *
+     * The rules are evaluated in order they are declared. Rules are evaluated after forced modules are applied (see {@link ResolutionStrategy#force(Object...)}
+     *
+     * @return this
+     * @since 2.4
+     */
+    DependencySubstitutions withProject(Object id, Closure<?> rule);
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ModuleDependencySubstitution.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ModuleDependencySubstitution.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * Provides means to substitute a different dependency in place of a module dependency.
+ *
+ * @since 2.4
+ */
+@Incubating
+@HasInternalProtocol
+public interface ModuleDependencySubstitution extends DependencySubstitution<ModuleComponentSelector> {
+    /**
+     * Allows to override the version when the dependency {@link #getRequested()} is resolved.
+     * Can be used to select a version that is different than requested.
+     * Forcing modules via {@link ResolutionStrategy#force(Object...)} uses this capability.
+     * <p>
+     * If you need to change not only the version but also group or name please use the {@link #useTarget(Object)} method.
+     *
+     * @param version to use when resolving this dependency, cannot be null.
+     * It is valid to configure the same version as requested.
+     */
+    void useVersion(String version);
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ProjectDependencySubstitution.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ProjectDependencySubstitution.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * Provides means to substitute a different dependency in place of a project dependency.
+ *
+ * @since 2.4
+ */
+@Incubating
+@HasInternalProtocol
+public interface ProjectDependencySubstitution extends DependencySubstitution<ProjectComponentSelector> {
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Defines the strategies around dependency resolution.
- * For example, forcing certain dependency versions, conflict resolutions or snapshot timeouts.
+ * For example, forcing certain dependency versions, substitutions, conflict resolutions or snapshot timeouts.
  * <p>
  * Examples:
  * <pre autoTested=''>
@@ -42,15 +42,17 @@ import java.util.concurrent.TimeUnit;
  *     //  *replace existing forced modules with new ones:
  *     forcedModules = ['asm:asm-all:3.3.1']
  *
- *     // add a dependency resolve rule
- *     eachDependency { DependencyResolveDetails details ->
+ *     // add dependency substitution rules
+ *     dependencySubstitution {
  *       //specifying a fixed version for all libraries with 'org.gradle' group
- *       if (details.requested.group == 'org.gradle') {
- *           details.useVersion'1.4'
- *       }
- *       //changing 'groovy-all' into 'groovy':
- *       if (details.requested.name == 'groovy-all') {
- *          details.useTarget group: details.requested.group, name: 'groovy', version: details.requested.version
+ *       eachModule { ModuleDependencySubstitution details ->
+ *         if (details.requested.group == 'org.gradle') {
+ *           details.useVersion '2.4'
+ *         }
+ *         //changing 'groovy-all' into 'groovy':
+ *         if (details.requested.name == 'groovy-all') {
+ *           details.useTarget group: details.requested.group, name: 'groovy', version: details.requested.version
+ *         }
  *       }
  *     }
  *
@@ -140,7 +142,7 @@ public interface ResolutionStrategy {
     Set<ModuleVersionSelector> getForcedModules();
 
     /**
-     * Adds a dependency resolve rule that is triggered for every dependency (including transitive)
+     * Adds a dependency substitution rule that is triggered for every dependency (including transitive)
      * when the configuration is being resolved. The action receives an instance of {@link DependencyResolveDetails}
      * that can be used to find out what dependency is being resolved and to influence the resolution process.
      * Example:
@@ -172,6 +174,7 @@ public interface ResolutionStrategy {
      * @since 1.4
      */
     @Incubating
+    @Deprecated
     ResolutionStrategy eachDependency(Action<? super DependencyResolveDetails> rule);
 
     /**
@@ -238,4 +241,10 @@ public interface ResolutionStrategy {
      */
     @Incubating
     ResolutionStrategy componentSelection(Action<? super ComponentSelectionRules> action);
+
+    @Incubating
+    DependencySubstitutions getDependencySubstitution();
+
+    @Incubating
+    ResolutionStrategy dependencySubstitution(Action<? super DependencySubstitutions> action);
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/result/ComponentSelectionReason.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/result/ComponentSelectionReason.java
@@ -42,8 +42,8 @@ public interface ComponentSelectionReason {
     boolean isConflictResolution();
 
     /**
-     * Informs whether the component was selected by the dependency resolve rule.
-     * Users can configure dependency resolve rules via {@link org.gradle.api.artifacts.ResolutionStrategy#eachDependency(org.gradle.api.Action)}
+     * Informs whether the component was selected by the dependency substitution rule.
+     * Users can configure dependency substitution rules via {@link org.gradle.api.artifacts.ResolutionStrategy#getDependencySubstitution()}
      *
      * @since 1.4
      */

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/DependencyResolveDetailsInternal.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/DependencyResolveDetailsInternal.java
@@ -17,14 +17,11 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.DependencyResolveDetails;
-import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 
-public interface DependencyResolveDetailsInternal<T extends ComponentSelector> extends DependencyResolveDetails<T> {
+@SuppressWarnings("deprecation")
+public interface DependencyResolveDetailsInternal extends DependencyResolveDetails {
 
-    ComponentSelector getTarget();
-
-    @Deprecated
     void useVersion(String version, ComponentSelectionReason selectionReason);
 
     ComponentSelectionReason getSelectionReason();

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/DependencySubstitutionInternal.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/DependencySubstitutionInternal.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.artifacts.DependencySubstitution;
+import org.gradle.api.artifacts.ModuleVersionSelector;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.result.ComponentSelectionReason;
+
+public interface DependencySubstitutionInternal<T extends ComponentSelector> extends DependencySubstitution<T> {
+
+    ModuleVersionSelector getOldRequested();
+
+    void useTarget(Object notation, ComponentSelectionReason selectionReason);
+
+    ComponentSelector getTarget();
+
+    ComponentSelectionReason getSelectionReason();
+
+    boolean isUpdated();
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/ModuleDependencySubstitutionInternal.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/ModuleDependencySubstitutionInternal.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.artifacts.ModuleDependencySubstitution;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.artifacts.result.ComponentSelectionReason;
+
+public interface ModuleDependencySubstitutionInternal extends ModuleDependencySubstitution, DependencySubstitutionInternal<ModuleComponentSelector> {
+    void useVersion(String version, ComponentSelectionReason selectionReason);
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/ProjectDependencySubstitutionInternal.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/ProjectDependencySubstitutionInternal.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.artifacts.ProjectDependencySubstitution;
+import org.gradle.api.artifacts.component.ProjectComponentSelector;
+
+public interface ProjectDependencySubstitutionInternal extends ProjectDependencySubstitution, DependencySubstitutionInternal<ProjectComponentSelector> {
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
@@ -234,8 +234,8 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         declaredDependencies 'a', 'b'
         declaredReplacements 'a->b'
         buildFile << """
-            configurations.all { resolutionStrategy.eachDependency { dep ->
-                if (dep.requested.name == 'b') {
+            configurations.all { resolutionStrategy.dependencySubstitution.eachModule { dep ->
+                if (dep.requested.module == 'b') {
                     dep.useTarget 'org:d:1'
                 }
             }}
@@ -247,8 +247,8 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         declaredDependencies 'a', 'b'
         declaredReplacements 'a->b'
         buildFile << """
-            configurations.all { resolutionStrategy.eachDependency { dep ->
-                if (dep.requested.name == 'a') {
+            configurations.all { resolutionStrategy.dependencySubstitution.eachModule { dep ->
+                if (dep.requested.module == 'a') {
                     dep.useTarget 'org:b:1'
                 }
             }}
@@ -261,8 +261,8 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         declaredDependencies 'a', 'b'
         declaredReplacements 'a->d'
         buildFile << """
-            configurations.all { resolutionStrategy.eachDependency { dep ->
-                if (dep.requested.name == 'b') {
+            configurations.all { resolutionStrategy.dependencySubstitution.eachModule { dep ->
+                if (dep.requested.module == 'b') {
                     dep.useTarget 'org:d:1'
                 }
             }}
@@ -275,9 +275,9 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         declaredDependencies 'c', 'd'
         declaredReplacements 'a->b'
         buildFile << """
-            configurations.all { resolutionStrategy.eachDependency { dep ->
-                if (dep.requested.name == 'c') { dep.useTarget 'org:a:1' }
-                if (dep.requested.name == 'd') { dep.useTarget 'org:b:1' }
+            configurations.all { resolutionStrategy.dependencySubstitution.eachModule { dep ->
+                if (dep.requested.module == 'c') { dep.useTarget 'org:a:1' }
+                if (dep.requested.module == 'd') { dep.useTarget 'org:b:1' }
             }}
         """
         expect: resolvedModules 'b'
@@ -288,8 +288,8 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         declaredDependencies 'a', 'b', 'c'
         declaredReplacements 'a->b', 'c->d'
         buildFile << """
-            configurations.all { resolutionStrategy.eachDependency { dep ->
-                if (dep.requested.name == 'b') { dep.useTarget 'org:d:1' }
+            configurations.all { resolutionStrategy.dependencySubstitution.eachModule { dep ->
+                if (dep.requested.module == 'b') { dep.useTarget 'org:d:1' }
             }}
         """
         expect: resolvedModules 'a', 'd'
@@ -300,8 +300,8 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         declaredDependencies 'a', 'b'
         declaredReplacements 'a->b', 'd->a'
         buildFile << """
-            configurations.all { resolutionStrategy.eachDependency { dep ->
-                if (dep.requested.name == 'b') { dep.useTarget 'org:d:1' }
+            configurations.all { resolutionStrategy.dependencySubstitution.eachModule { dep ->
+                if (dep.requested.module == 'b') { dep.useTarget 'org:d:1' }
             }}
         """
         //a->b->d->a

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
@@ -418,11 +418,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
     {
         settingsFile << 'include "api", "impl"'
         buildFile << """
-            allprojects {
-                $common
-                group "org.utils"
-                version = "1.6"
-            }
+            $common
 
             project(":impl") {
                 dependencies {
@@ -438,13 +434,9 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 1
                     assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
 
-                    assert deps[0].requested instanceof org.gradle.api.artifacts.component.ModuleComponentSelector
-                    assert deps[0].requested.group == "org.utils"
-                    assert deps[0].requested.module == "api"
-                    assert deps[0].requested.version == "1.5"
+                    assert deps[0].requested.matchesStrictly(modelId("org.utils", "api", "1.5"))
+                    assert deps[0].selected.componentId == projectId(":api")
 
-                    assert deps[0].selected.componentId instanceof org.gradle.api.artifacts.component.ProjectComponentIdentifier
-                    assert deps[0].selected.componentId.projectPath == ":api"
                     assert !deps[0].selected.selectionReason.forced
                     assert deps[0].selected.selectionReason.selectedByRule
                 }
@@ -462,8 +454,9 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << 'include "api", "impl"'
 
         buildFile << """
-            allprojects {
-                $common
+            $common
+
+            project(":api") {
                 configurations.create("default").extendsFrom(configurations.conf)
             }
 
@@ -481,13 +474,9 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 1
                     assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
 
-                    assert deps[0].requested instanceof org.gradle.api.artifacts.component.ProjectComponentSelector
-                    assert deps[0].requested.projectPath == ":api"
+                    assert deps[0].requested.matchesStrictly(projectId(":api"))
+                    assert deps[0].selected.componentId == modelId("org.utils", "api", "1.5")
 
-                    assert deps[0].selected.componentId instanceof org.gradle.api.artifacts.component.ModuleComponentIdentifier
-                    assert deps[0].selected.componentId.group == "org.utils"
-                    assert deps[0].selected.componentId.module == "api"
-                    assert deps[0].selected.componentId.version == "1.5"
                     assert !deps[0].selected.selectionReason.forced
                     assert deps[0].selected.selectionReason.selectedByRule
                 }
@@ -504,9 +493,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << 'include "api", "test"'
 
         buildFile << """
-            allprojects {
-                $common
-            }
+            $common
 
             project(":test") {
                 dependencies {
@@ -522,21 +509,14 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 2
                     assert deps.find {
                         it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                        it.selected.componentId instanceof org.gradle.api.artifacts.component.ModuleComponentIdentifier &&
-                        it.selected.componentId.group == "org.utils" &&
-                        it.selected.componentId.module == "impl" &&
-                        it.selected.componentId.version == "1.5" &&
+                        it.selected.componentId == modelId("org.utils", "impl", "1.5")
                         !it.selected.selectionReason.forced &&
                         !it.selected.selectionReason.selectedByRule
                     }
                     assert deps.find {
                         it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                        it.requested instanceof org.gradle.api.artifacts.component.ModuleComponentSelector &&
-                        it.requested.group == "org.utils" &&
-                        it.requested.module == "api" &&
-                        it.requested.version == "1.5" &&
-                        it.selected.componentId instanceof org.gradle.api.artifacts.component.ProjectComponentIdentifier &&
-                        it.selected.componentId.projectPath == ":api" &&
+                        it.requested.matchesStrictly(modelId("org.utils", "api", "1.5"))
+                        it.selected.componentId == projectId(":api")
                         !it.selected.selectionReason.forced &&
                         it.selected.selectionReason.selectedByRule
                     }
@@ -553,8 +533,9 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << 'include "api", "impl"'
 
         buildFile << """
-            allprojects {
-                $common
+            $common
+
+            project(":api") {
                 configurations.create("default").extendsFrom(configurations.conf)
             }
 
@@ -572,13 +553,9 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 1
                     assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
 
-                    assert deps[0].requested instanceof org.gradle.api.artifacts.component.ModuleComponentSelector
-                    assert deps[0].requested.group == "org.utils"
-                    assert deps[0].requested.module == "api"
-                    assert deps[0].requested.version == "1.5"
+                    assert deps[0].requested.matchesStrictly(modelId("org.utils", "api", "1.5"))
+                    assert deps[0].selected.componentId == projectId(":api")
 
-                    assert deps[0].selected.componentId instanceof org.gradle.api.artifacts.component.ProjectComponentIdentifier
-                    assert deps[0].selected.componentId.projectPath == ":api"
                     assert !deps[0].selected.selectionReason.forced
                     assert deps[0].selected.selectionReason.selectedByRule
                 }
@@ -595,8 +572,9 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         mavenRepo.module("org.utils", "bela", '1.5').publish()
 
         buildFile << """
-            allprojects {
-                $common
+            $common
+
+            project(":api") {
                 configurations.create("default").extendsFrom(configurations.conf)
             }
 
@@ -616,21 +594,14 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 2
                     assert deps.find {
                         it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                        it.selected.componentId instanceof org.gradle.api.artifacts.component.ModuleComponentIdentifier &&
-                        it.selected.componentId.group == "org.utils" &&
-                        it.selected.componentId.module == "bela" &&
-                        it.selected.componentId.version == "1.5" &&
+                        it.selected.componentId == modelId("org.utils", "bela", "1.5") &&
                         !it.selected.selectionReason.forced &&
                         !it.selected.selectionReason.selectedByRule
                     }
                     assert deps.find {
                         it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                        it.requested instanceof org.gradle.api.artifacts.component.ModuleComponentSelector &&
-                        it.requested.group == "org.utils" &&
-                        it.requested.module == "api" &&
-                        it.requested.version == "1.5" &&
-                        it.selected.componentId instanceof org.gradle.api.artifacts.component.ProjectComponentIdentifier &&
-                        it.selected.componentId.projectPath == ":api" &&
+                        it.requested.matchesStrictly(modelId("org.utils", "api", "1.5")) &&
+                        it.selected.componentId == projectId(":api") &&
                         !it.selected.selectionReason.forced &&
                         it.selected.selectionReason.selectedByRule
                     }
@@ -1106,14 +1077,25 @@ conf
     }
 
     String getCommon() {
-        """configurations { conf }
-        repositories {
-            maven { url "${mavenRepo.uri}" }
+        """
+        allprojects {
+            configurations { conf }
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            task resolveConf << { configurations.conf.files }
         }
-        task resolveConf << { configurations.conf.files }
 
         //resolving the configuration at the end:
         gradle.startParameter.taskNames += 'resolveConf'
+
+        def modelId(String group, String name, String version) {
+            return org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId(group, name, version)
+        }
+
+        def projectId(String projectPath) {
+            return org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier.newId(projectPath)
+        }
         """
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
@@ -451,11 +451,8 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
             }
 """
 
-        when:
-        run("impl:check")
-
-        then:
-        noExceptionThrown()
+        expect:
+        succeeds("impl:check")
     }
 
     void "can replace project dependency with external dependency"()
@@ -467,9 +464,6 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             allprojects {
                 $common
-
-                group "org.utils"
-                version = "1.6"
                 configurations.create("default").extendsFrom(configurations.conf)
             }
 
@@ -500,11 +494,8 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
             }
 """
 
-        when:
-        run("impl:check")
-
-        then:
-        noExceptionThrown()
+        expect:
+        succeeds("impl:check")
     }
 
     void "can replace transitive external dependency with project dependency"()
@@ -515,8 +506,6 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             allprojects {
                 $common
-                group "org.utils"
-                version = "1.6"
             }
 
             project(":test") {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
@@ -865,7 +865,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    void "project dependency substituted for an external dependency participates in conflict resolution (version #projectVersion)"()
+    void "project dependency substituted for an external dependency participates in conflict resolution (version #apiProjectVersion)"()
     {
         mavenRepo.module("org.utils", "api", '2.0').publish()
         settingsFile << 'include "api", "impl"'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
@@ -530,6 +530,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                         !it.selected.selectionReason.selectedByRule
                     }
                     assert deps.find {
+                        it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
                         it.requested instanceof org.gradle.api.artifacts.component.ModuleComponentSelector &&
                         it.requested.group == "org.utils" &&
                         it.requested.module == "api" &&

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
@@ -456,10 +456,6 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             $common
 
-            project(":api") {
-                configurations.create("default").extendsFrom(configurations.conf)
-            }
-
             project(":impl") {
                 dependencies {
                     conf project(path: ":api", configuration: "default")
@@ -535,10 +531,6 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             $common
 
-            project(":api") {
-                configurations.create("default").extendsFrom(configurations.conf)
-            }
-
             project(":impl") {
                 dependencies {
                     conf module(group: "org.utils", name: "api", version: "1.5")
@@ -573,10 +565,6 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
 
         buildFile << """
             $common
-
-            project(":api") {
-                configurations.create("default").extendsFrom(configurations.conf)
-            }
 
             project(":impl") {
                 dependencies {
@@ -621,10 +609,6 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
 
         buildFile << """
             $common
-
-            project(":api") {
-                configurations.create("default").extendsFrom(configurations.conf)
-            }
 
             project(":impl") {
                 configurations {
@@ -1138,10 +1122,15 @@ conf
     String getCommon() {
         """
         allprojects {
-            configurations { conf }
+            configurations {
+                conf
+            }
+            configurations.create("default").extendsFrom(configurations.conf)
+
             repositories {
                 maven { url "${mavenRepo.uri}" }
             }
+
             task resolveConf << { configurations.conf.files }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
@@ -434,7 +434,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 1
                     assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
 
-                    assert deps[0].requested.matchesStrictly(modelId("org.utils", "api", "1.5"))
+                    assert deps[0].requested.matchesStrictly(moduleId("org.utils", "api", "1.5"))
                     assert deps[0].selected.componentId == projectId(":api")
 
                     assert !deps[0].selected.selectionReason.forced
@@ -471,7 +471,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
 
                     assert deps[0].requested.matchesStrictly(projectId(":api"))
-                    assert deps[0].selected.componentId == modelId("org.utils", "api", "1.5")
+                    assert deps[0].selected.componentId == moduleId("org.utils", "api", "1.5")
 
                     assert !deps[0].selected.selectionReason.forced
                     assert deps[0].selected.selectionReason.selectedByRule
@@ -505,13 +505,13 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 2
                     assert deps.find {
                         it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                        it.selected.componentId == modelId("org.utils", "impl", "1.5")
+                        it.selected.componentId == moduleId("org.utils", "impl", "1.5")
                         !it.selected.selectionReason.forced &&
                         !it.selected.selectionReason.selectedByRule
                     }
                     assert deps.find {
                         it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                        it.requested.matchesStrictly(modelId("org.utils", "api", "1.5"))
+                        it.requested.matchesStrictly(moduleId("org.utils", "api", "1.5"))
                         it.selected.componentId == projectId(":api")
                         !it.selected.selectionReason.forced &&
                         it.selected.selectionReason.selectedByRule
@@ -545,7 +545,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 1
                     assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
 
-                    assert deps[0].requested.matchesStrictly(modelId("org.utils", "api", "1.5"))
+                    assert deps[0].requested.matchesStrictly(moduleId("org.utils", "api", "1.5"))
                     assert deps[0].selected.componentId == projectId(":api")
 
                     assert !deps[0].selected.selectionReason.forced
@@ -582,13 +582,13 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 2
                     assert deps.find {
                         it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                        it.selected.componentId == modelId("org.utils", "bela", "1.5") &&
+                        it.selected.componentId == moduleId("org.utils", "bela", "1.5") &&
                         !it.selected.selectionReason.forced &&
                         !it.selected.selectionReason.selectedByRule
                     }
                     assert deps.find {
                         it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                        it.requested.matchesStrictly(modelId("org.utils", "api", "1.5")) &&
+                        it.requested.matchesStrictly(moduleId("org.utils", "api", "1.5")) &&
                         it.selected.componentId == projectId(":api") &&
                         !it.selected.selectionReason.forced &&
                         it.selected.selectionReason.selectedByRule
@@ -628,8 +628,8 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 1
                     assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
 
-                    assert deps[0].requested.matchesStrictly(modelId("org.utils", "api", "1.5"))
-                    assert deps[0].selected.componentId == modelId("org.utils", "api", "1.5")
+                    assert deps[0].requested.matchesStrictly(moduleId("org.utils", "api", "1.5"))
+                    assert deps[0].selected.componentId == moduleId("org.utils", "api", "1.5")
 
                     assert !deps[0].selected.selectionReason.forced
                     assert !deps[0].selected.selectionReason.selectedByRule
@@ -640,7 +640,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert deps.size() == 1
                     assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
 
-                    assert deps[0].requested.matchesStrictly(modelId("org.utils", "api", "1.5"))
+                    assert deps[0].requested.matchesStrictly(moduleId("org.utils", "api", "1.5"))
                     assert deps[0].selected.componentId == projectId(":api")
 
                     assert !deps[0].selected.selectionReason.forced
@@ -1137,7 +1137,7 @@ conf
         //resolving the configuration at the end:
         gradle.startParameter.taskNames += 'resolveConf'
 
-        def modelId(String group, String name, String version) {
+        def moduleId(String group, String name, String version) {
             return org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId(group, name, version)
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
@@ -106,6 +106,18 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
         then: output.contains("Attempting to change configuration ':a' after it has been resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
     }
 
+    def "warns about changing substitution rules on a configuration that has been resolved"() {
+        buildFile << """
+            configurations { a }
+            configurations.a.resolve()
+            configurations.a.resolutionStrategy.dependencySubstitution.all {}
+        """
+        executer.withDeprecationChecksDisabled()
+
+        when: succeeds()
+        then: output.contains("Attempting to change configuration ':a' after it has been resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
+    }
+
     def "warns about changing component selection rules on a configuration that has been resolved"() {
         buildFile << """
             configurations { a }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -17,11 +17,13 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ConflictResolution;
+import org.gradle.api.artifacts.DependencySubstitution;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.cache.ResolutionRules;
-import org.gradle.api.internal.artifacts.DependencyResolveDetailsInternal;
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
+import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DependencySubstitutionsInternal;
 
 public interface ResolutionStrategyInternal extends ResolutionStrategy {
 
@@ -46,14 +48,17 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
     ResolutionRules getResolutionRules();
 
     /**
-     * @return the dependency resolve rule (may aggregate multiple rules)
+     * @return the dependency substitution rule (may aggregate multiple rules)
      */
-    Action<DependencyResolveDetailsInternal> getDependencyResolveRule();
+    Action<DependencySubstitution<ComponentSelector>> getDependencySubstitutionRule();
 
     /**
      * @return the version selection rules object
      */
     ComponentSelectionRulesInternal getComponentSelection();
+
+    @Override
+    DependencySubstitutionsInternal getDependencySubstitution();
 
     /**
      * @return copy of this resolution strategy. See the contract of {@link org.gradle.api.artifacts.Configuration#copy()}.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/AbstractDependencySubstitution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/AbstractDependencySubstitution.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice;
+
+import org.gradle.api.artifacts.ModuleVersionSelector;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.result.ComponentSelectionReason;
+import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
+import org.gradle.api.internal.artifacts.dsl.ComponentSelectorParsers;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
+
+public abstract class AbstractDependencySubstitution<T extends ComponentSelector> implements DependencySubstitutionInternal<T> {
+    private final T requested;
+    private final ModuleVersionSelector oldRequested;
+    private ComponentSelectionReason selectionReason;
+    private ComponentSelector target;
+
+    public AbstractDependencySubstitution(T requested, ModuleVersionSelector oldRequested) {
+        this.requested = requested;
+        this.target = requested;
+        this.oldRequested = oldRequested;
+    }
+
+    @Override
+    public T getRequested() {
+        return requested;
+    }
+
+    @Override
+    public ModuleVersionSelector getOldRequested() {
+        return oldRequested;
+    }
+
+    @Override
+    public void useTarget(Object notation) {
+        useTarget(notation, VersionSelectionReasons.SELECTED_BY_RULE);
+    }
+
+    @Override
+    public void useTarget(Object notation, ComponentSelectionReason selectionReason) {
+        this.target = ComponentSelectorParsers.parser().parseNotation(notation);
+        this.selectionReason = selectionReason;
+    }
+
+    @Override
+    public ComponentSelectionReason getSelectionReason() {
+        return selectionReason;
+    }
+
+    @Override
+    public ComponentSelector getTarget() {
+        return target;
+    }
+
+    @Override
+    public boolean isUpdated() {
+        return selectionReason != null;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultModuleDependencySubstitution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultModuleDependencySubstitution.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice;
+
+import org.gradle.api.artifacts.ModuleVersionSelector;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.artifacts.result.ComponentSelectionReason;
+import org.gradle.api.internal.artifacts.ModuleDependencySubstitutionInternal;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+
+public class DefaultModuleDependencySubstitution extends AbstractDependencySubstitution<ModuleComponentSelector> implements ModuleDependencySubstitutionInternal {
+
+    public DefaultModuleDependencySubstitution(ModuleComponentSelector requested, ModuleVersionSelector oldRequested) {
+        super(requested, oldRequested);
+    }
+
+    @Override
+    public void useVersion(String version) {
+        useVersion(version, VersionSelectionReasons.SELECTED_BY_RULE);
+    }
+
+    @Override
+    public void useVersion(String version, ComponentSelectionReason selectionReason) {
+        assert selectionReason != null;
+        if (version == null) {
+            throw new IllegalArgumentException("Configuring the dependency resolve details with 'null' version is not allowed.");
+        }
+        ModuleComponentSelector moduleTarget = getRequested();
+        if (!version.equals(moduleTarget.getVersion())) {
+            useTarget(DefaultModuleComponentSelector.newSelector(moduleTarget.getGroup(), moduleTarget.getModule(), version), selectionReason);
+        } else {
+            useTarget(moduleTarget, selectionReason);
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultProjectDependencySubstitution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultProjectDependencySubstitution.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice;
+
+import org.gradle.api.artifacts.ModuleVersionSelector;
+import org.gradle.api.artifacts.ProjectDependencySubstitution;
+import org.gradle.api.artifacts.component.ProjectComponentSelector;
+
+public class DefaultProjectDependencySubstitution extends AbstractDependencySubstitution<ProjectComponentSelector> implements ProjectDependencySubstitution {
+
+    public DefaultProjectDependencySubstitution(ProjectComponentSelector requested, ModuleVersionSelector oldRequested) {
+        super(requested, oldRequested);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultDependencySubstitutions.java
@@ -61,7 +61,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
     }
 
     private void addRule(Action<? super DependencySubstitution<? super ComponentSelector>> rule) {
-        mutationValidator.validateMutation(true);
+        mutationValidator.validateMutation(MutationValidator.MutationType.STRATEGY);
         substitutionRules.add(rule);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultDependencySubstitutions.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy;
+
+import com.google.common.base.Objects;
+import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.*;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.ClosureBackedAction;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
+import org.gradle.api.internal.artifacts.configurations.MutationValidator;
+import org.gradle.api.internal.artifacts.ivyservice.DefaultDependencyResolveDetails;
+import org.gradle.api.internal.notations.ModuleIdentiferNotationConverter;
+import org.gradle.internal.Actions;
+import org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier;
+import org.gradle.internal.exceptions.DiagnosticsVisitor;
+import org.gradle.internal.typeconversion.*;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class DefaultDependencySubstitutions implements DependencySubstitutionsInternal {
+    private final Set<Action<? super DependencySubstitution<? super ComponentSelector>>> substitutionRules;
+    private final NotationParser<Object, ModuleIdentifier> moduleIdentifierNotationParser;
+    private final NotationParser<Object, ProjectComponentIdentifier> projectIdentifierNotationParser;
+
+    private MutationValidator mutationValidator = MutationValidator.IGNORE;
+
+    public DefaultDependencySubstitutions() {
+        this(new LinkedHashSet<Action<? super DependencySubstitution<? super ComponentSelector>>>());
+    }
+
+    DefaultDependencySubstitutions(Set<Action<? super DependencySubstitution<? super ComponentSelector>>> substitutionRules) {
+        this.substitutionRules = substitutionRules;
+        this.moduleIdentifierNotationParser = createModuleIdentifierNotationParser();
+        this.projectIdentifierNotationParser = createProjectIdentifierNotationParser();
+    }
+
+    @Override
+    public Action<DependencySubstitution<ComponentSelector>> getDependencySubstitutionRule() {
+        return Actions.composite(substitutionRules);
+    }
+
+    private void addRule(Action<? super DependencySubstitution<? super ComponentSelector>> rule) {
+        mutationValidator.validateMutation(true);
+        substitutionRules.add(rule);
+    }
+
+    @Override
+    public DependencySubstitutions all(Action<? super DependencySubstitution<? super ComponentSelector>> rule) {
+        addRule(rule);
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public DependencySubstitutions allWithDependencyResolveDetails(Action<? super DependencyResolveDetails> rule) {
+        addRule(new DependencyResolveDetailsWrapperAction(rule));
+        return this;
+    }
+
+    @Override
+    public DependencySubstitutions all(Closure<?> action) {
+        return all(ClosureBackedAction.of(action));
+    }
+
+    @Override
+    public DependencySubstitutions eachModule(Action<? super ModuleDependencySubstitution> rule) {
+        return all(new TypeFilteringDependencySubstitutionAction<ModuleDependencySubstitution>(ModuleDependencySubstitution.class, rule));
+    }
+
+    @Override
+    public DependencySubstitutions eachModule(Closure<?> rule) {
+        return eachModule(ClosureBackedAction.of(rule));
+    }
+
+    @Override
+    public DependencySubstitutions withModule(Object id, Action<? super ModuleDependencySubstitution> rule) {
+        ModuleIdentifier moduleId = moduleIdentifierNotationParser.parseNotation(id);
+        return all(new ModuleIdFilteringDependencySubstitutionAction(moduleId, rule));
+    }
+
+    @Override
+    public DependencySubstitutions withModule(Object id, Closure<?> action) {
+        return withModule(id, ClosureBackedAction.of(action));
+    }
+
+    @Override
+    public DependencySubstitutions eachProject(Action<? super ProjectDependencySubstitution> rule) {
+        return all(new TypeFilteringDependencySubstitutionAction<ProjectDependencySubstitution>(ProjectDependencySubstitution.class, rule));
+    }
+
+    @Override
+    public DependencySubstitutions eachProject(Closure<?> rule) {
+        return eachProject(ClosureBackedAction.of(rule));
+    }
+
+    @Override
+    public DependencySubstitutions withProject(Object id, Action<? super ProjectDependencySubstitution> rule) {
+        ProjectComponentIdentifier componentId = projectIdentifierNotationParser.parseNotation(id);
+        return all(new ProjectIdFilteringDependencySubstitutionAction(componentId, rule));
+    }
+
+    @Override
+    public DependencySubstitutions withProject(Object id, Closure<?> rule) {
+        return withProject(id, ClosureBackedAction.of(rule));
+    }
+
+    @Override
+    public void beforeChange(MutationValidator validator) {
+        mutationValidator = validator;
+    }
+
+    @Override
+    public DependencySubstitutionsInternal copy() {
+        return new DefaultDependencySubstitutions(new LinkedHashSet<Action<? super DependencySubstitution<? super ComponentSelector>>>(substitutionRules));
+    }
+
+    private static NotationParser<Object, ModuleIdentifier> createModuleIdentifierNotationParser() {
+        return NotationParserBuilder
+                .toType(ModuleIdentifier.class)
+                .converter(new ModuleIdentiferNotationConverter())
+                .converter(new ModuleIdentifierMapNotationConverter())
+                .toComposite();
+    }
+
+    private static class ModuleIdentifierMapNotationConverter extends MapNotationConverter<ModuleIdentifier> {
+        @Override
+        public void describe(DiagnosticsVisitor visitor) {
+            visitor.example("Maps, e.g. [group: 'org.gradle', name:'gradle-core'].");
+        }
+
+        protected ModuleIdentifier parseMap(@MapKey("group") String group, @MapKey("name") String name) {
+            return DefaultModuleIdentifier.newId(group, name);
+        }
+    }
+
+    private static NotationParser<Object, ProjectComponentIdentifier> createProjectIdentifierNotationParser() {
+        return NotationParserBuilder
+                .toType(ProjectComponentIdentifier.class)
+                .fromCharSequence(new ProjectPathConverter())
+                .fromType(Project.class, new ProjectConverter())
+                .toComposite();
+    }
+
+    private static class ProjectPathConverter implements NotationConverter<String, ProjectComponentIdentifier> {
+        @Override
+        public void describe(DiagnosticsVisitor visitor) {
+            visitor.example("Project paths, e.g. ':api'.");
+        }
+
+        @Override
+        public void convert(String notation, NotationConvertResult<? super ProjectComponentIdentifier> result) throws TypeConversionException {
+            result.converted(DefaultProjectComponentIdentifier.newId(notation));
+        }
+    }
+
+    private static class ProjectConverter implements NotationConverter<Project, ProjectComponentIdentifier> {
+
+        @Override
+        public void describe(DiagnosticsVisitor visitor) {
+            visitor.example("Project objects, e.g. project(':api').");
+        }
+
+        @Override
+        public void convert(Project notation, NotationConvertResult<? super ProjectComponentIdentifier> result) throws TypeConversionException {
+            result.converted(DefaultProjectComponentIdentifier.newId(notation.getPath()));
+        }
+    }
+
+    private static class ModuleIdFilteringDependencySubstitutionAction implements Action<DependencySubstitution<ComponentSelector>> {
+        private final Action<? super ModuleDependencySubstitution> delegate;
+        private final ModuleIdentifier id;
+
+        public ModuleIdFilteringDependencySubstitutionAction(ModuleIdentifier id, Action<? super ModuleDependencySubstitution> delegate) {
+            this.id = id;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void execute(DependencySubstitution substitution) {
+            ComponentSelector requested = substitution.getRequested();
+            if (requested instanceof ModuleComponentSelector) {
+                ModuleComponentSelector requestedModule = (ModuleComponentSelector) requested;
+                if (Objects.equal(requestedModule.getGroup(), id.getGroup())
+                        && Objects.equal(requestedModule.getModule(), id.getName())) {
+                    delegate.execute((ModuleDependencySubstitution) substitution);
+                }
+            }
+        }
+    }
+
+    private static class ProjectIdFilteringDependencySubstitutionAction implements Action<DependencySubstitution<ComponentSelector>> {
+        private final Action<? super ProjectDependencySubstitution> delegate;
+        private final ProjectComponentIdentifier id;
+
+        public ProjectIdFilteringDependencySubstitutionAction(ProjectComponentIdentifier id, Action<? super ProjectDependencySubstitution> delegate) {
+            this.id = id;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void execute(DependencySubstitution substitution) {
+            ComponentSelector requested = substitution.getRequested();
+            if (requested.matchesStrictly(id)) {
+                delegate.execute((ProjectDependencySubstitution) substitution);
+            }
+        }
+    }
+
+    private static class TypeFilteringDependencySubstitutionAction<T extends DependencySubstitution<?>> implements Action<DependencySubstitution<ComponentSelector>> {
+        private final Class<T> type;
+        private final Action<? super T> delegate;
+
+        public TypeFilteringDependencySubstitutionAction(Class<T> type, Action<? super T> delegate) {
+            this.type = type;
+            this.delegate = delegate;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void execute(DependencySubstitution<ComponentSelector> substitution) {
+            if (type.isAssignableFrom(substitution.getClass())) {
+                delegate.execute((T) substitution);
+            }
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class DependencyResolveDetailsWrapperAction implements Action<DependencySubstitution<ComponentSelector>> {
+        private final Action<? super DependencyResolveDetails> delegate;
+
+        public DependencyResolveDetailsWrapperAction(Action<? super DependencyResolveDetails> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void execute(DependencySubstitution<ComponentSelector> substitution) {
+            DefaultDependencyResolveDetails details = new DefaultDependencyResolveDetails((DependencySubstitutionInternal<?>) substitution);
+            delegate.execute(details);
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.dsl.ModuleVersionSelectorParsers;
 import org.gradle.internal.Actions;
 import org.gradle.internal.typeconversion.NormalizedTimeUnit;
 import org.gradle.internal.typeconversion.TimeUnitsParser;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -88,7 +89,9 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         return this;
     }
 
+    @SuppressWarnings("deprecation")
     public ResolutionStrategy eachDependency(Action<? super DependencyResolveDetails> rule) {
+        DeprecationLogger.nagUserOfReplacedMethod("ResolutionStrategy.eachDependency()", "DependencySubstitution.eachModule()");
         mutationValidator.validateMutation(STRATEGY);
         dependencySubstitutions.allWithDependencyResolveDetails(rule);
         return this;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -19,8 +19,8 @@ package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.*;
 import org.gradle.api.artifacts.cache.ResolutionRules;
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
-import org.gradle.api.internal.artifacts.DependencyResolveDetailsInternal;
 import org.gradle.api.internal.artifacts.configurations.MutationValidator;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.dsl.ModuleVersionSelectorParsers;
@@ -42,17 +42,17 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private ConflictResolution conflictResolution = new LatestConflictResolution();
     private final DefaultComponentSelectionRules componentSelectionRules = new DefaultComponentSelectionRules();
 
-    private final Set<Action<? super DependencyResolveDetails>> dependencyResolveRules;
     private final DefaultCachePolicy cachePolicy;
+    private final DependencySubstitutionsInternal dependencySubstitutions;
     private MutationValidator mutationValidator = MutationValidator.IGNORE;
 
     public DefaultResolutionStrategy() {
-        this(new DefaultCachePolicy(), new LinkedHashSet<Action<? super DependencyResolveDetails>>());
+        this(new DefaultCachePolicy(), new DefaultDependencySubstitutions());
     }
 
-    DefaultResolutionStrategy(DefaultCachePolicy cachePolicy, Set<Action<? super DependencyResolveDetails>> dependencyResolveRules) {
+    DefaultResolutionStrategy(DefaultCachePolicy cachePolicy, DependencySubstitutionsInternal dependencySubstitutions) {
         this.cachePolicy = cachePolicy;
-        this.dependencyResolveRules = dependencyResolveRules;
+        this.dependencySubstitutions = dependencySubstitutions;
     }
 
     @Override
@@ -60,6 +60,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         mutationValidator = validator;
         cachePolicy.beforeChange(validator);
         componentSelectionRules.beforeChange(validator);
+        dependencySubstitutions.beforeChange(validator);
     }
 
     public Set<ModuleVersionSelector> getForcedModules() {
@@ -89,12 +90,12 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
 
     public ResolutionStrategy eachDependency(Action<? super DependencyResolveDetails> rule) {
         mutationValidator.validateMutation(STRATEGY);
-        dependencyResolveRules.add(rule);
+        dependencySubstitutions.allWithDependencyResolveDetails(rule);
         return this;
     }
 
-    public Action<DependencyResolveDetailsInternal> getDependencyResolveRule() {
-        Collection<Action<DependencyResolveDetailsInternal>> allRules = flattenElements(new ModuleForcingResolveRule(forcedModules), dependencyResolveRules);
+    public Action<DependencySubstitution<ComponentSelector>> getDependencySubstitutionRule() {
+        Collection<Action<DependencySubstitution<ComponentSelector>>> allRules = flattenElements(new ModuleForcingResolveRule(forcedModules), dependencySubstitutions.getDependencySubstitutionRule());
         return Actions.composite(allRules);
     }
 
@@ -137,8 +138,19 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         return this;
     }
 
+    @Override
+    public DependencySubstitutionsInternal getDependencySubstitution() {
+        return dependencySubstitutions;
+    }
+
+    @Override
+    public ResolutionStrategy dependencySubstitution(Action<? super DependencySubstitutions> action) {
+        action.execute(dependencySubstitutions);
+        return this;
+    }
+
     public DefaultResolutionStrategy copy() {
-        DefaultResolutionStrategy out = new DefaultResolutionStrategy(cachePolicy.copy(), new LinkedHashSet<Action<? super DependencyResolveDetails>>(dependencyResolveRules));
+        DefaultResolutionStrategy out = new DefaultResolutionStrategy(cachePolicy.copy(), dependencySubstitutions.copy());
 
         if (conflictResolution instanceof StrictConflictResolution) {
             out.failOnVersionConflict();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DependencySubstitutionsInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DependencySubstitutionsInternal.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.DependencyResolveDetails;
+import org.gradle.api.artifacts.DependencySubstitution;
+import org.gradle.api.artifacts.DependencySubstitutions;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.internal.artifacts.configurations.MutationValidator;
+
+public interface DependencySubstitutionsInternal extends DependencySubstitutions {
+    Action<DependencySubstitution<ComponentSelector>> getDependencySubstitutionRule();
+
+    DependencySubstitutions allWithDependencyResolveDetails(Action<? super DependencyResolveDetails> rule);
+
+    void beforeChange(MutationValidator validator);
+
+    DependencySubstitutionsInternal copy();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
@@ -19,15 +19,17 @@ package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
-import org.gradle.api.internal.artifacts.DependencyResolveDetailsInternal;
+import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
+import org.gradle.api.internal.artifacts.ModuleDependencySubstitutionInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ModuleForcingResolveRule implements Action<DependencyResolveDetailsInternal> {
+public class ModuleForcingResolveRule implements Action<DependencySubstitutionInternal<? extends ComponentSelector>> {
 
     private final Map<ModuleIdentifier, String> forcedModules;
 
@@ -42,13 +44,14 @@ public class ModuleForcingResolveRule implements Action<DependencyResolveDetails
         }
     }
 
-    public void execute(DependencyResolveDetailsInternal details) {
+    @Override
+    public void execute(DependencySubstitutionInternal<? extends ComponentSelector> details) {
         if (forcedModules == null) {
             return;
         }
-        ModuleIdentifier key = new DefaultModuleIdentifier(details.getRequested().getGroup(), details.getRequested().getName());
-        if (forcedModules.containsKey(key)) {
-            details.useVersion(forcedModules.get(key), VersionSelectionReasons.FORCED);
+        ModuleIdentifier key = new DefaultModuleIdentifier(details.getOldRequested().getGroup(), details.getOldRequested().getName());
+        if (forcedModules.containsKey(key) && details instanceof ModuleDependencySubstitutionInternal) {
+            ((ModuleDependencySubstitutionInternal) details).useVersion(forcedModules.get(key), VersionSelectionReasons.FORCED);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultDependencyResolver.java
@@ -95,7 +95,7 @@ public class DefaultDependencyResolver implements ArtifactDependencyResolver {
 
                 ProjectDependencyResolver projectDependencyResolver = new ProjectDependencyResolver(projectComponentRegistry, localComponentFactory, repositoryChain.getComponentIdResolver());
                 ResolutionStrategyInternal resolutionStrategy = configuration.getResolutionStrategy();
-                DependencyToComponentIdResolver idResolver = new DependencySubstitutionResolver(projectDependencyResolver, resolutionStrategy.getDependencyResolveRule());
+                DependencyToComponentIdResolver idResolver = new DependencySubstitutionResolver(projectDependencyResolver, resolutionStrategy.getDependencySubstitutionRule());
 
                 ArtifactResolver artifactResolver = createArtifactResolver(repositoryChain);
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultDependencyResolveDetailsSpec.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice
 
 import org.gradle.api.artifacts.ModuleVersionSelector
-import org.gradle.api.artifacts.component.ComponentSelector
+import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
@@ -30,7 +30,6 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         def details = newDependencyResolveDetails("org", "foo", "1.0")
 
         then:
-        details.selector == newComponentSelector("org", "foo", "1.0")
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newComponentSelector("org", "foo", "1.0")
         !details.updated
@@ -40,7 +39,6 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.useVersion("1.0") //the same version
 
         then:
-        details.selector == newComponentSelector("org", "foo", "1.0")
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newComponentSelector("org", "foo", "1.0")
         details.updated
@@ -50,7 +48,6 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.useVersion("2.0") //different version
 
         then:
-        details.selector == newComponentSelector("org", "foo", "1.0")
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target != newComponentSelector("org", "foo", "1.0")
         details.updated
@@ -68,7 +65,6 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.useVersion("1.0", VersionSelectionReasons.FORCED) //same version
 
         then:
-        details.selector == newComponentSelector("org", "foo", "1.0")
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newComponentSelector("org", "foo", "1.0")
         details.updated
@@ -78,7 +74,6 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.useVersion("3.0", VersionSelectionReasons.FORCED) //different version
 
         then:
-        details.selector == newComponentSelector("org", "foo", "1.0")
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target.version == "3.0"
         details.target.module == newComponentSelector("org", "foo", "1.0").module
@@ -95,7 +90,6 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.useVersion("3.0", VersionSelectionReasons.SELECTED_BY_RULE)
 
         then:
-        details.selector == newComponentSelector("org", "foo", "1.0")
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target.version == "3.0"
         details.target.module == newComponentSelector("org", "foo", "1.0").module
@@ -155,10 +149,10 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
     }
 
     private static def newDependencyResolveDetails(String group, String name, String version) {
-        return new DefaultDependencyResolveDetails(newComponentSelector(group, name, version), newVersionSelector(group, name, version))
+        return new DefaultDependencyResolveDetails(new DefaultModuleDependencySubstitution(newComponentSelector(group, name, version), newVersionSelector(group, name, version)))
     }
 
-    private static ComponentSelector newComponentSelector(String group, String module, String version) {
+    private static ModuleComponentSelector newComponentSelector(String group, String module, String version) {
         return DefaultModuleComponentSelector.newSelector(group, module, version)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultModuleDependencySubstitutionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultModuleDependencySubstitutionTest.groovy
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.component.ProjectComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
+import org.gradle.internal.typeconversion.UnsupportedNotationException
+import spock.lang.Specification
+
+class DefaultModuleDependencySubstitutionTest extends Specification {
+
+    def "can specify version to use"() {
+        when:
+        def details = newModuleDependencySubstitution("org", "foo", "1.0")
+
+        then:
+        details.requested == newComponentSelector("org", "foo", "1.0")
+        details.target == newComponentSelector("org", "foo", "1.0")
+        !details.updated
+        !details.selectionReason
+
+        when:
+        details.useVersion("1.0") //the same version
+
+        then:
+        details.requested == newComponentSelector("org", "foo", "1.0")
+        details.target == newComponentSelector("org", "foo", "1.0")
+        details.updated
+        details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE
+
+        when:
+        details.useVersion("2.0") //different version
+
+        then:
+        details.requested == newComponentSelector("org", "foo", "1.0")
+        details.target != newComponentSelector("org", "foo", "1.0")
+        details.updated
+        details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE
+
+        details.target.version == "2.0"
+        details.target.module == newComponentSelector("org", "foo", "1.0").module
+        details.target.group == newComponentSelector("org", "foo", "1.0").group
+    }
+
+    def "can specify version with selection reason"() {
+        def details = newModuleDependencySubstitution("org", "foo", "1.0")
+
+        when:
+        details.useVersion("1.0", VersionSelectionReasons.FORCED) //same version
+
+        then:
+        details.requested == newComponentSelector("org", "foo", "1.0")
+        details.target == newComponentSelector("org", "foo", "1.0")
+        details.updated
+        details.selectionReason == VersionSelectionReasons.FORCED
+
+        when:
+        details.useVersion("3.0", VersionSelectionReasons.FORCED) //different version
+
+        then:
+        details.requested == newComponentSelector("org", "foo", "1.0")
+        details.target.version == "3.0"
+        details.target.module == newComponentSelector("org", "foo", "1.0").module
+        details.target.group == newComponentSelector("org", "foo", "1.0").group
+        details.updated
+        details.selectionReason == VersionSelectionReasons.FORCED
+    }
+
+    def "can override version and selection reason"() {
+        def details = newModuleDependencySubstitution("org", "foo", "1.0")
+
+        when:
+        details.useVersion("2.0", VersionSelectionReasons.FORCED)
+        details.useVersion("3.0", VersionSelectionReasons.SELECTED_BY_RULE)
+
+        then:
+        details.requested == newComponentSelector("org", "foo", "1.0")
+        details.target.version == "3.0"
+        details.target.module == newComponentSelector("org", "foo", "1.0").module
+        details.target.group == newComponentSelector("org", "foo", "1.0").group
+        details.updated
+        details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE
+    }
+
+    def "does not allow null target"() {
+        def details = newModuleDependencySubstitution("org", "foo", "1.0")
+
+        when:
+        details.useTarget(null)
+
+        then:
+        thrown(UnsupportedNotationException)
+
+        when:
+        details.useTarget(null, VersionSelectionReasons.SELECTED_BY_RULE)
+
+        then:
+        thrown(UnsupportedNotationException)
+    }
+
+    def "does not allow null version"() {
+        def details = newModuleDependencySubstitution("org", "foo", "1.0")
+
+        when:
+        details.useVersion(null)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        details.useVersion(null, VersionSelectionReasons.SELECTED_BY_RULE)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "can specify target module"() {
+        def details = newModuleDependencySubstitution("org", "foo", "1.0")
+
+        when:
+        details.useTarget("org:bar:2.0")
+
+        then:
+        details.target instanceof ModuleComponentSelector
+        details.target.toString() == 'org:bar:2.0'
+        details.updated
+        details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE
+    }
+
+    def "can specify target project"() {
+        def project = Mock(Project)
+        def details = newModuleDependencySubstitution("org", "foo", "1.0")
+
+        when:
+        details.useTarget(project)
+
+        then:
+        _ * project.path >> ":bar"
+        details.target instanceof ProjectComponentSelector
+        details.target.projectPath == ":bar"
+        details.updated
+        details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE
+    }
+
+    def "can mix configuring version and target module"() {
+        def details = newModuleDependencySubstitution("org", "foo", "1.0")
+
+        when:
+        details.useVersion("1.5")
+
+        then:
+        details.target.toString() == 'org:foo:1.5'
+
+        when:
+        details.useTarget("com:bar:3.0")
+
+        then:
+        details.target.toString() == 'com:bar:3.0'
+
+        when:
+        details.useVersion('2.0')
+
+        then:
+        details.target.toString() == 'org:foo:2.0'
+    }
+
+    private static def newModuleDependencySubstitution(String group, String name, String version) {
+        return new DefaultModuleDependencySubstitution(newComponentSelector(group, name, version), DefaultModuleVersionSelector.newSelector(group, name, version))
+    }
+
+    private static ModuleComponentSelector newComponentSelector(String group, String module, String version) {
+        return DefaultModuleComponentSelector.newSelector(group, module, version)
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultProjectDependencySubstitutionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultProjectDependencySubstitutionTest.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.component.ProjectComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
+import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
+import org.gradle.internal.typeconversion.UnsupportedNotationException
+import spock.lang.Specification
+
+class DefaultProjectDependencySubstitutionTest extends Specification {
+
+    def "can override target and selection reason"() {
+        def details = newProjectDependencySubstitution("foo")
+
+        when:
+        details.useTarget("org:foo:2.0", VersionSelectionReasons.FORCED)
+        details.useTarget("org:foo:3.0", VersionSelectionReasons.SELECTED_BY_RULE)
+
+        then:
+        details.requested == newComponentSelector(":foo")
+        details.target.version == "3.0"
+        details.target.module == newComponentSelector("org", "foo", "1.0").module
+        details.target.group == newComponentSelector("org", "foo", "1.0").group
+        details.updated
+        details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE
+    }
+
+    def "does not allow null target"() {
+        def details = newProjectDependencySubstitution("foo")
+
+        when:
+        details.useTarget(null)
+
+        then:
+        thrown(UnsupportedNotationException)
+
+        when:
+        details.useTarget(null, VersionSelectionReasons.SELECTED_BY_RULE)
+
+        then:
+        thrown(UnsupportedNotationException)
+    }
+
+    def "can specify target module"() {
+        def details = newProjectDependencySubstitution("foo")
+
+        when:
+        details.useTarget("org:bar:2.0")
+
+        then:
+        details.target instanceof ModuleComponentSelector
+        details.target.toString() == 'org:bar:2.0'
+        details.updated
+        details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE
+    }
+
+    def "can specify target project"() {
+        def project = Mock(Project)
+        def details = newProjectDependencySubstitution("foo")
+
+        when:
+        details.useTarget(project)
+
+        then:
+        _ * project.path >> ":bar"
+        details.target instanceof ProjectComponentSelector
+        details.target.projectPath == ":bar"
+        details.updated
+        details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE
+    }
+
+    private static def newProjectDependencySubstitution(String name) {
+        return new DefaultProjectDependencySubstitution(newComponentSelector(":" + name), DefaultModuleVersionSelector.newSelector("com.test", name, "1.0"))
+    }
+
+    private static ProjectComponentSelector newComponentSelector(String projectPath) {
+        return DefaultProjectComponentSelector.newSelector(projectPath)
+    }
+
+    private static ModuleComponentSelector newComponentSelector(String group, String module, String version) {
+        return DefaultModuleComponentSelector.newSelector(group, module, version)
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DependencySubstitutionResolverSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DependencySubstitutionResolverSpec.groovy
@@ -16,7 +16,8 @@
 package org.gradle.api.internal.artifacts.ivyservice
 
 import org.gradle.api.Action
-import org.gradle.api.artifacts.DependencyResolveDetails
+import org.gradle.api.artifacts.DependencySubstitution
+import org.gradle.api.artifacts.ModuleDependencySubstitution
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.component.model.DependencyMetaData
@@ -39,7 +40,7 @@ class DependencySubstitutionResolverSpec extends Specification {
 
     def "passes through dependency when it does not match any rule"() {
         given:
-        rule.execute(_) >> { DependencyResolveDetails details ->
+        rule.execute(_) >> { DependencySubstitution details ->
         }
 
         when:
@@ -53,7 +54,7 @@ class DependencySubstitutionResolverSpec extends Specification {
         def substitutedDependency = Stub(DependencyMetaData)
 
         given:
-        rule.execute(_) >> { DependencyResolveDetails details ->
+        rule.execute(_) >> { ModuleDependencySubstitution details ->
             details.useVersion("new")
         }
 
@@ -68,7 +69,7 @@ class DependencySubstitutionResolverSpec extends Specification {
     def "explosive rule yields failure result that provides context"() {
         given:
         def failure = new RuntimeException("broken")
-        rule.execute(_) >> { DependencyResolveDetails details ->
+        rule.execute(_) >> { DependencySubstitution details ->
             throw failure
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultDependencySubstitutionsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultDependencySubstitutionsSpec.groovy
@@ -27,6 +27,8 @@ import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY
+
 class DefaultDependencySubstitutionsSpec extends Specification {
     DependencySubstitutionsInternal substitutions;
 
@@ -268,34 +270,34 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         substitutions.beforeChange(validator)
         
         when: substitutions.all(Mock(Action))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
         
         when: substitutions.all(Mock(Closure))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
         
         when: substitutions.eachModule(Mock(Action))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
         
         when: substitutions.eachModule(Mock(Closure))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
         
         when: substitutions.withModule("org:foo", Mock(Action))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
         
         when: substitutions.withModule("org:foo", Mock(Closure))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
         
         when: substitutions.eachProject(Mock(Action))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
         
         when: substitutions.eachProject(Mock(Closure))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
         
         when: substitutions.withProject(":foo", Mock(Action))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
         
         when: substitutions.withProject(":foo", Mock(Closure))
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
     }
 
     def "mutating copy does not trigger original validator"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultDependencySubstitutionsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultDependencySubstitutionsSpec.groovy
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ModuleDependencySubstitution
+import org.gradle.api.artifacts.ProjectDependencySubstitution
+import org.gradle.api.internal.artifacts.*
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
+import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultDependencySubstitutionsSpec extends Specification {
+    DependencySubstitutionsInternal substitutions;
+
+    def setup() {
+        substitutions = new DefaultDependencySubstitutions()
+    }
+
+    def "provides no op resolve rule when no rules or forced modules configured"() {
+        given:
+        def details = Mock(DependencySubstitutionInternal)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(details)
+
+        then:
+        0 * details._
+    }
+
+    def "all() matches modules and projects"() {
+        given:
+        def action = Mock(Action)
+        substitutions.all(action)
+
+        def moduleDetails = Mock(ModuleDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(moduleDetails)
+
+        then:
+        _ * moduleDetails.requested >> DefaultModuleComponentSelector.newSelector("org.utils", "api", "1.5")
+        1 * action.execute(moduleDetails)
+        0 * _
+
+        def projectDetails = Mock(ProjectDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(projectDetails)
+
+        then:
+        _ * projectDetails.requested >> DefaultProjectComponentSelector.newSelector(":api")
+        1 * action.execute(projectDetails)
+        0 * _
+    }
+
+    def "allWithDependencyResolveDetails() wraps substitution in legacy format"() {
+        given:
+        def action = Mock(Action)
+        substitutions.allWithDependencyResolveDetails(action)
+
+        def moduleOldRequested = DefaultModuleVersionSelector.newSelector("org.utils", "api", "1.5")
+        def moduleDetails = Mock(ModuleDependencySubstitutionInternal)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(moduleDetails)
+
+        then:
+        _ * moduleDetails.oldRequested >> moduleOldRequested
+        1 * action.execute({ DependencyResolveDetailsInternal details ->
+            details.requested == moduleOldRequested
+        })
+        0 * _
+
+        def projectOldRequested = DefaultModuleVersionSelector.newSelector("org.utils", "api", "1.5")
+        def projectDetails = Mock(ProjectDependencySubstitutionInternal)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(projectDetails)
+
+        then:
+        _ * projectDetails.oldRequested >> projectOldRequested
+        1 * action.execute({ DependencyResolveDetailsInternal details ->
+            details.requested == projectOldRequested
+        })
+        0 * _
+    }
+
+    def "eachModule() matches only modules"() {
+        given:
+        def action = Mock(Action)
+        substitutions.eachModule(action)
+
+        def moduleDetails = Mock(ModuleDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(moduleDetails)
+
+        then:
+        _ * moduleDetails.requested >> DefaultModuleComponentSelector.newSelector("org.utils", "api", "1.5")
+        1 * action.execute(moduleDetails)
+        0 * _
+
+        def projectDetails = Mock(ProjectDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(projectDetails)
+
+        then:
+        _ * projectDetails.requested >> DefaultProjectComponentSelector.newSelector(":api")
+        0 * _
+    }
+
+    @Unroll
+    def "withModule() matches only given module: #matchingModule"() {
+        given:
+        def matchingModuleVersionAction = Mock(Action)
+        def nonMatchingModuleVersionAction = Mock(Action)
+
+        substitutions.withModule(matchingModule, matchingModuleVersionAction)
+        substitutions.withModule(nonMatchingModule, nonMatchingModuleVersionAction)
+
+        def moduleDetails = Mock(ModuleDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(moduleDetails)
+
+        then:
+        _ * moduleDetails.requested >> DefaultModuleComponentSelector.newSelector("org.utils", "api", "1.5")
+        1 * matchingModuleVersionAction.execute(moduleDetails)
+        0 * nonMatchingModuleVersionAction.execute(_)
+        0 * _
+
+        def projectDetails = Mock(ProjectDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(projectDetails)
+
+        then:
+        _ * projectDetails.requested >> DefaultProjectComponentSelector.newSelector(":api")
+        0 * _
+
+        where:
+        matchingModule                    | nonMatchingModule
+        "org.utils:api"                   | "org.utils:impl"
+        [group: "org.utils", name: "api"] | [group: "org.utils", name: "impl"]
+    }
+
+    def "withModule() does not match projects"() {
+        given:
+        def action = Mock(Action)
+
+        substitutions.withModule("org.utils:api", action)
+
+        def projectDetails = Mock(ProjectDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(projectDetails)
+
+        then:
+        _ * projectDetails.requested >> DefaultProjectComponentSelector.newSelector(":api")
+        0 * _
+    }
+
+    def "eachProject() matches only projects"() {
+        given:
+        def action = Mock(Action)
+        substitutions.eachProject(action)
+
+        def projectDetails = Mock(ProjectDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(projectDetails)
+
+        then:
+        _ * projectDetails.requested >> DefaultProjectComponentSelector.newSelector(":api")
+        1 * action.execute(projectDetails)
+        0 * _
+
+        def moduleDetails = Mock(ModuleDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(moduleDetails)
+
+        then:
+        _ * moduleDetails.requested >> DefaultModuleComponentSelector.newSelector("org.utils", "api", "1.5")
+        0 * _
+    }
+
+    @Unroll
+    def "withProject() matches only given project: #matchingProject"() {
+        given:
+        def matchingProjectAction = Mock(Action)
+        def nonMatchingProjectAction = Mock(Action)
+
+        substitutions.withProject(matchingProject, matchingProjectAction)
+        substitutions.withProject(nonMatchingProject, nonMatchingProjectAction)
+
+        def projectDetails = Mock(ProjectDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(projectDetails)
+
+        then:
+        _ * projectDetails.requested >> DefaultProjectComponentSelector.newSelector(":api")
+        1 * matchingProjectAction.execute(projectDetails)
+        0 * nonMatchingProjectAction.execute(_)
+        0 * _
+
+        where:
+        matchingProject                                             | nonMatchingProject
+        ":api"                                                      | ":impl"
+        Mock(Project) { Project project -> project.path >> ":api" } | Mock(Project) { Project project -> project.path >> ":impl" }
+    }
+
+    def "withProject() does not match modules"() {
+        def action = Mock(Action)
+        substitutions.withProject(":api", action)
+        def moduleDetails = Mock(ModuleDependencySubstitution)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(moduleDetails)
+
+        then:
+        _ * moduleDetails.requested >> DefaultModuleComponentSelector.newSelector("org.utils", "api", "1.5")
+        0 * _
+    }
+
+    def "provides dependency substitution rule that orderly aggregates user specified rules"() {
+        given:
+        substitutions.eachModule({ it.useVersion("1.0") } as Action)
+        substitutions.eachModule({ it.useVersion("2.0") } as Action)
+        substitutions.eachModule({ it.useVersion("3.0") } as Action)
+        def details = Mock(ModuleDependencySubstitutionInternal)
+
+        when:
+        substitutions.dependencySubstitutionRule.execute(details)
+
+        then:
+        1 * details.useVersion("1.0")
+        then:
+        1 * details.useVersion("2.0")
+        then:
+        1 * details.useVersion("3.0")
+        0 * details._
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRuleSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRuleSpec.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy
 
-import org.gradle.api.internal.artifacts.DependencyResolveDetailsInternal
+import org.gradle.api.internal.artifacts.ModuleDependencySubstitutionInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
 import spock.lang.Specification
 
@@ -26,7 +26,7 @@ class ModuleForcingResolveRuleSpec extends Specification {
 
     def "forces modules"() {
         given:
-        def details = Mock(DependencyResolveDetailsInternal)
+        def details = Mock(ModuleDependencySubstitutionInternal)
 
         when:
         new ModuleForcingResolveRule([
@@ -38,7 +38,7 @@ class ModuleForcingResolveRuleSpec extends Specification {
         ]).execute(details)
 
         then:
-        _ * details.getRequested() >> requested
+        _ * details.getOldRequested() >> requested
         1 * details.useVersion(forcedVersion, VersionSelectionReasons.FORCED)
         0 * details._
 
@@ -52,7 +52,7 @@ class ModuleForcingResolveRuleSpec extends Specification {
 
     def "does not force modules if they dont match"() {
         given:
-        def details = Mock(DependencyResolveDetailsInternal)
+        def details = Mock(ModuleDependencySubstitutionInternal)
 
         when:
         new ModuleForcingResolveRule([
@@ -63,7 +63,7 @@ class ModuleForcingResolveRuleSpec extends Specification {
         ]).execute(details)
 
         then:
-        _ * details.getRequested() >> requested
+        _ * details.getOldRequested() >> requested
         0 * details._
 
         where:
@@ -78,7 +78,7 @@ class ModuleForcingResolveRuleSpec extends Specification {
     }
 
     def "does not force anything when input empty"() {
-        def details = Mock(DependencyResolveDetailsInternal)
+        def details = Mock(ModuleDependencySubstitutionInternal)
 
         when:
         new ModuleForcingResolveRule([]).execute(details)

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -182,20 +182,29 @@ In previous Gradle versions you could replace an external dependency with anothe
         }
     }
 
-Now the `requested` property on `DependencyResolveDetails` is deprecated; you can use the `selector` property instead. This returns a `ComponentSelector` instead
-a `ModuleVersionSelector`.
-
-The `useVersion()` method is also deprecated. You can use the `useTarget()` method instead:
+This method has been deprecated, and a new DSL has been introduced:
 
     resolutionStrategy {
-        eachDependency { details ->
-            if (details.selector instanceof ModuleComponentSelector && details.selector.group == 'com.example' && details.selector.module == 'my-module') {
-                useTarget group: 'com.example', name: 'my-module', version: '1.3'
-            }
+        dependencySubstitution {
+            withModule("com.example:my-module") { useVersion "1.3" }
         }
     }
 
-Note that `ModuleComponentSelector` has a `module` property to return the module's name, while `ModuleVersionSelector` had a `name` property.
+There are other options available to match module and project dependencies:
+
+    all { DependencySubstitution<ComponentSelector> details -> /* ... */ }
+    eachModule() { ModuleDependencySubstitution details -> /* ... */ }
+    withModule("com.example:my-module") { ModuleDependencySubstitution details -> /* ... */ }
+    eachProject() { ProjectDependencySubstitution details -> /* ... */ }
+    withProject(project(":api)) { ProjectDependencySubstitution details -> /* ... */ }
+
+Note that only `ModuleDependencySubstitution` has the `useVersion()` method. For the other substitutions you can use `useTarget()`:
+
+    resolutionStrategy {
+        dependencySubstitution {
+            withProject(project(":api")) { useTarget group: "org.utils", name: "api", version: "1.3" }
+        }
+    }
 
 ## Potential breaking changes
 
@@ -236,9 +245,9 @@ location to `install` to. The default repository was `mavenLocal()`.
 It is no longer possible to override this location by supplying a repository to the `PublishToMavenLocal` task. Any supplied repository
 will be ignored.
 
-### DependencyResolveDetails.getTarget() is gone
+### DependencyResolveDetails.getTarget() returns a `ComponentSelector`
 
-There still is a `getTarget()` method on `DefaultDependencyResolveDetails`, but it returns a `ComponentSelector` instead of a `ModuleVersionSelector`.
+The `getTarget()` method on the now deprecated `DefaultDependencyResolveDetails` returns a `ComponentSelector` instead of a `ModuleVersionSelector`.
 
 ### CommandLineToolConfiguration.withArguments() semantics have changed
 

--- a/subprojects/docs/src/samples/userguide/artifacts/resolutionStrategy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/resolutionStrategy/build.gradle
@@ -12,7 +12,7 @@ configurations.all {
 
 //START SNIPPET releasable-unit
 configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+    resolutionStrategy.dependencySubstitution.eachModule { ModuleDependencySubstitution details ->
         if (details.requested.group == 'org.gradle') {
             details.useVersion '1.4'
         }
@@ -22,9 +22,9 @@ configurations.all {
 
 //START SNIPPET custom-versioning-scheme
 configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+    resolutionStrategy.dependencySubstitution.eachModule { ModuleDependencySubstitution details ->
         if (details.requested.version == 'default') {
-            def version = findDefaultVersionInCatalog(details.requested.group, details.requested.name)
+            def version = findDefaultVersionInCatalog(details.requested.group, details.requested.module)
             details.useVersion version
         }
     }
@@ -38,8 +38,8 @@ def findDefaultVersionInCatalog(String group, String name) {
 
 //START SNIPPET blacklisting_version
 configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group == 'org.software' && details.requested.name == 'some-library' && details.requested.version == '1.2') {
+    resolutionStrategy.dependencySubstitution.eachModule { ModuleDependencySubstitution details ->
+        if (details.requested.group == 'org.software' && details.requested.module == 'some-library' && details.requested.version == '1.2') {
             //prefer different version which contains some necessary fixes
             details.useVersion '1.2.1'
         }
@@ -49,12 +49,12 @@ configurations.all {
 
 //START SNIPPET module_substitution
 configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.name == 'groovy-all') {
+    resolutionStrategy.dependencySubstitution.eachModule { ModuleDependencySubstitution details ->
+        if (details.requested.module == 'groovy-all') {
             //prefer 'groovy' over 'groovy-all':
             details.useTarget group: details.requested.group, name: 'groovy', version: details.requested.version
         }
-        if (details.requested.name == 'log4j') {
+        if (details.requested.module == 'log4j') {
             //prefer 'log4j-over-slf4j' over 'log4j', with fixed version:
             details.useTarget "org.slf4j:log4j-over-slf4j:1.7.7"
         }


### PR DESCRIPTION
Things left to do:

- [x] update spec
- [x] unit tests for new `DependencySubstitution` classes
- [x] deprecation warnings (and tests) for `ResolutionStrategy.eachDependency()`
- [x] fix `ClassLoadersCachingIntegrationTest` (unrelated, as it fails on master, too)
- [ ] update documentation

Tests:
- Resolved graph includes correct (substituted) dependencies
    - [x] Replacement of top-level dependency
    - [x] Replacement of transitive dependency
    - [x] Replacement of Client module dependency
- [x] Interaction with forced versions and other resolve rules
- [x] Conflict resolution where 2 external dependency versions are in graph, but only one version is replaced by project dependency
- [x] Additional dependency details (configuration, transitive, etc) are retained in substituted dependency
- [x] Real resolution of dependency files: pre-build the substituted project. (This test would later be modified to remove the pre-build step).
- [x] Dependency reports provide information on dependency substitution (already merged, see 4883e5ccca177a2f1ba9e1336878aefb5c26cd6f)

