### PR TITLE
Gradle 2.5 and above ignoring excluded dependencies in genereated ivy.xml 

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/MutableModuleDescriptorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/MutableModuleDescriptorState.java
@@ -23,6 +23,7 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.IvyArtifactName;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -87,7 +88,13 @@ public class MutableModuleDescriptorState extends ModuleDescriptorState {
         for (IvyArtifactName artifactName : dependencyMetadata.getArtifacts()) {
             dependency.addArtifact(artifactName, configurations);
         }
-
+        //GRADLE-3440
+        List<Exclude> excludeRules = dependencyMetadata.getExcludes(Arrays.asList(dependencyMetadata.getModuleConfigurations()));
+        if(excludeRules != null) {
+            for (Exclude rule : excludeRules) {
+                dependency.addExcludeRule(rule);
+            }
+        }
         dependencies.add(dependency);
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
@@ -66,15 +66,17 @@ class IvyDescriptor {
 
 
         ivy.dependencies.dependency.each { dep ->
+			
             def ivyDependency = new IvyDescriptorDependency(
                     org: dep.@org,
                     module: dep.@name,
                     revision: dep.@rev,
-                    conf: dep.@conf
+                    conf: dep.@conf,
+                    transitive: dep.@transitive
             )
 
             dep.exclude.each { exclude ->
-                ivyDependency.exclusions << new IvyDescriptorDependencyExclusion(org: exclude.@org, module: exclude.@module)
+                ivyDependency.exclusions << new IvyDescriptorDependencyExclusion(org: exclude.@org, module: exclude.@module, name: exclude.@name, type: exclude.@type, ext: exclude.@ext,  conf: exclude.@conf, matcher: exclude.@matcher)
             }
 
             def key = "${ivyDependency.org}:${ivyDependency.module}:${ivyDependency.revision}"

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependency.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependency.groovy
@@ -21,10 +21,28 @@ class IvyDescriptorDependency {
     String module
     String revision
     String conf
+    String transitive
     Collection<IvyDescriptorDependencyExclusion> exclusions = []
 
     IvyDescriptorDependency hasConf(def conf) {
         assert this.conf == conf
         return this
+    }
+    boolean transitiveEnabled() { 
+        return this.transitive != 'false'
+    }
+    boolean hasExcludes() {
+        this.exclusions && !this.exclusions.isEmpty()
+    }
+    //For Legacy ivy publish via uploadAr
+    boolean hasExclude(String org, String module, String name, String type, String ext, String conf, String matcher){
+        if(hasExcludes()) {
+            for(IvyDescriptorDependencyExclusion exclude : this.exclusions) {
+                if (exclude.org == org && exclude.module == module && exclude.name == name && exclude.type == type &&  exclude.ext == ext && exclude.conf == conf && exclude.matcher == matcher) {
+                    return true;
+                }
+           }
+        }
+        return false;
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependencyExclusion.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependencyExclusion.groovy
@@ -19,4 +19,9 @@ package org.gradle.test.fixtures.ivy
 class IvyDescriptorDependencyExclusion {
     String org
     String module
+    String name
+    String type
+    String ext
+    String conf
+    String matcher 
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenScope.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenScope.groovy
@@ -36,7 +36,16 @@ class MavenScope {
             assert dependency.hasType(type)
         }
     }
-
+    boolean hasDependencyExclusion(String dependency, String excludeGrpId, String excludeArtifactId){
+        def dep = expectDependency(dependency)
+        for(MavenDependencyExclusion exclusion : dep.exclusions) {
+			assert exclusion.artifactId.equals(excludeArtifactId) && exclusion.groupId.equals(excludeGrpId)
+            if(exclusion.artifactId.equals(excludeArtifactId) && exclusion.groupId.equals(excludeGrpId)) {
+                return true
+            }
+        }
+        return false
+    }
     MavenDependency expectDependency(String key) {
         final dependency = dependencies[key]
         if (dependency == null) {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -24,7 +24,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         given:
         createBuildScripts("""
             publishing {
-                publications {
+                publications {  
                     ivy(IvyPublication) {
                         from components.java
                     }
@@ -123,6 +123,15 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 compile 'org.springframework:spring-core:2.5.6', {
                     exclude group: 'commons-logging', module: 'commons-logging'
                 }
+                compile ("commons-beanutils:commons-beanutils:1.8.3") {
+                    exclude group : 'commons-logging'
+                }
+                compile ("commons-dbcp:commons-dbcp:1.4") {
+                    transitive = false
+                }
+                compile ("org.apache.camel:camel-jackson:2.15.3") {
+                    exclude module : 'camel-core'
+                }
             }
 
             publishing {
@@ -145,8 +154,30 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         dependency.exclusions[0].org == 'commons-logging'
         dependency.exclusions[0].module == 'commons-logging'
 
+        ivyModule.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].hasConf("runtime->default")
+        ivyModule.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].exclusions[0].org == 'commons-logging'
+
+        //TODO: Ivy-publish not supports this?
+        //assert !ivyModule.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].transitiveEnabled()
+
+        ivyModule.parsedIvy.dependencies["org.apache.camel:camel-jackson:2.15.3"].hasConf("runtime->default")
+        ivyModule.parsedIvy.dependencies["org.apache.camel:camel-jackson:2.15.3"].exclusions[0].module == 'camel-core'
+
         and:
-        resolveArtifacts(ivyModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar", "spring-core-2.5.6.jar"]
+        resolveArtifacts(ivyModule) == [
+            "camel-jackson-2.15.3.jar",
+            "commons-beanutils-1.8.3.jar",
+            "commons-collections-3.2.2.jar",
+            "commons-dbcp-1.4.jar",
+            "commons-io-1.4.jar",
+            "commons-pool-1.5.4.jar",
+            "jackson-annotations-2.4.0.jar",
+            "jackson-core-2.4.3.jar",
+            "jackson-databind-2.4.3.jar",
+            "jackson-module-jaxb-annotations-2.4.3.jar",
+            "publishTest-1.9.jar",
+            "spring-core-2.5.6.jar"
+        ]
     }
 
     def createBuildScripts(def append) {
@@ -178,6 +209,5 @@ $append
                 testCompile "junit:junit:4.12"
             }
 """
-
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -40,10 +40,14 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         mavenModule.assertPublishedAsJavaModule()
 
         mavenModule.parsedPom.scopes.keySet() == ["runtime"] as Set
-        mavenModule.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:3.2.2", "commons-io:commons-io:1.4")
-
+        mavenModule.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:3.2.2", "commons-io:commons-io:1.4", "org.springframework:spring-core:2.5.6","commons-beanutils:commons-beanutils:1.8.3", "commons-dbcp:commons-dbcp:1.4","org.apache.camel:camel-jackson:2.15.3")
+        assert mavenModule.parsedPom.scopes.runtime.hasDependencyExclusion("org.springframework:spring-core:2.5.6","commons-logging", "commons-logging")		
+        assert mavenModule.parsedPom.scopes.runtime.hasDependencyExclusion("commons-beanutils:commons-beanutils:1.8.3","commons-logging", "*")
+        assert mavenModule.parsedPom.scopes.runtime.hasDependencyExclusion("commons-dbcp:commons-dbcp:1.4","*", "*")
+        assert mavenModule.parsedPom.scopes.runtime.hasDependencyExclusion("org.apache.camel:camel-jackson:2.15.3","*", "camel-core")
+		
         and:
-        resolveArtifacts(mavenModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(mavenModule) == ["camel-jackson-2.15.3.jar", "commons-beanutils-1.8.3.jar", "commons-collections-3.2.2.jar", "commons-dbcp-1.4.jar", "commons-io-1.4.jar", "jackson-annotations-2.4.0.jar", "jackson-core-2.4.3.jar", "jackson-databind-2.4.3.jar", "jackson-module-jaxb-annotations-2.4.3.jar", "publishTest-1.9.jar", "spring-core-2.5.6.jar"]
     }
 
     def "can publish attached artifacts to maven repository"() {
@@ -72,8 +76,8 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         mavenModule.assertArtifactsPublished("publishTest-1.9.jar", "publishTest-1.9.pom", "publishTest-1.9-source.jar")
 
         and:
-        resolveArtifacts(mavenModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
-        resolveArtifacts(mavenModule, [classifier: 'source']) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9-source.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(mavenModule) == ["camel-jackson-2.15.3.jar", "commons-beanutils-1.8.3.jar", "commons-collections-3.2.2.jar", "commons-dbcp-1.4.jar", "commons-io-1.4.jar", "jackson-annotations-2.4.0.jar", "jackson-core-2.4.3.jar", "jackson-databind-2.4.3.jar", "jackson-module-jaxb-annotations-2.4.3.jar", "publishTest-1.9.jar", "spring-core-2.5.6.jar"]
+        resolveArtifacts(mavenModule, [classifier: 'source']) == ["camel-jackson-2.15.3.jar", "commons-beanutils-1.8.3.jar", "commons-collections-3.2.2.jar", "commons-dbcp-1.4.jar", "commons-io-1.4.jar", "jackson-annotations-2.4.0.jar", "jackson-core-2.4.3.jar", "jackson-databind-2.4.3.jar", "jackson-module-jaxb-annotations-2.4.3.jar", "publishTest-1.9-source.jar", "publishTest-1.9.jar", "spring-core-2.5.6.jar"]
     }
 
     def createBuildScripts(def append) {
@@ -103,6 +107,19 @@ $append
                 compileOnly "javax.servlet:servlet-api:2.5"
                 runtime "commons-io:commons-io:1.4"
                 testCompile "junit:junit:4.12"
+                //GRADLE-3440: Adding some exclusions for additional test coverage.
+                compile ("org.springframework:spring-core:2.5.6") {
+                    exclude group: 'commons-logging', module: 'commons-logging'
+                }
+                compile ("commons-beanutils:commons-beanutils:1.8.3") {
+                   exclude group : 'commons-logging'
+                }
+                compile ("commons-dbcp:commons-dbcp:1.4") {
+                   transitive = false
+                }
+                compile ("org.apache.camel:camel-jackson:2.15.3") {
+                   exclude module : 'camel-core'
+                }
             }
 """
 


### PR DESCRIPTION
I tried this fix locally for our projects and looks works good for the issue reported @ https://discuss.gradle.org/t/gradle-2-5-and-above-ignoring-excluded-dependencies-in-genereated-ivy-xml/15038

Can you please review and merge if this looks reasonable fix?
