### PR TITLE
Correct the description of `expand` in copy specs.

### DIFF
--- a/subprojects/docs/src/docs/userguide/workingWithFiles.xml
+++ b/subprojects/docs/src/docs/userguide/workingWithFiles.xml
@@ -251,8 +251,10 @@
             <sample id="filterOnCopy" dir="userguide/files/copy" title="Filtering files as they are copied">
                 <sourcefile file="build.gradle" snippet="filter-files"/>
             </sample>
-            <para>A “token” in a source file that both the “expand” and “filter” operations look for, is formatted
-            like “@tokenName@” for a token named “tokenName”.</para>
+            <para>When you use the <literal>ReplaceTokens</literal> class with the “filter” operation, the result is a template engine that replaces tokens of the form “@tokenName@” (the Apache Ant-style token) with a set of given values. The “expand” operation does the same thing except it treats the source files as
+            <ulink url="http://docs.groovy-lang.org/latest/html/api/groovy/text/SimpleTemplateEngine.html">Groovy templates</ulink>
+            in which tokens take the form “${tokenName}”. Be aware that you may need escape parts of your source files when
+            using this option, for example if it contains literal “$” or “&lt;%” strings.</para>
         </section>
         <section>
             <title>Using the <classname>CopySpec</classname> class</title>

--- a/subprojects/docs/src/docs/userguide/workingWithFiles.xml
+++ b/subprojects/docs/src/docs/userguide/workingWithFiles.xml
@@ -253,7 +253,7 @@
             </sample>
             <para>When you use the <literal>ReplaceTokens</literal> class with the “filter” operation, the result is a template engine that replaces tokens of the form “@tokenName@” (the Apache Ant-style token) with a set of given values. The “expand” operation does the same thing except it treats the source files as
             <ulink url="http://docs.groovy-lang.org/latest/html/api/groovy/text/SimpleTemplateEngine.html">Groovy templates</ulink>
-            in which tokens take the form “${tokenName}”. Be aware that you may need escape parts of your source files when
+            in which tokens take the form “${tokenName}”. Be aware that you may need to escape parts of your source files when
             using this option, for example if it contains literal “$” or “&lt;%” strings.</para>
         </section>
         <section>


### PR DESCRIPTION
The user guide said that the `filter` and `expand` operations on copy specs use
the same token format, which is incorrect. This change clarifies that `expand`
works with Groovy templates, not Ant-style ones.

This is a second attempt after #511.