### PR TITLE
Gradle tooling: find the correct wrapper on project import

### DIFF
--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
@@ -60,8 +60,9 @@ public class DistributionFactory {
         }
         if (wrapper.getDistribution() != null) {
             return new ZippedDistribution(wrapper.getConfiguration(), executorFactory);
+        } else {
+            return getDownloadedDistribution(GradleVersion.current().getVersion());
         }
-        return getDownloadedDistribution(GradleVersion.current().getVersion());
     }
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
@@ -55,6 +55,9 @@ public class DistributionFactory {
     public Distribution getDefaultDistribution(File projectDir, boolean searchUpwards) {
         BuildLayout layout = new BuildLayoutFactory().getLayoutFor(projectDir, searchUpwards);
         WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory(layout.getRootDirectory(), System.out);
+        if (wrapper.getDistribution() == null) {
+            wrapper = WrapperExecutor.forProjectDirectory(projectDir, System.out);
+        }
         if (wrapper.getDistribution() != null) {
             return new ZippedDistribution(wrapper.getConfiguration(), executorFactory);
         }


### PR DESCRIPTION
When importing projects in IDEA and using the "Use default gradle wrapper" option it looks for the gradle wrapper in the buildLayout.rootDirectory, and ignores the project directory.
So if there is a wrapper in the project dir and a settings.gradle in the parent the wrapper is not found.
However it works just fine from command line, so the behavior is inconsistent.