### PR TITLE
Remove "optimization" that omitted -source and -target from javac

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
@@ -38,7 +38,14 @@ import org.gradle.testfixtures.internal.NativeServicesTestFixture;
 import org.gradle.util.CollectionUtils;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,7 +67,11 @@ public abstract class AvailableJavaHomes {
 
     @Nullable
     public static JavaInfo getJdk(final JavaVersion version) {
-        return getAvailableJdk(new Spec<JvmInstallation>() {
+        return Iterables.getFirst(getAvailableJdks(version), null);
+    }
+
+    public static List<JavaInfo> getAvailableJdks(final JavaVersion version) {
+        return getAvailableJdks(new Spec<JvmInstallation>() {
             @Override
             public boolean isSatisfiedBy(JvmInstallation element) {
                 return version.equals(element.getJavaVersion());
@@ -96,6 +107,16 @@ public abstract class AvailableJavaHomes {
                     return Jvm.forHome(input.getJavaHome());
                 }
             }).toList();
+    }
+
+    public static Map<JavaInfo, JavaVersion> getAvailableJdksWithVersion() {
+        Map<JavaInfo, JavaVersion> result = new HashMap<JavaInfo, JavaVersion>();
+        for (JavaVersion javaVersion : JavaVersion.values()) {
+            for (JavaInfo javaInfo : getAvailableJdks(javaVersion)) {
+                result.put(javaInfo, javaVersion);
+            }
+        }
+        return result;
     }
 
     public static JavaInfo getAvailableJdk(final Spec<? super JvmInstallation> filter) {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
@@ -69,6 +69,9 @@ class JavaCompileParallelIntegrationTest extends AbstractIntegrationSpec {
             buildFile << """
 project(':$projectName') {
     tasks.withType(JavaCompile) {
+        sourceCompatibility = '1.6'
+        targetCompatibility = '1.6'
+
         options.with {
             fork = true
             forkOptions.executable = "${jdks.next()}"

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.compile
 
 import com.google.common.collect.Iterables
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
@@ -27,14 +28,14 @@ import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 @IgnoreIf({ //noinspection UnnecessaryQualifiedReference
-    GradleContextualExecuter.parallel || JavaCompileParallelIntegrationTest.availableJdksWithJavac().size() < 2
+    GradleContextualExecuter.parallel || JavaCompileParallelIntegrationTest.availableJdksWithJavac().keySet().size() < 2
 })
 class JavaCompileParallelIntegrationTest extends AbstractIntegrationSpec {
 
-    static List<JavaInfo> availableJdksWithJavac() {
-        AvailableJavaHomes.availableJdks.findAll {
+    static Map<JavaInfo, JavaVersion> availableJdksWithJavac() {
+        AvailableJavaHomes.getAvailableJdksWithVersion().findAll { jdk, version ->
             try {
-                if (it.javacExecutable) {
+                if (jdk.javacExecutable) {
                     return true
                 }
             }
@@ -48,7 +49,7 @@ class JavaCompileParallelIntegrationTest extends AbstractIntegrationSpec {
     @Issue("https://issues.gradle.org/browse/GRADLE-3029")
     def "system property java.home is not modified across compile task boundaries"() {
         def projectNames = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
-        def jdks = Iterables.cycle(availableJdksWithJavac()*.javacExecutable.collect(TextUtil.&escapeString)).iterator()
+        def jdks = Iterables.cycle(availableJdksWithJavac().entrySet()).iterator()
 
         settingsFile << "include ${projectNames.collect { "'$it'" }.join(', ')}"
         buildFile << """
@@ -66,15 +67,18 @@ class JavaCompileParallelIntegrationTest extends AbstractIntegrationSpec {
 """
 
         projectNames.each { projectName ->
+            def jdk = jdks.next()
+            def executable = TextUtil.escapeString(jdk.key.javacExecutable)
+            def version = jdk.value
             buildFile << """
 project(':$projectName') {
     tasks.withType(JavaCompile) {
-        sourceCompatibility = '1.6'
-        targetCompatibility = '1.6'
+        sourceCompatibility = '${version}'
+        targetCompatibility = '${version}'
 
         options.with {
             fork = true
-            forkOptions.executable = "${jdks.next()}"
+            forkOptions.executable = "${executable}"
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.base.Joiner;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
@@ -118,12 +117,12 @@ public class JavaCompilerArgumentsBuilder {
         }
 
         String sourceCompatibility = spec.getSourceCompatibility();
-        if (sourceCompatibility != null && !JavaVersion.current().equals(JavaVersion.toVersion(sourceCompatibility))) {
+        if (sourceCompatibility != null) {
             args.add("-source");
             args.add(sourceCompatibility);
         }
         String targetCompatibility = spec.getTargetCompatibility();
-        if (targetCompatibility != null && !JavaVersion.current().equals(JavaVersion.toVersion(targetCompatibility))) {
+        if (targetCompatibility != null) {
             args.add("-target");
             args.add(targetCompatibility);
         }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -42,11 +42,11 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         builder.build() == ["-g", USE_UNSHARED_COMPILER_TABLE_OPTION]
     }
 
-    def "generates no -source option when current Jvm Version is used"() {
+    def "generates -source option when current Jvm Version is used"() {
         spec.sourceCompatibility = JavaVersion.current().toString();
 
         expect:
-        builder.build() == ["-g", USE_UNSHARED_COMPILER_TABLE_OPTION]
+        builder.build() == ["-source", JavaVersion.current().toString(), "-g", USE_UNSHARED_COMPILER_TABLE_OPTION]
     }
 
     def "generates -source option when compatibility differs from current Jvm version"() {
@@ -56,11 +56,11 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         builder.build() == ["-source", "1.4", "-g", USE_UNSHARED_COMPILER_TABLE_OPTION]
     }
 
-    def "generates no -target option when current Jvm Version is used"() {
+    def "generates -target option when current Jvm Version is used"() {
         spec.targetCompatibility = JavaVersion.current().toString();
 
         expect:
-        builder.build() == ["-g", USE_UNSHARED_COMPILER_TABLE_OPTION]
+        builder.build() == ["-target", JavaVersion.current().toString(), "-g", USE_UNSHARED_COMPILER_TABLE_OPTION]
     }
 
     def "generates -target option when compatibility differs current Jvm version"() {


### PR DESCRIPTION
See
https://discuss.gradle.org/t/source-and-target-are-only-passed-to-javac-when-java-version-is-different-than-gradle-java-version/17235
and elastic/elasticsearch#18039

Note this is currently untested because the tip of master does not even compile in gradle...