### PR TITLE
Web app model

### DIFF
--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -583,10 +583,6 @@ A web application project will be defined to be any project that applies the 'wa
 
 In order to properly deploy a web application, the IDE needs to know about the location and contents of the web application directory.
 
-#### Estimate
-
-- ? Days
-
 #### The API
 
 ```

--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -572,6 +572,56 @@ might be confusing to users.
 - Is there any feature parity between the file-based and directory-based project formats?
 - There's no overarching, publicly-available documentation or specification on directory-based project files. It might be worth to contact JetBrains for a good resource.
 
+## Feature - Expose web application information
+
+This feature exposes information about web applications to the IDE, such that the IDE can create configurations that are consistent with what's defined in Gradle. The IDE should be able
+to correctly deploy the web application with information exposed by this feature.
+
+A web application project will be defined to be any project that applies the 'war' plugin.
+
+### Story - Expose web application directory
+
+In order to properly deploy a web application, the IDE needs to know about the location and contents of the web application directory.
+
+#### Estimate
+
+#### The API
+
+```
+interface WebApplicationProject {
+    String getWebApplicationDirectoryName();
+    File getWebApplicationDirectory();
+}
+
+class DefaultWebApplicationProject implements Serializable {
+    WebApplicationDirectory getWebApplicationDirectory();
+}
+
+class WebApplicationModelBuilder implements ToolingModelBuilder {
+    public boolean canBuild(String modelName);
+    public DefaultEclipseProject buildAll(String modelName, Project project);
+}
+```
+
+Note that the WebApplicationProject model directly maps to properties defined in the ('war' plugin)[https://docs.gradle.org/current/userguide/war_plugin.html].
+
+#### Implementation
+- Create `WebApplicationProject` model
+- Create `DefaultWebApplicationProject`
+- Create `WebApplicationModelBuilder`
+- Add `WebApplicationModelBuilder` to builders in `ToolingRegistrationAction`
+
+#### Test Coverage
+
+- WebApplicationProject.getWebApplicationDirectoryName returns correct default value
+- WebApplicationProject.getWebApplicationDirectory returns correct file when no custom web application directory has been defined in _build.gradle_ file
+- WebApplicationProject.getWebApplicationDirectory returns null when the directory does not exist.
+- WebApplicationProject.getWebApplicationDirectoryName returns correct value when custom web application directory is set
+- WebApplicationProject.getWebApplicationDirectory returns correct file when custom web application directory is set
+- WebApplicationProject.getWebApplicationDirectory returns null when custom web application directory is set, but directory does not exist
+
+The `WebApplicationModelBuilder` is tested transitively, as the following tests would all fail if the `WebApplicationModelBuilder` did not produce the correct model.
+
 # More candidates
 
 Some more features to mix into the above plan:

--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -596,7 +596,8 @@ interface WebApplicationProject {
 }
 
 class DefaultWebApplicationProject implements Serializable {
-    WebApplicationDirectory getWebApplicationDirectory();
+    String getWebApplicationDirectoryName();
+    File getWebApplicationDirectory();
 }
 
 class WebApplicationModelBuilder implements ToolingModelBuilder {

--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -602,7 +602,7 @@ class WebApplicationModelBuilder implements ToolingModelBuilder {
 }
 ```
 
-Note that the WebApplicationProject model directly maps to properties defined in the ('war' plugin)[https://docs.gradle.org/current/userguide/war_plugin.html].
+Note that the WebApplicationProject model directly maps to properties defined in the ['war' plugin](https://docs.gradle.org/current/userguide/war_plugin.html).
 
 #### Implementation
 

--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -585,7 +585,7 @@ In order to properly deploy a web application, the IDE needs to know about the l
 
 #### Estimate
 
-- 2 Days
+- ? Days
 
 #### The API
 
@@ -629,6 +629,7 @@ Note that the WebApplicationProject model directly maps to properties defined in
 - WebApplicationProject.getWebApplicationDirectoryName returns correct value when custom web application directory is set
 - WebApplicationProject.getWebApplicationDirectory returns correct file when custom web application directory is set
 - WebApplicationProject.getWebApplicationDirectory returns null when custom web application directory is set, but directory does not exist
+- WebApplicationProject model returns null when project does not apply the 'war' plugin
 
 The `WebApplicationModelBuilder` is tested transitively, as the following tests would all fail if the `WebApplicationModelBuilder` did not produce the correct model.
 

--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -602,7 +602,7 @@ class DefaultWebApplicationProject implements Serializable {
 
 class WebApplicationModelBuilder implements ToolingModelBuilder {
     public boolean canBuild(String modelName);
-    public DefaultEclipseProject buildAll(String modelName, Project project);
+    public DefaultWebApplicationProject buildAll(String modelName, Project project);
 }
 ```
 

--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -628,9 +628,6 @@ Note that the WebApplicationProject model directly maps to properties defined in
 - WebApplicationProject.getWebApplicationDirectory returns correct file when custom web application directory is set
 - WebApplicationProject.getWebApplicationDirectory returns null when custom web application directory is set, but directory does not exist
 - WebApplicationProject model returns null when project does not apply the 'war' plugin
-
-The `WebApplicationModelBuilder` is tested transitively, as the following tests would all fail if the `WebApplicationModelBuilder` did not produce the correct model.
-
 - Add WebApplicationProject to ModelMappingTest.groovy
 - Add WebApplicationProject to ModelBuilderBackedConsumerConnectionTest.groovy
 - Add WebApplicationProject to BuildActionRunnerBackedConsumerConnectionTest.groovy

--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -585,6 +585,8 @@ In order to properly deploy a web application, the IDE needs to know about the l
 
 #### Estimate
 
+- 2 Days
+
 #### The API
 
 ```
@@ -606,10 +608,17 @@ class WebApplicationModelBuilder implements ToolingModelBuilder {
 Note that the WebApplicationProject model directly maps to properties defined in the ('war' plugin)[https://docs.gradle.org/current/userguide/war_plugin.html].
 
 #### Implementation
+
 - Create `WebApplicationProject` model
 - Create `DefaultWebApplicationProject`
 - Create `WebApplicationModelBuilder`
 - Add `WebApplicationModelBuilder` to builders in `ToolingRegistrationAction`
+- Add model to ModelMapping.java
+- Add model to ActionAwareConsumerConnectionTest.groovy
+- Add model to BuildActionRunnerBackedConsumerConnection.java
+- Add model to InternalConnectionBackedConsumerConnection.java
+- Add model to BuildController.java documentation
+- Add model to ProjectConnection.java documentation
 
 #### Test Coverage
 
@@ -621,6 +630,13 @@ Note that the WebApplicationProject model directly maps to properties defined in
 - WebApplicationProject.getWebApplicationDirectory returns null when custom web application directory is set, but directory does not exist
 
 The `WebApplicationModelBuilder` is tested transitively, as the following tests would all fail if the `WebApplicationModelBuilder` did not produce the correct model.
+
+- Add WebApplicationProject to ModelMappingTest.groovy
+- Add WebApplicationProject to ModelBuilderBackedConsumerConnectionTest.groovy
+- Add WebApplicationProject to BuildActionRunnerBackedConsumerConnectionTest.groovy
+- Add WebApplicationProject to CancellableConsumerConnectionTest.groovy
+- Add WebApplicationProject to InternalConnectionBackedConsumerConnectionTest.groovy
+- Add WebApplicationProject to BuildActionRunnerBackedConsumerConnectionTest.groovy
 
 # More candidates
 

--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -583,6 +583,8 @@ A web application project will be defined to be any project that applies the 'wa
 
 In order to properly deploy a web application, the IDE needs to know about the location and contents of the web application directory.
 
+This story also introduces the `WebApplicationProject` model, an IDE agnostic model that exposes information about projects that apply the 'war' plugin.
+
 #### The API
 
 ```

--- a/design-docs/ide-integration.md
+++ b/design-docs/ide-integration.md
@@ -583,7 +583,7 @@ A web application project will be defined to be any project that applies the 'wa
 
 In order to properly deploy a web application, the IDE needs to know about the location and contents of the web application directory.
 
-This story also introduces the `WebApplicationProject` model, an IDE agnostic model that exposes information about projects that apply the 'war' plugin.
+This story also introduces the `WebApplicationProject` model, an IDE agnostic model that exposes information about web application projects.
 
 #### The API
 
@@ -627,7 +627,7 @@ Note that the WebApplicationProject model directly maps to properties defined in
 - WebApplicationProject.getWebApplicationDirectoryName returns correct value when custom web application directory is set
 - WebApplicationProject.getWebApplicationDirectory returns correct file when custom web application directory is set
 - WebApplicationProject.getWebApplicationDirectory returns null when custom web application directory is set, but directory does not exist
-- WebApplicationProject model returns null when project does not apply the 'war' plugin
+- WebApplicationProject model returns null when project is not a web application project
 - Add WebApplicationProject to ModelMappingTest.groovy
 - Add WebApplicationProject to ModelBuilderBackedConsumerConnectionTest.groovy
 - Add WebApplicationProject to BuildActionRunnerBackedConsumerConnectionTest.groovy


### PR DESCRIPTION
This pull request adds the feature of exposing web application information from the Gradle model to the _ide-integration.md_ file, and also adds the first story of the feature. This feature is being driven by the WTP integration work being done on the [Buildship project](https://github.com/eclipse/buildship).

The first story of the feature exposes the web application directory, as defined by a project when the `war` plugin is applied. This story is the first story of the feature, and as such defines the end point for which all future stories of this feature will be built on top of.

The feature/story attempts to make the definition IDE agnostic, such that both IDEA and Eclipse IDEs can consume the exposed resources.

The test coverage and implementation add the `WebApplicationProject` model to many of the existing tests and files. I'm not confident that this is correct, I am merely following by example (the example of `HierarchicalEclipseProject` to be exact).

Once the feature/story has been agreed upon, I can squash all commits.
This PR is meant for review, and not meant to be merged.