### PR TITLE
GRADLE-3299 Handle references to ${parent.artifactId} in pom files

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -145,6 +145,7 @@ public class PomReader implements PomParent {
     private void setDefaultParentGavProperties() {
         setGavPropertyValueWithoutReplacement(GavProperty.PARENT_GROUP_ID, getParentGroupId());
         setGavPropertyValueWithoutReplacement(GavProperty.PARENT_VERSION, getParentVersion());
+        setGavPropertyValueWithoutReplacement(GavProperty.PARENT_ARTIFACT_ID, getParentArtifactId());
     }
 
     private void setGavPropertyValueWithoutReplacement(GavProperty gavProperty, String propertyValue) {
@@ -156,6 +157,7 @@ public class PomReader implements PomParent {
     private enum GavProperty {
         PARENT_VERSION("parent.version", "project.parent.version"),
         PARENT_GROUP_ID("parent.groupId", "project.parent.groupId"),
+        PARENT_ARTIFACT_ID("parent.artifactId", "project.parent.artifactId"),
         GROUP_ID("project.groupId", "pom.groupId", "groupId"),
         ARTIFACT_ID("project.artifactId", "pom.artifactId", "artifactId"),
         VERSION("project.version", "pom.version", "version");

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
@@ -2247,4 +2247,54 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         'bundle'      | 'jar'         | null
         'custom-type' | 'custom-type' | null
     }
+
+    @Issue("GRADLE-3299")
+    def "correctly resolve references to parent.artifactId"() {
+        given:
+        def parent = tmpDir.file("parent.xml") << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group-one</groupId>
+    <artifactId>artifact-one</artifactId>
+    <version>version-one</version>
+</project>
+"""
+
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>\${project.parent.groupId}</groupId>
+    <artifactId>\${project.parent.artifactId}-ext</artifactId>
+    <version>\${project.parent.version}</version>
+
+    <parent>
+        <groupId>group-one</groupId>
+        <artifactId>artifact-one</artifactId>
+        <version>version-one</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>\${parent.groupId}</groupId>
+            <artifactId>\${parent.artifactId}-xxx</artifactId>
+            <version>\${parent.version}</version>
+        </dependency>
+    </dependencies>
+</project>
+"""
+        and:
+        parseContext.getMetaDataArtifact(_, MAVEN_POM) >> { new DefaultLocallyAvailableExternalResource(parent.toURI(), new DefaultLocallyAvailableResource(parent)) }
+
+        when:
+        def descriptor = parsePom()
+
+        then:
+        descriptor.moduleRevisionId == moduleId('group-one', 'artifact-one-ext', 'version-one')
+
+        descriptor.dependencies.length == 1
+        def depGroupOne = descriptor.dependencies[0]
+        depGroupOne.dependencyRevisionId == moduleId('group-one', 'artifact-one-xxx', 'version-one')
+        depGroupOne.moduleConfigurations == ['compile', 'runtime']
+        hasDefaultDependencyArtifact(depGroupOne)
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderProfileTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderProfileTest.groovy
@@ -169,7 +169,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 
         then:
         pomReader.parseActivePomProfiles().size() == 1
-        pomReader.properties.size() == 5
+        pomReader.properties.size() == 7
         !pomReader.properties.containsKey('prop1')
         !pomReader.properties.containsKey('prop3')
         pomReader.properties['prop2'] == 'myproperty2'
@@ -286,7 +286,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         pomProfile.properties['groupId.prop'] == 'group-two'
         pomProfile.properties['artifactId.prop'] == 'artifact-two'
         pomProfile.properties['version.prop'] == 'version-two'
-        pomReader.properties.size() == 7
+        pomReader.properties.size() == 9
         pomReader.properties['groupId.prop'] == 'group-two'
         pomReader.properties['artifactId.prop'] == 'artifact-two'
         pomReader.properties['version.prop'] == 'version-two'
@@ -331,7 +331,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 
         then:
         pomReader.parseActivePomProfiles().size() == 2
-        pomReader.properties.size() == 7
+        pomReader.properties.size() == 9
         pomReader.properties['groupId.prop'] == 'group-two'
         pomReader.properties['artifactId.prop'] == 'artifact-two'
         pomReader.properties['version.prop'] == 'version-two'
@@ -2243,7 +2243,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 
         then:
         pomReader.parseActivePomProfiles().size() == 2
-        pomReader.properties.size() == 7
+        pomReader.properties.size() == 9
         pomReader.properties['groupId.prop'] == 'group-two'
         pomReader.properties['artifactId.prop'] == 'artifact-two'
         pomReader.properties['version.prop'] == 'version-two'

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
@@ -95,11 +95,13 @@ class PomReaderTest extends AbstractPomReaderTest {
         pomReader.licenses[0].url == 'http://www.apache.org/licenses/LICENSE-2.0.txt'
         !pomReader.hasParent()
         pomReader.pomProperties.size() == 0
-        pomReader.properties.size() == 4
+        pomReader.properties.size() == 6
         pomReader.properties['parent.version'] == 'version-one'
         pomReader.properties['parent.groupId'] == 'group-one'
+        pomReader.properties['parent.artifactId'] == 'artifact-one'
         pomReader.properties['project.parent.version'] == 'version-one'
         pomReader.properties['project.parent.groupId'] == 'group-one'
+        pomReader.properties['project.parent.artifactId'] == 'artifact-one'
         pomReader.relocation == null
     }
 
@@ -134,7 +136,7 @@ class PomReaderTest extends AbstractPomReaderTest {
         pomReader.pomProperties.size() == 5
         pomReader.pomProperties.containsKey('some.prop1')
         pomReader.pomProperties.containsKey('some.prop2')
-        pomReader.properties.size() == 9
+        pomReader.properties.size() == 11
         pomReader.properties.containsKey('some.prop1')
         pomReader.properties.containsKey('some.prop2')
     }
@@ -487,11 +489,13 @@ class PomReaderTest extends AbstractPomReaderTest {
         pomReader.licenses == new License[0]
         !pomReader.hasParent()
         pomReader.pomProperties.size() == 0
-        pomReader.properties.size() == 13
+        pomReader.properties.size() == 15
         pomReader.properties['parent.version'] == 'version-one'
         pomReader.properties['parent.groupId'] == 'group-one'
+        pomReader.properties['parent.artifactId'] == 'artifact-one'
         pomReader.properties['project.parent.version'] == 'version-one'
         pomReader.properties['project.parent.groupId'] == 'group-one'
+        pomReader.properties['project.parent.artifactId'] == 'artifact-one'
         pomReader.properties['project.groupId'] == 'group-one'
         pomReader.properties['pom.groupId'] == 'group-one'
         pomReader.properties['groupId'] == 'group-one'
@@ -847,5 +851,33 @@ class PomReaderTest extends AbstractPomReaderTest {
 
         where:
         packaging << ['pom', 'jar', 'ejb', 'war', 'ear', 'rar', 'par']
+    }
+
+    @Issue("GRADLE-3299")
+    def "can define groupId with reference to parent.GroupId"() {
+        when:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>\${parent.groupId}</groupId>
+    <artifactId>\${parent.artifactId}</artifactId>
+    <version>\${parent.version}</version>
+
+    <parent>
+        <groupId>parent-group</groupId>
+        <artifactId>parent-artifact</artifactId>
+        <version>parent-version</version>
+    </parent>
+</project>
+"""
+        pomReader = new PomReader(locallyAvailableExternalResource)
+
+        then:
+        pomReader.parentGroupId == 'parent-group'
+        pomReader.parentArtifactId == 'parent-artifact'
+        pomReader.parentVersion == 'parent-version'
+        pomReader.groupId == pomReader.parentGroupId
+        pomReader.artifactId == pomReader.parentArtifactId
+        pomReader.version == pomReader.parentVersion
     }
 }


### PR DESCRIPTION
- prior to this fix only ${parent.version} and ${parent.groupId} could be referenced

as discussed with Benjamin Muschko, I created a bugfix for the above mentioned bug/problem.