### PR TITLE
PSS-11117. Adding Task.isCurrentlyUpToDate to tell whether a task's o…

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/Task.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/Task.java
@@ -553,6 +553,17 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     File getTemporaryDir();
 
     /**
+     * <p>Tells whether this task is currently up-to-date, using properties of the task but not of dependent tasks</p>
+     *
+     * Note that if this task has a dependency and build execution has not yet started, then it is possible for the task to
+     * be considered up-to-date before the build starts but for the task to be considered out-of-date when the task actually
+     * executes.
+     *
+     * @return whether this task is currently up-to-date.
+     */
+    boolean isCurrentlyUpToDate();
+
+    /**
      * <p>Specifies that this task must run after all of the supplied tasks.</p>
      *
      * <pre autoTested="true">
@@ -695,5 +706,6 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      */
     @Incubating
     TaskDependency getShouldRunAfter();
+
 }
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/AbstractTask.java
@@ -301,6 +301,10 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         return this;
     }
 
+    public boolean isCurrentlyUpToDate() {
+        return getExecuter().isCurrentlyUpToDate(this, state);
+    }
+
     public final void execute() {
         getExecuter().execute(this, state, new DefaultTaskExecutionContext());
         state.rethrowFailure();

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/TaskExecuter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/TaskExecuter.java
@@ -23,4 +23,10 @@ public interface TaskExecuter {
      * state.
      */
     void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context);
+
+    /**
+     * Tells whether the task is currently up-to-date and in need of re-running
+     * Note that this could potentially change after running other dependency steps
+     */
+    boolean isCurrentlyUpToDate(TaskInternal task, TaskStateInternal state);
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/AbstractDelegatingTaskExecuter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/AbstractDelegatingTaskExecuter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,27 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.internal.tasks.execution;
 
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskExecuter;
-import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskStateInternal;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 
 /**
- * A {@link TaskExecuter} which marks tasks as up-to-date if they did no work.
+ * A {@link TaskExecuter} which performs validation before executing the task.
  */
-public class PostExecutionAnalysisTaskExecuter extends AbstractDelegatingTaskExecuter {
+public abstract class AbstractDelegatingTaskExecuter implements TaskExecuter {
+    private static final Logger LOGGER = Logging.getLogger(AbstractDelegatingTaskExecuter.class);
+    protected final TaskExecuter executer;
 
-    public PostExecutionAnalysisTaskExecuter(TaskExecuter executer) {
-        super(executer);
+    public AbstractDelegatingTaskExecuter(TaskExecuter nextExecuter) {
+        this.executer = nextExecuter;
     }
 
-    public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
-        executer.execute(task, state, context);
-        if (!state.getDidWork()) {
-            state.upToDate();
-        }
+    /**
+     * By default, it is assumed that this executer doesn't affect the up-to-datedness of the task
+     */
+    public boolean isCurrentlyUpToDate(TaskInternal task, TaskStateInternal state) {
+        return executer.isCurrentlyUpToDate(task, state);
     }
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -51,6 +51,10 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         }
     }
 
+    public boolean isCurrentlyUpToDate(TaskInternal task, TaskStateInternal state) {
+        return task.getTaskActions().size() == 0;
+    }
+
     private GradleException executeActions(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
         logger.debug("Executing actions for {}.", task);
         final List<ContextAwareTaskAction> actions = new ArrayList<ContextAwareTaskAction>(task.getTaskActions());

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/ExecuteAtMostOnceTaskExecuter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/ExecuteAtMostOnceTaskExecuter.java
@@ -26,12 +26,11 @@ import org.gradle.api.logging.Logging;
 /**
  * A {@link org.gradle.api.internal.tasks.TaskExecuter} which will execute a task once only.
  */
-public class ExecuteAtMostOnceTaskExecuter implements TaskExecuter {
+public class ExecuteAtMostOnceTaskExecuter extends AbstractDelegatingTaskExecuter {
     private static final Logger LOGGER = Logging.getLogger(ExecuteAtMostOnceTaskExecuter.class);
-    private final TaskExecuter executer;
 
     public ExecuteAtMostOnceTaskExecuter(TaskExecuter executer) {
-        this.executer = executer;
+        super(executer);
     }
 
     public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/SkipOnlyIfTaskExecuter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/SkipOnlyIfTaskExecuter.java
@@ -27,12 +27,11 @@ import org.gradle.api.logging.Logging;
 /**
  * A {@link org.gradle.api.internal.tasks.TaskExecuter} which skips tasks whose onlyIf predicate evaluates to false
  */
-public class SkipOnlyIfTaskExecuter implements TaskExecuter {
+public class SkipOnlyIfTaskExecuter extends AbstractDelegatingTaskExecuter {
     private static final Logger LOGGER = Logging.getLogger(SkipOnlyIfTaskExecuter.class);
-    private final TaskExecuter executer;
 
     public SkipOnlyIfTaskExecuter(TaskExecuter executer) {
-        this.executer = executer;
+        super(executer);
     }
 
     public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuter.java
@@ -26,12 +26,11 @@ import org.gradle.api.logging.Logging;
 /**
  * A {@link org.gradle.api.internal.tasks.TaskExecuter} which skips tasks that have no actions.
  */
-public class SkipTaskWithNoActionsExecuter implements TaskExecuter {
+public class SkipTaskWithNoActionsExecuter extends AbstractDelegatingTaskExecuter {
     private static final Logger LOGGER = Logging.getLogger(SkipTaskWithNoActionsExecuter.class);
-    private final TaskExecuter executer;
 
     public SkipTaskWithNoActionsExecuter(TaskExecuter executer) {
-        this.executer = executer;
+        super(executer);
     }
 
     public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
@@ -50,5 +49,14 @@ public class SkipTaskWithNoActionsExecuter implements TaskExecuter {
             return;
         }
         executer.execute(task, state, context);
+    }
+
+
+    public boolean isCurrentlyUpToDate(TaskInternal task, TaskStateInternal state) {
+        if (task.getActions().isEmpty()) {
+            LOGGER.debug("{} is up-to-date because it has no actions.", task);
+            return true;
+        }
+        return super.isCurrentlyUpToDate(task, state);
     }
 }

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/ValidatingTaskExecuter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/execution/ValidatingTaskExecuter.java
@@ -28,11 +28,10 @@ import java.util.List;
 /**
  * A {@link TaskExecuter} which performs validation before executing the task.
  */
-public class ValidatingTaskExecuter implements TaskExecuter {
-    private final TaskExecuter executer;
+public class ValidatingTaskExecuter extends AbstractDelegatingTaskExecuter {
 
     public ValidatingTaskExecuter(TaskExecuter executer) {
-        this.executer = executer;
+        super(executer);
     }
 
     public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.java
@@ -81,7 +81,10 @@ public class ExecuteActionsTaskExecuterTest {
         context.checking(new Expectations() {{
             allowing(task).getTaskActions();
             will(returnValue(emptyList()));
+        }});
+        assertThat(executer.isCurrentlyUpToDate(task, state), equalTo(true));
 
+        context.checking(new Expectations() {{
             one(listener).beforeActions(task);
             inSequence(sequence);
 
@@ -106,7 +109,10 @@ public class ExecuteActionsTaskExecuterTest {
         context.checking(new Expectations() {{
             allowing(task).getTaskActions();
             will(returnValue(toList(action1, action2)));
+        }});
+        assertThat(executer.isCurrentlyUpToDate(task, state), equalTo(false));
 
+        context.checking(new Expectations() {{
             one(listener).beforeActions(task);
             inSequence(sequence);
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuterTest.groovy
@@ -45,6 +45,12 @@ class SkipEmptySourceFilesTaskExecuterTest extends Specification {
         sourceFiles.empty >> true
 
         when:
+        boolean plannedToBeUpToDate = executer.isCurrentlyUpToDate(task, state)
+
+        then:
+        plannedToBeUpToDate == true
+
+        when:
         executer.execute(task, state, executionContext)
 
         then:
@@ -58,6 +64,12 @@ class SkipEmptySourceFilesTaskExecuterTest extends Specification {
         given:
         taskInputs.hasSourceFiles >> true
         sourceFiles.empty >> false
+
+        when:
+        boolean plannedToBeUpToDate = executer.isCurrentlyUpToDate(task, state)
+
+        then:
+        plannedToBeUpToDate == false
 
         when:
         executer.execute(task, state, executionContext)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuterTest.groovy
@@ -52,6 +52,19 @@ public class SkipUpToDateTaskExecuterTest extends Specification {
         1 * taskArtifactState.finished()
         0 * _
     }
+
+    def knowsInAdvanceToSkipTaskWhenOutputsAreUpToDate() {
+        when:
+        boolean plannedToBeUpToDate = executer.isCurrentlyUpToDate(task, taskState)
+
+        then:
+        plannedToBeUpToDate == true
+        1 * repository.getStateFor(task) >> taskArtifactState
+        1 * taskArtifactState.isUpToDate([]) >> true
+        1 * taskArtifactState.finished()
+        0 * _
+    }
+
     
     def executesTaskWhenOutputsAreNotUpToDate() {
         when:
@@ -77,6 +90,19 @@ public class SkipUpToDateTaskExecuterTest extends Specification {
         1 * task.outputs >> outputs
         1 * outputs.setHistory(null)
         1 * taskContext.setTaskArtifactState(null)
+        1 * taskArtifactState.finished()
+        0 * _
+    }
+
+    def knowsInAdvanceToExecuteTaskWhenOutputsAreNotUpToDate() {
+        when:
+        boolean plannedToBeUpToDate = executer.isCurrentlyUpToDate(task, taskState)
+
+        then:
+        plannedToBeUpToDate == false
+        1 * delegate.isCurrentlyUpToDate(task, taskState) >> false
+        1 * repository.getStateFor(task) >> taskArtifactState
+        1 * taskArtifactState.isUpToDate([]) >> false
         1 * taskArtifactState.finished()
         0 * _
     }


### PR DESCRIPTION
…utputs match its inputs

This allows user build scripts to create a plan for which tasks will be run and, for example, preemptively stop and restart services if their database content will be changing
See https://discuss.gradle.org/t/feature-request-new-type-of-task-dependency-that-adds-a-task-to-the-build-if-a-later-task-will-be-participating-and-not-expected-to-be-up-to-date-in-the-build/12009 for details