### PR TITLE
Upgrade to Guava 19.0

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -27,7 +27,7 @@ repositories {
 dependencies {
     compile 'org.ow2.asm:asm-all:5.0.3'
     compile gradleApi()
-    compile 'com.google.guava:guava-jdk5:14.0.1@jar'
+    compile 'com.google.guava:guava:19.0@jar'
     compile 'commons-lang:commons-lang:2.6@jar'
     compile localGroovy()
     testCompile 'junit:junit:4.12@jar'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -83,7 +83,7 @@ libraries.commons_httpclient = dependencies.module('org.apache.httpcomponents:ht
 
 libraries += [
         dom4j: 'dom4j:dom4j:1.6.1@jar',
-        guava: 'com.google.guava:guava-jdk5:17.0@jar',
+        guava: 'com.google.guava:guava:19.0@jar',
         jsr305: 'com.google.code.findbugs:jsr305:1.3.9@jar',
         groovy: "org.codehaus.groovy:groovy-all:${versions.groovy}",
         jaxen: 'jaxen:jaxen:1.1@jar',

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsSpec.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsSpec.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.plugins.quality.internal.findbugs;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import java.io.Serializable;
 import java.util.List;
@@ -39,12 +39,12 @@ public class FindBugsSpec implements Serializable {
     public String getMaxHeapSize() {
         return maxHeapSize;
     }
-    
+
     public boolean isDebugEnabled() {
         return debugEnabled;
     }
-    
+
     public String toString() {
-        return Objects.toStringHelper(this).add("arguments", arguments).add("debugEnabled", debugEnabled).toString();
+        return MoreObjects.toStringHelper(this).add("arguments", arguments).add("debugEnabled", debugEnabled).toString();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/util/internal/CachingPatternSpecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/util/internal/CachingPatternSpecFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.util.internal;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -85,7 +86,7 @@ public class CachingPatternSpecFactory extends PatternSpecFactory {
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                 .add("key", key)
                 .add("spec", spec)
                 .toString();
@@ -127,7 +128,7 @@ public class CachingPatternSpecFactory extends PatternSpecFactory {
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                 .add("relativePath", relativePath)
                 .add("specKey", specKey)
                 .toString();
@@ -170,7 +171,7 @@ public class CachingPatternSpecFactory extends PatternSpecFactory {
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                 .add("patterns", patterns)
                 .add("include", include)
                 .add("caseSensitive", caseSensitive)

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonForkOptions.java
@@ -15,9 +15,8 @@
  */
 package org.gradle.api.internal.tasks.compile.daemon;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Sets;
-
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Nullable;
 
@@ -35,7 +34,7 @@ public class DaemonForkOptions {
     public DaemonForkOptions(@Nullable String minHeapSize, @Nullable String maxHeapSize, Iterable<String> jvmArgs) {
         this(minHeapSize, maxHeapSize, jvmArgs, Collections.<File>emptyList(), Collections.<String>emptyList());
     }
-    
+
     public DaemonForkOptions(@Nullable String minHeapSize, @Nullable String maxHeapSize, Iterable<String> jvmArgs, Iterable<File> classpath,
                              Iterable<String> sharedPackages) {
         this.minHeapSize = minHeapSize;
@@ -104,12 +103,12 @@ public class DaemonForkOptions {
         }
         throw new InvalidUserDataException("Cannot parse heap size: " + heapSize);
     }
-    
+
     private String mergeHeapSize(String heapSize1, String heapSize2) {
         int mergedHeapSizeMb = Math.max(getHeapSizeMb(heapSize1), getHeapSizeMb(heapSize2));
         return mergedHeapSizeMb == -1 ? null : String.valueOf(mergedHeapSizeMb) + "m";
     }
-    
+
     private Set<String> getNormalizedJvmArgs(Iterable<String> jvmArgs) {
         Set<String> normalized = Sets.newLinkedHashSet();
         for (String jvmArg : jvmArgs) {
@@ -117,16 +116,16 @@ public class DaemonForkOptions {
         }
         return normalized;
     }
-    
+
     private Set<File> getNormalizedClasspath(Iterable<File> classpath) {
         return Sets.newLinkedHashSet(classpath);
     }
-    
+
     private Set<String> getNormalizedSharedPackages(Iterable<String> allowedPackages) {
         return Sets.newLinkedHashSet(allowedPackages);
     }
-    
+
     public String toString() {
-        return Objects.toStringHelper(this).add("minHeapSize", minHeapSize).add("maxHeapSize", maxHeapSize).add("jvmArgs", jvmArgs).add("classpath", classpath).toString();
+        return MoreObjects.toStringHelper(this).add("minHeapSize", minHeapSize).add("maxHeapSize", maxHeapSize).add("jvmArgs", jvmArgs).add("classpath", classpath).toString();
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/api/internal/AnnotationMember.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/api/internal/AnnotationMember.java
@@ -51,7 +51,7 @@ public class AnnotationMember extends Member implements Comparable<AnnotationMem
 
     protected ComparisonChain compare(AnnotationMember o) {
         return super.compare(o)
-            .compare(visible, o.visible);
+            .compareFalseFirst(visible, o.visible);
     }
 
     @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/gradle/DefaultGradlePublication.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/gradle/DefaultGradlePublication.java
@@ -16,7 +16,7 @@
 
 package org.gradle.tooling.internal.gradle;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import org.gradle.tooling.model.GradleModuleVersion;
 
 import java.io.Serializable;
@@ -34,7 +34,7 @@ public class DefaultGradlePublication implements Serializable {
     }
 
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("id", id)
                 .toString();
     }


### PR DESCRIPTION
Removals in Guava:

- `InputSupplier` and `OutputSupplier`-related APIs (18.0)
- `Enums.valueOfFunction()` (18.0)
- `MapMaker.softValues()` (19.0)
- `AsyncEventBus.dispatchQueuedEvents()` (19.0)

If a plugin depends on these APIs, it will break. Otherwise things would function as before for Gradle users.

The advantage of upgrading is that we could start to use Java 6 or Java 7 features with Guava, as well as bugfixes and performance improvements.