### PR TITLE
Port to Takari Polyglot 0.1.8

### DIFF
--- a/subprojects/maven/maven.gradle
+++ b/subprojects/maven/maven.gradle
@@ -24,8 +24,8 @@ dependencies {
     compile libraries.slf4j_api
 
     compile libraries.maven3
-    compile "org.sonatype.pmaven:pmaven-common:0.8-20100325@jar"
-    compile "org.sonatype.pmaven:pmaven-groovy:0.8-20100325@jar"
+    compile "io.takari.polyglot:polyglot-common:0.1.8@jar"
+    compile "io.takari.polyglot:polyglot-groovy:0.1.8@jar"
     compile "org.codehaus.plexus:plexus-component-annotations:1.5.2@jar"
 
     testCompile libraries.xmlunit


### PR DESCRIPTION
Use Takari Polyglot instead of Sonatype Polyglot Maven.

Despite seemingly lower version, Takari Polyglot is replacement for Sonatype Polyglot Maven, which is not developed any longer.