### PR TITLE
Fix NPE in :performance:test when building in detched HEAD state

### DIFF
--- a/subprojects/performance/src/testFixtures/groovy/org/gradle/performance/fixture/Git.groovy
+++ b/subprojects/performance/src/testFixtures/groovy/org/gradle/performance/fixture/Git.groovy
@@ -34,7 +34,7 @@ class Git {
         def repository = new FileRepositoryBuilder().findGitDir().build()
         try {
             branchName = repository.branch
-            commitId = repository.getRef(repository.fullBranch).objectId.name
+            commitId = repository.resolve(repository.fullBranch).name
         } finally {
             repository.close()
         }

--- a/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/test/plugins/NativeBinariesTestPlugin.java
+++ b/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/test/plugins/NativeBinariesTestPlugin.java
@@ -120,7 +120,9 @@ public class NativeBinariesTestPlugin implements Plugin<Project> {
                 @Override
                 public void execute(Task checkTask) {
                     for (NativeTestSuiteBinarySpec testBinary : binaries.withType(NativeTestSuiteBinarySpec.class)) {
-                        checkTask.dependsOn(testBinary.getTasks().getRun());
+                        if (testBinary.isBuildable()) {
+                            checkTask.dependsOn(testBinary.getTasks().getRun());
+                        }
                     }
                 }
             });


### PR DESCRIPTION
When building in a detached HEAD state (eg. after git checkout REL_2.5) a number of tests in :performance:test fail with a NPE in Git.groovy as follows:

```
can use 'last' baseline version to refer to most recently released version

java.lang.NullPointerException: Cannot get property 'objectId' on null object
	at org.gradle.performance.fixture.Git.<init>(Git.groovy:37)
	at org.gradle.performance.fixture.Git.current(Git.groovy:28)
	at org.gradle.performance.fixture.CrossVersionPerformanceTestRunner.run(CrossVersionPerformanceTestRunner.groovy:64)
	at org.gradle.performance.fixture.CrossVersionPerformanceTestRunnerTest.can use 'last' baseline version to refer to most recently released version(CrossVersionPerformanceTestRunnerTest.groovy:88)
```
