### PR TITLE
Fix failing test on OpenJDK

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/PathLimitationIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/PathLimitationIntegTest.groovy
@@ -103,7 +103,7 @@ class PathLimitationIntegTest extends Specification {
         process.waitFor() == 0
         process.exitValue() == 0
         and:
-        process.errorStream.text.contains("java version")
+        process.errorStream.text.contains("version")
 
         where:
         absolutePathLength << [258, 259, 260]


### PR DESCRIPTION
Relaxed too restrictive assertion. Without that one of `PathLimitationIntegTest` tests was failing when OpenJDK was used.

```
Condition not satisfied:

process.errorStream.text.contains("java version")
|       |           |    |
|       |           |    false
|       |           openjdk version "1.8.0_72"
|       |           OpenJDK Runtime Environment (build 1.8.0_72-b16)
|       |           OpenJDK 64-Bit Server VM (build 25.72-b16, mixed mode)
|       java.lang.UNIXProcess$ProcessPipeInputStream@17499f72
java.lang.UNIXProcess@704ed4e5

	at org.gradle.process.internal.PathLimitationIntegTest.JavaProcessBuilder handles workingDir with absolute path length #absolutePathLength(PathLimitationIntegTest.groovy:106)
```
