### PR TITLE
Checking that bin directory exists before making start scripts executable

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -223,6 +223,15 @@ startScripts {
         result.assertOutputContains("App Home: ${file('build/install/sample').absolutePath}")
     }
 
+    @Requires(TestPrecondition.UNIX_DERIVATIVE)
+    def "can execute installDist if startScript skipped"() {
+        when:
+        executer.withArguments("-x", "startScript")
+
+        then:
+        executer.withTasks('installDist').run()
+    }
+
     ExecutionResult runViaStartScript() {
         OperatingSystem.current().isWindows() ? runViaWindowsStartScript() : runViaUnixStartScript()
     }

--- a/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/groovy/org/gradle/api/plugins/ApplicationPlugin.java
@@ -97,10 +97,13 @@ public class ApplicationPlugin implements Plugin<Project> {
             @Override
             public void execute(Task task) {
                 Sync sync = (Sync) task;
-                HashMap<String, Object> args = new HashMap<String, Object>();
-                args.put("file", "" + sync.getDestinationDir().getAbsolutePath() + "/bin/" + pluginConvention.getApplicationName());
-                args.put("perm", "ugo+x");
-                project.getAnt().invokeMethod("chmod", args);
+                File binDir = new File(sync.getDestinationDir(), "bin");
+                if (binDir.isDirectory()) {
+                    HashMap<String, Object> args = new HashMap<String, Object>();
+                    args.put("file", binDir.getAbsolutePath() + File.separator + pluginConvention.getApplicationName());
+                    args.put("perm", "ugo+x");
+                    project.getAnt().invokeMethod("chmod", args);
+                }
             }
         });
     }


### PR DESCRIPTION
This pull request fixes exception `bin does not exist` when running `gradle clean installDist -x startScript`.

To reproduce this bug you need to add application plugin to your project and run `gradle clean installDist -x startScript --stacktrace`. It is reproducable only on UNIX derivative systems.

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [ ] Before submitting a pull request, I started a discussion on the
[Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev)
or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I wrote a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [ ] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.