### PR TITLE
Update user guide page titles.

### DIFF
--- a/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
@@ -29,6 +29,22 @@
         chapter toc,title
     </xsl:param>
 
+    <!--
+      Customize HTML page titles to include "User Guide" and version to help
+      with Google results. See issue doc-portal#9.
+    -->
+    <xsl:template match="book" mode="object.title.markup.textonly">
+        <xsl:value-of select="bookinfo/title"/>
+        <xsl:text> Version </xsl:text>
+        <xsl:value-of select="bookinfo/releaseinfo"/>
+    </xsl:template>
+
+    <xsl:template match="chapter" mode="object.title.markup.textonly">
+        <xsl:value-of select="title"/>
+        <xsl:text> - </xsl:text>
+        <xsl:apply-templates select="/book" mode="object.title.markup.textonly"/>
+    </xsl:template>
+
     <!-- HEADERS AND FOOTERS -->
 
     <!-- Use custom header -->

--- a/subprojects/docs/src/docs/stylesheets/userGuideSingleHtml.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideSingleHtml.xsl
@@ -17,4 +17,15 @@
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
     <xsl:import href="html/docbook.xsl"/>
     <xsl:import href="userGuideHtmlCommon.xsl"/>
+
+    <!--
+      Customize HTML page titles to include "User Guide" and version to help
+      with Google results. See issue doc-portal#9.
+    -->
+    <xsl:template match="book" mode="object.title.markup.textonly">
+        <xsl:value-of select="bookinfo/title"/>
+        <xsl:text> Version </xsl:text>
+        <xsl:value-of select="bookinfo/releaseinfo"/>
+        <xsl:text> (Single Page)</xsl:text>
+    </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
This is mainly to improve Google search results so that user guide pages appear
with the text "Gradle User Guide" rather than "Gradle Release Notes". This
change also makes the titles consistent with the DSL reference.