### PR TITLE
[GRADLE-3261] expose Project#copy(Action) and Project.copySpec()

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/Project.java
@@ -1352,6 +1352,25 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @return The CopySpec
      */
     CopySpec copySpec(Closure closure);
+    
+    /**
+     * Copies the specified files.  The given action is used to configure a {@link CopySpec}, which is then used to
+     * copy the files. 
+     * @see #copy(Closure)
+     * @param action Action to configure the CopySpec
+     * @return {@link WorkResult} that can be used to check if the copy did any work.
+     */
+    WorkResult copy(Action<? super CopySpec> action);
+    
+    /**
+     * Creates a {@link CopySpec} which can later be used to copy files or create an archive. The given action is used
+     * to configure the {@link CopySpec} before it is returned by this method.
+     *
+     * @see #copySpec(Closure)
+     * @param aciton Action to configure the CopySpec
+     * @return The CopySpec
+     */
+    CopySpec copySpec(Action<? super CopySpec> action);
 
     /**
      * Returns the evaluation state of this project. You can use this to access information about the evaluation of this


### PR DESCRIPTION
I didn't add tests for the methods, as they were already there in AbstractProject and tested indirectly through the tests for the Closure-backed methods. But if you think it worthwhile, I can add some.