### PR TITLE
Fix typo in userguide cross-reference

### DIFF
--- a/subprojects/docs/src/docs/userguide/customPlugins.xml
+++ b/subprojects/docs/src/docs/userguide/customPlugins.xml
@@ -75,7 +75,7 @@
         <para>
             One thing to note is that a new instance of a given plugin is created for each project it is applied to. Also
             note that the <apilink class="org.gradle.api.Plugin"/> class is a generic type. This example has it receiving the
-            <apilink class="org.gradle.api.Plugin"/> type as a type parameter. It's possible to write unusual custom
+            <apilink class="org.gradle.api.Project"/> type as a type parameter. It's possible to write unusual custom
             plugins that take different type parameters, but this will be unlikely (until someone figures out more
             creative things to do here). 
         </para>


### PR DESCRIPTION
The sample code is

    class GreetingPlugin implements Plugin<Project> {
        void apply(Project project) {
            project.task('hello') << {
                println "Hello from the GreetingPlugin"
            }
        }
    }

The text currently says:

> Also note that the `Plugin` class is a generic type. This example has it receiving the `Plugin` type as a type parameter.

Looks like `Project` was intended here.