### PR TITLE
Do not attempt to set AWT system properties in the daemon JVM.

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
@@ -54,7 +54,8 @@ public class EstablishBuildEnvironment extends BuildCommandOnly {
             if (SystemProperties.getInstance().getNonStandardImportantProperties().contains(entry.getKey())) {
                 continue;
             }
-            if (entry.getKey().startsWith("sun.")) {
+            if (entry.getKey().startsWith("sun.") || entry.getKey().startsWith("awt.")
+                    || entry.getKey().contains(".awt.")) {
                 continue;
             }
             System.setProperty(entry.getKey(), entry.getValue());


### PR DESCRIPTION
This is similar to commit b02870f which fixed GRADLE-2460, and also
manifests only when using different JDKs.

If the client runs with Apple JDK6 and the daemon runs with OpenJDK8
on Mac OS for example, the daemon will attempt to set, among others,
java.awt.graphicsenv to "apple.awt.CGraphicsEnvironment". This
implementation class does not exist in the daemon JVM, and if the
build attempts to use the graphics subsystem in any way (fonts, etc)
it will fail with a seemingly odd missing class error.

See bug http://b.android.com/162448 for details.