### PR TITLE
Add sourceSet.output to PMD classpath

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginAuxclasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginAuxclasspathIntegrationTest.groovy
@@ -114,10 +114,12 @@ project("rule-using") {
             public class AuxclasspathRule extends AbstractJavaRule {
 
                 private static final String JUNIT_TEST = "junit.framework.TestCase";
+                private static final String CLASS1 = "org.gradle.ruleusing.Class1";
 
                 @Override
                 public Object visit(final ASTCompilationUnit node, final Object data) {
-                    if (node.getClassTypeResolver().classNameExists(JUNIT_TEST)) {
+                    if (node.getClassTypeResolver().classNameExists(JUNIT_TEST)
+                        && node.getClassTypeResolver().classNameExists(CLASS1)) {
                         addViolationWithMessage(data, node, "auxclasspath configured.");
                     } else {
                         addViolationWithMessage(data, node, "auxclasspath not configured.");

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -180,14 +180,14 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
     }
 
     @Override
-    protected void configureForSourceSet(final SourceSet sourceSet, Pmd task) {
+    protected void configureForSourceSet(final SourceSet sourceSet, final Pmd task) {
         task.setDescription("Run PMD analysis for " + sourceSet.getName() + " classes");
         task.setSource(sourceSet.getAllJava());
         ConventionMapping taskMapping = task.getConventionMapping();
         taskMapping.map("classpath", new Callable<FileCollection>() {
             @Override
             public FileCollection call() throws Exception {
-                return sourceSet.getCompileClasspath();
+                return task.getProject().files(sourceSet.getOutput(), sourceSet.getCompileClasspath());
             }
         });
     }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -187,7 +187,7 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         taskMapping.map("classpath", new Callable<FileCollection>() {
             @Override
             public FileCollection call() throws Exception {
-                return task.getProject().files(sourceSet.getOutput(), sourceSet.getCompileClasspath());
+                return sourceSet.getOutput().plus(sourceSet.getCompileClasspath());
             }
         });
     }

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -220,8 +220,9 @@ class PmdPluginTest extends Specification {
         project.sourceSets {
             main
         }
+        def mainSourceSet = project.sourceSets.main
+        def pmdTask = project.tasks.getByName("pmdMain")
         expect:
-        project.tasks.getByName("pmdMain").classpath.getFiles() ==
-            project.files(project.sourceSets.main.output, project.sourceSets.main.compileClasspath).getFiles()
+        pmdTask.classpath.files == (mainSourceSet.output + mainSourceSet.compileClasspath).files
     }
 }

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -221,6 +221,7 @@ class PmdPluginTest extends Specification {
             main
         }
         expect:
-        project.tasks.getByName("pmdMain").classpath == project.sourceSets.main.compileClasspath
+        project.tasks.getByName("pmdMain").classpath.getFiles() ==
+            project.files(project.sourceSets.main.output, project.sourceSets.main.compileClasspath).getFiles()
     }
 }

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
@@ -50,7 +50,10 @@
             </tr>
             <tr>
                 <td>classpath</td>
-                <td><literal><replaceable>sourceSet</replaceable>.compileClasspath</literal></td>
+                <td>
+                    <literal><replaceable>sourceSet</replaceable>.output</literal> and
+                    <literal><replaceable>sourceSet</replaceable>.compileClasspath</literal>
+                </td>
             </tr>
         </table>
     </section>


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [ ] Before submitting a pull request, I started a discussion on the
[Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev)
or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I wrote a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [ ] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.

---

For the typeresolution feature in PMD it is necessary, that the compiled
classes of the project itself are on the "auxclasspath", too.

Currently, only "sourceSet.compileClasspath" is used. With this change, both "sourceSet.output" and "sourceSet.compileClasspath" will be used. The unit tests have been adjusted accordingly.

This problem has been found via [pmd#1468](https://sourceforge.net/p/pmd/bugs/1468/), where you can find a complete sample project.

The workaround is, to configure pmdMain manually, e.g.:

~~~
pmdMain {
   classpath = files(sourceSets.main.compileClasspath, sourceSets.main.output)
}
~~~

This PR will make this configuration the default.


