### PR TITLE
Add TOCs to individual chapters.

### DIFF
--- a/subprojects/docs/src/docs/css/userguide.css
+++ b/subprojects/docs/src/docs/css/userguide.css
@@ -37,6 +37,14 @@ div.toc p b {
     font-weight: normal;
 }
 
+.chapter > .toc {
+    margin-bottom: 1em;
+}
+
+.chapter > .toc > dl {
+    margin-left: 1.5em;
+}
+
 /*
  * HEADER/FOOTER
  */

--- a/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
@@ -23,6 +23,12 @@
     <xsl:param name="chunk.quietly">1</xsl:param>
     <xsl:param name="use.id.as.filename">1</xsl:param>
 
+    <xsl:param name="generate.toc">
+        book toc,title,example
+        part toc,title
+        chapter toc,title
+    </xsl:param>
+
     <!-- HEADERS AND FOOTERS -->
 
     <!-- Use custom header -->

--- a/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
@@ -41,7 +41,6 @@
 
     <xsl:param name="generate.toc">
         book toc,title,example
-        part toc,title
     </xsl:param>
 
     <xsl:param name="formal.title.placement">


### PR DESCRIPTION
The chunked version of the user guide (the one with an HTML page per chapter)
now has a short TOC at the beginning of each chapter containing that chapter's
top level sections.