### PR TITLE
Fine tune anchor generation in user guide.

### DIFF
--- a/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
@@ -146,8 +146,10 @@
                     <xsl:attribute name="name">
                         <xsl:value-of select="$refId"/>
                     </xsl:attribute>
-                    <xsl:attribute name="class">section-anchor</xsl:attribute>
-                    <xsl:attribute name="href">#<xsl:value-of select="$refId"/></xsl:attribute>
+                    <xsl:if test="$node[local-name() = 'section']">
+                        <xsl:attribute name="class">section-anchor</xsl:attribute>
+                        <xsl:attribute name="href">#<xsl:value-of select="$refId"/></xsl:attribute>
+                    </xsl:if>
                 </a>
             </xsl:when>
         </xsl:choose>


### PR DESCRIPTION
The 'section-anchor' class was being added to all generated `<a>` elements with
a `name` attribute. This modification to the XSL stylesheet now makes the class
conditional on the underlying element being a `<section>`.