### PR TITLE
Add new '-Dorg.gradle.profile.ProfileAsJsonReportRenderer.enabled=true' system property for outputing profile data in JSON

### DIFF
--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile libraries.commons_io
     compile libraries.commons_lang
     compile libraries.guava
+    compile libraries.gson
     compile libraries.jcip
     compile libraries.inject
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -42,6 +42,7 @@ import org.gradle.invocation.DefaultGradle;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.profile.ReportAsJsonGeneratingProfileListener;
 import org.gradle.profile.ProfileEventAdapter;
 import org.gradle.profile.ReportGeneratingProfileListener;
 import org.gradle.util.DeprecationLogger;
@@ -133,6 +134,9 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         listenerManager.addListener(serviceRegistry.get(ProfileEventAdapter.class));
         if (startParameter.isProfile()) {
             listenerManager.addListener(new ReportGeneratingProfileListener());
+        }
+        if (ReportAsJsonGeneratingProfileListener.isEnabled()) {
+            listenerManager.addListener(new ReportAsJsonGeneratingProfileListener());
         }
         ScriptUsageLocationReporter usageLocationReporter = new ScriptUsageLocationReporter();
         listenerManager.addListener(usageLocationReporter);

--- a/subprojects/core/src/main/java/org/gradle/profile/ProfileAsJsonReportBindings.java
+++ b/subprojects/core/src/main/java/org/gradle/profile/ProfileAsJsonReportBindings.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.profile;
+
+import org.gradle.util.GradleVersion;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Data bindings for rendering the profile report in JSON
+ */
+public class ProfileAsJsonReportBindings {
+    public final String title;
+    public final String profiledBuild;
+    public final String startedOn;
+    public final String generatedBy;
+    public final String generatedAt;
+    public final BuildBindings measurements;
+
+    public ProfileAsJsonReportBindings(BuildProfile buildProfile) {
+        final SimpleDateFormat isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+        this.title = "Profile report";
+
+        StringBuilder sb = new StringBuilder();
+        for (String name : buildProfile.getStartParameter().getExcludedTaskNames()) {
+            sb.append("-x ");
+            sb.append(name);
+            sb.append(" ");
+        }
+        for (String name : buildProfile.getStartParameter().getTaskNames()) {
+            sb.append(name);
+            sb.append(" ");
+        }
+        String tasks = sb.toString().trim();
+        if (tasks.length() == 0) {
+            tasks = "(no tasks specified)";
+        }
+        this.profiledBuild = tasks;
+        this.startedOn = isoDateFormat.format(buildProfile.getBuildStarted());
+        this.generatedBy = String.format("Gradle %s", GradleVersion.current().getVersion());
+        this.generatedAt = isoDateFormat.format(new Date());
+        this.measurements = new BuildBindings(buildProfile);
+    }
+
+    public static class DurationBindings {
+        public final long duration;
+
+        public DurationBindings(long duration) {
+            this.duration = duration;
+        }
+    }
+
+    public static class ProjectConfigurationBindings {
+        public final long duration;
+        public final Map<String, DurationBindings> projects;
+
+        public ProjectConfigurationBindings(CompositeOperation<Operation> profiledProjectConfiguration) {
+            this.duration = profiledProjectConfiguration.getElapsedTime();
+
+            final Map<String, DurationBindings> projectConfigurations = new LinkedHashMap<String, DurationBindings>();
+            for (Operation operation : profiledProjectConfiguration) {
+                projectConfigurations.put(operation.getDescription(), new DurationBindings(operation.getElapsedTime()));
+            }
+
+            this.projects = projectConfigurations;
+        }
+    }
+
+    public static class DependencyResolutionBindings {
+        public final long duration;
+        public final Map<String, DurationBindings> dependencies;
+
+        public DependencyResolutionBindings(CompositeOperation<ContinuousOperation> profiledDependencyResolution) {
+            this.duration = profiledDependencyResolution.getElapsedTime();
+
+            final Map<String, DurationBindings> dependencyResolutions = new LinkedHashMap<String, DurationBindings>();
+            for (Operation operation : profiledDependencyResolution) {
+                dependencyResolutions.put(operation.getDescription(), new DurationBindings(operation.getElapsedTime()));
+            }
+
+            this.dependencies = dependencyResolutions;
+        }
+    }
+
+    public static class DurationStatusBindings {
+        public final long duration;
+        public final String status;
+
+        public DurationStatusBindings(long duration, String status) {
+            this.duration = duration;
+            this.status = status;
+        }
+    }
+
+    public static class TaskExecutionBindings {
+        public final long duration;
+        public final Map<String, DurationStatusBindings> tasks;
+
+        public TaskExecutionBindings(ProjectProfile projectProfile) {
+            this.duration = projectProfile.getElapsedTime();
+
+            final Map<String, DurationStatusBindings> taskExecutions = new LinkedHashMap<String, DurationStatusBindings>();
+            for (TaskExecution taskExecution : projectProfile.getTasks()) {
+                taskExecutions.put(taskExecution.getPath(), new DurationStatusBindings(taskExecution.getElapsedTime(), taskExecution.getStatus()));
+            }
+
+            this.tasks = taskExecutions;
+        }
+    }
+
+    public static class ProjectExecutionBindings {
+        public final long duration;
+        public final Map<String, TaskExecutionBindings> projects;
+
+        public ProjectExecutionBindings(BuildProfile buildProfile) {
+            this.duration = buildProfile.getElapsedTotalExecutionTime();
+
+            final Map<String, TaskExecutionBindings> projectExecutions = new LinkedHashMap<String, TaskExecutionBindings>();
+            for (ProjectProfile projectProfile : buildProfile.getProjects()) {
+                projectExecutions.put(projectProfile.getPath(), new TaskExecutionBindings(projectProfile));
+            }
+
+            this.projects = projectExecutions;
+        }
+    }
+
+    public static class BuildBindings {
+       public final DurationBindings totalBuildTime;
+       public final DurationBindings startup;
+       public final DurationBindings settingsAndBuildsrc;
+       public final DurationBindings loadingProjects;
+       public final ProjectConfigurationBindings configuringProjects;
+       public final DependencyResolutionBindings resolvingDependencies;
+       public final ProjectExecutionBindings executingProjects;
+
+        public BuildBindings(BuildProfile buildProfile) {
+            this.totalBuildTime = new DurationBindings(buildProfile.getElapsedTotal());
+            this.startup = new DurationBindings(buildProfile.getElapsedStartup());
+            this.settingsAndBuildsrc = new DurationBindings(buildProfile.getElapsedSettings());
+            this.loadingProjects = new DurationBindings(buildProfile.getElapsedProjectsLoading());
+            this.configuringProjects = new ProjectConfigurationBindings(buildProfile.getProjectConfiguration());
+            this.resolvingDependencies = new DependencyResolutionBindings(buildProfile.getDependencySets());
+            this.executingProjects = new ProjectExecutionBindings(buildProfile);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/profile/ProfileAsJsonReportRenderer.java
+++ b/subprojects/core/src/main/java/org/gradle/profile/ProfileAsJsonReportRenderer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.profile;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.gradle.api.UncheckedIOException;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+
+public class ProfileAsJsonReportRenderer {
+
+    public void writeTo(BuildProfile buildProfile, File file) {
+        try {
+            File parentFile = file.getParentFile();
+
+            if (parentFile != null) {
+                if (!parentFile.mkdirs() && !parentFile.isDirectory()) {
+                    throw new IOException(String.format("Unable to create directory '%s'", parentFile));
+                }
+            }
+
+            ProfileAsJsonReportBindings jsonReportBindings = new ProfileAsJsonReportBindings(buildProfile);
+
+            Gson gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .serializeNulls()
+                .setPrettyPrinting()
+                .create();
+
+            FileWriter fileWriter = new FileWriter(file);
+            try {
+                gson.toJson(jsonReportBindings, fileWriter);
+            } finally {
+                fileWriter.close();
+            }
+
+        } catch (Exception e) {
+            throw new UncheckedIOException(String.format("Could not write to file '%s'.", file), e);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/profile/ReportAsJsonGeneratingProfileListener.java
+++ b/subprojects/core/src/main/java/org/gradle/profile/ReportAsJsonGeneratingProfileListener.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.profile;
+
+import org.gradle.BuildAdapter;
+import org.gradle.api.invocation.Gradle;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class ReportAsJsonGeneratingProfileListener extends BuildAdapter implements ProfileListener {
+    private static final SimpleDateFormat FILE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
+    private static final String PROFILE_AS_JSON_PROPERTY = ProfileAsJsonReportRenderer.class.getName() + ".enabled";
+
+    private File buildDir;
+
+    public static boolean isEnabled() {
+        return Boolean.getBoolean(PROFILE_AS_JSON_PROPERTY);
+    }
+
+    @Override
+    public void projectsEvaluated(Gradle gradle) {
+        buildDir = gradle.getRootProject().getBuildDir();
+    }
+
+    public void buildFinished(BuildProfile buildProfile) {
+        ProfileAsJsonReportRenderer renderer = new ProfileAsJsonReportRenderer();
+        File file = new File(buildDir, "reports/profile/profile-" + FILE_DATE_FORMAT.format(new Date(buildProfile.getBuildStarted())) + ".json");
+        renderer.writeTo(buildProfile, file);
+    }
+}
+


### PR DESCRIPTION
This is a follow up to my previous pull-request #615 to bring my change inline with what we agreed would be acceptable at the Gradle summit. 
1. The feature is hidden behind a secret system property ('org.gradle.profile.ProfileAsJsonReportRenderer.enabled')
2. The JSON report is rendered using the Gson libraries. 

Any of the checked boxes below indicate that I took action:
- [X] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [X] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [X] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:
- [X] Before submitting a pull request, I started a discussion on the
  [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev)
  or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I wrote a design document. A design document can be
  brief but explains the use case or problem you are trying to solve,
  touches on the planned implementation approach as well as the test cases
  that verify the behavior. Optimally, design documents should be submitted
  as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
  can be found in the Gradle GitHub repository. Please let us know if you need help with
  creating the design document. We are happy to help!
- [X] The pull request contains an appropriate level of unit and integration
  test coverage to verify the behavior. Before submitting the pull request
  I ran a build on your local machine via the command
  `./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
  DSL reference and Javadocs where applicable.

Gradle will output profile data as JSON when this system option enabled
