### PR TITLE
Added the ability to turn off gradle testng listener

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/JdkVersionsContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/JdkVersionsContinuousIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.launcher.continuous
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.jvm.JavaInfo
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.Requires
@@ -36,10 +35,7 @@ class JdkVersionsContinuousIntegrationTest extends AbstractContinuousIntegration
         failureDescriptionContains("Continuous build requires Java 7 or later.")
     }
 
-    @Requires(adhoc = { JdkVersionsContinuousIntegrationTest.java6()  &&
-            // This test doesn't work on Java 1.6 CI commit builds as these builds rebuild the distribution using Java 6 rather than reuse
-            // the distribution that is shared by the coverage builds. The following approximates "don't run this test on the Java 1.6 CI commit builds"
-            (JavaVersion.current().java7Compatible || !GradleContextualExecuter.embedded) })
+    @Requires(adhoc = { JdkVersionsContinuousIntegrationTest.java6() && JavaVersion.current().java7Compatible })
     def "can use java6 client with later build runtime"() {
         given:
         executer

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactory.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactory.java
@@ -61,7 +61,12 @@ class TestNGListenerAdapterFactory {
                 if (!realReturnType.equals(void.class) && realReturnType.isPrimitive()) {
                     boxedReturnType = JavaReflectionUtil.getWrapperTypeForPrimitiveType(realReturnType);
                 }
-
+                if (method.getName().equals("equals") && args.length == 1){
+                    return proxyEquals(proxy, args[0]);
+                }
+                if (method.getName().equals("hashCode")){
+                    return proxyHashCode(proxy);
+                }
                 return invoke(listener.getClass(), listener, boxedReturnType, method, args);
             }
 
@@ -69,6 +74,29 @@ class TestNGListenerAdapterFactory {
                 T listenerCast = listenerType.cast(listener);
                 JavaMethod<T, R> javaMethod = JavaReflectionUtil.method(listenerType, returnType, method.getName(), method.getParameterTypes());
                 return javaMethod.invoke(listenerCast, args);
+            }
+
+            @Override
+            public boolean equals(Object obj1) {
+                return proxyEquals(this, obj1);
+            }
+
+            @Override
+            public int hashCode() {
+                return proxyHashCode(this);
+            }
+
+            protected Integer proxyHashCode(Object proxy) {
+                return new Integer(System.identityHashCode(proxy));
+            }
+
+            protected Boolean proxyEquals(Object proxy, Object other) {
+                if(other == null)
+                    return Boolean.FALSE;
+                String className1 = Proxy.getInvocationHandler(proxy).getClass().toString();
+                String className2 = Proxy.isProxyClass(other.getClass())?Proxy.getInvocationHandler(other).getClass().toString():other.getClass().toString();
+                return className1.equalsIgnoreCase(className2) ? Boolean.TRUE : Boolean.FALSE;
+
             }
         });
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
@@ -34,6 +34,7 @@ public class TestNGSpec implements Serializable {
     private final boolean javadocAnnotations;
     private final List testResources;
     private final boolean useDefaultListener;
+    private final boolean testReportEnabled;
     private final Set<String> includeGroups;
     private final Set<String> excludeGroups;
     private final Set<String> listeners;
@@ -58,6 +59,7 @@ public class TestNGSpec implements Serializable {
         this.configFailurePolicy = options.getConfigFailurePolicy();
         this.preserveOrder = options.getPreserveOrder();
         this.groupByInstances = options.getGroupByInstances();
+        this.testReportEnabled = options.getTestReportEnabled();
     }
 
     public Set<String> getListeners() {
@@ -74,6 +76,10 @@ public class TestNGSpec implements Serializable {
 
     public boolean getUseDefaultListeners() {
         return useDefaultListener;
+    }
+
+    public boolean getTestReportEnabled() {
+        return testReportEnabled;
     }
 
     public List getTestResources() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -129,7 +129,8 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         } else {
             testNg.setTestClasses(testClasses.toArray(new Class[0]));
         }
-        testNg.addListener((Object) adaptListener(new TestNGTestResultProcessorAdapter(resultProcessor, idGenerator, timeProvider)));
+        if (options.getTestReportEnabled())
+            testNg.addListener((Object) adaptListener(new TestNGTestResultProcessorAdapter(resultProcessor, idGenerator, timeProvider)));
         testNg.run();
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -61,6 +61,8 @@ public class TestNGOptions extends TestFrameworkOptions {
 
     private boolean useDefaultListeners;
 
+    private boolean testReportEnabled = true;
+
     private String suiteName = "Gradle suite";
 
     private String testName = "Gradle test";
@@ -185,6 +187,16 @@ public class TestNGOptions extends TestFrameworkOptions {
 
     public TestNGOptions useDefaultListeners(boolean useDefaultListeners) {
         this.useDefaultListeners = useDefaultListeners;
+        return this;
+    }
+
+    public TestNGOptions testReportEnabled() {
+        testReportEnabled = true;
+        return this;
+    }
+
+    public TestNGOptions testReportEnabled(boolean testReportEnabled) {
+        this.testReportEnabled = testReportEnabled;
         return this;
     }
 
@@ -354,6 +366,17 @@ public class TestNGOptions extends TestFrameworkOptions {
 
     public void setUseDefaultListeners(boolean useDefaultListeners) {
         this.useDefaultListeners = useDefaultListeners;
+    }
+
+    /**
+     * This option allows to turn off Gradle test listener. The default value is true, which means that the listener is enabled.
+     */
+    public boolean getTestReportEnabled() {
+        return testReportEnabled;
+    }
+
+    public void setTestReportEnabled(boolean testReportEnabled) {
+        this.testReportEnabled = testReportEnabled;
     }
 
     /**

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactorySpec.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactorySpec.groovy
@@ -30,6 +30,18 @@ class TestNGListenerAdapterFactorySpec extends Specification {
         factory.createAdapter(listener) instanceof IConfigurationListener2
     }
 
+    def "equals function works as expected"() {
+        when:
+        ITestListener listener1 = factory.createAdapter(listener);
+        ITestListener listener2 = factory.createAdapter(listener);
+
+        then:
+            listener1.equals(listener2)
+            !listener1.equals(listener)
+            !listener1.equals(null)
+    }
+
+
     /**
      * covered by {@link org.gradle.testing.testng.TestNGIntegrationTest}
      */


### PR DESCRIPTION
Added the ability to turn off gradle testng listener, since

a. not everyone needs its report
b. it introduces HUGE performance issues (see https://issues.gradle.org/browse/GRADLE-3189)

To turn off gradle test report user needs to set testReportEnabled = false.