### PR TITLE
Configuration re-resolution, take 3

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -276,7 +276,10 @@ it.exclude group: '*', module: 'badArtifact'
 
         when:
         libRequest(repo, "commons-lang", "commons-lang", 2.6)
+        // Required for the 'webinar-impl' project's POM
         libRequest(repo, "junit", "junit", 4.10)
+        // Required for the 'webinar-war' project's POM
+        libRequest(repo, "junit", "junit", "3.8.1")
         libRequest(repo, "org.hamcrest", "hamcrest-core", 1.1)
 
         run 'clean', 'build'

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -264,15 +264,17 @@ project(':api') {
         run("impl:build")
 
         then:
+        // :api tasks are executed, and :other is not configured
+        result.executedTasks.find { it.startsWith ":api" }
         fixture.assertProjectsConfigured(":", ":impl", ":api")
 
         when:
         run("impl:build", "--no-rebuild") // impl -> api
 
         then:
-        //api tasks are not executed and api is not configured
+        // :api tasks are not executed, and :other is not configured
         !result.executedTasks.find { it.startsWith ":api" }
-        fixture.assertProjectsConfigured(":", ":impl")
+        fixture.assertProjectsConfigured(":", ":impl", ":api")
     }
 
     def "respects external task dependencies"() {

--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ProjectDependency.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ProjectDependency.java
@@ -22,7 +22,7 @@ import org.gradle.internal.HasInternalProtocol;
  * <p>A {@code ProjectDependency} is a {@link Dependency} on another project in the current project hierarchy.</p>
  */
 @HasInternalProtocol
-public interface ProjectDependency extends ModuleDependency, SelfResolvingDependency {
+public interface ProjectDependency extends ModuleDependency {
     /**
      * Returns the project associated with this project dependency.
      */

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -26,19 +26,17 @@ import org.gradle.initialization.ProjectAccessListener;
 
 public class DefaultProjectDependency extends AbstractModuleDependency implements ProjectDependencyInternal {
     private ProjectInternal dependencyProject;
-    private final boolean buildProjectDependencies;
     private final ProjectAccessListener projectAccessListener;
 
-    public DefaultProjectDependency(ProjectInternal dependencyProject, ProjectAccessListener projectAccessListener, boolean buildProjectDependencies) {
-        this(dependencyProject, null, projectAccessListener, buildProjectDependencies);
+    public DefaultProjectDependency(ProjectInternal dependencyProject, ProjectAccessListener projectAccessListener) {
+        this(dependencyProject, null, projectAccessListener);
     }
 
     public DefaultProjectDependency(ProjectInternal dependencyProject, String configuration,
-                                    ProjectAccessListener projectAccessListener, boolean buildProjectDependencies) {
+                                    ProjectAccessListener projectAccessListener) {
         super(configuration);
         this.dependencyProject = dependencyProject;
         this.projectAccessListener = projectAccessListener;
-        this.buildProjectDependencies = buildProjectDependencies;
     }
 
     public Project getDependencyProject() {
@@ -63,7 +61,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
 
     public ProjectDependency copy() {
         DefaultProjectDependency copiedProjectDependency = new DefaultProjectDependency(dependencyProject,
-                getConfiguration(), projectAccessListener, buildProjectDependencies);
+                getConfiguration(), projectAccessListener);
         copyTo(copiedProjectDependency);
         return copiedProjectDependency;
     }
@@ -114,15 +112,12 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         if (!this.getConfiguration().equals(that.getConfiguration())) {
             return false;
         }
-        if (this.buildProjectDependencies != that.buildProjectDependencies) {
-            return false;
-        }
         return true;
     }
 
     @Override
     public int hashCode() {
-        return getDependencyProject().hashCode() ^ getConfiguration().hashCode() ^ (buildProjectDependencies ? 1 : 0);
+        return getDependencyProject().hashCode() ^ getConfiguration().hashCode();
     }
 
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -20,21 +20,13 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.internal.artifacts.CachingDependencyResolveContext;
 import org.gradle.api.internal.artifacts.DependencyResolveContext;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.AbstractTaskDependency;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.initialization.ProjectAccessListener;
-
-import java.io.File;
-import java.util.Set;
 
 public class DefaultProjectDependency extends AbstractModuleDependency implements ProjectDependencyInternal {
     private ProjectInternal dependencyProject;
     private final boolean buildProjectDependencies;
-    private final TaskDependencyImpl taskDependency = new TaskDependencyImpl();
     private final ProjectAccessListener projectAccessListener;
 
     public DefaultProjectDependency(ProjectInternal dependencyProject, ProjectAccessListener projectAccessListener, boolean buildProjectDependencies) {
@@ -76,16 +68,6 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         return copiedProjectDependency;
     }
 
-    public Set<File> resolve() {
-        return resolve(true);
-    }
-
-    public Set<File> resolve(boolean transitive) {
-        CachingDependencyResolveContext context = new CachingDependencyResolveContext(transitive);
-        context.add(this);
-        return context.resolve().getFiles();
-    }
-
     public void beforeResolved() {
         projectAccessListener.beforeResolvingProjectDependency(dependencyProject);
     }
@@ -98,10 +80,6 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
                 context.add(dependency);
             }
         }
-    }
-
-    public TaskDependencyInternal getBuildDependencies() {
-        return taskDependency;
     }
 
     public boolean contentEquals(Dependency dependency) {
@@ -152,18 +130,5 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     public String toString() {
         return "DefaultProjectDependency{" + "dependencyProject='" + dependencyProject + '\'' + ", configuration='"
                 + getConfiguration() + '\'' + '}';
-    }
-
-    private class TaskDependencyImpl extends AbstractTaskDependency {
-        public void resolve(TaskDependencyResolveContext context) {
-            if (!buildProjectDependencies) {
-                return;
-            }
-            projectAccessListener.beforeResolvingProjectDependency(dependencyProject);
-
-            Configuration configuration = getProjectConfiguration();
-            context.add(configuration);
-            context.add(configuration.getAllArtifacts());
-        }
     }
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/project/AbstractProject.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/project/AbstractProject.java
@@ -143,6 +143,8 @@ public abstract class AbstractProject extends AbstractPluginAware implements Pro
 
     private final Path path;
 
+    private final Set<ProjectChangeListener> changeListeners = new LinkedHashSet<ProjectChangeListener>();
+
     public AbstractProject(String name,
                            ProjectInternal parent,
                            File projectDir,
@@ -296,6 +298,7 @@ public abstract class AbstractProject extends AbstractPluginAware implements Pro
     }
 
     public void setDescription(String description) {
+        notifyChangeListeners("description");
         this.description = description;
     }
 
@@ -309,6 +312,7 @@ public abstract class AbstractProject extends AbstractPluginAware implements Pro
     }
 
     public void setGroup(Object group) {
+        notifyChangeListeners("group");
         this.group = group;
     }
 
@@ -317,6 +321,7 @@ public abstract class AbstractProject extends AbstractPluginAware implements Pro
     }
 
     public void setVersion(Object version) {
+        notifyChangeListeners("version");
         this.version = version;
     }
 
@@ -325,6 +330,7 @@ public abstract class AbstractProject extends AbstractPluginAware implements Pro
     }
 
     public void setStatus(Object status) {
+        notifyChangeListeners("status");
         this.status = status;
     }
 
@@ -528,6 +534,7 @@ public abstract class AbstractProject extends AbstractPluginAware implements Pro
     }
 
     public void setBuildDir(Object path) {
+        notifyChangeListeners("buildDir");
         buildDir = path;
     }
 
@@ -988,5 +995,21 @@ public abstract class AbstractProject extends AbstractPluginAware implements Pro
     @Override
     public ProjectAccessListener getProjectAccessListener() {
         return projectAccessListener;
+    }
+
+    @Override
+    public void addChangeListener(ProjectChangeListener listener) {
+        changeListeners.add(listener);
+    }
+
+    @Override
+    public void removeChangeListener(ProjectChangeListener listener) {
+        changeListeners.remove(listener);
+    }
+
+    private void notifyChangeListeners(String property) {
+        for (ProjectChangeListener listener : changeListeners) {
+            listener.beforeChange(this, property);
+        }
     }
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/project/ProjectChangeListener.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/project/ProjectChangeListener.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project;
+
+public interface ProjectChangeListener {
+    void beforeChange(ProjectInternal project, String changedProperty);
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/project/ProjectInternal.java
@@ -99,4 +99,8 @@ public interface ProjectInternal extends Project, ProjectIdentifier, ScriptAware
     void fireDeferredConfiguration();
 
     ProjectAccessListener getProjectAccessListener();
+
+    void addChangeListener(ProjectChangeListener validator);
+
+    void removeChangeListener(ProjectChangeListener validator);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.internal.artifacts.DependencyResolveContext
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.initialization.ProjectAccessListener
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -102,35 +101,6 @@ class DefaultProjectDependencyTest extends Specification {
 
         when:
         projectDependency.resolve(context)
-
-        then:
-        0 * _
-    }
-
-    void "is Buildable"() {
-        def context = Mock(TaskDependencyResolveContext)
-
-        def conf = project.configurations.create('conf')
-        def listener = Mock(ProjectAccessListener)
-        projectDependency = new DefaultProjectDependency(project, 'conf', listener, true)
-
-        when:
-        projectDependency.buildDependencies.resolve(context)
-
-        then:
-        1 * context.add(conf)
-        1 * context.add({it.is(conf.allArtifacts)})
-        1 * listener.beforeResolvingProjectDependency(project)
-        0 * _
-    }
-
-    void "does not build project dependencies if configured so"() {
-        def context = Mock(TaskDependencyResolveContext)
-        project.configurations.create('conf')
-        projectDependency = new DefaultProjectDependency(project, 'conf', listener, false)
-
-        when:
-        projectDependency.buildDependencies.resolve(context)
 
         then:
         0 * _

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -61,11 +61,12 @@ class DefaultProjectDependencyTest extends Specification {
     void "transitive resolution resolves all dependencies"() {
         def context = Mock(DependencyResolveContext)
 
+        ProjectInternal dep1Project = TestUtil.createRootProject()
         def superConf = project.configurations.create("superConf")
         def conf = project.configurations.create("conf")
         conf.extendsFrom(superConf)
 
-        def dep1 = Mock(ProjectDependency)
+        def dep1 = Mock(ProjectDependency) { it.dependencyProject >> dep1Project }
         def dep2 = Mock(ExternalDependency)
         conf.dependencies.add(dep1)
         superConf.dependencies.add(dep2)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -31,9 +31,9 @@ import static org.junit.Assert.assertThat
 class DefaultProjectDependencyTest extends Specification {
 
     ProjectInternal project = TestUtil.createRootProject()
-    ProjectAccessListener listener = Mock()
+    def listener = Mock(ProjectAccessListener)
 
-    private projectDependency = new DefaultProjectDependency(project, null, false)
+    private projectDependency = new DefaultProjectDependency(project, null)
 
     void setup() {
         project.version = "1.2"
@@ -52,7 +52,7 @@ class DefaultProjectDependencyTest extends Specification {
         def conf = project.configurations.create("conf1")
 
         when:
-        projectDependency = new DefaultProjectDependency(project, "conf1", null, true)
+        projectDependency = new DefaultProjectDependency(project, "conf1", null)
 
         then:
         projectDependency.projectConfiguration == conf
@@ -70,7 +70,7 @@ class DefaultProjectDependencyTest extends Specification {
         conf.dependencies.add(dep1)
         superConf.dependencies.add(dep2)
 
-        projectDependency = new DefaultProjectDependency(project, "conf", null, true)
+        projectDependency = new DefaultProjectDependency(project, "conf", null)
 
         when:
         projectDependency.resolve(context)
@@ -84,7 +84,7 @@ class DefaultProjectDependencyTest extends Specification {
 
     void "if resolution context is not transitive it will not contain all dependencies"() {
         def context = Mock(DependencyResolveContext)
-        projectDependency = new DefaultProjectDependency(project, null, true)
+        projectDependency = new DefaultProjectDependency(project, null)
 
         when:
         projectDependency.resolve(context)
@@ -96,7 +96,7 @@ class DefaultProjectDependencyTest extends Specification {
 
     void "if dependency is not transitive the resolution context will not contain all dependencies"() {
         def context = Mock(DependencyResolveContext)
-        projectDependency = new DefaultProjectDependency(project, null, true)
+        projectDependency = new DefaultProjectDependency(project, null)
         projectDependency.setTransitive(false)
 
         when:
@@ -133,28 +133,26 @@ class DefaultProjectDependencyTest extends Specification {
     }
 
     private createProjectDependency() {
-        def out = new DefaultProjectDependency(project, "conf", listener, true)
+        def out = new DefaultProjectDependency(project, "conf", listener)
         out.addArtifact(new DefaultDependencyArtifact("name", "type", "ext", "classifier", "url"))
         out
     }
 
     void "knows if is equal"() {
         expect:
-        assertThat(new DefaultProjectDependency(project, listener, true),
-                strictlyEqual(new DefaultProjectDependency(project, listener, true)))
+        assertThat(new DefaultProjectDependency(project, listener),
+                strictlyEqual(new DefaultProjectDependency(project, listener)))
 
-        assertThat(new DefaultProjectDependency(project, "conf1", listener, false),
-                strictlyEqual(new DefaultProjectDependency(project, "conf1", listener, false)))
+        assertThat(new DefaultProjectDependency(project, "conf1", listener),
+                strictlyEqual(new DefaultProjectDependency(project, "conf1", listener)))
 
         when:
-        def base = new DefaultProjectDependency(project, "conf1", listener, true)
-        def differentConf = new DefaultProjectDependency(project, "conf2", listener, true)
-        def differentBuildDeps = new DefaultProjectDependency(project, "conf1", listener, false)
-        def differentProject = new DefaultProjectDependency(Mock(ProjectInternal), "conf1", listener, true)
+        def base = new DefaultProjectDependency(project, "conf1", listener)
+        def differentConf = new DefaultProjectDependency(project, "conf2", listener)
+        def differentProject = new DefaultProjectDependency(Mock(ProjectInternal), "conf1", listener)
 
         then:
         base != differentConf
-        base != differentBuildDeps
         base != differentProject
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
@@ -484,8 +484,6 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     assert files*.name.sort() == ["artifact.txt"]
                     assert files*.text.sort() == ["Lajos"]
                 }
-                // TODO:PREZI Remove this when PR#412 is merged
-                check.dependsOn project(":api").build
             }
 """
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -194,7 +194,7 @@ project(':b') {
         succeeds "check"
     }
 
-    public void "resolved project artifacts reflect late changes in project attributes"() {
+    public void "resolved project artifacts reflect project properties changed after task graph is built"() {
         given:
         file('settings.gradle') << "include 'a', 'b'"
 
@@ -202,7 +202,9 @@ project(':b') {
         file('a/build.gradle') << '''
             apply plugin: 'base'
             configurations { compile }
+            dependencies { compile project(path: ':b', configuration: 'compile') }
             task aJar(type: Jar) { }
+            gradle.taskGraph.whenReady { project.version = 'late' }
             artifacts { compile aJar }
 '''
         file('b/build.gradle') << '''
@@ -210,14 +212,18 @@ project(':b') {
             version = 'early'
             configurations { compile }
             task bJar(type: Jar) { }
-            gradle.taskGraph.whenReady { project.version = 'late' }
+            gradle.taskGraph.whenReady { project.version = 'transitive-late' }
             artifacts { compile bJar }
 '''
         file('build.gradle') << '''
-            configurations { compile }
-            dependencies { compile project(path: ':a', configuration: 'compile'), project(path: ':b', configuration: 'compile') }
-            task test(dependsOn: configurations.compile) << {
-                assert configurations.compile.collect { it.name } == ['a.jar', 'b-late.jar']
+            configurations {
+                compile
+                testCompile { extendsFrom compile }
+            }
+            dependencies { compile project(path: ':a', configuration: 'compile') }
+            task test(dependsOn: [configurations.compile, configurations.testCompile]) << {
+                assert configurations.compile.collect { it.name } == ['a-late.jar', 'b-transitive-late.jar']
+                assert configurations.testCompile.collect { it.name } == ['a-late.jar', 'b-transitive-late.jar']
             }
 '''
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -293,6 +293,42 @@ project(':b') {
             }
 '''
 
+        executer.withDeprecationChecksDisabled()
+
+        expect:
+        succeeds "test"
+    }
+
+    public void "resolved project artifacts are re-resolved if transitive project changes"() {
+        given:
+        file('settings.gradle') << "include 'a', 'b'"
+
+        and:
+        file('a/build.gradle') << '''
+            apply plugin: 'base'
+            configurations { compile }
+            task aJar(type: Jar) { }
+            version = 'early'
+            gradle.taskGraph.whenReady { project.version = 'late' }
+            artifacts { compile aJar }
+'''
+        file('b/build.gradle') << '''
+            apply plugin: 'base'
+            configurations { compile }
+            dependencies { compile project(path: ':a', configuration: 'compile') }
+            task bJar(type: Jar) { }
+            artifacts { compile bJar }
+'''
+        file('build.gradle') << '''
+            configurations { compile }
+            dependencies { compile project(path: ':b', configuration: 'compile') }
+            task test(dependsOn: configurations.compile) << {
+                assert configurations.compile*.name.sort() == ['a-late.jar', 'b.jar']
+            }
+'''
+
+        executer.withDeprecationChecksDisabled()
+
         expect:
         succeeds "test"
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -234,7 +234,8 @@ project(':b') {
             apply plugin: 'base'
             configurations { compile }
             task configureJar << {
-                tasks.aJar.archiveName = "modified-artifact.txt"
+                tasks.aJar.extension = "txt"
+                tasks.aJar.classifier = "modified"
             }
             task aJar(type: Jar) {
                 dependsOn configureJar
@@ -248,8 +249,8 @@ project(':b') {
             }
             dependencies { compile project(path: ':a', configuration: 'compile') }
             task test(dependsOn: [configurations.compile, configurations.testCompile]) << {
-                assert configurations.compile.collect { it.name } == ['modified-artifact.txt']
-                assert configurations.testCompile.collect { it.name } == ['modified-artifact.txt']
+                assert configurations.compile.collect { it.name } == ['a-modified.txt']
+                assert configurations.testCompile.collect { it.name } == ['a-modified.txt']
             }
 '''
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
@@ -181,6 +181,25 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
         then: output.contains("Attempting to change configuration ':a' after it has been included in dependency resolution. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
     }
 
+    def "allows changing any lenient property of a configuration whose child has been resolved"() {
+        buildFile << """
+            configurations {
+                a
+                b.extendsFrom a
+                c.extendsFrom b
+            }
+            configurations.c.resolve()
+            configurations.a.resolutionStrategy.failOnVersionConflict()
+            configurations.a.resolutionStrategy.force "org.utils:api:1.3"
+            configurations.a.resolutionStrategy.forcedModules = [ "org.utils:api:1.4" ]
+            configurations.a.resolutionStrategy.eachDependency {}
+            configurations.a.resolutionStrategy.cacheDynamicVersionsFor 0, "seconds"
+            configurations.a.resolutionStrategy.cacheChangingModulesFor 0, "seconds"
+            configurations.a.resolutionStrategy.componentSelection.all {}
+        """
+        expect: succeeds()
+    }
+
     def "warning is upgraded to an error when configuration is resolved"() {
         buildFile << """
             configurations {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
@@ -181,6 +181,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
         when: succeeds()
         then: output.contains("Attempting to change configuration ':a' after it has been included in dependency resolution. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
+        and:  output.contains("Attempting to change configuration ':c' via changing a parent configuration after it has been resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
     }
 
     @Issue("GRADLE-3155")
@@ -198,6 +199,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
         when: succeeds()
         then: output.contains("Attempting to change configuration ':a' after it has been included in dependency resolution. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
+        and:  output.contains("Attempting to change configuration ':c' via changing a parent configuration after it has been resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
     }
 
     @Issue("GRADLE-3155")
@@ -215,6 +217,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
         when: succeeds()
         then: output.contains("Attempting to change configuration ':a' after it has been included in dependency resolution. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
+        and:  output.contains("Attempting to change configuration ':c' via changing a parent configuration after it has been resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
     }
 
     def "allows changing any lenient property of a configuration whose child has been resolved"() {
@@ -251,6 +254,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
         when: fails()
         then: output.contains("Attempting to change configuration ':a' after it has been included in dependency resolution. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
+        and: output.contains("Attempting to change configuration ':b' via changing a parent configuration after it has been resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
         and: failure.assertHasCause("Cannot change configuration ':a' after it has been resolved.")
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
@@ -283,4 +283,106 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
         """
         expect: succeeds()
     }
+
+    def "allows changing a non-empty configuration that does not affect a resolved configuration"() {
+        buildFile << """
+            configurations {
+                a
+                b
+            }
+            dependencies { b files("some.jar") }
+            configurations.b.resolve()
+            dependencies { a "a:b:c" }
+        """
+        expect: succeeds()
+    }
+
+    def "does not allow changing an observed dependent project's version"() {
+        settingsFile << "include 'api'"
+        buildFile << """
+            allprojects {
+                apply plugin: "java"
+            }
+            project(":api").version = "early"
+            dependencies {
+                compile project(":api")
+            }
+            configurations.compile.resolve()
+            project(":api").version = "late"
+"""
+        executer.withDeprecationChecksDisabled()
+
+        when: fails()
+        then: failure.assertHasCause("Cannot change configuration ':compile' after it has been resolved.")
+    }
+
+    def "warns about changing an observed dependent project's group"() {
+        settingsFile << "include 'api'"
+        buildFile << """
+            allprojects {
+                apply plugin: "java"
+            }
+            project(":api").group = "something"
+            dependencies {
+                compile project(":api")
+            }
+            configurations.compile.resolve()
+            project(":api").group = "lajos"
+"""
+        executer.withDeprecationChecksDisabled()
+
+        when: succeeds()
+        then: output.contains("Attempting to change configuration ':compile' after it has been resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
+    }
+
+    def "does not allow changing an observed transitive dependent project's version"() {
+        settingsFile << "include 'api', 'impl'"
+        buildFile << """
+            allprojects {
+                apply plugin: "java"
+            }
+            project(":api").version = "early"
+            project(":impl") {
+                dependencies {
+                    compile project(":api")
+                }
+            }
+            dependencies {
+                compile project(":impl")
+            }
+            configurations.compile.resolve()
+            project(":api").version = "late"
+"""
+        executer.withDeprecationChecksDisabled()
+
+        when: fails()
+        then: failure.assertHasCause("Cannot change configuration ':compile' after it has been resolved.")
+    }
+
+    def "does not allow changing a dependency project's dependencies after configuration is resolved"() {
+        settingsFile << "include 'api', 'impl'"
+        buildFile << """
+            allprojects {
+                apply plugin: "java"
+            }
+            dependencies {
+                compile project(":impl")
+            }
+            project(":impl") {
+                dependencies {
+                    compile project(":api")
+                }
+            }
+            configurations.compile.resolve()
+            project(":api") {
+                dependencies {
+                    compile files("some.jar")
+                }
+            }
+"""
+        executer.withDeprecationChecksDisabled()
+
+        when: fails()
+        then: failure.assertHasCause("Cannot change configuration ':compile' after it has been resolved.")
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsupportedConfigurationMutationTest.groovy
@@ -130,6 +130,42 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
         then: output.contains("Attempting to change configuration ':a' after it has been resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
     }
 
+    def "warns about changing a configuration that has been resolved for task dependencies"() {
+        mavenRepo.module("org.utils", "extra", '1.5').publish()
+
+        settingsFile << "include 'api', 'impl'"
+        buildFile << """
+            allprojects {
+                apply plugin: "java"
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+
+            project(":impl") {
+                dependencies {
+                    compile project(":api")
+                }
+
+                task addDependency << {
+                    dependencies {
+                        compile "org.utils:extra:1.5"
+                    }
+                }
+
+                task checkIt(dependsOn: [addDependency, configurations.compile]) << {
+                    def files = configurations.compile.files
+                    assert files*.name.sort() == ["api.jar", "extra-1.5.jar"]
+                    assert files*.exists() == [ true, true ]
+                }
+            }
+"""
+        executer.withDeprecationChecksDisabled()
+
+        when: succeeds("impl:checkIt")
+        then: output.contains("Attempting to change configuration ':impl:compile' after it has been resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle 3.0")
+    }
+
     @Issue("GRADLE-3155")
     def "warns about adding dependencies to a configuration whose child has been resolved"() {
         buildFile << """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -93,14 +93,15 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         ConfigurationContainerInternal createConfigurationContainer(Instantiator instantiator, ConfigurationResolver configurationResolver, DomainObjectContext domainObjectContext,
-                                                                    ListenerManager listenerManager, DependencyMetaDataProvider metaDataProvider, ProjectAccessListener projectAccessListener) {
+                                                                    ListenerManager listenerManager, DependencyMetaDataProvider metaDataProvider, ProjectAccessListener projectAccessListener, ProjectFinder projectFinder) {
             return instantiator.newInstance(DefaultConfigurationContainer.class,
                     configurationResolver,
                     instantiator,
                     domainObjectContext,
                     listenerManager,
                     metaDataProvider,
-                    projectAccessListener);
+                    projectAccessListener,
+                    projectFinder);
         }
 
         DependencyHandler createDependencyHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
@@ -26,19 +26,17 @@ import org.gradle.internal.reflect.Instantiator;
 public class DefaultProjectDependencyFactory {
     private final ProjectAccessListener projectAccessListener;
     private final Instantiator instantiator;
-    private final boolean buildProjectDependencies;
 
-    public DefaultProjectDependencyFactory(ProjectAccessListener projectAccessListener, Instantiator instantiator, boolean buildProjectDependencies) {
+    public DefaultProjectDependencyFactory(ProjectAccessListener projectAccessListener, Instantiator instantiator) {
         this.projectAccessListener = projectAccessListener;
         this.instantiator = instantiator;
-        this.buildProjectDependencies = buildProjectDependencies;
     }
 
     public ProjectDependency create(ProjectInternal project, String configuration) {
-        return instantiator.newInstance(DefaultProjectDependency.class, project, configuration, projectAccessListener, buildProjectDependencies);
+        return instantiator.newInstance(DefaultProjectDependency.class, project, configuration, projectAccessListener);
     }
 
     public ProjectDependency create(Project project) {
-        return instantiator.newInstance(DefaultProjectDependency.class, project, projectAccessListener, buildProjectDependencies);
+        return instantiator.newInstance(DefaultProjectDependency.class, project, projectAccessListener);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -76,11 +76,10 @@ class DependencyManagementBuildScopeServices {
 
     DependencyFactory createDependencyFactory(Instantiator instantiator,
                                               ProjectAccessListener projectAccessListener,
-                                              StartParameter startParameter,
                                               ClassPathRegistry classPathRegistry,
                                               FileLookup fileLookup) {
         DefaultProjectDependencyFactory factory = new DefaultProjectDependencyFactory(
-                projectAccessListener, instantiator, startParameter.isBuildProjectDependencies());
+                projectAccessListener, instantiator);
 
         ProjectDependencyFactory projectDependencyFactory = new ProjectDependencyFactory(factory);
 
@@ -204,7 +203,8 @@ class DependencyManagementBuildScopeServices {
 
     ArtifactDependencyResolver createArtifactDependencyResolver(ResolveIvyFactory resolveIvyFactory, LocalComponentFactory publishModuleDescriptorConverter, DependencyDescriptorFactory dependencyDescriptorFactory,
                                                                 CacheLockingManager cacheLockingManager, IvyContextManager ivyContextManager, ResolutionResultsStoreFactory resolutionResultsStoreFactory,
-                                                                VersionComparator versionComparator, ProjectRegistry<ProjectInternal> projectRegistry, ComponentIdentifierFactory componentIdentifierFactory) {
+                                                                VersionComparator versionComparator, ProjectRegistry<ProjectInternal> projectRegistry, ComponentIdentifierFactory componentIdentifierFactory,
+                                                                StartParameter startParameter) {
         ArtifactDependencyResolver resolver = new DefaultDependencyResolver(
                 resolveIvyFactory,
                 publishModuleDescriptorConverter,
@@ -215,7 +215,8 @@ class DependencyManagementBuildScopeServices {
                 cacheLockingManager,
                 ivyContextManager,
                 resolutionResultsStoreFactory,
-                versionComparator
+                versionComparator,
+                startParameter.isBuildProjectDependencies()
         );
         return new ErrorHandlingArtifactDependencyResolver(
                 new ShortcircuitEmptyConfigsArtifactDependencyResolver(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationContainerInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationContainerInternal.java
@@ -22,4 +22,7 @@ import org.gradle.api.artifacts.UnknownConfigurationException;
 public interface ConfigurationContainerInternal extends ConfigurationContainer {
     ConfigurationInternal getByName(String name) throws UnknownConfigurationException;
     ConfigurationInternal detachedConfiguration(Dependency... dependencies);
+
+    void addMutationValidator(MutationValidator validator);
+    void removeMutationValidator(MutationValidator validator);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -27,4 +27,8 @@ public interface ConfigurationInternal extends Configuration, DependencyMetaData
     String getPath();
 
     void markAsObserved();
+
+    void addMutationValidator(MutationValidator validator);
+
+    void removeMutationValidator(MutationValidator validator);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -18,9 +18,13 @@ package org.gradle.api.internal.artifacts.configurations;
 import org.gradle.api.artifacts.Configuration;
 
 public interface ConfigurationInternal extends Configuration, DependencyMetaDataProvider {
+    enum InternalState { UNOBSERVED, OBSERVED, TASK_DEPENDENCIES_RESOLVED, RESULTS_RESOLVED}
+
+    InternalState getInternalState();
+
     ResolutionStrategyInternal getResolutionStrategy();
 
     String getPath();
 
-    void includedInResolveResult();
+    void markAsObserved();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -20,18 +20,17 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.*;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.artifacts.*;
 import org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfigurationResult;
 import org.gradle.api.internal.file.AbstractFileCollection;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -282,38 +281,19 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
     }
 
-    private void collectProjectDependencies(Set<ResolvedDependency> resolvedDependencies, Map<ModuleVersionIdentifier, Project> projectMapping, DefaultTaskDependency taskDependency) {
-        for (ResolvedDependency dependency : resolvedDependencies) {
-            if (dependency instanceof DefaultResolvedDependency) {
-                DefaultResolvedDependency resolvedDependency = (DefaultResolvedDependency) dependency;
-                ResolvedConfigurationIdentifier id = resolvedDependency.getId();
-                Project project = projectMapping.get(id.getId());
-
-                if (project != null) {
-                    Configuration targetConfig = project.getConfigurations().getByName(id.getConfiguration());
-                    taskDependency.add(targetConfig.getAllArtifacts());
-                }
-            }
-
-            // Handling transitive dependencies
-            collectProjectDependencies(dependency.getChildren(), projectMapping, taskDependency);
-        }
-    }
-
     public TaskDependency getBuildDependencies() {
         DefaultTaskDependency taskDependency = new DefaultTaskDependency();
         taskDependency.add(allDependencies.getBuildDependencies());
 
-        final Map<ModuleVersionIdentifier, Project> projectMapping = new HashMap<ModuleVersionIdentifier, Project>();
-        for (ResolvedComponentResult resolvedComponentResult : getIncoming().getResolutionResult().getAllComponents()) {
-            if (resolvedComponentResult.getId() instanceof ProjectComponentIdentifier) {
-                ProjectComponentIdentifier projectId = (ProjectComponentIdentifier)resolvedComponentResult.getId();
-                Project project = projectFinder.getProject(projectId.getProjectPath());
-                projectMapping.put(resolvedComponentResult.getModuleVersion(), project);
+        resolveNow();
+        for (ResolvedProjectConfigurationResult projectResult : cachedResolverResults.getResolvedProjectConfigurationResults().getAllProjectConfigurationResults()) {
+            ProjectInternal project = projectFinder.getProject(projectResult.getId().getProjectPath());
+            for (String targetConfigName : projectResult.getTargetConfigurations()) {
+                Configuration targetConfig = project.getConfigurations().getByName(targetConfigName);
+                taskDependency.add(targetConfig);
+                taskDependency.add(targetConfig.getAllArtifacts());
             }
         }
-
-        collectProjectDependencies(getResolvedConfiguration().getFirstLevelModuleDependencies(), projectMapping, taskDependency);
 
         return taskDependency;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -187,9 +187,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                         "Cyclic extendsFrom from %s and %s is not allowed. See existing hierarchy: %s", this,
                         configuration, configuration.getHierarchy()));
             }
-            this.extendsFrom.add(configuration);
-            inheritedArtifacts.addCollection(configuration.getAllArtifacts());
-            inheritedDependencies.addCollection(configuration.getAllDependencies());
+            if (this.extendsFrom.add(configuration)) {
+                inheritedArtifacts.addCollection(configuration.getAllArtifacts());
+                inheritedDependencies.addCollection(configuration.getAllDependencies());
+            }
         }
         return this;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -332,10 +332,18 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 ResolvableDependencies incoming = getIncoming();
                 broadcast.beforeResolve(incoming);
                 cachedResolverResults = resolver.resolve(this);
-                for (Configuration configuration : extendsFrom) {
-                    ((ConfigurationInternal) configuration).markAsObserved();
-                }
                 resolvedWithFailures = cachedResolverResults.getResolvedConfiguration().hasError();
+
+                // Mark all affected configurations as observed
+                markAsObserved();
+                for (ResolvedProjectConfigurationResult projectResult : cachedResolverResults.getResolvedProjectConfigurationResults().getAllProjectConfigurationResults()) {
+                    ProjectInternal project = projectFinder.getProject(projectResult.getId().getProjectPath());
+                    for (String targetConfigName : projectResult.getTargetConfigurations()) {
+                        ConfigurationInternal targetConfig = (ConfigurationInternal) project.getConfigurations().getByName(targetConfigName);
+                        targetConfig.markAsObserved();
+                    }
+                }
+
                 markAsResolved(requestedState);
                 broadcast.afterResolve(incoming);
             } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.configurations.MutationValidator.Mutati
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfigurationResult;
 import org.gradle.api.internal.file.AbstractFileCollection;
+import org.gradle.api.internal.project.ProjectChangeListener;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.specs.Spec;
@@ -107,15 +108,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         resolutionListenerBroadcast = listenerManager.createAnonymousBroadcaster(DependencyResolutionListener.class);
 
-        RunnableMutationValidator veto = new RunnableMutationValidator(MutationType.CONTENT) {
-            @Override
-            public void validateMutation(MutationType type) {
-                DefaultConfiguration.this.validateMutation(type);
-            }
-        };
+        final VetoValidator veto = new VetoValidator();
 
-        DefaultDomainObjectSet<Dependency> ownDependencies = new DefaultDomainObjectSet<Dependency>(Dependency.class);
-        ownDependencies.beforeChange(veto);
+        DefaultDomainObjectSet<Dependency> ownDependencies = createOwnDependencies(veto);
 
         dependencies = new DefaultDependencySet(String.format("%s dependencies", getDisplayName()), ownDependencies);
         inheritedDependencies = CompositeDomainObjectSet.create(Dependency.class, ownDependencies);
@@ -128,6 +123,33 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         allArtifacts = new DefaultPublishArtifactSet(String.format("%s all artifacts", getDisplayName()), inheritedArtifacts);
 
         resolutionStrategy.beforeChange(veto);
+    }
+
+    private static DefaultDomainObjectSet<Dependency> createOwnDependencies(final VetoValidator veto) {
+        DefaultDomainObjectSet<Dependency> ownDependencies = new DefaultDomainObjectSet<Dependency>(Dependency.class);
+        ownDependencies.beforeChange(veto);
+
+        ownDependencies.whenObjectAdded(new Action<Dependency>() {
+            @Override
+            public void execute(Dependency dependency) {
+                if (dependency instanceof ProjectDependency) {
+                    ProjectInternal project = (ProjectInternal) ((ProjectDependency) dependency).getDependencyProject();
+                    project.addChangeListener(veto);
+                    ((ConfigurationContainerInternal) project.getConfigurations()).addMutationValidator(veto);
+                }
+            }
+        });
+        ownDependencies.whenObjectRemoved(new Action<Dependency>() {
+            @Override
+            public void execute(Dependency dependency) {
+                if (dependency instanceof ProjectDependency) {
+                    ProjectInternal project = (ProjectInternal) ((ProjectDependency) dependency).getDependencyProject();
+                    project.removeChangeListener(veto);
+                    ((ConfigurationContainerInternal) project.getConfigurations()).removeMutationValidator(veto);
+                }
+            }
+        });
+        return ownDependencies;
     }
 
     public String getName() {
@@ -697,4 +719,37 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
     }
 
+    private class VetoValidator extends RunnableMutationValidator implements ProjectChangeListener {
+        private boolean running;
+
+        public VetoValidator() {
+            super(MutationType.CONTENT);
+        }
+
+        @Override
+        public void validateMutation(MutationType type) {
+            // TODO:PREZI This is really ugly, and should be replaced with something better
+            // It is a workaround for the case when a project depends on itself.
+            // See ArtifactDependenciesIntegrationTest.projectCanDependOnItself()
+            if (!running) {
+                running = true;
+                try {
+                    DefaultConfiguration.this.validateMutation(type);
+                } finally {
+                    running = false;
+                }
+            }
+        }
+
+        @Override
+        public void beforeChange(ProjectInternal project, String changedProperty) {
+            if ("version".equals(changedProperty)) {
+                // version is used in resolving artifact names
+                validateMutation(MutationType.CONTENT);
+            } else if ("group".equals(changedProperty)) {
+                // group influences conflict resolution
+                validateMutation(MutationType.STRATEGY);
+            }
+        }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -72,11 +72,12 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private final ListenerBroadcast<DependencyResolutionListener> resolutionListenerBroadcast;
     private Set<ExcludeRule> excludeRules = new LinkedHashSet<ExcludeRule>();
     private final ProjectAccessListener projectAccessListener;
+    private boolean modified;
+    private boolean resolvedWithFailures;
 
     // This lock only protects the following fields
     private final Object lock = new Object();
-    private State state = State.UNRESOLVED;
-    private boolean includedInResult;
+    private InternalState state = InternalState.UNOBSERVED;
     private ResolverResults cachedResolverResults;
     private final ResolutionStrategyInternal resolutionStrategy;
     private final ProjectFinder projectFinder;
@@ -126,9 +127,24 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         return name;
     }
 
-    public State getState() {
+    @Override
+    public InternalState getInternalState() {
         synchronized (lock) {
             return state;
+        }
+    }
+
+    public State getState() {
+        synchronized (lock) {
+            if (state == InternalState.RESULTS_RESOLVED || state == InternalState.TASK_DEPENDENCIES_RESOLVED) {
+                if (resolvedWithFailures) {
+                    return State.RESOLVED_WITH_FAILURES;
+                } else {
+                    return State.RESOLVED;
+                }
+            } else {
+                return State.UNRESOLVED;
+            }
         }
     }
 
@@ -249,35 +265,47 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         return new ConfigurationFileCollection(WrapUtil.toLinkedSet(dependencies));
     }
 
-    public void includedInResolveResult() {
-        includedInResult = true;
+    public void markAsObserved() {
+        synchronized (lock) {
+            if (state == InternalState.UNOBSERVED) {
+                state = InternalState.OBSERVED;
+            }
+        }
         for (Configuration configuration : extendsFrom) {
-            ((ConfigurationInternal) configuration).includedInResolveResult();
+            ((ConfigurationInternal) configuration).markAsObserved();
         }
     }
 
     public ResolvedConfiguration getResolvedConfiguration() {
-        resolveNow();
+        resolveNow(InternalState.RESULTS_RESOLVED);
         return cachedResolverResults.getResolvedConfiguration();
     }
 
-    private void resolveNow() {
+    private void resolveNow(InternalState requestedState) {
         synchronized (lock) {
-            if (state == State.UNRESOLVED) {
+            boolean needsResolve = state == InternalState.UNOBSERVED || state == InternalState.OBSERVED || modified;
+            if (needsResolve) {
                 DependencyResolutionListener broadcast = getDependencyResolutionBroadcast();
                 ResolvableDependencies incoming = getIncoming();
                 broadcast.beforeResolve(incoming);
                 cachedResolverResults = resolver.resolve(this);
                 for (Configuration configuration : extendsFrom) {
-                    ((ConfigurationInternal) configuration).includedInResolveResult();
+                    ((ConfigurationInternal) configuration).markAsObserved();
                 }
-                if (cachedResolverResults.getResolvedConfiguration().hasError()) {
-                    state = State.RESOLVED_WITH_FAILURES;
-                } else {
-                    state = State.RESOLVED;
-                }
+                resolvedWithFailures = cachedResolverResults.getResolvedConfiguration().hasError();
+                modified = false;
+                markAsResolved(requestedState);
                 broadcast.afterResolve(incoming);
+            } else {
+                markAsResolved(requestedState);
             }
+        }
+    }
+
+    private void markAsResolved(InternalState requestedState) {
+        // We can't move back from resolved for results state
+        if (state != InternalState.RESULTS_RESOLVED) {
+            state = requestedState;
         }
     }
 
@@ -285,7 +313,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         DefaultTaskDependency taskDependency = new DefaultTaskDependency();
         taskDependency.add(allDependencies.getBuildDependencies());
 
-        resolveNow();
+        resolveNow(InternalState.TASK_DEPENDENCIES_RESOLVED);
         for (ResolvedProjectConfigurationResult projectResult : cachedResolverResults.getResolvedProjectConfigurationResults().getAllProjectConfigurationResults()) {
             ProjectInternal project = projectFinder.getProject(projectResult.getId().getProjectPath());
             for (String targetConfigName : projectResult.getTargetConfigurations()) {
@@ -356,7 +384,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         return resolvableDependencies;
     }
 
-    public Configuration copy() {
+    public ConfigurationInternal copy() {
         return createCopy(getDependencies(), false);
     }
 
@@ -434,18 +462,36 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     private void validateMutation(MutationType type) {
-        boolean userAlreadyNagged = false;
-        if (getState() != State.UNRESOLVED) {
-            if (type == MutationType.CONTENT) {
-                throw new InvalidUserDataException(String.format("Cannot change %s after it has been resolved.", getDisplayName()));
-            } else {
-                userAlreadyNagged = true;
+        switch (state) {
+            case UNOBSERVED:
+                // Nothing from the configuration has been observed yet, can change anything.
+                break;
+            case OBSERVED:
+                // The configuration has been used in a resolution, and it is deprecated for
+                // build logic to change any dependencies, artifacts, exclude rules or parent
+                // configurations (non-content properties).
+                if (type == MutationType.CONTENT) {
+                    DeprecationLogger.nagUserOfDeprecatedBehaviour(String.format("Attempting to change %s after it has been included in dependency resolution", getDisplayName()));
+                }
+                break;
+            case TASK_DEPENDENCIES_RESOLVED:
+                // The task dependencies for the configuration have been calculated using
+                // Configuration.getBuildDependencies(). It is deprecated for build logic to
+                // change anything about the configuration.
                 DeprecationLogger.nagUserOfDeprecatedBehaviour(String.format("Attempting to change %s after it has been resolved", getDisplayName()));
-            }
+                break;
+            case RESULTS_RESOLVED:
+                // The public result for the configuration has been calculated. It is an
+                // error to change non-content properties, and deprecated to change anything else
+                // about the configuration.
+                if (type == MutationType.CONTENT) {
+                    throw new InvalidUserDataException(String.format("Cannot change %s after it has been resolved.", getDisplayName()));
+                } else {
+                    DeprecationLogger.nagUserOfDeprecatedBehaviour(String.format("Attempting to change %s after it has been resolved", getDisplayName()));
+                }
+                break;
         }
-        if (!userAlreadyNagged && includedInResult) {
-            DeprecationLogger.nagUserOfDeprecatedBehaviour(String.format("Attempting to change %s after it has been included in dependency resolution", getDisplayName()));
-        }
+        modified = true;
     }
 
     class ConfigurationFileCollection extends AbstractFileCollection {
@@ -581,7 +627,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
 
         public ResolutionResult getResolutionResult() {
-            DefaultConfiguration.this.resolveNow();
+            DefaultConfiguration.this.resolveNow(InternalState.RESULTS_RESOLVED);
             return DefaultConfiguration.this.cachedResolverResults.getResolutionResult();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -20,14 +20,19 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.*;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolutionResult;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.artifacts.*;
 import org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType;
+import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.file.AbstractFileCollection;
+import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskDependency;
@@ -75,12 +80,14 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private boolean includedInResult;
     private ResolverResults cachedResolverResults;
     private final ResolutionStrategyInternal resolutionStrategy;
+    private final ProjectFinder projectFinder;
 
     public DefaultConfiguration(String path, String name, ConfigurationsProvider configurationsProvider,
                                 ConfigurationResolver resolver, ListenerManager listenerManager,
                                 DependencyMetaDataProvider metaDataProvider,
                                 ResolutionStrategyInternal resolutionStrategy,
-                                ProjectAccessListener projectAccessListener) {
+                                ProjectAccessListener projectAccessListener,
+                                ProjectFinder projectFinder) {
         this.path = path;
         this.name = name;
         this.configurationsProvider = configurationsProvider;
@@ -89,6 +96,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         this.metaDataProvider = metaDataProvider;
         this.resolutionStrategy = resolutionStrategy;
         this.projectAccessListener = projectAccessListener;
+        this.projectFinder = projectFinder;
 
         resolutionListenerBroadcast = listenerManager.createAnonymousBroadcaster(DependencyResolutionListener.class);
 
@@ -274,8 +282,40 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
     }
 
+    private void collectProjectDependencies(Set<ResolvedDependency> resolvedDependencies, Map<ModuleVersionIdentifier, Project> projectMapping, DefaultTaskDependency taskDependency) {
+        for (ResolvedDependency dependency : resolvedDependencies) {
+            if (dependency instanceof DefaultResolvedDependency) {
+                DefaultResolvedDependency resolvedDependency = (DefaultResolvedDependency) dependency;
+                ResolvedConfigurationIdentifier id = resolvedDependency.getId();
+                Project project = projectMapping.get(id.getId());
+
+                if (project != null) {
+                    Configuration targetConfig = project.getConfigurations().getByName(id.getConfiguration());
+                    taskDependency.add(targetConfig.getAllArtifacts());
+                }
+            }
+
+            // Handling transitive dependencies
+            collectProjectDependencies(dependency.getChildren(), projectMapping, taskDependency);
+        }
+    }
+
     public TaskDependency getBuildDependencies() {
-        return allDependencies.getBuildDependencies();
+        DefaultTaskDependency taskDependency = new DefaultTaskDependency();
+        taskDependency.add(allDependencies.getBuildDependencies());
+
+        final Map<ModuleVersionIdentifier, Project> projectMapping = new HashMap<ModuleVersionIdentifier, Project>();
+        for (ResolvedComponentResult resolvedComponentResult : getIncoming().getResolutionResult().getAllComponents()) {
+            if (resolvedComponentResult.getId() instanceof ProjectComponentIdentifier) {
+                ProjectComponentIdentifier projectId = (ProjectComponentIdentifier)resolvedComponentResult.getId();
+                Project project = projectFinder.getProject(projectId.getProjectPath());
+                projectMapping.put(resolvedComponentResult.getModuleVersion(), project);
+            }
+        }
+
+        collectProjectDependencies(getResolvedConfiguration().getFirstLevelModuleDependencies(), projectMapping, taskDependency);
+
+        return taskDependency;
     }
 
     /**
@@ -355,7 +395,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private DefaultConfiguration createCopy(Set<Dependency> dependencies, boolean recursive) {
         DetachedConfigurationsProvider configurationsProvider = new DetachedConfigurationsProvider();
         DefaultConfiguration copiedConfiguration = new DefaultConfiguration(path + "Copy", name + "Copy",
-                configurationsProvider, resolver, listenerManager, metaDataProvider, resolutionStrategy.copy(), projectAccessListener);
+                configurationsProvider, resolver, listenerManager, metaDataProvider, resolutionStrategy.copy(), projectAccessListener, projectFinder);
         configurationsProvider.setTheOnlyConfiguration(copiedConfiguration);
         // state, cachedResolvedConfiguration, and extendsFrom intentionally not copied - must re-resolve copy
         // copying extendsFrom could mess up dependencies when copy was re-resolved

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.configurations;
 
+import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.artifacts.Configuration;
@@ -30,6 +31,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.event.ListenerManager;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class DefaultConfigurationContainer extends AbstractNamedDomainObjectContainer<Configuration>
@@ -43,6 +45,15 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
     private final DependencyMetaDataProvider dependencyMetaDataProvider;
     private final ProjectAccessListener projectAccessListener;
     private final ProjectFinder projectFinder;
+    private final Set<MutationValidator> mutationValidators = new LinkedHashSet<MutationValidator>();
+    private final MutationValidator childValidator = new MutationValidator() {
+        @Override
+        public void validateMutation(MutationType type) {
+            for (MutationValidator validator : mutationValidators) {
+                validator.validateMutation(type);
+            }
+        }
+    };
 
     private int detachedConfigurationDefaultNameCounter = 1;
 
@@ -57,6 +68,20 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
         this.projectAccessListener = projectAccessListener;
         this.projectFinder = projectFinder;
+
+        // Track mutation
+        whenObjectAdded(new Action<Configuration>() {
+            @Override
+            public void execute(Configuration configuration) {
+                ((ConfigurationInternal) configuration).addMutationValidator(childValidator);
+            }
+        });
+        whenObjectRemoved(new Action<Configuration>() {
+            @Override
+            public void execute(Configuration configuration) {
+                ((ConfigurationInternal) configuration).removeMutationValidator(childValidator);
+            }
+        });
     }
 
     @Override
@@ -112,5 +137,15 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         }
         
         return reply.toString();
+    }
+
+    @Override
+    public void addMutationValidator(MutationValidator validator) {
+        mutationValidators.add(validator);
+    }
+
+    @Override
+    public void removeMutationValidator(MutationValidator validator) {
+        mutationValidators.remove(validator);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.UnknownConfigurationException;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
+import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.reflect.Instantiator;
@@ -41,12 +42,13 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
     private final ListenerManager listenerManager;
     private final DependencyMetaDataProvider dependencyMetaDataProvider;
     private final ProjectAccessListener projectAccessListener;
+    private final ProjectFinder projectFinder;
 
     private int detachedConfigurationDefaultNameCounter = 1;
 
     public DefaultConfigurationContainer(ConfigurationResolver resolver,
                                          Instantiator instantiator, DomainObjectContext context, ListenerManager listenerManager,
-                                         DependencyMetaDataProvider dependencyMetaDataProvider, ProjectAccessListener projectAccessListener) {
+                                         DependencyMetaDataProvider dependencyMetaDataProvider, ProjectAccessListener projectAccessListener, ProjectFinder projectFinder) {
         super(Configuration.class, instantiator, new Configuration.Namer());
         this.resolver = resolver;
         this.instantiator = instantiator;
@@ -54,12 +56,13 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         this.listenerManager = listenerManager;
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
         this.projectAccessListener = projectAccessListener;
+        this.projectFinder = projectFinder;
     }
 
     @Override
     protected Configuration doCreate(String name) {
         return instantiator.newInstance(DefaultConfiguration.class, context.absoluteProjectPath(name), name, this, resolver,
-                listenerManager, dependencyMetaDataProvider, instantiator.newInstance(DefaultResolutionStrategy.class), projectAccessListener);
+                listenerManager, dependencyMetaDataProvider, instantiator.newInstance(DefaultResolutionStrategy.class), projectAccessListener, projectFinder);
     }
 
     public Set<Configuration> getAll() {
@@ -86,7 +89,7 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         DetachedConfigurationsProvider detachedConfigurationsProvider = new DetachedConfigurationsProvider();
         DefaultConfiguration detachedConfiguration = new DefaultConfiguration(
                 name, name, detachedConfigurationsProvider, resolver,
-                listenerManager, dependencyMetaDataProvider, new DefaultResolutionStrategy(), projectAccessListener);
+                listenerManager, dependencyMetaDataProvider, new DefaultResolutionStrategy(), projectAccessListener, projectFinder);
         DomainObjectSet<Dependency> detachedDependencies = detachedConfiguration.getDependencies();
         for (Dependency dependency : dependencies) {
             detachedDependencies.add(dependency.copy());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationsToArtifactsConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationsToArtifactsConverter.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
 
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.internal.component.local.model.MutableLocalComponentMetaData;
 
 public class DefaultConfigurationsToArtifactsConverter implements ConfigurationsToArtifactsConverter {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationsToArtifactsConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationsToArtifactsConverter.java
@@ -16,38 +16,14 @@
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
 
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.internal.component.model.DefaultIvyArtifactName;
-import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.local.model.MutableLocalComponentMetaData;
-import org.gradle.util.GUtil;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class DefaultConfigurationsToArtifactsConverter implements ConfigurationsToArtifactsConverter {
 
     public void addArtifacts(MutableLocalComponentMetaData metaData, Iterable<? extends Configuration> configurations) {
-        ModuleVersionIdentifier id = metaData.getId();
         for (Configuration configuration : configurations) {
-            for (PublishArtifact publishArtifact : configuration.getArtifacts()) {
-                IvyArtifactName ivyArtifact = createIvyArtifact(publishArtifact, id);
-                metaData.addArtifact(configuration.getName(), ivyArtifact, publishArtifact.getFile());
-            }
+            metaData.addArtifacts(configuration.getName(), configuration.getArtifacts());
         }
-    }
-
-    public IvyArtifactName createIvyArtifact(PublishArtifact publishArtifact, ModuleVersionIdentifier moduleVersionIdentifier) {
-        Map<String, String> extraAttributes = new HashMap<String, String>();
-        if (GUtil.isTrue(publishArtifact.getClassifier())) {
-            extraAttributes.put(Dependency.CLASSIFIER, publishArtifact.getClassifier());
-        }
-        String name = publishArtifact.getName();
-        if (!GUtil.isTrue(name)) {
-            name = moduleVersionIdentifier.getName();
-        }
-        return new DefaultIvyArtifactName(name, publishArtifact.getType(), publishArtifact.getExtension(), extraAttributes);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultDependencyResolver.java
@@ -68,10 +68,11 @@ public class DefaultDependencyResolver implements ArtifactDependencyResolver {
     private final IvyContextManager ivyContextManager;
     private final ResolutionResultsStoreFactory storeFactory;
     private final VersionComparator versionComparator;
+    private final boolean buildProjectDependencies;
 
     public DefaultDependencyResolver(ResolveIvyFactory ivyFactory, LocalComponentFactory localComponentFactory, DependencyDescriptorFactory dependencyDescriptorFactory,
                                      ProjectComponentRegistry projectComponentRegistry, CacheLockingManager cacheLockingManager, IvyContextManager ivyContextManager,
-                                     ResolutionResultsStoreFactory storeFactory, VersionComparator versionComparator) {
+                                     ResolutionResultsStoreFactory storeFactory, VersionComparator versionComparator, boolean buildProjectDependencies) {
         this.ivyFactory = ivyFactory;
         this.localComponentFactory = localComponentFactory;
         this.dependencyDescriptorFactory = dependencyDescriptorFactory;
@@ -80,6 +81,7 @@ public class DefaultDependencyResolver implements ArtifactDependencyResolver {
         this.ivyContextManager = ivyContextManager;
         this.storeFactory = storeFactory;
         this.versionComparator = versionComparator;
+        this.buildProjectDependencies = buildProjectDependencies;
     }
 
     public void resolve(final ConfigurationInternal configuration,
@@ -120,7 +122,12 @@ public class DefaultDependencyResolver implements ArtifactDependencyResolver {
                 Store<TransientConfigurationResults> oldModelCache = stores.newModelStore();
                 TransientConfigurationResultsBuilder oldTransientModelBuilder = new TransientConfigurationResultsBuilder(oldModelStore, oldModelCache);
                 DefaultResolvedConfigurationBuilder oldModelBuilder = new DefaultResolvedConfigurationBuilder(oldTransientModelBuilder);
-                ResolvedProjectConfigurationResultBuilder projectModelBuilder = new DefaultResolvedProjectConfigurationResultBuilder();
+                ResolvedProjectConfigurationResultBuilder projectModelBuilder;
+                if (buildProjectDependencies) {
+                    projectModelBuilder = new DefaultResolvedProjectConfigurationResultBuilder();
+                } else {
+                    projectModelBuilder = ResolvedProjectConfigurationResultBuilder.NOOP_BUILDER;
+                }
 
                 // Resolve the dependency graph
                 builder.resolve(configuration, newModelBuilder, oldModelBuilder, projectModelBuilder);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultDependencyResolver.java
@@ -122,7 +122,13 @@ public class DefaultDependencyResolver implements ArtifactDependencyResolver {
                 DefaultResolvedConfigurationBuilder oldModelBuilder = new DefaultResolvedConfigurationBuilder(oldTransientModelBuilder);
                 ResolvedProjectConfigurationResultBuilder projectModelBuilder = new DefaultResolvedProjectConfigurationResultBuilder();
 
+                // Resolve the dependency graph
                 builder.resolve(configuration, newModelBuilder, oldModelBuilder, projectModelBuilder);
+
+                // Resolve the artifacts : this should not happen when resolving the task dependencies for a configuration, but only for a public resolve.
+                oldModelBuilder.resolveArtifacts();
+                // TODO:DAZ Need to ensure that all resources are released at this point.
+
                 DefaultLenientConfiguration result = new DefaultLenientConfiguration(configuration, oldModelBuilder, cacheLockingManager);
                 results.resolved(new DefaultResolvedConfiguration(result), newModelBuilder.complete(), projectModelBuilder.complete());
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/AbstractArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/AbstractArtifactSet.java
@@ -31,14 +31,14 @@ import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-abstract class AbstractResolvedArtifactSet implements ResolvedArtifactSet {
+abstract class AbstractArtifactSet implements ArtifactSet {
     private final ModuleVersionIdentifier moduleVersionIdentifier;
     private final ComponentResolveMetaData component;
     private final ArtifactResolver artifactResolver;
     private final long id;
     private Set<ResolvedArtifact> resolvedArtifacts;
 
-    public AbstractResolvedArtifactSet(long id, ModuleVersionIdentifier ownerId, ComponentResolveMetaData component, ArtifactResolver artifactResolver) {
+    public AbstractArtifactSet(long id, ModuleVersionIdentifier ownerId, ComponentResolveMetaData component, ArtifactResolver artifactResolver) {
         this.id = id;
         this.moduleVersionIdentifier = ownerId;
         this.component = component;
@@ -64,6 +64,10 @@ abstract class AbstractResolvedArtifactSet implements ResolvedArtifactSet {
         // TODO:DAZ Need to avoid hanging onto state when artifacts are not used: for now maybe resolve artifact sets explicitly even when not required
         // TODO:DAZ ArtifactResolver should be provided when resolving, not when constructing
         return resolvedArtifacts;
+    }
+
+    protected ArtifactResolver getArtifactResolver() {
+        return artifactResolver;
     }
 
     protected abstract Set<ComponentArtifactMetaData> resolveComponentArtifacts();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/AbstractResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/AbstractResolvedArtifactSet.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
@@ -31,11 +31,11 @@ import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-public abstract class AbstractResolvedArtifactSet implements ResolvedArtifactSet {
-    protected final ModuleVersionIdentifier moduleVersionIdentifier;
-    protected final ComponentResolveMetaData component;
-    protected final ArtifactResolver artifactResolver;
-    protected final long id;
+abstract class AbstractResolvedArtifactSet implements ResolvedArtifactSet {
+    private final ModuleVersionIdentifier moduleVersionIdentifier;
+    private final ComponentResolveMetaData component;
+    private final ArtifactResolver artifactResolver;
+    private final long id;
     private Set<ResolvedArtifact> resolvedArtifacts;
 
     public AbstractResolvedArtifactSet(long id, ModuleVersionIdentifier ownerId, ComponentResolveMetaData component, ArtifactResolver artifactResolver) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ArtifactSet.java
@@ -20,7 +20,7 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 
 import java.util.Set;
 
-public interface ResolvedArtifactSet {
+public interface ArtifactSet {
     long getId();
     Set<ResolvedArtifact> getArtifacts();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ConfigurationArtifactsSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ConfigurationArtifactsSet.java
@@ -23,7 +23,7 @@ import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import java.util.Set;
 
 // TODO:DAZ Probably want to resolve early for external modules, and only hang onto Configuration node for local components
-class ConfigurationArtifactsSet extends AbstractResolvedArtifactSet {
+class ConfigurationArtifactsSet extends AbstractArtifactSet {
     private final DependencyGraphBuilder.ConfigurationNode childConfiguration;
     private final ModuleResolutionFilter selector;
 
@@ -35,6 +35,6 @@ class ConfigurationArtifactsSet extends AbstractResolvedArtifactSet {
 
     @Override
     protected Set<ComponentArtifactMetaData> resolveComponentArtifacts() {
-        return childConfiguration.getArtifacts(selector);
+        return childConfiguration.getArtifacts(selector, getArtifactResolver());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ConfigurationArtifactsSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ConfigurationArtifactsSet.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
+
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleResolutionFilter;
+import org.gradle.internal.component.model.ComponentArtifactMetaData;
+import org.gradle.internal.resolve.resolver.ArtifactResolver;
+
+import java.util.Set;
+
+// TODO:DAZ Probably want to resolve early for external modules, and only hang onto Configuration node for local components
+class ConfigurationArtifactsSet extends AbstractResolvedArtifactSet {
+    private final DependencyGraphBuilder.ConfigurationNode childConfiguration;
+    private final ModuleResolutionFilter selector;
+
+    public ConfigurationArtifactsSet(DependencyGraphBuilder.ConfigurationNode childConfiguration, ModuleResolutionFilter selector, ArtifactResolver artifactResolver, long id) {
+        super(id, childConfiguration.toId(), childConfiguration.metaData.getComponent(), artifactResolver);
+        this.childConfiguration = childConfiguration;
+        this.selector = selector;
+    }
+
+    @Override
+    protected Set<ComponentArtifactMetaData> resolveComponentArtifacts() {
+        return childConfiguration.getArtifacts(selector);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyArtifactSet.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.internal.component.model.ComponentArtifactMetaData;
@@ -23,10 +23,10 @@ import org.gradle.internal.resolve.resolver.ArtifactResolver;
 
 import java.util.Set;
 
-public class PredeterminedArtifactSet extends AbstractResolvedArtifactSet {
+class DependencyArtifactSet extends AbstractResolvedArtifactSet {
     private final Set<ComponentArtifactMetaData> artifacts;
 
-    public PredeterminedArtifactSet(ModuleVersionIdentifier ownerId, ComponentResolveMetaData component, Set<ComponentArtifactMetaData> artifacts, ArtifactResolver artifactResolver, long id) {
+    public DependencyArtifactSet(ModuleVersionIdentifier ownerId, ComponentResolveMetaData component, Set<ComponentArtifactMetaData> artifacts, ArtifactResolver artifactResolver, long id) {
         super(id, ownerId, component, artifactResolver);
         this.artifacts = artifacts;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyArtifactSet.java
@@ -23,7 +23,7 @@ import org.gradle.internal.resolve.resolver.ArtifactResolver;
 
 import java.util.Set;
 
-class DependencyArtifactSet extends AbstractResolvedArtifactSet {
+class DependencyArtifactSet extends AbstractArtifactSet {
     private final Set<ComponentArtifactMetaData> artifacts;
 
     public DependencyArtifactSet(ModuleVersionIdentifier ownerId, ComponentResolveMetaData component, Set<ComponentArtifactMetaData> artifacts, ArtifactResolver artifactResolver, long id) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
@@ -633,7 +633,6 @@ public class DependencyGraphBuilder {
         private final ResolveState resolveState;
         private ModuleResolutionFilter previousTraversal;
         private Set<ComponentArtifactMetaData> artifacts;
-        private Map<IvyArtifactName, ResolvedArtifact> resolvedArtifacts = new HashMap<IvyArtifactName, ResolvedArtifact>();
 
         private ConfigurationNode(ModuleVersionResolveState moduleRevision, ResolvedConfigurationIdentifier id, ResolveState resolveState) {
             this.moduleRevision = moduleRevision;
@@ -652,26 +651,21 @@ public class DependencyGraphBuilder {
             return String.format("%s(%s)", moduleRevision, metaData.getName());
         }
 
-        public Set<ResolvedArtifact> getArtifacts(ResolvedConfigurationBuilder builder, ModuleResolutionFilter moduleResolutionFilter) {
+        public Set<ComponentArtifactMetaData> getArtifacts(ModuleResolutionFilter moduleResolutionFilter) {
             if (artifacts == null) {
                 BuildableArtifactSetResolveResult result = new DefaultBuildableArtifactSetResolveResult();
                 resolveState.artifactResolver.resolveModuleArtifacts(metaData.getComponent(), new DefaultComponentUsage(metaData.getName()), result);
                 artifacts = result.getArtifacts();
             }
 
-            Set<ResolvedArtifact> result = new LinkedHashSet<ResolvedArtifact>();
+            Set<ComponentArtifactMetaData> result = new LinkedHashSet<ComponentArtifactMetaData>();
             ModuleIdentifier moduleId = id.getId().getModule();
             for (ComponentArtifactMetaData artifact : artifacts) {
                 IvyArtifactName artifactName = artifact.getName();
                 if (!moduleResolutionFilter.acceptArtifact(moduleId, artifactName)) {
                     continue;
                 }
-                ResolvedArtifact resolvedArtifact = resolvedArtifacts.get(artifactName);
-                if (resolvedArtifact == null) {
-                    resolvedArtifact = builder.newArtifact(id, metaData.getComponent(), artifact, resolveState.artifactResolver);
-                    resolvedArtifacts.put(artifactName, resolvedArtifact);
-                }
-                result.add(resolvedArtifact);
+                result.add(artifact);
             }
 
             return result;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
@@ -651,6 +651,7 @@ public class DependencyGraphBuilder {
             return String.format("%s(%s)", moduleRevision, metaData.getName());
         }
 
+        // TODO:DAZ Move this into the ArtifactSet: we don't want to keep all of these references.
         public Set<ComponentArtifactMetaData> getArtifacts(ModuleResolutionFilter moduleResolutionFilter) {
             if (artifacts == null) {
                 BuildableArtifactSetResolveResult result = new DefaultBuildableArtifactSetResolveResult();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
@@ -652,10 +652,11 @@ public class DependencyGraphBuilder {
         }
 
         // TODO:DAZ Move this into the ArtifactSet: we don't want to keep all of these references.
-        public Set<ComponentArtifactMetaData> getArtifacts(ModuleResolutionFilter moduleResolutionFilter) {
+        // The main question is how to maintain the cache of all artifacts pre-filtered.
+        public Set<ComponentArtifactMetaData> getArtifacts(ModuleResolutionFilter moduleResolutionFilter, ArtifactResolver artifactResolver) {
             if (artifacts == null) {
                 BuildableArtifactSetResolveResult result = new DefaultBuildableArtifactSetResolveResult();
-                resolveState.artifactResolver.resolveModuleArtifacts(metaData.getComponent(), new DefaultComponentUsage(metaData.getName()), result);
+                artifactResolver.resolveModuleArtifacts(metaData.getComponent(), new DefaultComponentUsage(metaData.getName()), result);
                 artifacts = result.getArtifacts();
             }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedArtifactSet.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.artifacts.ResolvedArtifact;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedConfigurationDependencyGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedConfigurationDependencyGraphVisitor.java
@@ -79,7 +79,7 @@ class ResolvedConfigurationDependencyGraphVisitor implements DependencyGraphVisi
         }
     }
 
-    private ResolvedArtifactSet getArtifacts(DependencyGraphBuilder.DependencyEdge dependency, DependencyGraphBuilder.ConfigurationNode childConfiguration) {
+    private ArtifactSet getArtifacts(DependencyGraphBuilder.DependencyEdge dependency, DependencyGraphBuilder.ConfigurationNode childConfiguration) {
         long id = idGenerator.generateId();
         Set<ComponentArtifactMetaData> artifacts = dependency.getArtifacts(childConfiguration.metaData);
         if (!artifacts.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedConfigurationDependencyGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedConfigurationDependencyGraphVisitor.java
@@ -21,11 +21,12 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultUnresolvedDependency;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.DefaultResolvedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleResolutionFilter;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.AbstractResolvedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.PredeterminedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.ResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.ResolvedConfigurationBuilder;
 import org.gradle.internal.component.model.ComponentArtifactMetaData;
-import org.gradle.internal.component.model.ComponentResolveMetaData;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.id.LongIdGenerator;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -74,7 +75,7 @@ class ResolvedConfigurationDependencyGraphVisitor implements DependencyGraphVisi
         ResolvedConfigurationIdentifier parent = dependency.from.id;
         ResolvedConfigurationIdentifier child = childConfiguration.id;
         oldModelBuilder.addChild(parent, child);
-        oldModelBuilder.addArtifacts(child, parent, getArtifacts(dependency, childConfiguration, oldModelBuilder));
+        oldModelBuilder.addArtifacts(child, parent, getArtifacts(dependency, childConfiguration));
 
         if (parent == root.id) {
             ModuleDependency moduleDependency = dependency.getModuleDependency();
@@ -82,17 +83,13 @@ class ResolvedConfigurationDependencyGraphVisitor implements DependencyGraphVisi
         }
     }
 
-    private ResolvedArtifactSet getArtifacts(DependencyGraphBuilder.DependencyEdge dependency, DependencyGraphBuilder.ConfigurationNode childConfiguration, ResolvedConfigurationBuilder builder) {
+    private ResolvedArtifactSet getArtifacts(DependencyGraphBuilder.DependencyEdge dependency, DependencyGraphBuilder.ConfigurationNode childConfiguration) {
+        long id = idGenerator.generateId();
         Set<ComponentArtifactMetaData> artifacts = dependency.getArtifacts(childConfiguration.metaData);
         if (artifacts.isEmpty()) {
-            artifacts = childConfiguration.getArtifacts(dependency.getSelector());
+            return new ConfigurationArtifactsSet(childConfiguration, dependency.getSelector(), artifactResolver, id);
         }
-        return newArtifactSet(childConfiguration.toId(), childConfiguration.metaData.getComponent(), artifacts, artifactResolver);
-    }
-
-    private ResolvedArtifactSet newArtifactSet(ModuleVersionIdentifier ownerId, ComponentResolveMetaData component, Set<ComponentArtifactMetaData> artifact, ArtifactResolver artifactResolver) {
-        long id = idGenerator.generateId();
-        return new DefaultResolvedArtifactSet(ownerId, component, artifact, artifactResolver, id);
+        return new PredeterminedArtifactSet(childConfiguration.toId(), childConfiguration.metaData.getComponent(), artifacts, artifactResolver, id);
     }
 
     public void finish(DependencyGraphBuilder.ConfigurationNode root) {
@@ -179,6 +176,23 @@ class ResolvedConfigurationDependencyGraphVisitor implements DependencyGraphVisi
 
         private BrokenDependency(ModuleVersionResolveException failure) {
             this.failure = failure;
+        }
+    }
+
+    // TODO:DAZ Probably want to resolve early for external modules, and only hang onto Configuration node for local components
+    private static class ConfigurationArtifactsSet extends AbstractResolvedArtifactSet {
+        private final DependencyGraphBuilder.ConfigurationNode childConfiguration;
+        private final ModuleResolutionFilter selector;
+
+        public ConfigurationArtifactsSet(DependencyGraphBuilder.ConfigurationNode childConfiguration, ModuleResolutionFilter selector, ArtifactResolver artifactResolver, long id) {
+            super(id, childConfiguration.toId(), childConfiguration.metaData.getComponent(), artifactResolver);
+            this.childConfiguration = childConfiguration;
+            this.selector = selector;
+        }
+
+        @Override
+        protected Set<ComponentArtifactMetaData> resolveComponentArtifacts() {
+            return childConfiguration.getArtifacts(selector);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedConfigurationDependencyGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedConfigurationDependencyGraphVisitor.java
@@ -78,15 +78,16 @@ class ResolvedConfigurationDependencyGraphVisitor implements DependencyGraphVisi
     }
 
     private Set<ResolvedArtifact> getArtifacts(DependencyGraphBuilder.DependencyEdge dependency, DependencyGraphBuilder.ConfigurationNode childConfiguration, ResolvedConfigurationBuilder builder) {
-        Set<ComponentArtifactMetaData> dependencyArtifacts = dependency.getArtifacts(childConfiguration.metaData);
-        if (dependencyArtifacts.isEmpty()) {
-            return childConfiguration.getArtifacts(builder, dependency.getSelector());
+        Set<ComponentArtifactMetaData> artifacts = dependency.getArtifacts(childConfiguration.metaData);
+        if (artifacts.isEmpty()) {
+            artifacts = childConfiguration.getArtifacts(dependency.getSelector());
         }
-        Set<ResolvedArtifact> artifacts = new LinkedHashSet<ResolvedArtifact>();
-        for (ComponentArtifactMetaData artifact : dependencyArtifacts) {
-            artifacts.add(builder.newArtifact(childConfiguration.id, childConfiguration.metaData.getComponent(), artifact, artifactResolver));
+
+        Set<ResolvedArtifact> resolvedArtifacts = new LinkedHashSet<ResolvedArtifact>();
+        for (ComponentArtifactMetaData artifact : artifacts) {
+            resolvedArtifacts.add(builder.newArtifact(childConfiguration.id, childConfiguration.metaData.getComponent(), artifact, artifactResolver));
         }
-        return artifacts;
+        return resolvedArtifacts;
     }
 
     public void finish(DependencyGraphBuilder.ConfigurationNode root) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedArtifactSet.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.internal.artifacts.DefaultResolvedArtifact;
+import org.gradle.api.internal.artifacts.ivyservice.dynamicversions.DefaultResolvedModuleVersion;
+import org.gradle.internal.Factory;
+import org.gradle.internal.component.model.ComponentArtifactMetaData;
+import org.gradle.internal.component.model.ComponentResolveMetaData;
+import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.resolve.resolver.ArtifactResolver;
+import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class DefaultResolvedArtifactSet implements ResolvedArtifactSet {
+    private final ModuleVersionIdentifier moduleVersionIdentifier;
+    private final ComponentResolveMetaData component;
+    private final Set<ComponentArtifactMetaData> artifacts;
+    private final ArtifactResolver artifactResolver;
+    private final long id;
+    private Set<ResolvedArtifact> resolvedArtifacts;
+
+    public DefaultResolvedArtifactSet(ModuleVersionIdentifier ownerId, ComponentResolveMetaData component, Set<ComponentArtifactMetaData> artifacts, ArtifactResolver artifactResolver, long id) {
+        this.moduleVersionIdentifier = ownerId;
+        this.component = component;
+        this.artifacts = artifacts;
+        this.artifactResolver = artifactResolver;
+        this.id = id;
+    }
+    
+    public long getId() {
+        return id;
+    }
+
+    public Set<ResolvedArtifact> getArtifacts() {
+        if (resolvedArtifacts == null) {
+            resolvedArtifacts = new LinkedHashSet<ResolvedArtifact>(artifacts.size());
+            for (ComponentArtifactMetaData artifact : artifacts) {
+                resolvedArtifacts.add(createResolvedArtifact(artifact));
+            }
+        }
+        // TODO:DAZ Clear state that is no longer required to build the set of artifacts
+        return resolvedArtifacts;
+    }
+
+    private ResolvedArtifact createResolvedArtifact(ComponentArtifactMetaData artifact) {
+        Factory<File> artifactSource = new LazyArtifactSource(artifact, component.getSource(), artifactResolver);
+        return new DefaultResolvedArtifact(new DefaultResolvedModuleVersion(moduleVersionIdentifier), artifact.getName(), artifactSource, id);
+    }
+
+    private static class LazyArtifactSource implements Factory<File> {
+        private final ArtifactResolver artifactResolver;
+        private final ModuleSource moduleSource;
+        private final ComponentArtifactMetaData artifact;
+
+        private LazyArtifactSource(ComponentArtifactMetaData artifact, ModuleSource moduleSource, ArtifactResolver artifactResolver) {
+            this.artifact = artifact;
+            this.artifactResolver = artifactResolver;
+            this.moduleSource = moduleSource;
+        }
+
+        public File create() {
+            DefaultBuildableArtifactResolveResult result = new DefaultBuildableArtifactResolveResult();
+            artifactResolver.resolveArtifact(artifact, moduleSource, result);
+            return result.getFile();
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedArtifactSet.java
@@ -53,18 +53,18 @@ public class DefaultResolvedArtifactSet implements ResolvedArtifactSet {
 
     public Set<ResolvedArtifact> getArtifacts() {
         if (resolvedArtifacts == null) {
+            // TODO:DAZ Cut the state that we hold to just what is absolutely required for artifact resolution
             resolvedArtifacts = new LinkedHashSet<ResolvedArtifact>(artifacts.size());
             for (ComponentArtifactMetaData artifact : artifacts) {
-                resolvedArtifacts.add(createResolvedArtifact(artifact));
+                Factory<File> artifactSource = new LazyArtifactSource(artifact, component.getSource(), artifactResolver);
+                ResolvedArtifact resolvedArtifact = new DefaultResolvedArtifact(new DefaultResolvedModuleVersion(moduleVersionIdentifier), artifact.getName(), artifactSource, id);
+                resolvedArtifacts.add(resolvedArtifact);
             }
         }
-        // TODO:DAZ Clear state that is no longer required to build the set of artifacts
+        // TODO:DAZ Once artifacts are built, clear all state that is no longer required
+        // TODO:DAZ Need to avoid hanging onto state when artifacts are not used: for now maybe resolve artifact sets explicitly even when not required
+        // TODO:DAZ ArtifactResolver should be provided when resolving, not when constructing
         return resolvedArtifacts;
-    }
-
-    private ResolvedArtifact createResolvedArtifact(ComponentArtifactMetaData artifact) {
-        Factory<File> artifactSource = new LazyArtifactSource(artifact, component.getSource(), artifactResolver);
-        return new DefaultResolvedArtifact(new DefaultResolvedModuleVersion(moduleVersionIdentifier), artifact.getName(), artifactSource, id);
     }
 
     private static class LazyArtifactSource implements Factory<File> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedConfigurationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedConfigurationBuilder.java
@@ -20,8 +20,6 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
-import org.gradle.internal.id.IdGenerator;
-import org.gradle.internal.id.LongIdGenerator;
 
 import java.util.*;
 
@@ -31,7 +29,6 @@ public class DefaultResolvedConfigurationBuilder implements
     private final Map<Long, ResolvedArtifactSet> artifactSets = new LinkedHashMap<Long, ResolvedArtifactSet>();
     private final Set<ResolvedArtifact> artifacts = new LinkedHashSet<ResolvedArtifact>();
     private final Set<UnresolvedDependency> unresolvedDependencies = new LinkedHashSet<UnresolvedDependency>();
-    private final IdGenerator<Long> idGenerator = new LongIdGenerator();
     private final Map<ResolvedConfigurationIdentifier, ModuleDependency> modulesMap = new HashMap<ResolvedConfigurationIdentifier, ModuleDependency>();
 
     private final TransientConfigurationResultsBuilder builder;
@@ -63,7 +60,7 @@ public class DefaultResolvedConfigurationBuilder implements
         builder.parentSpecificArtifacts(child, parent, artifactSet.getId());
         artifactSets.put(artifactSet.getId(), artifactSet);
 
-        // TODO:DAZ Defer this resolution
+        // TODO:DAZ Defer this resolution until a separate 'resolveArtifacts' step (or on demand)
         for (ResolvedArtifact artifact : artifactSet.getArtifacts()) {
             artifacts.add(artifact);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedConfigurationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedConfigurationBuilder.java
@@ -20,7 +20,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ArtifactSet;
 
 import java.util.*;
 
@@ -29,7 +29,7 @@ public class DefaultResolvedConfigurationBuilder implements
 
     private final Set<UnresolvedDependency> unresolvedDependencies = new LinkedHashSet<UnresolvedDependency>();
     private final Map<ResolvedConfigurationIdentifier, ModuleDependency> modulesMap = new HashMap<ResolvedConfigurationIdentifier, ModuleDependency>();
-    private List<ResolvedArtifactSet> resolvedArtifactSets = new ArrayList<ResolvedArtifactSet>();
+    private List<ArtifactSet> artifactSets = new ArrayList<ArtifactSet>();
     private Map<Long, Set<ResolvedArtifact>> resolvedArtifactsById;
     private Set<ResolvedArtifact> allResolvedArtifacts;
 
@@ -58,9 +58,9 @@ public class DefaultResolvedConfigurationBuilder implements
         builder.parentChildMapping(parent, child);
     }
 
-    public void addArtifacts(ResolvedConfigurationIdentifier child, ResolvedConfigurationIdentifier parent, ResolvedArtifactSet artifactSet) {
+    public void addArtifacts(ResolvedConfigurationIdentifier child, ResolvedConfigurationIdentifier parent, ArtifactSet artifactSet) {
         builder.parentSpecificArtifacts(child, parent, artifactSet.getId());
-        resolvedArtifactSets.add(artifactSet);
+        artifactSets.add(artifactSet);
     }
 
     public void newResolvedDependency(ResolvedConfigurationIdentifier id) {
@@ -92,14 +92,14 @@ public class DefaultResolvedConfigurationBuilder implements
         if (allResolvedArtifacts == null) {
             allResolvedArtifacts = new LinkedHashSet<ResolvedArtifact>();
             resolvedArtifactsById = new LinkedHashMap<Long, Set<ResolvedArtifact>>();
-            for (ResolvedArtifactSet artifactSet : resolvedArtifactSets) {
+            for (ArtifactSet artifactSet : artifactSets) {
                 Set<ResolvedArtifact> resolvedArtifacts = artifactSet.getArtifacts();
                 allResolvedArtifacts.addAll(resolvedArtifacts);
                 resolvedArtifactsById.put(artifactSet.getId(), resolvedArtifacts);
             }
 
             // Release ResolvedArtifactSet instances so we're not holding onto state
-            resolvedArtifactSets = null;
+            artifactSets = null;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/PredeterminedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/PredeterminedArtifactSet.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.internal.component.model.ComponentArtifactMetaData;
+import org.gradle.internal.component.model.ComponentResolveMetaData;
+import org.gradle.internal.resolve.resolver.ArtifactResolver;
+
+import java.util.Set;
+
+public class PredeterminedArtifactSet extends AbstractResolvedArtifactSet {
+    private final Set<ComponentArtifactMetaData> artifacts;
+
+    public PredeterminedArtifactSet(ModuleVersionIdentifier ownerId, ComponentResolveMetaData component, Set<ComponentArtifactMetaData> artifacts, ArtifactResolver artifactResolver, long id) {
+        super(id, ownerId, component, artifactResolver);
+        this.artifacts = artifacts;
+    }
+
+    @Override
+    protected Set<ComponentArtifactMetaData> resolveComponentArtifacts() {
+        return artifacts;
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedArtifactSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,11 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
-import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ResolvedArtifact;
-import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
 
 import java.util.Set;
 
-public interface ResolvedContentsMapping {
-
-    Set<ResolvedArtifact> getArtifacts(long id);
-
-    ModuleDependency getModuleDependency(ResolvedConfigurationIdentifier id);
+public interface ResolvedArtifactSet {
+    long getId();
+    Set<ResolvedArtifact> getArtifacts();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedArtifactSet;
 
 //builds old model of resolved dependency graph based on the result events
 public interface ResolvedConfigurationBuilder {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ArtifactSet;
 
 //builds old model of resolved dependency graph based on the result events
 public interface ResolvedConfigurationBuilder {
@@ -29,7 +29,7 @@ public interface ResolvedConfigurationBuilder {
 
     void addChild(ResolvedConfigurationIdentifier parent, ResolvedConfigurationIdentifier child);
 
-    void addArtifacts(ResolvedConfigurationIdentifier child, ResolvedConfigurationIdentifier parent, ResolvedArtifactSet artifacts);
+    void addArtifacts(ResolvedConfigurationIdentifier child, ResolvedConfigurationIdentifier parent, ArtifactSet artifacts);
 
     void newResolvedDependency(ResolvedConfigurationIdentifier id);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
@@ -28,9 +28,11 @@ public interface ResolvedConfigurationBuilder {
 
     void addChild(ResolvedConfigurationIdentifier parent, ResolvedConfigurationIdentifier child);
 
-    void done(ResolvedConfigurationIdentifier root);
-
     void addArtifacts(ResolvedConfigurationIdentifier child, ResolvedConfigurationIdentifier parent, ResolvedArtifactSet artifacts);
 
     void newResolvedDependency(ResolvedConfigurationIdentifier id);
+
+    void done(ResolvedConfigurationIdentifier root);
+
+    void resolveArtifacts();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
@@ -16,14 +16,8 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
 import org.gradle.api.artifacts.ModuleDependency;
-import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
-import org.gradle.internal.component.model.ComponentResolveMetaData;
-import org.gradle.internal.resolve.resolver.ArtifactResolver;
-import org.gradle.internal.component.model.ComponentArtifactMetaData;
-
-import java.util.Set;
 
 //builds old model of resolved dependency graph based on the result events
 public interface ResolvedConfigurationBuilder {
@@ -36,9 +30,7 @@ public interface ResolvedConfigurationBuilder {
 
     void done(ResolvedConfigurationIdentifier root);
 
-    void addParentSpecificArtifacts(ResolvedConfigurationIdentifier child, ResolvedConfigurationIdentifier parent, Set<ResolvedArtifact> artifacts);
+    void addArtifacts(ResolvedConfigurationIdentifier child, ResolvedConfigurationIdentifier parent, ResolvedArtifactSet artifacts);
 
     void newResolvedDependency(ResolvedConfigurationIdentifier id);
-
-    ResolvedArtifact newArtifact(ResolvedConfigurationIdentifier owner, ComponentResolveMetaData component, ComponentArtifactMetaData artifact, ArtifactResolver artifactResolver);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResultsBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResultsBuilder.java
@@ -88,7 +88,7 @@ public class TransientConfigurationResultsBuilder {
         writeId(PARENT_CHILD, parent, child);
     }
 
-    public void parentSpecificArtifact(ResolvedConfigurationIdentifier child, ResolvedConfigurationIdentifier parent, final long artifactId) {
+    public void parentSpecificArtifacts(ResolvedConfigurationIdentifier child, ResolvedConfigurationIdentifier parent, final long artifactId) {
         writeId(PARENT_ARTIFACT, child, parent);
         binaryStore.write(new BinaryStore.WriteAction() {
             public void write(Encoder encoder) throws IOException {
@@ -176,7 +176,7 @@ public class TransientConfigurationResultsBuilder {
                         if (artifactChild == null) {
                             throw new IllegalStateException(String.format("Unexpected child dependency id %s. Seen ids: %s", artifactChildId, allDependencies.keySet()));
                         }
-                        artifactParent.addParentSpecificArtifacts(artifactChild, newHashSet(mapping.getArtifact(decoder.readLong())));
+                        artifactParent.addParentSpecificArtifacts(artifactChild, newHashSet(mapping.getArtifacts(decoder.readLong())));
                         break;
                     default:
                         throw new IOException("Unknown value type read from stream: " + type);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/projectresult/ResolvedProjectConfigurationResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/projectresult/ResolvedProjectConfigurationResultBuilder.java
@@ -18,8 +18,26 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 
+import java.util.Collections;
+
 public interface ResolvedProjectConfigurationResultBuilder {
     void registerRoot(ComponentIdentifier componentId);
     void addProjectComponentResult(ProjectComponentIdentifier componentId, String configurationName);
     ResolvedProjectConfigurationResults complete();
+
+    static ResolvedProjectConfigurationResultBuilder NOOP_BUILDER = new ResolvedProjectConfigurationResultBuilder() {
+
+        @Override
+        public void registerRoot(ComponentIdentifier componentId) {
+        }
+
+        @Override
+        public void addProjectComponentResult(ProjectComponentIdentifier componentId, String configurationName) {
+        }
+
+        @Override
+        public ResolvedProjectConfigurationResults complete() {
+            return new DefaultResolvedProjectConfigurationResults(Collections.<ResolvedProjectConfigurationResult>emptySet());
+        }
+    };
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetaData.java
@@ -27,10 +27,7 @@ import org.gradle.api.Nullable;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
-import org.gradle.internal.component.model.AbstractModuleDescriptorBackedMetaData;
-import org.gradle.internal.component.model.ComponentArtifactMetaData;
-import org.gradle.internal.component.model.ConfigurationMetaData;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.*;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -82,7 +79,7 @@ abstract class AbstractModuleComponentResolveMetaData extends AbstractModuleDesc
         setId(DefaultModuleVersionIdentifier.newId(componentId));
     }
 
-    public ModuleComponentArtifactMetaData artifact(Artifact artifact) {
+    public ModuleComponentArtifactMetaData artifact(IvyArtifactName artifact) {
         return new DefaultModuleComponentArtifactMetaData(getComponentId(), artifact);
     }
 
@@ -121,7 +118,7 @@ abstract class AbstractModuleComponentResolveMetaData extends AbstractModuleDesc
     private void populateArtifactsFromDescriptor() {
         Map<Artifact, ModuleComponentArtifactMetaData> artifactToMetaData = Maps.newLinkedHashMap();
         for (Artifact descriptorArtifact : getDescriptor().getAllArtifacts()) {
-            ModuleComponentArtifactMetaData artifact = artifact(descriptorArtifact);
+            ModuleComponentArtifactMetaData artifact = new DefaultModuleComponentArtifactMetaData(getComponentId(), descriptorArtifact);
             artifactToMetaData.put(descriptorArtifact, artifact);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/BuildableIvyModuleResolveMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/BuildableIvyModuleResolveMetaData.java
@@ -60,7 +60,7 @@ public class BuildableIvyModuleResolveMetaData extends DefaultIvyModuleResolveMe
     }
 
     private boolean artifactsEqual(Artifact a, Artifact b) {
-        return new DefaultIvyArtifactName(a).equals(new DefaultIvyArtifactName(b));
+        return DefaultIvyArtifactName.forIvyArtifact(a).equals(DefaultIvyArtifactName.forIvyArtifact(b));
     }
 
     private static void attachArtifact(MDArtifact artifact, Set<String> configurations, DefaultModuleDescriptor target) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetaData.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.internal.component.external.model;
 
-import org.apache.ivy.core.module.descriptor.Artifact;
 import org.gradle.api.Nullable;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetaData;
@@ -32,8 +31,6 @@ public interface ModuleComponentResolveMetaData extends ComponentResolveMetaData
     ModuleComponentResolveMetaData withSource(ModuleSource source);
 
     Set<ModuleComponentArtifactMetaData> getArtifacts();
-
-    ModuleComponentArtifactMetaData artifact(Artifact artifact);
 
     ModuleComponentArtifactMetaData artifact(String type, @Nullable String extension, @Nullable String classifier);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetaData.java
@@ -194,16 +194,15 @@ public class DefaultLocalComponentMetaData implements MutableLocalComponentMetaD
             return dependencies;
         }
 
-        public ComponentArtifactMetaData artifact(Artifact artifact) {
+        public ComponentArtifactMetaData artifact(IvyArtifactName ivyArtifactName) {
             resolveArtifacts();
 
             // TODO:DAZ Work out what this actually means: I think it's used for finding the _real_ artifact that matches one declared in a dependency
             // In that case we should be inspecting the included PublishArtifact instances and building a ComponentArtifactMetaData for the matching one.
             // TODO:DAZ Maybe fail if the artifacts have not yet been built for the component
 
-            IvyArtifactName ivyName = DefaultIvyArtifactName.forIvyArtifact(artifact);
-            DefaultLocalArtifactMetaData candidate = artifactsByIvyName.get(ivyName);
-            return candidate != null ? candidate : new DefaultLocalArtifactMetaData(componentIdentifier, id.toString(), ivyName, null);
+            DefaultLocalArtifactMetaData candidate = artifactsByIvyName.get(ivyArtifactName);
+            return candidate != null ? candidate : new DefaultLocalArtifactMetaData(componentIdentifier, id.toString(), ivyArtifactName, null);
         }
 
         // TODO:DAZ This is only used in unit tests

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentMetaData.java
@@ -35,6 +35,7 @@ public interface LocalComponentMetaData {
      */
     BuildableIvyModulePublishMetaData toPublishMetaData();
 
+    // TODO:DAZ This is only used in tests
     @Nullable
     LocalArtifactMetaData getArtifact(ComponentArtifactIdentifier artifactIdentifier);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/MutableLocalComponentMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/MutableLocalComponentMetaData.java
@@ -18,15 +18,13 @@ package org.gradle.internal.component.local.model;
 
 import org.apache.ivy.core.module.descriptor.ExcludeRule;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
+import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.internal.component.model.DependencyMetaData;
-import org.gradle.internal.component.model.IvyArtifactName;
-
-import java.io.File;
 
 public interface MutableLocalComponentMetaData extends LocalComponentMetaData {
     ModuleDescriptor getModuleDescriptor();
 
-    void addArtifact(String configuration, IvyArtifactName artifact, File file);
+    void addArtifacts(String configuration, PublishArtifactSet artifacts);
 
     void addConfiguration(String name, boolean visible, String description, String[] superConfigs, boolean transitive);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetaData.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.component.model;
 
-import org.apache.ivy.core.module.descriptor.Artifact;
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.gradle.api.Nullable;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -73,7 +72,7 @@ public interface ComponentResolveMetaData {
      * Converts the given Ivy artifact to the corresponding artifact meta-data. This method is here to allow us to migrate away from the Ivy types and
      * will be removed.
      */
-    ComponentArtifactMetaData artifact(Artifact artifact);
+    ComponentArtifactMetaData artifact(IvyArtifactName artifact);
 
     /**
      * Returns the known artifacts for this component. There may be additional component available that are not included in this set.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetaData.java
@@ -78,6 +78,7 @@ public interface ComponentResolveMetaData {
     /**
      * Returns the known artifacts for this component. There may be additional component available that are not included in this set.
      */
+    // TODO:DAZ This is only used in unit tests
     Set<? extends ComponentArtifactMetaData> getArtifacts();
 
     boolean isGenerated();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultDependencyMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultDependencyMetaData.java
@@ -86,8 +86,7 @@ public class DefaultDependencyMetaData implements DependencyMetaData {
         }
         Set<ComponentArtifactMetaData> artifacts = new LinkedHashSet<ComponentArtifactMetaData>();
         for (DependencyArtifactDescriptor artifactDescriptor : dependencyArtifacts) {
-            ModuleRevisionId id = toConfiguration.getComponent().getDescriptor().getModuleRevisionId();
-            Artifact artifact = new DefaultArtifact(id, null, artifactDescriptor.getName(), artifactDescriptor.getType(), artifactDescriptor.getExt(), artifactDescriptor.getUrl(), artifactDescriptor.getQualifiedExtraAttributes());
+            DefaultIvyArtifactName artifact = DefaultIvyArtifactName.forIvyArtifact(artifactDescriptor);
             artifacts.add(toConfiguration.getComponent().artifact(artifact));
         }
         return artifacts;
@@ -99,8 +98,9 @@ public class DefaultDependencyMetaData implements DependencyMetaData {
             return Collections.emptySet();
         }
         Set<IvyArtifactName> artifactSet = Sets.newLinkedHashSet();
-        for (DependencyArtifactDescriptor artifact : dependencyArtifacts) {
-            artifactSet.add(new DefaultIvyArtifactName(artifact.getName(), artifact.getType(), artifact.getExt(), artifact.getExtraAttributes()));
+        for (DependencyArtifactDescriptor artifactDescriptor : dependencyArtifacts) {
+            DefaultIvyArtifactName artifact = DefaultIvyArtifactName.forIvyArtifact(artifactDescriptor);
+            artifactSet.add(artifact);
         }
         return artifactSet;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.model;
 
 import com.google.common.base.Objects;
 import org.apache.ivy.core.module.descriptor.Artifact;
+import org.apache.ivy.core.module.descriptor.DependencyArtifactDescriptor;
 import org.gradle.api.Nullable;
 import org.gradle.util.GUtil;
 
@@ -33,7 +34,11 @@ public class DefaultIvyArtifactName implements IvyArtifactName {
     private final Map<String, String> attributes;
 
     public static DefaultIvyArtifactName forIvyArtifact(Artifact a) {
-        return new DefaultIvyArtifactName(a.getName(), a.getType(), a.getExt(), a.getQualifiedExtraAttributes());
+        return new DefaultIvyArtifactName(a.getName(), a.getType(), a.getExt(), a.getExtraAttributes());
+    }
+
+    public static DefaultIvyArtifactName forIvyArtifact(DependencyArtifactDescriptor a) {
+        return new DefaultIvyArtifactName(a.getName(), a.getType(), a.getExt(), a.getExtraAttributes());
     }
 
     public DefaultIvyArtifactName(String name, String type, @Nullable String extension, Map<String, String> attributes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
@@ -20,6 +20,7 @@ import com.google.common.base.Objects;
 import org.apache.ivy.core.module.descriptor.Artifact;
 import org.apache.ivy.core.module.descriptor.DependencyArtifactDescriptor;
 import org.gradle.api.Nullable;
+import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.util.GUtil;
 
 import java.util.Collections;
@@ -39,6 +40,18 @@ public class DefaultIvyArtifactName implements IvyArtifactName {
 
     public static DefaultIvyArtifactName forIvyArtifact(DependencyArtifactDescriptor a) {
         return new DefaultIvyArtifactName(a.getName(), a.getType(), a.getExt(), a.getExtraAttributes());
+    }
+
+    public static DefaultIvyArtifactName forPublishArtifact(PublishArtifact publishArtifact, String moduleName) {
+        Map<String, String> extraAttributes = new HashMap<String, String>();
+        if (GUtil.isTrue(publishArtifact.getClassifier())) {
+            extraAttributes.put(CLASSIFIER, publishArtifact.getClassifier());
+        }
+        String name = publishArtifact.getName();
+        if (!GUtil.isTrue(name)) {
+            name = moduleName;
+        }
+        return new DefaultIvyArtifactName(name, publishArtifact.getType(), publishArtifact.getExtension(), extraAttributes);
     }
 
     public DefaultIvyArtifactName(String name, String type, @Nullable String extension, Map<String, String> attributes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
@@ -32,8 +32,8 @@ public class DefaultIvyArtifactName implements IvyArtifactName {
     private final String extension;
     private final Map<String, String> attributes;
 
-    public DefaultIvyArtifactName(Artifact a) {
-        this(a.getName(), a.getType(), a.getExt(), a.getAttributes());
+    public static DefaultIvyArtifactName forIvyArtifact(Artifact a) {
+        return new DefaultIvyArtifactName(a.getName(), a.getType(), a.getExt(), a.getQualifiedExtraAttributes());
     }
 
     public DefaultIvyArtifactName(String name, String type, @Nullable String extension, Map<String, String> attributes) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
 import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.reflect.Instantiator
@@ -33,19 +34,20 @@ public class DefaultConfigurationContainerSpec extends Specification {
     private ListenerManager listenerManager = Mock()
     private DependencyMetaDataProvider metaDataProvider = Mock()
     private ProjectAccessListener projectAccessListener = Mock()
+    private ProjectFinder projectFinder = Mock()
 
     def ConfigurationInternal conf = Mock()
 
     private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(
             resolver, instantiator, domainObjectContext,
-            listenerManager, metaDataProvider, projectAccessListener);
+            listenerManager, metaDataProvider, projectAccessListener, projectFinder);
 
     def "adds and gets"() {
         _ * conf.getName() >> "compile"
         1 * domainObjectContext.absoluteProjectPath("compile") >> ":compile"
         1 * instantiator.newInstance(DefaultResolutionStrategy.class) >> { new DefaultResolutionStrategy() }
         1 * instantiator.newInstance(DefaultConfiguration.class, ":compile", "compile", configurationContainer,
-                resolver, listenerManager, metaDataProvider, _ as ResolutionStrategyInternal, projectAccessListener) >> conf
+                resolver, listenerManager, metaDataProvider, _ as ResolutionStrategyInternal, projectAccessListener, projectFinder) >> conf
 
         when:
         def compile = configurationContainer.create("compile")
@@ -65,7 +67,7 @@ public class DefaultConfigurationContainerSpec extends Specification {
         1 * domainObjectContext.absoluteProjectPath("compile") >> ":compile"
         1 * instantiator.newInstance(DefaultResolutionStrategy.class) >> { new DefaultResolutionStrategy() }
         1 * instantiator.newInstance(DefaultConfiguration.class, ":compile", "compile", configurationContainer,
-                resolver, listenerManager, metaDataProvider, _ as ResolutionStrategyInternal, projectAccessListener) >> conf
+                resolver, listenerManager, metaDataProvider, _ as ResolutionStrategyInternal, projectAccessListener, projectFinder) >> conf
 
         when:
         def compile = configurationContainer.create("compile") {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -23,10 +23,11 @@ import org.gradle.api.internal.ClassGeneratorBackedInstantiator
 import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.MissingMethodException
 import org.gradle.api.internal.artifacts.ConfigurationResolver
+import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.initialization.ProjectAccessListener
+import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
-import org.gradle.internal.event.ListenerManager
 import org.gradle.util.JUnit4GroovyMockery
 import org.jmock.integration.junit4.JMock
 import org.junit.Before
@@ -35,7 +36,6 @@ import org.junit.runner.RunWith
 
 import static org.hamcrest.Matchers.*
 import static org.junit.Assert.assertThat
-
 
 @RunWith(JMock)
 class DefaultConfigurationContainerTest {
@@ -48,7 +48,7 @@ class DefaultConfigurationContainerTest {
     private Instantiator instantiator = new ClassGeneratorBackedInstantiator(new AsmBackedClassGenerator(), DirectInstantiator.INSTANCE)
     private DefaultConfigurationContainer configurationContainer = instantiator.newInstance(DefaultConfigurationContainer.class,
             resolver, instantiator, { name -> name } as DomainObjectContext,
-            listenerManager, metaDataProvider, projectAccessListener)
+            listenerManager, metaDataProvider, projectAccessListener, context.mock(ProjectFinder))
 
     @Before
     public void setup() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -414,7 +414,7 @@ class DefaultConfigurationSpec extends Specification {
         config.state == Configuration.State.RESOLVED
     }
 
-    def "modified configuration is re-resolved"() {
+    def "resolving configuration twice returns the same result objects"() {
         def config = conf("conf")
         def result = Mock(ResolutionResult)
         def resolverResults = new ResolverResults()
@@ -422,22 +422,24 @@ class DefaultConfigurationSpec extends Specification {
         resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
 
         when:
-        config.getBuildDependencies()
-
-        then:
-        1 * resolver.resolve(config) >> resolverResults
-        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
-        config.internalState == ConfigurationInternal.InternalState.TASK_DEPENDENCIES_RESOLVED
-        config.state == Configuration.State.RESOLVED
-
-        when:
-        config.dependencies.add(Mock(Dependency))
-        config.incoming.getResolutionResult()
+        def previousResolutionResult = config.incoming.resolutionResult
+        def previousResolvedConfiguration = config.resolvedConfiguration
 
         then:
         1 * resolver.resolve(config) >> resolverResults
         config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
         config.state == Configuration.State.RESOLVED
+
+        when:
+        def nextResolutionResult = config.incoming.resolutionResult
+        def nextResolvedConfiguration = config.resolvedConfiguration
+
+        then:
+        0 * resolver.resolve(_)
+        config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
+        config.state == Configuration.State.RESOLVED
+        previousResolutionResult == nextResolutionResult
+        previousResolvedConfiguration == nextResolvedConfiguration
     }
 
     def "copied configuration is not resolved"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -332,6 +332,131 @@ class DefaultConfigurationSpec extends Specification {
         out == result
     }
 
+    def "resolving configuration for task dependencies puts it into the right state"() {
+        def config = conf("conf")
+        def result = Mock(ResolutionResult)
+        def resolverResults = new ResolverResults()
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
+
+        when:
+        config.getBuildDependencies()
+
+        then:
+        1 * resolver.resolve(config) >> resolverResults
+        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
+        config.internalState == ConfigurationInternal.InternalState.TASK_DEPENDENCIES_RESOLVED
+        config.state == Configuration.State.RESOLVED
+    }
+
+    def "resolving configuration puts it into the right state"() {
+        def config = conf("conf")
+        def result = Mock(ResolutionResult)
+        def resolverResults = new ResolverResults()
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, Mock(ResolvedProjectConfigurationResults))
+
+        when:
+        config.incoming.getResolutionResult()
+
+        then:
+        1 * resolver.resolve(config) >> resolverResults
+        config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
+        config.state == Configuration.State.RESOLVED
+    }
+
+    def "resolving configuration for task dependencies, and then resolving it for results does not re-resolve configuration"() {
+        def config = conf("conf")
+        def result = Mock(ResolutionResult)
+        def resolverResults = new ResolverResults()
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
+
+        when:
+        config.getBuildDependencies()
+
+        then:
+        1 * resolver.resolve(config) >> resolverResults
+        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
+        config.internalState == ConfigurationInternal.InternalState.TASK_DEPENDENCIES_RESOLVED
+        config.state == Configuration.State.RESOLVED
+
+        when:
+        config.incoming.getResolutionResult()
+
+        then:
+        0 * resolver.resolve(_)
+        config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
+        config.state == Configuration.State.RESOLVED
+    }
+
+    def "resolving configuration for results, and then resolving it for task dependencies does not re-resolve configuration"() {
+        def config = conf("conf")
+        def result = Mock(ResolutionResult)
+        def resolverResults = new ResolverResults()
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
+
+        when:
+        config.incoming.getResolutionResult()
+
+        then:
+        1 * resolver.resolve(config) >> resolverResults
+        config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
+        config.state == Configuration.State.RESOLVED
+
+        when:
+        config.getBuildDependencies()
+
+        then:
+        0 * resolver.resolve(_)
+        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
+        config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
+        config.state == Configuration.State.RESOLVED
+    }
+
+    def "modified configuration is re-resolved"() {
+        def config = conf("conf")
+        def result = Mock(ResolutionResult)
+        def resolverResults = new ResolverResults()
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
+
+        when:
+        config.getBuildDependencies()
+
+        then:
+        1 * resolver.resolve(config) >> resolverResults
+        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
+        config.internalState == ConfigurationInternal.InternalState.TASK_DEPENDENCIES_RESOLVED
+        config.state == Configuration.State.RESOLVED
+
+        when:
+        config.dependencies.add(Mock(Dependency))
+        config.incoming.getResolutionResult()
+
+        then:
+        1 * resolver.resolve(config) >> resolverResults
+        config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
+        config.state == Configuration.State.RESOLVED
+    }
+
+    def "copied configuration is not resolved"() {
+        def config = conf("conf")
+        def result = Mock(ResolutionResult)
+        def resolverResults = new ResolverResults()
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, Mock(ResolvedProjectConfigurationResults))
+
+        when:
+        config.incoming.resolutionResult
+        def copy = config.copy()
+
+        then:
+        1 * resolver.resolve(config) >> resolverResults
+        1 * resolutionStrategy.copy() >> Mock(ResolutionStrategyInternal)
+        copy.internalState == ConfigurationInternal.InternalState.UNOBSERVED
+        copy.state == Configuration.State.UNRESOLVED
+    }
+
     def "provides task dependency from project dependency using 'needed'"() {
         def conf = conf("conf")
         when: def dep = conf.getTaskDependencyFromProjectDependency(true, "foo") as TasksFromProjectDependencies

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -349,8 +349,16 @@ class DefaultConfigurationSpec extends Specification {
         config.state == Configuration.State.RESOLVED
     }
 
-    def "resolving configuration puts it into the right state"() {
+    def "resolving configuration puts it into the right state and broadcasts events"() {
+        def listenerBroadcaster = Mock(ListenerBroadcast)
+
+        when:
         def config = conf("conf")
+
+        then:
+        1 * listenerManager.createAnonymousBroadcaster(_) >> listenerBroadcaster
+
+        def listener = Mock(DependencyResolutionListener)
         def result = Mock(ResolutionResult)
         def resolverResults = new ResolverResults()
         resolverResults.resolved(Mock(ResolvedConfiguration), result, Mock(ResolvedProjectConfigurationResults))
@@ -359,7 +367,10 @@ class DefaultConfigurationSpec extends Specification {
         config.incoming.getResolutionResult()
 
         then:
+        1 * listenerBroadcaster.getSource() >> listener
+        1 * listener.beforeResolve(config.incoming)
         1 * resolver.resolve(config) >> resolverResults
+        1 * listener.afterResolve(config.incoming)
         config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
         config.state == Configuration.State.RESOLVED
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -65,8 +65,10 @@ class DefaultConfigurationSpec extends Specification {
     ResolvedConfiguration resolvedConfiguration(Configuration config, ConfigurationResolver dependencyResolver = resolver) {
         ResolvedConfiguration resolvedConfiguration = Mock()
         def results = new ResolverResults()
-        results.resolved(resolvedConfiguration, Mock(ResolutionResult), Mock(ResolvedProjectConfigurationResults))
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        results.resolved(resolvedConfiguration, Mock(ResolutionResult), projectConfigurationResults)
         1 * dependencyResolver.resolve(config) >> results
+        1 * projectConfigurationResults.allProjectConfigurationResults >> ([] as Set)
         resolvedConfiguration
     }
 
@@ -322,13 +324,16 @@ class DefaultConfigurationSpec extends Specification {
         def config = conf("conf")
         def result = Mock(ResolutionResult)
         def resolverResults = new ResolverResults()
-        resolverResults.resolved(Mock(ResolvedConfiguration), result, Mock(ResolvedProjectConfigurationResults))
+
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
 
         when:
         def out = config.incoming.resolutionResult
 
         then:
         1 * resolver.resolve(config) >> resolverResults
+        1 * projectConfigurationResults.allProjectConfigurationResults >> ([] as Set)
         out == result
     }
 
@@ -344,9 +349,27 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         1 * resolver.resolve(config) >> resolverResults
-        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
+        _ * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
         config.internalState == ConfigurationInternal.InternalState.TASK_DEPENDENCIES_RESOLVED
         config.state == Configuration.State.RESOLVED
+    }
+
+    def "resolving configuration marks parent configuration as observed"() {
+        def parent = conf("parent", ":parent")
+        def config = conf("conf")
+        config.extendsFrom parent
+        def result = Mock(ResolutionResult)
+        def resolverResults = new ResolverResults()
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
+
+        when:
+        config.resolve()
+
+        then:
+        1 * resolver.resolve(config) >> resolverResults
+        _ * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
+        parent.internalState == ConfigurationInternal.InternalState.OBSERVED
     }
 
     def "resolving configuration puts it into the right state and broadcasts events"() {
@@ -361,7 +384,9 @@ class DefaultConfigurationSpec extends Specification {
         def listener = Mock(DependencyResolutionListener)
         def result = Mock(ResolutionResult)
         def resolverResults = new ResolverResults()
-        resolverResults.resolved(Mock(ResolvedConfiguration), result, Mock(ResolvedProjectConfigurationResults))
+
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
 
         when:
         config.incoming.getResolutionResult()
@@ -370,6 +395,7 @@ class DefaultConfigurationSpec extends Specification {
         1 * listenerBroadcaster.getSource() >> listener
         1 * listener.beforeResolve(config.incoming)
         1 * resolver.resolve(config) >> resolverResults
+        1 * projectConfigurationResults.allProjectConfigurationResults >> ([] as Set)
         1 * listener.afterResolve(config.incoming)
         config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
         config.state == Configuration.State.RESOLVED
@@ -387,7 +413,7 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         1 * resolver.resolve(config) >> resolverResults
-        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
+        2 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
         config.internalState == ConfigurationInternal.InternalState.TASK_DEPENDENCIES_RESOLVED
         config.state == Configuration.State.RESOLVED
 
@@ -412,6 +438,7 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         1 * resolver.resolve(config) >> resolverResults
+        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
         config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
         config.state == Configuration.State.RESOLVED
 
@@ -441,6 +468,7 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         1 * resolver.resolve(config) >> resolverResults
+        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
         1 * resolvedConfiguration.getFiles(_) >> resolvedFiles
         config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
         config.state == Configuration.State.RESOLVED
@@ -473,14 +501,21 @@ class DefaultConfigurationSpec extends Specification {
         def config = conf("conf")
         def result = Mock(ResolutionResult)
         def resolverResults = new ResolverResults()
-        resolverResults.resolved(Mock(ResolvedConfiguration), result, Mock(ResolvedProjectConfigurationResults))
+
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
 
         when:
         config.incoming.resolutionResult
-        def copy = config.copy()
 
         then:
         1 * resolver.resolve(config) >> resolverResults
+        1 * projectConfigurationResults.getAllProjectConfigurationResults() >> ([] as Set)
+
+        when:
+        def copy = config.copy()
+
+        then:
         1 * resolutionStrategy.copy() >> Mock(ResolutionStrategyInternal)
         copy.internalState == ConfigurationInternal.InternalState.UNOBSERVED
         copy.state == Configuration.State.UNRESOLVED
@@ -504,12 +539,15 @@ class DefaultConfigurationSpec extends Specification {
         def conf = conf("conf")
         def result = Mock(ResolutionResult)
         def resolverResults = new ResolverResults()
-        resolverResults.resolved(Mock(ResolvedConfiguration), result, Mock(ResolvedProjectConfigurationResults))
+
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
 
         when:
         conf.incoming.getResolutionResult()
         then:
         1 * resolver.resolve(conf) >> resolverResults
+        1 * projectConfigurationResults.allProjectConfigurationResults >> ([] as Set)
 
         when: conf.dependencies.add(Mock(Dependency))
         then:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -22,9 +22,11 @@ import org.gradle.api.artifacts.*
 import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.ResolverResults
+import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfigurationResults
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.tasks.TaskDependency
+import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.event.ListenerBroadcast
 import org.gradle.internal.event.ListenerManager
 import spock.lang.Specification
@@ -36,9 +38,11 @@ class DefaultConfigurationSpec extends Specification {
     ListenerManager listenerManager = Mock()
     DependencyMetaDataProvider metaDataProvider = Mock()
     ResolutionStrategyInternal resolutionStrategy = Mock()
+    ProjectAccessListener projectAccessListener = Mock()
+    ProjectFinder projectFinder = Mock()
 
     DefaultConfiguration conf(String confName = "conf", String path = ":conf") {
-        new DefaultConfiguration(path, confName, configurationsProvider, resolver, listenerManager, metaDataProvider, resolutionStrategy, null)
+        new DefaultConfiguration(path, confName, configurationsProvider, resolver, listenerManager, metaDataProvider, resolutionStrategy, projectAccessListener, projectFinder)
     }
 
     DefaultPublishArtifact artifact(String name) {
@@ -192,6 +196,10 @@ class DefaultConfigurationSpec extends Specification {
         Task task = Mock()
         TaskDependency taskDep = Mock()
         def config = conf("conf")
+        def resolvedConfiguration = Mock(ResolvedConfiguration)
+        def resolverResults = new ResolverResults()
+        def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
+        resolverResults.resolved(resolvedConfiguration, Mock(ResolutionResult), projectConfigurationResults)
 
         given:
         config.dependencies.add(dependency)
@@ -203,6 +211,9 @@ class DefaultConfigurationSpec extends Specification {
         then:
         depTaskDeps == [task] as Set
         fileTaskDeps == [task] as Set
+        _ * resolvedConfiguration.hasError() >> false
+        _ * resolver.resolve(config) >> resolverResults
+        _ * projectConfigurationResults.allProjectConfigurationResults >> ([] as Set)
         _ * dependency.buildDependencies >> taskDep
         _ * taskDep.getDependencies(_) >> ([task] as Set)
         0 * _._

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -419,27 +419,43 @@ class DefaultConfigurationSpec extends Specification {
         def result = Mock(ResolutionResult)
         def resolverResults = new ResolverResults()
         def projectConfigurationResults = Mock(ResolvedProjectConfigurationResults)
-        resolverResults.resolved(Mock(ResolvedConfiguration), result, projectConfigurationResults)
+        def resolvedConfiguration = Mock(ResolvedConfiguration)
+        def resolvedFiles = Mock(Set)
+        resolverResults.resolved(resolvedConfiguration, result, projectConfigurationResults)
 
         when:
+        def previousFiles = config.files
         def previousResolutionResult = config.incoming.resolutionResult
         def previousResolvedConfiguration = config.resolvedConfiguration
 
         then:
         1 * resolver.resolve(config) >> resolverResults
+        1 * resolvedConfiguration.getFiles(_) >> resolvedFiles
         config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
         config.state == Configuration.State.RESOLVED
 
         when:
+        def nextFiles = config.files
         def nextResolutionResult = config.incoming.resolutionResult
         def nextResolvedConfiguration = config.resolvedConfiguration
 
         then:
         0 * resolver.resolve(_)
+        1 * resolvedConfiguration.getFiles(_) >> resolvedFiles
         config.internalState == ConfigurationInternal.InternalState.RESULTS_RESOLVED
         config.state == Configuration.State.RESOLVED
-        previousResolutionResult == nextResolutionResult
-        previousResolvedConfiguration == nextResolvedConfiguration
+
+        // We get back the same resolution results
+        previousResolutionResult == result
+        nextResolutionResult == result
+
+        // We get back the same resolved configuration
+        previousResolvedConfiguration == resolvedConfiguration
+        nextResolvedConfiguration == resolvedConfiguration
+
+        // And the same files
+        previousFiles == resolvedFiles
+        nextFiles == resolvedFiles
     }
 
     def "copied configuration is not resolved"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
@@ -165,6 +165,13 @@ public class DefaultConfigurationTest {
         configuration.extendsFrom(otherConfiguration);
     }
 
+    @Test
+    public void extendsFromTheSameConfigurationOnlyExtendsItOnce() {
+        Configuration configuration1 = createNamedConfiguration("otherConf1");
+        configuration.extendsFrom(configuration1, configuration1);
+        assertThat(configuration.getExtendsFrom(), equalTo(toSet(configuration1)));
+    }
+
     @Test(expected = InvalidUserDataException.class)
     public void extendsFromWithIndirectCycleShouldThrowInvalidUserDataEx() {
         Configuration otherConfiguration1 = createNamedConfiguration("otherConf1");

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
@@ -483,7 +483,6 @@ public class DefaultConfigurationTest {
         final FileCollectionDependency fileCollectionDependencyStub = context.mock(FileCollectionDependency.class);
 
         context.checking(new Expectations() {{
-            TaskDependency projectTaskDependencyDummy = context.mock(TaskDependency.class, "projectDep");
             TaskDependency fileTaskDependencyStub = context.mock(TaskDependency.class, "fileDep");
 
             allowing(fileCollectionDependencyStub).getBuildDependencies();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
@@ -387,7 +387,7 @@ public class DefaultConfigurationTest {
     public void buildArtifacts() {
         final Task otherConfTaskMock = context.mock(Task.class, "otherConfTask");
         final Task artifactTaskMock = context.mock(Task.class, "artifactTask");
-        final Configuration otherConfiguration = context.mock(ConfigurationInternal.class);
+        final ConfigurationInternal otherConfiguration = context.mock(ConfigurationInternal.class);
         final TaskDependency otherArtifactTaskDependencyMock = context.mock(TaskDependency.class, "otherConfTaskDep");
         final PublishArtifact otherArtifact = context.mock(PublishArtifact.class, "otherArtifact");
         final PublishArtifactSet inheritedArtifacts = new DefaultPublishArtifactSet("artifacts", toDomainObjectSet(PublishArtifact.class, otherArtifact));
@@ -404,13 +404,15 @@ public class DefaultConfigurationTest {
 
             allowing(otherConfiguration).getAllDependencies();
 
+            allowing(otherConfiguration).addMutationValidator(with(any(MutationValidator.class)));
+
             allowing(otherArtifact).getBuildDependencies();
             will(returnValue(otherArtifactTaskDependencyMock));
             
             allowing(otherArtifactTaskDependencyMock).getDependencies(with(any(Task.class)));
             will(returnValue(toSet(otherConfTaskMock)));
         }});
-        configuration.setExtendsFrom(toSet(otherConfiguration));
+        configuration.setExtendsFrom(toSet((Configuration) otherConfiguration));
         assertThat((Set<Task>) configuration.getAllArtifacts().getBuildDependencies().getDependencies(context.mock(Task.class, "caller")),
                 equalTo(toSet(artifactTaskMock, otherConfTaskMock)));
     }
@@ -419,7 +421,7 @@ public class DefaultConfigurationTest {
     public void getAllArtifactFiles() {
         final Task otherConfTaskMock = context.mock(Task.class, "otherConfTask");
         final Task artifactTaskMock = context.mock(Task.class, "artifactTask");
-        final Configuration otherConfiguration = context.mock(ConfigurationInternal.class);
+        final ConfigurationInternal otherConfiguration = context.mock(ConfigurationInternal.class);
         final TaskDependency otherConfTaskDependencyMock = context.mock(TaskDependency.class, "otherConfTaskDep");
         final TaskDependency artifactTaskDependencyMock = context.mock(TaskDependency.class, "artifactTaskDep");
         final File artifactFile1 = new File("artifact1");
@@ -439,6 +441,8 @@ public class DefaultConfigurationTest {
 
             allowing(otherConfiguration).getExtendsFrom();
             will(returnValue(toSet()));
+
+            allowing(otherConfiguration).addMutationValidator(with(any(MutationValidator.class)));
 
             allowing(otherConfiguration).getArtifacts();
             will(returnValue(toSet(otherArtifact)));
@@ -463,7 +467,7 @@ public class DefaultConfigurationTest {
         }});
 
         configuration.getArtifacts().add(artifact);
-        configuration.setExtendsFrom(toSet(otherConfiguration));
+        configuration.setExtendsFrom(toSet((Configuration) otherConfiguration));
 
         FileCollection files = configuration.getAllArtifacts().getFiles();
         assertThat(files.getFiles(), equalTo(toSet(artifactFile1, artifactFile2)));
@@ -511,6 +515,8 @@ public class DefaultConfigurationTest {
 
             allowing(otherConfiguration).getAllDependencies();
             will(returnValue(inherited));
+
+            allowing(otherConfiguration).addMutationValidator(with(any(MutationValidator.class)));
 
             allowing(otherConfiguration).markAsObserved();
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
@@ -459,20 +459,12 @@ public class DefaultConfigurationTest {
     @Test
     public void buildDependenciesDelegatesToAllSelfResolvingDependencies() {
         final Task target = context.mock(Task.class, "target");
-        final Task projectDepTaskDummy = context.mock(Task.class, "projectDepTask");
         final Task fileDepTaskDummy = context.mock(Task.class, "fileDepTask");
-        final ProjectDependency projectDependencyStub = context.mock(ProjectDependency.class);
         final FileCollectionDependency fileCollectionDependencyStub = context.mock(FileCollectionDependency.class);
 
         context.checking(new Expectations() {{
             TaskDependency projectTaskDependencyDummy = context.mock(TaskDependency.class, "projectDep");
             TaskDependency fileTaskDependencyStub = context.mock(TaskDependency.class, "fileDep");
-
-            allowing(projectDependencyStub).getBuildDependencies();
-            will(returnValue(projectTaskDependencyDummy));
-
-            allowing(projectTaskDependencyDummy).getDependencies(target);
-            will(returnValue(toSet(projectDepTaskDummy)));
 
             allowing(fileCollectionDependencyStub).getBuildDependencies();
             will(returnValue(fileTaskDependencyStub));
@@ -481,11 +473,9 @@ public class DefaultConfigurationTest {
             will(returnValue(toSet(fileDepTaskDummy)));
         }});
 
-        configuration.getDependencies().add(projectDependencyStub);
         configuration.getDependencies().add(fileCollectionDependencyStub);
 
-        assertThat(configuration.getBuildDependencies().getDependencies(target), equalTo((Set) toSet(fileDepTaskDummy,
-                projectDepTaskDummy)));
+        assertThat(configuration.getBuildDependencies().getDependencies(target), equalTo((Set) toSet(fileDepTaskDummy)));
     }
 
     @Test

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
@@ -25,12 +25,14 @@ import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.*;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
+import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfigurationResults;
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskDependency;
+import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.util.*;
@@ -358,12 +360,12 @@ public class DefaultConfigurationTest {
 
     private DefaultConfiguration createNamedConfiguration(String confName) {
         return new DefaultConfiguration(confName, confName, configurationContainer,
-                dependencyResolver, listenerManager, metaDataProvider, new DefaultResolutionStrategy(), null);
+                dependencyResolver, listenerManager, metaDataProvider, new DefaultResolutionStrategy(), context.mock(ProjectAccessListener.class), context.mock(ProjectFinder.class));
     }
     
     private DefaultConfiguration createNamedConfiguration(String path, String confName) {
         return new DefaultConfiguration(path, confName, configurationContainer,
-                dependencyResolver, listenerManager, metaDataProvider, new DefaultResolutionStrategy(), null);
+                dependencyResolver, listenerManager, metaDataProvider, new DefaultResolutionStrategy(), context.mock(ProjectAccessListener.class), context.mock(ProjectFinder.class));
     }
 
     @SuppressWarnings("unchecked")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
@@ -339,9 +339,16 @@ public class DefaultConfigurationTest {
     private void prepareResolve(final ResolvedConfiguration resolvedConfiguration, final boolean withErrors) {
         context.checking(new Expectations() {{
             ResolverResults result = new ResolverResults();
-            result.resolved(resolvedConfiguration, context.mock(ResolutionResult.class), context.mock(ResolvedProjectConfigurationResults.class));
+
+            ResolvedProjectConfigurationResults projectConfigurationResults = context.mock(ResolvedProjectConfigurationResults.class);
+            result.resolved(resolvedConfiguration, context.mock(ResolutionResult.class), projectConfigurationResults);
+
+            allowing(projectConfigurationResults).getAllProjectConfigurationResults();
+            will(returnValue(Collections.emptySet()));
+
             allowing(dependencyResolver).resolve(configuration);
             will(returnValue(result));
+
             allowing(resolvedConfiguration).hasError();
             will(returnValue(withErrors));
         }});
@@ -373,7 +380,7 @@ public class DefaultConfigurationTest {
     public void buildArtifacts() {
         final Task otherConfTaskMock = context.mock(Task.class, "otherConfTask");
         final Task artifactTaskMock = context.mock(Task.class, "artifactTask");
-        final Configuration otherConfiguration = context.mock(Configuration.class);
+        final Configuration otherConfiguration = context.mock(ConfigurationInternal.class);
         final TaskDependency otherArtifactTaskDependencyMock = context.mock(TaskDependency.class, "otherConfTaskDep");
         final PublishArtifact otherArtifact = context.mock(PublishArtifact.class, "otherArtifact");
         final PublishArtifactSet inheritedArtifacts = new DefaultPublishArtifactSet("artifacts", toDomainObjectSet(PublishArtifact.class, otherArtifact));
@@ -405,7 +412,7 @@ public class DefaultConfigurationTest {
     public void getAllArtifactFiles() {
         final Task otherConfTaskMock = context.mock(Task.class, "otherConfTask");
         final Task artifactTaskMock = context.mock(Task.class, "artifactTask");
-        final Configuration otherConfiguration = context.mock(Configuration.class);
+        final Configuration otherConfiguration = context.mock(ConfigurationInternal.class);
         final TaskDependency otherConfTaskDependencyMock = context.mock(TaskDependency.class, "otherConfTaskDep");
         final TaskDependency artifactTaskDependencyMock = context.mock(TaskDependency.class, "artifactTaskDep");
         final File artifactFile1 = new File("artifact1");
@@ -475,6 +482,8 @@ public class DefaultConfigurationTest {
 
         configuration.getDependencies().add(fileCollectionDependencyStub);
 
+        resolveSuccessfullyAsResolvedConfiguration();
+
         assertThat(configuration.getBuildDependencies().getDependencies(target), equalTo((Set) toSet(fileDepTaskDummy)));
     }
 
@@ -483,7 +492,7 @@ public class DefaultConfigurationTest {
         final Task target = context.mock(Task.class, "target");
         final Task otherConfTaskMock = context.mock(Task.class, "otherConfTask");
         final TaskDependency dependencyTaskDependencyStub = context.mock(TaskDependency.class, "otherConfTaskDep");
-        final Configuration otherConfiguration = context.mock(Configuration.class, "otherConf");
+        final ConfigurationInternal otherConfiguration = context.mock(ConfigurationInternal.class, "otherConf");
         final FileCollectionDependency fileCollectionDependencyStub = context.mock(FileCollectionDependency.class);
         final DependencySet inherited = new DefaultDependencySet("dependencies", toDomainObjectSet(Dependency.class, fileCollectionDependencyStub));
 
@@ -496,6 +505,8 @@ public class DefaultConfigurationTest {
             allowing(otherConfiguration).getAllDependencies();
             will(returnValue(inherited));
 
+            allowing(otherConfiguration).includedInResolveResult();
+
             allowing(fileCollectionDependencyStub).getBuildDependencies();
             will(returnValue(dependencyTaskDependencyStub));
 
@@ -504,6 +515,8 @@ public class DefaultConfigurationTest {
         }});
 
         configuration.extendsFrom(otherConfiguration);
+
+        resolveSuccessfullyAsResolvedConfiguration();
 
         assertThat(configuration.getBuildDependencies().getDependencies(target), equalTo((Set) toSet(otherConfTaskMock)));
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
@@ -29,6 +29,8 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfigurationResults;
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact;
+import org.gradle.api.internal.project.ProjectChangeListener;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskDependency;
@@ -575,7 +577,7 @@ public class DefaultConfigurationTest {
 
     @Test
     public void getTypedDependencies() {
-        ProjectDependency projectDependency = context.mock(ProjectDependency.class);
+        ProjectDependency projectDependency = prepareProjectDependency("dep");
         configuration.getDependencies().add(context.mock(Dependency.class));
         configuration.getDependencies().add(projectDependency);
         assertThat(configuration.getDependencies().withType(ProjectDependency.class), hasSameItems(toSet(projectDependency)));
@@ -602,14 +604,32 @@ public class DefaultConfigurationTest {
         assertCorrectInstanceInAllDependencies(configuration.getAllDependencies(), dependencyConf);
     }
 
+    private ProjectDependency prepareProjectDependency(String name) {
+        final ProjectDependency projectDependency = context.mock(ProjectDependency.class, name);
+        final ProjectInternal project = context.mock(ProjectInternal.class, name + "Project");
+        final ConfigurationContainerInternal configurationContainer = context.mock(ConfigurationContainerInternal.class, name + "ProjectConfigurations");
+        context.checking(new Expectations() {{
+            allowing(projectDependency).getDependencyProject();
+            will(returnValue(project));
+
+            allowing(project).addChangeListener(with(any(ProjectChangeListener.class)));
+
+            allowing(project).getConfigurations();
+            will(returnValue(configurationContainer));
+
+            allowing(configurationContainer).addMutationValidator(with(any(MutationValidator.class)));
+        }});
+        return projectDependency;
+    }
+
     @Test
     public void getAllTypedDependencies() {
-        ProjectDependency projectDependencyCurrentConf = context.mock(ProjectDependency.class, "projectDepCurrentConf");
+        ProjectDependency projectDependencyCurrentConf = prepareProjectDependency("projectDepCurrentConf");
         configuration.getDependencies().add(context.mock(Dependency.class, "depCurrentConf"));
         configuration.getDependencies().add(projectDependencyCurrentConf);
         Configuration otherConf = createNamedConfiguration("otherConf");
         configuration.extendsFrom(otherConf);
-        ProjectDependency projectDependencyExtendedConf = context.mock(ProjectDependency.class, "projectDepExtendedConf");
+        ProjectDependency projectDependencyExtendedConf = prepareProjectDependency("projectDepExtendedConf");
         otherConf.getDependencies().add(context.mock(Dependency.class, "depExtendedConf"));
         otherConf.getDependencies().add(projectDependencyExtendedConf);
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationTest.java
@@ -505,7 +505,7 @@ public class DefaultConfigurationTest {
             allowing(otherConfiguration).getAllDependencies();
             will(returnValue(inherited));
 
-            allowing(otherConfiguration).includedInResolveResult();
+            allowing(otherConfiguration).markAsObserved();
 
             allowing(fileCollectionDependencyStub).getBuildDependencies();
             will(returnValue(dependencyTaskDependencyStub));

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationsToArtifactsConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationsToArtifactsConverterTest.groovy
@@ -15,14 +15,8 @@
  */
 
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter
-
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.PublishArtifact
-import org.gradle.api.internal.DefaultDomainObjectSet
-import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
-import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet
-import org.gradle.internal.component.model.IvyArtifactName
+import org.gradle.api.artifacts.PublishArtifactSet
 import org.gradle.internal.component.local.model.MutableLocalComponentMetaData
 import spock.lang.Specification
 
@@ -33,68 +27,22 @@ class DefaultConfigurationsToArtifactsConverterTest extends Specification {
         def metaData = Mock(MutableLocalComponentMetaData)
         def config1 = Stub(Configuration)
         def config2 = Stub(Configuration)
-        def artifact1 = Stub(PublishArtifact)
-        def artifact2 = Stub(PublishArtifact)
-        def file1 = new File("file-1")
-        def file2 = new File("file-2")
+        def artifacts1 = Stub(PublishArtifactSet)
+        def artifacts2 = Stub(PublishArtifactSet)
 
         given:
         config1.name >> "config1"
-        config1.artifacts >> new DefaultPublishArtifactSet("art1", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact, [artifact1]))
+        config1.artifacts >> artifacts1
         config2.name >> "config2"
-        config2.artifacts >> new DefaultPublishArtifactSet("art1", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact, [artifact2]))
+        config2.artifacts >> artifacts2
 
-        and:
-        artifact1.name >> 'art1'
-        artifact1.type >> 'type1'
-        artifact1.extension >> 'ext1'
-        artifact2.name >> 'art2'
-        artifact2.type >> 'type2'
-        artifact2.extension >> 'ext2'
-        artifact2.classifier >> 'classifier'
 
         when:
         converter.addArtifacts(metaData, [config1, config2])
 
         then:
-        1 * metaData.addArtifact("config1", _, file1) >> { name, IvyArtifactName artifact, file ->
-            assert artifact.name == 'art1'
-            assert artifact.type == 'type1'
-            assert artifact.extension == 'ext1'
-            assert artifact.attributes == [:]
-        }
-        1 * metaData.addArtifact("config2", _, file2) >> { name, IvyArtifactName artifact, file ->
-            assert artifact.name == 'art2'
-            assert artifact.type == 'type2'
-            assert artifact.extension == 'ext2'
-            assert artifact.attributes == [(Dependency.CLASSIFIER): 'classifier']
-        }
-        _ * metaData.id
-        0 * metaData._
-    }
-
-    def "artifact name defaults to module name when not specified"() {
-        def metaData = Mock(MutableLocalComponentMetaData)
-        def config = Stub(Configuration)
-        def artifact = Stub(PublishArtifact)
-        def file = new File("file-1")
-
-        given:
-        config.name >> "config1"
-        config.artifacts >> new DefaultPublishArtifactSet("art1", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact, [artifact]))
-
-        and:
-        artifact.type >> 'type1'
-        artifact.extension >> 'ext1'
-
-        when:
-        converter.addArtifacts(metaData, [config])
-
-        then:
-        1 * metaData.addArtifact("config1", _, file) >> { name, IvyArtifactName ivyArtifact, f ->
-            assert ivyArtifact.name == 'module'
-        }
-        _ * metaData.id >> DefaultModuleVersionIdentifier.newId("group", "module", "version")
+        1 * metaData.addArtifacts("config1", artifacts1)
+        1 * metaData.addArtifacts("config2", artifacts2)
         0 * metaData._
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
@@ -58,6 +58,6 @@ public class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDe
         AbstractProject dependencyProject = TestUtil.createRootProject();
         dependencyProject.setGroup("someGroup");
         dependencyProject.setVersion("someVersion");
-        return new DefaultProjectDependency(dependencyProject, dependencyConfiguration, {} as ProjectAccessListener, true);
+        return new DefaultProjectDependency(dependencyProject, dependencyConfiguration, {} as ProjectAccessListener);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -1084,7 +1084,7 @@ class DependencyGraphBuilderTest extends Specification {
         }
 
         @Override
-        ComponentArtifactMetaData artifact(Artifact artifact) {
+        ComponentArtifactMetaData artifact(IvyArtifactName artifact) {
             return null
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -85,6 +85,7 @@ class DependencyGraphBuilderTest extends Specification {
     private DefaultLenientConfiguration resolve() {
         def results = new DefaultResolvedConfigurationBuilder(new TransientConfigurationResultsBuilder(new DummyBinaryStore(), new DummyStore()))
         builder.resolve(configuration, resultBuilder, results, projectModelBuilder)
+        results.resolveArtifacts()
         new DefaultLenientConfiguration(configuration, results, Stub(CacheLockingManager))
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
@@ -30,7 +30,7 @@ public class ProjectDependencyFactoryTest extends Specification {
     def projectDummy = Mock(ProjectInternal)
     def projectFinder = Mock(ProjectFinder)
 
-    def depFactory = new DefaultProjectDependencyFactory(Mock(ProjectAccessListener), DirectInstantiator.INSTANCE, true)
+    def depFactory = new DefaultProjectDependencyFactory(Mock(ProjectAccessListener), DirectInstantiator.INSTANCE)
     def factory = new ProjectDependencyFactory(depFactory)
 
     def "creates project dependency with map notation"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetaDataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetaDataTest.groovy
@@ -19,6 +19,7 @@ import org.apache.ivy.core.module.descriptor.*
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.IvyUtil
+import org.gradle.internal.component.model.DefaultIvyArtifactName
 import org.gradle.internal.component.model.DependencyMetaData
 import spock.lang.Specification
 
@@ -197,9 +198,10 @@ abstract class AbstractModuleComponentResolveMetaDataTest extends Specification 
 
     def "can adapt an Ivy artifact to a Gradle artifact"() {
         def artifact = artifact("one")
+        def artifactName = DefaultIvyArtifactName.forIvyArtifact(artifact)
 
         expect:
-        def artifactMetaData = metaData.artifact(artifact)
+        def artifactMetaData = metaData.artifact(artifactName)
         artifactMetaData.componentId == metaData.componentId
         artifactMetaData.id.componentIdentifier == metaData.componentId
         artifactMetaData.name.name == "one"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetaDataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetaDataTest.groovy
@@ -15,8 +15,8 @@
  */
 
 package org.gradle.internal.component.local.model
+
 import org.apache.ivy.core.module.descriptor.Configuration
-import org.apache.ivy.core.module.descriptor.DefaultArtifact
 import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor
 import org.apache.ivy.core.module.descriptor.DependencyDescriptor
 import org.gradle.api.artifacts.component.ComponentIdentifier
@@ -79,7 +79,6 @@ class DefaultLocalComponentMetaDataTest extends Specification {
         given:
         moduleDescriptor.addConfiguration(new Configuration("conf1"))
         moduleDescriptor.addConfiguration(new Configuration("conf2"))
-        moduleDescriptor.addConfiguration(new Configuration("conf3"))
 
         when:
         metaData.addArtifact("conf1", artifact, file)
@@ -194,10 +193,6 @@ class DefaultLocalComponentMetaDataTest extends Specification {
         publishArtifact.artifact.type == artifact.type
         publishArtifact.artifact.ext == artifact.extension
         publishArtifact.file == file
-    }
-
-    def artifact() {
-        return new DefaultArtifact(moduleDescriptor.getModuleRevisionId(), null, "artifact", "type", "ext")
     }
 
     def artifactName() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetaDataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetaDataTest.groovy
@@ -15,7 +15,6 @@
  */
 
 package org.gradle.internal.component.local.model
-
 import org.apache.ivy.core.module.descriptor.Configuration
 import org.apache.ivy.core.module.descriptor.DefaultArtifact
 import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetaDataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetaDataTest.groovy
@@ -70,14 +70,6 @@ class DefaultLocalComponentMetaDataTest extends Specification {
         resolveArtifact.name.name == artifact.name
         resolveArtifact.name.type == artifact.type
         resolveArtifact.name.extension == artifact.extension
-
-        and:
-        moduleDescriptor.getArtifacts("conf").size() == 1
-        def ivyArtifact = (moduleDescriptor.getArtifacts("conf") as List).first()
-        ivyArtifact.name == artifact.name
-        ivyArtifact.type == artifact.type
-        ivyArtifact.ext == artifact.extension
-        ivyArtifact.configurations == ["conf"]
     }
 
     def "can add artifact to several configurations"() {
@@ -99,12 +91,6 @@ class DefaultLocalComponentMetaDataTest extends Specification {
         and:
         def resolveMetaData = metaData.toResolveMetaData()
         resolveMetaData.artifacts.size() == 1
-
-        and:
-        moduleDescriptor.getArtifacts("conf1").size() == 1
-        moduleDescriptor.getArtifacts("conf2").size() == 1
-        def ivyArtifact = (moduleDescriptor.getArtifacts("conf1") as List).first()
-        ivyArtifact.configurations == ["conf1", "conf2"]
     }
 
     def "can lookup an artifact given an Ivy artifact"() {
@@ -118,7 +104,7 @@ class DefaultLocalComponentMetaDataTest extends Specification {
         metaData.addArtifact("conf", artifact, file)
 
         and:
-        def ivyArtifact = metaData.toResolveMetaData().descriptor.allArtifacts.find { it.name == artifact.name }
+        def ivyArtifact = artifactName()
 
         expect:
         def resolveArtifact = metaData.toResolveMetaData().artifact(ivyArtifact)
@@ -127,7 +113,7 @@ class DefaultLocalComponentMetaDataTest extends Specification {
     }
 
     def "can lookup an unknown artifact given an Ivy artifact"() {
-        def artifact = artifact()
+        def artifact = artifactName()
 
         expect:
         def resolveArtifact = metaData.toResolveMetaData().artifact(artifact)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/DefaultIvyArtifactNameTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/DefaultIvyArtifactNameTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.model
 
+import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.util.Matchers
 import spock.lang.Specification
 
@@ -61,5 +62,31 @@ class DefaultIvyArtifactNameTest extends Specification {
         withClassifier.classifier == 'classifier'
         emptyClassifier.classifier == null
         noClassifier.classifier == null
+    }
+
+    def "creates for PublishArtifact"() {
+        def publishArtifact = Mock(PublishArtifact) {
+            getExtension() >> "art-ext"
+            getType() >> "art-type"
+            getClassifier() >> "art-classifier"
+        }
+
+        when:
+        1 * publishArtifact.getName() >> "art-name"
+
+        then:
+        def name = DefaultIvyArtifactName.forPublishArtifact(publishArtifact, "default-name")
+        name.name == "art-name"
+        name.extension == "art-ext"
+        name.type == "art-type"
+        name.classifier == "art-classifier"
+        name.attributes == [classifier: "art-classifier"]
+
+        when:
+        1 * publishArtifact.getName() >> null
+
+        then:
+        def nameWithDefault = DefaultIvyArtifactName.forPublishArtifact(publishArtifact, "default-name")
+        nameWithDefault.name == "default-name"
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
@@ -230,7 +230,7 @@ public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
         List<SelfResolvingDependency> externalDependencies = new ArrayList<SelfResolvingDependency>();
 
         for (Dependency dependency : configuration.getAllDependencies()) {
-            if (dependency instanceof SelfResolvingDependency && !(dependency instanceof ProjectDependency)) {
+            if (dependency instanceof SelfResolvingDependency) {
                 externalDependencies.add((SelfResolvingDependency) dependency);
             }
         }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -22,12 +22,14 @@ import spock.lang.Issue;
 public class TestTaskIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("GRADLE-2702")
-    def "should not resolve configurations when there are no tests"() {
+    def "should not resolve configuration results when there are no tests"() {
         buildFile << """
             apply plugin: 'java'
 
-            configure([configurations.testRuntime, configurations.testCompile]) {
-                incoming.beforeResolve { assert false : "should not be resolved" }
+            configure([configurations.testRuntime, configurations.testCompile]) { configuration ->
+                incoming.afterResolve {
+                    assert configuration.internalState != org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.RESULTS_RESOLVED : "should not be resolved"
+                }
             }
         """
 


### PR DESCRIPTION
Let's try again.

Changes compared to PR #412:

* rebased to master
* configurations are marked as observed only after resolution is finished – this is a lot simpler, and the whole `beforeObserve()` logic is not required anymore, and hence it is not present here anymroe

There are still failing integration tests:

* [ ] Plugins relying on `ResolvableDependencies.beforeResolve()` will produce warnings about changing configurations too late (as in `Antlr2PluginIntegrationTest`: "Attempting to change configuration ':antlr' after it has been included in dependency resolution.") These will be fixed by merging PR #424.

* [ ] `ProjectDependencyResolveIntegrationTest.resolved project artifacts contain project version in their names` is ignored for now. This will be fixed by a separate effort to delay resolving actual artifacts in a configuration.

