### PR TITLE
Made default file lock timeout customizable

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -39,7 +39,7 @@ import static org.gradle.internal.UncheckedException.throwAsUncheckedException;
  */
 public class DefaultFileLockManager implements FileLockManager {
     private static final Logger LOGGER = Logging.getLogger(DefaultFileLockManager.class);
-    public static final int DEFAULT_LOCK_TIMEOUT = 60000;
+    public static final int DEFAULT_LOCK_TIMEOUT = Integer.valueOf(System.getProperty("org.gradle.file_lock_timeout", "60000"));
 
     private final Set<File> lockedFiles = new CopyOnWriteArraySet<File>();
     private final ProcessMetaDataProvider metaDataProvider;


### PR DESCRIPTION
When there too many workers sometimes 60 seconds wait time is not enough. For more details see discussion in #666.

to: @ghale 
