### PR TITLE
Add ability to revalidate external resource requests

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedChangingModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedChangingModulesIntegrationTest.groovy
@@ -62,9 +62,9 @@ public class CachedChangingModulesIntegrationTest extends AbstractHttpDependency
 
         when:
         server.resetExpectations()
-        module.metaData.expectGet()
-        sourceArtifact.expectHead()
-        module.pom.expectHead()
+        module.metaData.expectGetRevalidate()
+        sourceArtifact.expectHeadRevalidate()
+        module.pom.expectHeadRevalidate()
         then:
         run 'retrieve'
 
@@ -72,13 +72,13 @@ public class CachedChangingModulesIntegrationTest extends AbstractHttpDependency
         module.publishWithChangedContent()
         server.resetExpectations()
 
-        module.metaData.expectGet()
-        module.pom.sha1.expectGet()
-        module.pom.expectHead()
-        module.pom.expectGet()
-        sourceArtifact.expectHead()
-        sourceArtifact.expectGet()
-        sourceArtifact.sha1.expectGet()
+        module.metaData.expectGetRevalidate()
+        module.pom.sha1.expectGetRevalidate()
+        module.pom.expectHeadRevalidate()
+        module.pom.expectGetRevalidate()
+        sourceArtifact.expectHeadRevalidate()
+        sourceArtifact.expectGetRevalidate()
+        sourceArtifact.sha1.expectGetRevalidate()
         then:
         run 'retrieve'
 
@@ -133,8 +133,8 @@ public class CachedChangingModulesIntegrationTest extends AbstractHttpDependency
         when:
         server.resetExpectations()
         module.metaData.expectGetMissing()
-        sourceArtifact.expectHead()
-        module.pom.expectHead()
+        sourceArtifact.expectHeadRevalidate()
+        module.pom.expectHeadRevalidate()
         then:
         run 'retrieve'
 
@@ -143,12 +143,12 @@ public class CachedChangingModulesIntegrationTest extends AbstractHttpDependency
         server.resetExpectations()
 
         module.metaData.expectGetMissing()
-        module.pom.sha1.expectGet()
-        module.pom.expectHead()
-        module.pom.expectGet()
-        sourceArtifact.expectHead()
-        sourceArtifact.expectGet()
-        sourceArtifact.sha1.expectGet()
+        module.pom.sha1.expectGetRevalidate()
+        module.pom.expectHeadRevalidate()
+        module.pom.expectGetRevalidate()
+        sourceArtifact.expectHeadRevalidate()
+        sourceArtifact.expectGetRevalidate()
+        sourceArtifact.sha1.expectGetRevalidate()
         then:
         run 'retrieve'
 
@@ -200,7 +200,7 @@ public class CachedChangingModulesIntegrationTest extends AbstractHttpDependency
 
         when:
         server.resetExpectations()
-        module.ivy.expectHead()
+        module.ivy.expectHeadRevalidate()
         module.getArtifact(classifier: 'source').expectHead()
         then:
         run 'retrieve'
@@ -208,13 +208,13 @@ public class CachedChangingModulesIntegrationTest extends AbstractHttpDependency
         when:
         module.publishWithChangedContent()
         server.resetExpectations()
-        module.ivy.expectHead()
+        module.ivy.expectHeadRevalidate()
         module.getArtifact(classifier: 'source').expectHead()
 
-        module.ivy.sha1.expectGet()
-        module.ivy.expectGet()
-        module.getArtifact(classifier: 'source').expectGet()
-        module.getArtifact(classifier: 'source').sha1.expectGet()
+        module.ivy.sha1.expectGetRevalidate()
+        module.ivy.expectGetRevalidate()
+        module.getArtifact(classifier: 'source').expectGetRevalidate()
+        module.getArtifact(classifier: 'source').sha1.expectGetRevalidate()
 
         then:
         run 'retrieve'

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceArtifactResolver.java
@@ -66,7 +66,7 @@ class DefaultExternalResourceArtifactResolver implements ExternalResourceArtifac
             result.attempted(location);
             LOGGER.debug("Loading {}", location);
             try {
-                if (repository.getResourceMetaData(location.getUri()) != null) {
+                if (repository.getResourceMetaData(location.getUri(), true) != null) {
                     return true;
                 }
             } catch (Exception e) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenMetadataLoader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenMetadataLoader.java
@@ -54,7 +54,7 @@ class MavenMetadataLoader {
     }
 
     private void parseMavenMetadataInfo(final URI metadataLocation, final MavenMetadata metadata) {
-        ExternalResource resource = repository.getResource(metadataLocation);
+        ExternalResource resource = repository.getResource(metadataLocation, true);
         if (resource == null) {
             throw new MissingResourceException(metadataLocation, String.format("Maven meta-data not available: %s", metadataLocation));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceAccessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceAccessor.java
@@ -32,8 +32,8 @@ public class ProgressLoggingExternalResourceAccessor extends AbstractProgressLog
         this.delegate = delegate;
     }
 
-    public ExternalResourceReadResponse openResource(URI location) {
-        ExternalResourceReadResponse resource = delegate.openResource(location);
+    public ExternalResourceReadResponse openResource(URI location, boolean revalidate) {
+        ExternalResourceReadResponse resource = delegate.openResource(location, revalidate);
         if (resource != null) {
             return new ProgressLoggingExternalResource(location, resource);
         } else {
@@ -42,8 +42,8 @@ public class ProgressLoggingExternalResourceAccessor extends AbstractProgressLog
     }
 
     @Nullable
-    public ExternalResourceMetaData getMetaData(URI location) {
-        return delegate.getMetaData(location);
+    public ExternalResourceMetaData getMetaData(URI location, boolean revalidate) {
+        return delegate.getMetaData(location, revalidate);
     }
 
     private class ProgressLoggingExternalResource implements ExternalResourceReadResponse {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/DefaultExternalResourceRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/DefaultExternalResourceRepository.java
@@ -59,13 +59,13 @@ public class DefaultExternalResourceRepository implements ExternalResourceReposi
         return new DefaultExternalResourceRepository(name, loggingAccessor, loggingUploader, lister, loggingAccessor, loggingUploader);
     }
 
-    public ExternalResource getResource(URI source) {
-        ExternalResourceReadResponse response = accessor.openResource(source);
+    public ExternalResource getResource(URI source, boolean revalidate) {
+        ExternalResourceReadResponse response = accessor.openResource(source, revalidate);
         return response == null ? null : new DefaultExternalResource(source, response);
     }
 
-    public ExternalResourceMetaData getResourceMetaData(URI source) {
-        return accessor.getMetaData(source);
+    public ExternalResourceMetaData getResourceMetaData(URI source, boolean revalidate) {
+        return accessor.getMetaData(source, revalidate);
     }
 
     public void put(LocalResource source, URI destination) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/ExternalResourceRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/ExternalResourceRepository.java
@@ -35,11 +35,13 @@ public interface ExternalResourceRepository {
     /**
      * Attempts to fetch the given resource.
      *
+     * @param source The location of the resource to obtain
+     * @param revalidate Ensure the external resource is not stale
      * @return null if the resource is not found.
      * @throws ResourceException On failure to fetch resource.
      */
     @Nullable
-    ExternalResource getResource(URI source) throws ResourceException;
+    ExternalResource getResource(URI source, boolean revalidate) throws ResourceException;
 
     /**
      * Transfer a resource to the repository
@@ -54,11 +56,12 @@ public interface ExternalResourceRepository {
      * Fetches only the metadata for the result.
      *
      * @param source The location of the resource to obtain the metadata for
+     * @param revalidate Ensure the external resource is not stale
      * @return The resource metadata, or null if the resource does not exist
      * @throws ResourceException On failure to fetch resource metadata.
      */
     @Nullable
-    ExternalResourceMetaData getResourceMetaData(URI source) throws ResourceException;
+    ExternalResourceMetaData getResourceMetaData(URI source, boolean revalidate) throws ResourceException;
 
     /**
      * Return a listing of child resources names.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileResourceConnector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileResourceConnector.java
@@ -71,7 +71,7 @@ public class FileResourceConnector implements ExternalResourceRepository {
         }
     }
 
-    public LocallyAvailableExternalResource getResource(URI uri) {
+    public LocallyAvailableExternalResource getResource(URI uri, boolean revalidate) {
         File localFile = getFile(uri);
         if (!localFile.exists()) {
             return null;
@@ -79,8 +79,8 @@ public class FileResourceConnector implements ExternalResourceRepository {
         return new DefaultLocallyAvailableExternalResource(uri, new DefaultLocallyAvailableResource(localFile));
     }
 
-    public ExternalResourceMetaData getResourceMetaData(URI location) {
-        ExternalResource resource = getResource(location);
+    public ExternalResourceMetaData getResourceMetaData(URI location, boolean revalidate) {
+        ExternalResource resource = getResource(location, revalidate);
         return resource == null ? null : resource.getMetaData();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
@@ -55,7 +55,7 @@ public class FileTransport extends AbstractRepositoryTransport {
         }
 
         public LocallyAvailableExternalResource getResource(URI source, ResourceFileStore fileStore, @Nullable LocallyAvailableResourceCandidates localCandidates) throws IOException {
-            return connector.getResource(source);
+            return connector.getResource(source, false);
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionListerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionListerTest.groovy
@@ -57,7 +57,7 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [metaDataResource.toString()]
 
         and:
-        1 * repository.getResource(metaDataResource) >> resource
+        1 * repository.getResource(metaDataResource, true) >> resource
         1 * resource.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("""
 <metadata>
     <versioning>
@@ -92,7 +92,7 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [location1.toString(), location2.toString()]
 
         and:
-        1 * repository.getResource(location1) >> resource1
+        1 * repository.getResource(location1, true) >> resource1
         1 * resource1.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("""
 <metadata>
     <versioning>
@@ -103,7 +103,7 @@ class MavenVersionListerTest extends Specification {
     </versioning>
 </metadata>""".bytes))
         }
-        1 * repository.getResource(location2) >> resource2
+        1 * repository.getResource(location2, true) >> resource2
         1 * resource2.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("""
 <metadata>
     <versioning>
@@ -130,7 +130,7 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [metaDataResource.toString()]
 
         and:
-        1 * repository.getResource(metaDataResource) >> resource
+        1 * repository.getResource(metaDataResource, true) >> resource
         1 * resource.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("""
 <metadata>
     <versioning>
@@ -159,7 +159,7 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [metaDataResource.toString()]
 
         and:
-        1 * repository.getResource(metaDataResource) >> null
+        1 * repository.getResource(metaDataResource, true) >> null
         0 * repository._
     }
 
@@ -181,7 +181,7 @@ class MavenVersionListerTest extends Specification {
 
         and:
         1 * resource.close()
-        1 * repository.getResource(metaDataResource) >> resource;
+        1 * repository.getResource(metaDataResource, true) >> resource;
         1 * resource.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("yo".bytes)) }
         0 * repository._
     }
@@ -202,7 +202,7 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [metaDataResource.toString()]
 
         and:
-        1 * repository.getResource(metaDataResource) >> { throw failure }
+        1 * repository.getResource(metaDataResource, true) >> { throw failure }
         0 * repository._
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
@@ -62,7 +62,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
         1 * index.lookup("scheme:thing") >> null
         1 * localCandidates.isNone() >> true
         1 * repository.withProgressLogging() >> progressLoggingRepo
-        1 * progressLoggingRepo.getResource(uri) >> null
+        1 * progressLoggingRepo.getResource(uri, false) >> null
         0 * _._
     }
 
@@ -80,7 +80,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
         and:
         1 * index.lookup("scheme:thing") >> null
         1 * localCandidates.isNone() >> false
-        1 * repository.getResourceMetaData(uri) >> null
+        1 * repository.getResourceMetaData(uri, true) >> null
         0 * _._
     }
 
@@ -103,7 +103,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
         1 * index.lookup("scheme:thing") >> null
         1 * localCandidates.isNone() >> true
         1 * repository.withProgressLogging() >> progressLoggingRepo
-        1 * progressLoggingRepo.getResource(uri) >> remoteResource
+        1 * progressLoggingRepo.getResource(uri, false) >> remoteResource
         _ * remoteResource.name >> "remoteResource"
         1 * remoteResource.withContent(_) >> { ExternalResource.ContentAction a ->
             a.execute(new ByteArrayInputStream(), metaData)
@@ -167,7 +167,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
         timeProvider.currentTime >> 24000L
         cached.cachedAt >> 23999L
         cached.externalResourceMetaData >> cachedMetaData
-        1 * repository.getResourceMetaData(uri) >> remoteMetaData
+        1 * repository.getResourceMetaData(uri, true) >> remoteMetaData
         localCandidates.none >> false
         remoteMetaData.sha1 >> sha1
         remoteMetaData.etag >> null
@@ -210,14 +210,14 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
 
         and:
         1 * index.lookup("scheme:thing") >> null
-        1 * repository.getResourceMetaData(uri) >> remoteMetaData
+        1 * repository.getResourceMetaData(uri, true) >> remoteMetaData
         localCandidates.none >> false
         remoteMetaData.sha1 >> null
         remoteMetaData.etag >> null
         remoteMetaData.lastModified >> null
         cachedMetaData.etag >> null
         cachedMetaData.lastModified >> null
-        1 * repository.getResource(new URI("scheme:thing.sha1")) >> remoteSha1
+        1 * repository.getResource(new URI("scheme:thing.sha1"), true) >> remoteSha1
         1 * remoteSha1.withContent(_) >> { Transformer t ->
             t.transform(new ByteArrayInputStream(sha1.asZeroPaddedHexString(40).bytes))
         }
@@ -254,16 +254,16 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
 
         and:
         1 * index.lookup("scheme:thing") >> null
-        1 * repository.getResourceMetaData(uri) >> remoteMetaData
+        1 * repository.getResourceMetaData(uri, true) >> remoteMetaData
         localCandidates.none >> false
         remoteMetaData.sha1 >> null
         remoteMetaData.etag >> null
         remoteMetaData.lastModified >> null
         cachedMetaData.etag >> null
         cachedMetaData.lastModified >> null
-        1 * repository.getResource(new URI("scheme:thing.sha1")) >> null
+        1 * repository.getResource(new URI("scheme:thing.sha1"), true) >> null
         1 * repository.withProgressLogging() >> progressLoggingRepo
-        1 * progressLoggingRepo.getResource(uri) >> remoteResource
+        1 * progressLoggingRepo.getResource(uri, true) >> remoteResource
         1 * remoteResource.withContent(_) >> { ExternalResource.ContentAction a ->
             a.execute(new ByteArrayInputStream(), remoteMetaData)
         }
@@ -306,7 +306,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
         timeProvider.currentTime >> 24000L
         cached.cachedAt >> 23999L
         cached.externalResourceMetaData >> cachedMetaData
-        1 * repository.getResourceMetaData(uri) >> remoteMetaData
+        1 * repository.getResourceMetaData(uri, true) >> remoteMetaData
         localCandidates.none >> false
         remoteMetaData.sha1 >> sha1
         remoteMetaData.etag >> null
@@ -317,7 +317,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
         localCandidate.file >> candidate
         cached.cachedFile >> cachedFile
         1 * repository.withProgressLogging() >> progressLoggingRepo
-        1 * progressLoggingRepo.getResource(uri) >> remoteResource
+        1 * progressLoggingRepo.getResource(uri, true) >> remoteResource
         1 * remoteResource.withContent(_) >> { ExternalResource.ContentAction a ->
             a.execute(new ByteArrayInputStream(), remoteMetaData)
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceAccessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceAccessorTest.groovy
@@ -38,10 +38,10 @@ class ProgressLoggingExternalResourceAccessorTest extends Specification {
     @Unroll
     def "delegates #method to delegate resource accessor"() {
         when:
-        progressLoggerAccessor."$method"(new URI("location"))
+        progressLoggerAccessor."$method"(new URI("location"), false)
 
         then:
-        1 * accessor."$method"(new URI("location"))
+        1 * accessor."$method"(new URI("location"), false)
 
         where:
         method << ['getMetaData', 'openResource']
@@ -49,10 +49,10 @@ class ProgressLoggingExternalResourceAccessorTest extends Specification {
 
     def "getResource returns null when delegate returns null"() {
         setup:
-        accessor.openResource(new URI("location")) >> null
+        accessor.openResource(new URI("location"), false) >> null
 
         when:
-        def loadedResource = progressLoggerAccessor.openResource(new URI("location"))
+        def loadedResource = progressLoggerAccessor.openResource(new URI("location"), false)
 
         then:
         loadedResource == null
@@ -60,10 +60,10 @@ class ProgressLoggingExternalResourceAccessorTest extends Specification {
 
     def "wraps response in delegate"() {
         setup:
-        accessor.openResource(new URI("location")) >> externalResource
+        accessor.openResource(new URI("location"), false) >> externalResource
 
         when:
-        def loadedResource = progressLoggerAccessor.openResource(new URI("location"))
+        def loadedResource = progressLoggerAccessor.openResource(new URI("location"), false)
 
         then:
         loadedResource != null
@@ -80,12 +80,12 @@ class ProgressLoggingExternalResourceAccessorTest extends Specification {
 
     def "fires progress events as content is read"() {
         setup:
-        accessor.openResource(new URI("location")) >> externalResource
+        accessor.openResource(new URI("location"), false) >> externalResource
         metaData.getContentLength() >> 4096
         externalResource.openStream() >> new ByteArrayInputStream(new byte[4096])
 
         when:
-        def resource = progressLoggerAccessor.openResource(new URI("location"))
+        def resource = progressLoggerAccessor.openResource(new URI("location"), false)
         def inputStream = resource.openStream()
         inputStream.read()
         inputStream.read()
@@ -108,12 +108,12 @@ class ProgressLoggingExternalResourceAccessorTest extends Specification {
 
     def "fires complete event when response closed with partially read stream"() {
         setup:
-        accessor.openResource(new URI("location")) >> externalResource
+        accessor.openResource(new URI("location"), false) >> externalResource
         metaData.getContentLength() >> 4096
         externalResource.openStream() >> new ByteArrayInputStream(new byte[4096])
 
         when:
-        def resource = progressLoggerAccessor.openResource(new URI("location"))
+        def resource = progressLoggerAccessor.openResource(new URI("location"), false)
         def inputStream = resource.openStream()
         inputStream.read(new byte[1600])
         resource.close()
@@ -128,12 +128,12 @@ class ProgressLoggingExternalResourceAccessorTest extends Specification {
 
     def "no progress events logged for resources smaller 1024 bytes"() {
         setup:
-        accessor.openResource(new URI("location")) >> externalResource
+        accessor.openResource(new URI("location"), false) >> externalResource
         metaData.getContentLength() >> 1023
         externalResource.openStream() >> new ByteArrayInputStream(new byte[1023])
 
         when:
-        def resource = progressLoggerAccessor.openResource(new URI("location"))
+        def resource = progressLoggerAccessor.openResource(new URI("location"), false)
         def inputStream = resource.openStream()
         inputStream.read(new byte[1024])
         resource.close()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/AbstractHttpResource.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/AbstractHttpResource.groovy
@@ -39,11 +39,15 @@ abstract class AbstractHttpResource implements RemoteResource {
 
     abstract void expectGetMissing()
 
+    abstract void expectGetRevalidate()
+
     abstract void expectHead()
 
     abstract void expectHeadBroken()
 
     abstract void expectHeadMissing()
+
+    abstract void expectHeadRevalidate()
 
     abstract void expectPut()
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpDirectoryResource.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpDirectoryResource.groovy
@@ -49,6 +49,11 @@ class HttpDirectoryResource extends AbstractHttpResource {
     }
 
     @Override
+    void expectGetRevalidate() {
+        server.expectGetRevalidate(path, directory)
+    }
+
+    @Override
     void expectHead() {
         throw new UnsupportedOperationException()
     }
@@ -60,6 +65,11 @@ class HttpDirectoryResource extends AbstractHttpResource {
 
     @Override
     void expectHeadMissing() {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void expectHeadRevalidate() {
         throw new UnsupportedOperationException()
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpResource.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpResource.groovy
@@ -49,6 +49,11 @@ abstract class HttpResource extends AbstractHttpResource {
         server.expectGetMissing(getPath(), credentials)
     }
 
+    @Override
+    void expectGetRevalidate() {
+        server.expectGetRevalidate(getPath(), file)
+    }
+
     void expectHead() {
         server.expectHead(getPath(), file)
     }
@@ -59,6 +64,10 @@ abstract class HttpResource extends AbstractHttpResource {
 
     void expectHeadBroken() {
         server.expectHeadBroken(path)
+    }
+
+    void expectHeadRevalidate() {
+        server.expectHeadRevalidate(path, file)
     }
 
     void expectPut(PasswordCredentials credentials) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
@@ -355,6 +355,13 @@ class HttpServer extends ServerWithExpectations {
     }
 
     /**
+     * Expects one HEAD request for the given URL, asserting that the request is revalidated.
+     */
+    void expectHeadRevalidate(String path, File srcFile) {
+        expect(path, false, ['HEAD'], revalidateFileHandler(path, srcFile))
+    }
+
+    /**
      * Allows one HEAD request for the given URL with http authentication.
      */
     void expectHead(String path, String username, String password, File srcFile, Long lastModified = null, Long contentLength = null) {
@@ -366,6 +373,13 @@ class HttpServer extends ServerWithExpectations {
      */
     HttpResourceInteraction expectGet(String path, File srcFile) {
         return expect(path, false, ['GET'], fileHandler(path, srcFile))
+    }
+
+    /**
+     * Allows one GET request for the given URL, asserting that the request revalidates. Reads the request content from the given file.
+     */
+    HttpResourceInteraction expectGetRevalidate(String path, File srcFile) {
+        return expect(path, false, ['GET'], revalidateFileHandler(path, srcFile))
     }
 
     /**

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/MavenHttpModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/MavenHttpModule.groovy
@@ -78,6 +78,13 @@ class MavenHttpModule extends DelegatingMavenModule<MavenHttpModule> implements 
         return this
     }
 
+    MavenHttpModule revalidate() {
+        server.allowGetOrHeadMissing(pomPath)
+        server.allowGetOrHeadMissing(metaDataPath)
+        server.allowGetOrHeadWithRevalidate(artifactPath, artifactFile)
+        return this
+    }
+
     void missing() {
         server.allowGetOrHeadMissing(pomPath)
         server.allowGetOrHeadMissing(metaDataPath)

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportWagonAdapter.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportWagonAdapter.java
@@ -37,7 +37,7 @@ public class RepositoryTransportWagonAdapter {
 
     public boolean getRemoteFile(File destination, String resourceName) throws ResourceException {
         URI uriForResource = getUriForResource(resourceName);
-        ExternalResource resource = transport.getRepository().getResource(uriForResource);
+        ExternalResource resource = transport.getRepository().getResource(uriForResource, false);
         if (resource == null) {
             return false;
         }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportWagonAdapterTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportWagonAdapterTest.groovy
@@ -39,7 +39,7 @@ class RepositoryTransportWagonAdapterTest extends Specification {
         delegate.getRemoteFile(null, resourceName)
 
         then:
-        1 * repositoryTransport.getRepository().getResource({ it.toString() == expected })
+        1 * repositoryTransport.getRepository().getResource({ it.toString() == expected }, false)
         where:
         repoUrl                          | resourceName    | expected
         S3_URI                           | 'a/b/some.jar'  | 's3://somewhere/maven/a/b/some.jar'
@@ -52,7 +52,7 @@ class RepositoryTransportWagonAdapterTest extends Specification {
         RepositoryTransport repositoryTransport = Mock()
         ExternalResourceRepository externalResourceRepo = Mock()
         repositoryTransport.getRepository() >> externalResourceRepo
-        externalResourceRepo.getResource(_) >> Mock(ExternalResource)
+        externalResourceRepo.getResource(_, false) >> Mock(ExternalResource)
 
         RepositoryTransportWagonAdapter delegate = new RepositoryTransportWagonAdapter(repositoryTransport, S3_URI)
 
@@ -65,7 +65,7 @@ class RepositoryTransportWagonAdapterTest extends Specification {
         RepositoryTransport repositoryTransport = Mock()
         ExternalResourceRepository externalResourceRepo = Mock()
         repositoryTransport.getRepository() >> externalResourceRepo
-        externalResourceRepo.getResource(_) >> null
+        externalResourceRepo.getResource(_, false) >> null
 
         RepositoryTransportWagonAdapter delegate = new RepositoryTransportWagonAdapter(repositoryTransport, S3_URI)
 

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/resolve/service/PluginResolutionCachingIntegrationTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/resolve/service/PluginResolutionCachingIntegrationTest.groovy
@@ -69,7 +69,7 @@ class PluginResolutionCachingIntegrationTest extends AbstractIntegrationSpec {
         reset()
         args "--refresh-dependencies"
         pluginQuery()
-        moduleResolution()
+        moduleResolutionWithRevalidate()
         build()
 
         reset()
@@ -166,6 +166,10 @@ class PluginResolutionCachingIntegrationTest extends AbstractIntegrationSpec {
 
     void moduleResolution() {
         module.allowAll()
+    }
+
+    void moduleResolutionWithRevalidate() {
+        module.revalidate()
     }
 
     void pluginQuery() {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/HttpPluginResolutionServiceClient.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/HttpPluginResolutionServiceClient.java
@@ -83,7 +83,7 @@ public class HttpPluginResolutionServiceClient implements PluginResolutionServic
         final URI requestUri = toUri(requestUrl, "plugin request");
 
         try {
-            HttpResponseResource response = getResourceAccessor().getRawResource(requestUri);
+            HttpResponseResource response = getResourceAccessor().getRawResource(requestUri, false);
             try {
                 final int statusCode = response.getStatusCode();
                 String contentType = response.getContentType();

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/HttpPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/HttpPluginResolutionServiceClientTest.groovy
@@ -120,17 +120,17 @@ class HttpPluginResolutionServiceClientTest extends Specification {
         client.queryPluginMetadata(PLUGIN_PORTAL_URL, true, customRequest)
 
         then:
-        1 * resourceAccessor.getRawResource(new URI("$PLUGIN_PORTAL_URL/${GradleVersion.current().getVersion()}/plugin/use/foo%2Fbar/1%2F0")) >> Stub(HttpResponseResource) {
+        1 * resourceAccessor.getRawResource(new URI("$PLUGIN_PORTAL_URL/${GradleVersion.current().getVersion()}/plugin/use/foo%2Fbar/1%2F0"), false) >> Stub(HttpResponseResource) {
             getStatusCode() >> 500
             getContentType() >> "application/json"
             openStream() >> new ByteArrayInputStream("{errorCode: 'FOO', message: 'BAR'}".getBytes("utf8"))
         }
-        0 * resourceAccessor.getRawResource(_)
+        0 * resourceAccessor.getRawResource(_, false)
     }
 
     private void stubResponse(int statusCode, String jsonResponse = null) {
         interaction {
-            resourceAccessor.getRawResource(_) >> Stub(HttpResponseResource) {
+            resourceAccessor.getRawResource(_, false) >> Stub(HttpResponseResource) {
                 getStatusCode() >> statusCode
                 if (jsonResponse != null) {
                     getContentType() >> "application/json"

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceAccessor.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceAccessor.java
@@ -17,8 +17,6 @@
 package org.gradle.internal.resource.transport.http;
 
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestBase;
 import org.gradle.api.Nullable;
 import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
 import org.gradle.internal.resource.transfer.ExternalResourceAccessor;
@@ -43,12 +41,12 @@ public class HttpResourceAccessor implements ExternalResourceAccessor {
     }
 
     @Nullable
-    public HttpResponseResource openResource(final URI uri) {
+    public HttpResponseResource openResource(final URI uri, boolean revalidate) {
         abortOpenResources();
         String location = uri.toString();
         LOGGER.debug("Constructing external resource: {}", location);
 
-        HttpResponse response = http.performGet(location);
+        HttpResponse response = http.performGet(location, revalidate);
         if (response != null) {
             HttpResponseResource resource = wrapResponse(uri, response);
             return recordOpenGetResource(resource);
@@ -61,28 +59,20 @@ public class HttpResourceAccessor implements ExternalResourceAccessor {
      * Same as #getResource except that it always gives access to the response body,
      * irrespective of the returned HTTP status code. Never returns {@code null}.
      */
-    public HttpResponseResource getRawResource(final URI uri) {
+    public HttpResponseResource getRawResource(final URI uri, boolean revalidate) {
         abortOpenResources();
         String location = uri.toString();
         LOGGER.debug("Constructing external resource: {}", location);
-
-        HttpRequestBase request = new HttpGet(uri);
-        HttpResponse response;
-        try {
-            response = http.performHttpRequest(request);
-        } catch (IOException e) {
-            throw new HttpRequestException(String.format("Could not %s '%s'.", request.getMethod(), request.getURI()), e);
-        }
-
+        HttpResponse response = http.performGet(location, revalidate);
         HttpResponseResource resource = wrapResponse(uri, response);
         return recordOpenGetResource(resource);
     }
 
-    public ExternalResourceMetaData getMetaData(URI uri) {
+    public ExternalResourceMetaData getMetaData(URI uri, boolean revalidate) {
         abortOpenResources();
         String location = uri.toString();
         LOGGER.debug("Constructing external resource metadata: {}", location);
-        HttpResponse response = http.performHead(location);
+        HttpResponse response = http.performHead(location, revalidate);
         return response == null ? null : new HttpResponseResource("HEAD", uri, response).getMetaData();
     }
 

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceLister.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceLister.java
@@ -34,7 +34,7 @@ public class HttpResourceLister implements ExternalResourceLister {
     }
 
     public List<String> list(final URI directory) {
-        final ExternalResourceReadResponse response = accessor.openResource(directory);
+        final ExternalResourceReadResponse response = accessor.openResource(directory, true);
         if (response == null) {
             return null;
         }

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientHelperTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientHelperTest.groovy
@@ -36,11 +36,27 @@ class HttpClientHelperTest extends Specification {
         }
 
         when:
-        client.performRequest(new HttpGet("http://gradle.org"))
+        client.performRequest(new HttpGet("http://gradle.org"), false)
 
         then:
         HttpRequestException e = thrown()
         e.cause.message == "ouch"
+    }
+
+    def "request with revalidate adds Cache-Control header"() {
+        def client = new HttpClientHelper(httpSettings) {
+            @Override
+            protected HttpResponse executeGetOrHead(HttpRequestBase method) {
+                return null
+            }
+        }
+
+        when:
+        def request = new HttpGet("http://gradle.org")
+        client.performRequest(request, true)
+
+        then:
+        request.getHeaders("Cache-Control")[0].value == "max-age=0"
     }
 
     private HttpSettings getHttpSettings() {

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceListerTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceListerTest.groovy
@@ -27,7 +27,7 @@ class HttpResourceListerTest extends Specification {
 
     def "consumeExternalResource closes resource after reading into stream"() {
         setup:
-        accessorMock.openResource(new URI("http://testrepo/")) >> externalResource;
+        accessorMock.openResource(new URI("http://testrepo/"), true) >> externalResource;
         when:
         lister.list(new URI("http://testrepo/"))
         then:
@@ -39,7 +39,7 @@ class HttpResourceListerTest extends Specification {
 
     def "list returns null if HttpAccessor returns null"(){
         setup:
-        accessorMock.openResource(new URI("http://testrepo/"))  >> null
+        accessorMock.openResource(new URI("http://testrepo/"), true)  >> null
         expect:
         null == lister.list(new URI("http://testrepo"))
     }

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnector.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnector.java
@@ -45,7 +45,7 @@ public class S3ResourceConnector implements ExternalResourceConnector {
         return s3Client.list(parent);
     }
 
-    public ExternalResourceReadResponse openResource(URI location) {
+    public ExternalResourceReadResponse openResource(URI location, boolean revalidate) {
         LOGGER.debug("Attempting to get resource: {}", location);
         S3Object s3Object = s3Client.getResource(location);
         if (s3Object == null) {
@@ -54,7 +54,7 @@ public class S3ResourceConnector implements ExternalResourceConnector {
         return new S3Resource(s3Object, location);
     }
 
-    public ExternalResourceMetaData getMetaData(URI location) {
+    public ExternalResourceMetaData getMetaData(URI location, boolean revalidate) {
         LOGGER.debug("Attempting to get resource metadata: {}", location);
         S3Object s3Object = s3Client.getMetaData(location);
         if (s3Object == null) {

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnectorTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnectorTest.groovy
@@ -40,7 +40,7 @@ class S3ResourceConnectorTest extends Specification {
         }
 
         when:
-        def s3Resource = new S3ResourceConnector(s3Client).openResource(uri)
+        def s3Resource = new S3ResourceConnector(s3Client).openResource(uri, false)
 
         then:
         s3Resource != null

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResourceAccessor.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpResourceAccessor.java
@@ -37,7 +37,7 @@ public class SftpResourceAccessor implements ExternalResourceAccessor {
         this.credentials = credentials;
     }
 
-    public ExternalResourceMetaData getMetaData(URI uri) {
+    public ExternalResourceMetaData getMetaData(URI uri, boolean revalidate) {
         LockableSftpClient sftpClient = sftpClientFactory.createSftpClient(uri, credentials);
         try {
             SftpATTRS attributes = sftpClient.getSftpClient().lstat(uri.getPath());
@@ -66,8 +66,8 @@ public class SftpResourceAccessor implements ExternalResourceAccessor {
         return new DefaultExternalResourceMetaData(uri, lastModified, contentLength);
     }
 
-    public ExternalResourceReadResponse openResource(URI location) {
-        ExternalResourceMetaData metaData = getMetaData(location);
+    public ExternalResourceReadResponse openResource(URI location, boolean revalidate) {
+        ExternalResourceMetaData metaData = getMetaData(location, revalidate);
         return metaData != null ? new SftpResource(sftpClientFactory, metaData, location, credentials) : null;
     }
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/transfer/DefaultExternalResourceConnector.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/transfer/DefaultExternalResourceConnector.java
@@ -51,16 +51,16 @@ public class DefaultExternalResourceConnector implements ExternalResourceConnect
 
     @Nullable
     @Override
-    public ExternalResourceReadResponse openResource(URI location) {
+    public ExternalResourceReadResponse openResource(URI location, boolean revalidate) {
         STATS.resource(location);
-        return accessor.openResource(location);
+        return accessor.openResource(location, revalidate);
     }
 
     @Nullable
     @Override
-    public ExternalResourceMetaData getMetaData(URI location) {
+    public ExternalResourceMetaData getMetaData(URI location, boolean revalidate) {
         STATS.metadata(location);
-        return accessor.getMetaData(location);
+        return accessor.getMetaData(location, revalidate);
     }
 
     @Nullable

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/transfer/ExternalResourceAccessor.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/transfer/ExternalResourceAccessor.java
@@ -33,11 +33,12 @@ public interface ExternalResourceAccessor {
      * must throw an {@link ResourceException} to indicate a fatal condition.
      *
      * @param location The address of the resource to obtain
+     * @param revalidate The resource should be revalidated as part of the request
      * @return The resource if it exists, otherwise null. Caller is responsible for closing the result.
      * @throws ResourceException If the resource may exist, but not could be obtained for some reason.
      */
     @Nullable
-    ExternalResourceReadResponse openResource(URI location) throws ResourceException;
+    ExternalResourceReadResponse openResource(URI location, boolean revalidate) throws ResourceException;
 
     /**
      * Obtains only the metadata about the resource.
@@ -48,10 +49,11 @@ public interface ExternalResourceAccessor {
      * must throw an {@link ResourceException} to indicate a fatal condition.
      *
      * @param location The location of the resource to obtain the metadata for
+     * @param revalidate The resource should be revalidated as part of the request
      * @return The available metadata, null if the resource doesn't exist
      * @throws ResourceException If the resource may exist, but not could be obtained for some reason
      */
     @Nullable
-    ExternalResourceMetaData getMetaData(URI location) throws ResourceException;
-    
+    ExternalResourceMetaData getMetaData(URI location, boolean revalidate) throws ResourceException;
+
 }


### PR DESCRIPTION
An added 'revalidate' argument allows Cache-Control: max-age=0 to be added in cases where it's desirable for artifact repositories or caching proxies to revalidate requests:

- Listing version metadata
- Resource has exceeded it's cache lifetime on disk, such as dynamic/snapshot dependencies or when --refresh-dependencies is specified

Some more background here:

https://groups.google.com/forum/#!topic/gradle-dev/nTWs8SfTUA8