### PR TITLE
PMD priority level support

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginIntegrationTest.groovy
@@ -85,6 +85,20 @@ class PmdPluginIntegrationTest extends WellBehavedPluginTest {
         output.contains("2 PMD rule violations were found. See the report at:")
     }
 
+    void "can configure priority level threshold"() {
+        badCode()
+        buildFile << """
+            pmd {
+                minimumWarningLevel = 2
+            }
+        """
+
+        expect:
+        succeeds("check")
+        file("build/reports/pmd/main.xml").exists()
+        file("build/reports/pmd/test.xml").exists()
+    }
+
     def "can set target JDK for PMD versions prior to 5.0"() {
         badCode()
         buildFile << """

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginIntegrationTest.groovy
@@ -89,14 +89,18 @@ class PmdPluginIntegrationTest extends WellBehavedPluginTest {
         badCode()
         buildFile << """
             pmd {
-                minimumWarningLevel = 2
+                minimumPriority = 2
             }
         """
 
         expect:
-        succeeds("check")
-        file("build/reports/pmd/main.xml").exists()
-        file("build/reports/pmd/test.xml").exists()
+        fails("check")
+        file("build/reports/pmd/main.xml").assertContents(not(containsClass("org.gradle.Class1")))
+        file("build/reports/pmd/test.xml").
+                assertContents(containsClass("org.gradle.Class1Test")).
+                assertContents(containsLine(containsString('BooleanInstantiation'))).
+                assertContents(not(containsLine(containsString('OverrideBothEqualsAndHashcode')))
+        )
     }
 
     def "can set target JDK for PMD versions prior to 5.0"() {
@@ -181,7 +185,8 @@ class PmdPluginIntegrationTest extends WellBehavedPluginTest {
         fails("check")
         failure.assertHasDescription("Execution failed for task ':pmdTest'.")
         failure.assertThatCause(containsString("2 PMD rule violations were found. See the report at:"))
-        output.contains "Class1Test.java:1:\tEmpty initializer was found"
+        output.contains "Class1Test.java:1:\tAvoid instantiating Boolean objects"
+        output.contains "Class1Test.java:1:\tEnsure you override both equals() and hashCode()"
     }
 
     private void writeBuildFile() {
@@ -207,10 +212,13 @@ class PmdPluginIntegrationTest extends WellBehavedPluginTest {
     }
 
     private badCode() {
+        // No Warnings
         file("src/main/java/org/gradle/Class1.java") <<
                 "package org.gradle; class Class1 { public boolean isFoo(Object arg) { return true; } }"
+        // PMD Lvl 2 Warning BooleanInstantiation
+        // PMD Lvl 3 Warning OverrideBothEqualsAndHashcode
         file("src/test/java/org/gradle/Class1Test.java") <<
-                "package org.gradle; class Class1Test<T> { {} public boolean equals(Object arg) { return true; } }"
+                "package org.gradle; class Class1Test<T> { public boolean equals(Object arg) { return java.lang.Boolean.valueOf(true); } }"
     }
 
     private customCode() {

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
@@ -23,7 +23,7 @@ import static org.gradle.util.Matchers.containsLine
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.not
 
-@TargetVersions(['4.3', '5.0.4', '5.1.1', '5.2.3'])
+@TargetVersions(['4.3', '5.0.4', '5.1.1', '5.2.3', '5.3.1'])
 class PmdPluginVersionIntegrationTest extends MultiVersionIntegrationSpec {
     def "can use different PMD versions"() {
         given:

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.groovy
@@ -101,7 +101,7 @@ class Pmd extends SourceTask implements VerificationTask, Reporting<PmdReports> 
 	 *
 	 * Example: minimumPriority = 3
 	 */
-	int minimumWarningLevel
+	int minimumPriority
 
     /**
      * Whether or not to write PMD results to {@code System.out}.
@@ -140,8 +140,8 @@ class Pmd extends SourceTask implements VerificationTask, Reporting<PmdReports> 
                 setRuleSets(["java-basic"])
             }
         }
-        if (0 != getMinimumWarningLevel()) {
-            antPmdArgs["minimumPriority"] = getMinimumWarningLevel()
+        if (0 != getMinimumPriority()) {
+            antPmdArgs["minimumPriority"] = getMinimumPriority()
         }
 
         antBuilder.withClasspath(getPmdClasspath()).execute { a ->

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.groovy
@@ -95,6 +95,15 @@ class Pmd extends SourceTask implements VerificationTask, Reporting<PmdReports> 
     boolean ignoreFailures
 
     /**
+	 * The rule priority threshold; rules with lower priority than they will not be used
+	 *
+	 * Ignored if 0
+	 *
+	 * Example: minimumPriority = 3
+	 */
+	int minimumWarningLevel
+
+    /**
      * Whether or not to write PMD results to {@code System.out}.
      */
     @Incubating
@@ -130,6 +139,9 @@ class Pmd extends SourceTask implements VerificationTask, Reporting<PmdReports> 
             if (getRuleSets() == ["basic"]) {
                 setRuleSets(["java-basic"])
             }
+        }
+        if (0 != getMinimumWarningLevel()) {
+            antPmdArgs["minimumPriority"] = getMinimumWarningLevel()
         }
 
         antBuilder.withClasspath(getPmdClasspath()).execute { a ->

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.groovy
@@ -50,9 +50,9 @@ class PmdExtension extends CodeQualityExtension {
 	 *
 	 * Ignored if 0
 	 *
-	 * Example: minimumWarningLevel = 3
+	 * Example: minimumPriority = 3
 	 */
-	int minimumWarningLevel
+	int minimumPriority
 
     /**
      * Sets the target jdk used with pmd.

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.groovy
@@ -45,6 +45,15 @@ class PmdExtension extends CodeQualityExtension {
      */
     TargetJdk targetJdk
 
+	/**
+	 * The rule priority threshold; rules with lower priority than they will not be used
+	 *
+	 * Ignored if 0
+	 *
+	 * Example: minimumWarningLevel = 3
+	 */
+	int minimumWarningLevel
+
     /**
      * Sets the target jdk used with pmd.
      *

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.groovy
@@ -87,6 +87,7 @@ class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
             ruleSetConfig = { extension.ruleSetConfig }
             ruleSetFiles = { extension.ruleSetFiles }
             ignoreFailures = { extension.ignoreFailures }
+            minimumWarningLevel = { extension.minimumWarningLevel }
             consoleOutput = { extension.consoleOutput }
             targetJdk = { extension.targetJdk }
             task.reports.all { report ->

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.groovy
@@ -87,7 +87,7 @@ class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
             ruleSetConfig = { extension.ruleSetConfig }
             ruleSetFiles = { extension.ruleSetFiles }
             ignoreFailures = { extension.ignoreFailures }
-            minimumWarningLevel = { extension.minimumWarningLevel }
+            minimumPriority = { extension.minimumPriority }
             consoleOutput = { extension.consoleOutput }
             targetJdk = { extension.targetJdk }
             task.reports.all { report ->

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -56,7 +56,7 @@ class PmdPluginTest extends Specification {
         extension.ruleSetFiles.empty
         extension.reportsDir == project.file("build/reports/pmd")
         !extension.ignoreFailures
-        extension.minimumWarningLevel == 0
+        extension.minimumPriority == 0
     }
 
     def "configures pmd task for each source set"() {
@@ -109,7 +109,7 @@ class PmdPluginTest extends Specification {
             assert reports.xml.destination == project.file("build/reports/pmd/${sourceSet.name}.xml")
             assert reports.html.destination == project.file("build/reports/pmd/${sourceSet.name}.html")
             assert ignoreFailures == false
-            assert minimumWarningLevel == 0
+            assert minimumPriority == 0
         }
     }
 
@@ -126,7 +126,7 @@ class PmdPluginTest extends Specification {
         task.reports.xml.destination == project.file("build/reports/pmd/custom.xml")
         task.reports.html.destination == project.file("build/reports/pmd/custom.html")
         task.ignoreFailures == false
-        task.minimumWarningLevel == 0
+        task.minimumPriority == 0
     }
 
     def "adds pmd tasks to check lifecycle task"() {
@@ -156,7 +156,7 @@ class PmdPluginTest extends Specification {
             ruleSetFiles = project.files("my-ruleset.xml")
             reportsDir = project.file("pmd-reports")
             ignoreFailures = true
-            minimumWarningLevel = 3
+            minimumPriority = 3
         }
 
         expect:
@@ -180,7 +180,7 @@ class PmdPluginTest extends Specification {
             assert reports.xml.destination == project.file("pmd-reports/${sourceSet.name}.xml")
             assert reports.html.destination == project.file("pmd-reports/${sourceSet.name}.html")
             assert ignoreFailures == true
-            assert minimumWarningLevel == 3
+            assert minimumPriority == 3
         }
     }
 
@@ -192,7 +192,7 @@ class PmdPluginTest extends Specification {
             ruleSetFiles = project.files("my-ruleset.xml")
             reportsDir = project.file("pmd-reports")
             ignoreFailures = true
-            minimumWarningLevel = 3
+            minimumPriority = 3
         }
 
         expect:
@@ -206,7 +206,7 @@ class PmdPluginTest extends Specification {
         task.reports.html.destination == project.file("pmd-reports/custom.html")
         task.outputs.files.files == task.reports.enabled*.destination as Set
         task.ignoreFailures == true
-        task.minimumWarningLevel == 3
+        task.minimumPriority == 3
     }
 
 }

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -56,6 +56,7 @@ class PmdPluginTest extends Specification {
         extension.ruleSetFiles.empty
         extension.reportsDir == project.file("build/reports/pmd")
         !extension.ignoreFailures
+        extension.minimumWarningLevel == 0
     }
 
     def "configures pmd task for each source set"() {
@@ -108,6 +109,7 @@ class PmdPluginTest extends Specification {
             assert reports.xml.destination == project.file("build/reports/pmd/${sourceSet.name}.xml")
             assert reports.html.destination == project.file("build/reports/pmd/${sourceSet.name}.html")
             assert ignoreFailures == false
+            assert minimumWarningLevel == 0
         }
     }
 
@@ -124,6 +126,7 @@ class PmdPluginTest extends Specification {
         task.reports.xml.destination == project.file("build/reports/pmd/custom.xml")
         task.reports.html.destination == project.file("build/reports/pmd/custom.html")
         task.ignoreFailures == false
+        task.minimumWarningLevel == 0
     }
 
     def "adds pmd tasks to check lifecycle task"() {
@@ -153,6 +156,7 @@ class PmdPluginTest extends Specification {
             ruleSetFiles = project.files("my-ruleset.xml")
             reportsDir = project.file("pmd-reports")
             ignoreFailures = true
+            minimumWarningLevel = 3
         }
 
         expect:
@@ -176,6 +180,7 @@ class PmdPluginTest extends Specification {
             assert reports.xml.destination == project.file("pmd-reports/${sourceSet.name}.xml")
             assert reports.html.destination == project.file("pmd-reports/${sourceSet.name}.html")
             assert ignoreFailures == true
+            assert minimumWarningLevel == 3
         }
     }
 
@@ -187,6 +192,7 @@ class PmdPluginTest extends Specification {
             ruleSetFiles = project.files("my-ruleset.xml")
             reportsDir = project.file("pmd-reports")
             ignoreFailures = true
+            minimumWarningLevel = 3
         }
 
         expect:
@@ -200,6 +206,7 @@ class PmdPluginTest extends Specification {
         task.reports.html.destination == project.file("pmd-reports/custom.html")
         task.outputs.files.files == task.reports.enabled*.destination as Set
         task.ignoreFailures == true
+        task.minimumWarningLevel == 3
     }
 
 }


### PR DESCRIPTION
The PMD Ant task has a minimumPriority option that allows the caller to turn off the lower priority (higher number) warnings. This is desirable as many of the level 4 and 5 warnings don't have enough value to make fixing them worth the effort.  This change adds the option to the Gradle plugin.