### PR TITLE
Update default output dir path

### DIFF
--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipsePlugin.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipsePlugin.groovy
@@ -115,7 +115,7 @@ class EclipsePlugin extends IdePlugin {
 
     private void configureEclipseClasspath(Project project, EclipseModel model) {
         model.classpath = instantiator.newInstance(EclipseClasspath, project)
-        model.classpath.conventionMapping.defaultOutputDir = { new File(project.projectDir, 'bin') }
+        model.classpath.conventionMapping.defaultOutputDir = project.buildDir
 
         project.plugins.withType(JavaBasePlugin) {
             maybeAddTask(project, this, ECLIPSE_CP_TASK_NAME, GenerateEclipseClasspath) { task ->

--- a/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipsePlugin.groovy
+++ b/subprojects/ide/src/main/groovy/org/gradle/plugins/ide/eclipse/EclipsePlugin.groovy
@@ -115,7 +115,7 @@ class EclipsePlugin extends IdePlugin {
 
     private void configureEclipseClasspath(Project project, EclipseModel model) {
         model.classpath = instantiator.newInstance(EclipseClasspath, project)
-        model.classpath.conventionMapping.defaultOutputDir = project.buildDir
+        model.classpath.conventionMapping.defaultOutputDir = { project.buildDir }
 
         project.plugins.withType(JavaBasePlugin) {
             maybeAddTask(project, this, ECLIPSE_CP_TASK_NAME, GenerateEclipseClasspath) { task ->

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
@@ -150,7 +150,7 @@ class EclipsePluginTest extends Specification {
         assert classpath.plusConfigurations == configurations
         assert classpath.minusConfigurations == []
         assert classpath.containers == ['org.eclipse.jdt.launching.JRE_CONTAINER'] + additionalContainers as Set
-        assert classpath.defaultOutputDir == new File(project.projectDir, 'bin')
+        assert classpath.defaultOutputDir == project.buildDir
     }
 
     private void checkEclipseJdt() {


### PR DESCRIPTION
Update default output dir path to match the project configured path so that command line builds can use the same cache as ide builds. If the user needs different paths for some reason, it would make sense to change the default at that time. This also possibly reduces the amount of .gitignore lines since the user won't have to ignore 2 build paths by default.