### PR TITLE
GRADLE-1945 IDE plugins do not warn that some deps are unresolved

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
@@ -16,8 +16,10 @@
 package org.gradle.plugins.ide.eclipse
 
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.junit.Rule
 import org.junit.Test
+
 import spock.lang.Issue
 
 class EclipseClasspathIntegrationTest extends AbstractEclipseIntegrationTest {
@@ -67,6 +69,51 @@ dependencies {
         libraries[2].assertHasNoSource()
         libraries[2].assertHasNoJavadoc()
     }
+
+    @Test
+    @Issue("GRADLE-1945")
+    void logUnresolvedDependencies() {
+        //given
+        def module = mavenRepo.module('coolGroup', 'niceArtifact', '1.0')
+        module.artifact(classifier: 'sources')
+        module.artifact(classifier: 'javadoc')
+        module.publish()
+
+        //when
+        ExecutionResult result = runEclipseTask """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+repositories {
+    maven { url "${mavenRepo.uri}" }
+}
+
+configurations {
+    myConfig
+}
+
+dependencies {
+    myConfig group: 'myGroup', name: 'myCustomName', version: '1.0'
+    runtime  group: 'myGroup', name: 'myRuntimeName', version: '1.0'
+    compile  group: 'coolGroup', name: 'niceArtifact', version: '1.0'
+
+    eclipse {
+        classpath {
+            plusConfigurations += [ configurations.myConfig ]
+        }
+    }
+} 
+"""
+        String expected = """:eclipseClasspath
+Could not resolve: myGroup:myRuntimeName:1.0 (configuration ':testRuntime')
+Could not resolve: myGroup:myCustomName:1.0 (configuration ':myConfig')
+:eclipseJdt
+:eclipseProject
+:eclipse
+"""
+        result.assertOutputEquals(expected, true, false)
+    }
+
 
     @Test
     @Issue("GRADLE-1622")

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.plugins.ide.api.XmlFileContentMerger
 import org.gradle.plugins.ide.eclipse.model.internal.ClasspathFactory
 import org.gradle.plugins.ide.eclipse.model.internal.FileReferenceFactory
+import org.gradle.plugins.ide.internal.resolver.LoggingUnresolvedIdeDependencyHandler
 import org.gradle.util.ConfigureUtil
 /**
  * The build path settings for the generated Eclipse project. Used by the
@@ -203,7 +204,10 @@ class EclipseClasspath {
      * Calculates, resolves and returns dependency entries of this classpath.
      */
     public List<ClasspathEntry> resolveDependencies() {
-        return new ClasspathFactory().createEntries(this)
+        def classpathFactory = new ClasspathFactory()
+        def entries = classpathFactory.createEntries(this)
+        new LoggingUnresolvedIdeDependencyHandler().handle(classpathFactory.getUnresolvedDependencies(this))
+        return entries
     }
 
     void mergeXmlClasspath(Classpath xmlClasspath) {

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.groovy
@@ -21,6 +21,7 @@ import org.gradle.plugins.ide.internal.IdeDependenciesExtractor
 import org.gradle.plugins.ide.internal.resolver.model.IdeLocalFileDependency
 import org.gradle.plugins.ide.internal.resolver.model.IdeProjectDependency
 import org.gradle.plugins.ide.internal.resolver.model.IdeExtendedRepoFileDependency
+import org.gradle.plugins.ide.internal.resolver.model.UnresolvedIdeRepoFileDependency
 import org.gradle.util.DeprecationLogger
 
 class ClasspathFactory {
@@ -80,6 +81,10 @@ class ClasspathFactory {
             entries.addAll(classFoldersCreator.create(classpath))
         }
         return entries
+    }
+
+    Collection<UnresolvedIdeRepoFileDependency> getUnresolvedDependencies(EclipseClasspath classpath) {
+        return dependenciesExtractor.unresolvedExternalDependencies(classpath.plusConfigurations, classpath.minusConfigurations);
     }
 
     private AbstractLibrary createLibraryEntry(

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/idea/model/IdeaModule.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/idea/model/IdeaModule.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Incubating
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.dsl.ConventionProperty
 import org.gradle.plugins.ide.idea.model.internal.IdeaDependenciesProvider
+import org.gradle.plugins.ide.internal.resolver.LoggingUnresolvedIdeDependencyHandler
 import org.gradle.util.ConfigureUtil
 
 /**
@@ -309,7 +310,9 @@ class IdeaModule {
      * @return dependencies
      */
     Set<Dependency> resolveDependencies() {
-        return new IdeaDependenciesProvider().provide(this)
+        def ideaDependenciesProvider = new IdeaDependenciesProvider()
+        new LoggingUnresolvedIdeDependencyHandler().handle(ideaDependenciesProvider.getUnresolvedDependencies(this))
+        return ideaDependenciesProvider.provide(this)
     }
 
     /**

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
@@ -32,6 +32,7 @@ import org.gradle.plugins.ide.internal.resolver.model.IdeDependencyKey;
 import org.gradle.plugins.ide.internal.resolver.model.IdeExtendedRepoFileDependency;
 import org.gradle.plugins.ide.internal.resolver.model.IdeLocalFileDependency;
 import org.gradle.plugins.ide.internal.resolver.model.IdeProjectDependency;
+import org.gradle.plugins.ide.internal.resolver.model.UnresolvedIdeRepoFileDependency;
 import org.gradle.util.CollectionUtils;
 
 import java.io.File;
@@ -91,6 +92,10 @@ public class IdeaDependenciesProvider {
         }
         result.addAll(provideFromScopeRuleMappings(ideaModule));
         return result;
+    }
+
+    Collection<UnresolvedIdeRepoFileDependency> getUnresolvedDependencies(IdeaModule ideaModule) {
+        return dependenciesExtractor.unresolvedExternalDependencies(ideaConfigurations(ideaModule), Collections.<Configuration>emptyList());
     }
 
     private Set<Dependency> provideFromScopeRuleMappings(IdeaModule ideaModule) {

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/internal/IdeDependenciesExtractor.java
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/internal/IdeDependenciesExtractor.java
@@ -28,6 +28,8 @@ import org.gradle.api.artifacts.result.ArtifactResult;
 import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.component.Artifact;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.language.base.artifact.SourcesArtifact;
 import org.gradle.language.java.artifact.JavadocArtifact;
@@ -43,6 +45,8 @@ import java.io.File;
 import java.util.*;
 
 public class IdeDependenciesExtractor {
+
+    private static final Logger logger = Logging.getLogger(IdeDependenciesExtractor.class);
 
     private final IdeDependencyResolver ideDependencyResolver = new DefaultIdeDependencyResolver();
 
@@ -88,6 +92,13 @@ public class IdeDependenciesExtractor {
         Collection<IdeExtendedRepoFileDependency> resolvedAndUnresolved = new ArrayList<IdeExtendedRepoFileDependency>(unresolvedDependencies.size() + resolvedDependencies.size());
         resolvedAndUnresolved.addAll(resolvedDependencies);
         resolvedAndUnresolved.addAll(unresolvedDependencies);
+
+        // we lose information about unresolved dependencies as
+        // soon as we leave this method so we log it here
+        for (UnresolvedIdeRepoFileDependency unresolvedDep : unresolvedDependencies) {
+            logger.warn("Could not resolve: " + unresolvedDep.getDisplayName() + " (" + unresolvedDep.getDeclaredConfiguration() + ")");
+        }
+
         return resolvedAndUnresolved;
     }
 

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/internal/IdeDependenciesExtractor.java
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/internal/IdeDependenciesExtractor.java
@@ -28,8 +28,6 @@ import org.gradle.api.artifacts.result.ArtifactResult;
 import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.component.Artifact;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.language.base.artifact.SourcesArtifact;
 import org.gradle.language.java.artifact.JavadocArtifact;
@@ -45,8 +43,6 @@ import java.io.File;
 import java.util.*;
 
 public class IdeDependenciesExtractor {
-
-    private static final Logger logger = Logging.getLogger(IdeDependenciesExtractor.class);
 
     private final IdeDependencyResolver ideDependencyResolver = new DefaultIdeDependencyResolver();
 
@@ -93,12 +89,6 @@ public class IdeDependenciesExtractor {
         resolvedAndUnresolved.addAll(resolvedDependencies);
         resolvedAndUnresolved.addAll(unresolvedDependencies);
 
-        // we lose information about unresolved dependencies as
-        // soon as we leave this method so we log it here
-        for (UnresolvedIdeRepoFileDependency unresolvedDep : unresolvedDependencies) {
-            logger.warn("Could not resolve: " + unresolvedDep.getDisplayName() + " (" + unresolvedDep.getDeclaredConfiguration() + ")");
-        }
-
         return resolvedAndUnresolved;
     }
 
@@ -134,7 +124,7 @@ public class IdeDependenciesExtractor {
         }
     }
 
-    private Collection<UnresolvedIdeRepoFileDependency> unresolvedExternalDependencies(Collection<Configuration> plusConfigurations, Collection<Configuration> minusConfigurations) {
+    public Collection<UnresolvedIdeRepoFileDependency> unresolvedExternalDependencies(Iterable<Configuration> plusConfigurations, Iterable<Configuration> minusConfigurations) {
         final LinkedHashMap<File, UnresolvedIdeRepoFileDependency> unresolved = new LinkedHashMap<File, UnresolvedIdeRepoFileDependency>();
 
         for (Configuration c : plusConfigurations) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
@@ -68,14 +68,17 @@ public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
      * @return Unresolved IDE repositoru file dependencies
      */
     public List<UnresolvedIdeRepoFileDependency> getUnresolvedIdeRepoFileDependencies(Configuration configuration) {
-        List<ComponentSelector> componentSelectors = getUnresolvedComponentSelectors(configuration);
+        ResolutionResult result = getIncomingResolutionResult(configuration);
+        List<UnresolvedDependencyResult> unresolvedDependencies = findAllUnresolvedDependencyResults(result.getRoot().getDependencies());
         List<UnresolvedIdeRepoFileDependency> unresolvedIdeRepoFileDependencies = new ArrayList<UnresolvedIdeRepoFileDependency>();
 
-        for (ComponentSelector componentSelector : componentSelectors) {
+        for (UnresolvedDependencyResult unresolvedDependencyResult : unresolvedDependencies) {
+            Throwable failure = unresolvedDependencyResult.getFailure();
+            ComponentSelector componentSelector = unresolvedDependencyResult.getAttempted();
+
             String displayName = componentSelector.getDisplayName();
             File file = new File(unresolvedFileName(componentSelector));
-            UnresolvedIdeRepoFileDependency unresolvedIdeRepoFileDependency = new UnresolvedIdeRepoFileDependency(configuration, displayName, file);
-            unresolvedIdeRepoFileDependencies.add(unresolvedIdeRepoFileDependency);
+            unresolvedIdeRepoFileDependencies.add(new UnresolvedIdeRepoFileDependency(configuration, file, failure, displayName));
         }
 
         return unresolvedIdeRepoFileDependencies;
@@ -206,24 +209,6 @@ public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
      */
     private ResolutionResult getIncomingResolutionResult(Configuration configuration) {
         return configuration.getIncoming().getResolutionResult();
-    }
-
-    /**
-     * Gets unresolved component selectors for a given configuration.
-     *
-     * @param configuration Configuration
-     * @return List of unresolved component selectors
-     */
-    private List<ComponentSelector> getUnresolvedComponentSelectors(Configuration configuration) {
-        ResolutionResult result = getIncomingResolutionResult(configuration);
-        List<UnresolvedDependencyResult> unresolvedDependencies = findAllUnresolvedDependencyResults(result.getRoot().getDependencies());
-        List<ComponentSelector> componentSelectors = new ArrayList<ComponentSelector>();
-
-        for (UnresolvedDependencyResult unresolvedDependencyResult : unresolvedDependencies) {
-            componentSelectors.add(unresolvedDependencyResult.getAttempted());
-        }
-
-        return componentSelectors;
     }
 
     /**

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
@@ -72,7 +72,9 @@ public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
         List<UnresolvedIdeRepoFileDependency> unresolvedIdeRepoFileDependencies = new ArrayList<UnresolvedIdeRepoFileDependency>();
 
         for (ComponentSelector componentSelector : componentSelectors) {
-            UnresolvedIdeRepoFileDependency unresolvedIdeRepoFileDependency = new UnresolvedIdeRepoFileDependency(configuration, new File(unresolvedFileName(componentSelector)));
+            String displayName = componentSelector.getDisplayName();
+            File file = new File(unresolvedFileName(componentSelector));
+            UnresolvedIdeRepoFileDependency unresolvedIdeRepoFileDependency = new UnresolvedIdeRepoFileDependency(configuration, displayName, file);
             unresolvedIdeRepoFileDependencies.add(unresolvedIdeRepoFileDependency);
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/LoggingUnresolvedIdeDependencyHandler.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/LoggingUnresolvedIdeDependencyHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal.resolver;
+
+import java.util.Collection;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.plugins.ide.internal.resolver.model.UnresolvedIdeRepoFileDependency;
+
+/**
+ * Logs all unresolved dependencies. 
+ */
+public class LoggingUnresolvedIdeDependencyHandler implements UnresolvedIdeDependencyHandler {
+
+    private final Logger logger = Logging.getLogger(LoggingUnresolvedIdeDependencyHandler.class);
+
+    public void handle(Collection<UnresolvedIdeRepoFileDependency> deps) {
+        for (UnresolvedIdeRepoFileDependency dep : deps) {
+            logger.warn("Could not resolve: " + dep.getDisplayName() + " (" + dep.getDeclaredConfiguration() + ")");
+        }
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/UnresolvedIdeDependencyHandler.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/UnresolvedIdeDependencyHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal.resolver;
+
+import java.util.Collection;
+
+import org.gradle.plugins.ide.internal.resolver.model.UnresolvedIdeRepoFileDependency;
+
+public interface UnresolvedIdeDependencyHandler {
+
+    void handle(Collection<UnresolvedIdeRepoFileDependency> dep);
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/model/UnresolvedIdeRepoFileDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/model/UnresolvedIdeRepoFileDependency.java
@@ -22,9 +22,11 @@ import java.io.File;
 
 public class UnresolvedIdeRepoFileDependency extends IdeExtendedRepoFileDependency {
     private Exception problem;
+    private final String displayName;
 
-    public UnresolvedIdeRepoFileDependency(Configuration declaredConfiguration, File file) {
+    public UnresolvedIdeRepoFileDependency(Configuration declaredConfiguration, String displayName, File file) {
         super(declaredConfiguration, file);
+        this.displayName = displayName;
     }
 
     public Exception getProblem() {
@@ -33,5 +35,9 @@ public class UnresolvedIdeRepoFileDependency extends IdeExtendedRepoFileDependen
 
     public void setProblem(Exception problem) {
         this.problem = problem;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/model/UnresolvedIdeRepoFileDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/model/UnresolvedIdeRepoFileDependency.java
@@ -21,20 +21,19 @@ import org.gradle.api.artifacts.Configuration;
 import java.io.File;
 
 public class UnresolvedIdeRepoFileDependency extends IdeExtendedRepoFileDependency {
-    private Exception problem;
+
+    private final Throwable problem;
     private final String displayName;
 
-    public UnresolvedIdeRepoFileDependency(Configuration declaredConfiguration, String displayName, File file) {
+    public UnresolvedIdeRepoFileDependency(Configuration declaredConfiguration, File file, Throwable problem, String displayName) {
         super(declaredConfiguration, file);
+
         this.displayName = displayName;
-    }
-
-    public Exception getProblem() {
-        return problem;
-    }
-
-    public void setProblem(Exception problem) {
         this.problem = problem;
+    }
+
+    public Throwable getProblem() {
+        return problem;
     }
 
     public String getDisplayName() {


### PR DESCRIPTION
This PR aims to fix [GRADLE-1945](https://issues.gradle.org/browse/GRADLE-1945). It should work equally well for IntelliJ and eclipse. I've tested it with "usual" configurations and a custom one. Also, manipulation through `plusConfigurations` works as expected. The following SSCCE illustrates the effect of the proposed changes:

```gradle
apply plugin: 'java'
apply plugin: 'eclipse'
apply plugin: 'idea'

repositories {
    mavenCentral()
}

configurations {
    myConfig
}

dependencies {
    myConfig group: 'myGroup', name: 'myCustomName', version: '1.0'
    runtime  group: 'myGroup', name: 'myRuntimeName', version: '1.0'
    compile  group: 'com.google.guava', name: 'guava', version: '18.0'

    eclipse {
        classpath {
            plusConfigurations += [ configurations.myConfig ]
        }
    }
}
```

Running the eclipse and idea task now reports the missing/unresolved dependencies:

```bash
$ gradleInst/bin/gradle eclipse idea
:eclipseClasspath
Could not resolve: myGroup:myRuntimeName:1.0 (configuration ':testRuntime')
Could not resolve: myGroup:myCustomName:1.0 (configuration ':myConfig')
:eclipseJdt
:eclipseProject
:eclipse
:ideaModule
Could not resolve: myGroup:myRuntimeName:1.0 (configuration ':runtime')
Could not resolve: myGroup:myRuntimeName:1.0 (configuration ':testRuntime')
:ideaProject
:ideaWorkspace
:idea
```

I've signed the CLA using the online form. Thus, it should be available for you already.
