### PR TITLE
Use the JCIP ThreadSafe annotation instead of the one from httpcomponents

### DIFF
--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/repository/internal/DefaultPluginRepositoryRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/repository/internal/DefaultPluginRepositoryRegistry.java
@@ -17,7 +17,7 @@
 package org.gradle.plugin.repository.internal;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.http.annotation.ThreadSafe;
+import net.jcip.annotations.ThreadSafe;
 import org.gradle.plugin.repository.GradlePluginPortal;
 import org.gradle.plugin.repository.PluginRepository;
 


### PR DESCRIPTION
Hi,

DefaultPluginRepositoryRegistry is the only class using the ThreadSafe annotation from the org.apache.http.annotation package. The other ThreadSafe annotations come from net.jcip.annotations. I guess this is an auto-import mistake. This will become a problem when upgrading to httpcomponents-core >= 4.4.5 because the annotation has been removed.