### PR TITLE
BaseDirFileResolverSpec Incorrectly Assumes That File System Root Q:\ Is Non-Existent

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
@@ -161,7 +161,7 @@ class BaseDirFileResolverSpec extends Specification {
 
     @Requires(TestPrecondition.WINDOWS)
     def "normalizes non-existent file system root"() {
-        def file = new File("Q:\\")
+        def file = nonexistentFsRoot()
         assert !file.exists()
         assert file.absolute
 
@@ -214,5 +214,13 @@ The following types/formats are supported:
 
     private File[] getFsRoots() {
         File.listRoots().findAll { !it.absolutePath.startsWith("A:") }
+    }
+    
+    private File nonexistentFsRoot() {
+        ('Z'..'A').collect { 
+            "$it:\\" 
+        }.findResult {
+            new File(it).exists() ? null : new File(it)
+        }
     }
 }


### PR DESCRIPTION
In BaseDirFileResolverSpec, eliminate the assumption in test "normalizes non-existent file system root" that file system root Q:\ is non-existent.
