### PR TITLE
Release of JaCoCo 0.7.6 requires update of Gradle Plugin

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
@@ -26,7 +26,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>0.7.1.201405082137</literal></td>
+                <td><literal>0.7.6.201602180812</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>

--- a/subprojects/docs/src/docs/userguide/jacocoPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/jacocoPlugin.xml
@@ -126,6 +126,10 @@
                 <td>[]</td>
             </tr>
             <tr>
+                <td>includeNoLocationClasses</td>
+                <td>false</td>
+            </tr>
+            <tr>
                 <td>sessionId</td>
                 <td>
                     <literal>auto-generated</literal>

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
@@ -23,7 +23,7 @@ apply plugin: "jacoco"
 
 // START SNIPPET jacoco-configuration
 jacoco {
-    toolVersion = "0.7.1.201405082137"
+    toolVersion = "0.7.6.201602180812"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // END SNIPPET jacoco-configuration

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoVersionIntegTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoVersionIntegTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.util.TestPrecondition
 import org.junit.Test
 
 @Requires(TestPrecondition.JDK7_OR_EARLIER)
-@TargetVersions(['0.6.0.201210061924', '0.6.2.201302030002', '0.7.1.201405082137'])
+@TargetVersions(['0.6.0.201210061924', '0.6.2.201302030002', '0.7.1.201405082137', '0.7.6.201602180812'])
 class JacocoVersionIntegTest extends MultiVersionIntegrationSpec {
 
     @Test

--- a/subprojects/jacoco/src/main/groovy/org/gradle/internal/jacoco/JacocoAgentJar.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/internal/jacoco/JacocoAgentJar.groovy
@@ -50,7 +50,7 @@ class JacocoAgentJar {
 
     boolean supportsJmx() {
         def pre062 = getAgentConf().any {
-            it.name ==~ /org.jacoco.agent-([0]\.[0-6]\.[0-1\.].*)\.jar/
+            it.name ==~ /org.jacoco.agent-([0]\.[0-6]\.[0-1]\..*)\.jar/
         }
         return !pre062
     }

--- a/subprojects/jacoco/src/main/groovy/org/gradle/internal/jacoco/JacocoAgentJar.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/internal/jacoco/JacocoAgentJar.groovy
@@ -54,4 +54,11 @@ class JacocoAgentJar {
         }
         return !pre062
     }
+
+    boolean supportsInclNoLocationClasses() {
+        def pre076 = getAgentConf().any {
+            it.name ==~ /org.jacoco.agent-([0]\.[0-7]\.[0-5]\..*)\.jar/
+        }
+        return !pre076;
+    }
 }

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.groovy
@@ -36,7 +36,7 @@ class JacocoPluginExtension {
     /**
      * Version of Jacoco JARs to use.
      */
-    String toolVersion = '0.7.1.201405082137'
+    String toolVersion = '0.7.6.201602180812'
 
     protected final Project project
 

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.groovy
@@ -76,7 +76,7 @@ class JacocoTaskExtension {
     boolean dumpOnExit = true
 
     /**
-     * THe type of output to generate. Defaults to {@link Output#FILE}.
+     * The type of output to generate. Defaults to {@link Output#FILE}.
      */
     Output output = Output.FILE
 

--- a/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.groovy
+++ b/subprojects/jacoco/src/main/groovy/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.groovy
@@ -65,6 +65,15 @@ class JacocoTaskExtension {
     List<String> excludeClassLoaders = []
 
     /**
+     * Whether or not classes without source location should be instrumented.
+     * Defaults to {@code false}.
+     *
+     * This property is only taken into account if the used JaCoCo version
+     * supports this option (JaCoCo version >= 0.7.6)
+     */
+    boolean includeNoLocationClasses = false
+
+    /**
      * An identifier for the session written to the execution data. Defaults
      * to an auto-generated identifier.
      */
@@ -156,6 +165,9 @@ class JacocoTaskExtension {
         arg 'includes', getIncludes()
         arg 'excludes', getExcludes()
         arg 'exclclassloader', getExcludeClassLoaders()
+        if (agent.supportsInclNoLocationClasses()) {
+            arg 'inclnolocationclasses', getIncludeNoLocationClasses()
+        }
         arg 'sessionid', getSessionId()
         arg 'dumponexit', getDumpOnExit()
         arg 'output', getOutput().asArg

--- a/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoTaskExtensionSpec.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoTaskExtensionSpec.groovy
@@ -30,10 +30,11 @@ class JacocoTaskExtensionSpec extends Specification {
     def 'asJvmArg with default arguments assembles correct string'() {
         setup:
         agent.supportsJmx() >> true
+        agent.supportsInclNoLocationClasses() >> true
         agent.jar >> temporaryFolder.file('fakeagent.jar')
         task.getWorkingDir() >> temporaryFolder.file(".")
         expect:
-        extension.asJvmArg == "-javaagent:fakeagent.jar=append=true,dumponexit=true,output=file,jmx=false"
+        extension.asJvmArg == "-javaagent:fakeagent.jar=append=true,inclnolocationclasses=false,dumponexit=true,output=file,jmx=false"
     }
 
     def 'supports jacocoagent with no jmx support'() {
@@ -46,9 +47,20 @@ class JacocoTaskExtensionSpec extends Specification {
         extension.asJvmArg == "-javaagent:../fakeagent.jar=append=true,dumponexit=true,output=file"
     }
 
+    def 'supports jacocoagent with no inclNoLocationClasses support'() {
+        given:
+        agent.supportsInclNoLocationClasses() >> false
+        agent.jar >> temporaryFolder.file('fakeagent.jar')
+        task.getWorkingDir() >> temporaryFolder.file("workingDir")
+
+        expect:
+        extension.asJvmArg == "-javaagent:../fakeagent.jar=append=true,dumponexit=true,output=file"
+    }
+
     def 'asJvmArg with all arguments assembles correct string'() {
         given:
         agent.supportsJmx() >> true
+        agent.supportsInclNoLocationClasses() >> true
         agent.jar >> temporaryFolder.file('workingDir/subfolder/fakeagent.jar')
         task.getWorkingDir() >> temporaryFolder.file("workingDir")
 
@@ -58,6 +70,7 @@ class JacocoTaskExtensionSpec extends Specification {
             includes = ['org.*', '*.?acoco*']
             excludes = ['org.?joberstar']
             excludeClassLoaders = ['com.sun.*', 'org.fak?.*']
+            includeNoLocationClasses = false
             sessionId = 'testSession'
             dumpOnExit = false
             output = JacocoTaskExtension.Output.TCP_SERVER
@@ -74,6 +87,7 @@ class JacocoTaskExtensionSpec extends Specification {
             builder << "includes=org.*:*.?acoco*,"
             builder << "excludes=org.?joberstar,"
             builder << "exclclassloader=com.sun.*:org.fak?.*,"
+            builder << "inclnolocationclasses=false,"
             builder << "sessionid=testSession,"
             builder << "dumponexit=false,"
             builder << "output=tcpserver,"


### PR DESCRIPTION
Without those changes JaCoCo Plugin is not usable with JaCoCo versions 0.7.3 - 0.7.5 for some Gradle users - see JaCoCo/JaCoCo#288