### PR TITLE
Compatibility fix for BouncyCastle >= 1.52

### DIFF
--- a/subprojects/signing/src/main/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactory.java
+++ b/subprojects/signing/src/main/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactory.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.signing.signatory.pgp;
 import org.bouncycastle.openpgp.PGPSecretKey;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
 import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
+import org.bouncycastle.openpgp.bc.BcPGPSecretKeyRingCollection;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Nullable;
 import org.gradle.api.Project;
@@ -121,7 +122,7 @@ public class PgpSignatoryFactory {
     protected PGPSecretKey readSecretKey(InputStream input, String keyId, String sourceDescription) {
         Object keyRingCollection;
         try {
-            keyRingCollection = new PGPSecretKeyRingCollection(input);
+            keyRingCollection = new BcPGPSecretKeyRingCollection(input);
         } catch (Exception e) {
             throw new InvalidUserDataException("Unable to read secret key from " + sourceDescription + " (it may not be a PGP secret key ring)", e);
         }


### PR DESCRIPTION
Hi,

Gradle fails to compile with BouncyCastle >= 1.52. This is due to the removal of the `PGPSecretKeyRingCollection(InputStream)` constructor (deprecated in 1.51). Here is a simple patch fixing this issue.