### PR TITLE
Make check task depend only on buildable native test binaries & fix test case

### DIFF
--- a/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/test/plugins/NativeBinariesTestPlugin.java
+++ b/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/test/plugins/NativeBinariesTestPlugin.java
@@ -97,7 +97,9 @@ public class NativeBinariesTestPlugin implements Plugin<Project> {
                 @Override
                 public void execute(Task checkTask) {
                     for (NativeTestSuiteBinarySpec testBinary : binaries) {
-                        checkTask.dependsOn(testBinary.getTasks().getRun());
+                        if (testBinary.isBuildable()) {
+                            checkTask.dependsOn(testBinary.getTasks().getRun());
+                        }
                     }
                 }
             });


### PR DESCRIPTION
This PR is my attempt at fixing the issue as described here: https://discuss.gradle.org/t/gradle-2-5-google-test-plugin-tries-to-compile-tests-for-incorrect-platform/10590

The problem occurs with both the cunit and google-test plugins where it adds all native tests as dependencies of the check lifecycle task, including ones that are not buildable (in my case because the necessary toolchain is not available on the build platform.) My solution is simply to add only buildable tests as dependencies.

This patch also incidentally fixes what looks like a bug in the test where it checks
`project.tasks.getByName("check") dependsOn("runTestBinary")`
It looks to me like this was intended to use the `TaskDependencyMatchers.dependsOn` matcher to assert that the dependency exists, but instead invokes dependsOn to add the dependency. The dependency wasn't there in the first place because `attachBinariesToCheckLifecycle()` was never invoked.