### PR TITLE
Added check configuration, enforcement, inclusion/exclusion patterns for JaCoCo (GRADLE-2783)

### DIFF
--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/JacocoReport.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/JacocoReport.groovy
@@ -67,6 +67,8 @@ class JacocoReport extends JacocoBase implements Reporting<JacocoReportsContaine
     @Nested
     private final JacocoReportsContainerImpl reports
 
+    private Closure checkClosure
+
     JacocoReport() {
         reports = instantiator.newInstance(JacocoReportsContainerImpl, this)
         onlyIf { getExecutionData().every { it.exists() } } //TODO SF it should be 'any' instead of 'every'
@@ -80,6 +82,10 @@ class JacocoReport extends JacocoBase implements Reporting<JacocoReportsContaine
     @Inject
     protected IsolatedAntBuilder getAntBuilder() {
         throw new UnsupportedOperationException();
+    }
+
+    public void setCheck(Closure checkClosure) {
+        this.checkClosure = checkClosure
     }
 
     @TaskAction
@@ -106,6 +112,9 @@ class JacocoReport extends JacocoBase implements Reporting<JacocoReportsContaine
                 }
                 if(reports.csv.isEnabled()) {
                     csv(destfile: reports.csv.destination)
+                }
+                if(checkClosure!=null) {
+                    delegate.check checkClosure
                 }
             }
         }

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/JacocoReport.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/JacocoReport.groovy
@@ -159,7 +159,9 @@ class JacocoReport extends JacocoBase implements Reporting<JacocoReportsContaine
                 }
                 if (task.checkClosure!=null) {
                     def ch = delegate.check(task.checkClosure).getWrapper()
-                    if (!ignoreFailures) ch.setAttribute('violationsproperty',violationsProperty)
+                    if (!ignoreFailures) {
+                        ch.setAttribute('violationsproperty',violationsProperty)
+                    }
                     ch.setAttribute('failonviolation',false)
                 }
             }

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/JacocoReport.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/JacocoReport.groovy
@@ -129,7 +129,6 @@ class JacocoReport extends JacocoBase implements Reporting<JacocoReportsContaine
         patternSet.exclude(excludeSpec)
     }
 
-    @Override
     @TaskAction
     void generate() {
         def task = this

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/JacocoReport.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/tasks/JacocoReport.groovy
@@ -71,8 +71,10 @@ class JacocoReport extends JacocoBase implements Reporting<JacocoReportsContaine
     @Nested
     private final JacocoReportsContainerImpl reports
 
+    protected final PatternFilterable patternSet = new PatternSet()
+
     boolean ignoreFailure = false
-    protected final PatternFilterable patternSet = new PatternSet();
+
     private Closure checkClosure
 
     JacocoReport() {
@@ -94,14 +96,37 @@ class JacocoReport extends JacocoBase implements Reporting<JacocoReportsContaine
         this.checkClosure = checkClosure
     }
 
-    public void include(String... includes) { patternSet.include(includes); }
-    public void include(Iterable<String> includes) { patternSet.include(includes); }
-    public void include(Spec<FileTreeElement> includeSpec) { patternSet.include(includeSpec); }
-    public void include(Closure includeSpec) { patternSet.include(includeSpec); }
-    public void exclude(String... excludes) { patternSet.exclude(excludes); }
-    public void exclude(Iterable<String> excludes) { patternSet.exclude(excludes); }
-    public void exclude(Spec<FileTreeElement> excludeSpec) { patternSet.exclude(excludeSpec); }
-    public void exclude(Closure excludeSpec) { patternSet.exclude(excludeSpec); }
+    public void include(String... includes) {
+        patternSet.include(includes)
+    }
+
+    public void include(Iterable<String> includes) {
+        patternSet.include(includes)
+    }
+
+    public void include(Spec<FileTreeElement> includeSpec) {
+        patternSet.include(includeSpec)
+    }
+
+    public void include(Closure includeSpec) {
+        patternSet.include(includeSpec)
+    }
+
+    public void exclude(String... excludes) {
+        patternSet.exclude(excludes)
+    }
+
+    public void exclude(Iterable<String> excludes) {
+        patternSet.exclude(excludes)
+    }
+
+    public void exclude(Spec<FileTreeElement> excludeSpec) {
+        patternSet.exclude(excludeSpec)
+    }
+
+    public void exclude(Closure excludeSpec) {
+        patternSet.exclude(excludeSpec)
+    }
 
     @TaskAction
     void generate() {


### PR DESCRIPTION
Adds support for the check element of the JaCoCo ant task.
The check supports an ignoreFailure option and include/exclude patterns

Usage:
```groovy
jacocoTestReport {
    ignoreFailure = true
    exclude '**/Test*.*'
    check {
        rule(element:'BUNDLE') {
            limit(counter:'BRANCHES',minimum:'0.80')
        }
    }
}
```