### PR TITLE
Make environment variables also define property names with dots

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/initialization/DefaultGradlePropertiesLoader.java
+++ b/subprojects/core/src/main/groovy/org/gradle/initialization/DefaultGradlePropertiesLoader.java
@@ -92,7 +92,9 @@ public class DefaultGradlePropertiesLoader implements IGradlePropertiesLoader {
         Map<String, String> envProjectProperties = new HashMap<String, String>();
         for (Map.Entry<String, String> entry : envProperties.entrySet()) {
             if (entry.getKey().startsWith(ENV_PROJECT_PROPERTIES_PREFIX) && entry.getKey().length() > ENV_PROJECT_PROPERTIES_PREFIX.length()) {
-                envProjectProperties.put(entry.getKey().substring(ENV_PROJECT_PROPERTIES_PREFIX.length()), entry.getValue());
+                String name = entry.getKey().substring(ENV_PROJECT_PROPERTIES_PREFIX.length());
+                envProjectProperties.put(name, entry.getValue());
+                envProjectProperties.put(name.replace('_', '.'), entry.getValue());
             }
         }
         logger.debug("Found env project properties: {}", envProjectProperties.keySet());

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
@@ -145,6 +145,17 @@ public class DefaultGradlePropertiesLoaderTest {
     }
 
     @Test
+    public void environmentVariablesDefinePropertiesWithUnderscoresReplacedByDots() {
+        envProperties = GUtil.map(
+                IGradlePropertiesLoader.ENV_PROJECT_PROPERTIES_PREFIX + "env_prop", "env value");
+
+        gradlePropertiesLoader.loadProperties(settingsDir, startParameter, systemProperties, envProperties);
+        Map<String, String> properties = gradlePropertiesLoader.mergeProperties(Collections.<String, String>emptyMap());
+
+        assertEquals("env value", properties.get("env.prop"));
+    }
+
+    @Test
     public void environmentVariablesHavePrecedenceOverProjectProperties() {
         writePropertyFile(gradleUserHomeDir, GUtil.map("prop", "user value"));
         writePropertyFile(settingsDir, GUtil.map("prop", "settings value"));

--- a/subprojects/docs/src/docs/userguide/buildEnvironment.xml
+++ b/subprojects/docs/src/docs/userguide/buildEnvironment.xml
@@ -108,8 +108,8 @@
         </para>
         <para>You can also add properties directly to your project object via the <option>-P</option> command line option.
         </para>
-        <para>Gradle can also set project properties when it sees specially-named system properties or
-            environment variables. This feature is very useful when you don't have admin rights to a continuous integration
+        <para>Gradle can also set project properties when it sees specially-named environment variables or
+            system properties. This feature is very useful when you don't have admin rights to a continuous integration
             server and you need to set property values that should not be easily visible, typically for security reasons.
             In that situation, you can't use the <option>-P</option> option, and you can't change the system-level
             configuration files.  The correct strategy is to change the configuration of your continuous integration
@@ -122,12 +122,10 @@
             </footnote>
         </para>
         <para>
-            If the environment variable name looks like
-            <literal>ORG_GRADLE_PROJECT_<replaceable>prop</replaceable>=somevalue</literal>,
-            then Gradle will set a <literal>prop</literal> property on your project object, with the value
-            of <literal>somevalue</literal>. Gradle also supports this for
-            system properties, but with a different naming pattern, which looks like
-            <literal>org.gradle.project.<replaceable>prop</replaceable></literal>.
+            If Gradle's environment contains a variable that looks like <literal>ORG_GRADLE_PROJECT_<replaceable>prop_name</replaceable>=somevalue</literal>,
+            then Gradle will set both a <literal>prop_name</literal> and a <literal>prop.name</literal> property on your project object,
+            each with the value of <literal>somevalue</literal>. To set a project property via a system property, name the latter like
+            <literal>org.gradle.project.<replaceable>prop_name</replaceable></literal>.
         </para>
         <para>You can also set system properties in the <filename>gradle.properties</filename> file. If a property
             name in such a file has the prefix “<literal>systemProp.</literal>”, like “<literal>systemProp.propName</literal>”,


### PR DESCRIPTION
It is common for properties to have dots in their names. Previously, such
properties could not have been defined via environment variables as e.g.
Linux does not permit to have dots in environment variables names. Address
this limitation by making environment variables also define properties
that have underscores replaced with dots in their names. This way
properties with dots in their name can be set via the environment by
setting the appropriate environment variable that has the dots replaced
with underscores.