### PR TITLE
GRADLE-2475 Copy sysprop args to StartParameter for buildSrc build

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/StartParameter.java
+++ b/subprojects/core/src/main/groovy/org/gradle/StartParameter.java
@@ -166,6 +166,7 @@ public class StartParameter extends LoggingConfiguration implements Serializable
         p.parallelProjectExecution = parallelProjectExecution;
         p.configureOnDemand = configureOnDemand;
         p.maxWorkerCount = maxWorkerCount;
+        p.systemPropertiesArgs = new HashMap<String, String>(systemPropertiesArgs);
         return p;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -259,6 +259,7 @@ class StartParameterTest extends Specification {
         parameter.logLevel = LogLevel.DEBUG
         parameter.colorOutput = false
         parameter.configureOnDemand = true
+        parameter.systemPropertiesArgs.put("testprop", "foo")
 
         // Non-copied
         parameter.currentDir = new File("other")
@@ -288,6 +289,7 @@ class StartParameterTest extends Specification {
         newParameter.refreshDependencies == parameter.refreshDependencies
         newParameter.rerunTasks == parameter.rerunTasks
         newParameter.recompileScripts == parameter.recompileScripts
+        newParameter.systemPropertiesArgs == parameter.systemPropertiesArgs
 
         newParameter.buildFile == null
         newParameter.taskRequests.empty


### PR DESCRIPTION
Java system properties specified through JAVA_OPTS or GRADLE_OPTS
currently are visible within buildSrc builds. However, passing sysprops
on the command line does not work. This was because the StartParameter that
is cloned for buildSrc did not copy the sysprop args, which is fixed by
this change.