### PR TITLE
Improve error message "Could not find tools.jar" when running Gradle with a JRE

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JdkTools.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JdkTools.java
@@ -54,7 +54,9 @@ public class JdkTools {
         if (!javaVersion.isJava9Compatible()) {
             File toolsJar = javaInfo.getToolsJar();
             if (toolsJar == null) {
-                throw new IllegalStateException("Could not find tools.jar");
+                String javaHome = javaInfo.getJavaHome().getAbsolutePath();
+                throw new IllegalStateException("Could not find tools.jar. Please check that "
+                                                + javaHome + " contains a valid JDK installation.");
             }
             DefaultClassPath defaultClassPath = new DefaultClassPath(toolsJar);
             isolatedToolsLoader = new MutableURLClassLoader(filteringClassLoader, defaultClassPath.getAsURLs());

--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JdkTools.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JdkTools.java
@@ -54,9 +54,9 @@ public class JdkTools {
         if (!javaVersion.isJava9Compatible()) {
             File toolsJar = javaInfo.getToolsJar();
             if (toolsJar == null) {
-                String javaHome = javaInfo.getJavaHome().getAbsolutePath();
                 throw new IllegalStateException("Could not find tools.jar. Please check that "
-                                                + javaHome + " contains a valid JDK installation.");
+                                                + javaInfo.getJavaHome().getAbsolutePath()
+                                                + " contains a valid JDK installation.");
             }
             DefaultClassPath defaultClassPath = new DefaultClassPath(toolsJar);
             isolatedToolsLoader = new MutableURLClassLoader(filteringClassLoader, defaultClassPath.getAsURLs());

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/jvm/JdkToolsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/jvm/JdkToolsTest.groovy
@@ -36,6 +36,7 @@ class JdkToolsTest extends Specification {
         when:
         new JdkTools(Mock(JavaInfo) {
             getToolsJar() >> null
+            getJavaHome() >> new File('.')
         })
 
         then:


### PR DESCRIPTION
I stumbled over this message myself and didn't know what was wrong, and I have the issue pop up with  	colleagues now and then. I think giving a nudge in the direction of the most probable cause is a good idea.