### PR TITLE
Made Installation Clearer

### DIFF
--- a/subprojects/docs/src/docs/userguide/installation.xml
+++ b/subprojects/docs/src/docs/userguide/installation.xml
@@ -61,8 +61,9 @@
 <section>
 <title>Environment variables</title>
 
-<para>For running Gradle, add <filename><replaceable>GRADLE_HOME</replaceable>/bin</filename> to your <envar>PATH</envar>
-    environment variable. Usually, this is sufficient to run Gradle.
+<para>For running Gradle, firstly add the environment variable <envar>GRADLE_HOME</envar>. This should point to the unpacked files from the 
+    Gradle website. Next add <filename><replaceable>GRADLE_HOME</replaceable>/bin</filename> to your <envar>PATH</envar> environment variable. 
+    Usually, this is sufficient to run Gradle.
 </para>
 </section>
 


### PR DESCRIPTION
I Know it might seem like it's obvious, but how can you use an environment var you have not declared, and just in-case anyone does not realize which folder to set `GRADLE_HOME` to.