### PR TITLE
Wrapper: Allow SHA-256 verification of the downloaded gradle version

### DIFF
--- a/subprojects/docs/src/docs/userguide/gradleWrapper.xml
+++ b/subprojects/docs/src/docs/userguide/gradleWrapper.xml
@@ -89,6 +89,18 @@
         <para>If you build via the wrapper, any existing Gradle distribution installed on the machine is ignored.
         </para>
     </section>
+    <section id='sec:verification'>
+        <title>Verification of downloaded Gradle distributions</title>
+        <para>The Gradle Wrapper allows for verification of the downloaded Gradle distribution via SHA-256 hash sum comparison. 
+            This raises the security against targetted attacks by preventing a man-in-the-middle attacker from injecting a different gradle distrubution for you.
+        </para>
+        <para>
+            To enable this feature, download your gradle distribution manually and calculate the SHA-256 hash sum of it, e.g.,
+            via <command>sha256sum gradle-2.3-bin.zip</command>.
+            Add the returned hash sum to <literal>gradle-wrapper.properties</literal> using the <literal>distributionSha256Sum</literal> property, e.g.,
+            <literal>distributionSha256Sum=010dd9f31849abc3d5644e282943b1c1c355f8e2635c5789833979ce590a3774</literal>
+        </para>
+    </section>
     <section id='sec:unix_file_permissions'>
         <title>Unix file permissions</title>
         <para>The Wrapper task adds appropriate file permissions to allow the execution of the <literal>gradlew</literal> *NIX command.

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -121,7 +121,7 @@ public class Install {
                         + " via SHA-256 hash sum comparison failed! This is a serious problem,"
                         + " it means that you retrieved a different gradle distribution zip than expected."
                         + " Please inform the maintainer!"
-                        + "You can try to delete the cached gradle distribtion at " +
+                        + "You can try to delete the cached gradle distribtion at "
                         + distDir.getAbsolutePath()
                         + " and try again.");
             }

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -22,6 +22,8 @@ import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import java.security.MessageDigest;
+import java.security.SignatureException;
 
 public class Install {
     public static final String DEFAULT_DISTRIBUTION_PATH = "wrapper/dists";
@@ -38,6 +40,7 @@ public class Install {
 
     public File createDist(WrapperConfiguration configuration) throws Exception {
         final URI distributionUrl = configuration.getDistribution();
+        final String distributionSha256Sum = configuration.getDistributionSha256Sum();
 
         final PathAssembler.LocalDistribution localDistribution = pathAssembler.getDistribution(configuration);
         final File distDir = localDistribution.getDistributionDir();
@@ -47,7 +50,8 @@ public class Install {
             public File call() throws Exception {
                 final File markerFile = new File(localZipFile.getParentFile(), localZipFile.getName() + ".ok");
                 if (distDir.isDirectory() && markerFile.isFile()) {
-                    return getDistributionRoot(distDir, distDir.getAbsolutePath());
+                    return getAndVerifyDistributionRoot(localZipFile, distributionSha256Sum,
+                            distDir, distDir.getAbsolutePath());
                 }
 
                 boolean needsDownload = !localZipFile.isFile();
@@ -68,7 +72,8 @@ public class Install {
                 logger.log("Unzipping " + localZipFile.getAbsolutePath() + " to " + distDir.getAbsolutePath());
                 unzip(localZipFile, distDir);
 
-                File root = getDistributionRoot(distDir, distributionUrl.toString());
+                File root = getAndVerifyDistributionRoot(localZipFile, distributionSha256Sum,
+                        distDir, distributionUrl.toString());
                 setExecutablePermissions(root);
                 markerFile.createNewFile();
 
@@ -77,7 +82,48 @@ public class Install {
         });
     }
 
-    private File getDistributionRoot(File distDir, String distributionDescription) {
+    private String calculateSha256Sum(File file)
+            throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        InputStream fis = new FileInputStream(file);
+        int n = 0;
+        byte[] buffer = new byte[4096];
+        while (n != -1) {
+            n = fis.read(buffer);
+            if (n > 0) {
+                md.update(buffer, 0, n);
+            }
+        }
+        byte byteData[] = md.digest();
+
+        StringBuffer hexString = new StringBuffer();
+        for (int i=0; i < byteData.length; i++) {
+            String hex=Integer.toHexString(0xff & byteData[i]);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+
+        return hexString.toString();
+    }
+
+    private File getAndVerifyDistributionRoot(File localZipFile, String distributionSha256Sum,
+                                              File distDir, String distributionDescription)
+            throws Exception {
+        // check SHA-256 checksum verification
+        if (distributionSha256Sum != null) {
+            logger.log("Verifying " + localZipFile.getName());
+
+            if (!distributionSha256Sum.equals(calculateSha256Sum(localZipFile))) {
+                deleteDir(distDir);
+                throw new SignatureException("SHA-256 sum verification failed for "
+                        + localZipFile.getName()
+                        + ". The cache has been deleted, try re-building! "
+                        + "If this problem persists, inform the project maintainer!");
+            }
+        }
+
         List<File> dirs = listDirs(distDir);
         if (dirs.isEmpty()) {
             throw new RuntimeException(String.format("Gradle distribution '%s' does not contain any directories. Expected to find exactly 1 directory.", distributionDescription));

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -111,16 +111,19 @@ public class Install {
     private File getAndVerifyDistributionRoot(File localZipFile, String distributionSha256Sum,
                                               File distDir, String distributionDescription)
             throws Exception {
-        // check SHA-256 checksum verification
+        // if a SHA-256 hash sum has been defined in gradle-wrapper.properties, verify it here
         if (distributionSha256Sum != null) {
-            logger.log("Verifying " + localZipFile.getName());
+            logger.log("Verifying " + localZipFile.getName() + " via SHA-256 hash sum comparison.");
 
             if (!distributionSha256Sum.equals(calculateSha256Sum(localZipFile))) {
-                deleteDir(distDir);
-                throw new SignatureException("SHA-256 sum verification failed for "
+                throw new SignatureException("Verification of "
                         + localZipFile.getName()
-                        + ". The cache has been deleted, try re-building! "
-                        + "If this problem persists, inform the project maintainer!");
+                        + " via SHA-256 hash sum comparison failed! This is a serious problem,"
+                        + " it means that you retrieved a different gradle distribution zip than expected."
+                        + " Please inform the maintainer!"
+                        + "You can try to delete the cached gradle distribtion at " +
+                        + distDir.getAbsolutePath()
+                        + " and try again.");
             }
         }
 

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
@@ -21,6 +21,7 @@ public class WrapperConfiguration {
     private URI distribution;
     private String distributionBase = PathAssembler.GRADLE_USER_HOME_STRING;
     private String distributionPath = Install.DEFAULT_DISTRIBUTION_PATH;
+    private String distributionSha256Sum;
     private String zipBase = PathAssembler.GRADLE_USER_HOME_STRING;
     private String zipPath = Install.DEFAULT_DISTRIBUTION_PATH;
 
@@ -46,6 +47,14 @@ public class WrapperConfiguration {
 
     public void setDistributionPath(String distributionPath) {
         this.distributionPath = distributionPath;
+    }
+
+    public String getDistributionSha256Sum() {
+        return distributionSha256Sum;
+    }
+
+    public void setDistributionSha256Sum(String distributionSha256Sum) {
+        this.distributionSha256Sum = distributionSha256Sum;
     }
 
     public String getZipBase() {

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
@@ -27,8 +27,9 @@ import java.util.Properties;
 public class WrapperExecutor {
     public static final String DISTRIBUTION_URL_PROPERTY = "distributionUrl";
     public static final String DISTRIBUTION_BASE_PROPERTY = "distributionBase";
-    public static final String ZIP_STORE_BASE_PROPERTY = "zipStoreBase";
     public static final String DISTRIBUTION_PATH_PROPERTY = "distributionPath";
+    public static final String DISTRIBUTION_SHA_256_SUM = "distributionSha256Sum";
+    public static final String ZIP_STORE_BASE_PROPERTY = "zipStoreBase";
     public static final String ZIP_STORE_PATH_PROPERTY = "zipStorePath";
     private final Properties properties;
     private final File propertiesFile;
@@ -56,6 +57,7 @@ public class WrapperExecutor {
                 config.setDistribution(prepareDistributionUri());
                 config.setDistributionBase(getProperty(DISTRIBUTION_BASE_PROPERTY, config.getDistributionBase()));
                 config.setDistributionPath(getProperty(DISTRIBUTION_PATH_PROPERTY, config.getDistributionPath()));
+                config.setDistributionSha256Sum(getProperty(DISTRIBUTION_SHA_256_SUM, config.getDistributionSha256Sum(), false));
                 config.setZipBase(getProperty(ZIP_STORE_BASE_PROPERTY, config.getZipBase()));
                 config.setZipPath(getProperty(ZIP_STORE_PATH_PROPERTY, config.getZipPath()));
             } catch (Exception e) {
@@ -128,10 +130,14 @@ public class WrapperExecutor {
     }
 
     private String getProperty(String propertyName) {
-        return getProperty(propertyName, null);
+        return getProperty(propertyName, null, true);
     }
 
     private String getProperty(String propertyName, String defaultValue) {
+        return getProperty(propertyName, defaultValue, true);
+    }
+
+    private String getProperty(String propertyName, String defaultValue, boolean required) {
         String value = properties.getProperty(propertyName);
         if (value != null) {
             return value;
@@ -139,7 +145,11 @@ public class WrapperExecutor {
         if (defaultValue != null) {
             return defaultValue;
         }
-        return reportMissingProperty(propertyName);
+        if (required) {
+            return reportMissingProperty(propertyName);
+        } else {
+            return null;
+        }
     }
 
     private String reportMissingProperty(String propertyName) {


### PR DESCRIPTION
Allow SHA-256 verification of the downloaded gradle version. This is similar to what can be done via the gradle-witness plugin for Maven dependencies [0] but for the gradle wrapper itself. To use this functionality do a sha256sum gradle-2.3-bin.zip and add the resulting hash to gradle-wrapper.properties, e.g., distributionSha256Sum=010dd9f31849abc3d5644e282943b1c1c355f8e2635c5789833979ce590a3774

I explicitly put this code into public domain to avoid signing the CLA.

[0] https://github.com/WhisperSystems/gradle-witness