### PR TITLE
Fix non-ascii filename gets too long.

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/FileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/FileUtils.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
 
@@ -25,23 +26,41 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 public class FileUtils {
     public static final int WINDOWS_PATH_LIMIT = 260;
 
     /**
-     * Converts a string into a string that is safe to use as a file name. The result will only include ascii characters and numbers, and the "-","_", #, $ and "." characters.
+     * Followings are reserved characters by windows:
+     * <ul>
+     * <li>&lt; (less than)</li>
+     * <li>&gt; (greater than)</li>
+     * <li>: (colon)</li>
+     * <li>" (double quote)</li>
+     * <li>/ (forward slash)</li>
+     * <li>\ (backslash)</li>
+     * <li>| (vertical bar or pipe)</li>
+     * <li>? (question mark)</li>
+     * <li>* (asterisk)</li>
+     * </ul>
+     * <p>
+     * ¥ (yen sign) is escaped for security reasons:
+     * <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd374047(v=vs.85).aspx#SC_char_sets_in_file_names">Security Considerations for Character Sets in File Names</a>
+     * <p>
+     * # (number sign) is actually valid, and it is added to escape illegal characters.
+     */
+    private static final Set<Character> ILLEGAL_CHARS = ImmutableSet.of('\\', '/', ':', '*', '?', '"', '<', '>', '|', '\0', '¥', '#');
+
+    /**
+     * Converts a string into a string that is safe to use as a file name.
      */
     public static String toSafeFileName(String name) {
         int size = name.length();
-        StringBuffer rc = new StringBuffer(size * 2);
+        StringBuilder rc = new StringBuilder(size * 2);
         for (int i = 0; i < size; i++) {
             char c = name.charAt(i);
-            boolean valid = c >= 'a' && c <= 'z';
-            valid = valid || (c >= 'A' && c <= 'Z');
-            valid = valid || (c >= '0' && c <= '9');
-            valid = valid || (c == '_') || (c == '-') || (c == '.') || (c == '$');
-            if (valid) {
+            if (!ILLEGAL_CHARS.contains(c)) {
                 rc.append(c);
             } else {
                 // Encode the character using hex notation

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/FileUtilsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/FileUtilsTest.groovy
@@ -30,13 +30,17 @@ class FileUtilsTest extends Specification {
         expect:
         toSafeFileName(input) == output
         where:
-        input         | output
-        'Test_$1-2.3' | 'Test_$1-2.3'
-        'with space'  | 'with#20space'
-        'with #'      | 'with#20#23'
-        'with /'      | 'with#20#2f'
-        'with \\'     | 'with#20#5c'
-        'with / \\ #' | 'with#20#2f#20#5c#20#23'
+        input               | output
+        'Test_$1-2.3'       | 'Test_$1-2.3'
+        'with space'        | 'with space'
+        'with #'            | 'with #23'
+        'with /'            | 'with #2f'
+        'with \\'           | 'with #5c'
+        'with / \\ #'       | 'with #2f #5c #23'
+        'with : * ? \"'     | 'with #3a #2a #3f #22'
+        'with < > | \0'     | 'with #3c #3e #7c #0'
+        'with \u65e5\u672c' | 'with \u65e5\u672c'
+        'with yen sign ¥'   | 'with yen sign #a5'
     }
 
     def "assertInWindowsPathLengthLimitation throws exception when path limit exceeded"() {


### PR DESCRIPTION
This PR fixes a problem that non-ascii class name causes test result xml file name becomes too long that filesystem cant handle it.
https://discuss.gradle.org/t/filenotfoundexception-is-thrown-when-i-use-japanese-letters-in-java-class-name/14743/2

- Instead of escaping non-ascii characters, escape non allowed characters.
- Referred:
  - https://msdn.microsoft.com/en-us/library/aa365247
  - https://developer.apple.com/library/mac/qa/qa1392/_index.html
  - https://github.com/apache/maven-surefire/blob/surefire-2.19.1/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/FileReporterUtils.java
