### PR TITLE
Added buildscriptConfiguration option to dependencies task

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -32,6 +32,7 @@ class ModelReportIntegrationTest extends AbstractIntegrationSpec {
         modelReportOutput.hasNodeStructure({
             model() {
                 tasks {
+                    buildscriptDependencies()
                     components(nodeValue: "task ':components'", type: 'org.gradle.api.reporting.components.ComponentReport')
                     dependencies()
                     dependencyInsight()
@@ -78,6 +79,7 @@ model {
                     values(type: 'java.util.List<java.lang.Double>', creator: 'model.container @ build.gradle line 12, column 5')
                 }
                 tasks {
+                    buildscriptDependencies(nodeValue: "task ':buildscriptDependencies'")
                     components(nodeValue: "task ':components'")
                     dependencies(nodeValue: "task ':dependencies'")
                     dependencyInsight(nodeValue: "task ':dependencyInsight'")
@@ -143,6 +145,7 @@ model {
                     username(nodeValue: 'uname', type: 'java.lang.String', creator: 'model.primaryCredentials @ build.gradle line 22, column 5')
                 }
                 tasks {
+                    buildscriptDependencies(nodeValue: "task ':buildscriptDependencies'")
                     components(nodeValue: "task ':components'")
                     dependencies(nodeValue: "task ':dependencies'")
                     dependencyInsight(nodeValue: "task ':dependencyInsight'")
@@ -233,6 +236,12 @@ model {
 + tasks
       | Type:   \torg.gradle.model.ModelMap<org.gradle.api.Task>
       | Creator: \tProject.<init>.tasks()
+    + buildscriptDependencies
+          | Type:   \torg.gradle.api.tasks.diagnostics.BuildscriptDependencyReportTask
+          | Value:  \ttask ':buildscriptDependencies\'
+          | Creator: \ttasks.addPlaceholderAction(buildscriptDependencies)
+          | Rules:
+             ⤷ copyToTaskContainer
     + components
           | Type:   \torg.gradle.api.reporting.components.ComponentReport
           | Value:  \ttask ':components'

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTaskIntegrationTest.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+import static org.gradle.util.TextUtil.toPlatformLineSeparators
+
+class BuildscriptDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        executer.requireOwnGradleUserHomeDir()
+    }
+
+    def "reports external dependency name and version change"() {
+        mavenRepo.module("org", "leaf1").publish()
+        mavenRepo.module("org", "leaf2").publish()
+        mavenRepo.module("org", "leaf3").publish()
+        mavenRepo.module("org", "leaf4").publish()
+
+        mavenRepo.module("org", "toplevel1").dependsOn('leaf1', 'leaf2').publish()
+        mavenRepo.module("org", "toplevel2").dependsOn('leaf3', 'leaf4').publish()
+
+        file("settings.gradle") << "include 'client', 'impl'"
+
+        buildFile << """
+            buildscript {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                dependencies {
+                    classpath 'org:toplevel1:1.0'
+                }
+            }
+
+            project(":impl") {
+                buildscript {
+                    repositories {
+                        maven { url "${mavenRepo.uri}" }
+                    }
+                    dependencies {
+                        classpath 'org:toplevel2:1.0'
+                    }
+                }
+
+                configurations {
+                    config1
+                }
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                dependencies {
+                    config1 'org:leaf1:1.0'
+                }
+            }
+"""
+
+        when:
+        run(":impl:buildscriptDependencies")
+
+        then:
+        output.contains(toPlatformLineSeparators("""
+classpath
+\\--- org:toplevel2:1.0
+     +--- org:leaf3:1.0
+     \\--- org:leaf4:1.0
+"""))
+        when:
+        run(":client:buildscriptDependencies")
+
+        then:
+        output.contains(toPlatformLineSeparators("""
+classpath
+No dependencies
+"""))
+
+        when:
+        run(":buildscriptDependencies")
+
+        then:
+        output.contains(toPlatformLineSeparators("""
+classpath
+\\--- org:toplevel1:1.0
+     +--- org:leaf1:1.0
+     \\--- org:leaf2:1.0
+"""))
+    }
+}

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/plugins/HelpTasksPlugin.java
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/plugins/HelpTasksPlugin.java
@@ -44,6 +44,7 @@ public class HelpTasksPlugin implements Plugin<ProjectInternal> {
     public static final String HELP_GROUP = "help";
     public static final String PROPERTIES_TASK = "properties";
     public static final String DEPENDENCIES_TASK = "dependencies";
+    public static final String BUILDSCRIPT_DEPENDENCIES_TASK = "buildscriptDependencies";
     public static final String DEPENDENCY_INSIGHT_TASK = "dependencyInsight";
     public static final String COMPONENTS_TASK = "components";
     public static final String MODEL_TASK = "model";
@@ -59,6 +60,7 @@ public class HelpTasksPlugin implements Plugin<ProjectInternal> {
         tasks.addPlaceholderAction(PROPERTIES_TASK, PropertyReportTask.class, new PropertyReportTaskAction(projectName));
         tasks.addPlaceholderAction(DEPENDENCY_INSIGHT_TASK, DependencyInsightReportTask.class, new DependencyInsightReportTaskAction(projectName));
         tasks.addPlaceholderAction(DEPENDENCIES_TASK, DependencyReportTask.class, new DependencyReportTaskAction(projectName));
+        tasks.addPlaceholderAction(BUILDSCRIPT_DEPENDENCIES_TASK, BuildscriptDependencyReportTask.class, new BuildscriptDependencyReportTaskAction(projectName));
         tasks.addPlaceholderAction(COMPONENTS_TASK, ComponentReport.class, new ComponentReportAction(projectName));
         tasks.addPlaceholderAction(MODEL_TASK, ModelReport.class, new ModelReportAction(projectName));
     }
@@ -156,6 +158,20 @@ public class HelpTasksPlugin implements Plugin<ProjectInternal> {
 
         public void execute(DependencyReportTask task) {
             task.setDescription("Displays all dependencies declared in " + projectName + ".");
+            task.setGroup(HELP_GROUP);
+            task.setImpliesSubProjects(true);
+        }
+    }
+
+    private static class BuildscriptDependencyReportTaskAction implements Action<BuildscriptDependencyReportTask> {
+        private final String projectName;
+
+        public BuildscriptDependencyReportTaskAction(String projectName) {
+            this.projectName = projectName;
+        }
+
+        public void execute(BuildscriptDependencyReportTask task) {
+            task.setDescription("Displays all buildscript dependencies declared in " + projectName + ".");
             task.setGroup(HELP_GROUP);
             task.setImpliesSubProjects(true);
         }

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/plugins/ProjectReportsPlugin.java
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/plugins/ProjectReportsPlugin.java
@@ -87,16 +87,6 @@ public class ProjectReportsPlugin implements Plugin<Project> {
         BuildscriptDependencyReportTask buildscriptDependencyReportTask = project.getTasks().create(BUILDSCRIPT_DEPENDENCY_REPORT,
                 BuildscriptDependencyReportTask.class);
         buildscriptDependencyReportTask.setDescription("Generates a buildscript report about your library dependencies.");
-        buildscriptDependencyReportTask.conventionMapping("outputFile", new Callable<Object>() {
-            public Object call() throws Exception {
-                return new File(convention.getProjectReportDir(), "buildscriptDependencies.txt");
-            }
-        });
-        buildscriptDependencyReportTask.conventionMapping("projects", new Callable<Object>() {
-            public Object call() throws Exception {
-                return convention.getProjects();
-            }
-        });
 
         HtmlDependencyReportTask htmlDependencyReportTask = project.getTasks().create(HTML_DEPENDENCY_REPORT,
                 HtmlDependencyReportTask.class);

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/plugins/ProjectReportsPlugin.java
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/plugins/ProjectReportsPlugin.java
@@ -20,6 +20,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.reporting.dependencies.HtmlDependencyReportTask;
+import org.gradle.api.tasks.diagnostics.BuildscriptDependencyReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyReportTask;
 import org.gradle.api.tasks.diagnostics.PropertyReportTask;
 import org.gradle.api.tasks.diagnostics.TaskReportTask;
@@ -34,6 +35,7 @@ public class ProjectReportsPlugin implements Plugin<Project> {
     public static final String TASK_REPORT = "taskReport";
     public static final String PROPERTY_REPORT = "propertyReport";
     public static final String DEPENDENCY_REPORT = "dependencyReport";
+    public static final String BUILDSCRIPT_DEPENDENCY_REPORT = "buildscriptDependencyReport";
     public static final String HTML_DEPENDENCY_REPORT = "htmlDependencyReport";
     public static final String PROJECT_REPORT = "projectReport";
 
@@ -77,6 +79,20 @@ public class ProjectReportsPlugin implements Plugin<Project> {
             }
         });
         dependencyReportTask.conventionMapping("projects", new Callable<Object>() {
+            public Object call() throws Exception {
+                return convention.getProjects();
+            }
+        });
+
+        BuildscriptDependencyReportTask buildscriptDependencyReportTask = project.getTasks().create(BUILDSCRIPT_DEPENDENCY_REPORT,
+                BuildscriptDependencyReportTask.class);
+        buildscriptDependencyReportTask.setDescription("Generates a buildscript report about your library dependencies.");
+        buildscriptDependencyReportTask.conventionMapping("outputFile", new Callable<Object>() {
+            public Object call() throws Exception {
+                return new File(convention.getProjectReportDir(), "buildscriptDependencies.txt");
+            }
+        });
+        buildscriptDependencyReportTask.conventionMapping("projects", new Callable<Object>() {
             public Object call() throws Exception {
                 return convention.getProjects();
             }

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/AbstractDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/AbstractDependencyReportTask.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.internal.tasks.options.Option;
+import org.gradle.api.tasks.diagnostics.internal.DependencyReportRenderer;
+import org.gradle.api.tasks.diagnostics.internal.ReportRenderer;
+import org.gradle.api.tasks.diagnostics.internal.dependencies.AsciiDependencyReportRenderer;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Displays the dependency tree for a configuration.
+ */
+abstract public class AbstractDependencyReportTask extends AbstractReportTask {
+
+    private DependencyReportRenderer renderer = new AsciiDependencyReportRenderer();
+
+    private Set<Configuration> configurations;
+
+    public ReportRenderer getRenderer() {
+        return renderer;
+    }
+
+    /**
+     * Set the renderer to use to build a report. If unset, AsciiGraphRenderer will be used.
+     */
+    public void setRenderer(DependencyReportRenderer renderer) {
+        this.renderer = renderer;
+    }
+
+    public void generate(Project project) throws IOException {
+        SortedSet<Configuration> sortedConfigurations = new TreeSet<Configuration>(new Comparator<Configuration>() {
+            public int compare(Configuration conf1, Configuration conf2) {
+                return conf1.getName().compareTo(conf2.getName());
+            }
+        });
+        sortedConfigurations.addAll(getReportConfigurations());
+        for (Configuration configuration : sortedConfigurations) {
+            renderer.startConfiguration(configuration);
+            renderer.render(configuration);
+            renderer.completeConfiguration(configuration);
+        }
+    }
+
+    private Set<Configuration> getReportConfigurations() {
+        return configurations != null ? configurations : getTaskConfigurations();
+    }
+
+    /**
+     * Returns the configurations to generate the report for. Defaults to all configurations of this task's containing
+     * project.
+     *
+     * @return the configurations.
+     */
+    public Set<Configuration> getConfigurations() {
+        return configurations;
+    }
+
+    /**
+     * Sets the configurations to generate the report for.
+     *
+     * @param configurations The configuration. Must not be null.
+     */
+    public void setConfigurations(Set<Configuration> configurations) {
+        this.configurations = configurations;
+    }
+
+    /**
+     * Sets the single configuration (by name) to generate the report for.
+     *
+     * @param configurationName name of the configuration to generate the report for
+     */
+    @Option(option = "configuration", description = "The configuration to generate the report for.")
+    public void setConfiguration(String configurationName) {
+        this.configurations = Collections.singleton(getTaskConfigurations().getByName(configurationName));
+    }
+
+    abstract public ConfigurationContainer getTaskConfigurations();
+}

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTask.java
@@ -15,35 +15,34 @@
  */
 package org.gradle.api.tasks.diagnostics;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.diagnostics.internal.DependencyReportRenderer;
 import org.gradle.api.tasks.diagnostics.internal.ProjectReportGenerator;
 import org.gradle.api.tasks.diagnostics.internal.ReportGenerator;
-import org.gradle.api.tasks.diagnostics.internal.ReportRenderer;
 import org.gradle.api.tasks.diagnostics.internal.dependencies.AsciiDependencyReportRenderer;
 import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.logging.StyledTextOutputFactory;
-
-import javax.inject.Inject;
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
 
 /**
  * Displays the buildscript dependency tree for a project. An instance of this type is used when you
  * execute the {@code buildscriptDependencies} task from the command-line.
  */
-public class BuildscriptDependencyReportTask extends ConventionTask {
+public class BuildscriptDependencyReportTask extends DefaultTask {
 
     private DependencyReportRenderer renderer = new AsciiDependencyReportRenderer();
-    private File outputFile;
     private Set<Project> projects;
 
     public BuildscriptDependencyReportTask() {
@@ -85,59 +84,13 @@ public class BuildscriptDependencyReportTask extends ConventionTask {
             }
         };
 
-        ReportGenerator reportGenerator = new ReportGenerator(getRenderer(), getClientMetaData(), getOutputFile(),
+        ReportGenerator reportGenerator = new ReportGenerator(renderer, getClientMetaData(), null,
                 getTextOutputFactory(), projectReportGenerator);
-        reportGenerator.generateReport(new TreeSet<Project>(getProjects()));
+        reportGenerator.generateReport(projects);
     }
 
-    public ReportRenderer getRenderer() {
-        return renderer;
-    }
-
-    /**
-     * Set the renderer to use to build a report. If unset, AsciiGraphRenderer will be used.
-     */
-    public void setRenderer(DependencyReportRenderer renderer) {
-        this.renderer = renderer;
-    }
-
-    /**
-     * Returns the file which the report will be written to. When set to {@code null}, the report is written to {@code System.out}.
-     * Defaults to {@code null}.
-     *
-     * @return The output file. May be null.
-     */
-    @OutputFile
-    @Optional
-    public File getOutputFile() {
-        return outputFile;
-    }
-
-    /**
-     * Sets the file which the report will be written to. Set this to {@code null} to write the report to {@code System.out}.
-     *
-     * @param outputFile The output file. May be null.
-     */
-    public void setOutputFile(File outputFile) {
-        this.outputFile = outputFile;
-    }
-
-    /**
-     * Returns the set of project to generate this report for. By default, the report is generated for the task's
-     * containing project.
-     *
-     * @return The set of files.
-     */
-    public Set<Project> getProjects() {
-        return projects;
-    }
-
-    /**
-     * Specifies the set of projects to generate this report for.
-     *
-     * @param projects The set of projects. Must not be null.
-     */
-    public void setProjects(Set<Project> projects) {
-        this.projects = projects;
+    @VisibleForTesting
+    protected void setRenderer(DependencyReportRenderer dependencyReportRenderer) {
+        this.renderer = dependencyReportRenderer;
     }
 }

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@ package org.gradle.api.tasks.diagnostics;
 import org.gradle.api.artifacts.ConfigurationContainer;
 
 /**
- * Displays the dependency tree for a project. An instance of this type is used when you
- * execute the {@code dependencies} task from the command-line.
+ * Displays the buildscript dependency tree for a project. An instance of this type is used when you
+ * execute the {@code buildscriptDependencies} task from the command-line.
  */
-public class DependencyReportTask extends AbstractDependencyReportTask {
+public class BuildscriptDependencyReportTask extends AbstractDependencyReportTask {
 
     @Override
     public ConfigurationContainer getTaskConfigurations() {
-        return getProject().getConfigurations();
+        return getProject().getBuildscript().getConfigurations();
     }
 }

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/internal/ProjectReportGenerator.java
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/internal/ProjectReportGenerator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal;
+
+import org.gradle.api.Project;
+
+import java.io.IOException;
+
+public interface ProjectReportGenerator {
+    void generateReport(Project project) throws IOException;
+}

--- a/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/internal/ReportGenerator.java
+++ b/subprojects/diagnostics/src/main/groovy/org/gradle/api/tasks/diagnostics/internal/ReportGenerator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal;
+
+import org.gradle.api.Project;
+import org.gradle.api.UncheckedIOException;
+import org.gradle.initialization.BuildClientMetaData;
+import org.gradle.logging.StyledTextOutputFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+
+public class ReportGenerator {
+
+    private final ReportRenderer renderer;
+    private final BuildClientMetaData buildClientMetaData;
+    private final File outputFile;
+    private final StyledTextOutputFactory textOutputFactory;
+    private final ProjectReportGenerator projectReportGenerator;
+
+    public ReportGenerator(ReportRenderer renderer, BuildClientMetaData buildClientMetaData, File outputFile,
+                           StyledTextOutputFactory textOutputFactory, ProjectReportGenerator projectReportGenerator) {
+        this.renderer = renderer;
+        this.buildClientMetaData = buildClientMetaData;
+        this.outputFile = outputFile;
+        this.textOutputFactory = textOutputFactory;
+        this.projectReportGenerator = projectReportGenerator;
+    }
+
+    public void generateReport(Set<Project> projects) {
+        try {
+            ReportRenderer renderer = getRenderer();
+            renderer.setClientMetaData(getClientMetaData());
+            File outputFile = getOutputFile();
+            if (outputFile != null) {
+                renderer.setOutputFile(outputFile);
+            } else {
+                renderer.setOutput(getTextOutputFactory().create(getClass()));
+            }
+            for (Project project : projects) {
+                renderer.startProject(project);
+                projectReportGenerator.generateReport(project);
+                renderer.completeProject(project);
+            }
+            renderer.complete();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    protected ReportRenderer getRenderer() {
+        return renderer;
+    }
+
+    protected BuildClientMetaData getClientMetaData() {
+        return buildClientMetaData;
+    }
+
+    /**
+     * Returns the file which the report will be written to. When set to {@code null}, the report is written to {@code System.out}.
+     *
+     * @return The output file. May be null.
+     */
+    protected File getOutputFile() {
+        return outputFile;
+    }
+
+    protected StyledTextOutputFactory getTextOutputFactory() {
+        return textOutputFactory;
+    }
+}

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTaskTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTaskTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics;
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.diagnostics.internal.DependencyReportRenderer
+import org.gradle.api.tasks.diagnostics.internal.dependencies.AsciiDependencyReportRenderer
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+class BuildscriptDependencyReportTaskTest extends Specification {
+    private Project project = new ProjectBuilder().build()
+    private BuildscriptDependencyReportTask task = TestUtil.createTask(BuildscriptDependencyReportTask.class, project)
+    private DependencyReportRenderer renderer = Mock(DependencyReportRenderer)
+    private Configuration conf1 = project.buildscript.configurations.create("conf1")
+    private Configuration conf2 = project.buildscript.configurations.create("conf2")
+    private Configuration classpath = project.buildscript.configurations.getByName("classpath")
+
+    void setup() {
+        task.renderer = renderer
+    }
+
+    def "task is configured correctly"() {
+        task = TestUtil.createTask(BuildscriptDependencyReportTask.class);
+
+        expect:
+        task.renderer instanceof AsciiDependencyReportRenderer
+        task.configurations == null
+    }
+
+    def "renders all configurations in the project"() {
+        when:
+        task.generate(project)
+
+        then: 1 * renderer.startConfiguration(classpath)
+        then: 1 * renderer.render(classpath)
+        then: 1 * renderer.completeConfiguration(classpath)
+
+        then: 1 * renderer.startConfiguration(conf1)
+        then: 1 * renderer.render(conf1)
+        then: 1 * renderer.completeConfiguration(conf1)
+
+
+        then: 1 * renderer.startConfiguration(conf2)
+        then: 1 * renderer.render(conf2)
+        then: 1 * renderer.completeConfiguration(conf2)
+
+        0 * renderer._
+    }
+
+    def "rendering can be limited to specific configurations"() {
+        given:
+        project.buildscript.configurations.create("a")
+        def bConf = project.buildscript.configurations.create("b")
+        task.configurations = [bConf] as Set
+
+        when:
+        task.generate(project)
+
+        then:
+        1 * renderer.startConfiguration(bConf)
+        1 * renderer.render(bConf)
+        1 * renderer.completeConfiguration(bConf)
+        0 * renderer._
+    }
+
+    def "rendering can be limited to a single configuration, specified by name"() {
+        given:
+        project.buildscript.configurations.create("a")
+        def bConf = project.buildscript.configurations.create("b")
+
+        when:
+        task.configuration = "b"
+
+        then:
+        task.configurations == [bConf] as Set
+    }
+}

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTaskTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTaskTest.groovy
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.tasks.diagnostics;
+
+package org.gradle.api.tasks.diagnostics
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.diagnostics.internal.DependencyReportRenderer
 import org.gradle.api.tasks.diagnostics.internal.dependencies.AsciiDependencyReportRenderer
-import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class BuildscriptDependencyReportTaskTest extends Specification {
-    private Project project = new ProjectBuilder().build()
+    private Project project = TestUtil.createRootProject()
     private BuildscriptDependencyReportTask task = TestUtil.createTask(BuildscriptDependencyReportTask.class, project)
     private DependencyReportRenderer renderer = Mock(DependencyReportRenderer)
     private Configuration conf1 = project.buildscript.configurations.create("conf1")
@@ -40,12 +40,11 @@ class BuildscriptDependencyReportTaskTest extends Specification {
 
         expect:
         task.renderer instanceof AsciiDependencyReportRenderer
-        task.configurations == null
     }
 
     def "renders all configurations in the project"() {
         when:
-        task.generate(project)
+        task.generate()
 
         then: 1 * renderer.startConfiguration(classpath)
         then: 1 * renderer.render(classpath)
@@ -60,34 +59,6 @@ class BuildscriptDependencyReportTaskTest extends Specification {
         then: 1 * renderer.render(conf2)
         then: 1 * renderer.completeConfiguration(conf2)
 
-        0 * renderer._
-    }
 
-    def "rendering can be limited to specific configurations"() {
-        given:
-        project.buildscript.configurations.create("a")
-        def bConf = project.buildscript.configurations.create("b")
-        task.configurations = [bConf] as Set
-
-        when:
-        task.generate(project)
-
-        then:
-        1 * renderer.startConfiguration(bConf)
-        1 * renderer.render(bConf)
-        1 * renderer.completeConfiguration(bConf)
-        0 * renderer._
-    }
-
-    def "rendering can be limited to a single configuration, specified by name"() {
-        given:
-        project.buildscript.configurations.create("a")
-        def bConf = project.buildscript.configurations.create("b")
-
-        when:
-        task.configuration = "b"
-
-        then:
-        task.configurations == [bConf] as Set
     }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTaskTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/BuildscriptDependencyReportTaskTest.groovy
@@ -16,34 +16,24 @@
 
 package org.gradle.api.tasks.diagnostics
 
-import org.gradle.api.Project
+
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.tasks.diagnostics.internal.DependencyReportRenderer
-import org.gradle.api.tasks.diagnostics.internal.dependencies.AsciiDependencyReportRenderer
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class BuildscriptDependencyReportTaskTest extends Specification {
-    private Project project = TestUtil.createRootProject()
+    private DefaultProject project = TestUtil.createRootProject()
     private BuildscriptDependencyReportTask task = TestUtil.createTask(BuildscriptDependencyReportTask.class, project)
     private DependencyReportRenderer renderer = Mock(DependencyReportRenderer)
     private Configuration conf1 = project.buildscript.configurations.create("conf1")
     private Configuration conf2 = project.buildscript.configurations.create("conf2")
     private Configuration classpath = project.buildscript.configurations.getByName("classpath")
 
-    void setup() {
-        task.renderer = renderer
-    }
-
-    def "task is configured correctly"() {
-        task = TestUtil.createTask(BuildscriptDependencyReportTask.class);
-
-        expect:
-        task.renderer instanceof AsciiDependencyReportRenderer
-    }
-
     def "renders all configurations in the project"() {
         when:
+        task.setRenderer(renderer)
         task.generate()
 
         then: 1 * renderer.startConfiguration(classpath)

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/ReportGeneratorTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/ReportGeneratorTest.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal
+
+import org.gradle.initialization.BuildClientMetaData
+import org.gradle.logging.StyledTextOutput
+import org.gradle.logging.StyledTextOutputFactory
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
+import org.junit.Rule
+import spock.lang.Specification
+
+class ReportGeneratorTest extends Specification {
+
+    ReportRenderer renderer = Mock(ReportRenderer)
+    BuildClientMetaData buildClientMetaData = Mock(BuildClientMetaData)
+    ProjectReportGenerator projectReportGenerator = Mock(ProjectReportGenerator)
+    StyledTextOutput styledTextOutput = Mock(StyledTextOutput)
+
+    @Rule
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+
+    def createReportGenerator(File file = null) {
+        StyledTextOutputFactory textOutputFactory = Mock(StyledTextOutputFactory)
+        textOutputFactory.create(_) >> styledTextOutput
+        return new ReportGenerator(renderer, buildClientMetaData, file, textOutputFactory, projectReportGenerator)
+    }
+
+    def 'completes renderer at end of generation'() {
+        setup:
+        def generator = createReportGenerator()
+        def project = TestUtil.createRootProject()
+
+        when:
+        generator.generateReport([project] as Set)
+
+        then:
+        1 * renderer.setClientMetaData(buildClientMetaData)
+
+        then:
+        1 * renderer.setOutput(styledTextOutput)
+        0 * renderer.setOutputFile(_)
+
+        then:
+        1 * renderer.startProject(project)
+
+        then:
+        1 * projectReportGenerator.generateReport(project)
+
+        then:
+        1 * renderer.completeProject(project)
+
+        then:
+        1 * renderer.complete()
+    }
+
+    def 'sets outputFileName on renderer before generation'() {
+        setup:
+        final File file = tmpDir.getTestDirectory().file("report.txt");
+        def generator = createReportGenerator(file)
+        def project = TestUtil.createRootProject()
+
+        when:
+        generator.generateReport([project] as Set)
+
+        then:
+        1 * renderer.setClientMetaData(buildClientMetaData)
+
+        then:
+        1 * renderer.setOutputFile(file)
+        0 * renderer.setOutput(_)
+
+        then:
+        1 * renderer.startProject(project)
+
+        then:
+        1 * projectReportGenerator.generateReport(project)
+
+        then:
+        1 * renderer.completeProject(project)
+
+        then:
+        1 * renderer.complete()
+    }
+
+
+    def 'passes each project to renderer'() {
+        setup:
+        def project = TestUtil.createRootProject()
+        def child1 = TestUtil.createChildProject(project, "child1");
+        def child2 = TestUtil.createChildProject(project, "child2");
+        def generator = createReportGenerator()
+
+        when:
+        generator.generateReport(project.getAllprojects())
+
+        then:
+        1 * renderer.setClientMetaData(buildClientMetaData)
+        1 * renderer.setOutput(styledTextOutput)
+
+        then:
+        1 * renderer.startProject(project)
+        1 * projectReportGenerator.generateReport(project)
+        1 * renderer.completeProject(project)
+
+        then:
+        1 * renderer.startProject(child1)
+        1 * projectReportGenerator.generateReport(child1)
+        1 * renderer.completeProject(child1)
+
+        then:
+        1 * renderer.startProject(child2)
+        1 * projectReportGenerator.generateReport(child2)
+        1 * renderer.completeProject(child2)
+
+        then:
+        1 * renderer.complete()
+    }
+}

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.diagnostics.AbstractDependencyReportTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.diagnostics.AbstractDependencyReportTask.xml
@@ -1,0 +1,28 @@
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>outputFile</td>
+            </tr>
+            <tr>
+                <td>projects</td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.diagnostics.BuildscriptDependencyReportTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.diagnostics.BuildscriptDependencyReportTask.xml
@@ -1,0 +1,51 @@
+<!--
+  ~ Copyright 2015 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Default with <literal>project-report</literal> plugin</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>configurations</td>
+                <td><literal>project.buildscript.configurations</literal></td>
+            </tr>
+            <tr>
+                <td>outputFile</td>
+                <td><filename><replaceable>${project.projectReportDir}</replaceable>/buildscriptDependencies.txt</filename></td>
+            </tr>
+            <tr>
+                <td>projects</td>
+                <td><literal>[project]</literal></td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/userguide/commandLineTutorial.xml
+++ b/subprojects/docs/src/docs/userguide/commandLineTutorial.xml
@@ -184,6 +184,16 @@
                 <output args="-q api:dependencies --configuration testCompile"/>
             </sample>
         </section>
+        <section id="sec:listing_buildscript_dependencies">
+            <title>Listing project buildscript dependencies</title>
+            <para id="para:commandline_buildscript_dependency_report">Running <userinput>gradle buildscriptDependencies</userinput>
+                gives you a list of the buildscript dependencies of the selected project, broken down by configuration. For each
+                configuration, the direct and transitive dependencies of that configuration are shown in a tree.
+                Since a dependency report can get large, it can be useful to restrict the report to a particular configuration.
+                This is achieved with the optional <userinput>--configuration</userinput> parameter.
+                The output of <userinput>buildscriptDependencies</userinput> is the same as <userinput>dependencies</userinput>.
+            </para>
+        </section>
         <section id="sec:dependency_insight">
             <title>Getting the insight into a particular dependency</title>
             <para id="para:commandline_dependency_insight_report">Running <userinput>gradle dependencyInsight</userinput>

--- a/subprojects/docs/src/samples/userguideOutput/basicRuleSourcePlugin-model-task.out
+++ b/subprojects/docs/src/samples/userguideOutput/basicRuleSourcePlugin-model-task.out
@@ -50,6 +50,12 @@ Root project
       | Creator: 	Project.<init>.tasks()
       | Rules:
          ⤷ PersonRules#createHelloTask
+    + buildscriptDependencies
+          | Type:   	org.gradle.api.tasks.diagnostics.BuildscriptDependencyReportTask
+          | Value:  	task ':buildscriptDependencies'
+          | Creator: 	tasks.addPlaceholderAction(buildscriptDependencies)
+          | Rules:
+             ⤷ copyToTaskContainer
     + components
           | Type:   	org.gradle.api.reporting.components.ComponentReport
           | Value:  	task ':components'

--- a/subprojects/docs/src/samples/userguideOutput/taskListAllReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/taskListAllReport.out
@@ -24,6 +24,9 @@ wrapper - Generates Gradle wrapper files. [incubating]
 
 Help tasks
 ----------
+buildscriptDependencies - Displays all buildscript dependencies declared in root project 'projectReports'.
+api:buildscriptDependencies - Displays all buildscript dependencies declared in project ':api'.
+webapp:buildscriptDependencies - Displays all buildscript dependencies declared in project ':webapp'.
 components - Displays the components produced by root project 'projectReports'. [incubating]
 api:components - Displays the components produced by project ':api'. [incubating]
 webapp:components - Displays the components produced by project ':webapp'. [incubating]

--- a/subprojects/docs/src/samples/userguideOutput/taskListReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/taskListReport.out
@@ -18,6 +18,7 @@ wrapper - Generates Gradle wrapper files. [incubating]
 
 Help tasks
 ----------
+buildscriptDependencies - Displays all buildscript dependencies declared in root project 'projectReports'.
 components - Displays the components produced by root project 'projectReports'. [incubating]
 dependencies - Displays all dependencies declared in root project 'projectReports'.
 dependencyInsight - Displays the insight into a specific dependency in root project 'projectReports'.


### PR DESCRIPTION
Recently I have been helping a lot of people work with buildscript dependency issues (where plugins upgrade shared libraries). It seemed like the dependencies task should be able to put this report out.

When adding the buildscriptConfiguration option with dependencies the task will now look at the buildscript's configurations vs the project configurations allowing people to list all of their buildscript dependencies to find conflicts.