### PR TITLE
Upgrade JAnsi to get some (Windows specific) bug fixes

### DIFF
--- a/subprojects/native/native.gradle
+++ b/subprojects/native/native.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile libraries.slf4j_api
     compile libraries.jna
     compile libraries.nativePlatform
-    compile module('org.fusesource.jansi:jansi:1.2.1') {
+    compile module('org.fusesource.jansi:jansi:1.13') {
         dependency libraries.jna
     }
     compile libraries.guava


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

This is a trivial change that only upgrades the existing jansi dependency:

This is also in preparation for supporting colored output in Cygwin's /
MSYS2's mintty terminal on Windows.