### PR TITLE
Launching From Finder on Mac Fails

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -157,4 +157,9 @@ function splitJvmOpts() {
 eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
 JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
 
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [[ "$(uname)" == "Darwin" ]] && [[ "$HOME" == "$PWD" ]]; then
+  cd $(dirname $0)
+fi
+
 exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/gradlew
+++ b/gradlew
@@ -159,7 +159,7 @@ JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
 
 # by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
 if [[ "$(uname)" == "Darwin" ]] && [[ "$HOME" == "$PWD" ]]; then
-  cd $(dirname $0)
+  cd "$(dirname "$0")"
 fi
 
 exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/NonInteractiveLaunchIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/NonInteractiveLaunchIntegrationTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.util.concurrent.PollingConditions
+
+class NonInteractiveLaunchIntegrationTest extends AbstractIntegrationSpec {
+
+    private prepareWrapper() {
+        buildFile << """
+wrapper {
+    gradleVersion = '2.13'
+}
+
+task hello << {
+    file('hello.txt').createNewFile()
+}
+
+defaultTasks 'hello'
+"""
+
+        executer.withTasks('wrapper').run()
+    }
+
+    @Requires(TestPrecondition.MAC_OS_X)
+    def "can execute from Finder"() {
+        def conditions = new PollingConditions(timeout: 60, initialDelay: 10, delay: 1)
+
+        given:
+        prepareWrapper()
+        File gradlew = file("gradlew")
+
+        expect:
+        gradlew.exists()
+
+        when:
+        // use the open program since that is what Finder uses
+        // set the cwd to the testDirectory to reproduce where gradle normally is run from
+        ["/usr/bin/open", "-g", gradlew.absolutePath].execute([], testDirectory)
+
+        then:
+        // the hello task writes a file named "hello.txt" to the project dir
+        // stdout is not used for the test because the open program does not provide stdout
+        // the process is forked so we just have to wait a bit
+        conditions.eventually {
+            assert file("hello.txt").exists()
+        }
+    }
+}

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -163,7 +163,7 @@ eval splitJvmOpts \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar}
 
 # by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
 if [[ "\$(uname)" == "Darwin" ]] && [[ "\$HOME" == "\$PWD" ]]; then
-  cd \$(dirname \$0)
+  cd "\$(dirname "\$0")"
 fi
 
 exec "\$JAVACMD" "\${JVM_OPTS[@]}" -classpath "\$CLASSPATH" ${mainClassName} "\$@"

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -161,4 +161,9 @@ function splitJvmOpts() {
 eval splitJvmOpts \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar}
 <% if ( appNameSystemProperty ) { %>JVM_OPTS[\${#JVM_OPTS[*]}]="-D${appNameSystemProperty}=\$APP_BASE_NAME"<% } %>
 
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [[ "\$(uname)" == "Darwin" ]] && [[ "\$HOME" == "\$PWD" ]]; then
+  cd \$(dirname \$0)
+fi
+
 exec "\$JAVACMD" "\${JVM_OPTS[@]}" -classpath "\$CLASSPATH" ${mainClassName} "\$@"

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
@@ -46,7 +46,7 @@ class UnixStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.unixLineSeparator).length == 164
+        destination.toString().split(TextUtil.unixLineSeparator).length == 169
     }
 
     def "defaultJvmOpts is expanded properly in unix script"() {


### PR DESCRIPTION
When you launch a shell script from Finder on Mac the `cwd` is the user's home dir, not the project dir.  This detects and fixes that.

PS: I'm not sure if this is where the template for Gradle Wrapper comes from.  Let me know if it is somewhere else.