### PR TITLE
Docs: adding extension with existing name throws

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/plugins/ExtensionContainer.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/plugins/ExtensionContainer.java
@@ -34,6 +34,7 @@ public interface ExtensionContainer {
      *
      * @param name Will be used as a sort of namespace of properties/methods.
      * @param extension Any object whose methods and properties will extend the target object
+     * @throws IllegalArgumentException When an extension with the given name already exists.
      */
     void add(String name, Object extension);
 
@@ -48,6 +49,7 @@ public interface ExtensionContainer {
      * @param type The type of the extension
      * @param constructionArguments The arguments to be used to construct the extension instance
      * @return The created instance
+     * @throws IllegalArgumentException When an extension with the given name already exists.
      */
     <T> T create(String name, Class<T> type, Object... constructionArguments);
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
@@ -104,6 +104,13 @@ public class ExtensionContainerTest extends Specification {
         then:
         IllegalArgumentException e2 = thrown()
         e2.message == "There's an extension registered with name 'foo'. You should not reassign it via a property setter."
+
+        when:
+        container.create('foo', Thing, 'bar')
+
+        then:
+        IllegalArgumentException e3 = thrown()
+        e3.message == "Cannot add extension with name 'foo', as there is an extension already registered with that name."
     }
 
     def "knows registered extensions"() {


### PR DESCRIPTION
Document that an IllegalArgumentException will be thrown if someone
tries to add an extension with a name that already exists. For
ExtensionContainer#add(..) this behavior is already covered by the test
"cannot replace an extension" in ExtensionContainerTest. Added the same
test for ExtensionContainer#create(..).