### PR TITLE
Fix NPE when configuring FileTree's builtBy by map

### DIFF
--- a/subprojects/core/src/main/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTree.java
+++ b/subprojects/core/src/main/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTree.java
@@ -55,8 +55,8 @@ public class DefaultConfigurableFileTree extends CompositeFileTree implements Co
         this.fileCopier = fileCopier;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
         patternSet = resolver.getPatternSetFactory().create();
-        ConfigureUtil.configureByMap(args, this);
         buildDependency = new DefaultTaskDependency(taskResolver);
+        ConfigureUtil.configureByMap(args, this);
     }
 
     public PatternSet getPatterns() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTreeTest.groovy
@@ -71,9 +71,10 @@ class DefaultConfigurableFileTreeTest extends AbstractTestForPatternSet {
     }
 
     @Test public void testFileSetConstructionFromMap() {
-        fileSet = new DefaultConfigurableFileTree(fileResolverStub, taskResolverStub, dir: testDir, includes: ['include'], fileCopier, directoryFileTreeFactory())
+        fileSet = new DefaultConfigurableFileTree(fileResolverStub, taskResolverStub, dir: testDir, includes: ['include'], builtBy: ['a'], fileCopier, directoryFileTreeFactory())
         assertEquals(testDir, fileSet.dir)
         assertEquals(['include'] as Set, fileSet.includes)
+        assertEquals(['a'] as Set, fileSet.builtBy)
     }
 
     @Test(expected = InvalidUserDataException) public void testFileSetConstructionWithNoBaseDirSpecified() {


### PR DESCRIPTION
Thank you very much for your contribution. We highly appreciate the time
and effort you put into pull request. Before you submit the pull request,
please review the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).

Make sure you check the following boxes.

For all changes:

- [x] Sign the [Gradle CLA](http://gradle.org/contributor-license-agreement/).

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, you started a discussion on the
[Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev)
or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [x] You considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. You can find [samples](https://github.com/gradle/gradle/tree/master/design-docs)
in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
you ran a build on your local machine via the command `./gradlew quickCheck`
and the tests for the modified module.
- [x] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.

 - `fileTree(dir: 'classes', builtBy: ['compile'])` is valid, and should not break