### PR TITLE
Add Project.propertyOrDefault method

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/dsl/DynamicObjectIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/dsl/DynamicObjectIntegrationTest.groovy
@@ -28,7 +28,7 @@ class DynamicObjectIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void canAddDynamicPropertiesToProject() {
-        
+
         file("settings.gradle").writelns("include 'child'");
         file("build.gradle").writelns(
                 "ext.rootProperty = 'root'",
@@ -74,7 +74,7 @@ class DynamicObjectIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void canAddDynamicMethodsToProject() {
-        
+
         file("settings.gradle").writelns("include 'child'");
         file("build.gradle").writelns(
                 "def rootMethod(p) { 'root' + p }",
@@ -108,7 +108,7 @@ class DynamicObjectIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void canAddMixinsToProject() {
-        
+
         file('build.gradle') << '''
 convention.plugins.test = new ConventionBean()
 
@@ -126,7 +126,7 @@ class ConventionBean {
 
     @Test
     public void canAddExtensionsToProject() {
-        
+
         file('build.gradle') << '''
 extensions.test = new ExtensionBean()
 
@@ -144,7 +144,7 @@ class ExtensionBean {
 
     @Test
     public void canAddPropertiesToProjectUsingGradlePropertiesFile() {
-        
+
         file("settings.gradle").writelns("include 'child'");
         file("gradle.properties") << '''
 global=some value
@@ -171,7 +171,7 @@ assert 'overridden value' == global
 
     @Test
     public void canAddDynamicPropertiesToCoreDomainObjects() {
-        
+
         file('build.gradle') << '''
             class GroovyTask extends DefaultTask { }
 
@@ -233,7 +233,7 @@ assert 'overridden value' == global
 
     @Test
     public void canAddMixInsToCoreDomainObjects() {
-        
+
         file('build.gradle') << '''
             class Extension { def doStuff() { 'method' } }
             class GroovyTask extends DefaultTask { }
@@ -287,7 +287,7 @@ assert 'overridden value' == global
 
     @Test
     public void canAddExtensionsToCoreDomainObjects() {
-        
+
         file('build.gradle') << '''
             class Extension { def doStuff() { 'method' } }
             class GroovyTask extends DefaultTask { }
@@ -341,7 +341,7 @@ assert 'overridden value' == global
 
     @Test
     public void mixesDslMethodsIntoCoreDomainObjects() {
-        
+
         file('build.gradle') << '''
             class GroovyTask extends DefaultTask {
                 def String prop
@@ -367,7 +367,7 @@ assert 'overridden value' == global
 
     @Test
     void canAddExtensionsToDynamicExtensions() {
-        
+
         file('build.gradle') << '''
             class Extension {
                 String name
@@ -392,7 +392,7 @@ assert 'overridden value' == global
 
     @Test
     public void canInjectMethodsFromParentProject() {
-        
+
         file("settings.gradle").writelns("include 'child'");
         file("build.gradle").writelns(
                 "subprojects {",
@@ -407,9 +407,9 @@ assert 'overridden value' == global
 
         executer.withTasks("testTask").run();
     }
-    
+
     @Test void canAddNewPropertiesViaTheAdhocNamespace() {
-        
+
         file("build.gradle") << """
             assert !hasProperty("p1")
 
@@ -444,7 +444,7 @@ assert 'overridden value' == global
                 assert ext.p1 == 2
             }
         """
-        
+
         executer.withTasks("run").run()
     }
 
@@ -472,7 +472,7 @@ assert 'overridden value' == global
 
     @Issue("GRADLE-2163")
     @Test void canDecorateBooleanPrimitiveProperties() {
-        
+
         file("build.gradle") << """
             class CustomBean {
                 boolean b
@@ -522,6 +522,30 @@ assert 'overridden value' == global
             task run << {
                 assert dynamic.methods.size() == 1
                 assert dynamic.props.p1 == 2
+            }
+        """
+
+        executer.withTasks("run").run()
+    }
+
+    @Issue("PR-578")
+    @Test
+    void findPropertyShouldReturnValueIfFound() {
+        buildFile << """
+            task run << {
+                assert project.findProperty('foundProperty') == 'foundValue'
+            }
+        """
+
+        executer.withTasks("run").withArguments('-PfoundProperty=foundValue').run();
+    }
+
+    @Issue("PR-578")
+    @Test
+    void findPropertyShouldReturnNullIfNotFound() {
+        buildFile << """
+            task run << {
+                assert project.findProperty('notFoundProperty') == null
             }
         """
 

--- a/subprojects/core/src/main/groovy/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/Project.java
@@ -1169,8 +1169,41 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param propertyName The name of the property.
      * @return The value of the property, possibly null.
      * @throws MissingPropertyException When the given property is unknown.
+     *
+     * @see Project#findProperty(String)
      */
     Object property(String propertyName) throws MissingPropertyException;
+
+    /**
+     * <p>Returns the value of the given property or null if not found.
+     * This method locates a property as follows:</p>
+     *
+     * <ol>
+     *
+     * <li>If this project object has a property with the given name, return the value of the property.</li>
+     *
+     * <li>If this project has an extension with the given name, return the extension.</li>
+     *
+     * <li>If this project's convention object has a property with the given name, return the value of the
+     * property.</li>
+     *
+     * <li>If this project has an extra property with the given name, return the value of the property.</li>
+     *
+     * <li>If this project has a task with the given name, return the task.</li>
+     *
+     * <li>Search up through this project's ancestor projects for a convention property or extra property with the
+     * given name.</li>
+     *
+     * <li>If not found, null value is returned.</li>
+     *
+     * </ol>
+     *
+     * @param propertyName The name of the property.
+     * @return The value of the property, possibly null or null if not found.
+     *
+     * @see Project#property(String)
+     */
+    Object findProperty(String propertyName);
 
     /**
      * <p>Returns the logger for this project. You can use this in your build file to write log messages.</p>

--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/project/AbstractProject.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/project/AbstractProject.java
@@ -774,6 +774,10 @@ public abstract class AbstractProject extends AbstractPluginAware implements Pro
         return extensibleDynamicObject.getProperty(propertyName);
     }
 
+    public Object findProperty(String propertyName) {
+        return hasProperty(propertyName) ? property(propertyName) : null;
+    }
+
     public void setProperty(String name, Object value) {
         extensibleDynamicObject.setProperty(name, value);
     }


### PR DESCRIPTION
TL;TR; A convenient way to set a default value for a property which could be not found. Without that hasProperty has to be used as a guard check.

#### Longer rationale.

Many plugins require certain properties to be set and fail otherwise in a configuration phase, even if no task from given plugin is called. This often refers to credentials (usernames, passwords, API keys, ...) which are set in ~/.gradle/gradle.properties. It is required to use a guard check with `project.hasProperty`:

```
codeCoverageOnline {
  key = project.hasProperty('ccoKey') ? project.getProperty('ccoKey') : 'N/A'
```

or create an empty value in project specific gradle.properties. With `Project.propertyOrDefault` there is a convenient way to a fallback value.

```
codeCoverageOnline {
  key = project.propertyOrDefault('ccoKey', 'N/A')
```

Btw, the tests I created are probably in not the best possible place, but I wasn't able to find a test which verifies reading properties itself.