### PR TITLE
Exclude "special" versions from non-inclusive upper bound.

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
@@ -25,7 +25,7 @@ public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
 
     public VersionSelector parseSelector(String selectorString) {
         if (VersionRangeSelector.ALL_RANGE.matcher(selectorString).matches()) {
-            return new VersionRangeSelector(selectorString, versionComparator.asStringComparator());
+            return new VersionRangeSelector(selectorString, versionComparator.asVersionComparator(), new VersionParser());
         }
 
         if (selectorString.endsWith("+")) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
@@ -71,16 +71,18 @@ public class VersionRangeSelectorTest extends AbstractVersionSelectorTest {
         accept("[1.0,2.0]", "1.5-dev-1")
         accept("[1.0,2.0]", "1.2.3-rc-2")
         accept("[1.0,2.0]", "2.0-final")
+        accept("[1.0,2.0]", "2.0-SNAPSHOT")
 
         accept("[1.0-dev-1,2.0[", "1.0")
         accept("[1.0,2.0-rc-2[", "2.0-rc-1")
-        accept("[1.0,2.0[", "2.0-final")
 
         accept("]1.0-dev-1,2.0]", "1.0")
         accept("]1.0-rc-2,2.0]", "1.0-rc-3")
 
         accept("]1.0-dev-1,1.0-dev-3[", "1.0-dev-2")
         accept("]1.0-dev-1,1.0-rc-1[", "1.0-dev-99")
+        
+        accept("[1.0-SNAPSHOT,2.0]", "1.0-SNAPSHOT")
     }
 
     def "rejects candidate versions that don't fall into the selector's range"() {
@@ -130,6 +132,16 @@ public class VersionRangeSelectorTest extends AbstractVersionSelectorTest {
 
         !accept("]1.0-dev-1,1.0-dev-3[", "1.0-dev-3")
         !accept("]1.0-dev-1,1.0-rc-1[", "1.0-final-0")
+        
+        !accept("[1.0,2.0[", "2.0-SNAPSHOT")
+        !accept("[1.0,2.0)", "2.0-SNAPSHOT") // equivalent to '[1.0,2.0['
+        !accept("[1.0,2.0[", "2.0-dev-1")
+        !accept("[1.0,2.0)", "2.0-rc-1")
+        !accept("[1.0,2.0[", "2.0-final")
+        
+        !accept("[1.0,2.0)", "1.0-dev-1")
+        !accept("[1.0,2.0)", "1.0-rc-1")
+        !accept("[1.0,2.0)", "1.0-SNAPSHOT")
     }
 
     def "metadata-aware accept method delivers same results"() {
@@ -150,6 +162,6 @@ public class VersionRangeSelectorTest extends AbstractVersionSelectorTest {
 
     @Override
     VersionSelector getSelector(String selector) {
-        return new VersionRangeSelector(selector, new DefaultVersionComparator().asStringComparator())
+        return new VersionRangeSelector(selector, new DefaultVersionComparator().asVersionComparator(), new VersionParser())
     }
 }


### PR DESCRIPTION
Don't include versions that have not become the released version but are still greater than the rest of the range.

Version like 2.0-SNAPSHOT and 2.0-dev are greater than 1.X and less than 2.0.  By strict comparison they would fall within [1.0,2.0), meaning up to but not including 2.0, yet they are preparing for 2.0 so they should be excluded.