### PR TITLE
Use official SQ Runner API to avoid compatibility issues

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.sonar.runner.SonarRunnerRootExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.sonar.runner.SonarRunnerRootExtension.xml
@@ -25,10 +25,6 @@
                 </tr>
             </thead>
             <tr>
-                <td>toolVersion</td>
-                <td><literal>2.3</literal></td>
-            </tr>
-            <tr>
                 <td>forkOptions</td>
                 <td></td>
             </tr>

--- a/subprojects/sonar/sonar.gradle
+++ b/subprojects/sonar/sonar.gradle
@@ -22,6 +22,7 @@ repositories {
 
 dependencies {
     // TODO - Cleanup and remove old SonarPlugin
+    compile "org.codehaus.sonar.runner:sonar-runner-api:2.4@jar"
 
     compile project(":core")
     compile project(":plugins")

--- a/subprojects/sonar/src/main/groovy/org/gradle/sonar/runner/SonarRunnerExtension.java
+++ b/subprojects/sonar/src/main/groovy/org/gradle/sonar/runner/SonarRunnerExtension.java
@@ -52,7 +52,6 @@ import org.gradle.listener.ActionBroadcast;
 @Incubating
 public class SonarRunnerExtension {
 
-    public static final String SONAR_RUNNER_CONFIGURATION_NAME = "sonarRunner";
     public static final String SONAR_RUNNER_EXTENSION_NAME = "sonarRunner";
     public static final String SONAR_RUNNER_TASK_NAME = "sonarRunner";
 

--- a/subprojects/sonar/src/main/groovy/org/gradle/sonar/runner/SonarRunnerRootExtension.java
+++ b/subprojects/sonar/src/main/groovy/org/gradle/sonar/runner/SonarRunnerRootExtension.java
@@ -29,8 +29,6 @@ import org.gradle.process.JavaForkOptions;
  * Example usage:
  * <pre autoTested=''>
  * sonarRunner {
- *   toolVersion = '2.3' // default
- *
  *   forkOptions {
  *     maxHeapSize = '1024m'
  *     jvmArgs '-XX:MaxPermSize=128m'
@@ -40,14 +38,6 @@ import org.gradle.process.JavaForkOptions;
  */
 public class SonarRunnerRootExtension extends SonarRunnerExtension {
 
-    /**
-     * The version of Sonar Runner used if another version was not specified with {@link #setToolVersion(String)}.
-     * <p>
-     * Value: {@value}
-     */
-    public static final String DEFAULT_SONAR_RUNNER_VERSION = "2.3"; // IMPORTANT: if updating this, update the DSL doc.
-
-    private String toolVersion = DEFAULT_SONAR_RUNNER_VERSION;
     private JavaForkOptions forkOptions;
 
     public SonarRunnerRootExtension(ActionBroadcast<SonarProperties> propertiesActions) {
@@ -61,20 +51,6 @@ public class SonarRunnerRootExtension extends SonarRunnerExtension {
      */
     public void forkOptions(Action<? super JavaForkOptions> action) {
         action.execute(forkOptions);
-    }
-
-    /**
-     * Version of Sonar Runner JARs to use.
-     * <p>
-     * Defaults to {@code 2.3}.
-     */
-    // IMPORTANT: update above if DEFAULT_SONAR_RUNNER_VERSION changes
-    public String getToolVersion() {
-        return toolVersion;
-    }
-
-    public void setToolVersion(String toolVersion) {
-        this.toolVersion = toolVersion;
     }
 
     /**

--- a/subprojects/sonar/src/main/groovy/org/gradle/sonar/runner/plugins/SonarRunnerPlugin.java
+++ b/subprojects/sonar/src/main/groovy/org/gradle/sonar/runner/plugins/SonarRunnerPlugin.java
@@ -24,10 +24,6 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.gradle.api.*;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.DependencySet;
-import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.plugins.JavaBasePlugin;
@@ -96,7 +92,6 @@ public class SonarRunnerPlugin implements Plugin<Project> {
             }
         });
         SonarRunnerRootExtension rootExtension = project.getExtensions().create(SonarRunnerExtension.SONAR_RUNNER_EXTENSION_NAME, SonarRunnerRootExtension.class, actionBroadcast);
-        addConfiguration(project, rootExtension);
         rootExtension.setForkOptions(sonarRunnerTask.getForkOptions());
     }
 
@@ -199,8 +194,6 @@ public class SonarRunnerPlugin implements Plugin<Project> {
             // prefix subproject keys with parent key, even if subproject keys are set explicitly.
             // Therefore it's better to rely on Sonar's defaults.
             properties.put("sonar.projectKey", getProjectKey(project));
-            properties.put("sonar.environment.information.key", "Gradle");
-            properties.put("sonar.environment.information.version", project.getGradle().getGradleVersion());
             properties.put("sonar.working.directory", new File(project.getBuildDir(), "sonar"));
         }
 
@@ -319,23 +312,6 @@ public class SonarRunnerPlugin implements Plugin<Project> {
         } else {
             return value.toString();
         }
-    }
-
-    private void addConfiguration(final Project project, final SonarRunnerRootExtension rootExtension) {
-        final Configuration configuration = project.getConfigurations().create(SonarRunnerExtension.SONAR_RUNNER_CONFIGURATION_NAME);
-        configuration
-                .setVisible(false)
-                .setTransitive(false)
-                .setDescription("The SonarRunner configuration to use to run analysis")
-                .whenEmpty(new Action<DependencySet>() {
-                    @Override
-                    public void execute(DependencySet dependencies) {
-                        String toolVersion = rootExtension.getToolVersion();
-                        DependencyHandler dependencyHandler = project.getDependencies();
-                        Dependency dependency = dependencyHandler.create("org.codehaus.sonar.runner:sonar-runner-dist:" + toolVersion);
-                        dependencies.add(dependency);
-                    }
-                });
     }
 
     private static void evaluateSonarPropertiesBlocks(ActionBroadcast<? super SonarProperties> propertiesActions, Map<String, Object> properties) {

--- a/subprojects/sonar/src/main/groovy/org/gradle/sonar/runner/tasks/SonarRunner.java
+++ b/subprojects/sonar/src/main/groovy/org/gradle/sonar/runner/tasks/SonarRunner.java
@@ -27,7 +27,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.DefaultJavaForkOptions;
-import org.gradle.process.internal.JavaExecHandleBuilder;
 import org.gradle.process.internal.streams.SafeStreams;
 import org.gradle.util.GUtil;
 import org.sonar.runner.api.ForkedRunner;

--- a/subprojects/sonar/src/test/groovy/org/gradle/sonar/runner/plugins/SonarRunnerPluginTest.groovy
+++ b/subprojects/sonar/src/test/groovy/org/gradle/sonar/runner/plugins/SonarRunnerPluginTest.groovy
@@ -109,12 +109,12 @@ class SonarRunnerPluginTest extends Specification {
         properties["sonar.dynamicAnalysis"] == "reuseReports"
 
         and:
-        properties["child.sonar.sources"] == ""
-        properties["child.sonar.projectName"] == "child"
-        properties["child.sonar.projectDescription"] == "description"
-        properties["child.sonar.projectVersion"] == "1.3"
-        properties["child.sonar.projectBaseDir"] == childProject.projectDir as String
-        properties["child.sonar.dynamicAnalysis"] == "reuseReports"
+        properties["group:child.sonar.sources"] == ""
+        properties["group:child.sonar.projectName"] == "child"
+        properties["group:child.sonar.projectDescription"] == "description"
+        properties["group:child.sonar.projectVersion"] == "1.3"
+        properties["group:child.sonar.projectBaseDir"] == childProject.projectDir as String
+        properties["group:child.sonar.dynamicAnalysis"] == "reuseReports"
     }
 
     def "adds additional default properties for target project"() {
@@ -126,10 +126,10 @@ class SonarRunnerPluginTest extends Specification {
         properties["sonar.working.directory"] == new File(parentProject.buildDir, "sonar") as String
 
         and:
-        !properties.containsKey("child.sonar.projectKey") // default left to Sonar
-        !properties.containsKey("child.sonar.environment.information.key")
-        !properties.containsKey("child.sonar.environment.information.version")
-        !properties.containsKey('child.sonar.working.directory')
+        !properties.containsKey("group:child.sonar.projectKey") // default left to Sonar
+        !properties.containsKey("group:child.sonar.environment.information.key")
+        !properties.containsKey("group:child.sonar.environment.information.version")
+        !properties.containsKey('group:child.sonar.working.directory')
     }
 
     def "defaults projectKey to project.name if project.group isn't set"() {
@@ -156,8 +156,8 @@ class SonarRunnerPluginTest extends Specification {
         then:
         properties["sonar.java.source"] == "1.5"
         properties["sonar.java.target"] == "1.6"
-        properties["child.sonar.java.source"] == "1.6"
-        properties["child.sonar.java.target"] == "1.7"
+        properties["group:child.sonar.java.source"] == "1.6"
+        properties["group:child.sonar.java.target"] == "1.7"
     }
 
     def "adds additional default properties for 'java' projects"() {
@@ -215,9 +215,9 @@ class SonarRunnerPluginTest extends Specification {
 
         then:
         properties["sonar.sources"] == ""
-        properties["child.sonar.sources"] == ""
-        properties["child2.sonar.sources"] == ""
-        properties["child.leaf.sonar.sources"] == ""
+        properties["group:child.sonar.sources"] == ""
+        properties["group:child2.sonar.sources"] == ""
+        properties["group:child.group:leaf.sonar.sources"] == ""
     }
 
     def "allows to configure Sonar properties via 'sonarRunner' extension"() {
@@ -244,8 +244,8 @@ class SonarRunnerPluginTest extends Specification {
         def properties = parentSonarRunnerTask().sonarProperties
 
         then:
-        properties["child.sonar.some.key"] == "other value"
-        properties["child.leaf.sonar.some.key"] == "other value"
+        properties["group:child.sonar.some.key"] == "other value"
+        properties["group:child.group:leaf.sonar.some.key"] == "other value"
     }
 
     def "adds 'modules' properties declaring (prefixes of) subprojects"() {
@@ -253,10 +253,10 @@ class SonarRunnerPluginTest extends Specification {
         def properties = parentSonarRunnerTask().sonarProperties
 
         then:
-        properties["sonar.modules"] == "child,child2"
-        properties["child.sonar.modules"] == "leaf"
-        !properties.containsKey("child2.sonar.modules")
-        !properties.containsKey("child.leaf.sonar.modules")
+        properties["sonar.modules"] == "group:child,group:child2"
+        properties["group:child.sonar.modules"] == "group:leaf"
+        !properties.containsKey("group:child2.sonar.modules")
+        !properties.containsKey("group:child.group:leaf.sonar.modules")
     }
 
     def "handles 'modules' properties correctly if plugin is applied to root project"() {
@@ -271,10 +271,10 @@ class SonarRunnerPluginTest extends Specification {
         def properties = rootProject.tasks.sonarRunner.sonarProperties
 
         then:
-        properties["sonar.modules"] == "parent,parent2"
-        properties["parent.sonar.modules"] == "child"
-        !properties.containsKey("parent2.sonar.modules")
-        !properties.containsKey("parent.child.sonar.modules")
+        properties["sonar.modules"] == "root:parent,root:parent2"
+        properties["root:parent.sonar.modules"] == "root.parent:child"
+        !properties.containsKey("root:parent2.sonar.modules")
+        !properties.containsKey("root:parent.root.parent:child.sonar.modules")
 
     }
 
@@ -327,6 +327,7 @@ class SonarRunnerPluginTest extends Specification {
     def "allows to set Sonar properties for target project via 'sonar.xyz' system properties"() {
         System.setProperty("sonar.some.key", "some value")
         System.setProperty("sonar.projectVersion", "3.2")
+        System.setProperty("sonarRunner.dumpToFile", "out.txt")
 
         when:
         def properties = parentSonarRunnerTask().sonarProperties
@@ -334,10 +335,11 @@ class SonarRunnerPluginTest extends Specification {
         then:
         properties["sonar.some.key"] == "some value"
         properties["sonar.projectVersion"] == "3.2"
+        properties["sonarRunner.dumpToFile"] == "out.txt"
 
         and:
-        !properties.containsKey("child.sonar.some.key")
-        properties["child.sonar.projectVersion"] == "1.3"
+        !properties.containsKey("group:child.sonar.some.key")
+        properties["group:child.sonar.projectVersion"] == "1.3"
     }
 
     def "handles system properties correctly if plugin is applied to root project"() {
@@ -357,8 +359,8 @@ class SonarRunnerPluginTest extends Specification {
         properties["sonar.projectVersion"] == "3.2"
 
         and:
-        !properties.containsKey("parent.sonar.some.key")
-        properties["parent.sonar.projectVersion"] == "1.3"
+        !properties.containsKey("group:parent.sonar.some.key")
+        properties["root:parent.sonar.projectVersion"] == "1.3"
     }
 
     def "system properties win over values set in build script"() {

--- a/subprojects/sonar/src/test/groovy/org/gradle/sonar/runner/plugins/SonarRunnerPluginTest.groovy
+++ b/subprojects/sonar/src/test/groovy/org/gradle/sonar/runner/plugins/SonarRunnerPluginTest.groovy
@@ -22,8 +22,6 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.TaskDependencyMatchers
 import org.gradle.internal.jvm.Jvm
 import org.gradle.process.JavaForkOptions
-import org.gradle.process.internal.DefaultJavaForkOptions
-import org.gradle.process.internal.JavaExecHandleBuilder
 import org.gradle.sonar.runner.SonarRunnerExtension
 import org.gradle.sonar.runner.SonarRunnerRootExtension
 import org.gradle.sonar.runner.tasks.SonarRunner
@@ -125,8 +123,6 @@ class SonarRunnerPluginTest extends Specification {
 
         then:
         properties["sonar.projectKey"] == "group:parent"
-        properties["sonar.environment.information.key"] == "Gradle"
-        properties["sonar.environment.information.version"] == parentProject.gradle.gradleVersion
         properties["sonar.working.directory"] == new File(parentProject.buildDir, "sonar") as String
 
         and:
@@ -388,17 +384,6 @@ class SonarRunnerPluginTest extends Specification {
         !properties.any { key, value -> key.startsWith("child.sonar.") }
     }
 
-    def "sets default fork options correctly"() {
-
-        when:
-        JavaForkOptions forkOptions = parentSonarRunnerTask().forkOptions
-        SonarRunnerRootExtension rootExtension = parentProject.extensions.sonarRunner
-
-        then:
-        forkOptions instanceof DefaultJavaForkOptions
-        rootExtension.toolVersion == '2.3'
-    }
-
     def "root extension can configure task fork options"() {
 
         parentProject.sonarRunner {
@@ -416,30 +401,8 @@ class SonarRunnerPluginTest extends Specification {
         forkOptions.allJvmArgs.contains('-XX:MaxPermSize=128m')
     }
 
-    def "sonar java process is configured properly"() {
-
-        when:
-        JavaExecHandleBuilder handleBuilder = parentSonarRunnerTask().prepareExec()
-
-        then:
-        handleBuilder.main == 'org.sonar.runner.Main'
-        handleBuilder.classpath.files*.name.contains("sonar-runner-dist-2.3.jar")
-    }
-
     private SonarRunner parentSonarRunnerTask() {
         parentProject.tasks.sonarRunner as SonarRunner
     }
 
-    def "can choose sonar runner version"() {
-
-        parentProject.sonarRunner {
-            toolVersion = '2.4'
-        }
-
-        when:
-        JavaExecHandleBuilder handleBuilder = parentSonarRunnerTask().prepareExec()
-
-        then:
-        handleBuilder.classpath.files*.name.contains("sonar-runner-dist-2.4.jar")
-    }
 }


### PR DESCRIPTION
- org.codehaus.sonar.runner:sonar-runner-dist is not an API so even if the ability to choose version of SQ Runner is applealing there is no garantee that future version will remain compatible
- use official entry point ForkedRunner
- remove ability to choose version of SQ Runner