### PR TITLE
Copy task: filesMatching and filesNotMatching should support multiple patterns

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/file/CopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/file/CopySpec.java
@@ -148,6 +148,17 @@ public interface CopySpec extends CopySourceSpec, CopyProcessingSpec, PatternFil
     CopySpec filesMatching(String pattern, Action<? super FileCopyDetails> action);
 
     /**
+     * Configure the {@link org.gradle.api.file.FileCopyDetails} for each file whose path matches any of the specified Ant-style patterns.
+     * This is equivalent to using eachFile() and selectively applying a configuration based on the file's path.
+     *
+     * @param patterns Ant-style patterns used to match against files' relative paths
+     * @param action action called for the FileCopyDetails of each file matching pattern
+     * @return this
+     */
+    @Incubating
+    CopySpec filesMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action);
+
+    /**
      * Configure the {@link org.gradle.api.file.FileCopyDetails} for each file whose path does not match the specified
      * Ant-style pattern. This is equivalent to using eachFile() and selectively applying a configuration based on the
      * file's path.
@@ -158,6 +169,18 @@ public interface CopySpec extends CopySourceSpec, CopyProcessingSpec, PatternFil
      */
     @Incubating
     CopySpec filesNotMatching(String pattern, Action<? super FileCopyDetails> action);
+
+    /**
+     * Configure the {@link org.gradle.api.file.FileCopyDetails} for each file whose path does not match any of the specified
+     * Ant-style patterns. This is equivalent to using eachFile() and selectively applying a configuration based on the
+     * file's path.
+     *
+     * @param patterns Ant-style patterns used to match against files' relative paths
+     * @param action action called for the FileCopyDetails of each file that does not match any pattern
+     * @return this
+     */
+    @Incubating
+    CopySpec filesNotMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action);
 
     /**
      * Adds the given specs as a child of this spec.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/CopySpecWrapper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/CopySpecWrapper.java
@@ -77,8 +77,18 @@ public class CopySpecWrapper implements CopySpec {
         return this;
     }
 
+    public CopySpec filesMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action) {
+        delegate.filesMatching(patterns, action);
+        return this;
+    }
+
     public CopySpec filesNotMatching(String pattern, Action<? super FileCopyDetails> action) {
         delegate.filesNotMatching(pattern, action);
+        return this;
+    }
+
+    public CopySpec filesNotMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action) {
+        delegate.filesNotMatching(patterns, action);
         return this;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
@@ -193,8 +193,7 @@ public class DefaultCopySpec implements CopySpecInternal {
 
     public CopySpec filesMatching(String pattern, Action<? super FileCopyDetails> action) {
         Spec<RelativePath> matcher = PatternMatcherFactory.getPatternMatcher(true, isCaseSensitive(), pattern);
-        return eachFile(
-            new MatchingCopyAction(matcher, action));
+        return eachFile(new MatchingCopyAction(matcher, action));
     }
 
     public CopySpec filesNotMatching(String pattern, Action<? super FileCopyDetails> action) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
@@ -196,9 +196,27 @@ public class DefaultCopySpec implements CopySpecInternal {
         return eachFile(new MatchingCopyAction(matcher, action));
     }
 
+    public CopySpec filesMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action) {
+        List<Spec> matchers = new ArrayList<Spec>();
+        for (String pattern : patterns) {
+            matchers.add(PatternMatcherFactory.getPatternMatcher(true, isCaseSensitive(), pattern));
+        }
+        Spec unionMatcher = Specs.union(matchers.toArray(new Spec[matchers.size()]));
+        return eachFile(new MatchingCopyAction(unionMatcher, action));
+    }
+
     public CopySpec filesNotMatching(String pattern, Action<? super FileCopyDetails> action) {
         Spec<RelativePath> matcher = PatternMatcherFactory.getPatternMatcher(true, isCaseSensitive(), pattern);
         return eachFile(new MatchingCopyAction(Specs.<RelativePath>negate(matcher), action));
+    }
+
+    public CopySpec filesNotMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action) {
+        List<Spec> matchers = new ArrayList<Spec>();
+        for (String pattern : patterns) {
+            matchers.add(PatternMatcherFactory.getPatternMatcher(true, isCaseSensitive(), pattern));
+        }
+        Spec unionMatcher = Specs.union(matchers.toArray(new Spec[matchers.size()]));
+        return eachFile(new MatchingCopyAction(Specs.<RelativePath>negate(unionMatcher), action));
     }
 
     public CopySpec include(String... includes) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DelegatingCopySpecInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DelegatingCopySpecInternal.java
@@ -68,8 +68,16 @@ public abstract class DelegatingCopySpecInternal implements CopySpecInternal {
         return getDelegateCopySpec().filesMatching(pattern, action);
     }
 
+    public CopySpec filesMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action) {
+        return getDelegateCopySpec().filesMatching(patterns, action);
+    }
+
     public CopySpec filesNotMatching(String pattern, Action<? super FileCopyDetails> action) {
         return getDelegateCopySpec().filesNotMatching(pattern, action);
+    }
+
+    public CopySpec filesNotMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action) {
+        return getDelegateCopySpec().filesNotMatching(patterns, action);
     }
 
     public CopySpec with(CopySpec... sourceSpecs) {

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -182,8 +182,24 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
     /**
      * {@inheritDoc}
      */
+    public AbstractCopyTask filesMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action) {
+        getMainSpec().filesMatching(patterns, action);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public AbstractCopyTask filesNotMatching(String pattern, Action<? super FileCopyDetails> action) {
         getMainSpec().filesNotMatching(pattern, action);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public AbstractCopyTask filesNotMatching(Iterable<String> patterns, Action<? super FileCopyDetails> action) {
+        getMainSpec().filesNotMatching(patterns, action);
         return this;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopySpecMatchingTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopySpecMatchingTest.groovy
@@ -20,8 +20,8 @@ import org.gradle.api.Action
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RelativePath
-import org.gradle.internal.Actions
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.internal.Actions
 import org.gradle.internal.reflect.DirectInstantiator
 import spock.lang.Specification
 
@@ -37,7 +37,7 @@ class CopySpecMatchingTest extends Specification {
         FileCopyDetails details1 = Mock()
         FileCopyDetails details2 = Mock()
 
-        details1.relativeSourcePath >>  RelativePath.parse(true, 'path/abc.txt')
+        details1.relativeSourcePath >> RelativePath.parse(true, 'path/abc.txt')
         details2.relativeSourcePath >> RelativePath.parse(true, 'path/bcd.txt')
 
         Action matchingAction = Mock()
@@ -51,6 +51,7 @@ class CopySpecMatchingTest extends Specification {
 
         then:
         1 * matchingAction.execute(details1)
+        0 * matchingAction.execute(details2)
     }
 
 
@@ -60,7 +61,7 @@ class CopySpecMatchingTest extends Specification {
         FileCopyDetails details1 = Mock()
         FileCopyDetails details2 = Mock()
 
-        details1.relativeSourcePath >>  RelativePath.parse(true, 'path/abc.txt')
+        details1.relativeSourcePath >> RelativePath.parse(true, 'path/abc.txt')
         details2.relativeSourcePath >> RelativePath.parse(true, 'path/bcd.txt')
 
         Action matchingAction = Mock()
@@ -73,6 +74,7 @@ class CopySpecMatchingTest extends Specification {
         }
 
         then:
+        0 * matchingAction.execute(details1)
         1 * matchingAction.execute(details2)
     }
 
@@ -80,8 +82,10 @@ class CopySpecMatchingTest extends Specification {
         given:
         DefaultCopySpec childSpec = new DefaultCopySpec(TestFiles.resolver(), DirectInstantiator.INSTANCE)
         CopySpecResolver childResolver = childSpec.buildResolverRelativeToParent(copySpec.buildRootResolver())
+
         when:
         copySpec.filesMatching("**/*.java", Actions.doNothing())
+
         then:
         1 == childResolver.allCopyActions.size()
         childResolver.allCopyActions[0] instanceof MatchingCopyAction

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopySpecMatchingTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopySpecMatchingTest.groovy
@@ -33,7 +33,6 @@ class CopySpecMatchingTest extends Specification {
 
     def canMatchFiles() {
         given:
-
         FileCopyDetails details1 = Mock()
         FileCopyDetails details2 = Mock()
 
@@ -54,10 +53,34 @@ class CopySpecMatchingTest extends Specification {
         0 * matchingAction.execute(details2)
     }
 
+    def canMatchFilesWithMultiplePatterns() {
+        given:
+        FileCopyDetails details1 = Mock()
+        FileCopyDetails details2 = Mock()
+        FileCopyDetails details3 = Mock()
+
+        details1.relativeSourcePath >> RelativePath.parse(true, 'path/abc.txt')
+        details2.relativeSourcePath >> RelativePath.parse(true, 'path/bcd.txt')
+        details3.relativeSourcePath >> RelativePath.parse(true, 'path/cde.txt')
+
+        Action matchingAction = Mock()
+
+        when:
+        copySpec.filesMatching(["**/a*", "**/c*"], matchingAction)
+        copySpec.copyActions.each { copyAction ->
+            copyAction.execute(details1)
+            copyAction.execute(details2)
+            copyAction.execute(details3)
+        }
+
+        then:
+        1 * matchingAction.execute(details1)
+        0 * matchingAction.execute(details2)
+        1 * matchingAction.execute(details3)
+    }
 
     def canNotMatchFiles() {
         given:
-
         FileCopyDetails details1 = Mock()
         FileCopyDetails details2 = Mock()
 
@@ -76,6 +99,32 @@ class CopySpecMatchingTest extends Specification {
         then:
         0 * matchingAction.execute(details1)
         1 * matchingAction.execute(details2)
+    }
+
+    def canNotMatchFilesWithMultiplePatterns() {
+        given:
+        FileCopyDetails details1 = Mock()
+        FileCopyDetails details2 = Mock()
+        FileCopyDetails details3 = Mock()
+
+        details1.relativeSourcePath >> RelativePath.parse(true, 'path/abc.txt')
+        details2.relativeSourcePath >> RelativePath.parse(true, 'path/bcd.txt')
+        details3.relativeSourcePath >> RelativePath.parse(true, 'path/cde.txt')
+
+        Action matchingAction = Mock()
+
+        when:
+        copySpec.filesNotMatching(["**/a*", "**/c*"], matchingAction)
+        copySpec.copyActions.each { copyAction ->
+            copyAction.execute(details1)
+            copyAction.execute(details2)
+            copyAction.execute(details3)
+        }
+
+        then:
+        0 * matchingAction.execute(details1)
+        1 * matchingAction.execute(details2)
+        0 * matchingAction.execute(details3)
     }
 
     def matchingSpecInherited() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecTest.groovy
@@ -265,6 +265,24 @@ public class DefaultCopySpecTest {
     }
 
     @Test
+    public void testMatchingWithMultiplePatternsCreatesAppropriateAction() {
+        spec.filesMatching(["root/**/a*", "special/*", "banner.txt"], Actions.doNothing())
+        assertEquals(1, spec.copyActions.size())
+        assertThat(spec.copyActions[0], instanceOf(MatchingCopyAction))
+
+        Spec<RelativePath> matchSpec = spec.copyActions[0].matchSpec
+        assertTrue(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/root/folder/abc')))
+        assertTrue(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/root/abc')))
+        assertTrue(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/special/foo')))
+        assertTrue(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'banner.txt')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/notRoot/abc')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/not/root/abc')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/root/bbc')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/notRoot/bbc')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/not/special/bar')))
+    }
+
+    @Test
     public void testNotMatchingCreatesAppropriateAction() {
         // no path component starting with an a
         spec.filesNotMatching("**/a*/**", Actions.doNothing())
@@ -277,6 +295,25 @@ public class DefaultCopySpecTest {
         assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'archives/folder/file')))
         assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'root/archives/file')))
         assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'root/folder/abc')))
+    }
+
+    @Test
+    public void testNotMatchingWithMultiplePatternsCreatesAppropriateAction() {
+        // no path component starting with an a or c
+        spec.filesNotMatching(["**/a*/**", "**/c*/**"], Actions.doNothing())
+        assertEquals(1, spec.copyActions.size())
+        assertThat(spec.copyActions[0], instanceOf(MatchingCopyAction))
+
+        Spec<RelativePath> matchSpec = spec.copyActions[0].matchSpec
+        assertTrue(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'root/folder1/folder2')))
+        assertTrue(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'modules/project1')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'archives/folder/file')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'root/archives/file')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'root/folder/abc')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'collections/folder/file')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'root/collections/file')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'root/folder/cde')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, 'archives/collections/file')))
     }
 
     @Test

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecTest.groovy
@@ -259,6 +259,7 @@ public class DefaultCopySpecTest {
         assertTrue(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/root/folder/abc')))
         assertTrue(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/root/abc')))
         assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/notRoot/abc')))
+        assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/not/root/abc')))
         assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/root/bbc')))
         assertFalse(matchSpec.isSatisfiedBy(RelativePath.parse(true, '/notRoot/bbc')))
     }
@@ -309,7 +310,7 @@ public class DefaultCopySpecTest {
     }
 
     @Test
-    void "Add spec in between two child specs if given child does not exist"() {
+    void "Append spec after two child specs if given child does not exist"() {
         DefaultCopySpec child1 = spec.addChild()
         DefaultCopySpec child2 = spec.addChild()
         assert child1 != null
@@ -327,7 +328,7 @@ public class DefaultCopySpecTest {
     }
 
     @Test
-    void "Add spec in between two child specs if given child is null"() {
+    void "Append spec after two child specs if given child is null"() {
         DefaultCopySpec child1 = spec.addChild()
         DefaultCopySpec child2 = spec.addChild()
         assert child1 != null
@@ -366,7 +367,6 @@ public class DefaultCopySpecTest {
         assert spec.fileMode == 1
         assert spec.dirMode == 2
         assert spec.filteringCharset == "UTF8"
-
     }
 
     @Test


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, I started a discussion on the
[Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev)
or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I wrote a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [x] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
