### PR TITLE
Include directories when using a S3Client to list objects in a prefix.

### DIFF
--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
@@ -99,10 +99,11 @@ class S3ClientIntegrationTest extends Specification {
         server.stubListFile(temporaryFolder.testDirectory, bucketName)
 
         then:
-        def files = s3Client.list(new URI("s3://${bucketName}/maven/release/"))
-        !files.isEmpty()
-        files.each {
-            assert it.contains(".")
+        def listing = s3Client.list(new URI("s3://${bucketName}/maven/release/"))
+        !listing.isEmpty()
+        listing.each {
+            // Files contain a "." and directories end with "/"
+            assert it.contains(".") || it.endsWith("/")
         }
 
         where:

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -145,6 +145,15 @@ public class S3Client {
 
     private List<String> resolveResourceNames(ObjectListing objectListing) {
         List<String> results = new ArrayList<String>();
+
+        results.addAll(resolveFileResourceNames(objectListing));
+        results.addAll(resolveDirectoryResourceNames(objectListing));
+
+        return results;
+    }
+
+    private List<String> resolveFileResourceNames(ObjectListing objectListing) {
+        List<String> results = new ArrayList<String>();
         List<S3ObjectSummary> objectSummaries = objectListing.getObjectSummaries();
         if (null != objectSummaries) {
             for (S3ObjectSummary objectSummary : objectSummaries) {
@@ -154,9 +163,13 @@ public class S3Client {
                     results.add(fileName);
                 }
             }
-
         }
 
+        return results;
+    }
+
+    private List<String> resolveDirectoryResourceNames(ObjectListing objectListing) {
+        List<String> results = new ArrayList<String>();
         List<String> commonPrefixes = objectListing.getCommonPrefixes();
         if(null != commonPrefixes) {
             for(String prefix : commonPrefixes) {

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -41,8 +41,8 @@ import java.util.regex.Pattern;
 
 public class S3Client {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3Client.class);
-    private static final Pattern FILENAME_PATTERN = Pattern.compile("[^\\/]+\\.*$");
-    private static final Pattern DIRNAME_PATTERN = Pattern.compile("([^\\/]+)[\\/]$");
+    private static final Pattern FILENAME_PATTERN = Pattern.compile("[^/]+\\.*$");
+    private static final Pattern DIRNAME_PATTERN = Pattern.compile("[^/]+/$");
 
     private AmazonS3Client amazonS3Client;
     private final S3ConnectionProperties s3ConnectionProperties;
@@ -187,7 +187,7 @@ public class S3Client {
         Matcher matcher = DIRNAME_PATTERN.matcher(key);
         if (matcher.find()) {
             // Add a "/" to differentiate directories from files
-            return matcher.group(1) + "/";
+            return matcher.group(0);
         }
         return null;
     }

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -42,6 +42,7 @@ import java.util.regex.Pattern;
 public class S3Client {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3Client.class);
     private static final Pattern FILENAME_PATTERN = Pattern.compile("[^\\/]+\\.*$");
+    private static final Pattern DIRNAME_PATTERN = Pattern.compile("([^\\/]+)[\\/]$");
 
     private AmazonS3Client amazonS3Client;
     private final S3ConnectionProperties s3ConnectionProperties;
@@ -153,8 +154,29 @@ public class S3Client {
                     results.add(fileName);
                 }
             }
+
         }
+
+        List<String> commonPrefixes = objectListing.getCommonPrefixes();
+        if(null != commonPrefixes) {
+            for(String prefix : commonPrefixes) {
+                String dirName = extractDirectoryName(prefix);
+                if(null != dirName) {
+                    results.add(dirName);
+                }
+            }
+        }
+
         return results;
+    }
+
+    private String extractDirectoryName(String key) {
+        Matcher matcher = DIRNAME_PATTERN.matcher(key);
+        if (matcher.find()) {
+            // Add a "/" to differentiate directories from files
+            return matcher.group(1) + "/";
+        }
+        return null;
     }
 
     private String extractResourceName(String key) {

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -186,7 +186,6 @@ public class S3Client {
     private String extractDirectoryName(String key) {
         Matcher matcher = DIRNAME_PATTERN.matcher(key);
         if (matcher.find()) {
-            // Add a "/" to differentiate directories from files
             return matcher.group(0);
         }
         return null;

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -119,6 +119,7 @@ public class S3Client {
     public List<String> list(URI parent) {
         List<String> results = new ArrayList<String>();
 
+        S3ResourceResolver resourceResolver = new S3ResourceResolver();
         S3RegionalResource s3RegionalResource = new S3RegionalResource(parent);
         String bucketName = s3RegionalResource.getBucketName();
         String s3BucketKey = s3RegionalResource.getKey();
@@ -130,11 +131,11 @@ public class S3Client {
                 .withMaxKeys(1000)
                 .withDelimiter("/");
         ObjectListing objectListing = amazonS3Client.listObjects(listObjectsRequest);
-        results.addAll(S3ResourceResolver.resolveResourceNames(objectListing));
+        results.addAll(resourceResolver.resolveResourceNames(objectListing));
 
         while (objectListing.isTruncated()) {
             objectListing = amazonS3Client.listNextBatchOfObjects(objectListing);
-            results.addAll(S3ResourceResolver.resolveResourceNames(objectListing));
+            results.addAll(resourceResolver.resolveResourceNames(objectListing));
         }
         return results;
     }

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -40,18 +40,21 @@ import java.util.List;
 public class S3Client {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3Client.class);
 
+    private S3ResourceResolver resourceResolver;
     private AmazonS3Client amazonS3Client;
     private final S3ConnectionProperties s3ConnectionProperties;
 
     public S3Client(AmazonS3Client amazonS3Client, S3ConnectionProperties s3ConnectionProperties) {
         this.s3ConnectionProperties = s3ConnectionProperties;
         this.amazonS3Client = amazonS3Client;
+        this.resourceResolver = new S3ResourceResolver();
     }
 
     public S3Client(AwsCredentials awsCredentials, S3ConnectionProperties s3ConnectionProperties) {
         this.s3ConnectionProperties = s3ConnectionProperties;
         AWSCredentials credentials = awsCredentials == null ? null : new BasicAWSCredentials(awsCredentials.getAccessKey(), awsCredentials.getSecretKey());
         amazonS3Client = createAmazonS3Client(credentials);
+        this.resourceResolver = new S3ResourceResolver();
     }
 
     private AmazonS3Client createAmazonS3Client(AWSCredentials credentials) {
@@ -119,7 +122,6 @@ public class S3Client {
     public List<String> list(URI parent) {
         List<String> results = new ArrayList<String>();
 
-        S3ResourceResolver resourceResolver = new S3ResourceResolver();
         S3RegionalResource s3RegionalResource = new S3RegionalResource(parent);
         String bucketName = s3RegionalResource.getBucketName();
         String s3BucketKey = s3RegionalResource.getKey();

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceNameExtractor.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceNameExtractor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class S3ResourceNameExtractor {
+    private static final Pattern FILENAME_PATTERN = Pattern.compile("[^/]+\\.*$");
+    private static final Pattern DIRNAME_PATTERN = Pattern.compile("[^/]+/$");
+
+    /**
+     * Extracts the directory name from a common prefix
+     */
+    public static String extractDirectoryName(String key) {
+        Matcher matcher = DIRNAME_PATTERN.matcher(key);
+        if (matcher.find()) {
+            return matcher.group(0);
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the filename of a file in S3.  Filename must contain a '.'
+     */
+    public static String extractResourceName(String key) {
+        Matcher matcher = FILENAME_PATTERN.matcher(key);
+        if (matcher.find()) {
+            String group = matcher.group(0);
+            return group.contains(".") ? group : null;
+        }
+        return null;
+    }
+}

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceNameExtractor.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceNameExtractor.java
@@ -26,7 +26,7 @@ public class S3ResourceNameExtractor {
     /**
      * Extracts the directory name from a common prefix
      */
-    public static String extractDirectoryName(String key) {
+    public String extractDirectoryName(String key) {
         Matcher matcher = DIRNAME_PATTERN.matcher(key);
         if (matcher.find()) {
             return matcher.group(0);
@@ -37,7 +37,7 @@ public class S3ResourceNameExtractor {
     /**
      * Extracts the filename of a file in S3.  Filename must contain a '.'
      */
-    public static String extractResourceName(String key) {
+    public String extractResourceName(String key) {
         Matcher matcher = FILENAME_PATTERN.matcher(key);
         if (matcher.find()) {
             String group = matcher.group(0);

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolver.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolver.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class S3ResourceResolver {
 
-    public static List<String> resolveResourceNames(ObjectListing objectListing) {
+    public List<String> resolveResourceNames(ObjectListing objectListing) {
         List<String> results = new ArrayList<String>();
 
         results.addAll(resolveFileResourceNames(objectListing));
@@ -33,13 +33,14 @@ public class S3ResourceResolver {
         return results;
     }
 
-    public static List<String> resolveFileResourceNames(ObjectListing objectListing) {
+    public List<String> resolveFileResourceNames(ObjectListing objectListing) {
         List<String> results = new ArrayList<String>();
+        S3ResourceNameExtractor nameExtractor = new S3ResourceNameExtractor();
         List<S3ObjectSummary> objectSummaries = objectListing.getObjectSummaries();
         if (null != objectSummaries) {
             for (S3ObjectSummary objectSummary : objectSummaries) {
                 String key = objectSummary.getKey();
-                String fileName = S3ResourceNameExtractor.extractResourceName(key);
+                String fileName = nameExtractor.extractResourceName(key);
                 if (null != fileName) {
                     results.add(fileName);
                 }
@@ -49,12 +50,13 @@ public class S3ResourceResolver {
         return results;
     }
 
-    public static List<String> resolveDirectoryResourceNames(ObjectListing objectListing) {
+    public List<String> resolveDirectoryResourceNames(ObjectListing objectListing) {
         List<String> results = new ArrayList<String>();
+        S3ResourceNameExtractor nameExtractor = new S3ResourceNameExtractor();
         List<String> commonPrefixes = objectListing.getCommonPrefixes();
         if(null != commonPrefixes) {
             for(String prefix : commonPrefixes) {
-                String dirName = S3ResourceNameExtractor.extractDirectoryName(prefix);
+                String dirName = nameExtractor.extractDirectoryName(prefix);
                 if(null != dirName) {
                     results.add(dirName);
                 }

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolver.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3;
+
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.services.s3.model.ObjectListing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class S3ResourceResolver {
+
+    public static List<String> resolveResourceNames(ObjectListing objectListing) {
+        List<String> results = new ArrayList<String>();
+
+        results.addAll(resolveFileResourceNames(objectListing));
+        results.addAll(resolveDirectoryResourceNames(objectListing));
+
+        return results;
+    }
+
+    public static List<String> resolveFileResourceNames(ObjectListing objectListing) {
+        List<String> results = new ArrayList<String>();
+        List<S3ObjectSummary> objectSummaries = objectListing.getObjectSummaries();
+        if (null != objectSummaries) {
+            for (S3ObjectSummary objectSummary : objectSummaries) {
+                String key = objectSummary.getKey();
+                String fileName = S3ResourceNameExtractor.extractResourceName(key);
+                if (null != fileName) {
+                    results.add(fileName);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    public static List<String> resolveDirectoryResourceNames(ObjectListing objectListing) {
+        List<String> results = new ArrayList<String>();
+        List<String> commonPrefixes = objectListing.getCommonPrefixes();
+        if(null != commonPrefixes) {
+            for(String prefix : commonPrefixes) {
+                String dirName = S3ResourceNameExtractor.extractDirectoryName(prefix);
+                if(null != dirName) {
+                    results.add(dirName);
+                }
+            }
+        }
+
+        return results;
+    }
+}

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolver.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolver.java
@@ -24,6 +24,12 @@ import java.util.List;
 
 public class S3ResourceResolver {
 
+    private S3ResourceNameExtractor nameExtractor;
+
+    public S3ResourceResolver() {
+        this.nameExtractor = new S3ResourceNameExtractor();
+    }
+
     public List<String> resolveResourceNames(ObjectListing objectListing) {
         List<String> results = new ArrayList<String>();
 
@@ -35,7 +41,6 @@ public class S3ResourceResolver {
 
     public List<String> resolveFileResourceNames(ObjectListing objectListing) {
         List<String> results = new ArrayList<String>();
-        S3ResourceNameExtractor nameExtractor = new S3ResourceNameExtractor();
         List<S3ObjectSummary> objectSummaries = objectListing.getObjectSummaries();
         if (null != objectSummaries) {
             for (S3ObjectSummary objectSummary : objectSummaries) {
@@ -52,7 +57,6 @@ public class S3ResourceResolver {
 
     public List<String> resolveDirectoryResourceNames(ObjectListing objectListing) {
         List<String> results = new ArrayList<String>();
-        S3ResourceNameExtractor nameExtractor = new S3ResourceNameExtractor();
         List<String> commonPrefixes = objectListing.getCommonPrefixes();
         if(null != commonPrefixes) {
             for(String prefix : commonPrefixes) {

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
@@ -20,7 +20,6 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.s3.model.ObjectListing
 import com.amazonaws.services.s3.model.PutObjectRequest
-import com.amazonaws.services.s3.model.S3ObjectSummary
 import com.google.common.base.Optional
 import org.gradle.api.resources.ResourceException
 import org.gradle.internal.credentials.DefaultAwsCredentials
@@ -51,66 +50,6 @@ class S3ClientTest extends Specification {
             assert putObjectRequest.key == 'maven/snapshot/myFile.txt'
             assert putObjectRequest.metadata.contentLength == 12
         }
-    }
-
-    def "should extract file name from s3 listing"() {
-        S3Client s3Client = new S3Client(Mock(AmazonS3Client), s3ConnectionProperties)
-
-        expect:
-        s3Client.extractResourceName(listing) == expected
-
-        where:
-        listing         | expected
-        '/a/b/file.pom' | 'file.pom'
-        '/file.pom'     | 'file.pom'
-        '/file.pom'     | 'file.pom'
-        '/SNAPSHOT/'    | null
-        '/SNAPSHOT/bin' | null
-        '/'             | null
-    }
-
-    def "should extract directory name from s3 common prefix"() {
-        S3Client s3Client = new S3Client(Mock(AmazonS3Client), s3ConnectionProperties)
-
-        expect:
-        s3Client.extractDirectoryName(commonPrefix) == expected
-
-        where:
-        commonPrefix                | expected
-        '/a/b/directory.with.dot/'  | 'directory.with.dot/'
-        '/directory.with.dot/'      | 'directory.with.dot/'
-        '/directoryWithoutDot/'     | 'directoryWithoutDot/'
-        '/directory.with.dot'       | null
-        '/'                         | null
-    }
-
-    def "should resolve all resource names from an AWS objectlisting"() {
-        setup:
-        S3Client s3Client = new S3Client(Mock(AmazonS3Client), s3ConnectionProperties)
-        ObjectListing objectListing = Mock()
-        S3ObjectSummary objectSummary = Mock()
-        objectSummary.getKey() >> '/SNAPSHOT/some.jar'
-
-        S3ObjectSummary objectSummary2 = Mock()
-        objectSummary2.getKey() >> '/SNAPSHOT/someOther.jar'
-        objectListing.getObjectSummaries() >> [objectSummary, objectSummary2]
-
-        objectListing.getCommonPrefixes() >> ['/SNAPSHOT/', '/SNAPSHOT/1.0.8/']
-
-        when:
-        def results = s3Client.resolveDirectoryResourceNames(objectListing)
-        then:
-        results == ['SNAPSHOT/', '1.0.8/']
-
-        when:
-        results = s3Client.resolveFileResourceNames(objectListing)
-        then:
-        results == ['some.jar', 'someOther.jar']
-
-        when:
-        results = s3Client.resolveResourceNames(objectListing)
-        then:
-        results == ['some.jar', 'someOther.jar', 'SNAPSHOT/', '1.0.8/']
     }
 
     def "should make batch call when more than one object listing exists"() {

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
@@ -84,7 +84,7 @@ class S3ClientTest extends Specification {
         '/'                         | null
     }
 
-    def "should resolve resource names from an AWS objectlisting"() {
+    def "should resolve all resource names from an AWS objectlisting"() {
         setup:
         S3Client s3Client = new S3Client(Mock(AmazonS3Client), s3ConnectionProperties)
         ObjectListing objectListing = Mock()
@@ -98,8 +98,17 @@ class S3ClientTest extends Specification {
         objectListing.getCommonPrefixes() >> ['/SNAPSHOT/', '/SNAPSHOT/1.0.8/']
 
         when:
-        def results = s3Client.resolveResourceNames(objectListing)
+        def results = s3Client.resolveDirectoryResourceNames(objectListing)
+        then:
+        results == ['SNAPSHOT/', '1.0.8/']
 
+        when:
+        results = s3Client.resolveFileResourceNames(objectListing)
+        then:
+        results == ['some.jar', 'someOther.jar']
+
+        when:
+        results = s3Client.resolveResourceNames(objectListing)
         then:
         results == ['some.jar', 'someOther.jar', 'SNAPSHOT/', '1.0.8/']
     }

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceNameExtractorTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceNameExtractorTest.groovy
@@ -20,8 +20,11 @@ import spock.lang.Specification
 
 class S3ResourceNameExtractorTest extends Specification {
     def "should extract file name from s3 listing"() {
+        setup:
+        S3ResourceNameExtractor extractor = new S3ResourceNameExtractor()
+
         expect:
-        S3ResourceNameExtractor.extractResourceName(listing) == expected
+        extractor.extractResourceName(listing) == expected
 
         where:
         listing         | expected
@@ -34,8 +37,11 @@ class S3ResourceNameExtractorTest extends Specification {
     }
 
     def "should extract directory name from s3 common prefix"() {
+        setup:
+        S3ResourceNameExtractor extractor = new S3ResourceNameExtractor()
+
         expect:
-        S3ResourceNameExtractor.extractDirectoryName(commonPrefix) == expected
+        extractor.extractDirectoryName(commonPrefix) == expected
 
         where:
         commonPrefix                | expected

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceNameExtractorTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceNameExtractorTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3
+
+import spock.lang.Specification
+
+class S3ResourceNameExtractorTest extends Specification {
+    def "should extract file name from s3 listing"() {
+        expect:
+        S3ResourceNameExtractor.extractResourceName(listing) == expected
+
+        where:
+        listing         | expected
+        '/a/b/file.pom' | 'file.pom'
+        '/file.pom'     | 'file.pom'
+        '/file.pom'     | 'file.pom'
+        '/SNAPSHOT/'    | null
+        '/SNAPSHOT/bin' | null
+        '/'             | null
+    }
+
+    def "should extract directory name from s3 common prefix"() {
+        expect:
+        S3ResourceNameExtractor.extractDirectoryName(commonPrefix) == expected
+
+        where:
+        commonPrefix                | expected
+        '/a/b/directory.with.dot/'  | 'directory.with.dot/'
+        '/directory.with.dot/'      | 'directory.with.dot/'
+        '/directoryWithoutDot/'     | 'directoryWithoutDot/'
+        '/directory.with.dot'       | null
+        '/'                         | null
+    }
+}

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolverTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolverTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.aws.s3
+
+import com.amazonaws.services.s3.model.ObjectListing
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import spock.lang.Specification
+
+class S3ResourceResolverTest extends Specification {
+    def "should resolve all resource names from an AWS objectlisting"() {
+        setup:
+        ObjectListing objectListing = Mock()
+        S3ObjectSummary objectSummary = Mock()
+        objectSummary.getKey() >> '/SNAPSHOT/some.jar'
+
+        S3ObjectSummary objectSummary2 = Mock()
+        objectSummary2.getKey() >> '/SNAPSHOT/someOther.jar'
+        objectListing.getObjectSummaries() >> [objectSummary, objectSummary2]
+
+        objectListing.getCommonPrefixes() >> ['/SNAPSHOT/', '/SNAPSHOT/1.0.8/']
+
+        when:
+        def results = S3ResourceResolver.resolveDirectoryResourceNames(objectListing)
+        then:
+        results == ['SNAPSHOT/', '1.0.8/']
+
+        when:
+        results = S3ResourceResolver.resolveFileResourceNames(objectListing)
+        then:
+        results == ['some.jar', 'someOther.jar']
+
+        when:
+        results = S3ResourceResolver.resolveResourceNames(objectListing)
+        then:
+        results == ['some.jar', 'someOther.jar', 'SNAPSHOT/', '1.0.8/']
+    }
+}

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolverTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ResourceResolverTest.groovy
@@ -32,19 +32,20 @@ class S3ResourceResolverTest extends Specification {
         objectListing.getObjectSummaries() >> [objectSummary, objectSummary2]
 
         objectListing.getCommonPrefixes() >> ['/SNAPSHOT/', '/SNAPSHOT/1.0.8/']
+        S3ResourceResolver resolver = new S3ResourceResolver()
 
         when:
-        def results = S3ResourceResolver.resolveDirectoryResourceNames(objectListing)
+        def results = resolver.resolveDirectoryResourceNames(objectListing)
         then:
         results == ['SNAPSHOT/', '1.0.8/']
 
         when:
-        results = S3ResourceResolver.resolveFileResourceNames(objectListing)
+        results = resolver.resolveFileResourceNames(objectListing)
         then:
         results == ['some.jar', 'someOther.jar']
 
         when:
-        results = S3ResourceResolver.resolveResourceNames(objectListing)
+        results = resolver.resolveResourceNames(objectListing)
         then:
         results == ['some.jar', 'someOther.jar', 'SNAPSHOT/', '1.0.8/']
     }


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [X] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [X] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [X] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [ ] Before submitting a pull request, I started a discussion on the
[Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev)
or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [X] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.

Ensure that directories are correctly included when listing the contents of an S3 prefix so that dynamic version dependencies will be able to discover the correct version to use.

- Directories are given as 'common prefixes' when listing the the items in an S3 prefix, so we need to process them into the list of things returned by the S3Client.