### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ libraries.bndlib = dependencies.module('biz.aQute.bnd:bndlib:2.4.0')
 libraries.commons_cli = 'commons-cli:commons-cli:1.2@jar'
 libraries.commons_io = dependencies.module(versions.commons_io)
 libraries.commons_lang = 'commons-lang:commons-lang:2.6@jar'
-libraries.commons_collections = 'commons-collections:commons-collections:3.2.1@jar'
+libraries.commons_collections = 'commons-collections:commons-collections:3.2.2@jar'
 libraries.jsch = "com.jcraft:jsch:0.1.53"
 libraries.ivy = dependencies.module('org.apache.ivy:ivy:2.2.0'){
     dependency libraries.jsch

--- a/subprojects/docs/src/samples/application/build.gradle
+++ b/subprojects/docs/src/samples/application/build.gradle
@@ -39,5 +39,5 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
 }

--- a/subprojects/docs/src/samples/ivy-publish/java-multi-project/build.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/java-multi-project/build.gradle
@@ -28,7 +28,7 @@ project(":project2") {
     description = "The second project"
 
     dependencies {
-       compile 'commons-collections:commons-collections:3.1'
+       compile 'commons-collections:commons-collections:3.2.2'
     }
 }
 

--- a/subprojects/docs/src/samples/ivy-publish/multiple-publications/build.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/multiple-publications/build.gradle
@@ -49,7 +49,7 @@ project(":project2") {
     // END SNIPPET multiple-publications
 
     dependencies {
-       compile 'commons-collections:commons-collections:3.1', project(':project1')
+       compile 'commons-collections:commons-collections:3.2.2', project(':project1')
     }
 
     // START SNIPPET multiple-publications

--- a/subprojects/docs/src/samples/ivy-publish/multiple-publications/output/project2-impl.ivy.xml
+++ b/subprojects/docs/src/samples/ivy-publish/multiple-publications/output/project2-impl.ivy.xml
@@ -10,7 +10,7 @@
     <artifact name="project2-impl" type="jar" ext="jar" conf="runtime"/>
   </publications>
   <dependencies>
-    <dependency org="commons-collections" name="commons-collections" rev="3.1" conf="runtime-&gt;default"/>
+    <dependency org="commons-collections" name="commons-collections" rev="3.2.2" conf="runtime-&gt;default"/>
     <dependency org="org.gradle.sample" name="project1-sample" rev="1.1" conf="runtime-&gt;default"/>
   </dependencies>
 </ivy-module>

--- a/subprojects/docs/src/samples/java/base/prod/build.gradle
+++ b/subprojects/docs/src/samples/java/base/prod/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile group: 'commons-collections', name: 'commons-collections', version: '3.2'
+    compile group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
     "default" configurations.runtime
 }
 

--- a/subprojects/docs/src/samples/java/multiproject/services/webservice/build.gradle
+++ b/subprojects/docs/src/samples/java/multiproject/services/webservice/build.gradle
@@ -5,7 +5,7 @@ version = '2.5'
 // START SNIPPET dependency-configurations
 dependencies {
 // END SNIPPET dependency-configurations    
-    compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    compile project(':shared'), 'commons-collections:commons-collections:3.2.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
 // START SNIPPET dependency-configurations
     compile project(path: ':api', configuration: 'spi')
 // END SNIPPET dependency-configurations

--- a/subprojects/docs/src/samples/java/quickstart/build.gradle
+++ b/subprojects/docs/src/samples/java/quickstart/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 // START SNIPPET dependencies
 dependencies {
-    compile group: 'commons-collections', name: 'commons-collections', version: '3.2'
+    compile group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
     testCompile group: 'junit', name: 'junit', version: '4.+'
 }
 // END SNIPPET dependencies

--- a/subprojects/docs/src/samples/java/withIntegrationTests/build.gradle
+++ b/subprojects/docs/src/samples/java/withIntegrationTests/build.gradle
@@ -13,7 +13,7 @@ sourceSets {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    integrationTestCompile 'commons-collections:commons-collections:3.2'
+    integrationTestCompile 'commons-collections:commons-collections:3.2.2'
     integrationTestCompile sourceSets.main.output
     integrationTestCompile configurations.testCompile
     integrationTestCompile sourceSets.test.output

--- a/subprojects/docs/src/samples/maven-publish/javaProject/build.gradle
+++ b/subprojects/docs/src/samples/maven-publish/javaProject/build.gradle
@@ -5,7 +5,7 @@ group = 'org.gradle.sample'
 version = '1.0'
 
 dependencies {
-   compile 'commons-collections:commons-collections:3.0'
+   compile 'commons-collections:commons-collections:3.2.2'
 }
 
 repositories {

--- a/subprojects/docs/src/samples/maven-publish/multiple-publications/build.gradle
+++ b/subprojects/docs/src/samples/maven-publish/multiple-publications/build.gradle
@@ -37,7 +37,7 @@ project(":project1") {
 
 project(":project2") {
     dependencies {
-       compile 'commons-collections:commons-collections:3.1', project(':project1')
+       compile 'commons-collections:commons-collections:3.2.2', project(':project1')
     }
 
     // START SNIPPET multiple-publications

--- a/subprojects/docs/src/samples/maven-publish/multiple-publications/output/project2-impl.pom.xml
+++ b/subprojects/docs/src/samples/maven-publish/multiple-publications/output/project2-impl.pom.xml
@@ -10,7 +10,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <version>3.2.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/subprojects/docs/src/samples/scala/force/build.gradle
+++ b/subprojects/docs/src/samples/scala/force/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 }
 
 dependencies {
-    compile 'commons-collections:commons-collections:3.2'
+    compile 'commons-collections:commons-collections:3.2.2'
     testCompile 'junit:junit:4.12'
 }
 

--- a/subprojects/docs/src/samples/scala/quickstart/build.gradle
+++ b/subprojects/docs/src/samples/scala/quickstart/build.gradle
@@ -14,6 +14,6 @@ dependencies {
 // END SNIPPET scala-dependency
 
 dependencies {
-    compile 'commons-collections:commons-collections:3.2'
+    compile 'commons-collections:commons-collections:3.2.2'
     testCompile 'junit:junit:4.12'
 }

--- a/subprojects/docs/src/samples/scala/zinc/build.gradle
+++ b/subprojects/docs/src/samples/scala/zinc/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 }
 
 dependencies {
-    compile 'commons-collections:commons-collections:3.2'
+    compile 'commons-collections:commons-collections:3.2.2'
     testCompile 'junit:junit:4.12'
 }
 

--- a/subprojects/docs/src/samples/sonar/quickstart/build.gradle
+++ b/subprojects/docs/src/samples/sonar/quickstart/build.gradle
@@ -31,6 +31,6 @@ repositories {
 }
 
 dependencies {
-    compile group: 'commons-collections', name: 'commons-collections', version: '3.2'
+    compile group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
     testCompile group: 'junit', name: 'junit', version: '4.+'
 }

--- a/subprojects/docs/src/samples/sonarRunner/quickstart/build.gradle
+++ b/subprojects/docs/src/samples/sonarRunner/quickstart/build.gradle
@@ -27,6 +27,6 @@ sonarRunner {
 // END SNIPPET version-settings
 
 dependencies {
-    compile "commons-collections:commons-collections:3.2"
+    compile "commons-collections:commons-collections:3.2.2"
     testCompile "junit:junit:4.+"
 }

--- a/subprojects/docs/src/samples/userguide/javaLibraryDistribution/build.gradle
+++ b/subprojects/docs/src/samples/userguide/javaLibraryDistribution/build.gradle
@@ -28,5 +28,5 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
 }

--- a/subprojects/docs/src/samples/userguideOutput/externalDependencies.out
+++ b/subprojects/docs/src/samples/userguideOutput/externalDependencies.out
@@ -1,6 +1,6 @@
 hibernate-core-3.6.7.Final.jar
 antlr-2.7.6.jar
-commons-collections-3.1.jar
+commons-collections-3.2.2.jar
 dom4j-1.6.1.jar
 hibernate-commons-annotations-3.2.0.Final.jar
 hibernate-jpa-2.0-api-1.0.1.Final.jar

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/api/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/api/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 dependencies {
-    runtime 'commons-collections:commons-collections:3.2@jar'
+    runtime 'commons-collections:commons-collections:3.2.2@jar'
     testCompile 'junit:junit:4.7'
 }
 

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
@@ -6,7 +6,7 @@
 	<classpathentry kind="src" path="src/test/resources"/>
 	<classpathentry kind="src" path="src/integTest/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
-	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar">
+	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="../"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
@@ -22,7 +22,7 @@
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/junit/junit/4.12/@SHA1@/junit-4.12-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar">
+	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="../"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
@@ -6,6 +6,6 @@
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="src" path="src/test/resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
-	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar"/>
+	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar"/>
 	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar"/>
 </classpath>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
@@ -15,5 +15,5 @@
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar"/>
+	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar"/>
 </classpath>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6WtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6WtpComponent.xml
@@ -16,7 +16,7 @@
 		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5.jar">
 			<dependency-type>uses</dependency-type>
 		</dependent-module>
-		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar">
+		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 			<dependency-type>uses</dependency-type>
 		</dependent-module>
 	</wb-module>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
@@ -17,5 +17,5 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar"/>
-	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar"/>
+	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar"/>
 </classpath>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceWtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceWtpComponent.xml
@@ -9,7 +9,7 @@
 		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">
 			<dependency-type>uses</dependency-type>
 		</dependent-module>
-		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar">
+		<dependent-module deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 			<dependency-type>uses</dependency-type>
 		</dependent-module>
 	</wb-module>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/groovyproject/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/groovyproject/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'groovy'
 
 dependencies {
-    runtime 'commons-collections:commons-collections:3.2@jar'
+    runtime 'commons-collections:commons-collections:3.2.2@jar'
     testCompile 'junit:junit:4.7'
 }

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/api/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/api/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    runtime 'commons-collections:commons-collections:3.2@jar'
+    runtime 'commons-collections:commons-collections:3.2.2@jar'
 }
 
 cleanIdea.doLast {

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/api/api.iml.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/api/api.iml.xml
@@ -12,11 +12,11 @@
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar!/"/>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar!/"/>
         </CLASSES>
         <JAVADOC/>
         <SOURCES>
-          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar!/"/>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar!/"/>
         </SOURCES>
       </library>
     </orderEntry>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webservice/webservice.iml.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webservice/webservice.iml.xml
@@ -24,11 +24,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar!/"/>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar!/"/>
         </CLASSES>
         <JAVADOC/>
         <SOURCES>
-          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar!/"/>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar!/"/>
         </SOURCES>
       </library>
     </orderEntry>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/overwritesExistingDependencies/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/overwritesExistingDependencies/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    runtime 'commons-collections:commons-collections:3.2@jar'
+    runtime 'commons-collections:commons-collections:3.2.2@jar'
     runtime 'junit:junit:4.7@jar'
 }
 

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/overwritesExistingDependencies/expectedFiles/root.iml.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/overwritesExistingDependencies/expectedFiles/root.iml.xml
@@ -10,11 +10,11 @@
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2.jar!/"/>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar!/"/>
         </CLASSES>
         <JAVADOC/>
         <SOURCES>
-          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2/@SHA1@/commons-collections-3.2-sources.jar!/"/>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar!/"/>
         </SOURCES>
       </library>
     </orderEntry>

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesApplicationIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesApplicationIntegrationTest.groovy
@@ -62,7 +62,7 @@ class SamplesApplicationIntegrationTest extends AbstractIntegrationSpec {
         installDir.file('bin/application').assertIsFile()
         installDir.file('bin/application.bat').assertIsFile()
         installDir.file('lib/application-1.0.2.jar').assertIsFile()
-        installDir.file('lib/commons-collections-3.2.1.jar').assertIsFile()
+        installDir.file('lib/commons-collections-3.2.2jar').assertIsFile()
 
         installDir.file('LICENSE').assertIsFile()
         installDir.file('docs/readme.txt').assertIsFile()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
@@ -123,7 +123,7 @@ class SamplesJavaMultiProjectIntegrationTest extends AbstractIntegrationTest {
                 "WEB-INF/lib/$SHARED_NAME-1.0.jar".toString(),
                 "WEB-INF/lib/$API_NAME-1.0.jar".toString(),
                 "WEB-INF/lib/$API_NAME-spi-1.0.jar".toString(),
-                'WEB-INF/lib/commons-collections-3.2.jar',
+                'WEB-INF/lib/commons-collections-3.2.2.jar',
                 'WEB-INF/lib/commons-io-1.2.jar',
                 'WEB-INF/lib/commons-lang-2.4.jar'
         )

--- a/subprojects/integ-test/src/integTest/resources/org/gradle/integtests/eclipseproject/java/expectedApiClasspathFile.txt
+++ b/subprojects/integ-test/src/integTest/resources/org/gradle/integtests/eclipseproject/java/expectedApiClasspathFile.txt
@@ -6,6 +6,6 @@
   <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
   <classpathentry kind="src" path="src/test/java" output="build/classes/test"/>
   <classpathentry kind="src" path="src/test/resources" output="build/classes/test"/>
-  <classpathentry kind="lib" path="$cachePath/commons-collections/commons-collections/jars/commons-collections-3.2.jar"/>
+  <classpathentry kind="lib" path="$cachePath/commons-collections/commons-collections/jars/commons-collections-3.2.2.jar"/>
   <classpathentry kind="lib" path="$cachePath/junit/junit/jars/junit-4.7.jar"/>
 </classpath>

--- a/subprojects/integ-test/src/integTest/resources/org/gradle/integtests/eclipseproject/scala/expectedClasspathFile.txt
+++ b/subprojects/integ-test/src/integTest/resources/org/gradle/integtests/eclipseproject/scala/expectedClasspathFile.txt
@@ -5,7 +5,7 @@
   <classpathentry kind="src" path="src/main/scala"/>
   <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
   <classpathentry kind="src" path="src/test/scala" output="build/classes/test"/>
-  <classpathentry kind="lib" path="$cachePath/commons-collections/commons-collections/jars/commons-collections-3.2.jar"/>
+  <classpathentry kind="lib" path="$cachePath/commons-collections/commons-collections/jars/commons-collections-3.2.2.jar"/>
   <classpathentry kind="lib" path="$cachePath/junit/junit/jars/junit-4.7.jar"/>
   <classpathentry kind="lib" path="$cachePath/org.scala-lang/scala-library/jars/scala-library-2.9.2.jar"/>
 </classpath>

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishEarIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishEarIntegTest.groovy
@@ -36,7 +36,7 @@ class IvyPublishEarIntegTest extends AbstractIvyPublishIntegTest {
             }
 
             dependencies {
-                compile "commons-collections:commons-collections:3.2.1"
+                compile "commons-collections:commons-collections:3.2.2"
                 runtime "commons-io:commons-io:1.4"
             }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -45,10 +45,10 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
             expectArtifact("publishTest").hasAttributes("jar", "jar", ["runtime"])
         }
-        ivyModule.parsedIvy.assertDependsOn("commons-collections:commons-collections:3.2.1@runtime", "commons-io:commons-io:1.4@runtime")
+        ivyModule.parsedIvy.assertDependsOn("commons-collections:commons-collections:3.2.2@runtime", "commons-io:commons-io:1.4@runtime")
 
         and:
-        resolveArtifacts(ivyModule) == ["commons-collections-3.2.1.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(ivyModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
     }
 
     public void "ignores extra artifacts added to configurations"() {
@@ -113,7 +113,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         ivyModule.parsedIvy.expectArtifact("publishTest", "jar", "source").hasAttributes("jar", "sources", ["runtime"], "source")
 
         and:
-        resolveArtifacts(ivyModule) == ["commons-collections-3.2.1.jar", "commons-io-1.4.jar", "publishTest-1.9-source.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(ivyModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9-source.jar", "publishTest-1.9.jar"]
     }
 
     public void "generated ivy descriptor includes dependency exclusions"() {
@@ -146,7 +146,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         dependency.exclusions[0].module == 'commons-logging'
 
         and:
-        resolveArtifacts(ivyModule) == ["commons-collections-3.2.1.jar", "commons-io-1.4.jar", "publishTest-1.9.jar", "spring-core-2.5.6.jar"]
+        resolveArtifacts(ivyModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar", "spring-core-2.5.6.jar"]
     }
 
     def createBuildScripts(def append) {
@@ -172,7 +172,7 @@ $append
             }
 
             dependencies {
-                compile "commons-collections:commons-collections:3.2.1"
+                compile "commons-collections:commons-collections:3.2.2"
                 compileOnly "javax.servlet:servlet-api:2.5"
                 runtime "commons-io:commons-io:1.4"
                 testCompile "junit:junit:4.12"

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishWarIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishWarIntegTest.groovy
@@ -35,7 +35,7 @@ class IvyPublishWarIntegTest extends AbstractIvyPublishIntegTest {
             }
 
             dependencies {
-                compile "commons-collections:commons-collections:3.2.1"
+                compile "commons-collections:commons-collections:3.2.2"
                 runtime "commons-io:commons-io:1.4"
                 providedCompile "commons-lang:commons-lang:2.6"
                 providedRuntime "commons-cli:commons-cli:1.2"

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
@@ -67,7 +67,7 @@ public class SamplesIvyPublishIntegrationTest extends AbstractIntegrationSpec {
 
         project2module.parsedIvy.configurations.keySet() == ['default', 'runtime'] as Set
         project2module.parsedIvy.description == "The second project"
-        project2module.parsedIvy.assertDependsOn('commons-collections:commons-collections:3.1@runtime')
+        project2module.parsedIvy.assertDependsOn('commons-collections:commons-collections:3.2.2@runtime')
 
         def actualIvyXmlText = project1module.ivyFile.text.replaceFirst('publication="\\d+"', 'publication="«PUBLICATION-TIME-STAMP»"').trim()
         actualIvyXmlText == getExpectedIvyOutput(javaProject.dir.file("output-ivy.xml"))

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyEarProjectPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyEarProjectPublishIntegrationTest.groovy
@@ -36,7 +36,7 @@ repositories {
 }
 
 dependencies {
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "commons-collections:commons-collections:3.2.2"
     runtime "commons-io:commons-io:1.4"
 }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyJavaProjectPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyJavaProjectPublishIntegrationTest.groovy
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "commons-collections:commons-collections:3.2.2"
     compileOnly "javax.servlet:servlet-api:2.5"
     runtime "commons-io:commons-io:1.4"
 }
@@ -57,7 +57,7 @@ uploadArchives {
 
         with (ivyModule.parsedIvy) {
             dependencies.size() == 3
-            dependencies["commons-collections:commons-collections:3.2.1"].hasConf("compile->default")
+            dependencies["commons-collections:commons-collections:3.2.2"].hasConf("compile->default")
             dependencies["commons-io:commons-io:1.4"].hasConf("runtime->default")
             dependencies["javax.servlet:servlet-api:2.5"].hasConf("compileOnly->default")
         }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyWarProjectPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyWarProjectPublishIntegrationTest.groovy
@@ -35,7 +35,7 @@ repositories {
 }
 
 dependencies {
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "commons-collections:commons-collections:3.2.2"
     runtime "commons-io:commons-io:1.4"
 }
 

--- a/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyRemoteLegacyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyRemoteLegacyPublishIntegrationTest.groovy
@@ -49,7 +49,7 @@ version = '2'
 group = 'org.gradle'
 
 dependencies {
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "commons-collections:commons-collections:3.2.2"
     runtime "commons-io:commons-io:1.4"
 }
 
@@ -83,7 +83,7 @@ uploadArchives {
 
         with (module.parsedIvy) {
             dependencies.size() == 2
-            dependencies["commons-collections:commons-collections:3.2.1"].hasConf("compile->default")
+            dependencies["commons-collections:commons-collections:3.2.2"].hasConf("compile->default")
             dependencies["commons-io:commons-io:1.4"].hasConf("runtime->default")
         }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishEarIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishEarIntegTest.groovy
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "commons-collections:commons-collections:3.2.2"
     runtime "commons-io:commons-io:1.4"
 }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -40,10 +40,10 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         mavenModule.assertPublishedAsJavaModule()
 
         mavenModule.parsedPom.scopes.keySet() == ["runtime"] as Set
-        mavenModule.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:3.2.1", "commons-io:commons-io:1.4")
+        mavenModule.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:3.2.2", "commons-io:commons-io:1.4")
 
         and:
-        resolveArtifacts(mavenModule) == ["commons-collections-3.2.1.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(mavenModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
     }
 
     def "can publish attached artifacts to maven repository"() {
@@ -72,8 +72,8 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         mavenModule.assertArtifactsPublished("publishTest-1.9.jar", "publishTest-1.9.pom", "publishTest-1.9-source.jar")
 
         and:
-        resolveArtifacts(mavenModule) == ["commons-collections-3.2.1.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
-        resolveArtifacts(mavenModule, [classifier: 'source']) == ["commons-collections-3.2.1.jar", "commons-io-1.4.jar", "publishTest-1.9-source.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(mavenModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(mavenModule, [classifier: 'source']) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9-source.jar", "publishTest-1.9.jar"]
     }
 
     def createBuildScripts(def append) {
@@ -99,7 +99,7 @@ $append
             }
 
             dependencies {
-                compile "commons-collections:commons-collections:3.2.1"
+                compile "commons-collections:commons-collections:3.2.2"
                 compileOnly "javax.servlet:servlet-api:2.5"
                 runtime "commons-io:commons-io:1.4"
                 testCompile "junit:junit:4.12"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -212,7 +212,7 @@ project(":project1") {
     version = "1.0"
 
     dependencies {
-        compile "commons-collections:commons-collections:3.2.1"
+        compile "commons-collections:commons-collections:3.2.2"
         compile "commons-io:commons-io:1.4"
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishWarProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishWarProjectIntegTest.groovy
@@ -37,7 +37,7 @@ class MavenPublishWarProjectIntegTest extends AbstractMavenPublishIntegTest {
             }
 
             dependencies {
-                compile "commons-collections:commons-collections:3.2.1"
+                compile "commons-collections:commons-collections:3.2.2"
                 runtime "commons-io:commons-io:1.4"
                 testRuntime "junit:junit:4.12"
             }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
@@ -80,7 +80,7 @@ public class SamplesMavenPublishIntegrationTest extends AbstractIntegrationSpec 
         module.assertPublished()
         module.assertArtifactsPublished("javaProject-1.0.jar", "javaProject-1.0-sources.jar", "javaProject-1.0.pom")
         module.parsedPom.packaging == null
-        module.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:3.0")
+        module.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:3.2.2")
     }
 
     def pomCustomization() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenEarProjectPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenEarProjectPublishIntegrationTest.groovy
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "commons-collections:commons-collections:3.2.2"
     runtime "commons-io:commons-io:1.4"
 }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenJavaProjectPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenJavaProjectPublishIntegrationTest.groovy
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "commons-collections:commons-collections:3.2.2"
     runtime "commons-io:commons-io:1.4"
 }
 
@@ -57,7 +57,7 @@ uploadArchives {
         then:
         def mavenModule = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
         mavenModule.assertArtifactsPublished("publishTest-1.9.pom", "publishTest-1.9.jar")
-        mavenModule.parsedPom.scopes.compile.assertDependsOn("commons-collections:commons-collections:3.2.1")
+        mavenModule.parsedPom.scopes.compile.assertDependsOn("commons-collections:commons-collections:3.2.2")
         mavenModule.parsedPom.scopes.runtime.assertDependsOn("commons-io:commons-io:1.4")
     }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
@@ -45,8 +45,8 @@ version = '1.0'
 repositories { mavenCentral() }
 configurations { custom }
 dependencies {
-    custom 'commons-collections:commons-collections:3.2'
-    runtime 'commons-collections:commons-collections:3.2'
+    custom 'commons-collections:commons-collections:3.2.2'
+    runtime 'commons-collections:commons-collections:3.2.2'
 }
 uploadArchives {
     repositories {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenWarProjectPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenWarProjectPublishIntegrationTest.groovy
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "commons-collections:commons-collections:3.2.2"
     runtime "commons-io:commons-io:1.4"
 }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaLibraryDistributionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaLibraryDistributionIntegrationTest.groovy
@@ -44,7 +44,7 @@ class JavaLibraryDistributionIntegrationTest extends WellBehavedPluginTest {
             mavenCentral()
         }
         dependencies {
-            compile 'commons-collections:commons-collections:3.1'
+            compile 'commons-collections:commons-collections:3.2.2'
             runtime 'commons-lang:commons-lang:2.6'
         }
         """
@@ -56,7 +56,7 @@ class JavaLibraryDistributionIntegrationTest extends WellBehavedPluginTest {
         def expandDir = file('expanded')
         file('build/distributions/DefaultJavaDistribution.zip').unzipTo(expandDir)
         expandDir.assertHasDescendants(
-                'DefaultJavaDistribution/lib/commons-collections-3.1.jar',
+                'DefaultJavaDistribution/lib/commons-collections-3.2.2.jar',
                 'DefaultJavaDistribution/lib/commons-lang-2.6.jar',
                 'DefaultJavaDistribution/DefaultJavaDistribution.jar')
         expandDir.file('DefaultJavaDistribution/DefaultJavaDistribution.jar').assertIsCopyOf(file('build/libs/DefaultJavaDistribution.jar'))


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/