### PR TITLE
ivy publishing: generate excludes of transitive dependencies in ivy descriptors

### DIFF
--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependency.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependency.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.ivy.internal.dependency;
 
 import org.gradle.api.artifacts.DependencyArtifact;
+import org.gradle.api.artifacts.ExcludeRule;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,6 +29,7 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
     private final String revision;
     private final String confMapping;
     private final List<DependencyArtifact> artifacts = new ArrayList<DependencyArtifact>();
+    private final List<ExcludeRule> excludeRules = new ArrayList<ExcludeRule>();
 
     public DefaultIvyDependency(String organisation, String module, String revision, String confMapping) {
         this.organisation = organisation;
@@ -39,6 +41,11 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
     public DefaultIvyDependency(String organisation, String module, String revision, String confMapping, Collection<DependencyArtifact> artifacts) {
         this(organisation, module, revision, confMapping);
         this.artifacts.addAll(artifacts);
+    }
+
+    public DefaultIvyDependency(String organisation, String module, String revision, String confMapping, Collection<DependencyArtifact> artifacts, Collection<ExcludeRule> excludeRules) {
+        this(organisation, module, revision, confMapping, artifacts);
+        this.excludeRules.addAll(excludeRules);
     }
 
     public String getOrganisation() {
@@ -59,5 +66,9 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
 
     public Iterable<DependencyArtifact> getArtifacts() {
         return artifacts;
+    }
+
+    public Iterable<ExcludeRule> getExcludeRules() {
+        return excludeRules;
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/IvyDependencyInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/IvyDependencyInternal.java
@@ -17,8 +17,11 @@
 package org.gradle.api.publish.ivy.internal.dependency;
 
 import org.gradle.api.artifacts.DependencyArtifact;
+import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.publish.ivy.IvyDependency;
 
 public interface IvyDependencyInternal extends IvyDependency {
     Iterable<DependencyArtifact> getArtifacts();
+
+    Iterable<ExcludeRule> getExcludeRules();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
@@ -42,6 +43,7 @@ import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
 import org.gradle.internal.reflect.Instantiator;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Set;
 
 public class DefaultIvyPublication implements IvyPublicationInternal {
@@ -116,12 +118,13 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
 
     private void addProjectDependency(ProjectDependency dependency, String confMapping) {
         ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(dependency);
-        ivyDependencies.add(new DefaultIvyDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion(), confMapping));
+        ivyDependencies.add(new DefaultIvyDependency(
+                identifier.getGroup(), identifier.getName(), identifier.getVersion(), confMapping, Collections.<DependencyArtifact>emptyList(), dependency.getExcludeRules()));
     }
 
     private void addModuleDependency(ModuleDependency dependency, String confMapping) {
-        ivyDependencies.add(new DefaultIvyDependency(dependency.getGroup(), dependency.getName(), dependency.getVersion(), confMapping, dependency.getArtifacts()));
-     }
+        ivyDependencies.add(new DefaultIvyDependency(dependency.getGroup(), dependency.getName(), dependency.getVersion(), confMapping, dependency.getArtifacts(), dependency.getExcludeRules()));
+    }
 
     public void configurations(Action<? super IvyConfigurationContainer> config) {
         config.execute(configurations);

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
@@ -19,6 +19,7 @@ package org.gradle.api.publish.ivy.internal.publisher;
 import javax.xml.namespace.QName;
 import org.gradle.api.*;
 import org.gradle.api.artifacts.DependencyArtifact;
+import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.internal.xml.SimpleXmlWriter;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.api.publish.ivy.IvyArtifact;
@@ -192,9 +193,19 @@ public class IvyDescriptorFileGenerator {
             for (DependencyArtifact dependencyArtifact : dependency.getArtifacts()) {
                 printDependencyArtifact(dependencyArtifact, xmlWriter);
             }
+            for(ExcludeRule excludeRule : dependency.getExcludeRules()) {
+                writeDependencyExclude(excludeRule, xmlWriter);
+            }
             xmlWriter.endElement();
         }
         xmlWriter.endElement();
+    }
+
+    private void writeDependencyExclude(ExcludeRule excludeRule, OptionalAttributeXmlWriter xmlWriter) throws IOException {
+        xmlWriter.startElement("exclude")
+            .attribute("org", excludeRule.getGroup())
+            .attribute("module", excludeRule.getModule())
+            .endElement();
     }
 
     private void printDependencyArtifact(DependencyArtifact dependencyArtifact, OptionalAttributeXmlWriter xmlWriter) throws IOException {

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.ClassGeneratorBackedInstantiator
+import org.gradle.api.internal.artifacts.DefaultExcludeRule
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.Usage
@@ -119,6 +120,7 @@ class DefaultIvyPublicationTest extends Specification {
         moduleDependency.version >> "version"
         moduleDependency.configuration >> "dep-configuration"
         moduleDependency.artifacts >> [artifact]
+        moduleDependency.excludeRules >> [new DefaultExcludeRule("excludeGroup", "excludeModule")]
 
         and:
         publication.from(componentWithDependency(moduleDependency))
@@ -137,6 +139,11 @@ class DefaultIvyPublicationTest extends Specification {
             revision == "version"
             confMapping == "runtime->dep-configuration"
             artifacts == [artifact]
+            excludeRules.size == 1
+            with(excludeRules[0]) {
+                it.group == "excludeGroup"
+                it.module == "excludeModule"
+            }
         }
     }
 
@@ -144,7 +151,7 @@ class DefaultIvyPublicationTest extends Specification {
         given:
         def publication = createPublication()
         def projectDependency = Mock(ProjectDependency)
-
+        projectDependency.excludeRules >> [new DefaultExcludeRule("excludeGroup", "excludeModule")]
         and:
         projectDependencyResolver.resolve(projectDependency) >> DefaultModuleVersionIdentifier.newId("pub-org", "pub-module", "pub-revision")
         projectDependency.configuration >> "dep-configuration"
@@ -166,6 +173,11 @@ class DefaultIvyPublicationTest extends Specification {
             revision == "pub-revision"
             confMapping == "runtime->dep-configuration"
             artifacts == []
+            excludeRules.size == 1
+            with(excludeRules[0]) {
+                it.group == "excludeGroup"
+                it.module == "excludeModule"
+            }
         }
     }
 

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.api.publish.ivy.internal.publisher
 
+import org.gradle.api.internal.artifacts.DefaultExcludeRule
+
 import javax.xml.namespace.QName
 import org.gradle.api.Action
 import org.gradle.api.XmlProvider
@@ -220,6 +222,22 @@ class IvyDescriptorFileGeneratorTest extends Specification {
                     it.@ext.isEmpty()
                     it."@m:classifier" == "classy"
                 }
+            }
+        }
+    }
+
+    def "writes dependency with exclusion"() {
+        def excludeRule = new DefaultExcludeRule("excludeGroup", "excludeModule");
+
+        when:
+        generator.addDependency(new DefaultIvyDependency('dep-group', 'dep-name-1', 'dep-version', "confMappingProject", [], [excludeRule]))
+
+        then:
+        with (ivyXml) {
+            dependencies[0].dependency[0].exclude.size() == 1
+            with (dependencies[0].dependency[0].exclude[0]) {
+                it.@org == "excludeGroup"
+                it.@module == "excludeModule"
             }
         }
     }


### PR DESCRIPTION
This adds support for mapping excludes in dependencies to ivy descriptors. 

Example:

```gradle
dependencies {
   compile('fooGroup:fooModule:1.0') {
       exclude group: 'barGroup', module: 'barModule'
   }
}
```

will be mapped to the following ivy.xml

```xml
<dependencies>
<dependency org="fooGroup" name="fooModule" rev="1.0.0">
    <exclude org="barGroup" module="barModule"/>
</dependency>
</dependencies>
```

The pull request is related to https://discuss.gradle.org/t/generation-of-ivy-descriptors-with-excluded-transitive-dependencies/9684

Implementation seemed to be straight forward. I think in the maven publishing plugin it is done in a very similar way. This is my first change in gradle code, so please give comments if I missed something.

CLA is not signed yet. This should be done soon.