### PR TITLE
Support for preserving files in the destination dir for Sync task

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
@@ -15,6 +15,12 @@
  */
 package org.gradle.api.internal.file.copy;
 
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
@@ -22,20 +28,24 @@ import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.internal.tasks.SimpleWorkResult;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.util.GFileUtils;
-
-import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
 
 public class SyncCopyActionDecorator implements CopyAction {
     private final File baseDestDir;
     private final CopyAction delegate;
+    private CopySpec preserveSpec;
 
     public SyncCopyActionDecorator(File baseDestDir, CopyAction delegate) {
+        this(baseDestDir, delegate, null);
+    }
+
+    public SyncCopyActionDecorator(File baseDestDir, CopyAction delegate, CopySpec preserveSpec) {
         this.baseDestDir = baseDestDir;
         this.delegate = delegate;
+        this.preserveSpec = preserveSpec;
     }
 
     public WorkResult execute(final CopyActionProcessingStream stream) {
@@ -52,7 +62,8 @@ public class SyncCopyActionDecorator implements CopyAction {
             }
         });
 
-        SyncCopyActionDecoratorFileVisitor fileVisitor = new SyncCopyActionDecoratorFileVisitor(visited);
+        SyncCopyActionDecoratorFileVisitor fileVisitor = new SyncCopyActionDecoratorFileVisitor(visited,
+            preserveSpec);
 
         MinimalFileTree walker = new DirectoryFileTree(baseDestDir).postfix();
         walker.visit(fileVisitor);
@@ -63,10 +74,21 @@ public class SyncCopyActionDecorator implements CopyAction {
 
     private static class SyncCopyActionDecoratorFileVisitor implements FileVisitor {
         private final Set<RelativePath> visited;
+        private final Spec<FileTreeElement> preserveSpec;
+        private final PatternSet preserveSet;
         private boolean didWork;
 
-        private SyncCopyActionDecoratorFileVisitor(Set<RelativePath> visited) {
+        private SyncCopyActionDecoratorFileVisitor(
+            Set<RelativePath> visited,
+            CopySpec preserveSpec) {
             this.visited = visited;
+            PatternSet preserveSet = new PatternSet();
+            if (preserveSpec != null) {
+                preserveSet.include(preserveSpec.getIncludes());
+                preserveSet.exclude(preserveSpec.getExcludes());
+            }
+            this.preserveSet = preserveSet;
+            this.preserveSpec = preserveSet.getAsSpec();
         }
 
         public void visitDir(FileVisitDetails dirDetails) {
@@ -80,12 +102,14 @@ public class SyncCopyActionDecorator implements CopyAction {
         private void maybeDelete(FileVisitDetails fileDetails, boolean isDir) {
             RelativePath path = fileDetails.getRelativePath();
             if (!visited.contains(path)) {
-                if (isDir) {
-                    GFileUtils.deleteDirectory(fileDetails.getFile());
-                } else {
-                    GFileUtils.deleteQuietly(fileDetails.getFile());
+                if (preserveSet.isEmpty() || !preserveSpec.isSatisfiedBy(fileDetails)) {
+                    if (isDir) {
+                        GFileUtils.deleteDirectory(fileDetails.getFile());
+                    } else {
+                        GFileUtils.deleteQuietly(fileDetails.getFile());
+                    }
+                    didWork = true;
                 }
-                didWork = true;
             }
         }
     }


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [ ] Before submitting a pull request, I started a discussion on the
[Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev)
or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I wrote a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [x] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.

This is a gap from the Ant task, which supports preserving files
via preserveInTarget. This brings that functionality to the Sync
task to avoid having to rely on Ant.