### PR TITLE
Fix shell script generated by the InstallExecutable task

### DIFF
--- a/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/tasks/InstallExecutable.groovy
+++ b/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/tasks/InstallExecutable.groovy
@@ -148,8 +148,16 @@ ENDLOCAL
         runScript.text = """
 #/bin/sh
 APP_BASE_NAME=`dirname "\$0"`
-export DYLD_LIBRARY_PATH="\$APP_BASE_NAME/lib"
-export LD_LIBRARY_PATH="\$APP_BASE_NAME/lib"
+if [ -z "$DYLD_LIBRARY_PATH" ]; then
+    export DYLD_LIBRARY_PATH="\$APP_BASE_NAME/lib"
+else
+    export DYLD_LIBRARY_PATH="\$APP_BASE_NAME/lib:\$DYLD_LIBRARY_PATH"
+fi
+if [ -z "$LD_LIBRARY_PATH" ]; then
+    export LD_LIBRARY_PATH="\$APP_BASE_NAME/lib"
+else
+    export LD_LIBRARY_PATH="\$APP_BASE_NAME/lib:\$LD_LIBRARY_PATH"
+fi
 exec "\$APP_BASE_NAME/lib/${executable.name}" \"\$@\"
 """
 


### PR DESCRIPTION
The shell script generated by the InstallExecutable task completely ignores an existing library path. Instead, it should prepend the created library directory.

Why is this necessary? On our CI server, you can load different GCC versions via [modules](https://en.wikipedia.org/wiki/Environment_Modules_(software)). The current shell script doesn't launch our C++ application correctly, since it won't be able to find the correct libstdc++.