### PR TITLE
Ability to pass multiple values for one command line parameter

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/AbstractOptionElement.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/AbstractOptionElement.java
@@ -79,9 +79,9 @@ abstract class AbstractOptionElement implements OptionElement {
         return notationParser;
     }
 
-    protected static <T> NotationParser<CharSequence, T> createNotationParserOrFail(OptionNotationParserFactory optionNotationParserFactory, String optionName, Class<T> optionType, Class<?> declaringClass) {
+    protected static <T> NotationParser<CharSequence, T> createNotationParserOrFail(OptionValueNotationParserFactory optionValueNotationParserFactory, String optionName, Class<T> optionType, Class<?> declaringClass) {
         try {
-            return optionNotationParserFactory.toComposite(optionType);
+            return optionValueNotationParserFactory.toComposite(optionType);
         } catch (OptionValidationException ex) {
             throw new OptionValidationException(String.format("Option '%s' cannot be casted to type '%s' in class '%s'.",
                     optionName, optionType.getName(), declaringClass.getName()));

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/FieldOptionElement.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/FieldOptionElement.java
@@ -69,8 +69,8 @@ public class FieldOptionElement extends AbstractOptionElement {
     public void apply(Object object, List<String> parameterValues) {
         if (getOptionType() == Void.TYPE && parameterValues.size() == 0) {
             setFieldValue(object, true);
-        } else if (parameterValues.size() > 1) {
-            throw new IllegalArgumentException(String.format("Lists not supported for option"));
+        } else if (parameterValues.size() > 1  || List.class.equals(getOptionType())) {
+            setFieldValue(object, parameterValues);
         } else {
             Object arg = getNotationParser().parseNotation(parameterValues.get(0));
             setFieldValue(object, arg);

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/FieldOptionElement.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/FieldOptionElement.java
@@ -25,10 +25,10 @@ import java.util.List;
 
 public class FieldOptionElement extends AbstractOptionElement {
 
-    public static FieldOptionElement create(Option option, Field field, OptionNotationParserFactory optionNotationParserFactory){
+    public static FieldOptionElement create(Option option, Field field, OptionValueNotationParserFactory optionValueNotationParserFactory){
         String optionName = calOptionName(option, field);
         Class<?> optionType = calculateOptionType(field.getType());
-        NotationParser<CharSequence, ?> notationParser = createNotationParserOrFail(optionNotationParserFactory, optionName, optionType, field.getDeclaringClass());
+        NotationParser<CharSequence, ?> notationParser = createNotationParserOrFail(optionValueNotationParserFactory, optionName, optionType, field.getDeclaringClass());
         return new FieldOptionElement(field, optionName, option, optionType, notationParser);
     }
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/MethodOptionElement.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/MethodOptionElement.java
@@ -49,7 +49,7 @@ public class MethodOptionElement extends AbstractOptionElement {
     public void apply(Object object, List<String> parameterValues) {
         if (parameterValues.size() == 0) {
             invokeMethod(object, method, true);
-        } else if (parameterValues.size() > 1) {
+        } else if (parameterValues.size() > 1  || List.class.equals(getOptionType())) {
             invokeMethod(object, method, parameterValues);
         } else {
             invokeMethod(object, method, getNotationParser().parseNotation(parameterValues.get(0)));

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/MethodOptionElement.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/MethodOptionElement.java
@@ -50,15 +50,15 @@ public class MethodOptionElement extends AbstractOptionElement {
         if (parameterValues.size() == 0) {
             invokeMethod(object, method, true);
         } else if (parameterValues.size() > 1) {
-            throw new IllegalArgumentException(String.format("Lists not supported for option."));
+            invokeMethod(object, method, parameterValues);
         } else {
             invokeMethod(object, method, getNotationParser().parseNotation(parameterValues.get(0)));
         }
     }
 
-    public static MethodOptionElement create(Option option, Method method, OptionNotationParserFactory optionNotationParserFactory){
+    public static MethodOptionElement create(Option option, Method method, OptionValueNotationParserFactory optionValueNotationParserFactory){
         Class<?> optionType = calculateOptionType(method);
-        NotationParser<CharSequence, ?> notationParser = createNotationParserOrFail(optionNotationParserFactory, option.option(), optionType, method.getDeclaringClass());
+        NotationParser<CharSequence, ?> notationParser = createNotationParserOrFail(optionValueNotationParserFactory, option.option(), optionType, method.getDeclaringClass());
         return new MethodOptionElement(option, method, optionType, notationParser);
     }
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/OptionReader.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/OptionReader.java
@@ -30,7 +30,7 @@ import java.util.*;
 public class OptionReader {
     private final ListMultimap<Class<?>, OptionElement> cachedOptionElements = ArrayListMultimap.create();
     private final Map<OptionElement, JavaMethod<Object, Collection>> cachedOptionValueMethods = new HashMap<OptionElement, JavaMethod<Object, Collection>>();
-    private final OptionNotationParserFactory optionNotationParserFactory = new OptionNotationParserFactory();
+    private final OptionValueNotationParserFactory optionValueNotationParserFactory = new OptionValueNotationParserFactory();
 
     public List<OptionDescriptor> getOptions(Object target) {
         final Class<?> targetClass = target.getClass();
@@ -100,7 +100,7 @@ public class OptionReader {
                             field.getName(), field.getDeclaringClass().getName()));
                 }
 
-                fieldOptionElements.add(FieldOptionElement.create(option, field, optionNotationParserFactory));
+                fieldOptionElements.add(FieldOptionElement.create(option, field, optionValueNotationParserFactory));
             }
         }
         return fieldOptionElements;
@@ -115,7 +115,8 @@ public class OptionReader {
                     throw new OptionValidationException(String.format("@Option on static method '%s' not supported in class '%s'.",
                             method.getName(), method.getDeclaringClass().getName()));
                 }
-                final OptionElement methodOptionDescriptor = MethodOptionElement.create(option, method, optionNotationParserFactory);
+                final OptionElement methodOptionDescriptor = MethodOptionElement.create(option, method,
+                    optionValueNotationParserFactory);
                 methodOptionElements.add(methodOptionDescriptor);
             }
         }

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/OptionValueNotationParserFactory.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/tasks/options/OptionValueNotationParserFactory.java
@@ -23,17 +23,14 @@ import org.gradle.internal.typeconversion.NotationConverter;
 import org.gradle.internal.typeconversion.NotationConverterToNotationParserAdapter;
 import org.gradle.internal.typeconversion.NotationParser;
 
-public class OptionNotationParserFactory {
+public class OptionValueNotationParserFactory {
     public <T> NotationParser<CharSequence, T> toComposite(Class<T> targetType) throws OptionValidationException {
         assert targetType != null : "resultingType cannot be null";
         if (targetType == Void.TYPE) {
             return new UnsupportedNotationParser<T>();
-        }
-
-        if (targetType.isAssignableFrom(String.class)) {
+        } else if (targetType.isAssignableFrom(String.class) || targetType == java.util.List.class) {
             return Cast.uncheckedCast(new NoDescriptionValuesJustReturningParser());
-        }
-        if (targetType.isEnum()) {
+        } else if (targetType.isEnum()) {
             NotationConverter<CharSequence, T> converter = Cast.uncheckedCast(new EnumFromCharSequenceNotationParser<Enum>(targetType.asSubclass(Enum.class)));
             return new NotationConverterToNotationParserAdapter<CharSequence, T>(converter);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/options/OptionValueNotationParserFactorySpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/options/OptionValueNotationParserFactorySpec.groovy
@@ -19,11 +19,11 @@ package org.gradle.api.internal.tasks.options
 import org.gradle.api.GradleException
 import spock.lang.Specification
 
-class OptionNotationParserFactorySpec extends Specification {
+class OptionValueNotationParserFactorySpec extends Specification {
 
     def "creates notationparser for handling strings"(){
         given:
-        OptionNotationParserFactory factory = new OptionNotationParserFactory()
+        OptionValueNotationParserFactory factory = new OptionValueNotationParserFactory()
         when:
         def parser = factory.toComposite(String.class);
         then:
@@ -32,7 +32,7 @@ class OptionNotationParserFactorySpec extends Specification {
 
     def "creates notationparser for handling handles enums"(){
         given:
-        OptionNotationParserFactory factory = new OptionNotationParserFactory()
+        OptionValueNotationParserFactory factory = new OptionValueNotationParserFactory()
         when:
         def parser = factory.toComposite(TestEnum.class);
         then:
@@ -41,7 +41,7 @@ class OptionNotationParserFactorySpec extends Specification {
 
     def "fails on creating parser for unsupported"(){
         setup:
-        OptionNotationParserFactory factory = new OptionNotationParserFactory()
+        OptionValueNotationParserFactory factory = new OptionValueNotationParserFactory()
         when:
         factory.toComposite(File.class);
         then:

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -747,8 +747,8 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
      */
     @Option(option = "tests", description = "Sets test class or method name to be included, '*' is supported.")
     @Incubating
-    public Test setTestNameIncludePattern(String testNamePattern) {
-        filter.setIncludePatterns(testNamePattern);
+    public Test setTestNameIncludePattern(List<String> testNamePattern) {
+        filter.setIncludePatterns(testNamePattern.toArray(new String[]{}));
         return this;
     }
 


### PR DESCRIPTION
Changes in this PR:
* allow passing multiple values to task's parameter `task --param foo --param bar` (`@Option`);

Syntax:
```java
@Option(option = "param")
public Test paramSetter(List<String> params) {
```


* Command line parameter `--tests` of `Test` task can accept multiple values: 

`gradle test --tests "Foo" --tests "*.bar.*"`

Discussion in Google Groups: [https://groups.google.com/forum/#!topic/gradle-dev/sYZ6p_e-LRs](https://groups.google.com/forum/#!topic/gradle-dev/sYZ6p_e-LRs)
