### PR TITLE
Document existing behavior for input/output task dependencies

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/Input.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/Input.java
@@ -21,6 +21,11 @@ import java.lang.annotation.*;
  * <p>Attached to a task property to indicate that the property specifies some input value for the task.</p>
  *
  * <p>This annotation should be attached to the getter method or the field for the property.</p>
+ *
+ * <p>This will cause the task to fail the up-to-date check when the property has changed. When used on a
+ * {@link File} object that refers to a file or directory, the up-to-date check is only dependent on the
+ * path and not the contents of the file or directory. To make it depend on the contents, use
+ * {@link org.gradle.api.tasks.InputFile} or {@link org.gradle.api.tasks.InputDirectory} respectively.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/InputDirectory.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/InputDirectory.java
@@ -21,6 +21,10 @@ import java.lang.annotation.*;
  * <p>Marks a property as specifying an input directory for a task.</p>
  *
  * <p>This annotation should be attached to the getter method or the field for the property.</p>
+ *
+ * <p>The task will fail the up-to-date check when the directory location or contents
+ * have changed. To make the task dependent on the directory location but not the
+ * contents, use an {@link org.gradle.api.tasks.Input} annotation instead.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/InputFile.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/InputFile.java
@@ -21,6 +21,10 @@ import java.lang.annotation.*;
  * <p>Marks a property as specifying an input file for a task.</p>
  *
  * <p>This annotation should be attached to the getter method or the field for the property.</p>
+ *
+ * <p>This will cause the task to fail the up-to-date check when the file path or contents
+ * have changed. To make the up-to-date check only dependent on the path and not the contents
+ * of the file or directory, annotate it instead with {@link org.gradle.api.tasks.Input}.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/InputFiles.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/InputFiles.java
@@ -21,6 +21,9 @@ import java.lang.annotation.*;
  * <p>Marks a property as specifying the input files for a task.</p>
  *
  * <p>This annotation should be attached to the getter method or the field for the property.</p>
+ *
+ * <p>This will cause the task to fail the up-to-date check when the file paths or contents
+ * have changed. Also see {@link org.gradle.api.tasks.InputDirectory}.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/OutputDirectories.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/OutputDirectories.java
@@ -22,6 +22,11 @@ import java.lang.annotation.*;
  * <p>Marks a property as specifying one or more output directories for a task.</p>
  *
  * <p>This annotation should be attached to the getter method or the field for the property.</p>
+ *
+ * <p>This will cause the task to fail the up-to-date check when the directory paths or task
+ * output to those directories have been modified since the task was last run. Modifications
+ * to the directory outside of the task outputs are ignored. This allows multiple tasks to
+ * annotate the same path without interfering with each other's up-to-date checks.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/OutputDirectory.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/OutputDirectory.java
@@ -21,6 +21,11 @@ import java.lang.annotation.*;
  * <p>Marks a property as specifying an output directory for a task.</p>
  *
  * <p>This annotation should be attached to the getter method or the field for the property.</p>
+ *
+ * <p>This will cause the task to fail the up-to-date check when the directory path or task
+ * output to that directory has been modified since the task was last run. Modifications to
+ * to the directory outside of the task outputs are ignored. This allows multiple tasks to
+ * annotate the same path without interfering with each other's up-to-date checks.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/OutputFile.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/OutputFile.java
@@ -21,6 +21,9 @@ import java.lang.annotation.*;
  * <p>Marks a property as specifying an output file for a task.</p>
  *
  * <p>This annotation should be attached to the getter method or the field for the property.</p>
+ *
+ * <p>This will cause the task to fail the up-to-date check when the file path or contents
+ * are different to when the task was last run.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/OutputFiles.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/OutputFiles.java
@@ -22,6 +22,9 @@ import java.lang.annotation.*;
  * <p>Marks a property as specifying one or more output files for a task.</p>
  *
  * <p>This annotation should be attached to the getter method or the field for the property.</p>
+ *
+ * <p>This will cause the task to fail the up-to-date check when the file paths or contents
+ * are different to when the task was last run.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
This documents the existing behavior of the @Input* and @Output* task
dependencies. In particular it clarifies that how it impacts the "up-to-date"
checks on each task... and whether it depends on the content of an
annotated file or directory.

It also explains how to configure a dependency on only the path of a
file or directory and not the contents of it.

I have identified the behaviour through experimentation in Gradle 2.4.
Though this should get a review from someone familiar with the code.