### PR TITLE
Import the Sets class from Guava instead of testng

### DIFF
--- a/subprojects/maven/src/main/groovy/org/gradle/api/publication/maven/internal/pom/ProjectDependencyArtifactIdExtractorHack.java
+++ b/subprojects/maven/src/main/groovy/org/gradle/api/publication/maven/internal/pom/ProjectDependencyArtifactIdExtractorHack.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publication.maven.internal.pom;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.maven.project.MavenProject;
 import org.gradle.api.Nullable;
 import org.gradle.api.Project;
@@ -26,7 +27,6 @@ import org.gradle.api.artifacts.maven.MavenResolver;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.plugins.BasePluginConvention;
 import org.gradle.api.tasks.Upload;
-import org.testng.internal.annotations.Sets;
 
 import java.util.Collection;
 import java.util.Set;


### PR DESCRIPTION
Hi,

The class ProjectDependencyArtifactIdExtractorHack imports an internal class from testng that was removed in the version 6.9.0. I guess this import was a mistake caused by an IDE auto import and the intent was to use the Guava class instead. Here is a patch fixing this.