### PR TITLE
revert clean task group back to 'build'

### DIFF
--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/LifecycleBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/LifecycleBasePlugin.java
@@ -57,7 +57,7 @@ public class LifecycleBasePlugin implements Plugin<ProjectInternal> {
             @Override
             public void execute(Delete clean) {
                 clean.setDescription("Deletes the build directory.");
-                clean.setGroup(VERIFICATION_GROUP);
+                clean.setGroup(BUILD_GROUP);
                 clean.delete(new Callable<File>() {
                     public File call() throws Exception {
                         return project.getBuildDir();


### PR DESCRIPTION
see [#9a56608](https://github.com/gradle/gradle/commit/9a56608c6b0cd909a3165008be6f2771b10e5331), where it is accidentally (I assume) changed to 'verification'