### PR TITLE
Update gradleDaemon.xml

### DIFF
--- a/subprojects/docs/src/docs/userguide/gradleDaemon.xml
+++ b/subprojects/docs/src/docs/userguide/gradleDaemon.xml
@@ -67,7 +67,7 @@
             <para>
                 On Windows, this command will enable the Daemon for the current user:
                 <programlisting>
-                    (if not exist "%HOMEPATH%/.gradle" mkdir "%HOMEPATH%/.gradle") &amp;&amp; (echo org.gradle.daemon=true >> "%HOMEPATH%/.gradle/gradle.properties")
+                    (if not exist "%USERPROFILE%/.gradle" mkdir "%USERPROFILE%/.gradle") &amp;&amp; (echo org.gradle.daemon=true >> "%USERPROFILE%/.gradle/gradle.properties")
                 </programlisting>
                 On UNIX-like operating systems, the following Bash shell command will enable the Daemon for the current user:
                 <programlisting>


### PR DESCRIPTION
there are some issues with this line:
a, it does use the %HOMEPATH% variable, which does not include the drive. Therefor if executed on D: it's wrong
b, no need for " around the echo. This results in wrong output.