### PR TITLE
Building native: make implicitHeaders available for compiler in SourceSet scope

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/AbstractHeaderExportingSourceSet.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/AbstractHeaderExportingSourceSet.java
@@ -47,4 +47,8 @@ public abstract class AbstractHeaderExportingSourceSet extends BaseLanguageSourc
     public SourceDirectorySet getImplicitHeaders() {
         return implicitHeaders;
     }
+
+    public void implicitHeaders(Action<? super SourceDirectorySet> config) {
+        config.execute(getImplicitHeaders());
+    }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
@@ -71,10 +71,15 @@ abstract public class CompileTaskConfig implements SourceTransformTaskConfig {
         task.setTargetPlatform(binary.getTargetPlatform());
         task.setPositionIndependentCode(binary instanceof SharedLibraryBinarySpec);
 
-        // TODO:DAZ Not sure if these both need to be lazy
+        // TODO:DAZ Not sure if this need to be lazy
         task.includes(new Callable<Set<File>>() {
             public Set<File> call() throws Exception {
                 return ((HeaderExportingSourceSet) sourceSet).getExportedHeaders().getSrcDirs();
+            }
+        });
+        task.includes(new Callable<Set<File>>() {
+            public Set<File> call() throws Exception {
+                return ((HeaderExportingSourceSet) sourceSet).getImplicitHeaders().getSrcDirs();
             }
         });
         task.includes(new Callable<List<FileCollection>>() {

--- a/subprojects/platform-native/src/main/groovy/org/gradle/language/nativeplatform/HeaderExportingSourceSet.java
+++ b/subprojects/platform-native/src/main/groovy/org/gradle/language/nativeplatform/HeaderExportingSourceSet.java
@@ -37,6 +37,11 @@ public interface HeaderExportingSourceSet extends LanguageSourceSet {
     SourceDirectorySet getExportedHeaders();
 
     /**
+     * Configure the implicit header directories.
+     */
+    public void implicitHeaders(Action<? super SourceDirectorySet> config);
+
+    /**
      * The headers that are private to this source set and implicitly available. These are not explicitly made available for compilation.
      */
     SourceDirectorySet getImplicitHeaders();

--- a/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/internal/configure/NativeComponentRules.java
+++ b/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/internal/configure/NativeComponentRules.java
@@ -52,8 +52,9 @@ public class NativeComponentRules extends RuleSource {
                     headerSourceSet.getExportedHeaders().srcDir(String.format("src/%s/headers", component.getName()));
                 }
 
-                headerSourceSet.getImplicitHeaders().setSrcDirs(headerSourceSet.getSource().getSrcDirs());
-                headerSourceSet.getImplicitHeaders().include("**/*.h");
+                if (headerSourceSet.getImplicitHeaders().getSrcDirs().isEmpty()) {
+                    headerSourceSet.getImplicitHeaders().srcDir(String.format("src/%s/", component.getName()));
+                }
             }
         });
     }


### PR DESCRIPTION
Currently, there’s no full support for implicitHeaders in source set for native platforms (actually, implicitHeaders are not available for the compiler and unused).

This pull request makes implicitHeaders available in scope of SourceSet.

Topic at google groups:
https://groups.google.com/forum/#!topic/gradle-dev/qlkuCT0E5IQ
