### PR TITLE
Make the shell script generated by the InstallExecutable task use the configured library path

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -186,8 +186,16 @@ public class InstallExecutable extends DefaultTask {
         String runScriptText =
               "\n#/bin/sh"
             + "\nAPP_BASE_NAME=`dirname \"$0\"`"
-            + "\nexport DYLD_LIBRARY_PATH=\"$APP_BASE_NAME/lib\""
-            + "\nexport LD_LIBRARY_PATH=\"$APP_BASE_NAME/lib\""
+            + "\nif [ -z \"$DYLD_LIBRARY_PATH\" ]; then"
+            + "\n\texport DYLD_LIBRARY_PATH=\"$APP_BASE_NAME/lib\""
+            + "\nelse"
+            + "\n\texport DYLD_LIBRARY_PATH=\"$APP_BASE_NAME/lib:$DYLD_LIBRARY_PATH\""
+            + "\nfi"
+            + "\nif [ -z \"$LD_LIBRARY_PATH\" ]; then"
+            + "\n\texport LD_LIBRARY_PATH=\"$APP_BASE_NAME/lib\""
+            + "\nelse"
+            + "\n\texport LD_LIBRARY_PATH=\"$APP_BASE_NAME/lib:$LD_LIBRARY_PATH\""
+            + "\nfi"
             + "\nexec \"$APP_BASE_NAME/lib/" + executable.getName() + "\" \"$@\""
             + "\n";
         GFileUtils.writeFile(runScriptText, getRunScript());


### PR DESCRIPTION
The shell script generated by the InstallExecutable task overrides the configured library path. Instead, it should prepend the created library directory to the library path.

Why is this necessary? On our CI server, you can load different GCC versions via [modules](https://en.wikipedia.org/wiki/Environment_Modules_(software)). The current shell script doesn't launch our C++ application correctly, since it won't be able to find the correct libstdc++.

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`