### PR TITLE
Fix URL to plugin submit docs in user guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/customPlugins.xml
+++ b/subprojects/docs/src/docs/userguide/customPlugins.xml
@@ -209,7 +209,7 @@
                 If you are interested in publishing your plugin to be used by the wider Gradle community, you can publish it to the
                 <ulink url="http://plugins.gradle.org">Gradle plugin portal</ulink>.  This site provides the ability to search for and
                 gather information about plugins contributed by the Gradle community.  See the instructions
-                <ulink url="http://plugins.gradle.org/submit">here</ulink> on how to make your plugin available on this site.
+                <ulink url="http://plugins.gradle.org/docs/submit">here</ulink> on how to make your plugin available on this site.
             </para>
         </section>
 


### PR DESCRIPTION
The plugin submit documentation moved from http://plugins.gradle.org/submit to http://plugins.gradle.org/docs/submit, but the URL in the user guide section on custom plugins is not updated yet.