### PR TITLE
Allows disabling validation of ivy descriptors for a repository.

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -161,6 +161,20 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
     void layout(String layoutName, Closure config);
 
     /**
+     * Returns true if the Ivy descriptors from this repository will be validated. The default value is true.
+     *
+     * @return true if the Ivy descriptors from this repository will be validated.
+     */
+    boolean isValidateDescriptors();
+
+    /**
+     * Specifies whether the Ivy descriptors from this repository will be validated by the Ivy XML schema.
+     *
+     * @param validate
+     */
+    void setValidateDescriptors(boolean validate);
+
+    /**
      * Returns the meta-data provider used when resolving artifacts from this repository. The provider is responsible for locating and interpreting the meta-data
      * for the modules and artifacts contained in this repository. Using this provider, you can fine tune how this resolution happens.
      *

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/DisableIvyDescriptorValidationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/DisableIvyDescriptorValidationIntegrationTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.ivy
+
+import groovy.xml.XmlUtil;
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest;
+
+public class DisableIvyDescriptorValidationIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    def "does not try to validate ivy descriptor"() {
+        given:
+        buildFile << """
+repositories {
+    ivy {
+        url "${ivyHttpRepo.uri}"
+        validateDescriptors false
+    }
+}
+configurations { compile }
+dependencies {
+    compile 'group:projectA:1.2'
+}
+task showFiles << { println configurations.compile.files }
+"""
+
+        and:
+        def module = ivyHttpRepo.module('group', 'projectA', '1.2').artifact().publish()
+        def moduleDescriptorXml = new XmlSlurper().parse(module.ivyFile)
+        moduleDescriptorXml.info.'@invalid-attribute' = 'foo'
+        module.ivyFile.text = XmlUtil.serialize(moduleDescriptorXml)
+
+        when:
+        module.ivy.expectGet()
+        module.artifact.expectGet()
+
+        then:
+        succeeds "showFiles"
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractModuleDescriptorParser.java
@@ -35,8 +35,13 @@ public abstract class AbstractModuleDescriptorParser<T extends MutableModuleComp
         return parseMetaData(ivySettings, descriptorFile, true);
     }
 
-    public T parseMetaData(DescriptorParseContext ivySettings, LocallyAvailableExternalResource resource) throws MetaDataParseException {
-        return parseDescriptor(ivySettings, resource, true);
+    public T parseMetaData(DescriptorParseContext ivySettings, LocallyAvailableExternalResource resource, boolean validate) throws MetaDataParseException {
+        return parseDescriptor(ivySettings, resource, validate);
+    }
+
+    @Override
+    public T parseMetaData(DescriptorParseContext context, LocallyAvailableExternalResource resource) throws MetaDataParseException {
+        return parseMetaData(context, resource, true);
     }
 
     protected T parseDescriptor(DescriptorParseContext ivySettings, LocallyAvailableExternalResource resource, boolean validate) throws MetaDataParseException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/MetaDataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/MetaDataParser.java
@@ -23,6 +23,8 @@ import java.io.File;
 public interface MetaDataParser<T extends MutableModuleComponentResolveMetaData> {
     T parseMetaData(DescriptorParseContext context, LocallyAvailableExternalResource resource) throws MetaDataParseException;
 
+    T parseMetaData(DescriptorParseContext context, LocallyAvailableExternalResource resource, boolean validate) throws MetaDataParseException;
+
     T parseMetaData(DescriptorParseContext ivySettings, File descriptorFile) throws MetaDataParseException;
 
     T parseMetaData(DescriptorParseContext ivySettings, File descriptorFile, boolean validate) throws MetaDataParseException;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
@@ -84,7 +84,7 @@ public class DefaultFlatDirArtifactRepository extends AbstractArtifactRepository
             throw new InvalidUserDataException("You must specify at least one directory for a flat directory repository.");
         }
 
-        IvyResolver resolver = new IvyResolver(getName(), transportFactory.createTransport("file", getName(), null), locallyAvailableResourceFinder, false, resolverStrategy, artifactFileStore);
+        IvyResolver resolver = new IvyResolver(getName(), transportFactory.createTransport("file", getName(), null), locallyAvailableResourceFinder, false, resolverStrategy, artifactFileStore, true);
         for (File root : dirs) {
             resolver.addArtifactLocation(root.toURI(), "/[artifact]-[revision](-[classifier]).[ext]");
             resolver.addArtifactLocation(root.toURI(), "/[artifact](-[classifier]).[ext]");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -43,6 +43,7 @@ import java.util.Set;
 public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupportedRepository implements IvyArtifactRepository, ResolutionAwareRepository, PublicationAwareRepository {
     private Object baseUrl;
     private AbstractRepositoryLayout layout;
+    private boolean validateDescriptors = true;
     private final AdditionalPatternsRepositoryLayout additionalPatternsLayout;
     private final FileResolver fileResolver;
     private final RepositoryTransportFactory transportFactory;
@@ -101,7 +102,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         return new IvyResolver(
                 getName(), transport,
                 locallyAvailableResourceFinder,
-                metaDataProvider.dynamicResolve, resolverStrategy, artifactFileStore);
+                metaDataProvider.dynamicResolve, resolverStrategy, artifactFileStore, validateDescriptors);
     }
 
     public URI getUrl() {
@@ -139,6 +140,16 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
     public void layout(String layoutName, Action<? extends RepositoryLayout> config) {
         layout(layoutName);
         ((Action) config).execute(layout);
+    }
+
+    @Override
+    public void setValidateDescriptors(boolean validate) {
+        validateDescriptors = validate;
+    }
+
+    @Override
+    public boolean isValidateDescriptors() {
+        return validateDescriptors;
     }
 
     public IvyArtifactRepositoryMetaDataProvider getResolve() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
@@ -40,14 +40,17 @@ public class IvyResolver extends ExternalResourceResolver implements PatternBase
 
     private final boolean dynamicResolve;
     private final MetaDataParser<DefaultIvyModuleResolveMetaData> metaDataParser;
+    private final boolean validateDescriptors;
     private boolean m2Compatible;
 
     public IvyResolver(String name, RepositoryTransport transport,
                        LocallyAvailableResourceFinder<ModuleComponentArtifactMetaData> locallyAvailableResourceFinder,
-                       boolean dynamicResolve, ResolverStrategy resolverStrategy, FileStore<ModuleComponentArtifactMetaData> artifactFileStore) {
+                       boolean dynamicResolve, ResolverStrategy resolverStrategy, FileStore<ModuleComponentArtifactMetaData> artifactFileStore,
+                       boolean validateDescriptors) {
         super(name, transport.isLocal(), transport.getRepository(), transport.getResourceAccessor(), new ResourceVersionLister(transport.getRepository()), locallyAvailableResourceFinder, artifactFileStore);
         this.metaDataParser = new DownloadedIvyModuleDescriptorParser(resolverStrategy);
         this.dynamicResolve = dynamicResolve;
+        this.validateDescriptors = validateDescriptors;
     }
 
     @Override
@@ -78,6 +81,10 @@ public class IvyResolver extends ExternalResourceResolver implements PatternBase
         this.m2Compatible = m2compatible;
     }
 
+    public boolean isValidateDescriptors() {
+        return validateDescriptors;
+    }
+
     public void addArtifactLocation(URI baseUri, String pattern) {
         addArtifactPattern(toResourcePattern(baseUri, pattern));
     }
@@ -103,7 +110,7 @@ public class IvyResolver extends ExternalResourceResolver implements PatternBase
     }
 
     protected MutableModuleComponentResolveMetaData parseMetaDataFromResource(ModuleComponentIdentifier moduleComponentIdentifier, LocallyAvailableExternalResource cachedResource, DescriptorParseContext context) {
-        MutableModuleComponentResolveMetaData metaData = metaDataParser.parseMetaData(context, cachedResource);
+        MutableModuleComponentResolveMetaData metaData = metaDataParser.parseMetaData(context, cachedResource, validateDescriptors);
         checkMetadataConsistency(moduleComponentIdentifier, metaData);
         return metaData;
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -44,6 +44,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     def "default values"() {
         expect:
         repository.url == null
+        repository.validateDescriptors
         !repository.resolve.dynamicMode
     }
 
@@ -236,6 +237,25 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
             name == 'name'
             artifactPatterns == ['http://host/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])', 'http://host/[other]/artifact']
             ivyPatterns == ["http://host/[organisation]/[module]/[revision]/ivy-[revision].xml", 'http://host/[other]/ivy']
+        }
+    }
+
+    def "disables validation of ivy descriptors for this repository"() {
+        repository.name = 'name'
+        repository.url = 'http://host/'
+        repository.validateDescriptors = false
+
+        given:
+        fileResolver.resolveUri('http://host/') >> new URI('http://host/')
+        transportFactory.createTransport({ it == ['http'] as Set}, 'name', null) >> transport()
+
+        when:
+        def resolver = repository.createResolver()
+
+        then:
+        with(resolver) {
+            it instanceof IvyResolver
+            !validateDescriptors
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
 import spock.lang.Specification
 
 class IvyResolverTest extends Specification {
-    def resolver = new IvyResolver("repo", Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), false, Stub(ResolverStrategy), Stub(FileStore))
+    def resolver = new IvyResolver("repo", Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), false, Stub(ResolverStrategy), Stub(FileStore), true)
 
     def "has useful string representation"() {
         expect:

--- a/subprojects/docs/src/docs/userguide/depMngmt.xml
+++ b/subprojects/docs/src/docs/userguide/depMngmt.xml
@@ -973,6 +973,11 @@
                 <sample id="ivyRepository" dir="userguide/artifacts/defineRepository" title="Ivy repository with Maven compatible layout">
                     <sourcefile file="build.gradle" snippet="ivy-repo-with-m2compatible-layout"/>
                 </sample>
+                <para>If your Ivy repository has descriptors that don't pass the Ivy XML schema validation you can use the <literal>validateDescriptors</literal> option.
+                    By default Gradle will validate the descriptors.</para>
+                <sample id="ivyRepository" dir="userguide/artifacts/defineRepository" title="Ivy repository with validation of descriptors disabled">
+                    <sourcefile file="build.gradle" snippet="ivy-repo-with-validate-descriptors-disabled"/>
+                </sample>
             </section>
             <section>
                 <title>Accessing password protected Ivy repositories</title>

--- a/subprojects/docs/src/samples/userguide/artifacts/defineRepository/build.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/defineRepository/build.gradle
@@ -179,6 +179,15 @@ repositories {
 }
 //END SNIPPET ivy-repo-with-m2compatible-layout
 
+//START SNIPPET ivy-repo-with-validate-descriptors-disabled
+repositories {
+    ivy {
+        url "http://repo.mycompany.com/repo"
+        validateDescriptors false
+    }
+}
+//END SNIPPET ivy-repo-with-validate-descriptors-disabled
+
 //START SNIPPET ivy-repo-with-custom-pattern
 repositories {
     ivy {


### PR DESCRIPTION
Similar to what have been discussed [here](https://discuss.gradle.org/t/custom-ivy-resolver-deprecation-in-gradle-2-x/7492/5), our Ivy repository has descriptors with extra meta information about the artifacts, resulting in an invalid descriptor from the perspective of the Ivy XML schema.

Here's a pull request that adds a new attribute to the Ivy repository configuration, `validateDescriptors`, that specifies whether the descriptors from that repository will be validated.

Any feedback is appreaciated!
