### PR TITLE
S3 support session token when using AWS Temporary Security Credentials

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/credentials/AwsCredentials.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/credentials/AwsCredentials.java
@@ -44,4 +44,22 @@ public interface AwsCredentials extends Credentials {
      */
     void setSecretKey(String secretKey);
 
+    /**
+     * Returns the session token to use to authenticate with AWS.
+     *
+     * This will be normally null, unless one was retrieved as part of a call
+     * to the AWS Security Token Service (which will also return special values
+     * for accessKey and secretKey).
+     *
+     * @return the session token to use to authenticate with AWS.
+     */
+    String getSessionToken();
+
+    /**
+     * Sets the session token to use to authenticate with AWS.
+     *
+     * @param sessionToken the session token value received from a call to
+     *        the AWS Security Token Service.
+     */
+    void setSessionToken(String sessionToken);
 }

--- a/subprojects/core/src/main/groovy/org/gradle/internal/credentials/DefaultAwsCredentials.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/credentials/DefaultAwsCredentials.java
@@ -22,6 +22,7 @@ public class DefaultAwsCredentials implements AwsCredentials {
 
     private String accessKey;
     private String secretKey;
+    private String sessionToken;
 
     public String getAccessKey() {
         return accessKey;
@@ -37,5 +38,13 @@ public class DefaultAwsCredentials implements AwsCredentials {
 
     public void setSecretKey(String secretKey) {
         this.secretKey = secretKey;
+    }
+
+    public String getSessionToken() {
+        return sessionToken;
+    }
+
+    public void setSessionToken(String sessionToken) {
+        this.sessionToken = sessionToken;
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CredentialsDslIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CredentialsDslIntegrationTest.groovy
@@ -30,10 +30,11 @@ class CredentialsDslIntegrationTest extends AbstractIntegrationSpec {
         succeeds 'help'
 
         where:
-        scenario          | dsl
-        'simple'          | simplestDsl()
-        'awsCredentials'  | awsCredentials()
-        'ivyWithPassword' | ivyPasswordCredentials()
-        'passwordTyped'   | passwordCredentialsTyped()
+        scenario                | dsl
+        'simple'                | simplestDsl()
+        'awsCredentials'        | awsCredentials()
+        'awsSessionCredentials' | awsSessionCredentials()
+        'ivyWithPassword'       | ivyPasswordCredentials()
+        'passwordTyped'         | passwordCredentialsTyped()
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/support/RepositoryDslSupport.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/support/RepositoryDslSupport.groovy
@@ -60,6 +60,22 @@ class RepositoryDslSupport {
 
     }
 
+    def awsSessionCredentials() {
+        """
+        repositories {
+            maven {
+                url "${s3Url}"
+                credentials(AwsCredentials) {
+                    accessKey "myAccessKey"
+                    secretKey "mySecret"
+                    sessionToken "mySessionToken"
+                }
+            }
+        }
+        """
+
+    }
+
     def ivyPasswordCredentials(){
         """
 repositories {

--- a/subprojects/docs/src/docs/userguide/depMngmt.xml
+++ b/subprojects/docs/src/docs/userguide/depMngmt.xml
@@ -861,7 +861,7 @@
                 </tr>
                 <tr>
                     <td><literal>s3</literal></td>
-                    <td>access key/secret key</td>
+                    <td>access key/secret key/session token</td>
                 </tr>
             </table>
             <para>To define a repository use the <literal>repositories</literal> configuration block. Within the <literal>repositories</literal> closure,
@@ -877,7 +877,7 @@
             <sample id="mavenIvyRepositoriesAuth" dir="userguide/artifacts/defineRepository" title="Providing credentials to a Maven and Ivy repository">
                 <sourcefile file="build.gradle" snippet="maven-ivy-repository-auth"/>
             </sample>
-            <para>When using an AWS S3 backed repository you need to authenticate using <apilink class="org.gradle.api.credentials.AwsCredentials" />, providing access-key and a private-key.
+            <para>When using an AWS S3 backed repository you need to authenticate using <apilink class="org.gradle.api.credentials.AwsCredentials" />, providing access-key and a private-key.  When using the AWS Security Token Service (STS) to generate temporary security credentials, the optional session-token must also be provided.
                 The following example shows how to declare a S3 backed repository and providing AWS credentials:
             </para>
             <sample id="mavenIvyS3RepositoriesAuth" dir="userguide/artifacts/defineRepository" title="Declaring a S3 backed Maven and Ivy repository">

--- a/subprojects/docs/src/samples/userguide/artifacts/defineRepository/build.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/defineRepository/build.gradle
@@ -47,6 +47,15 @@ repositories {
             secretKey "someSecret"
         }
     }
+
+    ivy {
+        url "s3://myCompanyBucket/ivyrepo2"
+        credentials(AwsCredentials) {
+            accessKey "someKey"
+            secretKey "someSecret"
+            sessionToken "someSessionToken"
+        }
+    }
 }
 //END SNIPPET maven-ivy-s3-repository
 

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
@@ -120,6 +120,7 @@ class S3ClientIntegrationTest extends Specification {
         String bucketName = System.getenv('G_S3_BUCKET')
         credentials.setAccessKey(System.getenv('G_AWS_ACCESS_KEY_ID'))
         credentials.setSecretKey(System.getenv('G_AWS_SECRET_ACCESS_KEY'))
+        credentials.setSessionToken(System.getenv('G_AWS_SESSION_TOKEN'))
         S3Client s3Client = new S3Client(credentials, new S3ConnectionProperties())
 
         def fileContents = 'This is only a test'
@@ -140,6 +141,7 @@ class S3ClientIntegrationTest extends Specification {
         DefaultAwsCredentials credentials = new DefaultAwsCredentials()
         credentials.setAccessKey(System.getenv('G_AWS_ACCESS_KEY_ID'))
         credentials.setSecretKey(System.getenv('G_AWS_SECRET_ACCESS_KEY'))
+        credentials.setSessionToken(System.getenv('G_AWS_SESSION_TOKEN'))
 
         S3Client s3Client = new S3Client(credentials, new S3ConnectionProperties())
 

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -63,8 +63,7 @@ public class S3Client {
                 credentials = new BasicSessionCredentials(accessKey,
                                                           secretKey,
                                                           sessionToken);
-            }
-            else {
+            } else {
                 credentials = new BasicAWSCredentials(accessKey, secretKey);
             }
         }

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -21,6 +21,7 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.*;
@@ -53,7 +54,20 @@ public class S3Client {
 
     public S3Client(AwsCredentials awsCredentials, S3ConnectionProperties s3ConnectionProperties) {
         this.s3ConnectionProperties = s3ConnectionProperties;
-        AWSCredentials credentials = awsCredentials == null ? null : new BasicAWSCredentials(awsCredentials.getAccessKey(), awsCredentials.getSecretKey());
+        AWSCredentials credentials = null;
+        if (awsCredentials != null) {
+            String accessKey = awsCredentials.getAccessKey();
+            String secretKey = awsCredentials.getSecretKey();
+            String sessionToken = awsCredentials.getSessionToken();
+            if (sessionToken != null) {
+                credentials = new BasicSessionCredentials(accessKey,
+                                                          secretKey,
+                                                          sessionToken);
+            }
+            else {
+                credentials = new BasicAWSCredentials(accessKey, secretKey);
+            }
+        }
         amazonS3Client = createAmazonS3Client(credentials);
     }
 

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
@@ -112,11 +112,14 @@ class S3ClientTest extends Specification {
         s3Properties.getEndpoint() >> someEndpoint
 
         when:
-        S3Client s3Client = new S3Client(credentials(), s3Properties)
+        S3Client s3Client = new S3Client(creds, s3Properties)
 
         then:
         s3Client.amazonS3Client.clientOptions.pathStyleAccess == true
         s3Client.amazonS3Client.endpoint == someEndpoint.get()
+
+        where:
+        creds << [credentials(), sessionCredentials()]
     }
 
     def "should configure HTTPS proxy"() {
@@ -126,13 +129,16 @@ class S3ClientTest extends Specification {
         s3Properties.getEndpoint() >> Optional.absent()
         s3Properties.getMaxErrorRetryCount() >> Optional.absent()
         when:
-        S3Client s3Client = new S3Client(credentials(), s3Properties)
+        S3Client s3Client = new S3Client(creds, s3Properties)
 
         then:
         s3Client.amazonS3Client.clientConfiguration.proxyHost == 'localhost'
         s3Client.amazonS3Client.clientConfiguration.proxyPort == 8080
         s3Client.amazonS3Client.clientConfiguration.proxyPassword == 'password'
         s3Client.amazonS3Client.clientConfiguration.proxyUsername == 'username'
+
+        where:
+        creds << [credentials(), sessionCredentials()]
     }
 
     @Ignore
@@ -146,7 +152,7 @@ class S3ClientTest extends Specification {
         s3Properties.getEndpoint() >> endpointOverride
         when:
 
-        S3Client s3Client = new S3Client(credentials(), s3Properties)
+        S3Client s3Client = new S3Client(creds, s3Properties)
         then:
         s3Client.amazonS3Client.clientConfiguration.proxyHost == null
         s3Client.amazonS3Client.clientConfiguration.proxyPort == -1
@@ -157,6 +163,8 @@ class S3ClientTest extends Specification {
         nonProxied                                               | endpointOverride
         com.amazonaws.services.s3.internal.Constants.S3_HOSTNAME | Optional.absent()
         "mydomain.com"                                           | Optional.absent()
+
+        creds << [credentials(), sessionCredentials()]
     }
 
     def "should include uri when meta-data not found"() {
@@ -205,6 +213,12 @@ class S3ClientTest extends Specification {
         def credentials = new DefaultAwsCredentials()
         credentials.setAccessKey("AKey")
         credentials.setSecretKey("ASecret")
+        credentials
+    }
+
+    def sessionCredentials() {
+        def credentials = credentials()
+        credentials.setSessionToken("ASessionToken")
         credentials
     }
 }


### PR DESCRIPTION
Changes to AwsCredentials and supporting classes to allow use of sessionToken as part of accessKey, secretKey and sessionToken grouping used for Temporary Security Credentials -- using regular accessKey and secretKey credentials, a temporary set of credentials can be created using the AWS Security Token Service (which provides a temporary accessKey, secretKey, and sessionToken to use in place of the static accessKey and secretKey used to generate the temporary ones.

Tests have been updated, and the two S3ClientIntegrationTest instances that are normally ignored were tested, but left as ignored in the committed code.

Documentation, including examples have also been updated.