### PR TITLE
Include test resources in classpath when testing Play applications

### DIFF
--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayAppWithTestResourcesIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayAppWithTestResourcesIntegrationTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.integtest
+
+import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
+import org.gradle.play.integtest.fixtures.PlayApp
+import org.gradle.play.integtest.fixtures.PlayMultiVersionIntegrationTest
+import org.gradle.play.integtest.fixtures.app.WithTestResourcesApp
+
+class PlayAppWithTestResourcesIntegrationTest extends PlayMultiVersionIntegrationTest {
+
+    PlayApp playApp = new WithTestResourcesApp();
+
+    def setup() {
+        playApp.writeSources(testDirectory)
+        buildFile << """
+model {
+    components {
+        play {
+            targetPlatform "play-${version}"
+        }
+    }
+}
+"""
+    }
+
+    def "finds test resources during play app tests"() {
+        when:
+        succeeds("testPlayBinary")
+
+        then:
+        executedAndNotSkipped(
+            ":playBinary",
+            ":compilePlayBinaryTests",
+            ":processPlayBinaryTestResources",
+            ":testPlayBinary")
+
+        def result = new JUnitXmlTestExecutionResult(testDirectory, "build/playBinary/reports/test/xml")
+        result.assertTestClassesExecuted("ResourcesSpec")
+        result.testClass("ResourcesSpec").assertTestCount(2, 0, 0)
+    }
+}

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayTestApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayTestApplicationIntegrationTest.groovy
@@ -33,6 +33,7 @@ abstract class PlayTestApplicationIntegrationTest extends PlayMultiVersionApplic
                 ":createPlayBinaryAssetsJar",
                 ":playBinary",
                 ":compilePlayBinaryTests",
+                ":processPlayBinaryTestResources",
                 ":testPlayBinary")
 
         then:
@@ -49,6 +50,7 @@ abstract class PlayTestApplicationIntegrationTest extends PlayMultiVersionApplic
                 ":createPlayBinaryAssetsJar",
                 ":playBinary",
                 ":compilePlayBinaryTests",
+                ":processPlayBinaryTestResources",
                 ":testPlayBinary")
     }
 

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayTestPluginTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayTestPluginTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.project.ProjectIdentifier
+import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.testing.Test
 import org.gradle.language.scala.tasks.PlatformScalaCompile
 import org.gradle.model.ModelMap
@@ -76,6 +77,7 @@ class PlayTestPluginTest extends Specification {
 
         then:
         1 * taskModelMap.create("compileSomeBinaryTests", PlatformScalaCompile, _)
+        1 * taskModelMap.create("processSomeBinaryTestResources", Copy, _)
         1 * taskModelMap.create("testSomeBinary", Test, _)
         0 * taskModelMap.create(_)
         0 * taskModelMap.create(_, _, _)

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/app/WithTestResourcesApp.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/app/WithTestResourcesApp.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.integtest.fixtures.app
+
+import org.gradle.integtests.fixtures.SourceFile
+import org.gradle.play.integtest.fixtures.PlayApp
+
+import static org.gradle.play.integtest.fixtures.Repositories.PLAY_REPOSITORES
+
+class WithTestResourcesApp extends PlayApp {
+    List<SourceFile> appSources
+    List<SourceFile> viewSources
+    List<SourceFile> confSources
+    List<SourceFile> testSources
+
+    @Override
+    SourceFile getGradleBuild() {
+        def gradleBuild = sourceFile("", "build.gradle", "basicplayapp")
+        def gradleBuildWithRepositories = gradleBuild.content.concat """
+            allprojects {
+                ${PLAY_REPOSITORES}
+            }
+        """
+        return new SourceFile(gradleBuild.path, gradleBuild.name, gradleBuildWithRepositories)
+    }
+
+    public WithTestResourcesApp(){
+        appSources = sourceFiles("app", "basicplayapp");
+        viewSources = sourceFiles("app/views", "basicplayapp");
+        confSources = sourceFiles("conf", "shared") + sourceFiles("conf", "basicplayapp")
+        testSources = sourceFiles("test")
+    }
+}

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/withtestresourcesapp/test/ResourcesSpec.scala
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/withtestresourcesapp/test/ResourcesSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit._
+import org.junit.Assert._
+
+class ResourcesSpec  {
+    @Test
+    def findsTestResource() {
+        val url = getClass.getResource("/test-resource")
+        assertNotNull(url)
+    }
+
+    @Test
+    def doesNotFindMissingTestResource() {
+        val url = getClass.getResource("/non-existent-test-resource")
+        assertNull(url)
+    }
+}


### PR DESCRIPTION
When building with SBT, files in test/resources are placed into the test classpath. This pull request replicates this behavior.