### PR TITLE
Upgrade groovy to 2.4.6 to fix java 9 issues

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ ext {
 
 versions.commons_io = 'commons-io:commons-io:2.2'
 
-versions.groovy = "2.4.4"
+versions.groovy = "2.4.6"
 
 versions.bouncycastle = "1.51"
 


### PR DESCRIPTION
Groovy uses reflection heavily to determine which methods/members are
available for use. With the modularization of java 9, much of the jdk
has become fully inaccessible (where before it was discouraged to play
with). This commit updates to groovy 2.4.6, which works around bad code
in groovy that is too aggressive in finding those accessible elements.

See https://issues.apache.org/jira/browse/GROOVY-7587

Also note, a similar error can be seen using gradle with the nebula
ospackage plugin. With gradle 2.13 and java 9 b119, a failure occurs like
this:

```
Caused by: java.lang.reflect.InaccessibleObjectException: Cannot make
a non-public member of class java.lang.reflect.AccessibleObject
accessible
```

With a locally built gradle using this commit and java 9 b119, the build
is able to proceed.