### PR TITLE
Test org.gradle.api.reporting.components.ComponentReportIntegrationTest Fails When There Is No Installed Toolchain

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/components/ComponentReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/components/ComponentReportIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.reporting.components
 
 import org.gradle.api.JavaVersion
 import org.gradle.nativeplatform.fixtures.NativePlatformsTestFixture
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 
 class ComponentReportIntegrationTest extends AbstractComponentReportIntegrationTest {
     private JavaVersion currentJvm = JavaVersion.current()
@@ -25,6 +26,7 @@ class ComponentReportIntegrationTest extends AbstractComponentReportIntegrationT
     private String currentJdk = String.format("JDK %s (%s)", currentJvm.majorVersion, currentJvm);
     private String currentNative = NativePlatformsTestFixture.defaultPlatformName
 
+    @RequiresInstalledToolChain
     def "informs the user when project has no components defined"() {
         when:
         succeeds "components"
@@ -35,6 +37,7 @@ No components defined for this project.
 """
     }
 
+    @RequiresInstalledToolChain
     def "shows details of multiple components"() {
         given:
         buildFile << """


### PR DESCRIPTION
In `org.gradle.api.reporting.components.ComponentReportIntegrationTest` tests *informs the user when project has no components defined* and *shows details of multiple components* fail when there is no installed toolchain.  Annotated those tests with `@RequiresInstalledToolChain` so that they are ignored instead of failing when there is no installed toolchain.