### PR TITLE
Issue GRADLE-3349 (GroovyDoc task does not mark all properties that affect the output of the task as inputs)

### DIFF
--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
@@ -110,6 +110,6 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
         overviewSummary.text.contains("Goodbye World")
 
         where:
-        module << ['groovy', 'groovy']
+        module << ['groovy']
     }
 }

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Unroll
 @TargetCoverage({GroovydocCoverage.ALL_COVERAGE})
 class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
 
-    @Issue("https://issues.gradle.org//browse/GRADLE-3116")
+    @Issue("https://issues.gradle.org/browse/GRADLE-3116")
     def "can run groovydoc"() {
         when:
         buildFile << """
@@ -61,7 +61,7 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
         module << ['groovy']
     }
 
-    @Issue("https://issues.gradle.org//browse/GRADLE-3349")
+    @Issue("https://issues.gradle.org/browse/GRADLE-3349")
     @Unroll
     def "changes to overview causes groovydoc to be out of date when overview is set via #overviewSetting"() {
         File overviewFile = file("overview.html")

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.GroovydocCoverage
 import spock.lang.Issue
-import spock.lang.Unroll
 
 @TargetCoverage({GroovydocCoverage.ALL_COVERAGE})
 class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
@@ -62,8 +61,7 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3349")
-    @Unroll
-    def "changes to overview causes groovydoc to be out of date when overview is set via #overviewSetting"() {
+    def "changes to overview causes groovydoc to be out of date"() {
         File overviewFile = file("overview.html")
         String escapedOverviewPath = StringEscapeUtils.escapeJava(overviewFile.absolutePath)
 
@@ -80,7 +78,7 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
             }
 
             groovydoc {
-                ${overviewSetting}("${escapedOverviewPath}")
+                overviewText = resources.text.fromFile("${escapedOverviewPath}")
             }
         """
 
@@ -113,6 +111,5 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
 
         where:
         module << ['groovy', 'groovy']
-        overviewSetting << ["overviewText = resources.text.fromFile", "overview"]
     }
 }

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
@@ -16,12 +16,12 @@
 
 package org.gradle.groovy
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringEscapeUtils
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.GroovydocCoverage
 import spock.lang.Issue
-import spock.lang.Unroll;
+import spock.lang.Unroll
 
 @TargetCoverage({GroovydocCoverage.ALL_COVERAGE})
 class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/AntGroovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/AntGroovydoc.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.resources.TextResource;
 import org.gradle.util.VersionNumber;
 
 import java.io.File;
@@ -53,7 +54,9 @@ public class AntGroovydoc {
         this.ant = ant;
     }
 
-    public void execute(final FileCollection source, File destDir, boolean use, boolean noTimestamp, boolean noVersionStamp, String windowTitle, String docTitle, String header, String footer, String overview, boolean includePrivate, final Set<Groovydoc.Link> links, final Iterable<File> groovyClasspath, Iterable<File> classpath, Project project) {
+    public void execute(final FileCollection source, File destDir, boolean use, boolean noTimestamp, boolean noVersionStamp,
+            String windowTitle, String docTitle, String header, String footer, TextResource overview, boolean includePrivate,
+            final Set<Groovydoc.Link> links, final Iterable<File> groovyClasspath, Iterable<File> classpath, Project project) {
 
         final File tmpDir = new File(project.getBuildDir(), "tmp/groovydoc");
         FileOperations fileOperations = (ProjectInternal) project;
@@ -84,7 +87,10 @@ public class AntGroovydoc {
         putIfNotNull(args, "doctitle", docTitle);
         putIfNotNull(args, "header", header);
         putIfNotNull(args, "footer", footer);
-        putIfNotNull(args, "overview", overview);
+
+        if (overview != null) {
+            args.put("overview", overview.asFile().getAbsolutePath());
+        }
 
         invokeGroovydoc(links, combinedClasspath, args);
     }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -77,8 +77,9 @@ public class Groovydoc extends SourceTask {
     @TaskAction
     protected void generate() {
         checkGroovyClasspathNonEmpty(getGroovyClasspath().getFiles());
-        getAntGroovydoc().execute(getSource(), getDestinationDir(), isUse(), isNoTimestamp(), isNoVersionStamp(), getWindowTitle(), getDocTitle(), getHeader(),
-                getFooter(), getOverview(), isIncludePrivate(), getLinks(), getGroovyClasspath(), getClasspath(), getProject());
+        getAntGroovydoc().execute(getSource(), getDestinationDir(), isUse(), isNoTimestamp(), isNoVersionStamp(), getWindowTitle(),
+                getDocTitle(), getHeader(), getFooter(), getOverviewText(), isIncludePrivate(), getLinks(), getGroovyClasspath(),
+                getClasspath(), getProject());
     }
 
     private void checkGroovyClasspathNonEmpty(Collection<File> classpath) {
@@ -275,7 +276,7 @@ public class Groovydoc extends SourceTask {
      */
     @Deprecated
     public String getOverview() {
-        SingleMessageLogger.nagUserOfDeprecated("getOverview()", "Please use getOverviewText() instead");
+        reportOverviewDeprecation();
 
         if (overview == null) {
             return null;
@@ -291,7 +292,7 @@ public class Groovydoc extends SourceTask {
      */
     @Deprecated
     public void setOverview(String overview) {
-        SingleMessageLogger.nagUserOfDeprecated("setOverview()", "Please use setOverviewText(TextResource) instead");
+        reportOverviewDeprecation();
 
         this.overview = getProject().getResources().getText().fromFile(overview);
     }
@@ -353,6 +354,10 @@ public class Groovydoc extends SourceTask {
      */
     public void link(String url, String... packages) {
         links.add(new Link(url, packages));
+    }
+
+    private static final void reportOverviewDeprecation() {
+        SingleMessageLogger.nagUserOfDeprecated("The overview property", "Please use the overviewText property instead");
     }
 
     /**

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -269,6 +269,8 @@ public class Groovydoc extends SourceTask {
     /**
      * Returns a HTML file to be used for overview documentation. Set to {@code null} when there is no overview file.
      */
+    @InputFile
+    @Optional
     public String getOverview() {
         return overview;
     }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -32,6 +32,7 @@ import java.util.*;
 // Be careful running “Optimize Imports” as it will wipe this out.
 // If there's no import below this comment, this has happened.
 import org.gradle.api.tasks.Optional;
+import org.gradle.util.SingleMessageLogger;
 
 /**
  * <p>Generates HTML API documentation for Groovy source, and optionally, Java source.
@@ -274,6 +275,8 @@ public class Groovydoc extends SourceTask {
      */
     @Deprecated
     public String getOverview() {
+        SingleMessageLogger.nagUserOfDeprecated("getOverview()", "Please use getOverviewText() instead");
+
         if (overview == null) {
             return null;
         } else {
@@ -288,6 +291,8 @@ public class Groovydoc extends SourceTask {
      */
     @Deprecated
     public void setOverview(String overview) {
+        SingleMessageLogger.nagUserOfDeprecated("setOverview()", "Please use setOverviewText(TextResource) instead");
+
         this.overview = getProject().getResources().getText().fromFile(overview);
     }
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.logging.LogLevel;
+import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.*;
 
 import java.io.File;
@@ -62,7 +63,7 @@ public class Groovydoc extends SourceTask {
 
     private String footer;
 
-    private String overview;
+    private TextResource overview;
 
     private Set<Link> links = new HashSet<Link>();
 
@@ -268,18 +269,42 @@ public class Groovydoc extends SourceTask {
 
     /**
      * Returns a HTML file to be used for overview documentation. Set to {@code null} when there is no overview file.
+     *
+     * @deprecated please use {@link #getOverviewText()} instead
      */
-    @InputFile
-    @Optional
+    @Deprecated
     public String getOverview() {
-        return overview;
+        if (overview == null) {
+            return null;
+        } else {
+            return overview.asFile().getAbsolutePath();
+        }
     }
 
     /**
      * Sets a HTML file to be used for overview documentation (optional).
+     *
+     * @deprecated please use {@link #setOverviewText(TextResource)} instead
      */
+    @Deprecated
     public void setOverview(String overview) {
-        this.overview = overview;
+        this.overview = getProject().getResources().getText().fromFile(overview);
+    }
+
+    /**
+     * Returns a HTML text to be used for overview documentation. Set to {@code null} when there is no overview text.
+     */
+    @Nested
+    @Optional
+    public TextResource getOverviewText() {
+        return overview;
+    }
+
+    /**
+     * Sets a HTML text to be used for overview documentation (optional).
+     */
+    public void setOverviewText(TextResource overviewText) {
+        this.overview = overviewText;
     }
 
     /**


### PR DESCRIPTION
The overview property of the Groovydoc class has been annotated as InputFile and Optional