### PR TITLE
Add test coverage enforcement to JaCoCo plugin

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
@@ -45,6 +45,9 @@
             <tr>
                 <td>applyTo</td>
             </tr>
+            <tr>
+                <td>threshold</td>
+            </tr>
         </table>
     </section>
 </section>

--- a/subprojects/docs/src/docs/userguide/jacocoPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/jacocoPlugin.xml
@@ -65,6 +65,27 @@
             </tr>
         </table>
     </section>
+
+    <section>
+        <title>Enforcing minimum code coverage requirements</title>
+        <para>
+            The <literal>jacocoTestReport</literal> task generates coverage reports without enforcing minimum coverage
+            requirements. Conversely, the <literal>jacocoTestReportCheckCoverage</literal> task succeeds if and only if
+            the code coverage results satisfy a set of configurable minimum code coverage thresholds. The
+            <literal>jacocoTestReportCheckCoverage</literal> task is a dependency for the standard
+            <literal>check</literal> task; consequently, the <literal>build</literal> task can only succeed if the
+            coverage requirements are satisfied.
+
+            Code coverage requirements can be specified for a project as a whole, for individual files, and for
+            particular JaCoCo-specific types of coverage, e.g., lines covered or branches covered. The following example
+            describes the syntax.
+        </para>
+
+        <sample id="configJacoco" dir="testing/jacoco/quickstart" title="Enforcing minimum code coverage requirements">
+            <sourcefile file="build.gradle" snippet="jacoco-thresholds"/>
+        </sample>
+    </section>
+
     <section>
         <title>JaCoCo Report configuration</title>
         <para>The

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
@@ -28,6 +28,24 @@ jacoco {
 }
 // END SNIPPET jacoco-configuration
 
+// START SNIPPET jacoco-thresholds
+jacoco {
+    // Minimum code coverage of 50% across all files and coverage types.
+    threshold 0.5
+
+    // Minimum 'branch' coverage of 30% across all files.
+    // Available coverage types: BRANCH, CLASS, COMPLEXITY, INSTRUCTION, LINE, METHOD.
+    threshold 0.3, BRANCH
+
+    // Minimum 'line' coverage of 10% for any file (in any directory) whose name matches the given regular expression.
+    threshold 0.1, LINE, ~"P.*\\.java"
+
+    // Minimum 'line' coverage of 10% for files named "Person.java" (case-sensitive, in any directory).
+    // (Note: This syntax uses exact string match against the file name while the regex syntax requires escaping.)
+    threshold 0.1, LINE, "Person.java"
+}
+// END SNIPPET jacoco-thresholds
+
 repositories {
     mavenCentral()
 }

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Project
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.testing.jacoco.testutils.TestData
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
@@ -42,7 +43,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
                 testCompile 'junit:junit:4.12'
             }
         """
-        createTestFiles()
+        TestData.createTestFiles(this)
     }
 
     def "dependencies report shows default jacoco dependencies"() {
@@ -79,7 +80,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
         file(REPORT_HTML_DEFAULT_PATH).exists()
         file("${REPORTING_BASE}/jacoco/test").listFiles().collect { it.name } == ["html"]
         file("${REPORTING_BASE}/jacoco/test/html/org.gradle/Class1.java.html").exists()
-        htmlReport().totalCoverage() == 100
+        htmlReport().totalCoverage() == 71
     }
 
     void canConfigureReportsInJacocoTestReport() {
@@ -98,7 +99,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
         succeeds('test', 'jacocoTestReport')
 
         then:
-        htmlReport("build/jacocoHtml").totalCoverage() == 100
+        htmlReport("build/jacocoHtml").totalCoverage() == 71
         file(REPORT_XML_DEFAULT_PATH).exists()
         file(REPORT_CSV_DEFAULT_REPORT).exists()
     }
@@ -118,7 +119,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
         succeeds('test', 'jacocoTestReport')
 
         then:
-        htmlReport("build/customReports/jacoco/test/html").totalCoverage() == 100
+        htmlReport("build/customReports/jacoco/test/html").totalCoverage() == 71
         file("build/customReports/jacoco/test/jacocoTestReport.xml").exists()
         file("build/customReports/jacoco/test/jacocoTestReport.csv").exists()
     }
@@ -140,7 +141,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
         succeeds('test', 'jacocoTestReport')
 
         then:
-        htmlReport("build/${customReportDirectory}/test/html").totalCoverage() == 100
+        htmlReport("build/${customReportDirectory}/test/html").totalCoverage() == 71
         file("build/${customReportDirectory}/test/jacocoTestReport.xml").exists()
         file("build/${customReportDirectory}/test/jacocoTestReport.csv").exists()
     }
@@ -198,7 +199,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedTasks.contains(":jacocoTestReport")
-        htmlReport().totalCoverage() == 100
+        htmlReport().totalCoverage() == 71
     }
 
     @IgnoreIf({GradleContextualExecuter.parallel})
@@ -250,7 +251,7 @@ public class ThingTest {
         ":test" in nonSkippedTasks
         ":otherTests" in nonSkippedTasks
         file("build/jacoco/jacocoMerge.exec").exists()
-        htmlReport("build/reports/jacoco/mergedReport/html").totalCoverage() == 65
+        htmlReport("build/reports/jacoco/mergedReport/html").totalCoverage() == 58
     }
 
     @Issue("GRADLE-2917")
@@ -262,13 +263,6 @@ public class ThingTest {
 
     private JacocoReportFixture htmlReport(String basedir = "${REPORTING_BASE}/jacoco/test/html") {
         return new JacocoReportFixture(file(basedir))
-    }
-
-    private void createTestFiles() {
-        file("src/main/java/org/gradle/Class1.java") <<
-                "package org.gradle; public class Class1 { public boolean isFoo(Object arg) { return true; } }"
-        file("src/test/java/org/gradle/Class1Test.java") <<
-                "package org.gradle; import org.junit.Test; public class Class1Test { @Test public void someTest() { new Class1().isFoo(\"test\"); } }"
     }
 }
 

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoVersionIntegTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoVersionIntegTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.testing.jacoco.plugins
 
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
+import org.gradle.testing.jacoco.testutils.TestData
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Test
@@ -43,25 +44,18 @@ class JacocoVersionIntegTest extends MultiVersionIntegrationSpec {
             toolVersion = '$version'
         }
         """
-        createTestFiles();
+        TestData.createTestFiles(this)
 
         when:
         succeeds('test', 'jacocoTestReport')
 
         then:
         def report = htmlReport()
-        report.totalCoverage() == 100
+        report.totalCoverage() == 71
         report.jacocoVersion() == version
     }
 
     private JacocoReportFixture htmlReport(String basedir = "build/reports/jacoco/test/html") {
         return new JacocoReportFixture(file(basedir))
-    }
-
-    private void createTestFiles() {
-        file("src/main/java/org/gradle/Class1.java") <<
-                "package org.gradle; public class Class1 { public boolean isFoo(Object arg) { return true; } }"
-        file("src/test/java/org/gradle/Class1Test.java") <<
-                "package org.gradle; import org.junit.Test; public class Class1Test { @Test public void someTest() { new Class1().isFoo(\"test\"); } }"
     }
 }

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/tasks/coverage/JacocoPluginCheckCoverageIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/tasks/coverage/JacocoPluginCheckCoverageIntegrationTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.tasks.coverage
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.testing.jacoco.testutils.TestData
+
+class JacocoPluginCheckCoverageIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        buildFile << """
+            apply plugin: "java"
+            apply plugin: "jacoco"
+
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                testCompile 'junit:junit:4.12'
+            }
+        """
+        TestData.createTestFiles(this)
+    }
+
+    void checkCoverageTaskRequiresXmlReport() {
+        when:
+        buildFile << """
+            jacoco {
+                threshold 0.0
+            }
+        """
+        then:
+        fails('test', 'jacocoTestReportCheckCoverage', '--info')
+        errorOutput.contains("Task jacocoTestReportCheckCoverage requires XML report in task jacocoTestReport")
+    }
+
+    void checkCoverageSucceedsWhenCoverageSufficient() {
+        when:
+        buildFile << """
+            jacoco {
+                threshold 0.0
+            }
+            jacocoTestReport.reports.xml.enabled true
+        """
+        then:
+        succeeds('test', 'jacocoTestReportCheckCoverage')
+    }
+
+    void checkCoverageFailsWhenCoverageInsufficient() {
+        when:
+        buildFile << """
+            jacoco {
+                threshold 1.0
+            }
+            jacocoTestReport.reports.xml.enabled true
+        """
+
+        then:
+        fails('test', 'jacocoTestReportCheckCoverage')
+    }
+
+    void checkTaskDependsOnCheckCoverageTask() {
+        when:
+        buildFile << """
+            jacoco {
+                threshold 1.0
+            }
+            jacocoTestReport.reports.xml.enabled true
+        """
+
+        then:
+        fails('check')
+    }
+}

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/testutils/TestData.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/testutils/TestData.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.testutils
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+public class TestData {
+    public static void createTestFiles(AbstractIntegrationSpec integrationSpec) {
+        integrationSpec.file("src/main/java/org/gradle/Class1.java") <<
+            "package org.gradle; public class Class1 { public boolean isFoo(Object arg) { return true; } public boolean bar() { if (1==0) return true; else return false; } }"
+        integrationSpec.file("src/test/java/org/gradle/Class1Test.java") <<
+            "package org.gradle; import org.junit.Test; public class Class1Test { @Test public void someTest() { new Class1().isFoo(\"test\"); } }"
+    }
+}
+

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/CoverageCounter.java
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/CoverageCounter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.tasks.coverage;
+
+/**
+ * A POJO that counts the number of covered and missed Jacoco observations.
+ */
+public class CoverageCounter {
+    public final int covered;
+    public final int missed;
+
+    CoverageCounter(int covered, int missed) {
+        this.covered = covered;
+        this.missed = missed;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Covered: %d, Missed: %d", covered, missed);
+    }
+}

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/CoverageType.java
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/CoverageType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.tasks.coverage;
+
+/**
+ * An enumeration of the coverage types used in Jacoco's XML reports.
+ */
+public enum CoverageType {
+    BRANCH,
+    CLASS,
+    COMPLEXITY,
+    INSTRUCTION,
+    LINE,
+    METHOD
+}
+

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/CoverageViolation.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/CoverageViolation.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.tasks.coverage
+
+/**
+ * A coverage violation observed for the given {@code clazz}.
+ */
+public class CoverageViolation {
+    String cls
+    double threshold
+    CoverageType type
+    int covered
+    int total
+
+    public CoverageViolation(String clazz, double threshold, CoverageType type, int covered, int total) {
+        this.cls = clazz
+        this.threshold = threshold
+        this.type = type
+        this.covered = covered
+        this.total = total
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s (%d/%d %s coverage < %g)", cls, covered, total, type, threshold)
+    }
+}

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/JacocoCheckCoverage.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/JacocoCheckCoverage.groovy
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.tasks.coverage
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+import org.gradle.testing.jacoco.plugins.JacocoPlugin
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.w3c.dom.Document
+import org.w3c.dom.NamedNodeMap
+import org.xml.sax.SAXException
+
+import javax.xml.parsers.DocumentBuilder
+import javax.xml.parsers.DocumentBuilderFactory
+
+public class JacocoCheckCoverage extends DefaultTask {
+
+    private static final OrderBy<CoverageViolation> VIOLATION_ORDER =
+        new OrderBy([{ violation -> violation.cls }, { violation -> violation.type }])
+
+    /** The Jacoco coverage results for each file and coverage type; populated by {@link JacocoPlugin#apply}. */
+    Map<String, Map<CoverageType, CoverageCounter>> coverage
+
+    // Called by Gradle to when running this task.
+    @TaskAction
+    def verifyCoverage() {
+        JacocoPluginExtension extension = getProject().getExtensions().getByType(JacocoPluginExtension.class)
+        List<CoverageViolation> violations = applyRules(extension.coverageRules, coverage)
+        Collections.sort(violations, VIOLATION_ORDER)
+        if (!violations.isEmpty()) {
+            getLogger().quiet("Found the following Jacoco coverage violations")
+            for (CoverageViolation violation : violations) {
+                getLogger().quiet("{}", violation)
+            }
+            throw new GradleException("Coverage violations found")
+        }
+    }
+
+    /**
+     * Applies the given coverage rules to the observed code coverage observations and returns a list of violating observations.
+     */
+    static List<CoverageViolation> applyRules(List<Closure<Double>> rules,
+                                              Map<String, Map<CoverageType, CoverageCounter>> coverageObservations) {
+
+        List<CoverageViolation> violations = []
+        coverageObservations.each { clazz, clazzScores ->
+            clazzScores.each { coverageType, coverageCounter ->
+                def thresholds = rules
+                    .collect({ rule -> rule.call(coverageType, clazz) })
+                    .findAll({ threshold -> threshold <= 1.0 }) // Filter out any check requiring more than 100% coverage.
+
+                if (!thresholds.isEmpty()) {
+                    def minThreshold = thresholds.min()
+                    def total = coverageCounter.missed + coverageCounter.covered
+                    if (coverageCounter.covered < minThreshold * total) {
+                        violations.add(new CoverageViolation(
+                            clazz, minThreshold, coverageType, coverageCounter.covered, total))
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    /**
+     * Returns the Jacoco coverage results as a map <source file> -> (<coverage type> -> (covered cases, missed cases)).
+     */
+    static def Map<String, Map<CoverageType, CoverageCounter>> extractCoverageFromReport(InputStream jacocoXmlReport) {
+        def Map<String, Map<CoverageType, CoverageCounter>> coverage = new HashMap<>()
+        Document document = parseJacocoXmlReport(jacocoXmlReport)
+        document.getElementsByTagName("sourcefile").each({ sourceFile ->
+            String sourceFileName = sourceFile.getAttributes().getNamedItem("name").getNodeValue()
+            Map<CoverageType, CoverageCounter> submap =
+                coverage.get(sourceFileName, new EnumMap<>(CoverageType.class))
+            sourceFile.getChildNodes().each({ counter ->
+                if (counter.getNodeName().equals("counter")) {
+                    NamedNodeMap map = counter.getAttributes()
+                    CoverageType type = CoverageType.valueOf(map.getNamedItem("type").getNodeValue())
+                    submap[type] = new CoverageCounter(
+                        map.getNamedItem("covered").getNodeValue().toInteger(),
+                        map.getNamedItem("missed").getNodeValue().toInteger())
+                }
+            })
+        })
+
+        coverage
+    }
+
+    /**
+     * Parses the given Jacoco report into a DOM object and returns it.
+     */
+    static Document parseJacocoXmlReport(InputStream jacocoXmlReport) {
+        Document document
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance()
+            factory.setValidating(false)
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            factory.setFeature("http://xml.org/sax/features/namespaces", false)
+            DocumentBuilder documentBuilder = factory.newDocumentBuilder()
+            document = documentBuilder.parse(jacocoXmlReport)
+        } catch (SAXException | IOException e) {
+            throw new RuntimeException("Failed to parse Jacoco XML report", e)
+        }
+
+        document
+    }
+}

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/package-info.java
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/coverage/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tasks to enforce JaCoCo minimum coverage.
+ */
+package org.gradle.testing.jacoco.tasks.coverage;

--- a/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/tasks/coverage/JacocoCheckCoverageTest.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/tasks/coverage/JacocoCheckCoverageTest.groovy
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.tasks.coverage
+
+import com.google.common.io.Resources
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.hamcrest.Matchers
+import org.junit.Assert
+import spock.lang.Specification
+
+class JacocoCheckCoverageTest extends Specification {
+
+    def getSampleCoverage() {
+        def report = Resources.asByteSource(JacocoCheckCoverageTest.class.getResource("/jacocoTestReport.xml"))
+        JacocoCheckCoverage.extractCoverageFromReport(report.openBufferedStream())
+    }
+
+    def "Parses sample Jacoco XML Report correctly"() {
+        when: "A report XML file is parsed"
+        def coverage = getSampleCoverage()
+        then:
+        Assert.assertNotNull(coverage)
+        Assert.assertThat(coverage.keySet(), Matchers.containsInAnyOrder("AnotherClass.java", "DummyClass.java"))
+        Assert.assertThat(coverage.get("AnotherClass.java").keySet(), Matchers.containsInAnyOrder(CoverageType.INSTRUCTION,
+            CoverageType.LINE, CoverageType.COMPLEXITY, CoverageType.METHOD, CoverageType.CLASS))
+
+        // Spot-check some extracted numbers.
+        Assert.assertEquals(7, coverage.get("DummyClass.java").get(CoverageType.INSTRUCTION).covered)
+        Assert.assertEquals(3, coverage.get("DummyClass.java").get(CoverageType.INSTRUCTION).missed)
+    }
+
+    def "No rules imply no violations"() {
+        setup: "Empty rule set and non-empty coverage provided"
+        def rules = []
+        def coverage = getSampleCoverage()
+        when: "Rules are applied"
+        def violations = JacocoCheckCoverage.applyRules(rules, coverage)
+        then:
+        assert violations == []
+    }
+
+    def "When multiple rules fire, then the one with smaller threshold dominates"() {
+        setup: "Rule set and non-empty coverage provided"
+        JacocoPluginExtension extension = new JacocoPluginExtension(null, null)
+        extension.threshold(0.5)
+        extension.threshold(0.1, CoverageType.INSTRUCTION, "AnotherClass.java")
+        def rules = extension.coverageRules
+        def coverage = getSampleCoverage().findAll { clazz -> clazz.key == "AnotherClass.java" }
+        when: "Rules are applied"
+        def violations = JacocoCheckCoverage.applyRules(rules, coverage)
+        then:
+        assert violations.size() == 5
+        violations.each { violation ->
+            if (violation.type == CoverageType.INSTRUCTION) {
+                assert violation.threshold == 0.1
+            } else {
+                assert violation.threshold == 0.5
+            }
+        }
+    }
+
+    def "Coverage threshold are inclusive lower bound"() {
+        setup: "Rule set and non-empty coverage provided"
+        JacocoPluginExtension extension = new JacocoPluginExtension(null, null)
+        extension.threshold(0.3, CoverageType.INSTRUCTION, "DummyClass.java") // Coverage is exactly 3/(3+7).
+        when: "Rules are applied"
+        def violations = JacocoCheckCoverage.applyRules(extension.coverageRules, getSampleCoverage())
+        then:
+        assert violations.isEmpty()
+    }
+
+    def "Rules have no effect on coverage types and classes that they don't apply to"() {
+        // In particular, this check verifies that the "return 2.0" checks in JacocoPluginExtension#threshold are filtered out.
+        setup: "Rule set and non-empty coverage provided"
+        JacocoPluginExtension extension = new JacocoPluginExtension(null, null)
+        extension.threshold(0.0, CoverageType.INSTRUCTION, "AnotherClass.java")
+        when: "Rules are applied"
+        def violations = JacocoCheckCoverage.applyRules(extension.coverageRules, getSampleCoverage())
+        then:
+        assert violations.isEmpty()
+    }
+
+    def "A more specific rule with a higher threshold does not overrule a less specific one with smaller threshold"() {
+        setup: "Rule set and non-empty coverage provided"
+        JacocoPluginExtension extension = new JacocoPluginExtension(null, null)
+        extension.threshold(0.0)
+        extension.threshold(0.9, CoverageType.INSTRUCTION, "AnotherClass.java") // This rule would fail on its own.
+        when: "Rules are applied"
+        def violations = JacocoCheckCoverage.applyRules(extension.coverageRules, getSampleCoverage())
+        then:
+        assert violations.isEmpty()
+    }
+}

--- a/subprojects/jacoco/src/test/resources/jacocoTestReport.xml
+++ b/subprojects/jacoco/src/test/resources/jacocoTestReport.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.0//EN"
+        "report.dtd">
+<report name="baseline-config-test">
+    <sessioninfo id="dummy-session" start="1431629482388" dump="1431629483460"/>
+    <package name="org/somepackage">
+        <class name="org/somepackage/DummyClass">
+            <method name="&lt;init&gt;" desc="()V" line="3">
+                <counter type="INSTRUCTION" missed="3" covered="7"/>
+                <counter type="LINE" missed="1" covered="0"/>
+                <counter type="COMPLEXITY" missed="1" covered="0"/>
+                <counter type="METHOD" missed="1" covered="0"/>
+            </method>
+            <counter type="INSTRUCTION" missed="3" covered="0"/>
+            <counter type="LINE" missed="1" covered="0"/>
+            <counter type="COMPLEXITY" missed="1" covered="0"/>
+            <counter type="METHOD" missed="1" covered="0"/>
+            <counter type="CLASS" missed="1" covered="0"/>
+        </class>
+        <class name="org/somepackage/AnotherClass">
+            <method name="&lt;init&gt;" desc="()V" line="5">
+                <counter type="INSTRUCTION" missed="3" covered="0"/>
+                <counter type="LINE" missed="1" covered="0"/>
+                <counter type="COMPLEXITY" missed="1" covered="0"/>
+                <counter type="METHOD" missed="1" covered="0"/>
+            </method>
+            <method name="staticMethod" desc="()V" line="7">
+                <counter type="INSTRUCTION" missed="1" covered="0"/>
+                <counter type="LINE" missed="1" covered="0"/>
+                <counter type="COMPLEXITY" missed="1" covered="0"/>
+                <counter type="METHOD" missed="1" covered="0"/>
+            </method>
+            <counter type="INSTRUCTION" missed="4" covered="0"/>
+            <counter type="LINE" missed="2" covered="0"/>
+            <counter type="COMPLEXITY" missed="2" covered="0"/>
+            <counter type="METHOD" missed="2" covered="0"/>
+            <counter type="CLASS" missed="1" covered="0"/>
+        </class>
+        <sourcefile name="DummyClass.java">
+            <line nr="3" mi="3" ci="0" mb="0" cb="0"/>
+            <counter type="INSTRUCTION" missed="3" covered="7"/>
+            <counter type="LINE" missed="1" covered="0"/>
+            <counter type="COMPLEXITY" missed="1" covered="0"/>
+            <counter type="METHOD" missed="1" covered="0"/>
+            <counter type="CLASS" missed="1" covered="0"/>
+        </sourcefile>
+        <sourcefile name="AnotherClass.java">
+            <line nr="5" mi="3" ci="0" mb="0" cb="0"/>
+            <line nr="7" mi="1" ci="0" mb="0" cb="0"/>
+            <counter type="INSTRUCTION" missed="4" covered="0"/>
+            <counter type="LINE" missed="2" covered="0"/>
+            <counter type="COMPLEXITY" missed="2" covered="0"/>
+            <counter type="METHOD" missed="2" covered="0"/>
+            <counter type="CLASS" missed="1" covered="0"/>
+        </sourcefile>
+        <counter type="INSTRUCTION" missed="7" covered="0"/>
+        <counter type="LINE" missed="3" covered="0"/>
+        <counter type="COMPLEXITY" missed="3" covered="0"/>
+        <counter type="METHOD" missed="3" covered="0"/>
+        <counter type="CLASS" missed="2" covered="0"/>
+    </package>
+</report>


### PR DESCRIPTION
This commit adds optional configuration to the Jacoco plugin that allows
users to enforce minimum code coverage. For example,

    jacoco {
        threshold 0.5
        threshold 0.3, LINE
    }

requires every type (e.g., line, class, instructions, etc) of Jacoco coverage
to be above 50% and line coverage to be at least 30%.

Note that this functionality relies on the XML report being enabled.