### PR TITLE
Tar task also needs encoding

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/archive/TarCopyAction.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/archive/TarCopyAction.java
@@ -36,10 +36,12 @@ import java.io.OutputStream;
 public class TarCopyAction implements CopyAction {
     private final File tarFile;
     private final ArchiveOutputStreamFactory compressor;
+    private final String encoding;
 
-    public TarCopyAction(File tarFile, ArchiveOutputStreamFactory compressor) {
+    public TarCopyAction(File tarFile, ArchiveOutputStreamFactory compressor, String encoding) {
         this.tarFile = tarFile;
         this.compressor = compressor;
+        this.encoding = encoding;
     }
 
     public WorkResult execute(final CopyActionProcessingStream stream) {
@@ -56,7 +58,7 @@ public class TarCopyAction implements CopyAction {
             protected void doExecute(final OutputStream outStr) throws Exception {
                 TarOutputStream tarOutStr;
                 try {
-                    tarOutStr = new TarOutputStream(outStr);
+                    tarOutStr = new TarOutputStream(outStr, encoding);
                 } catch (Exception e) {
                     throw new GradleException(String.format("Could not create TAR '%s'.", tarFile), e);
                 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -33,6 +33,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     private String version;
     private String extension;
     private String classifier = "";
+    private String encoding;
 
     /**
      * Returns the archive name. If the name has not been explicitly set, the pattern for the name is:
@@ -155,6 +156,25 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
 
     public void setClassifier(String classifier) {
         this.classifier = classifier;
+    }
+
+    /**
+     * The encoding to use for filenames and the file comment of the archive.
+     *
+     * @return null if using the platform's default character encoding.
+     */
+    public String getEncoding() {
+        return this.encoding;
+    }
+
+    /**
+     * The encoding to use for filenames and the file comment of the archive.
+     * Defaults to the platform's default character encoding.
+     *
+     * @param encoding the encoding value
+     */
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
     }
 
     /**

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/Tar.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/Tar.java
@@ -41,7 +41,7 @@ public class Tar extends AbstractArchiveTask {
 
     @Override
     protected CopyAction createCopyAction() {
-        return new TarCopyAction(getArchivePath(), getCompressor());
+        return new TarCopyAction(getArchivePath(), getCompressor(), getEncoding());
     }
 
     private ArchiveOutputStreamFactory getCompressor() {

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/Zip.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/bundling/Zip.java
@@ -30,7 +30,6 @@ public class Zip extends AbstractArchiveTask {
     public static final String ZIP_EXTENSION = "zip";
     private ZipEntryCompression entryCompression = ZipEntryCompression.DEFLATED;
     private boolean allowZip64;
-    private String encoding;
 
     public Zip() {
         setExtension(ZIP_EXTENSION);
@@ -51,7 +50,7 @@ public class Zip extends AbstractArchiveTask {
     @Override
     protected CopyAction createCopyAction() {
         DocumentationRegistry documentationRegistry = getServices().get(DocumentationRegistry.class);
-        return new ZipCopyAction(getArchivePath(), getCompressor(), documentationRegistry, encoding);
+        return new ZipCopyAction(getArchivePath(), getCompressor(), documentationRegistry, getEncoding());
     }
 
     /**
@@ -98,25 +97,6 @@ public class Zip extends AbstractArchiveTask {
     @Incubating
     public boolean isZip64() {
         return allowZip64;
-    }
-
-    /**
-     * The encoding to use for filenames and the file comment of the archive.
-     *
-     * @return null if using the platform's default character encoding.
-     */
-    public String getEncoding() {
-        return this.encoding;
-    }
-
-    /**
-     * The encoding to use for filenames and the file comment of the archive.
-     * Defaults to the platform's default character encoding.
-     * 
-     * @param encoding the encoding value
-     */
-    public void setEncoding(String encoding) {
-        this.encoding = encoding;
     }
 
     /**

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -223,6 +223,11 @@ public class TestFile extends File {
         new TestFileHelper(this).untarTo(target, useNativeTools);
     }
 
+    public void untarTo(File target, String encoding) {
+        assertIsFile();
+        new TestFileHelper(this).untarTo(target, useNativeTools, encoding);
+    }
+
     public void copyTo(File target) {
         if (isDirectory()) {
             try {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
@@ -72,7 +72,7 @@ class TestFileHelper {
         unzip.execute()
     }
 
-    void untarTo(File target, boolean nativeTools) {
+    void untarTo(File target, boolean nativeTools, String encoding=null) {
         if (nativeTools && isUnix()) {
             target.mkdirs()
             def builder = new ProcessBuilder(['tar', '-xpf', file.absolutePath])
@@ -86,6 +86,9 @@ class TestFileHelper {
         def untar = new Untar()
         untar.setSrc(file)
         untar.setDest(target)
+        if (encoding != null) {
+            untar.setEncoding(encoding)
+        }
 
         if (file.name.endsWith(".tgz")) {
             def method = new Untar.UntarCompressionMethod()


### PR DESCRIPTION
@bigdaz @mark-vieira 
`Tar` task has a little different with `Zip`, the `Untar` in current `Ant` version (`1.9.3`) does not support to set encoding, and I noticed that there was a revert of `Ant` version from `1.9.5` to `1.9.3`. 

As mentioned in [Apache Ant Homepage](https://ant.apache.org/)

> Ant 1.9.6 fixes a regression in the zip package introduced with Ant 1.9.5.

I think `Ant 1.9.6` could make us all good ;)