### PR TITLE
Test DistributionLocatorIntegrationTest."locates snapshot versions" fails

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/DistributionLocatorIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/DistributionLocatorIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests
 
+import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.util.DistributionLocator
 import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
@@ -26,6 +27,7 @@ import spock.lang.Specification
 class DistributionLocatorIntegrationTest extends Specification {
 
     def locator = new DistributionLocator()
+    def distributions = new ReleasedVersionDistributions()
 
     def "locates release versions"() {
         expect:
@@ -37,7 +39,7 @@ class DistributionLocatorIntegrationTest extends Specification {
 
     def "locates snapshot versions"() {
         expect:
-        urlExist(locator.getDistributionFor(GradleVersion.version("2.5-20150412220016+0000")))
+        urlExist(locator.getDistributionFor(distributions.mostRecentSnapshot.version))
     }
 
     void urlExist(URI url) {

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle
@@ -37,6 +37,7 @@ task prepareVersionsInfo(type: PrepareVersionsInfo) {
     destFile = new File(generatedResourcesDir, "all-released-versions.properties")
     versions = releasedVersions.allVersions
     mostRecent = releasedVersions.mostRecentFinalRelease
+    mostRecentSnapshot = releasedVersions.mostRecentSnapshot
 }
 
 sourceSets.main.output.dir generatedResourcesDir, builtBy: prepareVersionsInfo
@@ -45,10 +46,12 @@ class PrepareVersionsInfo extends DefaultTask {
     @OutputFile File destFile
     @Input String mostRecent
     @Input List<String> versions
+    @Input String mostRecentSnapshot
 
     @TaskAction void prepareVersions() {
         def properties = new Properties()
         properties.mostRecent = mostRecent
+        properties.mostRecentSnapshot = mostRecentSnapshot
         properties.versions = versions.join(' ')
         destFile.withOutputStream {
             properties.store(it, "")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/ReleasedVersionDistributions.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/ReleasedVersionDistributions.java
@@ -68,6 +68,16 @@ public class ReleasedVersionDistributions {
         return buildContext.distribution(mostRecentFinal);
     }
 
+    public GradleDistribution getMostRecentSnapshot() {
+        String mostRecentSnapshot = getProperties().getProperty("mostRecentSnapshot");
+
+        if (mostRecentSnapshot == null) {
+            throw new RuntimeException("Unable to get the last snapshot version");
+        }
+
+        return buildContext.distribution(mostRecentSnapshot);
+    }
+
     public List<GradleDistribution> getAll() {
         if (distributions == null) {
             distributions = CollectionUtils.collect(getProperties().getProperty("versions").split("\\s+"), new Transformer<GradleDistribution, String>() {

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/versions/ReleasedVersionDistributionsTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/versions/ReleasedVersionDistributionsTest.groovy
@@ -51,6 +51,14 @@ class ReleasedVersionDistributionsTest extends Specification {
         versions().mostRecentFinalRelease.version == version("1.2")
     }
 
+    def "get most recent snapshot does that"() {
+        when:
+        props.mostRecentSnapshot = "2.5-20150413220018+0000"
+
+        then:
+        versions().mostRecentSnapshot.version == version("2.5-20150413220018+0000")
+    }
+
     def "get all final does that"() {
         when:
         props.versions = "1.3-rc-1 1.2"


### PR DESCRIPTION
It test for a snapshot version that is hard coded and outdated.
Change ReleasedVersionDistributions to know about the most recent nightly.
Used it for testing snapshot availability.