### PR TITLE
Use default AmazonS3Client provider chain (support for IAM instance profile credentials)

### DIFF
--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
@@ -82,24 +82,6 @@ repositories {
                 .assertHasCause("Credentials must be an instance of '${AwsCredentials.class.getName()}'.")
     }
 
-    def "fails when no credentials provided"() {
-        setup:
-        buildFile << """
-repositories {
-    maven {
-        url "${mavenS3Repo.uri}"
-    }
-}
-"""
-
-        when:
-        fails 'retrieve'
-        then:
-        failure.assertHasDescription("Could not resolve all dependencies for configuration ':compile'.")
-                .assertHasCause("AwsCredentials must be set for S3 backed repository.")
-
-    }
-
     def "should include resource uri when file not found"() {
         setup:
         buildFile << mavenAwsRepoDsl()

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -62,7 +62,12 @@ public class S3Client {
     }
 
     private AmazonS3Client createAmazonS3Client(AWSCredentials credentials) {
-        AmazonS3Client amazonS3Client = new AmazonS3Client(credentials, createConnectionProperties());
+        AmazonS3Client amazonS3Client;
+        if (credentials != null) {
+            amazonS3Client = new AmazonS3Client(credentials, createConnectionProperties());
+        } else { // Fallback to default credentials provider chain
+            amazonS3Client = new AmazonS3Client(createConnectionProperties());
+        }
         S3ClientOptions.Builder clientOptionsBuilder = S3ClientOptions.builder();
         Optional<URI> endpoint = s3ConnectionProperties.getEndpoint();
         if (endpoint.isPresent()) {

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactory.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactory.java
@@ -43,9 +43,6 @@ public class S3ConnectorFactory implements ResourceConnectorFactory {
     @Override
     public ExternalResourceConnector createResourceConnector(ResourceConnectorSpecification connectionDetails) {
         AwsCredentials awsCredentials = connectionDetails.getCredentials(AwsCredentials.class);
-        if(awsCredentials == null) {
-            throw new IllegalArgumentException("AwsCredentials must be set for S3 backed repository.");
-        }
         return new S3ResourceConnector(new S3Client(awsCredentials, new S3ConnectionProperties()));
     }
 }

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactoryTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactoryTest.groovy
@@ -16,23 +16,9 @@
 
 package org.gradle.internal.resource.transport.aws.s3
 
-import org.gradle.api.credentials.AwsCredentials
-import org.gradle.internal.resource.connector.ResourceConnectorSpecification
 import spock.lang.Specification
 
 class S3ConnectorFactoryTest extends Specification {
 
     S3ConnectorFactory factory = new S3ConnectorFactory()
-    def "fails when no aws credentials provided"() {
-        setup:
-        def resourceConnectorSpecification = Mock(ResourceConnectorSpecification)
-        1 * resourceConnectorSpecification.getCredentials(AwsCredentials) >> null
-
-        when:
-        factory.createResourceConnector(resourceConnectorSpecification)
-
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message ==  "AwsCredentials must be set for S3 backed repository."
-    }
 }


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [X] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [X] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:
N/A

**Info**

Currently, in order to connect an S3 repo, an AWS key id and secret must be hard-coded in a gradle build file, which can lead to security issues. 

There is a [story for adding IAM credential authentication to gradle](https://github.com/gradle/gradle/blob/master/design-docs/finding-and-using-credentials.md#story-an-s3-repository-can-be-configured-to-authenticate-using-awss-ec2-instance-metadata), but the AWS library used by gradle (written by Amazon) already has built-in support, so there's no need to bake extra logic into gradle itself.

The changes in this pull request will utilize S3's default authentication provider chain if no AWS credentials are provided in a build.gradle file. This chain is as follows (from the [official javadocs](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Client.html#AmazonS3Client(com.amazonaws.ClientConfiguration))):
- Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_KEY
- Java System Properties - aws.accessKeyId and aws.secretKey
- Instance Profile Credentials - delivered through the Amazon EC2 metadata service

This paradigm is followed by other s3 utilities (eg, boto), and will allow the use of IAM instance profile credentials with no additional work.

Example:
```
repositories {
    maven {
        url "s3://my-bucket/releases"

        // Use default provider chain by not setting key
        // credentials(AwsCredentials) {
        //     accessKey "aws_key_id"
        //     secretKey "aws_secret_key"
        // }
    }
}
```