### PR TITLE
Add setting for using Java default imports with Twirl

### DIFF
--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/basic/PlayBinaryBasicJavaAppIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/basic/PlayBinaryBasicJavaAppIntegrationTest.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.integtest.basic
+
+import org.gradle.play.integtest.PlayBinaryApplicationIntegrationTest
+import org.gradle.play.integtest.fixtures.PlayApp
+import org.gradle.play.integtest.fixtures.app.BasicPlayJavaApp
+
+class PlayBinaryBasicJavaAppIntegrationTest extends PlayBinaryApplicationIntegrationTest {
+    @Override
+    PlayApp getPlayApp() {
+        return new BasicPlayJavaApp()
+    }
+}

--- a/subprojects/platform-play/src/main/java/org/gradle/play/tasks/TwirlCompile.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/tasks/TwirlCompile.java
@@ -56,6 +56,12 @@ public class TwirlCompile extends SourceTask {
      */
     private File outputDirectory;
 
+    /**
+     * Whether the twirl compiler should use the Java ({@code true})
+     * or the Scala ({@code false}) default imports.
+     */
+    private boolean javaProject;
+
     private BaseForkOptions forkOptions;
     private TwirlStaleOutputCleaner cleaner;
     private PlayPlatform platform;
@@ -86,6 +92,16 @@ public class TwirlCompile extends SourceTask {
     }
 
     /**
+     * Returns whether the twirl compiler should use the Java ({@code true})
+     * or the Scala ({@code false}) default imports.
+     *
+     * @return Whether to use the Java ({@code true}) or the Scala ({@code false}) default imports.
+     */
+    public boolean isJavaProject() {
+        return javaProject;
+    }
+
+    /**
      * Specifies the directory to generate the parser source files into.
      *
      * @param outputDirectory The output directory. Must not be null.
@@ -94,11 +110,22 @@ public class TwirlCompile extends SourceTask {
         this.outputDirectory = outputDirectory;
     }
 
+    /**
+     * Specifies whether the twirl compiler should use the Java ({@code true})
+     * or the Scala ({@code false}) default imports.
+     *
+     * @param javaProject {@code true} if the Java default imports should be used,
+     *                    {@code false} otherwise.
+     */
+    public void setJavaProject(boolean javaProject) {
+        this.javaProject = javaProject;
+    }
+
     @TaskAction
     void compile(IncrementalTaskInputs inputs) {
         RelativeFileCollector relativeFileCollector = new RelativeFileCollector();
         getSource().visit(relativeFileCollector);
-        TwirlCompileSpec spec = new DefaultTwirlCompileSpec(relativeFileCollector.relativeFiles, getOutputDirectory(), getForkOptions(), useJavaDefaults());
+        TwirlCompileSpec spec = new DefaultTwirlCompileSpec(relativeFileCollector.relativeFiles, getOutputDirectory(), getForkOptions(), isJavaProject());
         if (!inputs.isIncremental()) {
             new CleaningPlayToolCompiler<TwirlCompileSpec>(getCompiler(), getOutputs()).execute(spec);
         } else {
@@ -126,10 +153,6 @@ public class TwirlCompile extends SourceTask {
     private Compiler<TwirlCompileSpec> getCompiler() {
         ToolProvider toolProvider = ((PlayToolChainInternal) getToolChain()).select(platform);
         return toolProvider.newCompiler(TwirlCompileSpec.class);
-    }
-
-    private boolean useJavaDefaults() {
-        return false; //TODO: add this as a configurable parameter
     }
 
     void setCleaner(TwirlStaleOutputCleaner cleaner) {

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/app/BasicPlayJavaApp.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/app/BasicPlayJavaApp.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.integtest.fixtures.app
+
+import org.gradle.play.integtest.fixtures.PlayApp
+
+class BasicPlayJavaApp extends PlayApp {
+}

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/app/controllers/Application.scala
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/app/controllers/Application.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import play.api._
+import play.api.mvc._
+
+object Application extends Controller {
+
+  def index = Action {
+    Ok(views.html.index("Your new application is ready."))
+  }
+
+  def shutdown = Action {
+    System.exit(0)
+    Ok("shutdown")
+  }
+}

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/app/views/index.scala.html
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/app/views/index.scala.html
@@ -1,0 +1,7 @@
+@(message: String)
+
+@main("Welcome to Play") {
+
+    @play20.welcome(message)
+
+}

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/app/views/main.scala.html
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/app/views/main.scala.html
@@ -1,0 +1,14 @@
+@(title: String)(content: Html)
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>@title</title>
+        <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
+        <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
+        <script src="@routes.Assets.at("javascripts/hello.js")" type="text/javascript"></script>
+    </head>
+    <body>
+@content
+      <p>@UUID.randomUUID().toString()</p>
+    </body>
+</html>

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/build.gradle
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'play'
+}
+
+model {
+    components {
+        play {
+            binaries.all {
+                tasks.withType(TwirlCompile) {
+                    javaProject = true
+                }
+            }
+        }
+    }
+}
+
+dependencies {
+    play "com.typesafe.play:play-java_2.11:2.3.9"
+}
+
+// repositories added in PlayApp class

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/conf/routes
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/conf/routes
@@ -1,0 +1,9 @@
+# Routes
+# Home page
+GET     /                           controllers.Application.index
+
+GET     /shutdown                   controllers.Application.shutdown
+
+# Map static resources from the /public folder to the /assets URL path
+GET     /assets/*file               controllers.Assets.at(path="/public", file)
+

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/test/ApplicationSpec.scala
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/test/ApplicationSpec.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit._
+
+class ApplicationSpec  {
+  @Test
+  def passingTest() {
+  }
+  @Test
+  def passingTest2() {
+  }
+}

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/test/IntegrationSpec.scala
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/test/IntegrationSpec.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit._
+
+class IntegrationSpec  {
+  @Test
+  def passingTest() {
+  }
+}

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/test/notATest.yaml
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/basicplayjavaapp/test/notATest.yaml
@@ -1,0 +1,7 @@
+name: Test
+number: 1234
+items:
+    - name: item1
+      description: first item
+    - name: item2
+      description: second item


### PR DESCRIPTION
In order to be able to compile Java-based Play projects with Gradle, it is necessary to tell the Twirl compiler to use different imports than in a Scala-based Play project.

This PR adds the `javaProject` setting to the `TwirlCompile` task, which enables users to specify whether the Scala imports (default) or the Java imports (if `javaProject = true`) should be used when compiling Twirl templates:
````
model {
    components {
        play {
            binaries.all {
                tasks.withType(TwirlCompile) {
                    javaProject = true
                }
            }
        }
    }
}
````
Related topic on the discussion forums: https://discuss.gradle.org/t/play-2-3-10-java-project-and-twirl-default-imports/11637