### PR TITLE
Fix project layout tables in docs for Groovy and Scala plugins

### DIFF
--- a/subprojects/docs/src/docs/userguide/groovyPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/groovyPlugin.xml
@@ -115,6 +115,7 @@
             <thead>
                 <tr>
                     <td>Directory</td>
+                    <td></td>
                     <td>Meaning</td>
                 </tr>
             </thead>
@@ -123,6 +124,7 @@
                 <td>
                     <filename>src/main/groovy</filename>
                 </td>
+                <td></td>
                 <td>Production Groovy sources. May also contain Java sources for joint compilation.</td>
             </tr>
             <xi:include href="javaProjectTestLayout.xml"/>
@@ -130,6 +132,7 @@
                 <td>
                     <filename>src/test/groovy</filename>
                 </td>
+                <td></td>
                 <td>Test Groovy sources. May also contain Java sources for joint compilation.</td>
             </tr>
             <xi:include href="javaProjectGenericLayout.xml"/>
@@ -137,6 +140,7 @@
                 <td>
                     <filename>src/<replaceable>sourceSet</replaceable>/groovy</filename>
                 </td>
+                <td></td>
                 <td>Groovy sources for the given source set. May also contain Java sources for joint compilation.</td>
             </tr>
         </table>

--- a/subprojects/docs/src/docs/userguide/scalaPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/scalaPlugin.xml
@@ -121,6 +121,7 @@
             <thead>
                 <tr>
                     <td>Directory</td>
+                    <td></td>
                     <td>Meaning</td>
                 </tr>
             </thead>
@@ -129,6 +130,7 @@
                 <td>
                     <filename>src/main/scala</filename>
                 </td>
+                <td></td>
                 <td>Production Scala sources. May also contain Java sources for joint compilation.</td>
             </tr>
             <xi:include href="javaProjectTestLayout.xml"/>
@@ -136,6 +138,7 @@
                 <td>
                     <filename>src/test/scala</filename>
                 </td>
+                <td></td>
                 <td>Test Scala sources. May also contain Java sources for joint compilation.</td>
             </tr>
             <xi:include href="javaProjectGenericLayout.xml"/>
@@ -143,6 +146,7 @@
                 <td>
                     <filename>src/<replaceable>sourceSet</replaceable>/scala</filename>
                 </td>
+                <td></td>
                 <td>Scala sources for the given source set. May also contain Java sources for joint compilation.</td>
             </tr>
         </table>


### PR DESCRIPTION
The project layout tables for the Groovy and Scala plugins are missing a few empty `<td>`  tags, which is breaking the columns.

Example:
![bad](https://cloud.githubusercontent.com/assets/1250248/13596944/4e9c16ac-e4db-11e5-9b0b-453ddebb7582.jpg)

After adding the missing tags:
![good](https://cloud.githubusercontent.com/assets/1250248/13596949/5697efe8-e4db-11e5-8ed0-193ccb567efb.jpg)

