### PR TITLE
Fixed a grammar error in log message ("SelectiveCompiler")

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
@@ -59,7 +59,7 @@ class SelectiveCompiler implements org.gradle.language.base.internal.compile.Com
 
         incrementalCompilationInitilizer.initializeCompilation(spec, recompilationSpec.getClassNames());
         if (spec.getSource().isEmpty()) {
-            LOG.lifecycle("None of the classes needs to compiled! Analysis took {}. ", clock.getTime());
+            LOG.lifecycle("None of the classes needs to be compiled! Analysis took {}. ", clock.getTime());
             return new RecompilationNotNecessary();
         }
 


### PR DESCRIPTION
 - Change "None of the classes needs to compiled" to "None of the classes needs to be compiled" (notice the "be").