### PR TITLE
Deterministic local build

### DIFF
--- a/gradle/buildReceipt.gradle
+++ b/gradle/buildReceipt.gradle
@@ -110,36 +110,12 @@ task createBuildReceipt(dependsOn: determineCommitId) {
     outputs.file receiptFile
     outputs.upToDateWhen { false }
     doLast {
-        def hostName
-        try {
-            hostName = InetAddress.localHost.hostName
-        } catch (UnknownHostException e) {
-            def baos = new ByteArrayOutputStream()
-            def execResult = exec {
-                ignoreExitValue = true
-                commandLine = ["hostname"]
-                standardOutput = baos
-            }
-            if (execResult.exitValue == 0) {
-                hostName = new String(baos.toByteArray(), "utf8").trim()
-            } else {
-                hostName = "unknown"
-            }
-        }
         def data = [
                 commitId: determineCommitId.commitId,
                 versionNumber: version,
                 versionBase: versionBase,
                 isSnapshot: isSnapshot,
-                rcNumber: rcNumber == null ? "" : rcNumber,
                 buildTimestamp: buildTimestamp,
-                buildNumber: System.properties["build.number"] ?: 'none',
-                username: System.properties["user.name"],
-                hostname: hostName,
-                javaVersion: System.properties["java.version"],
-                osName: System.properties["os.name"],
-                osVersion: System.properties["os.version"],
-                project: 'gradle'
         ]
 
         receiptFile.parentFile.mkdirs()

--- a/gradle/buildReceipt.gradle
+++ b/gradle/buildReceipt.gradle
@@ -107,11 +107,15 @@ task determineCommitId {
 
 task createBuildReceipt(dependsOn: determineCommitId) {
     ext.receiptFile = file("$buildDir/$buildReceiptFileName")
+    inputs.property "version", { version }
+    inputs.property "versionBase", { versionBase }
+    inputs.property "isSnapshot", { isSnapshot }
+    inputs.property "buildTimestamp", { buildTimestamp }
+    inputs.property "commitId", { snapshotBuild ? "HEAD" : determineCommitId.commitId }
     outputs.file receiptFile
-    outputs.upToDateWhen { false }
     doLast {
         def data = [
-                commitId: determineCommitId.commitId,
+                commitId: snapshotBuild ? "HEAD" : determineCommitId.commitId,
                 versionNumber: version,
                 versionBase: versionBase,
                 isSnapshot: isSnapshot,

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -106,10 +106,11 @@ class ClasspathManifest extends DefaultTask {
 
     @TaskAction
     def generate() {
-        // We write this out ourself instead of using the properties class to avoid the
-        // annoying timestamp that insists on placing in there, that throws out incremental.
-        def content = getProperties().entrySet().collect { "$it.key=$it.value" }.sort().join("\n")
-        manifestFile.setText(content, "ISO-8859-1")
+        // Remove Properties timestamp for reproducible build
+        def sw = new StringWriter()
+        getProperties().store(sw, "")
+        def content = sw.toString().split(/\n/).findAll { !it.startsWith("#") }.join("\n")
+        manifestFile.setText(content, "utf-8")
     }
 }
 

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -106,7 +106,10 @@ class ClasspathManifest extends DefaultTask {
 
     @TaskAction
     def generate() {
-        manifestFile.withOutputStream { properties.save(it, 'module definition') }
+        // We write this out ourself instead of using the properties class to avoid the
+        // annoying timestamp that insists on placing in there, that throws out incremental.
+        def content = getProperties().entrySet().collect { "$it.key=$it.value" }.sort().join("\n")
+        manifestFile.setText(content, "ISO-8859-1")
     }
 }
 

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -66,5 +66,5 @@ if (finalRelease) {
     version += "-$buildTimestamp"
 } else {
     isSnapshot = true
-    version += "-SNAPSHOT"
+    version += "-snapshot-1"
 }

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -1,9 +1,14 @@
-def timestampFormat = new java.text.SimpleDateFormat('yyyyMMddHHmmssZ')
-timestampFormat.timeZone = TimeZone.getTimeZone("UTC")
-
 if (buildTypes.promotionBuild.active) {
     logger.lifecycle "Invocation tasks: $gradle.startParameter.taskNames\nInvocation properties: $gradle.startParameter.projectProperties"
 }
+
+ext.rcNumber = project.hasProperty("rcNumber") ? project.rcNumber.toInteger() : null
+ext.finalRelease = project.hasProperty("finalRelease")
+ext.timestampedVersion = project.hasProperty("timestampedVersion")
+if (rcNumber != null && finalRelease) {
+    throw new InvalidUserDataException("Cannot set rcNumber and finalRelease at the same time")
+}
+ext.snapshotBuild = rcNumber == null && !finalRelease && !timestampedVersion;
 
 if (incomingDistributionsBuildReceipt) {
     ext.versionBase = incomingDistributionsBuildReceipt.versionBase
@@ -11,36 +16,37 @@ if (incomingDistributionsBuildReceipt) {
 } else {
     ext.versionBase = rootProject.file("version.txt").text.trim()
 
-    if (project.hasProperty("buildTimestamp")) {
-        ext.buildTime = timestampFormat.parse(buildTimestamp)
+    if (snapshotBuild) {
+        ext.buildTimestamp = "unknown";
     } else {
-        File timestampFile = file("$buildDir/timestamp.txt")
-        if (timestampFile.isFile()) {
-            boolean uptodate = true
-            def modified = timestampFile.lastModified()
-            project(':core').fileTree('src/main').visit {fte ->
-                if (fte.file.isFile() && fte.lastModified > modified) {
-                    uptodate = false
-                    fte.stopVisiting()
-                }
-            }
-            if (!uptodate) {
-                timestampFile.setLastModified(new Date().time)
-            }
+        def timestampFormat = new java.text.SimpleDateFormat('yyyyMMddHHmmssZ')
+        timestampFormat.timeZone = TimeZone.getTimeZone("UTC")
+        Date buildTime
+        if (project.hasProperty("buildTimestamp")) {
+            buildTime = timestampFormat.parse(buildTimestamp)
         } else {
-            timestampFile.parentFile.mkdirs()
-            timestampFile.createNewFile()
-        }
+            File timestampFile = file("$buildDir/timestamp.txt")
+            if (timestampFile.isFile()) {
+                boolean uptodate = true
+                def modified = timestampFile.lastModified()
+                project(':core').fileTree('src/main').visit {fte ->
+                    if (fte.file.isFile() && fte.lastModified > modified) {
+                        uptodate = false
+                        fte.stopVisiting()
+                    }
+                }
+                if (!uptodate) {
+                    timestampFile.setLastModified(new Date().time)
+                }
+            } else {
+                timestampFile.parentFile.mkdirs()
+                timestampFile.createNewFile()
+            }
 
-        ext.buildTime = new Date(timestampFile.lastModified())
+            buildTime = new Date(timestampFile.lastModified())
+        }
         ext.buildTimestamp = timestampFormat.format(buildTime)
     }
-}
-
-ext.rcNumber = project.hasProperty("rcNumber") ? project.rcNumber.toInteger() : null
-ext.finalRelease = project.hasProperty("finalRelease")
-if (rcNumber != null && finalRelease) {
-    throw new InvalidUserDataException("Cannot set rcNumber and finalRelease at the same time")
 }
 
 version = versionBase
@@ -50,7 +56,10 @@ if (finalRelease) {
     // use version base
 } else if (rcNumber != null) {
     version += "-rc-$rcNumber"
-} else {
+} else if (timestampedVersion) {
     isSnapshot = true
     version += "-$buildTimestamp"
+} else {
+    isSnapshot = true
+    version += "-SNAPSHOT"
 }

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -4,7 +4,12 @@ if (buildTypes.promotionBuild.active) {
 
 ext.rcNumber = project.hasProperty("rcNumber") ? project.rcNumber.toInteger() : null
 ext.finalRelease = project.hasProperty("finalRelease")
-ext.timestampedVersion = project.hasProperty("timestampedVersion")
+if (project.hasProperty("timestampedVersion")) {
+    def value = project.property("timestampedVersion")
+    ext.timestampedVersion = value != "false"
+} else {
+    ext.timestampedVersion = gradle.startParameter.taskNames.contains("install") || gradle.startParameter.taskNames.contains("installAll")
+}
 if (rcNumber != null && finalRelease) {
     throw new InvalidUserDataException("Cannot set rcNumber and finalRelease at the same time")
 }

--- a/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -42,7 +42,6 @@ public class GradleVersion implements Comparable<GradleVersion> {
     private final int majorPart;
     private final String buildTime;
     private final String commitId;
-    private final String buildNumber;
     private final Long snapshot;
     private final String versionPart;
     private final Stage stage;
@@ -62,11 +61,10 @@ public class GradleVersion implements Comparable<GradleVersion> {
 
             String version = properties.get("versionNumber").toString();
             String buildTimestamp = properties.get("buildTimestamp").toString();
-            String buildNumber = properties.get("buildNumber").toString();
             String commitId = properties.get("commitId").toString();
             Date buildTime = new SimpleDateFormat("yyyyMMddHHmmssZ").parse(buildTimestamp);
 
-            CURRENT = new GradleVersion(version, buildTime, buildNumber, commitId);
+            CURRENT = new GradleVersion(version, buildTime, commitId);
         } catch (Exception e) {
             throw new GradleException(String.format("Could not load version details from resource '%s'.", resource), e);
         } finally {
@@ -90,12 +88,11 @@ public class GradleVersion implements Comparable<GradleVersion> {
      * @throws IllegalArgumentException On unrecognized version string.
      */
     public static GradleVersion version(String version) throws IllegalArgumentException {
-        return new GradleVersion(version, null, null, null);
+        return new GradleVersion(version, null, null);
     }
 
-    private GradleVersion(String version, Date buildTime, String buildNumber, String commitId) {
+    private GradleVersion(String version, Date buildTime, String commitId) {
         this.version = version;
-        this.buildNumber = buildNumber;
         this.commitId = commitId;
         this.buildTime = buildTime == null ? null : formatBuildTime(buildTime);
         Matcher matcher = VERSION_PATTERN.matcher(version);
@@ -157,10 +154,6 @@ public class GradleVersion implements Comparable<GradleVersion> {
 
     public String getBuildTime() {
         return buildTime;
-    }
-
-    public String getBuildNumber() {
-        return buildNumber;
     }
 
     public String getRevision() {

--- a/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -62,7 +62,12 @@ public class GradleVersion implements Comparable<GradleVersion> {
             String version = properties.get("versionNumber").toString();
             String buildTimestamp = properties.get("buildTimestamp").toString();
             String commitId = properties.get("commitId").toString();
-            Date buildTime = new SimpleDateFormat("yyyyMMddHHmmssZ").parse(buildTimestamp);
+            Date buildTime;
+            if ("unknown".equals(buildTimestamp)) {
+                buildTime = null;
+            } else {
+                buildTime = new SimpleDateFormat("yyyyMMddHHmmssZ").parse(buildTimestamp);
+            }
 
             CURRENT = new GradleVersion(version, buildTime, commitId);
         } catch (Exception e) {

--- a/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 
 public class GradleVersion implements Comparable<GradleVersion> {
     public static final String URL = "http://www.gradle.org";
-    private static final Pattern VERSION_PATTERN = Pattern.compile("((\\d+)(\\.\\d+)+)(-(\\p{Alpha}+)-(\\d+[a-z]?))?(-(\\d{14}([-+]\\d{4})?))?");
+    private static final Pattern VERSION_PATTERN = Pattern.compile("((\\d+)(\\.\\d+)+)(-(\\p{Alpha}+)-(\\d+[a-z]?))?(-(SNAPSHOT|\\d{14}([-+]\\d{4})?))?");
     private static final int STAGE_MILESTONE = 0;
 
     private final String version;
@@ -120,7 +120,11 @@ public class GradleVersion implements Comparable<GradleVersion> {
             stage = null;
         }
 
-        if (matcher.group(8) != null) {
+        if (matcher.group(8) == null) {
+            snapshot = null;
+        } else if ("SNAPSHOT".equals(matcher.group(8))) {
+            snapshot = 0L;
+        } else {
             try {
                 if (matcher.group(9) != null) {
                     snapshot = new SimpleDateFormat("yyyyMMddHHmmssZ").parse(matcher.group(8)).getTime();
@@ -132,8 +136,6 @@ public class GradleVersion implements Comparable<GradleVersion> {
             } catch (ParseException e) {
                 throw UncheckedException.throwAsUncheckedException(e);
             }
-        } else {
-            snapshot = null;
         }
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
@@ -197,6 +197,7 @@ class GradleVersionTest extends Specification {
         '0.9-20101220110000-0100' | '0.9-20101220110000'
         '0.9'                     | '0.9-20101220100000+1000'
         '0.9'                     | '0.9-20101220100000'
+        '0.9'                     | '0.9-SNAPSHOT'
     }
 
     def "can get version base"() {
@@ -213,6 +214,7 @@ class GradleVersionTest extends Specification {
         '0.9-20101220100000+1000'             | "0.9"
         '0.9-20101220100000'                  | "0.9"
         '20.17-20101220100000+1000'           | "20.17"
+        '0.9-SNAPSHOT'                        | "0.9"
     }
 
     def "milestones are treated as base versions"() {
@@ -237,6 +239,7 @@ class GradleVersionTest extends Specification {
         '0.9-20101220100000+1000'             | "1.0"
         '0.9-20101220100000'                  | "1.0"
         '20.17-20101220100000+1000'           | "21.0"
+        '0.9-SNAPSHOT'                        | "1.0"
     }
 
     def "milestones are part of previous major version"() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
@@ -43,7 +43,6 @@ class GradleVersionTest extends Specification {
     def "current version has non-null parts"() {
         expect:
         version.version
-        version.buildTime
         version.nextMajor
         version.baseVersion
     }

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
@@ -50,7 +50,8 @@ class GradleVersionTest extends Specification {
     @Issue("https://issues.gradle.org/browse/GRADLE-1892")
     def "build time should always print in UTC"() {
         expect:
-        version.buildTime.endsWith("UTC")
+        // Note: buildTime is null when running a local build
+        version.buildTime == null || version.buildTime.endsWith("UTC")
     }
 
     def equalsAndHashCode() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
@@ -85,7 +85,8 @@ class GradleVersionTest extends Specification {
         version << [
                 '0.9-20101220110000+1100',
                 '0.9-20101220110000-0800',
-                '1.2-20120501110000'
+                '1.2-20120501110000',
+                '1.2-SNAPSHOT',
         ]
     }
 

--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -98,9 +98,10 @@ class PluginsManifest extends DefaultTask {
 
     @TaskAction
     def generate() {
-        // We write this out ourself instead of using the properties class to avoid the
-        // annoying timestamp that insists on placing in there, that throws out incremental.
-        def content = pluginProperties.entrySet().collect { "$it.key=$it.value" }.sort().join("\n")
-        propertiesFile.setText(content, "ISO-8859-1")
+        // Remove Properties timestamp for reproducible build
+        def sw = new StringWriter()
+        pluginProperties.store(sw, "")
+        def content = sw.toString().split(/\n/).findAll { !it.startsWith("#") }.join("\n")
+        propertiesFile.setText(content, "utf-8")
     }
 }

--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -92,12 +92,15 @@ class PluginsManifest extends DefaultTask {
     @Input
     Properties getPluginProperties() {
         def properties = new Properties()
-        properties.plugins = project.pluginProjects.collect { it.archivesBaseName }.join(',')
+        properties.plugins = project.pluginProjects.collect { it.archivesBaseName }.sort().join(',')
         return properties
     }
 
     @TaskAction
     def generate() {
-        propertiesFile.withOutputStream { pluginProperties.save(it, 'plugin definitions') }
+        // We write this out ourself instead of using the properties class to avoid the
+        // annoying timestamp that insists on placing in there, that throws out incremental.
+        def content = pluginProperties.entrySet().collect { "$it.key=$it.value" }.sort().join("\n")
+        propertiesFile.setText(content, "ISO-8859-1")
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -150,8 +150,6 @@ public class CommandLineActionFactory {
             sb.append(currentVersion.getVersion());
             sb.append("\n------------------------------------------------------------\n\nBuild time:   ");
             sb.append(currentVersion.getBuildTime());
-            sb.append("\nBuild number: ");
-            sb.append(currentVersion.getBuildNumber());
             sb.append("\nRevision:     ");
             sb.append(currentVersion.getRevision());
             sb.append("\n\nGroovy:       ");

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/CommandLineActionFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/CommandLineActionFactoryTest.groovy
@@ -223,7 +223,6 @@ Gradle ${version.version}
 ------------------------------------------------------------
 
 Build time:   $version.buildTime
-Build number: $version.buildNumber
 Revision:     $version.revision
 
 Groovy:       $GroovySystem.version


### PR DESCRIPTION
The goal here is to ensure that up-to-date checks succeed more often when building Gradle itself, speeding up the build for developers.

Currently in `master` timestamps are used in a number of places:

* in JAR manifests
* in some `.properties` files
* the current Git hash is also encoded in `build-receipt.properties`

Each of these introduce arbitrary changes to build outputs, preventing up-to-date checks to save build time. While they are required to produce releases, in most cases they don't add value when developing locally.

By specifying `-PtimestampedVersion` on the command-line the old behavior can be re-enabled.