### PR TITLE
Fix for test output filenames when using cucumber-jvm (both: xml and …

### DIFF
--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassTestResults.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassTestResults.java
@@ -26,6 +26,7 @@ import java.util.TreeSet;
  * Test results for a given class.
  */
 public class ClassTestResults extends CompositeTestResults {
+    private static final int MAX_FILENAME_BASE_LEN = 200;
     private final long id;
     private final String name;
     private final PackageTestResults packageResults;
@@ -49,7 +50,12 @@ public class ClassTestResults extends CompositeTestResults {
 
     @Override
     public String getBaseUrl() {
-        return String.format("classes/%s.html", FileUtils.toSafeFileName(name));
+        String safeFileName = FileUtils.toSafeFileName(name);
+                if(safeFileName.length()> MAX_FILENAME_BASE_LEN){
+            String idString = Long.toString(id);
+            safeFileName = safeFileName.substring(0, MAX_FILENAME_BASE_LEN-idString.length()-1)+"-"+idString;
+        }
+        return String.format("classes/%s.html", safeFileName);
     }
 
     public String getName() {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/PackageTestResults.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/report/PackageTestResults.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.internal.tasks.testing.junit.report;
 
+import org.gradle.internal.FileUtils;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
@@ -24,6 +26,7 @@ import java.util.TreeMap;
  */
 public class PackageTestResults extends CompositeTestResults {
     private static final String DEFAULT_PACKAGE = "default-package";
+    private static final int MAX_FILENAME_BASE_LEN = 200;
     private final String name;
     private final Map<String, ClassTestResults> classes = new TreeMap<String, ClassTestResults>();
 
@@ -38,7 +41,11 @@ public class PackageTestResults extends CompositeTestResults {
     }
 
     public String getBaseUrl() {
-        return String.format("packages/%s.html", name);
+        String safeFileName = FileUtils.toSafeFileName(name);
+        if (safeFileName.length() > MAX_FILENAME_BASE_LEN) {
+            safeFileName = safeFileName.substring(0, MAX_FILENAME_BASE_LEN);
+        }
+        return String.format("packages/%s.html", safeFileName);
     }
 
     public String getName() {

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGenerator.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGenerator.java
@@ -37,6 +37,7 @@ public class Binary2JUnitXmlReportGenerator {
     private final TestResultsProvider testResultsProvider;
     JUnitXmlResultWriter saxWriter;
     private final static Logger LOG = Logging.getLogger(Binary2JUnitXmlReportGenerator.class);
+    private final static int MAX_FILENAME_BASE_LEN = 200;
 
     public Binary2JUnitXmlReportGenerator(File testResultsDir, TestResultsProvider testResultsProvider, TestOutputAssociation outputAssociation) {
         this.testResultsDir = testResultsDir;
@@ -64,8 +65,13 @@ public class Binary2JUnitXmlReportGenerator {
         LOG.info("Finished generating test XML results ({}) into: {}", clock.getTime(), testResultsDir);
     }
 
-    private String getReportFileName(TestClassResult result) {
-        return "TEST-" + FileUtils.toSafeFileName(result.getClassName()) + ".xml";
+    String getReportFileName(TestClassResult result) {
+        String outFileName = FileUtils.toSafeFileName(result.getClassName());
+        if(outFileName.length()> MAX_FILENAME_BASE_LEN){
+            String idString = Long.toString(result.getId());
+            outFileName = outFileName.substring(0, MAX_FILENAME_BASE_LEN-idString.length()-1)+"-"+idString;
+        }
+        return "TEST-" + outFileName + ".xml";
     }
 
     private static String getHostname() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassTestResultsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/ClassTestResultsTest.groovy
@@ -30,7 +30,7 @@ class ClassTestResultsTest extends Specification {
 
     def baseUrlIsSafeFileName(String testName){
         given:
-        Pattern pattern = Pattern.compile("[a-zA-Z0-9\\.#_]");
+        Pattern pattern = Pattern.compile("[a-zA-Z0-9\\.#_/\$-]+");
 
         when:
         def baseUrl = new ClassTestResults(1, testName, null).getBaseUrl()
@@ -38,7 +38,7 @@ class ClassTestResultsTest extends Specification {
 
         then:
         baseUrl.length() < MAX_FILENAME_LEN
-        matcher.find()
+        matcher.matches()
 
         where:
         testName << [

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/PackageTestResultsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/PackageTestResultsTest.groovy
@@ -25,7 +25,7 @@ class PackageTestResultsTest extends Specification {
 
     def baseUrlIsSafeFileName(String testName){
         given:
-        Pattern pattern = Pattern.compile("[a-zA-Z0-9\\.#_]");
+        Pattern pattern = Pattern.compile("[a-zA-Z0-9\\.#_/\$-]+");
 
         when:
         def baseUrl = new PackageTestResults(testName, null).getBaseUrl()
@@ -33,7 +33,7 @@ class PackageTestResultsTest extends Specification {
 
         then:
         baseUrl.length() < MAX_FILENAME_LEN
-        matcher.find()
+        matcher.matches()
 
         where:
         testName << [

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/PackageTestResultsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/PackageTestResultsTest.groovy
@@ -16,24 +16,19 @@
 package org.gradle.api.internal.tasks.testing.junit.report
 
 import spock.lang.Specification
+
 import java.util.regex.Pattern
 
-class ClassTestResultsTest extends Specification {
+class PackageTestResultsTest extends Specification {
 
     public static final int MAX_FILENAME_LEN = 250
-
-    def determinesSimpleName() {
-        expect:
-        new ClassTestResults(1, 'org.gradle.Test', null).simpleName == 'Test'
-        new ClassTestResults(2, 'Test', null).simpleName == 'Test'
-    }
 
     def baseUrlIsSafeFileName(String testName){
         given:
         Pattern pattern = Pattern.compile("[a-zA-Z0-9\\.#_]");
 
         when:
-        def baseUrl = new ClassTestResults(1, testName, null).getBaseUrl()
+        def baseUrl = new PackageTestResults(testName, null).getBaseUrl()
         def matcher = pattern.matcher(baseUrl);
 
         then:

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -22,7 +22,11 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
+import java.util.regex.Pattern
+
 class Binary2JUnitXmlReportGeneratorSpec extends Specification {
+
+    public static final int MAX_FILENAME_LEN = 250
 
     @Rule private TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
     private resultsProvider = Mock(TestResultsProvider)
@@ -71,4 +75,26 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
         ex.message.startsWith('Could not write XML test results for FooTest')
         ex.cause.message == "Boo!"
     }
+
+    def fileNameIsSafe(String testName){
+        given:
+        Pattern pattern = Pattern.compile("[a-zA-Z0-9\\.#_]");
+        TestClassResult result = new TestClassResult(1, testName, 100)
+
+        when:
+        def fileName = generator.getReportFileName(result)
+        def matcher = pattern.matcher(fileName);
+
+        then:
+        fileName.length() < MAX_FILENAME_LEN
+        matcher.find()
+
+        where:
+        testName << [
+            'abc ~#@*+%{}<>\\[]|"^' * 20,
+            'ąęþó→↓←ß©ęœπąśðæŋ’ə…ł≤µń”„ćźż',
+            '| customer1 | 127.0.0.1 | nod1 | 2 | MML command | /webapp/protocolSelection?$selected_rows.Customer=customer1&$selected_rows.ElementManagerIP=127.0.0.1&$selected_rows.Manager=10.0.0.1&$selected_rows.Node=nod1&$selected_rows.NodeAlias=nod1&$selected_rows.Region=region1&datasource=the_silo&FORCE_SHOW_APPLET=YES&login=user3&VNECLI_NODE_TYPE_CLASS_PARAMETERS=OSSRC_IP%3D127.0.0.1%7CNode%3Dnod1&Protocol=OSSRC_MML |'
+        ]
+    }
+
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -78,16 +78,17 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
 
     def fileNameIsSafe(String testName){
         given:
-        Pattern pattern = Pattern.compile("[a-zA-Z0-9\\.#_]");
+        Pattern pattern = Pattern.compile("[a-zA-Z0-9\\.#_/\$-]+");
         TestClassResult result = new TestClassResult(1, testName, 100)
 
         when:
         def fileName = generator.getReportFileName(result)
         def matcher = pattern.matcher(fileName);
+        println fileName
 
         then:
         fileName.length() < MAX_FILENAME_LEN
-        matcher.find()
+        matcher.matches()
 
         where:
         testName << [


### PR DESCRIPTION
…html)

Hi,

Recently I came into similar troubles like described here: https://discuss.gradle.org/t/gradle-is-generating-files-with-their-names-too-big-in-cucumber-tests/8537/3

The problem is, that when using cucumber-jvm with junit, it returns for Scenario Outline list of parameter values as a class name. This leads to situations when filenames can contain illegal characters or are too long for operating system.

I've added use of FileUtils.toSafeFileName method in all cases when filename is generated, and also added limiting filename length.