### PR TITLE
Removing unnecessary validation

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/build/docs/SampleLayoutHandler.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/SampleLayoutHandler.groovy
@@ -128,9 +128,6 @@ class TreeNode {
         int i = 0
         for (; i < partsA.size() && i < partsB.size() && partsA[i] == partsB[i]; i++) {
         }
-        if (i == 0) {
-            return null
-        }
         return partsA.subList(0, i).join('/')
     }
 


### PR DESCRIPTION
The subList(0, 0) will return an empty list, so join('/') will always work... In this case returning an empty string instead of null. But in groovy, in general, we check using just the variable and for this (an empty string and a null value) will return false.

So, in my opinion... I think that we can avoid this if(i == 0) {return null}