### PR TITLE
Better names for configuration mutation types

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/MutationValidator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/MutationValidator.java
@@ -20,16 +20,28 @@ package org.gradle.api.internal.artifacts.configurations;
  * Used to validate mutation of an object and its sub-parts.
  */
 public interface MutationValidator {
+    enum MutationType {
+        /**
+         * The mutation of the resolution strategy of the configuration, i.e. caching, resolution rules etc.
+         */
+        STRATEGY,
+
+        /**
+         * The mutation of the content of the configuration, i.e. dependencies, artifacts, extended configurations etc.
+         */
+        CONTENT
+    }
+
     /**
      * Check if mutation is allowed.
      *
-     * @param lenient <code>false</code> if mutation should be completely forbidden, or <code>true</code> if mutation is allowed, but a deprecation warning should be shown.
+     * @param type the type of mutation to validate.
      */
-    void validateMutation(boolean lenient);
+    void validateMutation(MutationType type);
 
     static final MutationValidator IGNORE = new MutationValidator() {
         @Override
-        public void validateMutation(boolean lenient) {
+        public void validateMutation(MutationType type) {
         }
     };
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/RunnableMutationValidator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/RunnableMutationValidator.java
@@ -21,14 +21,14 @@ package org.gradle.api.internal.artifacts.configurations;
  * {@link org.gradle.api.internal.DefaultDomainObjectCollection#beforeChange(Runnable)}.
  */
 abstract public class RunnableMutationValidator implements MutationValidator, Runnable {
-    private final boolean leniencyAsRunnable;
+    private final MutationType typeAsRunnable;
 
-    public RunnableMutationValidator(boolean leniencyAsRunnable) {
-        this.leniencyAsRunnable = leniencyAsRunnable;
+    public RunnableMutationValidator(MutationType typeAsRunnable) {
+        this.typeAsRunnable = typeAsRunnable;
     }
 
     @Override
     public void run() {
-        validateMutation(leniencyAsRunnable);
+        validateMutation(typeAsRunnable);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY;
+
 public class DefaultCachePolicy implements CachePolicy, ResolutionRules {
     private static final int SECONDS_IN_DAY = 24 * 60 * 60;
 
@@ -65,17 +67,17 @@ public class DefaultCachePolicy implements CachePolicy, ResolutionRules {
     }
 
     public void eachDependency(Action<? super DependencyResolutionControl> rule) {
-        mutationValidator.validateMutation(true);
+        mutationValidator.validateMutation(STRATEGY);
         dependencyCacheRules.add(0, rule);
     }
 
     public void eachModule(Action<? super ModuleResolutionControl> rule) {
-        mutationValidator.validateMutation(true);
+        mutationValidator.validateMutation(STRATEGY);
         moduleCacheRules.add(0, rule);
     }
 
     public void eachArtifact(Action<? super ArtifactResolutionControl> rule) {
-        mutationValidator.validateMutation(true);
+        mutationValidator.validateMutation(STRATEGY);
         artifactCacheRules.add(0, rule);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRules.java
@@ -39,6 +39,8 @@ import org.gradle.internal.typeconversion.UnsupportedNotationException;
 import java.util.Collection;
 import java.util.Set;
 
+import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY;
+
 public class DefaultComponentSelectionRules implements ComponentSelectionRulesInternal {
     private static final String INVALID_SPEC_ERROR = "Could not add a component selection rule for module '%s'.";
 
@@ -105,7 +107,7 @@ public class DefaultComponentSelectionRules implements ComponentSelectionRulesIn
     }
 
     private ComponentSelectionRules addRule(SpecRuleAction<? super ComponentSelection> specRuleAction) {
-        mutationValidator.validateMutation(true);
+        mutationValidator.validateMutation(STRATEGY);
         rules.add(specRuleAction);
         return this;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY;
 import static org.gradle.util.GUtil.flattenElements;
 
 public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
@@ -66,7 +67,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     }
 
     public ResolutionStrategy failOnVersionConflict() {
-        mutationValidator.validateMutation(true);
+        mutationValidator.validateMutation(STRATEGY);
         this.conflictResolution = new StrictConflictResolution();
         return this;
     }
@@ -80,14 +81,14 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     }
 
     public DefaultResolutionStrategy force(Object... moduleVersionSelectorNotations) {
-        mutationValidator.validateMutation(true);
+        mutationValidator.validateMutation(STRATEGY);
         Set<ModuleVersionSelector> modules = ModuleVersionSelectorParsers.multiParser().parseNotation(moduleVersionSelectorNotations);
         this.forcedModules.addAll(modules);
         return this;
     }
 
     public ResolutionStrategy eachDependency(Action<? super DependencyResolveDetails> rule) {
-        mutationValidator.validateMutation(true);
+        mutationValidator.validateMutation(STRATEGY);
         dependencyResolveRules.add(rule);
         return this;
     }
@@ -98,7 +99,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     }
 
     public DefaultResolutionStrategy setForcedModules(Object ... moduleVersionSelectorNotations) {
-        mutationValidator.validateMutation(true);
+        mutationValidator.validateMutation(STRATEGY);
         Set<ModuleVersionSelector> modules = ModuleVersionSelectorParsers.multiParser().parseNotation(moduleVersionSelectorNotations);
         this.forcedModules.clear();
         this.forcedModules.addAll(modules);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
@@ -30,6 +30,8 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
+import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY
+
 public class DefaultCachePolicySpec extends Specification {
     private static final int SECOND = 1000;
     private static final int MINUTE = SECOND * 60;
@@ -217,19 +219,19 @@ public class DefaultCachePolicySpec extends Specification {
         cachePolicy.beforeChange(validator)
 
         when: cachePolicy.cacheChangingModulesFor(0, TimeUnit.HOURS)
-        then: (1.._) * validator.validateMutation(true)
+        then: (1.._) * validator.validateMutation(STRATEGY)
 
         when: cachePolicy.cacheDynamicVersionsFor(0, TimeUnit.HOURS)
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
 
         when: cachePolicy.eachArtifact(Actions.doNothing())
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
 
         when: cachePolicy.eachDependency(Actions.doNothing())
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
 
         when: cachePolicy.eachModule(Actions.doNothing())
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
     }
 
     def "mutation is not checked for copy"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRulesTest.groovy
@@ -33,6 +33,8 @@ import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.internal.typeconversion.UnsupportedNotationException
 import spock.lang.Specification
 
+import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY
+
 class DefaultComponentSelectionRulesTest extends Specification {
     static final GROUP = "group"
     static final MODULE = "module"
@@ -270,22 +272,22 @@ class DefaultComponentSelectionRulesTest extends Specification {
         rules.beforeChange(checker)
 
         when: rules.all(Actions.doNothing())
-        then: 1 * checker.validateMutation(true)
+        then: 1 * checker.validateMutation(STRATEGY)
 
         when: rules.all(Closure.IDENTITY)
-        then: 1 * checker.validateMutation(true)
+        then: 1 * checker.validateMutation(STRATEGY)
 
         when: rules.all(ruleSource)
-        then: 1 * checker.validateMutation(true)
+        then: 1 * checker.validateMutation(STRATEGY)
 
         when: rules.withModule("something", Actions.doNothing())
-        then: 1 * checker.validateMutation(true)
+        then: 1 * checker.validateMutation(STRATEGY)
 
         when: rules.withModule("something", Closure.IDENTITY)
-        then: 1 * checker.validateMutation(true)
+        then: 1 * checker.validateMutation(STRATEGY)
 
         when: rules.withModule("something", ruleSource)
-        then: 1 * checker.validateMutation(true)
+        then: 1 * checker.validateMutation(STRATEGY)
     }
 
     private class TestComponentSelectionAction implements Action<ComponentSelection> {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -30,6 +30,7 @@ import spock.lang.Specification
 import java.util.concurrent.TimeUnit
 
 import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.newSelector
+import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY
 
 public class DefaultResolutionStrategySpec extends Specification {
 
@@ -204,19 +205,19 @@ public class DefaultResolutionStrategySpec extends Specification {
         strategy.beforeChange(validator)
 
         when: strategy.failOnVersionConflict()
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
 
         when: strategy.force("org.utils:api:1.3")
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
 
         when: strategy.forcedModules = ["org.utils:api:1.4"]
-        then: (1.._) * validator.validateMutation(true)
+        then: (1.._) * validator.validateMutation(STRATEGY)
 
         when: strategy.eachDependency(Actions.doNothing())
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
 
         when: strategy.componentSelection.all(Actions.doNothing())
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
 
         when: strategy.componentSelection(new Action<ComponentSelectionRules>() {
             @Override
@@ -224,7 +225,7 @@ public class DefaultResolutionStrategySpec extends Specification {
                 componentSelectionRules.all(Actions.doNothing())
             }
         })
-        then: 1 * validator.validateMutation(true)
+        then: 1 * validator.validateMutation(STRATEGY)
     }
 
     def "mutation is not checked for copy"() {


### PR DESCRIPTION
Replace the `boolean` `lenient` parameter of configuration mutations with an enum that calls them what they are in the spec (i.e. `STRATEGY` and `CONTENT` mutations).