### PR TITLE
Add a task for verifying test file removal.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -320,7 +320,7 @@ gradle.addListener(new TaskExecutionListener() {
 // This will ensure that tests no longer leave files lying around.
 subprojects { prj ->
     task verifyTestFilesCleanup(type: EmptyDirectory) {
-        targetDir = prj.file("${prj.buildDir}/tmp/test files")
+        targetDir = prj.fileTree("${prj.buildDir}/tmp/test files")
         report = prj.file("${prj.buildDir}/reports/remains.txt")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 import org.gradle.build.Install
-import org.gradle.cleanup.EmptyDirectory
+import org.gradle.cleanup.EmptyDirectoryCheck
 
 defaultTasks 'assemble'
 apply plugin: 'java-base'
@@ -313,13 +313,12 @@ gradle.addListener(new TaskExecutionListener() {
 // files around.
 //
 // Once a subproject's report is "clean" we should add the following to that
-// subproject's buildsciprt:
+// subproject's buildscript:
 //
 // verifyTestFilesCleanup.errorWhenNotEmpty = true
 //
-// This will ensure that tests no longer leave files lying around.
 subprojects { prj ->
-    task verifyTestFilesCleanup(type: EmptyDirectory) {
+    task verifyTestFilesCleanup(type: EmptyDirectoryCheck) {
         targetDir = prj.fileTree("${prj.buildDir}/tmp/test files")
         report = prj.file("${prj.buildDir}/reports/remains.txt")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import org.gradle.build.Install
+import org.gradle.cleanup.EmptyDirectory
 
 defaultTasks 'assemble'
 apply plugin: 'java-base'
@@ -307,3 +308,19 @@ gradle.addListener(new TaskExecutionListener() {
         preferencesTraceFile << "$descr , '${task.path}', ${userPrefsDirectory.absolutePath}, ${userPrefsDirectory.exists()}\n"
     }
 })
+
+// Generate a report showing which tests in a subproject are leaving
+// files around.
+//
+// Once a subproject's report is "clean" we should add the following to that
+// subproject's buildsciprt:
+//
+// verifyTestFilesCleanup.errorWhenNotEmpty = true
+//
+// This will ensure that tests no longer leave files lying around.
+subprojects { prj ->
+    task verifyTestFilesCleanup(type: EmptyDirectory) {
+        targetDir = prj.file("${prj.buildDir}/tmp/test files")
+        report = prj.file("${prj.buildDir}/reports/remains.txt")
+    }
+}

--- a/buildSrc/src/main/groovy/org/gradle/cleanup/EmptyDirectory.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/cleanup/EmptyDirectory.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.cleanup
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+/**
+ * Ensures that a directory is empty or writes the names of files in
+ * the directory to a report file.
+ */
+class EmptyDirectory extends DefaultTask {
+    @Optional
+    @Input
+    File targetDir
+
+    @OutputFile
+    File report
+
+    @Input
+    boolean errorWhenNotEmpty
+
+    @TaskAction
+    def ensureEmptiness() {
+        def hasFile = false
+        def targetFiles = getProject().fileTree(targetDir)
+        targetFiles.visit { visitDetails ->
+            def f = visitDetails.getFile()
+            if (f.isFile()) {
+                hasFile = true
+                report << f.path + "\n"
+            }
+        }
+        if (hasFile && errorWhenNotEmpty) {
+            throw new GradleException("The directory ${targetDir.path} was not empty.")
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/org/gradle/cleanup/EmptyDirectory.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/cleanup/EmptyDirectory.groovy
@@ -17,6 +17,7 @@ package org.gradle.cleanup
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
@@ -28,7 +29,7 @@ import org.gradle.api.tasks.TaskAction
 class EmptyDirectory extends DefaultTask {
     @Optional
     @Input
-    File targetDir
+    FileTree targetDir
 
     @OutputFile
     File report
@@ -39,8 +40,7 @@ class EmptyDirectory extends DefaultTask {
     @TaskAction
     def ensureEmptiness() {
         def hasFile = false
-        def targetFiles = getProject().fileTree(targetDir)
-        targetFiles.visit { visitDetails ->
+        targetDir.visit { visitDetails ->
             def f = visitDetails.getFile()
             if (f.isFile()) {
                 hasFile = true
@@ -48,7 +48,7 @@ class EmptyDirectory extends DefaultTask {
             }
         }
         if (hasFile && errorWhenNotEmpty) {
-            throw new GradleException("The directory ${targetDir.path} was not empty.")
+            throw new GradleException("The directory ${targetDir.asPath} was not empty.")
         }
     }
 }

--- a/buildSrc/src/main/groovy/org/gradle/cleanup/EmptyDirectoryCheck.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/cleanup/EmptyDirectoryCheck.groovy
@@ -19,15 +19,14 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+
 /**
  * Ensures that a directory is empty or writes the names of files in
  * the directory to a report file.
  */
-class EmptyDirectory extends DefaultTask {
-    @Optional
+class EmptyDirectoryCheck extends DefaultTask {
     @Input
     FileTree targetDir
 

--- a/buildSrc/src/test/groovy/org/gradle/cleanup/EmptyDirectoryCheckTest.groovy
+++ b/buildSrc/src/test/groovy/org/gradle/cleanup/EmptyDirectoryCheckTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cleanup
+
+import org.gradle.api.Project
+import org.gradle.api.internal.AbstractTask
+import org.gradle.api.tasks.TaskExecutionException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class EmptyDirectoryCheckTest extends Specification {
+    @Rule
+    public final TemporaryFolder tempProjectDir = new TemporaryFolder()
+
+    Project project
+    File buildFile
+    File targetDir
+    File leftoverReport
+
+    def setup() {
+        buildFile = tempProjectDir.newFile('build.gradle')
+        targetDir = tempProjectDir.newFolder("clean_me")
+        tempProjectDir.newFolder("clean_me", "casserole")
+        leftoverReport = new File(tempProjectDir.getRoot(), "reports/leftovers.txt")
+    }
+
+    @Unroll
+    def "empty directory creates no output. errors: #withErrors"() {
+        given:
+        buildFile(withErrors)
+
+        when:
+        leftoversTask().execute()
+
+        then:
+        !leftoverReport.exists()
+
+        where:
+        withErrors << [true, false]
+    }
+
+    def "reports existing files"() {
+        given:
+        def files = populateLeftovers()
+        buildFile(false /* withErrors */)
+
+        when:
+        leftoversTask().execute()
+
+        then:
+        leftoverReport.exists()
+        def output = leftoverReport.getText("UTF-8")
+        files.each {
+            output.contains(it.path)
+        }
+    }
+
+    def "reports existing files and errors"() {
+        given:
+        def files = populateLeftovers()
+        buildFile(true /* withErrors */)
+
+        when:
+        leftoversTask().execute()
+
+        then:
+        TaskExecutionException tee = thrown()
+        tee.getCause().getMessage().contains(targetDir.path)
+        leftoverReport.exists()
+        def output = leftoverReport.getText("UTF-8")
+        files.each {
+            output.contains(it.path)
+        }
+    }
+
+    private def buildFile(boolean withErrors) {
+        buildFile << """
+            import org.gradle.cleanup.EmptyDirectoryCheck
+
+            task leftovers(type: EmptyDirectoryCheck) {
+                targetDir = fileTree('clean_me')
+                report = file('reports/leftovers.txt')
+                errorWhenNotEmpty = $withErrors
+            }
+        """
+    }
+
+    private def populateLeftovers() {
+        def files = new ArrayList<File>();
+        files.add(tempProjectDir.newFile("clean_me/casserole/peas.txt"))
+        files.add(tempProjectDir.newFile("clean_me/casserole/tuna.txt"))
+        files.add(tempProjectDir.newFile("clean_me/meatloaf.txt"))
+        return files
+    }
+
+    private def leftoversTask() {
+        project = ProjectBuilder.builder().withProjectDir(tempProjectDir.getRoot()).build()
+        return (AbstractTask) project.getTasksByName("leftovers", false /* recursive */).first()
+    }
+}


### PR DESCRIPTION
This adds a new task we can use in the Continuous Integration workflow both to detect when tests don't clean up all their files, and to eventually cause the builds to fail if a new one is introduced.