### PR TITLE
Keep directory hierarchy of Play app resources

### DIFF
--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/advanced/PlayAppWithNestedResourceIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/advanced/PlayAppWithNestedResourceIntegrationTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.integtest.advanced
+
+import org.gradle.play.integtest.fixtures.PlayApp
+import org.gradle.play.integtest.fixtures.PlayMultiVersionApplicationIntegrationTest
+import org.gradle.play.integtest.fixtures.app.AdvancedPlayApp
+
+class PlayAppWithNestedResourceIntegrationTest extends PlayMultiVersionApplicationIntegrationTest {
+    @Override
+    PlayApp getPlayApp() {
+        return new AdvancedPlayApp()
+    }
+
+    def "creates play app jar with nested resources"() {
+        when:
+        succeeds("createPlayBinaryJar")
+
+        then:
+        executed(
+            ":compilePlayBinaryRoutes",
+            ":compilePlayBinaryScala",
+            ":createPlayBinaryJar")
+
+        then:
+        verifyJars()
+
+        when:
+        succeeds("createPlayBinaryJar")
+        then:
+        skipped(
+            ":compilePlayBinaryRoutes",
+            ":compilePlayBinaryScala")
+    }
+
+    void verifyJars() {
+        jar("build/playBinary/lib/${playApp.name}.jar").containsDescendants(
+            "evolutions/default/1.sql"
+        )
+    }
+}

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayApplicationPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayApplicationPlugin.java
@@ -208,7 +208,7 @@ public class PlayApplicationPlugin implements Plugin<Project> {
 
                     ModelMap<JvmResourceSet> jvmResourceSets = componentSpec.getSources().withType(JvmResourceSet.class);
                     for (JvmResourceSet jvmResourceSet : jvmResourceSets.values()) {
-                        for (File resourceDir : jvmResourceSet.getSource()) {
+                        for (File resourceDir : jvmResourceSet.getSource().getSrcDirs()) {
                             classes.addResourceDir(resourceDir);
                         }
                     }

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/advancedplayapp/conf/evolutions/default/1.sql
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/advancedplayapp/conf/evolutions/default/1.sql
@@ -1,0 +1,5 @@
+-- Blank database evolution script
+
+# --- !Ups
+
+# --- !Downs


### PR DESCRIPTION
When creating the Play jar, all resources are placed at the root of the jar. This causes any methods searching for resources at specific paths to fail. Notably, database evolutions will fail silently because no evolution scripts are found in `evolutions/{database name}/`

This pull request attempts to fix the issue by keeping the directory structure when creating the jar.

Associated bug report:
https://discuss.gradle.org/t/play-plugin-does-not-keep-directory-structure-of-resource-files/11933