### PR TITLE
Fix eclipse plugin bug which remove javabuilder from .project

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -414,6 +414,21 @@ dependencies {
         """
     }
 
+    @Test
+    @Issue("https://github.com/gradle/gradle/pull/480")
+    void enableJavaBuilderAndScalaBuilderWithJavaAndScalaPlugin() {
+        runEclipseTask """
+apply plugin: "java"
+apply plugin: "scala"
+apply plugin: "eclipse"
+"""
+
+        def xml = parseProjectFile()
+        def buildCommandNames = xml.buildSpec.buildCommand.name.collect { it.text() }
+        assert buildCommandNames.contains('org.eclipse.jdt.core.javabuilder')
+        assert buildCommandNames.contains('org.scala-ide.sdt.core.scalabuilder')
+    }
+
     void assertHasExpectedContents(TestFile actualFile, String expectedFileName) {
         actualFile.assertExists()
         TestFile expectedFile = testDirectory.file("expectedFiles/$expectedFileName").assertIsFile()

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipsePlugin.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipsePlugin.groovy
@@ -106,7 +106,7 @@ class EclipsePlugin extends IdePlugin {
             }
 
             project.plugins.withType(ScalaBasePlugin) {
-                projectModel.buildCommands.set(projectModel.buildCommands.findIndexOf { it.name == "org.eclipse.jdt.core.javabuilder" },
+                projectModel.buildCommands.add(projectModel.buildCommands.findIndexOf { it.name == "org.eclipse.jdt.core.javabuilder" },
                         new BuildCommand("org.scala-ide.sdt.core.scalabuilder"))
                 projectModel.natures.add(projectModel.natures.indexOf("org.eclipse.jdt.core.javanature"), "org.scala-ide.sdt.core.scalanature")
             }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
@@ -127,6 +127,18 @@ class EclipsePluginTest extends Specification {
         folders == [project.file('generated-folder'), project.file('ws-generated'), project.file('generated-test'), project.file('test-resources'), project.file('../some/external/dir')]
     }
 
+    def "enable javabuilder and scalabuilder with java-plugin and scala-plugin"() {
+        when:
+        eclipsePlugin.apply(project)
+        project.apply(plugin: 'java')
+        project.apply(plugin: 'scala')
+
+        then:
+        def buildCommands = project.eclipse.project.buildCommands
+        assert buildCommands.contains(new BuildCommand('org.eclipse.jdt.core.javabuilder'))
+        assert buildCommands.contains(new BuildCommand('org.scala-ide.sdt.core.scalabuilder'))
+    }
+
     private void checkEclipseProjectTask(List buildCommands, List natures) {
         GenerateEclipseProject eclipseProjectTask = project.eclipseProject
         assert eclipseProjectTask instanceof GenerateEclipseProject


### PR DESCRIPTION
The current eclipse plugin replace javabuilder with scalabuilder if scala-plugin is enabled.

This patch fix eclipse plugin not to replace but to add scalabuilder.

Simple examples for reproduce
------------------------------

Without scala plugin:

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~bash
$ cat build.gradle
// apply plugin: "scala"
apply plugin: "java"
apply plugin: "eclipse"
$ ../gradle-latest/bin/gradle-source-build cleanEclipse eclipse
$ grep javabuilder .project
                        <name>org.eclipse.jdt.core.javabuilder</name>
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

With scala plugin (current version):

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~bash
$ cat build.gradle
apply plugin: "scala"
apply plugin: "java"
apply plugin: "eclipse"
$ ../gradle-latest/bin/gradle-source-build cleanEclipse eclipse
$ grep javabuilder .project
$ echo $?
1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

With scala plugin (patched version):

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~bash
$ cat build.gradle
apply plugin: "scala"
apply plugin: "java"
apply plugin: "eclipse"
$ ../gradle-latest/bin/gradle-source-build cleanEclipse eclipse
$ grep javabuilder .project
                        <name>org.eclipse.jdt.core.javabuilder</name>
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~