### PR TITLE
Delete will no longer follow symlinks and delete the contents of link

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeleteIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeleteIntegrationTest.groovy
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationTest
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.testfixtures.internal.NativeServicesTestFixture
+import org.gradle.util.PreconditionVerifier
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class DeleteIntegrationTest extends AbstractIntegrationTest {
+    @Rule public PreconditionVerifier verifier = new PreconditionVerifier()
+
+    @Before
+    public void setup() {
+        NativeServicesTestFixture.initialize();
+    }
+
+    @Test
+    @Requires(TestPrecondition.SYMLINKS)
+    public void willNotFollowSymlinks() {
+        TestFile orig = testDirectory.createDir('test/orig')
+        TestFile keep = orig.createFile('keep')
+
+        TestFile subject = testDirectory.createDir('test/subject')
+        TestFile remove = subject.createFile("remove")
+        TestFile link = subject.file('link')
+        link.createLink(orig)
+
+        Assert.assertTrue(orig.isDirectory())
+        Assert.assertTrue(orig.exists())
+        Assert.assertTrue(subject.isDirectory())
+        Assert.assertTrue(subject.exists())
+        Assert.assertTrue(keep.exists())
+        Assert.assertTrue(remove.exists())
+        Assert.assertTrue(link.exists())
+
+        testFile('build.gradle') << '''
+            task delete(type: Delete) {
+                delete 'test/subject'
+                followSymlinks = false
+            }
+'''
+
+        inTestDirectory().withTasks('delete').run()
+        Assert.assertTrue(orig.isDirectory())
+        Assert.assertTrue(orig.exists())
+        Assert.assertFalse(subject.isDirectory())
+        Assert.assertFalse(subject.exists())
+        Assert.assertTrue(keep.exists())
+        Assert.assertFalse(remove.exists())
+        Assert.assertFalse(link.exists())
+    }
+
+    @Test
+    @Requires(TestPrecondition.SYMLINKS)
+    public void willFollowSymlinks() {
+        TestFile orig = testDirectory.createDir('test/orig')
+        TestFile keep = orig.createFile('keep')
+
+        TestFile subject = testDirectory.createDir('test/subject')
+        TestFile remove = subject.createFile("remove")
+        TestFile link = subject.file('link')
+        link.createLink(orig)
+
+        Assert.assertTrue(orig.isDirectory())
+        Assert.assertTrue(orig.exists())
+        Assert.assertTrue(subject.isDirectory())
+        Assert.assertTrue(subject.exists())
+        Assert.assertTrue(keep.exists())
+        Assert.assertTrue(remove.exists())
+        Assert.assertTrue(link.exists())
+
+        testFile('build.gradle') << '''
+            task delete(type: Delete) {
+                delete 'test/subject'
+                followSymlinks = true
+            }
+'''
+
+        inTestDirectory().withTasks('delete').run()
+        Assert.assertTrue(orig.exists())
+        Assert.assertFalse(subject.exists())
+        Assert.assertFalse(keep.exists())
+        Assert.assertFalse(remove.exists())
+        Assert.assertFalse(link.exists())
+    }
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/Project.java
@@ -838,6 +838,8 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     /**
      * Deletes files and directories.
      *
+     * This will not follow symlinks unlike ant. If you need to follow symlinks too use {@link #ant(Closure)}.delete()
+     *
      * @param paths Any type of object accepted by {@link org.gradle.api.Project#files(Object...)}
      * @return true if anything got deleted, false otherwise
      */

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.FileTreeAdapter;
 import org.gradle.api.internal.file.copy.DefaultCopySpec;
 import org.gradle.api.internal.file.copy.DeleteActionImpl;
+import org.gradle.api.internal.file.copy.DeleteActionInternal;
 import org.gradle.api.internal.file.copy.FileCopier;
 import org.gradle.api.internal.resources.DefaultResourceHandler;
 import org.gradle.api.internal.tasks.TaskResolver;
@@ -54,7 +55,7 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
     private final TaskResolver taskResolver;
     private final TemporaryFileProvider temporaryFileProvider;
     private final Instantiator instantiator;
-    private final DeleteAction deleteAction;
+    private final DeleteActionInternal deleteAction;
     private final DefaultResourceHandler resourceHandler;
     private final FileCopier fileCopier;
     private final FileSystem fileSystem;
@@ -66,10 +67,10 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
         this.temporaryFileProvider = temporaryFileProvider;
         this.instantiator = instantiator;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
-        this.deleteAction = new DeleteActionImpl(fileResolver);
         this.resourceHandler = new DefaultResourceHandler(this, temporaryFileProvider);
-        fileCopier = new FileCopier(this.instantiator, this.fileResolver, fileLookup);
-        fileSystem = fileLookup.getFileSystem();
+        this.fileCopier = new FileCopier(this.instantiator, this.fileResolver, fileLookup);
+        this.fileSystem = fileLookup.getFileSystem();
+        this.deleteAction = new DeleteActionImpl(fileResolver, fileSystem);
     }
 
     public File file(Object path) {

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/DeleteActionInternal.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/copy/DeleteActionInternal.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.copy;
+
+import org.gradle.api.file.DeleteAction;
+
+public interface DeleteActionInternal extends DeleteAction {
+
+    /**
+     * Deletes files and directories. This method is named so to prevent a JDK bug where it can collide
+     * with {@link DeleteAction#delete(java.lang.Object...)}
+     *
+     * @param followSymlinks If true symlinks will be followed and the source will also be deleted.
+     * @param paths Any type of object accepted by {@link org.gradle.api.Project#files(Object...)}
+     * @return true if anything got deleted, false otherwise
+     */
+    boolean doDelete(boolean followSymlinks, Object... paths);
+}

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/Delete.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/Delete.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.file.FileResolver;
@@ -31,12 +32,15 @@ import java.util.Set;
  * <pre autoTested=''>
  * task makePretty(type: Delete) {
  *   delete 'uglyFolder', 'uglyFile'
+ *   followSymlinks = true
  * }
  * </pre>
  */
 public class Delete extends ConventionTask {
     private Set<Object> delete = new LinkedHashSet<Object>();
-    private boolean followSymlinks = false;
+
+    @Incubating
+    private boolean followSymlinks;
 
     @Inject
     public FileSystem getFileSystem() {

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/Delete.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/Delete.java
@@ -42,7 +42,6 @@ import java.util.Set;
 public class Delete extends ConventionTask {
     private Set<Object> delete = new LinkedHashSet<Object>();
 
-    @Incubating
     private boolean followSymlinks;
 
     @Inject
@@ -96,6 +95,7 @@ public class Delete extends ConventionTask {
      *
      * @return true if symlinks will be followed.
      */
+    @Incubating
     public boolean isFollowSymlinks() {
         return followSymlinks;
     }
@@ -105,6 +105,7 @@ public class Delete extends ConventionTask {
      *
      * @param followSymlinks if symlinks should be followed.
      */
+    @Incubating
     public void setFollowSymlinks(boolean followSymlinks) {
         this.followSymlinks = followSymlinks;
     }

--- a/subprojects/core/src/main/groovy/org/gradle/api/tasks/Delete.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/tasks/Delete.java
@@ -35,6 +35,9 @@ import java.util.Set;
  *   followSymlinks = true
  * }
  * </pre>
+ *
+ * Be default symlinks will not be followed when deleting files. To change this behavior set {@link Delete#followSymlinks} to true.
+ * On systems that do not support symlinks, this will have no effect.
  */
 public class Delete extends ConventionTask {
     private Set<Object> delete = new LinkedHashSet<Object>();

--- a/subprojects/core/src/main/groovy/org/gradle/internal/resource/local/PathKeyFileStore.java
+++ b/subprojects/core/src/main/groovy/org/gradle/internal/resource/local/PathKeyFileStore.java
@@ -57,10 +57,12 @@ public class PathKeyFileStore implements FileStore<String>, FileStoreSearcher<St
     public static final String IN_PROGRESS_MARKER_FILE_SUFFIX = ".fslck";
 
     private File baseDir;
-    private final DeleteAction deleteAction = new DeleteActionImpl(new IdentityFileResolver());
+    private final DeleteAction deleteAction;
 
     public PathKeyFileStore(File baseDir) {
         this.baseDir = baseDir;
+        IdentityFileResolver fileResolver = new IdentityFileResolver();
+        deleteAction = new DeleteActionImpl(fileResolver, fileResolver.getFileSystem());
     }
 
     protected File getBaseDir() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/DeleteTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/DeleteTest.java
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks;
 
 import org.gradle.api.internal.ConventionTask;
-import org.gradle.api.internal.file.TestFiles;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.util.Requires;
 import org.gradle.util.TestPrecondition;

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.Delete.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.Delete.xml
@@ -9,6 +9,7 @@
             </thead>
             <tr><td>delete</td></tr>
             <tr><td>targetFiles</td></tr>
+            <tr><td>followSymlinks</td></tr>
         </table>
     </section>
     <section>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -50,9 +50,12 @@ The following are the newly deprecated items in this Gradle release. If you have
 <!--
 ### Example breaking change
 -->
-The Delete task will no longer follow symlinks by default and project.delete() will not follow symlinks at all. This is a breaking behavior change where in previous versions of Gradle symlinks
-would be followed. If you need the Delete task to follow symlinks set `followSymlinks = true`. If you need to project.delete() to follow symlinks, replace it with ant.delete(). This was done to
-prevent issues where Gradle would attempt to files outside of Gradle's build directory like NPM installed in a user-writeable location.
+
+### Deleting no longer follows symlinks.
+
+The Delete task will no longer follow symlinks by default and project.delete() will not follow symlinks at all. Previous versions of Gradle would follow-symlinks during deletions. If you need the Delete
+task to follow symlinks set `followSymlinks = true`. If you need `project.delete()` to follow symlinks, replace it with `ant.delete()`. This was done to prevent issues where Gradle would attempt to delete files
+outside of Gradle's build directory (e.g. NPM installed in a user-writeable location.).
 
 ## External contributions
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -50,6 +50,9 @@ The following are the newly deprecated items in this Gradle release. If you have
 <!--
 ### Example breaking change
 -->
+The Delete task will no longer follow symlinks by default and project.delete() will not follow symlinks at all. This is a breaking behavior change where in previous versions of Gradle symlinks
+would be followed. If you need the Delete task to follow symlinks set `followSymlinks = true`. If you need to project.delete() to follow symlinks, replace it with ant.delete(). This was done to
+prevent issues where Gradle would attempt to files outside of Gradle's build directory like NPM installed in a user-writeable location.
 
 ## External contributions
 

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/FileSystem.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/FileSystem.java
@@ -54,4 +54,12 @@ public interface FileSystem extends Chmod, Stat {
      * @exception FileException if the operation fails
      */
     void createSymbolicLink(File link, File target) throws FileException;
+
+    /**
+     * Tells if the file is a symlink
+     *
+     * @param suspect the file to check
+     * @return true if symlink, false otherwise
+     */
+    boolean isSymlink(File suspect);
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/Symlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/Symlink.java
@@ -22,4 +22,6 @@ public interface Symlink {
     boolean isSymlinkSupported();
 
     void symlink(File link, File target) throws Exception;
+
+    boolean isSymlink(File suspect);
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.nativeintegration.filesystem.jdk7;
+
+import org.gradle.internal.nativeintegration.filesystem.Symlink;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class Jdk7Symlink implements Symlink {
+
+    private final boolean symlinksSupported;
+
+    Jdk7Symlink() {
+        symlinksSupported = doesSystemSupportSymlinks();
+    }
+
+    private boolean doesSystemSupportSymlinks() {
+        try {
+            Path sourceFile = Files.createTempFile("symlink", "test");
+            Path linkFile = Files.createTempFile("symlink", "test_link");
+
+            sourceFile.toFile().deleteOnExit();
+            Files.delete(linkFile);
+            Files.createSymbolicLink(linkFile, sourceFile);
+            linkFile.toFile().deleteOnExit();
+            return true;
+        } catch (IOException e) {
+            return false;
+        } catch (UnsupportedOperationException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isSymlinkSupported() {
+        return symlinksSupported;
+    }
+
+    @Override
+    public void symlink(File link, File target) throws Exception {
+        link.getParentFile().mkdirs();
+        Files.createSymbolicLink(link.toPath(), target.toPath());
+    }
+
+    @Override
+    public boolean isSymlink(File suspect) {
+        return Files.isSymbolicLink(suspect.toPath());
+    }
+}

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FileSystemServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FileSystemServices.java
@@ -40,7 +40,8 @@ public class FileSystemServices {
     public FileSystem createFileSystem(OperatingSystem operatingSystem, PosixFiles posixFiles) throws Exception {
         // Use no-op implementations for windows
         if (operatingSystem.isWindows()) {
-            return new GenericFileSystem(new EmptyChmod(), new FallbackStat(), new WindowsSymlink());
+            Symlink symlink = (Symlink) newInstance("org.gradle.internal.nativeintegration.filesystem.jdk7.Jdk7Symlink", WindowsSymlink.class);
+            return new GenericFileSystem(new EmptyChmod(), new FallbackStat(), symlink);
         }
 
         if (posixFiles instanceof UnavailablePosixFiles) {
@@ -52,8 +53,8 @@ public class FileSystemServices {
             return new GenericFileSystem(chmod, stat, symlink);
         }
 
-        LOGGER.debug("Using UnsupportedSymlink implementation.");
-        Symlink symlink = new UnsupportedSymlink();
+        Symlink symlink = (Symlink) newInstance("org.gradle.internal.nativeintegration.filesystem.jdk7.Jdk7Symlink", UnsupportedSymlink.class);
+        LOGGER.debug("Using {} implementation as symlink.", symlink.getClass().getSimpleName());
 
         // Use java 7 APIs, if available, otherwise fallback to no-op
         Object handler = newInstance("org.gradle.internal.nativeintegration.filesystem.jdk7.PosixJdk7FilePermissionHandler", UnsupportedFilePermissions.class);

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystem.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystem.java
@@ -60,6 +60,11 @@ class GenericFileSystem implements FileSystem {
     }
 
     @Override
+    public boolean isSymlink(File suspect) {
+        return symlink.isSymlink(suspect);
+    }
+
+    @Override
     public int getUnixMode(File f) {
         try {
             return stat.getUnixMode(f);

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedSymlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedSymlink.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.nativeintegration.filesystem.services;
 
+import net.rubygrapefruit.platform.PosixFile;
 import net.rubygrapefruit.platform.PosixFiles;
 import org.gradle.internal.nativeintegration.filesystem.Symlink;
 
@@ -38,5 +39,10 @@ class NativePlatformBackedSymlink implements Symlink {
     public void symlink(File link, File target) throws IOException {
         link.getParentFile().mkdirs();
         posixFiles.symlink(link, target.getPath());
+    }
+
+    @Override
+    public boolean isSymlink(File suspect) {
+        return posixFiles.stat(suspect).getType() == PosixFile.Type.Symlink;
     }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/UnsupportedSymlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/UnsupportedSymlink.java
@@ -31,4 +31,9 @@ class UnsupportedSymlink implements Symlink {
     public void symlink(File link, File target) throws IOException {
         throw new IOException("Support for the creation of symlinks is only available on this platform using Java 7 or later.");
     }
+
+    @Override
+    public boolean isSymlink(File suspect) {
+        return false;
+    }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/WindowsSymlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/WindowsSymlink.java
@@ -31,4 +31,9 @@ class WindowsSymlink implements Symlink {
     public void symlink(File link, File target) throws IOException {
         throw new IOException("Creation of symlinks is not supported on this platform.");
     }
+
+    @Override
+    public boolean isSymlink(File suspect) {
+        return false;
+    }
 }

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7SymlinkTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7SymlinkTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.nativeintegration.filesystem.jdk7
+
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import org.junit.Rule
+import spock.lang.Specification
+
+@Requires(TestPrecondition.JDK7_OR_LATER)
+class Jdk7SymlinkTest extends Specification {
+
+    @Rule TestNameTestDirectoryProvider temporaryFolder
+
+    @Requires(TestPrecondition.SYMLINKS)
+    def 'on symlink supporting system, it will return true for supported symlink'() {
+        expect:
+        new Jdk7Symlink().isSymlinkSupported()
+    }
+
+    @Requires(TestPrecondition.NO_SYMLINKS)
+    def 'on non symlink supporting system, it will return false for supported symlink'() {
+        expect:
+        !new Jdk7Symlink().isSymlinkSupported()
+    }
+
+    @Requires(TestPrecondition.SYMLINKS)
+    def 'can create and detect symlinks'() {
+        def symlink = new Jdk7Symlink()
+        def testDirectory = temporaryFolder.getTestDirectory().createDir()
+
+        when:
+        symlink.symlink(new File(testDirectory, 'testFile'), testDirectory.createFile('symFile'))
+
+        then:
+        symlink.isSymlink(new File(testDirectory, 'testFile'))
+
+        when:
+        symlink.symlink(new File(testDirectory, 'testDir'), testDirectory.createDir('symDir'))
+
+        then:
+        symlink.isSymlink(new File(testDirectory, 'testDir'))
+    }
+}


### PR DESCRIPTION
GRADLE-2892

As more languages come onboard with Gradle, symlinks become more common.
If we follow symlinks and try to delete the contents it could fail (for
system paths) or in the worst case, it will delete system contents (if
the build runs as root)

This change is a backwards incompatable change. Per the discussion on
https://groups.google.com/forum/#!topic/gradle-dev/2HIji78xT3I
it was decided to be important enough to introduce. The behavior change
is that `project.delete()` will not follow symlinks, if a user needs
symlinks to be followed they will have to use `ant.delete()` instead.
The `Delete` task has a property added called followSymlinks that will
toggle the following of symlinks. This way the user can opt into
changing the behavior for those tasks.

You can read the [Design Document](https://github.com/gradle/gradle/blob/master/design-docs/delete-should-not-follow-symlinks.md) for more information.