### PR TITLE
Add support for generating HTML reports to the Checkstyle plugin

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
@@ -43,6 +43,11 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.Class2"))
         file("build/reports/checkstyle/test.xml").assertContents(containsClass("org.gradle.TestClass1"))
         file("build/reports/checkstyle/test.xml").assertContents(containsClass("org.gradle.TestClass2"))
+
+        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.Class1"))
+        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.Class2"))
+        file("build/reports/checkstyle/test.html").assertContents(containsClass("org.gradle.TestClass1"))
+        file("build/reports/checkstyle/test.html").assertContents(containsClass("org.gradle.TestClass2"))
     }
 
     def "analyze bad code"() {
@@ -56,6 +61,9 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         failure.error.contains("Name 'class1' must match pattern")
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.class1"))
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.class2"))
+
+        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.class1"))
+        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.class2"))
     }
 
     def "can suppress console output"() {
@@ -73,6 +81,9 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         !failure.error.contains("Name 'class1' must match pattern")
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.class1"))
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.class2"))
+
+        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.class1"))
+        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.class2"))
     }
 
     def "can ignore failures"() {
@@ -88,6 +99,9 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         output.contains("Checkstyle rule violations were found. See the report at:")
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.class1"))
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.class2"))
+
+        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.class1"))
+        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.class2"))
     }
 
     @IgnoreIf({GradleContextualExecuter.parallel})
@@ -102,6 +116,7 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
 
         when:
         file("build/reports/checkstyle/main.xml").delete()
+        file("build/reports/checkstyle/main.html").delete()
 
         then:
         succeeds("checkstyleMain") && ":checkstyleMain" in nonSkippedTasks
@@ -113,12 +128,16 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
 
         when:
         buildFile << """
-            checkstyleMain.reports { xml.destination "foo.xml" }
+            checkstyleMain.reports {
+                xml.destination "foo.xml"
+                html.destination "bar.html"
+            }
         """
 
         then:
         succeeds "checkstyleMain"
         file("foo.xml").exists()
+        file("bar.html").exists()
     }
 
     private goodCode() {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.groovy
@@ -58,9 +58,11 @@ class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
             showViolations = { extension.showViolations }
         }
 
-        task.reports.xml.conventionMapping.with {
-            enabled = { true }
-            destination = { new File(extension.reportsDir, "${baseName}.xml") }
+        task.reports.all { report ->
+            report.conventionMapping.with {
+                enabled = { true }
+                destination = { new File(extension.reportsDir, "${baseName}.${report.name}") }
+            }
         }
     }
 

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleReports.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleReports.java
@@ -25,6 +25,13 @@ import org.gradle.api.reporting.SingleFileReport;
 public interface CheckstyleReports extends ReportContainer<SingleFileReport> {
 
     /**
+     * The checkstyle HTML report
+     *
+     * @return The checkstyle HTML report
+     */
+    SingleFileReport getHtml();
+
+    /**
      * The checkstyle XML report
      *
      * @return The checkstyle XML report

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleReportsImpl.java
@@ -25,8 +25,13 @@ import org.gradle.api.reporting.internal.TaskReportContainer;
 public class CheckstyleReportsImpl extends TaskReportContainer<SingleFileReport> implements CheckstyleReports {
     public CheckstyleReportsImpl(Task task) {
         super(SingleFileReport.class, task);
-        
+
+        add(TaskGeneratedSingleFileReport.class, "html", task);
         add(TaskGeneratedSingleFileReport.class, "xml", task);
+    }
+
+    public SingleFileReport getHtml() {
+        return getByName("html");
     }
 
     public SingleFileReport getXml() {

--- a/subprojects/code-quality/src/main/resources/checkstyle-noframes-sorted.xsl
+++ b/subprojects/code-quality/src/main/resources/checkstyle-noframes-sorted.xsl
@@ -1,0 +1,195 @@
+<xsl:stylesheet	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<xsl:output method="html" indent="yes"/>
+<xsl:decimal-format decimal-separator="." grouping-separator="," />
+
+<xsl:key name="files" match="file" use="@name" />
+
+<!-- Checkstyle XML Style Sheet by Stephane Bailliez <sbailliez@apache.org>         -->
+<!-- Part of the Checkstyle distribution found at http://checkstyle.sourceforge.net -->
+<!-- Usage (generates checkstyle_report.html):                                      -->
+<!--    <checkstyle failonviolation="false" config="${check.config}">               -->
+<!--      <fileset dir="${src.dir}" includes="**/*.java"/>                          -->
+<!--      <formatter type="xml" toFile="${doc.dir}/checkstyle_report.xml"/>         -->
+<!--    </checkstyle>                                                               -->
+<!--    <style basedir="${doc.dir}" destdir="${doc.dir}"                            -->
+<!--            includes="checkstyle_report.xml"                                    -->
+<!--            style="${doc.dir}/checkstyle-noframes-sorted.xsl"/>                 -->
+
+<xsl:template match="checkstyle">
+	<html>
+		<head>
+		<style type="text/css">
+    .bannercell {
+      border: 0px;
+      padding: 0px;
+    }
+    body {
+      margin-left: 10;
+      margin-right: 10;
+      font:normal 80% arial,helvetica,sanserif;
+      background-color:#FFFFFF;
+      color:#000000;
+    }
+    .a td {
+      background: #efefef;
+    }
+    .b td {
+      background: #fff;
+    }
+    th, td {
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      font-weight:bold;
+      background: #ccc;
+      color: black;
+    }
+    table, th, td {
+      font-size:100%;
+      border: none
+    }
+    table.log tr td, tr th {
+
+    }
+    h2 {
+      font-weight:bold;
+      font-size:140%;
+      margin-bottom: 5;
+    }
+    h3 {
+      font-size:100%;
+      font-weight:bold;
+      background: #525D76;
+      color: white;
+      text-decoration: none;
+      padding: 5px;
+      margin-right: 2px;
+      margin-left: 2px;
+      margin-bottom: 0;
+    }
+		</style>
+		</head>
+		<body>
+			<a name="top"></a>
+      <!-- jakarta logo -->
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td class="bannercell" rowspan="2">
+          <!--a href="http://jakarta.apache.org/">
+          <img src="http://jakarta.apache.org/images/jakarta-logo.gif" alt="http://jakarta.apache.org" align="left" border="0"/>
+          </a-->
+        </td>
+    		<td class="text-align:right"><h2>CheckStyle Audit</h2></td>
+    		</tr>
+    		<tr>
+    		<td class="text-align:right">Designed for use with <a href='http://checkstyle.sourceforge.net/'>CheckStyle</a> and <a href='http://jakarta.apache.org'>Ant</a>.</td>
+    		</tr>
+      </table>
+    	<hr size="1"/>
+
+			<!-- Summary part -->
+			<xsl:apply-templates select="." mode="summary"/>
+			<hr size="1" width="100%" align="left"/>
+
+			<!-- Package List part -->
+			<xsl:apply-templates select="." mode="filelist"/>
+			<hr size="1" width="100%" align="left"/>
+
+			<!-- For each package create its part -->
+            <xsl:apply-templates select="file[@name and generate-id(.) = generate-id(key('files', @name))]" />
+
+			<hr size="1" width="100%" align="left"/>
+
+
+		</body>
+	</html>
+</xsl:template>
+
+
+
+	<xsl:template match="checkstyle" mode="filelist">
+		<h3>Files</h3>
+		<table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
+      <tr>
+        <th>Name</th>
+        <th>Errors</th>
+      </tr>
+          <xsl:for-each select="file[@name and generate-id(.) = generate-id(key('files', @name))]">
+                <xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error)"/>
+				<xsl:variable name="errorCount" select="count(error)"/>
+				<tr>
+          <xsl:call-template name="alternated-row"/>
+					<td><a href="#f-{@name}"><xsl:value-of select="@name"/></a></td>
+					<td><xsl:value-of select="$errorCount"/></td>
+				</tr>
+			</xsl:for-each>
+		</table>
+	</xsl:template>
+
+
+	<xsl:template match="file">
+    <a name="f-{@name}"></a>
+    <h3>File <xsl:value-of select="@name"/></h3>
+
+    <table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
+    	<tr>
+    	  <th>Error Description</th>
+    	  <th>Line</th>
+      </tr>
+        <xsl:for-each select="key('files', @name)/error">
+          <xsl:sort data-type="number" order="ascending" select="@line"/>
+    	<tr>
+        <xsl:call-template name="alternated-row"/>
+    	  <td><xsl:value-of select="@message"/></td>
+    	  <td><xsl:value-of select="@line"/></td>
+    	</tr>
+    	</xsl:for-each>
+    </table>
+    <a href="#top">Back to top</a>
+	</xsl:template>
+
+
+	<xsl:template match="checkstyle" mode="summary">
+		<h3>Summary</h3>
+        <xsl:variable name="fileCount" select="count(file[@name and generate-id(.) = generate-id(key('files', @name))])"/>
+		<xsl:variable name="errorCount" select="count(file/error)"/>
+		<table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
+		<tr>
+			<th>Files</th>
+			<th>Errors</th>
+		</tr>
+		<tr>
+		  <xsl:call-template name="alternated-row"/>
+			<td><xsl:value-of select="$fileCount"/></td>
+			<td><xsl:value-of select="$errorCount"/></td>
+		</tr>
+		</table>
+	</xsl:template>
+
+  <xsl:template name="alternated-row">
+    <xsl:attribute name="class">
+      <xsl:if test="position() mod 2 = 1">a</xsl:if>
+      <xsl:if test="position() mod 2 = 0">b</xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+</xsl:stylesheet>
+
+

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
@@ -84,6 +84,7 @@ class CheckstylePluginTest extends Specification {
             assert config.inputFiles.singleFile == project.file("config/checkstyle/checkstyle.xml")
             assert configProperties == [:]
             assert reports.xml.destination == project.file("build/reports/checkstyle/${sourceSet.name}.xml")
+            assert reports.html.destination == project.file("build/reports/checkstyle/${sourceSet.name}.html")
             assert !ignoreFailures
             assert showViolations
         }
@@ -100,6 +101,7 @@ class CheckstylePluginTest extends Specification {
         task.config.inputFiles.singleFile == project.file("config/checkstyle/checkstyle.xml")
         task.configProperties == [:]
         task.reports.xml.destination == project.file("build/reports/checkstyle/custom.xml")
+        task.reports.html.destination == project.file("build/reports/checkstyle/custom.html")
         !task.ignoreFailures
     }
 
@@ -151,6 +153,7 @@ class CheckstylePluginTest extends Specification {
             assert config.inputFiles.singleFile == project.file("checkstyle-config")
             assert configProperties == [foo: "foo"]
             assert reports.xml.destination == project.file("checkstyle-reports/${sourceSet.name}.xml")
+            assert reports.html.destination == project.file("checkstyle-reports/${sourceSet.name}.html")
             assert ignoreFailures
             assert showViolations
         }
@@ -173,6 +176,7 @@ class CheckstylePluginTest extends Specification {
         task.config.inputFiles.singleFile == project.file("checkstyle-config")
         task.configProperties == [foo: "foo"]
         task.reports.xml.destination == project.file("checkstyle-reports/custom.xml")
+        task.reports.html.destination == project.file("checkstyle-reports/custom.html")
         task.ignoreFailures
     }
 

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstyleTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstyleTest.groovy
@@ -35,6 +35,9 @@ class CheckstyleTest extends Specification {
             !reports.xml.enabled
             reports.xml.destination == null
             reports.xml.outputType == Report.OutputType.FILE
+            !reports.html.enabled
+            reports.html.destination == null
+            reports.html.outputType == Report.OutputType.FILE
             !ignoreFailures
             showViolations
         }


### PR DESCRIPTION
The committed XSL file was taken from [1].

[1] https://svn.apache.org/repos/asf/hive/trunk/checkstyle/checkstyle-noframes-sorted.xsl