### PR TITLE
GRADLE-1574 fix + unit-test

### DIFF
--- a/subprojects/docs/src/samples/maven/pomGeneration/build.gradle
+++ b/subprojects/docs/src/samples/maven/pomGeneration/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile("group1:compile:1.0") {
         exclude(group: 'excludeGroup', module: 'excludeArtifact')
     }
+    // NOTE: explicit artifact reference makes a dependency non-transitive
     providedCompile "group2:providedCompile:1.0@jar"
     runtime "group3:runtime:1.0"
     providedRuntime("group4:providedRuntime:1.0@zip") {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -90,8 +90,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         return dependsOn(module.groupId, module.artifactId, module.version)
     }
 
-    MavenModule dependsOn(String group, String artifactId, String version, String type = null, String scope = null, String classifier = null) {
-        this.dependencies << [groupId: group, artifactId: artifactId, version: version, type: type, scope: scope, classifier: classifier]
+    MavenModule dependsOn(String group, String artifactId, String version, String type = null, String scope = null, String classifier = null, Collection<Map> exclusions = null) {
+        this.dependencies << [groupId: group, artifactId: artifactId, version: version, type: type, scope: scope, classifier: classifier, exclusions: exclusions]
         return this
     }
 
@@ -283,6 +283,16 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                                 }
                                 if (dep.classifier) {
                                     classifier(dep.classifier)
+                                }
+                                if (dep.exclusions) {
+                                    exclusions {
+                                        for (exc in dep.exclusions) {
+                                            exclusion {
+                                                groupId(exc.groupId)
+                                                artifactId(exc.artifactId)
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenFileModuleTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenFileModuleTest.groovy
@@ -57,7 +57,7 @@ class MavenFileModuleTest extends Specification {
         then:
         dependencies != null
         dependencies.size() == 1
-        dependencies.get(0) == [groupId: 'my-company', artifactId: 'dep1', version: '1.0', type: 'jar', scope: 'compile', classifier: null]
+        dependencies.get(0) == [groupId: 'my-company', artifactId: 'dep1', version: '1.0', type: 'jar', scope: 'compile', classifier: null, exclusions: null]
     }
 
     def "Check packaging for set packaging"() {

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenLocalModuleTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenLocalModuleTest.groovy
@@ -57,7 +57,7 @@ class MavenLocalModuleTest extends Specification {
         then:
         dependencies != null
         dependencies.size() == 1
-        dependencies.get(0) == [groupId: 'my-company', artifactId: 'dep1', version: '1.0', type: 'jar', scope: 'compile', classifier: null]
+        dependencies.get(0) == [groupId: 'my-company', artifactId: 'dep1', version: '1.0', type: 'jar', scope: 'compile', classifier: null, exclusions: null]
     }
 
     def "Check packaging for set packaging"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.test.fixtures.maven.MavenLocalRepository
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 import spock.lang.Ignore
+import spock.lang.Issue
+
 /**
  * Tests “simple” maven publishing scenarios
  */
@@ -135,6 +137,44 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
 
         and:
         resolveArtifacts(repoModule) == ['root-1.0.jar']
+    }
+
+    @Issue('GRADLE-1574')
+    def "publishes wildcard exclusions for a non-transitive dependency"() {
+        given:
+        using m2
+        def repoModule = mavenRepo.module('group', 'root', '1.0')
+        def localModule = localM2Repo.module('group', 'root', '1.0')
+
+        and:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java'
+
+            group = 'group'
+            version = '1.0'
+
+            dependencies {
+                compile ('commons-collections:commons-collections:3.2.2') { transitive = false }
+            }
+
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publishToMavenLocal'
+
+        then: "wildcard exclusions are applied to the dependency"
+        def pom = localModule.parsedPom
+        def exclusions = pom.scopes.runtime.dependencies['commons-collections:commons-collections:3.2.2'].exclusions
+        exclusions.size() == 1 && exclusions[0].groupId=='*' && exclusions[0].artifactId=='*'
     }
 
     def "can publish to custom maven local repo defined in settings.xml"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
@@ -446,4 +446,33 @@ uploadArchives {
         !localM2Repo.module("group", "root", "1.0").artifactFile(type: "jar").exists()
         customLocalRepo.module("group", "root", "1.0").assertPublishedAsJavaModule()
     }
+
+    @Issue('GRADLE-1574')
+    def "can publish pom with wildcard exclusions for non-transitive dependencies"() {
+        given:
+        def localM2Repo = m2.mavenRepo()
+        executer.beforeExecute(m2)
+
+        and:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'maven'
+            apply plugin: 'java'
+
+            group = 'group'
+            version = '1.0'
+
+            dependencies {
+                compile ('commons-collections:commons-collections:3.2.2') { transitive = false }
+            }
+        """
+
+        when:
+        succeeds 'install'
+
+        then:
+        def pom = localM2Repo.module("group", "root", "1.0").parsedPom
+        def exclusions = pom.scopes.compile.dependencies['commons-collections:commons-collections:3.2.2'].exclusions
+        exclusions.size() == 1 && exclusions[0].groupId=='*' && exclusions[0].artifactId=='*'
+    }
 }

--- a/subprojects/maven/src/integTest/resources/org/gradle/integtests/publish/maven/pomGeneration/expectedNewPom.txt
+++ b/subprojects/maven/src/integTest/resources/org/gradle/integtests/publish/maven/pomGeneration/expectedNewPom.txt
@@ -20,6 +20,12 @@
       <version>1.0</version>
       <type>zip</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>group4</groupId>
@@ -27,6 +33,12 @@
       <version>1.0</version>
       <type>war</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>group6</groupId>
@@ -39,6 +51,12 @@
       <artifactId>providedCompile</artifactId>
       <version>1.0</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>group1</groupId>

--- a/subprojects/maven/src/integTest/resources/org/gradle/integtests/publish/maven/pomGeneration/expectedPom.txt
+++ b/subprojects/maven/src/integTest/resources/org/gradle/integtests/publish/maven/pomGeneration/expectedPom.txt
@@ -12,6 +12,12 @@
       <version>1.0</version>
       <type>zip</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>group4</groupId>
@@ -19,6 +25,12 @@
       <version>1.0</version>
       <type>war</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>group6</groupId>
@@ -31,6 +43,12 @@
       <artifactId>providedCompile</artifactId>
       <version>1.0</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>group1</groupId>

--- a/subprojects/maven/src/main/groovy/org/gradle/api/publication/maven/internal/pom/DefaultPomDependenciesConverter.java
+++ b/subprojects/maven/src/main/groovy/org/gradle/api/publication/maven/internal/pom/DefaultPomDependenciesConverter.java
@@ -26,6 +26,7 @@ import org.gradle.api.publication.maven.internal.VersionRangeMapper;
 import java.util.*;
 
 class DefaultPomDependenciesConverter implements PomDependenciesConverter {
+    private static final List<Exclusion> EXCLUDE_ALL = initExcludeAll();
     private ExcludeRuleConverter excludeRuleConverter;
     private VersionRangeMapper versionRangeMapper;
 
@@ -155,6 +156,9 @@ class DefaultPomDependenciesConverter implements PomDependenciesConverter {
     }
 
     private List<Exclusion> getExclusions(ModuleDependency dependency, Set<Configuration> configurations) {
+        if (!dependency.isTransitive()) {
+            return EXCLUDE_ALL;
+        }
         List<Exclusion> mavenExclusions = new ArrayList<Exclusion>();
         Set<ExcludeRule> excludeRules = new HashSet<ExcludeRule>(dependency.getExcludeRules());
         for (Configuration configuration : configurations) {
@@ -167,6 +171,13 @@ class DefaultPomDependenciesConverter implements PomDependenciesConverter {
             }
         }
         return mavenExclusions;
+    }
+
+    private static List<Exclusion> initExcludeAll() {
+        Exclusion excludeAll = new Exclusion();
+        excludeAll.setGroupId("*");
+        excludeAll.setArtifactId("*");
+        return Collections.singletonList(excludeAll);
     }
 
     public ExcludeRuleConverter getExcludeRuleConverter() {

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -202,6 +202,7 @@ public class DefaultMavenPublicationTest extends Specification {
         moduleDependency.version >> "version"
         moduleDependency.artifacts >> [artifact]
         moduleDependency.excludeRules >> [excludeRule]
+        moduleDependency.transitive >> true
 
         and:
         publication.from(componentWithDependency(moduleDependency))
@@ -214,6 +215,38 @@ public class DefaultMavenPublicationTest extends Specification {
             version == "version"
             artifacts == [artifact]
             excludeRules == [excludeRule]
+        }
+    }
+
+    def "adopts non-transitive module dependency from added component"() {
+        given:
+        def publication = createPublication()
+        def moduleDependency = Mock(ModuleDependency)
+        def artifact = Mock(DependencyArtifact)
+        def excludeRule = Mock(ExcludeRule)
+
+        when:
+        moduleDependency.group >> "group"
+        moduleDependency.name >> "name"
+        moduleDependency.version >> "version"
+        moduleDependency.artifacts >> [artifact]
+        moduleDependency.excludeRules >> [excludeRule]
+        moduleDependency.transitive >> false
+
+        and:
+        publication.from(componentWithDependency(moduleDependency))
+
+        then:
+        publication.runtimeDependencies.size() == 1
+        with (publication.runtimeDependencies.asList().first()) {
+                groupId == "group"
+                artifactId == "name"
+                version == "version"
+                artifacts == [artifact]
+                excludeRules != [excludeRule]
+                excludeRules.size() == 1
+                excludeRules[0].group == '*'
+                excludeRules[0].module == '*'
         }
     }
 


### PR DESCRIPTION
Adds a wildcard exclusion for non-transitive dependencies, fixes [GRADLE-1574](https://issues.gradle.org/browse/GRADLE-1574).
Wildcard extensions are supported since [MNG-3832](https://issues.apache.org/jira/browse/MNG-3832) was resolved.
Related post: http://www.smartjava.org/content/maven-and-wildcard-exclusions.
Conflict fix for https://github.com/gradle/gradle/pull/484