### PR TITLE
Avoid recursing over the same items in enforceWithDependencies

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -654,14 +654,21 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     private void enforceFinalizerTasks(TaskInfo taskInfo) {
         for (TaskInfo finalizerNode : taskInfo.getFinalizers()) {
             if (finalizerNode.isRequired() || finalizerNode.isMustNotRun()) {
-                enforceWithDependencies(finalizerNode);
+                TreeSet<TaskInfo> enforcedTasks = new TreeSet<TaskInfo>();
+                enforceWithDependencies(finalizerNode, enforcedTasks);
             }
         }
     }
 
-    private void enforceWithDependencies(TaskInfo node) {
+    private void enforceWithDependencies(TaskInfo node, TreeSet<TaskInfo> enforcedTasks) {
+        if (enforcedTasks.contains(node)) {
+            return;
+        }
+
+        enforcedTasks.add(node);
+
         for (TaskInfo dependencyNode : node.getDependencySuccessors()) {
-            enforceWithDependencies(dependencyNode);
+            enforceWithDependencies(dependencyNode, enforcedTasks);
         }
         if (node.isMustNotRun() || node.isRequired()) {
             node.enforceRun();


### PR DESCRIPTION
Fix for issue https://issues.gradle.org/browse/GRADLE-3283

To reproduce the bug, create a build.gradle with the following task and run actualTask.  With the fix, the task finishes within a minute.  Without the change the task will finish when the universe implodes:
defaultTasks "actualTask"
1000.times { index ->
def testTask = task "testTask$index" << {}
index.times
{ testTask.dependsOn tasks.findByName("testTask$it") }
}
println "Done setting up"
task finalizerTask
finalizerTask.dependsOn testTask333
task actualTask
actualTask.finalizedBy finalizerTask