### PR TITLE
Add command line option for relaxed task name matching

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/StartParameter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/StartParameter.java
@@ -76,6 +76,7 @@ public class StartParameter extends LoggingConfiguration implements Serializable
     private boolean configureOnDemand;
     private int maxWorkerCount;
     private boolean continuous;
+    private boolean relaxedTaskNames;
 
     /**
      * Sets the project's cache location. Set to null to use the default location.
@@ -133,6 +134,7 @@ public class StartParameter extends LoggingConfiguration implements Serializable
         p.initScripts = new ArrayList<File>(initScripts);
         p.dryRun = dryRun;
         p.projectCacheDir = projectCacheDir;
+        p.relaxedTaskNames = relaxedTaskNames;
         return p;
     }
 
@@ -160,6 +162,7 @@ public class StartParameter extends LoggingConfiguration implements Serializable
         p.parallelProjectExecution = parallelProjectExecution;
         p.configureOnDemand = configureOnDemand;
         p.maxWorkerCount = maxWorkerCount;
+        p.relaxedTaskNames = relaxedTaskNames;
         return p;
     }
 
@@ -674,6 +677,7 @@ public class StartParameter extends LoggingConfiguration implements Serializable
             + ", parallelProjectExecution=" + parallelProjectExecution
             + ", configureOnDemand=" + configureOnDemand
             + ", maxWorkerCount=" + maxWorkerCount
+            + ", relaxedTaskNames=" + relaxedTaskNames
             + '}';
     }
 
@@ -699,4 +703,13 @@ public class StartParameter extends LoggingConfiguration implements Serializable
         this.continuous = enabled;
     }
 
+    @Incubating
+    public boolean isRelaxedTaskNames() {
+        return relaxedTaskNames;
+    }
+
+    @Incubating
+    public void setRelaxedTaskNames(boolean enabled) {
+        this.relaxedTaskNames = enabled;
+    }
 }

--- a/subprojects/core/src/main/groovy/org/gradle/initialization/DefaultCommandLineConverter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/initialization/DefaultCommandLineConverter.java
@@ -53,6 +53,9 @@ public class DefaultCommandLineConverter extends AbstractCommandLineConverter<St
     private static final String CONTINUOUS = "continuous";
     private static final String CONTINUOUS_SHORT_FLAG = "t";
 
+    private static final String RELAXED_TASK_NAMES = "relaxed-task-names";
+    private static final String RELAXED_TASK_NAMES_SHORT_FLAG = "r";
+
     private final CommandLineConverter<LoggingConfiguration> loggingConfigurationCommandLineConverter = new LoggingCommandLineConverter();
     private final SystemPropertiesCommandLineConverter systemPropertiesCommandLineConverter = new SystemPropertiesCommandLineConverter();
     private final ProjectPropertiesCommandLineConverter projectPropertiesCommandLineConverter = new ProjectPropertiesCommandLineConverter();
@@ -88,6 +91,7 @@ public class DefaultCommandLineConverter extends AbstractCommandLineConverter<St
         parser.option(MAX_WORKERS).hasArgument().hasDescription("Configure the number of concurrent workers Gradle is allowed to use.").incubating();
         parser.option(CONFIGURE_ON_DEMAND).hasDescription("Only relevant projects are configured in this build run. This means faster build for large multi-project builds.").incubating();
         parser.option(CONTINUOUS, CONTINUOUS_SHORT_FLAG).hasDescription("Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.").incubating();
+        parser.option(RELAXED_TASK_NAMES, RELAXED_TASK_NAMES_SHORT_FLAG).hasDescription("Relaxes task name matching. Tasks are found even if command line has a typo.").incubating();
         parser.allowOneOf(MAX_WORKERS, PARALLEL_THREADS);
     }
 
@@ -199,6 +203,10 @@ public class DefaultCommandLineConverter extends AbstractCommandLineConverter<St
 
         if (options.hasOption(CONTINUOUS)) {
             startParameter.setContinuous(true);
+        }
+
+        if (options.hasOption(RELAXED_TASK_NAMES)) {
+            startParameter.setRelaxedTaskNames(true);
         }
 
         return startParameter;

--- a/subprojects/core/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -111,6 +111,7 @@ class StartParameterTest extends Specification {
         !parameter.rerunTasks
         !parameter.recompileScripts
         !parameter.refreshDependencies
+        !parameter.relaxedTaskNames
 
         assertThat(parameter, isSerializable())
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
@@ -32,6 +32,11 @@ public class PropertiesToStartParameterConverter {
             startParameter.setParallelProjectExecutionEnabled(true);
         }
 
+        String relaxed = properties.get(GradleProperties.RELAXED_TASK_NAMES_PROPERTY);
+        if (isTrue(relaxed)) {
+            startParameter.setRelaxedTaskNames(true);
+        }
+
         String workers = properties.get(GradleProperties.WORKERS_PROPERTY);
         if (workers != null) {
             try {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/GradleProperties.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/GradleProperties.java
@@ -31,9 +31,11 @@ public class GradleProperties {
     public static final String CONFIGURE_ON_DEMAND_PROPERTY = "org.gradle.configureondemand";
     public static final String PARALLEL_PROPERTY = "org.gradle.parallel";
     public static final String WORKERS_PROPERTY = "org.gradle.workers.max";
+    public static final String RELAXED_TASK_NAMES_PROPERTY = "org.gradle.relaxedtasknames";
 
     public static final Set<String> ALL = newHashSet(IDLE_TIMEOUT_PROPERTY, DAEMON_BASE_DIR_PROPERTY, JVM_ARGS_PROPERTY,
-            JAVA_HOME_PROPERTY, DAEMON_ENABLED_PROPERTY, DEBUG_MODE_PROPERTY, CONFIGURE_ON_DEMAND_PROPERTY, PARALLEL_PROPERTY, WORKERS_PROPERTY);
+            JAVA_HOME_PROPERTY, DAEMON_ENABLED_PROPERTY, DEBUG_MODE_PROPERTY, CONFIGURE_ON_DEMAND_PROPERTY,
+            PARALLEL_PROPERTY, WORKERS_PROPERTY, RELAXED_TASK_NAMES_PROPERTY);
 
     public static boolean isTrue(Object propertyValue) {
         return propertyValue != null && propertyValue.toString().equalsIgnoreCase("true");

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
@@ -32,6 +32,7 @@ class PropertiesToStartParameterConverterTest extends Specification {
         converter.convert([(PARALLEL_PROPERTY): "false"], new StartParameter()).parallelThreadCount == 0
         converter.convert([(CONFIGURE_ON_DEMAND_PROPERTY): "TRUE"], new StartParameter()).configureOnDemand
         !converter.convert([(CONFIGURE_ON_DEMAND_PROPERTY): "xxx"], new StartParameter()).configureOnDemand
+        converter.convert([(RELAXED_TASK_NAMES_PROPERTY): "true"], new StartParameter()).relaxedTaskNames
     }
 
     def invalidMaxWorkersProperty() {


### PR DESCRIPTION
Inspired by https://github.com/tasomaniac/thefuck-gradle and [the accompanying blog post](https://medium.com/@tasomaniac/lifesaver-protip-the-fuck-gradle-rule-3291857181fc).

When turned on via command line or a `gradle.properties` setting, task name matching will accept matches with at most 3 character mismatches (levenshtein distance must be at most `min(3, pattern.length()/2)`), but only if there is a unique match.
The setting is `org.gradle.relaxedtasknames`, the command line flag is either `-r` or `--relaxed-task-names`