### PR TITLE
IDE plugins detect transitively substituted project dependencies

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencySubstitutionIntegrationTest.groovy
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 package org.gradle.plugins.ide.eclipse
+
 import org.gradle.integtests.fixtures.TestResources
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -49,7 +49,6 @@ project(":project2") {
         assert classpath.libs == []
     }
 
-    @Ignore("Not yet implemented")
     @Test
     void "transitive external dependency substituted with project dependency"() {
         mavenRepo.module("org.gradle", "module1").dependsOn("module2").publish()

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.plugins.ide.idea
 
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -53,7 +52,6 @@ project(":project2") {
         dependencies.assertHasModule('COMPILE', 'project1')
     }
 
-    @Ignore("Not yet implemented")
     @Test
     void "transitive external dependency substituted with project dependency"() {
         mavenRepo.module("org.gradle", "module1").dependsOn("module2").publish()

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
@@ -16,6 +16,8 @@
 
 package org.gradle.plugins.ide.internal.resolver;
 
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.*;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -30,10 +32,7 @@ import org.gradle.plugins.ide.internal.resolver.model.IdeProjectDependency;
 import org.gradle.plugins.ide.internal.resolver.model.UnresolvedIdeRepoFileDependency;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
     /**
@@ -45,7 +44,7 @@ public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
      */
     public List<IdeProjectDependency> getIdeProjectDependencies(Configuration configuration, Project project) {
         ResolutionResult result = getIncomingResolutionResult(configuration);
-        List<ResolvedComponentResult> projectComponents = findAllResolvedDependencyResults(result.getRoot().getDependencies(), ProjectComponentIdentifier.class);
+        Set<ResolvedComponentResult> projectComponents = findAllResolvedProjectDependencyResultsAccessibleOnlyFromRoot(result.getRoot());
 
         List<IdeProjectDependency> ideProjectDependencies = new ArrayList<IdeProjectDependency>();
 
@@ -58,24 +57,55 @@ public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
     }
 
     /**
-     * Finds all resolved components of the given type from the given set of dependency edges.
+     * Finds all project dependencies that are inaccessible from any other project dependencies of the component, only from root.
+     * Direct and transitive dependencies are both considered accessible here.
      *
-     * @param dependencies Dependencies
+     * @param root root component
      * @return Resolved dependency results
      */
-    private List<ResolvedComponentResult> findAllResolvedDependencyResults(Set<? extends DependencyResult> dependencies, Class<? extends ComponentIdentifier> type) {
-        List<ResolvedComponentResult> matches = new ArrayList<ResolvedComponentResult>();
+    private Set<ResolvedComponentResult> findAllResolvedProjectDependencyResultsAccessibleOnlyFromRoot(ResolvedComponentResult root) {
+        Multimap<ResolvedComponentResult, ResolvedComponentResult> parents = LinkedHashMultimap.create();
+        findAllResolvedDependencyResultsAndTheirDependenciesAndRecordTheirParents(parents, root);
 
-        for (DependencyResult dependencyResult : dependencies) {
-            if (dependencyResult instanceof ResolvedDependencyResult) {
-                ResolvedDependencyResult resolvedResult = (ResolvedDependencyResult) dependencyResult;
-                if (type.isInstance(resolvedResult.getSelected().getId())) {
-                    matches.add(resolvedResult.getSelected());
+        Set<ResolvedComponentResult> matches = new LinkedHashSet<ResolvedComponentResult>();
+
+        for (ResolvedComponentResult component : parents.keySet()) {
+            if (component.getId() instanceof ProjectComponentIdentifier) {
+                boolean hasNoParentOtherThanRoot = true;
+                for (ResolvedComponentResult parent : parents.get(component)) {
+                    if (!parent.getId().equals(root.getId()) && parent.getId() instanceof ProjectComponentIdentifier) {
+                        hasNoParentOtherThanRoot = false;
+                        break;
+                    }
+                }
+                if (hasNoParentOtherThanRoot) {
+                    matches.add(component);
                 }
             }
         }
 
         return matches;
+    }
+
+    private void findAllResolvedDependencyResultsAndTheirDependenciesAndRecordTheirParents(Multimap<ResolvedComponentResult, ResolvedComponentResult> parents, ResolvedComponentResult parent) {
+        for (DependencyResult dependencyResult : parent.getDependencies()) {
+            if (dependencyResult instanceof ResolvedDependencyResult) {
+                ResolvedComponentResult child = ((ResolvedDependencyResult) dependencyResult).getSelected();
+                // avoid circular dependencies by checking whether component result is already visited
+                if (parents.containsKey(child)) {
+                    continue;
+                }
+                recordParents(parents, parent, child);
+                findAllResolvedDependencyResultsAndTheirDependenciesAndRecordTheirParents(parents, child);
+            }
+        }
+    }
+
+    private void recordParents(Multimap<ResolvedComponentResult, ResolvedComponentResult> parents, ResolvedComponentResult parent, ResolvedComponentResult child) {
+        parents.put(child, parent);
+        for (ResolvedComponentResult grandParent : parents.get(parent)) {
+            recordParents(parents, grandParent, child);
+        }
     }
 
     /**
@@ -136,8 +166,8 @@ public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
      * Finds all resolved components of the given type from the given set of dependency edges. If resolved component has dependencies itself, recursively resolve them as well
      * and add them to the results. This method can handle circular dependencies.
      *
+     * @param matches Resolved dependency results
      * @param dependencies Dependencies
-     * @return Resolved dependency results
      */
     private void findAllResolvedDependencyResultsAndTheirDependencies(List<ResolvedComponentResult> matches, Set<? extends DependencyResult> dependencies, Class<? extends ComponentIdentifier> type) {
         for (DependencyResult dependencyResult : dependencies) {


### PR DESCRIPTION
This fixes https://github.com/prezi/gradle/issues/23