### PR TITLE
GRADLE-1574 fix

### DIFF
--- a/subprojects/maven/src/main/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -18,12 +18,10 @@ package org.gradle.api.publish.maven.internal.publication;
 
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.artifacts.ModuleDependency;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.artifacts.*;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.Usage;
@@ -43,6 +41,7 @@ import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.CollectionUtils;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -110,12 +109,27 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
 
     private void addProjectDependency(ProjectDependency dependency) {
         ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(dependency);
-        runtimeDependencies.add(new DefaultMavenDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion()));
+        runtimeDependencies.add(new DefaultMavenDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion(), Collections.<DependencyArtifact>emptyList(),
+            dependency.isTransitive()? Collections.<ExcludeRule>emptySet() : createExcludeAllRule()));
     }
 
     private void addModuleDependency(ModuleDependency dependency) {
-        runtimeDependencies.add(new DefaultMavenDependency(dependency.getGroup(), dependency.getName(), dependency.getVersion(), dependency.getArtifacts(), dependency.getExcludeRules()));
+        runtimeDependencies.add(new DefaultMavenDependency(dependency.getGroup(), dependency.getName(), dependency.getVersion(), dependency.getArtifacts(),
+            dependency.isTransitive() ? dependency.getExcludeRules() : createExcludeAllRule()));
      }
+
+    /**
+     * Maven supports wildcards in exclusion rules according to:
+     * http://www.smartjava.org/content/maven-and-wildcard-exclusions
+     * https://issues.apache.org/jira/browse/MNG-3832
+     * This should be used for non-transitive dependencies
+     * @return
+     */
+    private static Set<ExcludeRule> createExcludeAllRule() {
+        Set<ExcludeRule> excludeRules = new LinkedHashSet<ExcludeRule>();
+        excludeRules.add(new DefaultExcludeRule("*", "*"));
+        return excludeRules;
+    }
 
     public MavenArtifact artifact(Object source) {
         return mavenArtifacts.artifact(source);

--- a/subprojects/maven/src/main/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -110,7 +110,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private void addProjectDependency(ProjectDependency dependency) {
         ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(dependency);
         runtimeDependencies.add(new DefaultMavenDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion(), Collections.<DependencyArtifact>emptyList(),
-            dependency.isTransitive()? Collections.<ExcludeRule>emptySet() : createExcludeAllRule()));
+            dependency.isTransitive()? dependency.getExcludeRules() : createExcludeAllRule()));
     }
 
     private void addModuleDependency(ModuleDependency dependency) {

--- a/subprojects/maven/src/main/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -126,9 +126,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
      * @return
      */
     private static Set<ExcludeRule> createExcludeAllRule() {
-        Set<ExcludeRule> excludeRules = new LinkedHashSet<ExcludeRule>();
-        excludeRules.add(new DefaultExcludeRule("*", "*"));
-        return excludeRules;
+        return Collections.<ExcludeRule>singleton(new DefaultExcludeRule("*", "*"));
     }
 
     public MavenArtifact artifact(Object source) {

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -203,6 +203,7 @@ public class DefaultMavenPublicationTest extends Specification {
         moduleDependency.version >> "version"
         moduleDependency.artifacts >> [artifact]
         moduleDependency.excludeRules >> [excludeRule]
+        moduleDependency.transitive >> true
 
         and:
         publication.from(componentWithDependency(moduleDependency))
@@ -215,6 +216,38 @@ public class DefaultMavenPublicationTest extends Specification {
             version == "version"
             artifacts == [artifact]
             excludeRules == [excludeRule]
+        }
+    }
+
+    def "adopts non-transitive module dependency from added component"() {
+        given:
+        def publication = createPublication()
+        def moduleDependency = Mock(ModuleDependency)
+        def artifact = Mock(DependencyArtifact)
+        def excludeRule = Mock(ExcludeRule)
+
+        when:
+        moduleDependency.group >> "group"
+        moduleDependency.name >> "name"
+        moduleDependency.version >> "version"
+        moduleDependency.artifacts >> [artifact]
+        moduleDependency.excludeRules >> [excludeRule]
+        moduleDependency.transitive >> false
+
+        and:
+        publication.from(componentWithDependency(moduleDependency))
+
+        then:
+        publication.runtimeDependencies.size() == 1
+        with (publication.runtimeDependencies.asList().first()) {
+            groupId == "group"
+            artifactId == "name"
+            version == "version"
+            artifacts == [artifact]
+            excludeRules != [excludeRule]
+            excludeRules.size() == 1
+            excludeRules[0].group == '*'
+            excludeRules[0].module == '*'
         }
     }
 


### PR DESCRIPTION
Adds a wildcard exclusion for non-transitive dependencies, fixes [GRADLE-1574](https://issues.gradle.org/browse/GRADLE-1574).
Wildcard extensions are supported since [MNG-3832](https://issues.apache.org/jira/browse/MNG-3832) was resolved.
Related post: http://www.smartjava.org/content/maven-and-wildcard-exclusions