### PR TITLE
GRADLE-1843 Crash on dangling symlink: "Could not list contents of X"

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -116,10 +116,10 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
         AtomicBoolean stopFlag = new AtomicBoolean();
         Spec<FileTreeElement> spec = patternSet.getAsSpec();
         if (dir.exists()) {
-            if (dir.isFile()) {
-                processSingleFile(dir, visitor, spec, stopFlag);
-            } else {
+            if (dir.isDirectory()) {
                 walkDir(dir, path, visitor, spec, stopFlag);
+            } else {
+                processSingleFile(dir, visitor, spec, stopFlag);
             }
         } else {
             LOGGER.info("file or directory '" + dir + "', not found");


### PR DESCRIPTION
for me it fixed the problem of symlinks to folders and crashes, because !isFile() does not guarantee to be a folder....