### PR TITLE
Upgrade Ant to version 1.9.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,8 +25,8 @@ versions.groovy = "2.4.4"
 
 versions.bouncycastle = "1.51"
 
-libraries.ant = dependencies.module('org.apache.ant:ant:1.9.3') {
-    dependency 'org.apache.ant:ant-launcher:1.9.3@jar'
+libraries.ant = dependencies.module('org.apache.ant:ant:1.9.6') {
+    dependency 'org.apache.ant:ant-launcher:1.9.6@jar'
 }
 
 libraries.asm =  'org.ow2.asm:asm-all:5.0.3'


### PR DESCRIPTION
In order to support encoding for untar task, we need to upgrade Ant to version >= 1.9.5.

As mentioned in [Apache Ant Homepage](https://ant.apache.org/)

> Ant 1.9.6 fixes a regression in the zip package introduced with Ant 1.9.5.

So upgrade to  `Ant 1.9.6` directly.