### PR TITLE
Added check for NONSTOP_KERNEL to bypass ulimit.

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -30,6 +30,7 @@ die ( ) {
 cygwin=false
 msys=false
 darwin=false
+nonstop=false
 case "`uname`" in
   CYGWIN* )
     cygwin=true
@@ -39,6 +40,9 @@ case "`uname`" in
     ;;
   MINGW* )
     msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
     ;;
 esac
 
@@ -85,7 +89,7 @@ location of your Java installation."
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`
     if [ $? -eq 0 ] ; then
         if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -30,6 +30,7 @@ die ( ) {
 cygwin=false
 msys=false
 darwin=false
+nonstop=false
 case "`uname`" in
   CYGWIN* )
     cygwin=true
@@ -39,6 +40,9 @@ case "`uname`" in
     ;;
   MINGW* )
     msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
     ;;
 esac
 
@@ -85,7 +89,7 @@ location of your Java installation."
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "\$cygwin" = "false" -a "\$darwin" = "false" ] ; then
+if [ "\$cygwin" = "false" -a "\$darwin" = "false" -a "\$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`
     if [ \$? -eq 0 ] ; then
         if [ "\$MAX_FD" = "maximum" -o "\$MAX_FD" = "max" ] ; then


### PR DESCRIPTION
The change is analogous to how cygwin and darwin are handled. Current implementations of the operating system does not support an explicit ulimit. The command is simulated in bash only and causes warnings when products using gradle are run (e.g., Groovy).

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>