### PR TITLE
Prefix 'decorate' for ServiceRegistryProvider-Decorators

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -40,9 +40,10 @@ import java.util.concurrent.ConcurrentMap;
  * <li>Calling {@link #addProvider(Object)} to register a service provider bean. A provider bean may have factory, decorator and configuration methods as described below.</li>
  *
  * <li>Adding a factory method. A factory method should have a name that starts with 'create', and have a non-void return type. For example, <code>protected SomeService
- * createSomeService() { .... }</code>. Parameters are injected using services from this registry or its parents.</li>
+ * createSomeService() { .... }</code>. Parameters are injected using services from this registry or its parents. Note that factory methods with a
+ * single parameter and an return type equal to that parameter type are interpreted as decorator methods.</li>
  *
- * <li>Adding a decorator method. A decorator method should have a name that starts with 'decorate', take a single parameter, and a have a non-void return type. Before invoking the method, the
+ * <li>Adding a decorator method. A decorator method should have a name that starts with 'decorate', take a single parameter, and a have return type equal to the parameter type. Before invoking the method, the
  * parameter is located in the parent service registry and then passed to the method.</li>
  *
  * <li>Adding a configure method. A configure method should be called 'configure', take a {@link ServiceRegistration} parameter, and a have a void return type. Additional parameters
@@ -248,7 +249,6 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
                 if (method.getReturnType().equals(Void.TYPE)) {
                     throw new ServiceLookupException(String.format("Method %s.%s() must not return void.", type.getSimpleName(), method.getName()));
                 }
-
                 builder.add(iterator, builder.factories, method);
             }
         }
@@ -259,11 +259,11 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
         Iterator<Method> iterator = builder.remainingMethods.iterator();
         while (iterator.hasNext()) {
             Method method = iterator.next();
-            if (method.getName().startsWith("create") && method.getParameterTypes().length == 1 && method.getParameterTypes()[0].equals(method.getReturnType())) {
+            if ((method.getName().startsWith("create") || method.getName().startsWith("decorate"))
+                && method.getParameterTypes().length == 1 && method.getParameterTypes()[0].equals(method.getReturnType())) {
                 if (method.getReturnType().equals(Void.TYPE)) {
                     throw new ServiceLookupException(String.format("Method %s.%s() must not return void.", type.getSimpleName(), method.getName()));
                 }
-
                 builder.add(iterator, builder.decorators, method);
             }
         }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -316,7 +316,7 @@ class DefaultServiceRegistryTest extends Specification {
     def usesProviderDecoratorMethodToDecorateParentServiceInstance() {
         def parent = Mock(ServiceRegistry)
         def registry = new DefaultServiceRegistry(parent)
-        registry.addProvider(new TestDecoratingProvider())
+        registry.addProvider(decoratorProvider)
 
         given:
         _ * parent.get(Long) >> 110L
@@ -325,29 +325,57 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(Long) == 112L
         registry.get(Number) == 112L
         registry.get(Object) == 112L
+
+        where:
+        decoratorProvider << [ new TestDecoratingProviderWithCreate(), new TestDecoratingProviderWithDecorate() ]
     }
 
     def cachesServiceCreatedUsingProviderDecoratorMethod() {
         def parent = Mock(ServiceRegistry)
         def registry = new DefaultServiceRegistry(parent)
-        registry.addProvider(new TestDecoratingProvider())
+        registry.addProvider(decoratorProvider)
 
         given:
         _ * parent.get(Long) >> 11L
 
         expect:
         registry.get(Long).is(registry.get(Long))
+
+        where:
+        decoratorProvider << [ new TestDecoratingProviderWithCreate(), new TestDecoratingProviderWithDecorate() ]
+    }
+
+    def conflictWhenCreateAndDecorateMethodDecorateTheSameType() {
+        def parent = Mock(ServiceRegistry)
+        def registry = new DefaultServiceRegistry(parent)
+        registry.addProvider(new ConflictingDecoratorMethods())
+
+        given:
+        _ * parent.get(Long) >> 11L
+
+        when:
+        registry.get(Long).is(registry.get(Long))
+
+        then:
+        ServiceLookupException e = thrown()
+        e.message.contains("Multiple services of type Long available in DefaultServiceRegistry:")
+        e.message.contains("- Service Long at ConflictingDecoratorMethods.createLong()")
+        e.message.contains("- Service Long at ConflictingDecoratorMethods.decorateLong()")
+
     }
 
     def providerDecoratorMethodFailsWhenNoParentRegistry() {
         def registry = new DefaultServiceRegistry()
 
         when:
-        registry.addProvider(new TestDecoratingProvider())
+        registry.addProvider(decoratorProvider)
 
         then:
         ServiceLookupException e = thrown()
-        e.message == "Cannot use decorator method TestDecoratingProvider.createLong() when no parent registry is provided."
+        e.message.matches(/Cannot use decorator method TestDecoratingProviderWith.*\..*Long\(\) when no parent registry is provided\./)
+
+        where:
+        decoratorProvider << [ new TestDecoratingProviderWithCreate(), new TestDecoratingProviderWithDecorate() ]
     }
 
     def failsWhenProviderDecoratorMethodRequiresUnknownService() {
@@ -357,14 +385,17 @@ class DefaultServiceRegistryTest extends Specification {
         def registry = new DefaultServiceRegistry(parent)
 
         given:
-        registry.addProvider(new TestDecoratingProvider())
+        registry.addProvider(decoratorProvider)
 
         when:
         registry.get(Long)
 
         then:
         ServiceCreationException e = thrown()
-        e.message == "Cannot create service of type Long using TestDecoratingProvider.createLong() as required service of type Long is not available in parent registries."
+        e.message.matches(/Cannot create service of type Long using TestDecoratingProviderWith.*\..*Long\(\) as required service of type Long is not available in parent registries./)
+
+        where:
+        decoratorProvider << [ new TestDecoratingProviderWithCreate(), new TestDecoratingProviderWithDecorate() ]
     }
 
     def failsWhenProviderDecoratorMethodThrowsException() {
@@ -374,15 +405,18 @@ class DefaultServiceRegistryTest extends Specification {
         def registry = new DefaultServiceRegistry(parent)
 
         given:
-        registry.addProvider(new BrokenDecoratingProvider())
+        registry.addProvider(decoratorProvider)
 
         when:
         registry.get(Long)
 
         then:
         ServiceCreationException e = thrown()
-        e.message == "Could not create service of type Long using BrokenDecoratingProvider.createLong()."
-        e.cause == BrokenDecoratingProvider.failure
+        e.message.matches(/Could not create service of type Long using BrokenDecoratingProviderWith.*\..*Long\(\)\./)
+        e.cause == decoratorProvider.failure
+
+        where:
+        decoratorProvider << [ new BrokenDecoratingProviderWithCreate(), new BrokenDecoratingProviderWithDecorate() ]
     }
 
     def failsWhenThereIsACycleInDependenciesForProviderFactoryMethods() {
@@ -422,21 +456,24 @@ class DefaultServiceRegistryTest extends Specification {
         e.message == "Could not create service of type String using NullProvider.createString() as this method returned null."
     }
 
-    def failsWhenAProviderDecoratorMethodReturnsNull() {
+    def failsWhenAProviderDecoratorCreateMethodReturnsNull() {
         def parent = Stub(ServiceRegistry) {
             get(String) >> "parent"
         }
         def registry = new DefaultServiceRegistry(parent)
 
         given:
-        registry.addProvider(new NullDecorator())
+        registry.addProvider(decoratorProvider)
 
         when:
         registry.get(String)
 
         then:
         ServiceCreationException e = thrown()
-        e.message == "Could not create service of type String using NullDecorator.createString() as this method returned null."
+        e.message.matches(/Could not create service of type String using NullDecoratorWith.*\..*String\(\) as this method returned null\./)
+
+        where:
+        decoratorProvider << [ new NullDecoratorWithCreate(), new NullDecoratorWithDecorate() ]
     }
 
     def usesFactoryMethodToCreateServiceInstance() {
@@ -506,7 +543,7 @@ class DefaultServiceRegistryTest extends Specification {
 
     def usesDecoratorMethodToDecorateParentServiceInstance() {
         def parent = Mock(ServiceRegistry)
-        def registry = new RegistryWithDecoratorMethods(parent)
+        def registry = decoratorCreator.call(parent)  /* .call needed in spock 0.7 */
 
         when:
         def result = registry.get(Long)
@@ -516,15 +553,21 @@ class DefaultServiceRegistryTest extends Specification {
 
         and:
         1 * parent.get(Long) >> 110L
+
+        where:
+        decoratorCreator << [ { p -> new RegistryWithDecoratorMethodsWithCreate(p) }, { p -> new RegistryWithDecoratorMethodsWithDecorate(p) } ]
     }
 
-    def decoratorMethodFailsWhenNoParentRegistry() {
+    def decoratorCreateMethodFailsWhenNoParentRegistry() {
         when:
-        new RegistryWithDecoratorMethods()
+        decoratorCreator.call() /* .call needed in spock 0.7 */
 
         then:
         ServiceLookupException e = thrown()
-        e.message.matches(/Cannot use decorator method RegistryWithDecoratorMethods\..*() when no parent registry is provided./)
+        e.message.matches(/Cannot use decorator method RegistryWithDecoratorMethodsWith.*\..*\(\) when no parent registry is provided./)
+
+        where:
+        decoratorCreator << [ { new RegistryWithDecoratorMethodsWithCreate() }, { new RegistryWithDecoratorMethodsWithDecorate() } ]
     }
 
     def canRegisterServicesUsingAction() {
@@ -741,7 +784,7 @@ class DefaultServiceRegistryTest extends Specification {
     def usesDecoratorMethodToDecorateParentFactoryInstance() {
         def factory = Mock(Factory)
         def parent = Mock(ServiceRegistry)
-        def registry = new RegistryWithDecoratorMethods(parent)
+        def registry = decoratorCreator.call(parent)  /* .call needed in spock 0.7 */
 
         given:
         _ * parent.getFactory(Long) >> factory
@@ -750,6 +793,9 @@ class DefaultServiceRegistryTest extends Specification {
         expect:
         registry.newInstance(Long) == 12L
         registry.newInstance(Long) == 22L
+
+        where:
+        decoratorCreator << [ { p -> new RegistryWithDecoratorMethodsWithCreate(p) } , { p -> new RegistryWithDecoratorMethodsWithDecorate(p) } ]
     }
 
     def failsWhenMultipleFactoriesAreAvailableForServiceType() {
@@ -1186,13 +1232,30 @@ class DefaultServiceRegistryTest extends Specification {
         }
     }
 
-    private static class TestDecoratingProvider {
+
+    private static class ConflictingDecoratorMethods {
+        Long createLong(Long value) {
+            return value + 2
+        }
+
+        Long decorateLong(Long value) {
+            return value + 2
+        }
+    }
+
+    private static class TestDecoratingProviderWithCreate {
         Long createLong(Long value) {
             return value + 2
         }
     }
 
-    private static class BrokenDecoratingProvider {
+    private static class TestDecoratingProviderWithDecorate {
+        Long decorateLong(Long value) {
+            return value + 2
+        }
+    }
+
+    private static class BrokenDecoratingProviderWithCreate {
         static def failure = new RuntimeException()
 
         Long createLong(Long value) {
@@ -1200,8 +1263,22 @@ class DefaultServiceRegistryTest extends Specification {
         }
     }
 
-    private static class NullDecorator {
+    private static class BrokenDecoratingProviderWithDecorate {
+        static def failure = new RuntimeException()
+
+        Long decorateLong(Long value) {
+            throw failure
+        }
+    }
+
+    private static class NullDecoratorWithCreate {
         String createString(String value) {
+            return null
+        }
+    }
+
+    private static class NullDecoratorWithDecorate {
+        String decorateString(String value) {
             return null
         }
     }
@@ -1232,11 +1309,11 @@ class DefaultServiceRegistryTest extends Specification {
         }
     }
 
-    private static class RegistryWithDecoratorMethods extends DefaultServiceRegistry {
-        public RegistryWithDecoratorMethods() {
+    private static class RegistryWithDecoratorMethodsWithCreate extends DefaultServiceRegistry {
+        public RegistryWithDecoratorMethodsWithCreate() {
         }
 
-        public RegistryWithDecoratorMethods(ServiceRegistry parent) {
+        public RegistryWithDecoratorMethodsWithCreate(ServiceRegistry parent) {
             super(parent)
         }
 
@@ -1245,6 +1322,27 @@ class DefaultServiceRegistryTest extends Specification {
         }
 
         protected Factory<Long> createLongFactory(final Factory<Long> factory) {
+            return new Factory<Long>() {
+                public Long create() {
+                    return factory.create() + 2
+                }
+            };
+        }
+    }
+
+    private static class RegistryWithDecoratorMethodsWithDecorate extends DefaultServiceRegistry {
+        public RegistryWithDecoratorMethodsWithDecorate() {
+        }
+
+        public RegistryWithDecoratorMethodsWithDecorate(ServiceRegistry parent) {
+            super(parent)
+        }
+
+        protected Long decorateLong(Long value) {
+            return value + 10
+        }
+
+        protected Factory<Long> decorateLongFactory(final Factory<Long> factory) {
             return new Factory<Long>() {
                 public Long create() {
                     return factory.create() + 2


### PR DESCRIPTION
The decorator method of a ServiceRegistryProvider can now be prefixed with `decorate` instead of `create`. This is also documented in `org.gradle.internal.service.DefaultServiceRegistry` but never made it to the code. 
To stay backward compatible, the variant with `create` is still supported but in addition to that, the new prefix can also be used. 