### PR TITLE
When a copy task filters lines via closure, remove line if null is returned

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationTest.groovy
@@ -704,4 +704,33 @@ public class CopyTaskIntegrationTest extends AbstractIntegrationTest {
         file('dest').assertHasDescendants('bcd.txt', 'abc.log')
         file('dest/abc.log').text = 'content'
     }
+
+    @Test
+    public void testSingleLineRemoved() {
+        TestFile buildFile = testFile('build.gradle') << '''
+            task (copy, type:Copy) {
+                from "src/two/two.b"
+                into "dest"
+                def lineNumber = 1
+                filter { lineNumber++ % 2 == 0 ? null : it }
+            }'''
+        usingBuildFile(buildFile).withTasks('copy').run()
+        Iterator<String> it = testFile('dest/two.b').readLines().iterator()
+        assertThat(it.next(), startsWith('one'))
+        assertThat(it.next(), startsWith('three'))
+    }
+
+    @Test
+    public void testAllLinesRemoved() {
+        TestFile buildFile = testFile('build.gradle') << '''
+            task (copy, type:Copy) {
+                from "src/two/two.b"
+                into "dest"
+                def lineNumber = 1
+                filter { null }
+            }'''
+        usingBuildFile(buildFile).withTasks('copy').run()
+        Iterator<String> it = testFile('dest/two.b').readLines().iterator()
+        assertFalse(it.hasNext())
+    }
 }

--- a/subprojects/core/src/integTest/resources/org/gradle/api/tasks/copyTestResources/src/two/two.b
+++ b/subprojects/core/src/integTest/resources/org/gradle/api/tasks/copyTestResources/src/two/two.b
@@ -1,1 +1,3 @@
-Something to copy
+one
+two
+three

--- a/subprojects/core/src/main/groovy/org/gradle/api/file/ContentFilterable.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/file/ContentFilterable.java
@@ -61,7 +61,8 @@ public interface ContentFilterable {
 
     /**
      * Adds a content filter based on the provided closure.  The Closure will be called with each line (stripped of line
-     * endings) and should return a String to replace the line or {@code null} to remove the line.
+     * endings) and should return a String to replace the line or {@code null} to remove the line.  If every line is
+     * removed, the result will be an empty file, not an absent one.
      *
      * @param closure to implement line based filtering
      * @return this

--- a/subprojects/core/src/main/groovy/org/gradle/api/file/ContentFilterable.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/file/ContentFilterable.java
@@ -61,7 +61,7 @@ public interface ContentFilterable {
 
     /**
      * Adds a content filter based on the provided closure.  The Closure will be called with each line (stripped of line
-     * endings) and should return a String to replace the line.
+     * endings) and should return a String to replace the line or {@code null} to remove the line.
      *
      * @param closure to implement line based filtering
      * @return this

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/LineFilter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/LineFilter.java
@@ -24,11 +24,18 @@ import java.io.IOException;
 import java.io.Reader;
 
 public class LineFilter extends Reader {
+    private static enum State {
+        NORMAL,
+        SKIP_LINE,
+        EOF
+    };
+
     private final Closure closure;
     private String transformedLine;
     private int transformedIndex;
     private final BufferedReader bufferedIn;
     private final Reader in;
+    private State state = State.NORMAL;
 
     /**
      * Creates a new filtered reader.
@@ -42,7 +49,7 @@ public class LineFilter extends Reader {
         this.closure = closure;
     }
 
-    private String getTransformedLine() throws IOException {
+    private void readTransformedLine() throws IOException {
         StringBuilder line = new StringBuilder();
         boolean eol = false;
         int ch;
@@ -60,20 +67,26 @@ public class LineFilter extends Reader {
             }
         }
         if (line.length() == 0 && !eol) {
-            return null;
+            state = State.EOF;
+            return;
         }
-
-        StringBuilder result = new StringBuilder();
-        result.append(closure.call(line.toString()).toString());
+        Object result = closure.call(line.toString());
+        if (result == null) {
+            state = State.SKIP_LINE;
+            return;
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append(result.toString());
         if (eol) {
-            result.append(SystemProperties.getInstance().getLineSeparator());
+            builder.append(SystemProperties.getInstance().getLineSeparator());
         }
-        return result.toString();
+        state = State.NORMAL;
+        transformedLine = builder.toString();
     }
 
     private void ensureData() throws IOException {
-        if (transformedLine == null || transformedIndex >= transformedLine.length()) {
-            transformedLine = getTransformedLine();
+        while (state == State.SKIP_LINE || state == State.NORMAL && (transformedLine == null || transformedIndex >= transformedLine.length())) {
+            readTransformedLine();
             transformedIndex = 0;
         }
     }
@@ -81,7 +94,7 @@ public class LineFilter extends Reader {
     @Override
     public int read() throws IOException {
         ensureData();
-        if (transformedLine == null || transformedLine.length() == 0) {
+        if (state == State.EOF) {
             return -1;
         }
         return transformedLine.charAt(transformedIndex++);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/LineFilterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/LineFilterTest.groovy
@@ -77,6 +77,22 @@ class LineFilterTest {
         assertThat(filter.text, equalTo(lines("1 - one", "2 - two", "3 - three")))
     }
 
+    @Test void testClosureReturningNull() {
+        def input = new StringReader("one\ntwo\nthree\n")
+        def lineCount = 1
+        def filter = new LineFilter(input,  { lineCount++ % 2 == 0 ? null : it })
+
+        assertThat(filter.text, equalTo(lines("one", "three", "")))
+    }
+
+    @Test void testClosureAlwaysReturningNull() {
+        def input = new StringReader("one\ntwo\nthree\n")
+        def lineCount = 1
+        def filter = new LineFilter(input,  { null })
+
+        assertThat(filter.text, equalTo(lines()))
+    }
+
     private String lines(String ... lines) {
         (lines as List).join(SystemProperties.instance.lineSeparator)
     }

--- a/subprojects/docs/src/samples/userguide/files/copy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/files/copy/build.gradle
@@ -109,6 +109,10 @@ task filter(type: Copy) {
     filter { String line ->
         "[$line]"
     }
+    // Use a closure to remove lines
+    filter { String line ->
+        line.startsWith('-') ? null : line
+    }
 }
 // END SNIPPET filter-files
 


### PR DESCRIPTION
This feature was [requested on the forum last year](https://www.google.com/url?q=https%3A%2F%2Fdiscuss.gradle.org%2Ft%2Fit-should-be-possible-to-remove-lines-using-filter-closure%2F518%2F4&sa=D&sntz=1&usg=AFQjCNEILOx0v_mkoNVqMnoCtIMggsfIDw), but never implemented.  There is [a gradle-dev thread](https://groups.google.com/forum/#!topic/gradle-dev/miICu-menSk) for the proposed change.

This change required a minor restructuring of LineFilter.  Rather than tracking its state implicitly (with a null `transformedLine` representing end-of-file, except at beginning-of-file), it now tracks state explicitly, allowing it to loop continuously over input lines as the closure returns `null` without emitting output lines.

Unit and integration tests have been added for both the common case of only specific lines being removed in this manner as well as the edge case of *all* lines being removed.  The file `copyTestResources/src/two/two.b` was commandeered for the integration tests, as its contents were not being used in any other test and adding an entirely new file would have impacted other tests.

