### PR TITLE
Change camel case regex to support numbers

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/util/GUtil.java
+++ b/subprojects/core/src/main/groovy/org/gradle/util/GUtil.java
@@ -31,7 +31,7 @@ import static java.util.Collections.emptyList;
 
 public class GUtil {
     private static final Pattern WORD_SEPARATOR = Pattern.compile("\\W+");
-    private static final Pattern UPPER_LOWER = Pattern.compile("(\\p{Upper}*)(\\p{Lower}*)");
+    private static final Pattern UPPER_LOWER = Pattern.compile("(?m)([A-Z]*)([a-z0-9]*)");
 
     public static <T extends Collection> T flatten(Object[] elements, T addTo, boolean flattenMaps) {
         return flatten(asList(elements), addTo, flattenMaps);

--- a/subprojects/core/src/test/groovy/org/gradle/util/GUtilTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/GUtilTest.groovy
@@ -35,6 +35,7 @@ public class GUtilTest extends spock.lang.Specification {
         toCamelCase("Two Words") == "TwoWords"
         toCamelCase(" Two  \t words\n") == "TwoWords"
         toCamelCase("four or so Words") == "FourOrSoWords"
+        toCamelCase("123-project") == "123Project"
         toCamelCase("trailing-") == "Trailing"
         toCamelCase("ABC") == "ABC"
         toCamelCase(".") == ""
@@ -55,6 +56,7 @@ public class GUtilTest extends spock.lang.Specification {
         toLowerCamelCase("Two Words") == "twoWords"
         toLowerCamelCase(" Two  \t words\n") == "twoWords"
         toLowerCamelCase("four or so Words") == "fourOrSoWords"
+        toLowerCamelCase("123-project") == "123Project"
         toLowerCamelCase("trailing-") == "trailing"
         toLowerCamelCase("ABC") == "aBC"
         toLowerCamelCase(".") == ""
@@ -83,6 +85,8 @@ public class GUtilTest extends spock.lang.Specification {
         toConstant("ABC") == "ABC"
         toConstant("ABCThing") == "ABC_THING"
         toConstant("ABC Thing") == "ABC_THING"
+        toConstant("123-project") == "123_PROJECT"
+        toConstant("123abc-project") == "123ABC_PROJECT"
         toConstant(".") == ""
         toConstant("-") == ""
     }
@@ -106,6 +110,7 @@ public class GUtilTest extends spock.lang.Specification {
         toWords("ABC") == "abc"
         toWords("ABCThing") == "abc thing"
         toWords("ABC Thing") == "abc thing"
+        toWords("123Thing") == "123 thing"
         toWords(".") == ""
         toWords("_") == ""
     }

--- a/subprojects/core/src/test/groovy/org/gradle/util/GUtilTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/GUtilTest.groovy
@@ -36,6 +36,7 @@ public class GUtilTest extends spock.lang.Specification {
         toCamelCase(" Two  \t words\n") == "TwoWords"
         toCamelCase("four or so Words") == "FourOrSoWords"
         toCamelCase("123-project") == "123Project"
+        toCamelCase("i18n-admin") == "I18nAdmin"
         toCamelCase("trailing-") == "Trailing"
         toCamelCase("ABC") == "ABC"
         toCamelCase(".") == ""
@@ -57,6 +58,7 @@ public class GUtilTest extends spock.lang.Specification {
         toLowerCamelCase(" Two  \t words\n") == "twoWords"
         toLowerCamelCase("four or so Words") == "fourOrSoWords"
         toLowerCamelCase("123-project") == "123Project"
+        toLowerCamelCase("i18n-admin") == "i18nAdmin"
         toLowerCamelCase("trailing-") == "trailing"
         toLowerCamelCase("ABC") == "aBC"
         toLowerCamelCase(".") == ""
@@ -87,6 +89,7 @@ public class GUtilTest extends spock.lang.Specification {
         toConstant("ABC Thing") == "ABC_THING"
         toConstant("123-project") == "123_PROJECT"
         toConstant("123abc-project") == "123ABC_PROJECT"
+        toConstant("i18n-admin") == "I18N_ADMIN"
         toConstant(".") == ""
         toConstant("-") == ""
     }


### PR DESCRIPTION
I'm trying to use the gradle application plugin to create a distribution zip.  The name of my project is i18n-admin.

After unzipping the distribution and checking the generated startScript I noticed that the application jvm options were not being set. 

The generated script created this:

`eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $I_N_ADMIN_OPTS`

but I really want this
`eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $I18N_ADMIN_OPTS`

I traced it to the regex defined in GUtil