### PR TITLE
Updated docs for FileCopyDetails

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/file/FileCopyDetails.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/file/FileCopyDetails.java
@@ -25,6 +25,10 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * <p>Using this interface, you can change the destination path of the file, filter the content of the file, or exclude
  * the file from the result entirely.</p>
+ *
+ * <p>Access to the source file itself after any filters have been added is not a supported operation.
+ * </p>
+ *
  */
 @HasInternalProtocol
 @NonExtensible


### PR DESCRIPTION
Added a note to the class header that using `getFile()` with filters are not supported. (See also https://discuss.gradle.org/t/combining-eachfile-filter-results-in-failure/14801/2)