### PR TITLE
Removed scala console tasks

### DIFF
--- a/subprojects/scala/src/main/groovy/org/gradle/api/plugins/scala/ScalaBasePlugin.groovy
+++ b/subprojects/scala/src/main/groovy/org/gradle/api/plugins/scala/ScalaBasePlugin.groovy
@@ -77,7 +77,6 @@ class ScalaBasePlugin implements Plugin<Project> {
             sourceSet.resources.filter.exclude { FileTreeElement element -> sourceSet.scala.contains(element.file) }
 
             configureScalaCompile(javaPlugin, sourceSet)
-            configureScalaConsole(sourceSet)
         }
     }
 


### PR DESCRIPTION
From the discussion, located at:
https://discuss.gradle.org/t/scalaconsole-fails-for-gradle-2-6/11147,
it was suggested that the scalaConsole task be removed, since it
doesn't have ay automated test coverage, wasn't documened and
wasn't ever finshed properly.