### PR TITLE
[GRADLE-3329] Fix long lines of UTF-8 mangled in exec output

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
+++ b/subprojects/core/src/main/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
@@ -53,8 +53,8 @@ public class ExecOutputHandleRunner implements Runnable {
                     break;
                 }
                 outputStream.write(buffer, 0, nread);
-                outputStream.flush();
             }
+            outputStream.flush();
             CompositeStoppable.stoppable(inputStream, outputStream).stop();
         } catch (Throwable t) {
             LOGGER.error(String.format("Could not %s.", displayName), t);

--- a/subprojects/core/src/main/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
+++ b/subprojects/core/src/main/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
@@ -53,8 +53,8 @@ public class ExecOutputHandleRunner implements Runnable {
                     break;
                 }
                 outputStream.write(buffer, 0, nread);
+                outputStream.flush();
             }
-            outputStream.flush();
             CompositeStoppable.stoppable(inputStream, outputStream).stop();
         } catch (Throwable t) {
             LOGGER.error(String.format("Could not %s.", displayName), t);

--- a/subprojects/core/src/main/groovy/org/gradle/util/LineBufferingOutputStream.java
+++ b/subprojects/core/src/main/groovy/org/gradle/util/LineBufferingOutputStream.java
@@ -51,7 +51,7 @@ public class LineBufferingOutputStream extends OutputStream {
      */
     public void close() throws IOException {
         hasBeenClosed = true;
-        flush();
+        flushInternal();
         handler.endOfStream(null);
     }
 
@@ -80,9 +80,7 @@ public class LineBufferingOutputStream extends OutputStream {
 
         buf[count] = (byte) b;
         count++;
-        if (endsWithLineSeparator()) {
-            flush();
-        }
+        flush();
     }
 
     private boolean endsWithLineSeparator() {
@@ -98,6 +96,12 @@ public class LineBufferingOutputStream extends OutputStream {
     }
 
     public void flush() {
+        if (endsWithLineSeparator()) {
+            flushInternal();
+        }
+    }
+
+    private void flushInternal() {
         if (count != 0) {
             handler.text(new String(buf, 0, count));
         }

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunnerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunnerTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.process.internal.streams
 
-import groovy.transform.NotYetImplemented
 import org.gradle.internal.io.TextStream
 import org.gradle.util.LineBufferingOutputStream
 import spock.lang.Issue
@@ -25,7 +24,6 @@ import spock.lang.Specification
 class ExecOutputHandleRunnerTest extends Specification {
 
     @Issue("GRADLE-3329")
-    @NotYetImplemented
     def "passes long Unicode line as single line"() {
         def bufferLength = 8
         def text = "a" * (bufferLength - 1) + "\u0151"


### PR DESCRIPTION
Only flush `exec` output after all the data has been processed. This shouldn't affect line-by-line flushing, as exec outputs are piped through a `LineBufferingOutputStream` as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gradle/gradle/508)
<!-- Reviewable:end -->
