### PR TITLE
EmptyDirectoryCheckTest: Fix testing against the targetDir

### DIFF
--- a/buildSrc/src/test/groovy/org/gradle/cleanup/EmptyDirectoryCheckTest.groovy
+++ b/buildSrc/src/test/groovy/org/gradle/cleanup/EmptyDirectoryCheckTest.groovy
@@ -82,7 +82,7 @@ class EmptyDirectoryCheckTest extends Specification {
 
         then:
         TaskExecutionException tee = thrown()
-        tee.getCause().getMessage().contains(targetDir.path)
+        tee.getCause().getMessage().contains(targetDir.canonicalPath)
         leftoverReport.exists()
         def output = leftoverReport.getText("UTF-8")
         files.each {


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

This is a trivial bug fix in a test:

On Windows, `targetDir.path` might actually return the short-path notation to
a file, which is not literally contained in the exception's message text.
Fix that by asking `targetDir` for its canonical path.