### PR TITLE
GRADLE-3084 escaping of $ in unix scripts

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/plugins/StartScriptGenerator.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/plugins/StartScriptGenerator.groovy
@@ -39,6 +39,11 @@ class StartScriptGenerator {
     String mainClassName
 
     Iterable<String> defaultJvmOpts = []
+    
+    /**
+     * Flag to turn on escaping of meta characters like $ in default jvm opts 
+     */
+    Boolean escapeMetaCharactersInDefaultJvmOpts = false
 
     /**
      * The classpath, relative to the application home directory.
@@ -73,6 +78,7 @@ class StartScriptGenerator {
         scriptGenerationDetails.applicationName = applicationName
         scriptGenerationDetails.mainClassName = mainClassName
         scriptGenerationDetails.defaultJvmOpts = defaultJvmOpts
+        scriptGenerationDetails.escapeMetaCharactersInDefaultJvmOpts = escapeMetaCharactersInDefaultJvmOpts
         scriptGenerationDetails.optsEnvironmentVar = optsEnvironmentVar
         scriptGenerationDetails.exitEnvironmentVar = exitEnvironmentVar
         scriptGenerationDetails.classpath = classpath

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/ApplicationPlugin.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/ApplicationPlugin.groovy
@@ -102,6 +102,7 @@ class ApplicationPlugin implements Plugin<Project> {
         startScripts.conventionMapping.applicationName = { pluginConvention.applicationName }
         startScripts.conventionMapping.outputDir = { new File(project.buildDir, 'scripts') }
         startScripts.conventionMapping.defaultJvmOpts = { pluginConvention.applicationDefaultJvmArgs }
+        startScripts.conventionMapping.escapeMetaCharactersInDefaultJvmOpts = { pluginConvention.escapeMetaCharactersInDefaultJvmOpts }
     }
 
     private Task addInstallAppTask(Distribution distribution) {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/application/CreateStartScripts.groovy
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/tasks/application/CreateStartScripts.groovy
@@ -47,6 +47,13 @@ public class CreateStartScripts extends ConventionTask {
     @Input
     @Optional
     Iterable<String> defaultJvmOpts = []
+    
+    /**
+     * If script should escape meta characters like $
+     */
+    @Input
+    @Optional
+    Boolean escapeMetaCharactersInDefaultJvmOpts = false;
 
     /**
      * The application's name.
@@ -115,6 +122,7 @@ public class CreateStartScripts extends ConventionTask {
         generator.applicationName = getApplicationName()
         generator.mainClassName = getMainClassName()
         generator.defaultJvmOpts = getDefaultJvmOpts()
+        generator.escapeMetaCharactersInDefaultJvmOpts = getEscapeMetaCharactersInDefaultJvmOpts()
         generator.optsEnvironmentVar = getOptsEnvironmentVar()
         generator.exitEnvironmentVar = getExitEnvironmentVar()
         generator.classpath = getClasspath().collect { "lib/${it.name}".toString() }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/UnixStartScriptGenerator.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/UnixStartScriptGenerator.java
@@ -39,7 +39,8 @@ public class UnixStartScriptGenerator extends AbstractTemplateBasedStartScriptGe
         binding.put("applicationName", details.getApplicationName());
         binding.put("optsEnvironmentVar", details.getOptsEnvironmentVar());
         binding.put("mainClassName", details.getMainClassName());
-        binding.put("defaultJvmOpts", createJoinedDefaultJvmOpts(details.getDefaultJvmOpts()));
+        binding.put("defaultJvmOpts", createJoinedDefaultJvmOpts(details.getDefaultJvmOpts(), details.getEscapeMetaCharactersInDefaultJvmOpts()));
+        binding.put("escapeMetaCharactersInDefaultJvmOpts", String.valueOf(details.getEscapeMetaCharactersInDefaultJvmOpts()));
         binding.put("appNameSystemProperty", details.getAppNameSystemProperty());
         binding.put("appHomeRelativePath", createJoinedAppHomeRelativePath(details.getScriptRelPath()));
         binding.put("classpath", createJoinedClasspath(details.getClasspath()));
@@ -58,7 +59,7 @@ public class UnixStartScriptGenerator extends AbstractTemplateBasedStartScriptGe
         }));
     }
 
-    private String createJoinedDefaultJvmOpts(Iterable<String> defaultJvmOpts) {
+    private String createJoinedDefaultJvmOpts(Iterable<String> defaultJvmOpts, final Boolean escapeMetaCharactersInDefaultJvmOpts) {
         Iterable<String> quotedDefaultJvmOpts = Iterables.transform(defaultJvmOpts, new Function<String, String>() {
             public String apply(String jvmOpt) {
                 //quote ', ", \, $. Probably not perfect. TODO: identify non-working cases, fail-fast on them
@@ -66,7 +67,9 @@ public class UnixStartScriptGenerator extends AbstractTemplateBasedStartScriptGe
                 jvmOpt = jvmOpt.replace("\"", "\\\"");
                 jvmOpt = jvmOpt.replace("'", "'\"'\"'");
                 jvmOpt = jvmOpt.replace("`", "'\"`\"'");
-                jvmOpt = jvmOpt.replace("$", "\\$");
+                if(escapeMetaCharactersInDefaultJvmOpts){
+                  jvmOpt = jvmOpt.replace("$", "\\$");
+                }
                 StringBuilder quotedJvmOpt = new StringBuilder();
                 quotedJvmOpt.append("\"");
                 quotedJvmOpt.append(jvmOpt);

--- a/subprojects/plugins/src/main/java/org/gradle/api/scripting/JavaAppStartScriptGenerationDetails.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/scripting/JavaAppStartScriptGenerationDetails.java
@@ -40,6 +40,8 @@ public class JavaAppStartScriptGenerationDetails implements ScriptGenerationDeta
     private String mainClassName;
 
     private Iterable<String> defaultJvmOpts = new ArrayList<String>();
+    
+    private Boolean escapeMetaCharactersInDefaultJvmOpts = false;
 
     /**
      * The classpath, relative to the application home directory.
@@ -94,6 +96,14 @@ public class JavaAppStartScriptGenerationDetails implements ScriptGenerationDeta
 
     public void setDefaultJvmOpts(Iterable<String> defaultJvmOpts) {
         this.defaultJvmOpts = defaultJvmOpts;
+    }
+
+    public Boolean getEscapeMetaCharactersInDefaultJvmOpts() {
+      return escapeMetaCharactersInDefaultJvmOpts;
+    }
+
+    public void setEscapeMetaCharactersInDefaultJvmOpts(Boolean escapeMetaCharactersInDefaultJvmOpts) {
+      this.escapeMetaCharactersInDefaultJvmOpts = escapeMetaCharactersInDefaultJvmOpts;
     }
 
     public Iterable<String> getClasspath() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
@@ -111,7 +111,7 @@ class UnixStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().contains(/DEFAULT_JVM_OPTS='"-Dfoo=b\\ar baz" "-Xint/ + '\\$PATH' + /"'/)
+        destination.toString().contains(/DEFAULT_JVM_OPTS='"-Dfoo=b\\ar baz" "-Xint/ + '$PATH' + /"'/)
     }
 
     def "defaultJvmOpts is expanded properly in unix script -- empty list"() {


### PR DESCRIPTION
Added variable escapeMetaCharactersInDefaultJvmOpts to application plugin so that you are able to programmatically turn off the escape of the $ when creating unix run scripts. This is enabled by default, to disable and revert to old behavior set escapeMetaCharactersInDefaultJvmOpts = true in application closure

links to https://issues.gradle.org/browse/GRADLE-3084