### PR TITLE
NullPointerException avoided while getting env vars without value.

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/process/internal/DefaultProcessForkOptions.java
+++ b/subprojects/core/src/main/groovy/org/gradle/process/internal/DefaultProcessForkOptions.java
@@ -72,7 +72,7 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
     public Map<String, String> getActualEnvironment() {
         Map<String, String> actual = new HashMap<String, String>();
         for (Map.Entry<String, Object> entry : environment.entrySet()) {
-            actual.put(entry.getKey(), String.valueOf(entry.getValue().toString()));
+            actual.put(entry.getKey(), String.valueOf(entry.getValue()));
         }
         return actual;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultProcessForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultProcessForkOptionsTest.groovy
@@ -71,9 +71,9 @@ public class DefaultProcessForkOptionsTest {
 
     @Test
     public void convertsEnvironmentToString() {
-        options.environment = [key1: 12, key2: "${1+2}"]
+        options.environment = [key1: 12, key2: "${1+2}", key3: null]
 
-        assertThat(options.actualEnvironment, equalTo(key1: '12', key2: '3'))
+        assertThat(options.actualEnvironment, equalTo(key1: '12', key2: '3', key3: 'null'))
     }
 
     @Test
@@ -91,7 +91,7 @@ public class DefaultProcessForkOptionsTest {
 
         assertThat(options.environment, equalTo([key: 12, key2: "value"]))
     }
-    
+
     @Test
     public void canCopyToTargetOptions() {
         options.executable('executable')


### PR DESCRIPTION
 - Removed a useless .toString() call on a nullable object inside a String.valueOf() block.