### PR TITLE
Propagate system property org.gradle.userguide.samples.exclude to the in...

### DIFF
--- a/subprojects/integ-test/integ-test.gradle
+++ b/subprojects/integ-test/integ-test.gradle
@@ -28,6 +28,10 @@ integTestTasks.all {
         systemProperties['integTest.userGuideOutputDir'] = new File(project(':docs').samplesSrcDir, "userguideOutput").absolutePath
     }
 
+    // You can exclude the userguide samples by their ids by specifying this system property.
+    // E.g. ./gradlew integTest:integTest -D:integTest:integTest.single=UserGuideSamplesIntegrationTest -Dorg.gradle.userguide.samples.exclude=completeCUnitExample,nativeComponentReport
+    systemProperty "org.gradle.userguide.samples.exclude", System.getProperty("org.gradle.userguide.samples.exclude")
+
     // You can filter the userguide samples to be run by specifying this system property.
     // E.g. ./gradlew integTest:integTest -D:integTest:integTest.single=UserGuideSamplesIntegrationTest -Dorg.gradle.userguide.samples.filter=signing/.+
     systemProperty "org.gradle.userguide.samples.filter", System.getProperty("org.gradle.userguide.samples.filter")


### PR DESCRIPTION
Propagate system property `org.gradle.userguide.samples.exclude` to the integTest tasks because it is used by `UserGuideSamplesRunner`.