### PR TITLE
Ability to exclude some tests from execution

### DIFF
--- a/design-docs/test-selection.md
+++ b/design-docs/test-selection.md
@@ -1,222 +1,70 @@
 
-This spec decribes an approach to making test execution in Gradle more flexible
+Ability to control a set of tests to be executed via configuration and command line options and DSL.
 
-# Use cases
+# Motivation
+* In order to be able to detect, verify flaky tests it should be possible to exclude some tests from the testsuite without making changes in the code.
 
-- I have a set of functional tests.
-- I have a set of fast and slow tests.
-- I need to run my functional tests against multiple different environments.
-- I have unit tests for a C++ library, and I need to build and execute the unit tests for each variant of the library.
-- I have a set of performance tests.
-- My unit and functional tests have different dependencies.
-- My functional tests do not use the production classes directly.
-- My functional tests require some environment setup and tear down.
-- I have a set of test fixtures which are shared by different groups of tests.
-- I use several different test frameworks in my unit tests.
-- I want to measure code coverage for my integration tests.
-- I want int test code coverage to be included in sonarRunner analysis.
-- legacy integration tests are slow, I need a way to execute a single test method, from the command line.
+# Design
+There are four types of filters available: include/exclude for categories and individual filters.
+All filters could be provided via command line options or via Gradle DSL (`build.gradle`).
 
-# Introduce _test suite_
+## Comparison with other tools
 
-## Implementation plan
+TBD: double check capabilities of tools/frameworks listed in the table.
 
-Introduce the concept of a _test suite_ and add a container of test suites to the project. A new `testing` plugin
-will make these available:
+| Framework        | Includes           | Excludes | Regexps in includes/excludes | Categories | Ability to include/exclude multiple tests (categories) | Notes |
+| ------------- |:-------------:|   -----:|-----:|-----:|-----:|--:|
+| Javascript frameworks     | All the considered frameworks doesn't support any filtering (all the tests in projects are executed during every run). ||||||
+| Maven                     | Yes | Yes | Yes | Yes | Yes | [Stackoverflow: How can I skip test in some projects via command line options?](http://stackoverflow.com/questions/9123075/maven-how-can-i-skip-test-in-some-projects-via-command-line-options), [Stackoverflow: How to exclude all JUnit4 tests with a given category using Maven surefire?](http://stackoverflow.com/questions/14132174/how-to-exclude-all-junit4-tests-with-a-given-category-using-maven-surefire) |
+| SBT                       | Yes ([Scalatest](http://stackoverflow.com/questions/11159953/scalatest-in-sbt-is-there-a-way-to-run-a-single-test-without-tags)) | No | Yes (For classes only?) | Yes | Yes | [SBT: Testing](http://www.scala-sbt.org/0.13.5/docs/Detailed-Topics/Testing.html) |
+| RSpec (Ruby)               | Yes:  [RSpec filtering](http://www.relishapp.com/rspec/rspec-core/v/3-4/docs/filtering), [RSpec Command line](http://www.relishapp.com/rspec/rspec-core/v/3-4/docs/command-line/pattern-option) |||   [Yes](http://www.relishapp.com/rspec/rspec-core/v/3-4/docs/command-line/tag-option) | Yes | [PR 1671 Exclude Pattern](https://github.com/rspec/rspec-core/pull/1671) |
 
-    tests {
-        unit { ... }
-        functional { ... }
+## Gradle implementation
+### Command line options
+
+* `--include-tests` - pattern of test names which needs to be included in run. By default all the tests are included.
+* `--exclude-tests` - allows to specify a test name or pattern for tests to be excluded.
+* _Exclude filters_ are applied to the set of tests which were selected for execution by _include filters_
+* It's possible to specify full test name or pattern (`com.FooTest.*in*`, `***.foo`)
+* It's possible to pass multiple include/exclude parameters simultaneously: `--include-tests *.foo.* -include-tests *.bar.* --exclude-tests ***.fooBar`
+* scanForTestClasses
+
+
+* Rules provided via command line have higher priority over rules in build file.
+
+
+### Gradle DSL
+```
+test {
+
+    filter {
+        includeTests "*UiCheck"   // Currently: includeTestsMatching
+        includeTests "*DaoCheck"
+        excludeTests "*Account*Check"
+
+        includeCategories 'org.gradle.junit.CategoryA'
+        excludeCategories 'org.gradle.junit.CategoryB'
     }
+}
+```
 
-A test suite takes a test binary as input (where _binary_ is as defined in the [jvm languages](building-multiple-outputs-from-jvm-languages.md)
-and [native languages](continuous-delivery-for-c-plus-plus.md) specs). This binary includes the candidate tests that form
-part of the suite, subject to filtering. A binary defines its runtime dependencies and these are used to determine how to
-run the tests and which toolkits are to be used.
-
-A test suite may also define test toolkit-specific configuration, such as JUnit categories to include or exclude, and
-environment specific configuration, such as system properties to define:
-
-    tests {
-        unit {
-            junit {
-                includeCategory 'Fast'
-            }
-            testng {
-                excludeGroup 'Slow'
-            }
-            systemProperty 'someProp', 'some-value'
-        }
-    }
-
-A test suite has an associated task that executes the test suite. It may also have additional reporting tasks associated
-with it.
-
-TBD - strongly type test suites for JVM and native environments.
-
-TBD - It's probably worth splitting test suite into 2 things: the logical test suite, and the concrete executions of that
-suite for each environment and variant.
-
-Retrofit the `java` plugin to define a `unit` test suite that uses a `testClasses` binary build from the `test` source set.
-
-Add some "by-convention" plugins (say one for JVM and one for native environments) that define a number of conventions:
-
-- Define a `testFixtures` binary built from an associated `testFixtures` source set in `src/test-fixtures/$lang`.
-- When a test suite `foo` is added, define a `fooTest` binary built from an associated `fooTest` source set with source in `src/foo-test/$lang`.
-- Add the `testFixtures` binary as a dependency of each test binary.
-
-## Open issues
-
-# single test method execution
-
-## Use case
-
-Legacy integration tests are slow, @ need a way to execute a single test method, from command line.
-
-## New dsl brainstorm
-
-    test {
-        selection {
-            //using 'include' wording here could make it confusing with test.include
-            only "**/Foo*#someOtherMethod", "**/Foo*#someMethod"
-            only = []
-
-            //in/out
-            in "**/Foo*#someOtherMethod", "**/Foo*#someMethod"
-            out "**/Foo*#someOtherMethod", "**/Foo*#someMethod"
-
-            //if we deprecate test.include, we could do
-            include "**/Foo*#someOtherMethod", "**/Foo*#someMethod"
-            includes = []
-
-            //keep method selection separate
-            includeMethod
-            includeMethods = []
-
-            include {
-                method
-                methods = []
-            }
-
-            //some other elements we could add in future
-            exclude
-            excludes = []
-
-            unselect
-            unselections = []
-
-            include {
-                descendantsOf 'com.foo.SomeBaseClass'
-                annotatedWith 'com.foo.Slow'
-                matching { descriptor, testClass ->
-                    //...
-                }
-            }
-        }
-    }
-
-Plus consistent commandline support, e.g.
-
-gradle test --select **/Foo.java#someTest
-
-## command line interface
-
-It would be good to consider the command line interface when designing the dsl because they need to be consistent.
-The convenient command line should support:
-
-	- selecting class + method in one option
-	- allow wildcards for classes (wildcards for methods are not practical to implement)
-
-Examples:
-
-    --select com.bar.**.Foo#someTest
-    --select Foo#someTest
-    --select com.foo.bar.Foo#otherTest
-
-## Plan
-
-    1. Add --only @Option, that maps to new dsl: test.selection.only
-    1. Add --include @Option and deprecate test.single. The new option is equiv of test.include
-    1. Add --exclude @Option, the option maps to test.exclude
-    1. Add --debug (while we're in the area)
-
+# Implementation plan
 ## Stories
+### Add ability to exclude tests
+* Ability to specify tests to exclude via command line (`--exclude-tests` parameter)
+* Ability to specify tests to exclude via DSL
 
-### Add --only @Option, that maps to new dsl: test.selection.only
+### Add `--include-tests` option
+* Deprecate `--tests`
+* Deprecate -Dtest.single
 
-#### Test coverage:
+### Add support of multiple command line parameters for include/exclude values
 
-    - happy path, allows running tests for single methods
-    - when running the same test with different method, make sure it is not up-to-date
-    - works with JUnit and TestNG
-    - selected test(s) ignores completely any existing include configured in the build script but respects excludes
-    - is correctly incremental (e.g. same VS different values passed with --only)
-    - "Could not find matching test" error is emitted when no tests found for given --only
-    - 2 different test tasks, both use the option with different tests included
+## Testing
 
-### Add --include @Option to the test task, deprecate test.single property
+## Won't be implemented
 
-#### Test coverage:
-
-    - happy path
-    - selected test ignores completely any existing include configured in the build script
-    - is correctly incremental (e.g. same VS different values passed with --include)
-    - "Could not find matching test" error is emitted when no tests found for given --include
-    - 2 different test tasks, both use the option with different tests included
-    - if combined with --only, --only wins and --include is ignored
-
-### Add --exclude @Option to the test task:
-
-#### Test coverage:
-
-    - happy path
-    - exclude from command line replaces any excludes declared in the build script
-        (this behavior is consistent with --include)
-    - is correctly incremental (e.g. same VS different values passed with the option)
-    - "Could not find any tests" error is emitted when no tests found for given --exclude
-        (consistently with --include)
-    - --include and --exclude both working together together
-        - include declares a dir, exclude declares a single test from this dir,
-        the behavior should be consistent to how it works currently via DSL API (given both: includes and excludes configured in the build script)
-    - if combined with --only, --only wins and --exclude is ignored
-
-### Add --debug @Option to the test task
-
-#### Test coverage:
-
-    - smoke test, make sure the task is happy with the option and that debug property is set on the task
-
-## The api I currently think on implementing as a first story, please give feedback:
-
-    test {
-      //good old include
-      include '**/*SomeIntegrationTest'
-
-      //new stuff
-      selection {
-        include {
-          method 'method1', 'method2'
-          methods = []
-        }
-      }
-    }
-
-Plus, a convenience method directly in the test task, so that all above could be inlined into:
-
-    test {
-      select '**/*SomeIntegrationTest#method1,method2'
-      //or:
-      select '**/*SomeIntegrationTest#method1', '**/*SomeIntegrationTest#method2'
-    }
-
-Then, command line support could be:
-
-    gradle test --select **/*SomeIntegrationTest#method1,method2
-
-I would also deprecate test.single property
-
-
-
+# Open issues
 
 
 

--- a/subprojects/docs/src/docs/userguide/javaPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.xml
@@ -1211,7 +1211,7 @@
                 <itemizedlist>
                     <listitem>Filtering at the level of specific test methods; executing a single test method</listitem>
                     <listitem>Filtering based on custom annotations (future)</listitem>
-                    <listitem>Filtering based on test hierarchy; executing all tests that extend ceratain base class (future)</listitem>
+                    <listitem>Filtering based on test hierarchy; executing all tests that extend certain base class (future)</listitem>
                     <listitem>Filtering based on some custom runtime rule, e.g. particular value of a system property or some static state (future)</listitem>
                 </itemizedlist>
             </para>
@@ -1222,13 +1222,18 @@
                     <listitem>Fully qualified class name or fully qualified method name is supported,
                         e.g. “org.gradle.SomeTest”, “org.gradle.SomeTest.someMethod”</listitem>
                     <listitem>Wildcard '*' is supported for matching any characters</listitem>
-                    <listitem>Command line option “--tests” is provided to conveniently set the test filter.
+                    <listitem>Command line option “--include-tests” is provided to conveniently set the test filter.
                         Especially useful for the classic 'single test method execution' use case.
                         When the command line option is used, the inclusion filters declared in the build script are ignored.
                     </listitem>
                     <listitem>Gradle tries to filter the tests given the limitations of the test framework API.
                         Some advanced, synthetic tests may not be fully compatible with filtering.
                         However, the vast majority of tests and use cases should be handled neatly.
+                    </listitem>
+                    <listitem>
+                        There is an ability to exclude tests from execution by adding “--exclude-tests” command line option.
+                        If “--exclude-tests” is passed along with “--include-tests” then Gradle filters out tests from ”included” set only.
+                        When “--exclude-tests” is used alone then only tests specified in the filter won't be executed.
                     </listitem>
                     <listitem>Test filtering supersedes the file-based test selection. The latter may be completely replaced in future.
                         We will grow the the test filtering api and add more kinds of filters.
@@ -1248,28 +1253,28 @@
 
                 <itemizedlist>
                     <listitem>
-                        <para><literal>gradle test --tests org.gradle.SomeTest.someSpecificFeature</literal></para>
+                        <para><literal>gradle test --include-tests org.gradle.SomeTest.someSpecificFeature</literal></para>
                     </listitem>
                     <listitem>
-                        <para><literal>gradle test --tests *SomeTest.someSpecificFeature</literal></para>
+                        <para><literal>gradle test --include-tests *SomeTest.someSpecificFeature</literal></para>
                     </listitem>
                     <listitem>
-                        <para><literal>gradle test --tests *SomeSpecificTest</literal></para>
+                        <para><literal>gradle test --include-tests *SomeSpecificTest</literal></para>
                     </listitem>
                     <listitem>
-                        <para><literal>gradle test --tests *SomeSpecificTestSuite</literal></para>
+                        <para><literal>gradle test --include-tests *SomeSpecificTestSuite</literal></para>
                     </listitem>
                     <listitem>
-                        <para><literal>gradle test --tests all.in.specific.package*</literal></para>
+                        <para><literal>gradle test --include-tests all.in.specific.package*</literal></para>
                     </listitem>
                     <listitem>
-                        <para><literal>gradle test --tests *IntegTest</literal></para>
+                        <para><literal>gradle test --include-tests *IntegTest</literal></para>
                     </listitem>
                     <listitem>
-                        <para><literal>gradle test --tests *IntegTest*ui*</literal></para>
+                        <para><literal>gradle test --include-tests *IntegTest*ui* --exclude-tests com.generated.*</literal></para>
                     </listitem>
                     <listitem>
-                        <para><literal>gradle someTestTask --tests *UiTest someOtherTestTask --tests *WebTest*ui</literal></para>
+                        <para><literal>gradle someTestTask --include-tests *UiTest someOtherTestTask --include-tests *WebTest*ui</literal></para>
                     </listitem>
                 </itemizedlist>
             </para>

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
@@ -25,7 +25,8 @@ import java.util.Set;
 
 public class DefaultTestFilter implements TestFilter {
 
-    private Set<String> testNames = new HashSet<String>();
+    private Set<String> includeTestNames = new HashSet<String>();
+    private Set<String> excludeTestNames = Sets.newHashSet();
     private boolean failOnNoMatching = true;
 
     private void validateName(String name) {
@@ -34,20 +35,37 @@ public class DefaultTestFilter implements TestFilter {
         }
     }
 
+    public TestFilter excludeTestsMatching(String testNamePattern) {
+        validateName(testNamePattern);
+        excludeTestNames.add(testNamePattern);
+        return this;
+    }
+
+    public TestFilter excludeTest(String className, String methodName) {
+        excludeTestNames.add(testName(className, methodName));
+        return this;
+    }
+
     public TestFilter includeTestsMatching(String testNamePattern) {
         validateName(testNamePattern);
-        testNames.add(testNamePattern);
+        includeTestNames.add(testNamePattern);
         return this;
     }
 
     public TestFilter includeTest(String className, String methodName) {
-        validateName(className);
-        if(methodName == null || methodName.trim().isEmpty()){
-            testNames.add(new StringBuilder(className).append(".*").toString());
-        }else{
-            testNames.add(new StringBuilder(className).append(".").append(methodName).toString());
-        }
+        includeTestNames.add(testName(className, methodName));
         return this;
+    }
+
+    private String testName(String className, String methodName){
+        validateName(className);
+        StringBuilder testNameBuilder = new StringBuilder(className);
+        if (methodName == null || methodName.trim().isEmpty()) {
+            testNameBuilder.append(".*");
+        } else {
+            testNameBuilder.append(".").append(methodName);
+        }
+        return testNameBuilder.toString();
     }
 
     @Override
@@ -62,14 +80,28 @@ public class DefaultTestFilter implements TestFilter {
 
     @Input
     public Set<String> getIncludePatterns() {
-        return testNames;
+        return includeTestNames;
+    }
+
+    @Input
+    public Set<String> getExcludePatterns() {
+        return excludeTestNames;
     }
 
     public TestFilter setIncludePatterns(String... testNamePatterns) {
+        this.includeTestNames = getTestPatterns(testNamePatterns);
+        return this;
+    }
+
+    public TestFilter setExcludePatterns(String... testNamePatterns) {
+        this.excludeTestNames = getTestPatterns(testNamePatterns);
+        return this;
+    }
+
+    private Set<String> getTestPatterns(String... testNamePatterns) {
         for (String name : testNamePatterns) {
             validateName(name);
         }
-        this.testNames = Sets.newHashSet(testNamePatterns);
-        return this;
+        return Sets.newHashSet(testNamePatterns);
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -19,18 +19,32 @@ import com.google.common.base.Splitter;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
 public class TestSelectionMatcher {
 
     private final List<Pattern> includePatterns;
+    private final List<Pattern> excludePatterns;
 
     public TestSelectionMatcher(Collection<String> includedTests) {
-        includePatterns = new ArrayList<Pattern>(includedTests.size());
-        for (String includedTest : includedTests) {
-            includePatterns.add(preparePattern(includedTest));
+        this(includedTests, Collections.<String>emptyList());
+    }
+
+    public TestSelectionMatcher(Collection<String> includedTests, Collection<String> excludedTests) {
+        this.includePatterns = toPatterns(includedTests);
+        this.excludePatterns = toPatterns(excludedTests);
+    }
+
+    private List<Pattern> toPatterns(Collection<String> tests) {
+        List<Pattern> patterns = new LinkedList<Pattern>();
+
+        for (String test : tests) {
+            includePatterns.add(preparePattern(test));
         }
+        return patterns;
     }
 
     private Pattern preparePattern(String input) {
@@ -50,8 +64,16 @@ public class TestSelectionMatcher {
     }
 
     public boolean matchesTest(String className, String methodName) {
+
+        boolean matchesIncludePatterns = matchesTest(className, methodName, includePatterns);
+        boolean matchesExcludePatterns = matchesTest(className, methodName, excludePatterns);
+
+        return matchesIncludePatterns && !matchesExcludePatterns;
+    }
+
+    private boolean matchesTest(String className, String methodName, List<Pattern> patterns) {
         String fullName = className + "." + methodName;
-        for (Pattern pattern : includePatterns) {
+        for (Pattern pattern : patterns) {
             if (methodName != null && pattern.matcher(fullName).matches()) {
                 return true;
             }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -64,11 +64,15 @@ public class TestSelectionMatcher {
     }
 
     public boolean matchesTest(String className, String methodName) {
+        return matchesTest(className, methodName, includePatterns) || matchesTest(className, methodName, excludePatterns);
+    }
 
+    public boolean shouldRun(String className, String methodName){
         boolean allowedByIncludePatterns = includePatterns.isEmpty() || matchesTest(className, methodName, includePatterns);
         boolean matchedAnyExcludePatterns = !excludePatterns.isEmpty() && matchesTest(className, methodName, excludePatterns);
 
         return allowedByIncludePatterns && !matchedAnyExcludePatterns;
+
     }
 
     private boolean matchesTest(String className, String methodName, List<Pattern> patterns) {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -42,7 +42,7 @@ public class TestSelectionMatcher {
         List<Pattern> patterns = new LinkedList<Pattern>();
 
         for (String test : tests) {
-            includePatterns.add(preparePattern(test));
+            patterns.add(preparePattern(test));
         }
         return patterns;
     }
@@ -65,10 +65,10 @@ public class TestSelectionMatcher {
 
     public boolean matchesTest(String className, String methodName) {
 
-        boolean matchesIncludePatterns = matchesTest(className, methodName, includePatterns);
-        boolean matchesExcludePatterns = matchesTest(className, methodName, excludePatterns);
+        boolean allowedByIncludePatterns = includePatterns.isEmpty() || matchesTest(className, methodName, includePatterns);
+        boolean matchedAnyExcludePatterns = !excludePatterns.isEmpty() && matchesTest(className, methodName, excludePatterns);
 
-        return matchesIncludePatterns && !matchesExcludePatterns;
+        return allowedByIncludePatterns && !matchedAnyExcludePatterns;
     }
 
     private boolean matchesTest(String className, String methodName, List<Pattern> patterns) {

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilterTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilterTest.groovy
@@ -26,10 +26,11 @@ class DefaultTestFilterTest extends Specification {
     def spec = new DefaultTestFilter()
 
     def "allows configuring test names"() {
-        expect: spec.includePatterns.isEmpty()
+        expect:
+        spec.includePatterns.isEmpty()
+        spec.excludePatterns.isEmpty()
 
         when:
-//        todo
         spec.includeTestsMatching("*fooMethod")
         spec.includeTestsMatching("*.FooTest.*")
 
@@ -38,16 +39,31 @@ class DefaultTestFilterTest extends Specification {
         when: spec.setIncludePatterns("x")
 
         then: spec.includePatterns == ["x"] as Set
+
+        when:
+        spec.excludeTestsMatching("*baRMethod")
+        spec.excludeTestsMatching("*.BarTest.*")
+
+        then: spec.excludePatterns == ["*barMethod", "*.BarTest.*"] as Set
+
+        when: spec.setIncludePatterns("y")
+        then: spec.includePatterns == ["y"] as Set
+
     }
 
-    def "allows configuring by test class and methodname"() {
-        expect: spec.includePatterns.isEmpty()
+    def "allows configuring by test class and method name"() {
+        expect:
+        spec.includePatterns.isEmpty()
+        spec.excludePatterns.isEmpty()
 
         when:
         spec.includeTest("acme.FooTest", "bar")
         spec.includeTest("acme.BarTest", null)
+        spec.excludeTest("acme.FooTest", "bar1")
 
-        then: spec.includePatterns == ["acme.FooTest.bar", "acme.BarTest.*"] as Set
+        then:
+        spec.includePatterns == ["acme.FooTest.bar", "acme.BarTest.*"] as Set
+        spec.excludePatterns == ["acme.FooTest.bar1"] as Set
     }
 
     def "prevents empty names"() {

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilterTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilterTest.groovy
@@ -29,6 +29,7 @@ class DefaultTestFilterTest extends Specification {
         expect: spec.includePatterns.isEmpty()
 
         when:
+//        todo
         spec.includeTestsMatching("*fooMethod")
         spec.includeTestsMatching("*.FooTest.*")
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilterTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilterTest.groovy
@@ -37,17 +37,16 @@ class DefaultTestFilterTest extends Specification {
         then: spec.includePatterns == ["*fooMethod", "*.FooTest.*"] as Set
 
         when: spec.setIncludePatterns("x")
-
         then: spec.includePatterns == ["x"] as Set
 
         when:
-        spec.excludeTestsMatching("*baRMethod")
+        spec.excludeTestsMatching("*barMethod")
         spec.excludeTestsMatching("*.BarTest.*")
 
         then: spec.excludePatterns == ["*barMethod", "*.BarTest.*"] as Set
 
-        when: spec.setIncludePatterns("y")
-        then: spec.includePatterns == ["y"] as Set
+        when: spec.setExcludePatterns("y")
+        then: spec.excludePatterns == ["y"] as Set
 
     }
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -21,35 +21,34 @@ import spock.lang.Specification
 class TestSelectionMatcherTest extends Specification {
 
     def "knows if test matches class"() {
-        expect:
-        new TestSelectionMatcher(input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input).matchesTest(className, methodName) == match
 
         where:
-        input                 | className             | methodName | match
-        ["FooTest"]           | "FooTest"             | "whatever" | true
-        ["FooTest"]           | "fooTest"             | "whatever" | false
+        input                    | className                 | methodName            | match
+        ["FooTest"]              | "FooTest"                 | "whatever"            | true
+        ["FooTest"]              | "fooTest"                 | "whatever"            | false
 
-        ["com.foo.FooTest"]   | "com.foo.FooTest"     | "x"        | true
-        ["com.foo.FooTest"]   | "FooTest"             | "x"        | false
-        ["com.foo.FooTest"]   | "com_foo_FooTest"     | "x"        | false
+        ["com.foo.FooTest"]      | "com.foo.FooTest"         | "x"                   | true
+        ["com.foo.FooTest"]      | "FooTest"                 | "x"                   | false
+        ["com.foo.FooTest"]      | "com_foo_FooTest"         | "x"                   | false
 
-        ["com.foo.FooTest.*"] | "com.foo.FooTest"     | "aaa"      | true
-        ["com.foo.FooTest.*"] | "com.foo.FooTest"     | "bbb"      | true
-        ["com.foo.FooTest.*"] | "com.foo.FooTestx"    | "bbb"      | false
+        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "aaa"                 | true
+        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "bbb"                 | true
+        ["com.foo.FooTest.*"]    | "com.foo.FooTestx"        | "bbb"                 | false
 
-        ["*.FooTest.*"]       | "com.foo.FooTest"     | "aaa"      | true
-        ["*.FooTest.*"]       | "com.bar.FooTest"     | "aaa"      | true
-        ["*.FooTest.*"]       | "FooTest"             | "aaa"      | false
+        ["*.FooTest.*"]          | "com.foo.FooTest"         | "aaa"                 | true
+        ["*.FooTest.*"]          | "com.bar.FooTest"         | "aaa"                 | true
+        ["*.FooTest.*"]          | "FooTest"                 | "aaa"                 | false
 
-        ["com*FooTest"]       | "com.foo.FooTest"     | "aaa"      | true
-        ["com*FooTest"]       | "com.FooTest"         | "bbb"      | true
-        ["com*FooTest"]       | "FooTest"             | "bbb"      | false
+        ["com*FooTest"]          | "com.foo.FooTest"         | "aaa"                 | true
+        ["com*FooTest"]          | "com.FooTest"             | "bbb"                 | true
+        ["com*FooTest"]          | "FooTest"                 | "bbb"                 | false
 
-        ["*.foo.*"]           | "com.foo.FooTest"     | "aaaa"     | true
-        ["*.foo.*"]           | "com.foo.bar.BarTest" | "aaaa"     | true
-        ["*.foo.*"]           | "foo.Test"            | "aaaa"     | false
-        ["*.foo.*"]           | "fooTest"             | "aaaa"     | false
-        ["*.foo.*"]           | "foo"                 | "aaaa"     | false
+        ["*.foo.*"]              | "com.foo.FooTest"         | "aaaa"                | true
+        ["*.foo.*"]              | "com.foo.bar.BarTest"     | "aaaa"                | true
+        ["*.foo.*"]              | "foo.Test"                | "aaaa"                | false
+        ["*.foo.*"]              | "fooTest"                 | "aaaa"                | false
+        ["*.foo.*"]              | "foo"                     | "aaaa"                | false
     }
 
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -22,35 +22,55 @@ class TestSelectionMatcherTest extends Specification {
 
     def "knows if test matches class"() {
         expect:
-        new TestSelectionMatcher(inlude, exclude).matchesTest(className, methodName) == match
+        new TestSelectionMatcher(input).matchesTest(className, methodName) == match
 
         where:
-        include               | exclude | className             | methodName | match
-        ["FooTest"]           | []      | "FooTest"             | "whatever" | true
-        ["FooTest"]           | []      | "fooTest"             | "whatever" | false
+        input                 | className             | methodName | match
+        ["FooTest"]           | "FooTest"             | "whatever" | true
+        ["FooTest"]           | "fooTest"             | "whatever" | false
 
-        ["com.foo.FooTest"]   | []      | "com.foo.FooTest"     | "x"        | true
-        ["com.foo.FooTest"]   | []      | "FooTest"             | "x"        | false
-        ["com.foo.FooTest"]   | []      | "com_foo_FooTest"     | "x"        | false
+        ["com.foo.FooTest"]   | "com.foo.FooTest"     | "x"        | true
+        ["com.foo.FooTest"]   | "FooTest"             | "x"        | false
+        ["com.foo.FooTest"]   | "com_foo_FooTest"     | "x"        | false
 
-        ["com.foo.FooTest.*"] | []      | "com.foo.FooTest"     | "aaa"      | true
-        ["com.foo.FooTest.*"] | []      | "com.foo.FooTest"     | "bbb"      | true
-        ["com.foo.FooTest.*"] | []      | "com.foo.FooTestx"    | "bbb"      | false
+        ["com.foo.FooTest.*"] | "com.foo.FooTest"     | "aaa"      | true
+        ["com.foo.FooTest.*"] | "com.foo.FooTest"     | "bbb"      | true
+        ["com.foo.FooTest.*"] | "com.foo.FooTestx"    | "bbb"      | false
 
-        ["*.FooTest.*"]       | []      | "com.foo.FooTest"     | "aaa"      | true
-        ["*.FooTest.*"]       | []      | "com.bar.FooTest"     | "aaa"      | true
-        ["*.FooTest.*"]       | []      | "FooTest"             | "aaa"      | false
+        ["*.FooTest.*"]       | "com.foo.FooTest"     | "aaa"      | true
+        ["*.FooTest.*"]       | "com.bar.FooTest"     | "aaa"      | true
+        ["*.FooTest.*"]       | "FooTest"             | "aaa"      | false
 
-        ["com*FooTest"]       | []      | "com.foo.FooTest"     | "aaa"      | true
-        ["com*FooTest"]       | []      | "com.FooTest"         | "bbb"      | true
-        ["com*FooTest"]       | []      | "FooTest"             | "bbb"      | false
+        ["com*FooTest"]       | "com.foo.FooTest"     | "aaa"      | true
+        ["com*FooTest"]       | "com.FooTest"         | "bbb"      | true
+        ["com*FooTest"]       | "FooTest"             | "bbb"      | false
 
-        ["*.foo.*"]           | []      | "com.foo.FooTest"     | "aaaa"     | true
-        ["*.foo.*"]           | []      | "com.foo.bar.BarTest" | "aaaa"     | true
-        ["*.foo.*"]           | []      | "foo.Test"            | "aaaa"     | false
-        ["*.foo.*"]           | []      | "fooTest"             | "aaaa"     | false
-        ["*.foo.*"]           | []      | "foo"                 | "aaaa"     | false
+        ["*.foo.*"]           | "com.foo.FooTest"     | "aaaa"     | true
+        ["*.foo.*"]           | "com.foo.bar.BarTest" | "aaaa"     | true
+        ["*.foo.*"]           | "foo.Test"            | "aaaa"     | false
+        ["*.foo.*"]           | "fooTest"             | "aaaa"     | false
+        ["*.foo.*"]           | "foo"                 | "aaaa"     | false
     }
+
+
+    def "knows if test matches class with excludes"() {
+        expect:
+        new TestSelectionMatcher(include, exclude).matchesTest(className, methodName) == match
+
+        where:
+        include             | exclude       | className             | methodName | match
+        []                  | ["*.FooTest"] | "com.foo.FooTest"     | "whatever" | false
+        []                  | ["*.BarTest"] | "com.foo.FooTest"     | "whatever" | true
+
+        []                  | ["BarTest"]   | "com.foo.FooTest"     | "whatever" | true
+        ["*.foo.*"]         | ["FooTest"]   | "com.foo.bar.BarTest" | "whatever" | true
+        ["*.foo.*"]         | ["*.bar.*"]   | "com.foo.bar.BarTest" | "whatever" | false
+
+        ["com.foo.FooTest"] | ["*.foo.*"]   | "com.foo.FooTest"     | "whatever" | false
+        ["*.FooTest"]       | ["*.foo.*"]   | "com.foo.FooTest"     | "whatever" | false
+        ["*.FooTest"]       | ["*.bar.*"]   | "com.foo.FooTest"     | "whatever" | true
+    }
+
 
     def "knows if test matches"() {
         expect: new TestSelectionMatcher(input).matchesTest(className, methodName) == match
@@ -76,6 +96,20 @@ class TestSelectionMatcherTest extends Specification {
         ["com.FooTest***slow*"]  | "com.FooTest.OtherTest"   | "slow"                | true
         ["com.FooTest***slow*"]  | "FooTest"                 | "slowMethod"          | false
     }
+
+    def "knows if test matches with excludes"() {
+        expect:
+        new TestSelectionMatcher(include, exclude).matchesTest(className, methodName) == match
+
+        where:
+        include                 | exclude            | className     | methodName | match
+        ["FooTest.test"]        | ["*.excludedTest"] | "FooTest"     | "test"     | true
+        ["FooTest.test"]        | ["*.tes*"]         | "FooTest"     | "test"     | false
+
+        ["com.FooTest.*clude*"] | ["*.*clude*"]      | "com.FooTest" | "exclude"  | false
+
+    }
+
 
     def "matches any of input"() {
         expect: new TestSelectionMatcher(input).matchesTest(className, methodName) == match

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -54,7 +54,7 @@ class TestSelectionMatcherTest extends Specification {
 
     def "knows if test matches class with excludes"() {
         expect:
-        new TestSelectionMatcher(include, exclude).matchesTest(className, methodName) == match
+        new TestSelectionMatcher(include, exclude).shouldRun(className, methodName) == match
 
         where:
         include             | exclude       | className             | methodName | match
@@ -98,7 +98,7 @@ class TestSelectionMatcherTest extends Specification {
 
     def "knows if test matches with excludes"() {
         expect:
-        new TestSelectionMatcher(include, exclude).matchesTest(className, methodName) == match
+        new TestSelectionMatcher(include, exclude).shouldRun(className, methodName) == match
 
         where:
         include                 | exclude            | className     | methodName | match

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -21,34 +21,35 @@ import spock.lang.Specification
 class TestSelectionMatcherTest extends Specification {
 
     def "knows if test matches class"() {
-        expect: new TestSelectionMatcher(input).matchesTest(className, methodName) == match
+        expect:
+        new TestSelectionMatcher(inlude, exclude).matchesTest(className, methodName) == match
 
         where:
-        input                    | className                 | methodName            | match
-        ["FooTest"]              | "FooTest"                 | "whatever"            | true
-        ["FooTest"]              | "fooTest"                 | "whatever"            | false
+        include               | exclude | className             | methodName | match
+        ["FooTest"]           | []      | "FooTest"             | "whatever" | true
+        ["FooTest"]           | []      | "fooTest"             | "whatever" | false
 
-        ["com.foo.FooTest"]      | "com.foo.FooTest"         | "x"                   | true
-        ["com.foo.FooTest"]      | "FooTest"                 | "x"                   | false
-        ["com.foo.FooTest"]      | "com_foo_FooTest"         | "x"                   | false
+        ["com.foo.FooTest"]   | []      | "com.foo.FooTest"     | "x"        | true
+        ["com.foo.FooTest"]   | []      | "FooTest"             | "x"        | false
+        ["com.foo.FooTest"]   | []      | "com_foo_FooTest"     | "x"        | false
 
-        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "aaa"                 | true
-        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "bbb"                 | true
-        ["com.foo.FooTest.*"]    | "com.foo.FooTestx"        | "bbb"                 | false
+        ["com.foo.FooTest.*"] | []      | "com.foo.FooTest"     | "aaa"      | true
+        ["com.foo.FooTest.*"] | []      | "com.foo.FooTest"     | "bbb"      | true
+        ["com.foo.FooTest.*"] | []      | "com.foo.FooTestx"    | "bbb"      | false
 
-        ["*.FooTest.*"]          | "com.foo.FooTest"         | "aaa"                 | true
-        ["*.FooTest.*"]          | "com.bar.FooTest"         | "aaa"                 | true
-        ["*.FooTest.*"]          | "FooTest"                 | "aaa"                 | false
+        ["*.FooTest.*"]       | []      | "com.foo.FooTest"     | "aaa"      | true
+        ["*.FooTest.*"]       | []      | "com.bar.FooTest"     | "aaa"      | true
+        ["*.FooTest.*"]       | []      | "FooTest"             | "aaa"      | false
 
-        ["com*FooTest"]          | "com.foo.FooTest"         | "aaa"                 | true
-        ["com*FooTest"]          | "com.FooTest"             | "bbb"                 | true
-        ["com*FooTest"]          | "FooTest"                 | "bbb"                 | false
+        ["com*FooTest"]       | []      | "com.foo.FooTest"     | "aaa"      | true
+        ["com*FooTest"]       | []      | "com.FooTest"         | "bbb"      | true
+        ["com*FooTest"]       | []      | "FooTest"             | "bbb"      | false
 
-        ["*.foo.*"]              | "com.foo.FooTest"         | "aaaa"                | true
-        ["*.foo.*"]              | "com.foo.bar.BarTest"     | "aaaa"                | true
-        ["*.foo.*"]              | "foo.Test"                | "aaaa"                | false
-        ["*.foo.*"]              | "fooTest"                 | "aaaa"                | false
-        ["*.foo.*"]              | "foo"                     | "aaaa"                | false
+        ["*.foo.*"]           | []      | "com.foo.FooTest"     | "aaaa"     | true
+        ["*.foo.*"]           | []      | "com.foo.bar.BarTest" | "aaaa"     | true
+        ["*.foo.*"]           | []      | "foo.Test"            | "aaaa"     | false
+        ["*.foo.*"]           | []      | "fooTest"             | "aaaa"     | false
+        ["*.foo.*"]           | []      | "foo"                 | "aaaa"     | false
     }
 
     def "knows if test matches"() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
@@ -187,4 +187,57 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         !result.skippedTasks.contains(":test")
         new DefaultTestExecutionResult(testDirectory).testClass("FooTest").assertTestsExecuted("pass", "pass2")
     }
+
+
+    def "apply excludes in appropriate way"() {
+        buildFile << """
+            test {
+              filter.setIncludePatterns 'Foo*.pass*'
+            }
+        """
+        file("src/test/java/Foo1Test.java") << """import $imports;
+            public class Foo1Test {
+                @Test public void pass1() {}
+                @Test public void bar() {}
+            }
+        """
+        file("src/test/java/Foo2Test.java") << """import $imports;
+            public class Foo2Test {
+                @Test public void pass2() {}
+                @Test public void bar() {}
+            }
+        """
+        file("src/test/java/BarTest.java") << """import $imports;
+            public class BarTest {
+                @Test public void bar() {}
+            }
+        """
+        file("src/test/java/OtherTest.java") << """import $imports;
+            public class OtherTest {
+                @Test public void pass3() {}
+                @Test public void bar() {}
+            }
+        """
+
+        when:
+        run(command)
+
+        then:
+
+        def result = new DefaultTestExecutionResult(testDirectory)
+        result.assertTestClassesExecuted(classesExecuted)
+        result.testClass("Foo1Test").assertTestsExecuted(foo1TestsExecuted)
+        result.testClass("Foo1Test").assertTestsExecuted(foo2TestsExecuted)
+        result.testClass("BarTest").assertTestsExecuted(barTestsExecuted)
+        result.testClass("OtherTest").assertTestsExecuted(otherTestsExecuted)
+
+        where:
+        command                                                           | classesExecuted                                  | foo1TestsExecuted | foo2TestsExecuted | barTestsExecuted | otherTestsExecuted
+        ["test"]                                                          | ["Foo1Test", "Foo2Test", "BarTest", "OtherTest"] | ["pass1", "bar"]  | ["pass2", "bar"]  | ["bar"]          | ["pass3", "bar"]
+        ["test", "--include-tests", "*.pass*"]                            | ["Foo1Test", "Foo2Test", "OtherTest"]            | ["pass1"]         | ["pass2"]         | []               | ["pass3"]
+        ["test", "--include-tests", "*.pass*", "--exclude-tests", "Foo*"] | ["OtherTest"]                                    | []                | []                | []               | ["pass3"]
+        ["test", "--exclude-tests", "Foo*"]                               | ["BarTest", "OtherTest"]                         | []                | []                | ["bar"]          | ["pass3", "bar"]
+
+    }
+
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
@@ -150,7 +150,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         """
 
         //by command line
-        when: fails("test", "--tests", 'FooTest.missingMethod')
+        when: fails("test", "--include-tests", 'FooTest.missingMethod')
         then: failure.assertHasCause("No tests found for given includes: [FooTest.missingMethod]")
 
         //by build script
@@ -181,7 +181,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         then: result.skippedTasks.contains(":test") //up-to-date
 
         when:
-        run("test", "--tests", "FooTest.pass*")
+        run("test", "--include-tests", "FooTest.pass*")
 
         then:
         !result.skippedTasks.contains(":test")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnit3FilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnit3FilteringIntegrationTest.groovy
@@ -41,7 +41,7 @@ public class JUnit3FilteringIntegrationTest extends MultiVersionIntegrationSpec 
         """
 
         when:
-        succeeds("test", "--tests", "FooTest.testPass")
+        succeeds("test", "--include-tests", "FooTest.testPass")
 
         then:
         def result = new DefaultTestExecutionResult(testDirectory)
@@ -49,7 +49,7 @@ public class JUnit3FilteringIntegrationTest extends MultiVersionIntegrationSpec 
         result.testClass("FooTest").assertTestsExecuted("testPass")
 
         when:
-        fails("test", "--tests", "FooTest.unknown")
+        fails("test", "--include-tests", "FooTest.unknown")
 
         then:
         failure.assertHasCause("No tests found for given includes: [FooTest.unknown]")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassLevelFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassLevelFilteringIntegrationTest.groovy
@@ -66,7 +66,7 @@ public class JUnitClassLevelFilteringIntegrationTest extends MultiVersionIntegra
         """
 
         when:
-        run("test", "--tests", "FooTest.pass")
+        run("test", "--include-tests", "FooTest.pass")
 
         then:
         def result = new DefaultTestExecutionResult(testDirectory)
@@ -74,13 +74,13 @@ public class JUnitClassLevelFilteringIntegrationTest extends MultiVersionIntegra
         result.testClass("FooTest").assertTestsExecuted("other", "pass")
 
         when:
-        fails("test", "--tests", "FooTest.ignored")
+        fails("test", "--include-tests", "FooTest.ignored")
 
         then:
         failure.assertHasCause("No tests found for given includes: [FooTest.ignored]")
 
         when:
-        fails("test", "--tests", "NotFooTest.pass")
+        fails("test", "--include-tests", "NotFooTest.pass")
 
         then:
         failure.assertHasCause("No tests found for given includes: [NotFooTest.pass]")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitFilteringIntegrationTest.groovy
@@ -124,7 +124,7 @@ public class JUnitFilteringIntegrationTest extends AbstractTestFilteringIntegrat
         theParameterizedFiles()
 
         when:
-        run("test", "--tests", "*ParameterizedFoo.pass*")
+        run("test", "--include-tests", "*ParameterizedFoo.pass*")
 
         then:
         def result = new DefaultTestExecutionResult(testDirectory)
@@ -133,12 +133,12 @@ public class JUnitFilteringIntegrationTest extends AbstractTestFilteringIntegrat
     }
 
     @Issue("GRADLE-3112")
-    def "passing a suite argument to --tests runs all tests in the suite"() {
+    def "passing a suite argument to --include-tests runs all tests in the suite"() {
         given:
         theSuiteFiles()
 
         when:
-        run("test", "--tests", "*AllFooTests")
+        run("test", "--include-tests", "*AllFooTests")
 
         then:
         def result = new DefaultTestExecutionResult(testDirectory)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
@@ -79,7 +79,7 @@ public class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegra
         theUsualFiles()
 
         when:
-        run("test", "--tests", "*AwesomeSuite*")
+        run("test", "--include-tests", "*AwesomeSuite*")
 
         then:
         def result = new DefaultTestExecutionResult(testDirectory)

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
@@ -22,11 +22,13 @@ public class JUnitSpec implements Serializable {
     private final Set<String> includeCategories;
     private final Set<String> excludeCategories;
     private final Set<String> includedTests;
+    private final Set<String> excludedTests;
 
-    public JUnitSpec(Set<String> includeCategories, Set<String> excludeCategories, Set<String> includedTests) {
+    public JUnitSpec(Set<String> includeCategories, Set<String> excludeCategories, Set<String> includedTests, Set<String> excludedTests) {
         this.includeCategories = includeCategories;
         this.excludeCategories = excludeCategories;
         this.includedTests = includedTests;
+        this.excludedTests = excludedTests;
     }
 
     public Set<String> getIncludeCategories() {
@@ -43,5 +45,9 @@ public class JUnitSpec implements Serializable {
 
     public Set<String> getIncludedTests() {
         return includedTests;
+    }
+
+    public Set<String> getExcludedTests() {
+        return excludedTests;
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
@@ -43,6 +43,10 @@ public class JUnitSpec implements Serializable {
         return !(excludeCategories.isEmpty() && includeCategories.isEmpty());
     }
 
+    public boolean hasTestConfiguration() {
+        return !(excludedTests.isEmpty() && includedTests.isEmpty());
+    }
+
     public Set<String> getIncludedTests() {
         return includedTests;
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks.testing.junit;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Set;
 
 public class JUnitSpec implements Serializable {
@@ -23,6 +24,10 @@ public class JUnitSpec implements Serializable {
     private final Set<String> excludeCategories;
     private final Set<String> includedTests;
     private final Set<String> excludedTests;
+
+    public JUnitSpec(Set<String> includeCategories, Set<String> excludeCategories, Set<String> includedTests) {
+        this(includeCategories, excludeCategories, includedTests, Collections.<String>emptySet());
+    }
 
     public JUnitSpec(Set<String> includeCategories, Set<String> excludeCategories, Set<String> includedTests, Set<String> excludedTests) {
         this.includeCategories = includeCategories;

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
@@ -69,7 +69,7 @@ class JUnitTestFilter {
             // For test suites (including suite-like custom Runners), if the test suite class
             // matches the filter, run the entire suite instead of filtering away its contents.
             if (!isSuite || !matcher.matchesTest(testClassName, null)) {
-                includeExcludeFilters.add(new MethodNameIncludeFilter(matcher));
+                includeExcludeFilters.add(new MethodNameFilter(matcher));
             }
         }
 
@@ -78,18 +78,18 @@ class JUnitTestFilter {
     }
 
 
-    private static class MethodNameIncludeFilter extends org.junit.runner.manipulation.Filter {
+    private static class MethodNameFilter extends org.junit.runner.manipulation.Filter {
 
         private final TestSelectionMatcher matcher;
         private static final String FILTER_DESCRIPTION = "Includes matching test methods";
 
-        public MethodNameIncludeFilter(TestSelectionMatcher matcher) {
+        public MethodNameFilter(TestSelectionMatcher matcher) {
             this.matcher = matcher;
         }
 
-
-        protected boolean matchCheck(Description description) {
-            if (matcher.matchesTest(JUnitTestEventAdapter.className(description), JUnitTestEventAdapter.methodName(description))) {
+        @Override
+        public boolean shouldRun(Description description) {
+            if (matcher.shouldRun(JUnitTestEventAdapter.className(description), JUnitTestEventAdapter.methodName(description))) {
                 return true;
             }
 
@@ -100,11 +100,6 @@ class JUnitTestFilter {
             }
 
             return false;
-        }
-
-        @Override
-        public boolean shouldRun(Description description) {
-            return matchCheck(description);
         }
 
         public String describe(){

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
@@ -89,19 +89,6 @@ class JUnitTestFilter {
         }
     }
 
-
-    private static class MethodNameExcludeFilter extends MethodNameFilter {
-
-        public MethodNameExcludeFilter(TestSelectionMatcher matcher) {
-            super(matcher, "Excludes matching test methods");
-        }
-
-        @Override
-        public boolean shouldRun(Description description) {
-            return !matchCheck(description);
-        }
-    }
-
     private static abstract class MethodNameFilter extends org.junit.runner.manipulation.Filter {
 
         private final TestSelectionMatcher matcher;

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
@@ -63,22 +63,13 @@ class JUnitTestFilter {
 
         List<Filter> includeExcludeFilters = Lists.newArrayList();
 
-        if (!options.getIncludedTests().isEmpty()) {
-            TestSelectionMatcher matcher = new TestSelectionMatcher(options.getIncludedTests());
+        if (options.hasTestConfiguration()) {
+            TestSelectionMatcher matcher = new TestSelectionMatcher(options.getIncludedTests(), options.getExcludedTests());
 
             // For test suites (including suite-like custom Runners), if the test suite class
             // matches the filter, run the entire suite instead of filtering away its contents.
             if (!isSuite || !matcher.matchesTest(testClassName, null)) {
                 includeExcludeFilters.add(new MethodNameIncludeFilter(matcher));
-            }
-        }
-
-
-        if (!options.getExcludedTests().isEmpty()) {
-            TestSelectionMatcher matcher = new TestSelectionMatcher(options.getExcludedTests());
-
-            if (!isSuite || !matcher.matchesTest(testClassName, null)) {
-                includeExcludeFilters.add(new MethodNameExcludeFilter(matcher));
             }
         }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.junit;
+
+import com.beust.jcommander.internal.Lists;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Transformer;
+import org.gradle.api.internal.tasks.testing.filter.TestSelectionMatcher;
+import org.gradle.util.CollectionUtils;
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+
+import java.util.List;
+
+class JUnitTestFilter {
+    private final JUnitSpec options;
+    private final ClassLoader applicationClassLoader;
+
+    public JUnitTestFilter(JUnitSpec options, ClassLoader applicationClassLoader) {
+        this.options = options;
+        this.applicationClassLoader = applicationClassLoader;
+    }
+
+    List<Filter> getCategoryFilters(){
+
+        List<Filter> categoryFilters = Lists.newArrayList();
+
+        if (options.hasCategoryConfiguration()) {
+            Transformer<Class<?>, String> transformer = new Transformer<Class<?>, String>() {
+                public Class<?> transform(final String original) {
+                    try {
+                        return applicationClassLoader.loadClass(original);
+                    } catch (ClassNotFoundException e) {
+                        throw new InvalidUserDataException(String.format("Can't load category class [%s].", original), e);
+                    }
+                }
+            };
+            categoryFilters.add(new CategoryFilter(
+                CollectionUtils.collect(options.getIncludeCategories(), transformer),
+                CollectionUtils.collect(options.getExcludeCategories(), transformer)
+            ));
+        }
+
+        return categoryFilters;
+    }
+
+
+    List<Filter> getTestFilters(String testClassName, boolean isSuite){
+
+        List<Filter> includeExcludeFilters = Lists.newArrayList();
+
+        if (!options.getIncludedTests().isEmpty()) {
+            TestSelectionMatcher matcher = new TestSelectionMatcher(options.getIncludedTests());
+
+            // For test suites (including suite-like custom Runners), if the test suite class
+            // matches the filter, run the entire suite instead of filtering away its contents.
+            if (!isSuite || !matcher.matchesTest(testClassName, null)) {
+                includeExcludeFilters.add(new MethodNameIncludeFilter(matcher));
+            }
+        }
+
+
+        if (!options.getExcludedTests().isEmpty()) {
+            TestSelectionMatcher matcher = new TestSelectionMatcher(options.getExcludedTests());
+
+            if (!isSuite || !matcher.matchesTest(testClassName, null)) {
+                includeExcludeFilters.add(new MethodNameExcludeFilter(matcher));
+            }
+        }
+
+        return includeExcludeFilters;
+
+    }
+
+    private static class MethodNameIncludeFilter extends MethodNameFilter {
+
+        public MethodNameIncludeFilter(TestSelectionMatcher matcher) {
+            super(matcher, "Includes matching test methods");
+        }
+
+        @Override
+        public boolean shouldRun(Description description) {
+            return matchCheck(description);
+        }
+    }
+
+
+    private static class MethodNameExcludeFilter extends MethodNameFilter {
+
+        public MethodNameExcludeFilter(TestSelectionMatcher matcher) {
+            super(matcher, "Excludes matching test methods");
+        }
+
+        @Override
+        public boolean shouldRun(Description description) {
+            return !matchCheck(description);
+        }
+    }
+
+    private static abstract class MethodNameFilter extends org.junit.runner.manipulation.Filter {
+
+        private final TestSelectionMatcher matcher;
+        private final String filterDescription;
+
+        public MethodNameFilter(TestSelectionMatcher matcher, String filterDescription) {
+            this.matcher = matcher;
+            this.filterDescription = filterDescription;
+        }
+
+
+        protected boolean matchCheck(Description description) {
+            if (matcher.matchesTest(JUnitTestEventAdapter.className(description), JUnitTestEventAdapter.methodName(description))) {
+                return true;
+            }
+
+            for (Description child : description.getChildren()) {
+                if (shouldRun(child)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public String describe(){
+            return filterDescription;
+        }
+    }
+
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFilter.java
@@ -77,26 +77,14 @@ class JUnitTestFilter {
 
     }
 
-    private static class MethodNameIncludeFilter extends MethodNameFilter {
 
-        public MethodNameIncludeFilter(TestSelectionMatcher matcher) {
-            super(matcher, "Includes matching test methods");
-        }
-
-        @Override
-        public boolean shouldRun(Description description) {
-            return matchCheck(description);
-        }
-    }
-
-    private static abstract class MethodNameFilter extends org.junit.runner.manipulation.Filter {
+    private static class MethodNameIncludeFilter extends org.junit.runner.manipulation.Filter {
 
         private final TestSelectionMatcher matcher;
-        private final String filterDescription;
+        private static final String FILTER_DESCRIPTION = "Includes matching test methods";
 
-        public MethodNameFilter(TestSelectionMatcher matcher, String filterDescription) {
+        public MethodNameIncludeFilter(TestSelectionMatcher matcher) {
             this.matcher = matcher;
-            this.filterDescription = filterDescription;
         }
 
 
@@ -114,8 +102,13 @@ class JUnitTestFilter {
             return false;
         }
 
+        @Override
+        public boolean shouldRun(Description description) {
+            return matchCheck(description);
+        }
+
         public String describe(){
-            return filterDescription;
+            return FILTER_DESCRIPTION;
         }
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -50,7 +50,7 @@ public class JUnitTestFramework implements TestFramework {
 
     public WorkerTestClassProcessorFactory getProcessorFactory() {
         verifyJUnitCategorySupport();
-        return new TestClassProcessorFactoryImpl(new JUnitSpec(options.getIncludeCategories(), options.getExcludeCategories(), filter.getIncludePatterns()));
+        return new TestClassProcessorFactoryImpl(new JUnitSpec(options.getIncludeCategories(), options.getExcludeCategories(), filter.getIncludePatterns(), filter.getExcludePatterns()));
     }
 
     private void verifyJUnitCategorySupport() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -745,10 +745,17 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
      *
      * For more information on supported patterns see {@link TestFilter}
      */
-    @Option(option = "tests", description = "Sets test class or method name to be included, '*' is supported.")
+    @Option(option = "tests-include", description = "Sets test class or method name to be included, '*' is supported.")
     @Incubating
     public Test setTestNameIncludePattern(String testNamePattern) {
         filter.setIncludePatterns(testNamePattern);
+        return this;
+    }
+
+    @Option(option = "tests-exclude", description = "Sets test class or method name to be excluded, '*' is supported.")
+    @Incubating
+    public Test setTestNameExcludePattern(String testNamePattern) {
+        filter.setExcludePatterns(testNamePattern);
         return this;
     }
 

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
@@ -34,7 +34,7 @@ class JUnitTestClassProcessorTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
 
     def processor = Mock(TestResultProcessor)
-    def spec = new JUnitSpec([] as Set, [] as Set, [] as Set)
+    def spec = new JUnitSpec([] as Set, [] as Set, [] as Set, [] as Set)
 
     @Subject classProcessor = withSpec(spec)
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r112/TestFilteringCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r112/TestFilteringCrossVersionSpec.groovy
@@ -38,7 +38,7 @@ class TestFilteringCrossVersionSpec extends ToolingApiSpecification {
         """
 
         when:
-        withConnection { it.newBuild().withArguments('test', '--tests', 'FooTest.passes').run() }
+        withConnection { it.newBuild().withArguments('test', '--include-tests', 'FooTest.passes').run() }
 
         then:
         noExceptionThrown()


### PR DESCRIPTION
Changes in this PR add ability to use `--exclude-tests` for filtering tests. For example:
```
./gradlew test --include-tests com.bar.* --exclude-tests *.Foo*
```

Discussion in Google Groups: [https://groups.google.com/forum/#!topic/gradle-dev/bUp_8dLCXrA](https://groups.google.com/forum/#!topic/gradle-dev/bUp_8dLCXrA)

Changes in this PR:
* `--exclude-tests` command line option added;
* `--tests` marked as deprecated and `--include-tests` added as alias;
* new tests for `--exclude-tests` functionality added;
* existing tests and docs updated;
* refactored `JUnitTestClassExecuter.java`: internlas related to filtering moved to `JUnitTestFilter` (in separate commit. 