### PR TITLE
Add distribution as automatically applied plugin

### DIFF
--- a/subprojects/docs/src/docs/userguide/standardPlugins.xml
+++ b/subprojects/docs/src/docs/userguide/standardPlugins.xml
@@ -184,7 +184,7 @@
                     </link>
                 </td>
                 <td>
-                    <literal>java</literal>
+                    <literal>java</literal>, <literal>distribution</literal>
                 </td>
                 <td>-</td>
                 <td>


### PR DESCRIPTION
Distribution was missing as automatically applied plugin for application plugin on standard plugins page (it is correctly listed on application plugin's page)