### PR TITLE
Rename getModule() to getName() in the module component interfaces

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/component/ModuleComponentIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/component/ModuleComponentIdentifier.java
@@ -35,10 +35,10 @@ public interface ModuleComponentIdentifier extends ComponentIdentifier {
     /**
      * The module name of the component.
      *
-     * @return Component module
+     * @return Component name
      * @since 1.10
      */
-    String getModule();
+    String getName();
 
     /**
      * The module version of the component.

--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
@@ -37,7 +37,7 @@ public interface ModuleComponentSelector extends ComponentSelector {
      *
      * @return Module name
      */
-    String getModule();
+    String getName();
 
     /**
      * The version of the module to select the component from.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
@@ -98,6 +98,6 @@ public class DefaultModuleVersionIdentifier implements ModuleVersionIdentifier {
     }
 
     public static ModuleVersionIdentifier newId(ModuleComponentIdentifier componentId) {
-        return new DefaultModuleVersionIdentifier(componentId.getGroup(), componentId.getModule(), componentId.getVersion());
+        return new DefaultModuleVersionIdentifier(componentId.getGroup(), componentId.getName(), componentId.getVersion());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/IvyUtil.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/IvyUtil.java
@@ -33,7 +33,7 @@ public class IvyUtil {
     }
 
     public static ModuleRevisionId createModuleRevisionId(ModuleComponentIdentifier id) {
-        return createModuleRevisionId(id.getGroup(), id.getModule(), id.getVersion());
+        return createModuleRevisionId(id.getGroup(), id.getName(), id.getVersion());
     }
 
     private static String emptyStringIfNull(String value) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
@@ -40,7 +40,7 @@ public class DefaultDependencyResolveDetails implements DependencyResolveDetails
         // Temporary logic until we add DependencySubstitution back in
         if (delegate.getTarget() instanceof ModuleComponentSelector) {
             ModuleComponentSelector moduleComponentSelector = (ModuleComponentSelector) delegate.getTarget();
-            return DefaultModuleVersionSelector.newSelector(moduleComponentSelector.getGroup(), moduleComponentSelector.getModule(), moduleComponentSelector.getVersion());
+            return DefaultModuleVersionSelector.newSelector(moduleComponentSelector.getGroup(), moduleComponentSelector.getName(), moduleComponentSelector.getVersion());
         }
         // If the target is a project component, it must be unmodified from the requested
         return delegate.getOldRequested();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
@@ -175,7 +175,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
         public void execute(DependencySubstitution dependencySubstitution) {
             if (dependencySubstitution.getRequested() instanceof ModuleComponentSelector) {
                 ModuleComponentSelector requested = (ModuleComponentSelector) dependencySubstitution.getRequested();
-                if (moduleId.getGroup().equals(requested.getGroup()) && moduleId.getName().equals(requested.getModule())) {
+                if (moduleId.getGroup().equals(requested.getGroup()) && moduleId.getName().equals(requested.getName())) {
                     dependencySubstitution.useTarget(substitute);
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
@@ -209,7 +209,7 @@ public class GradlePomModuleDescriptorBuilder {
         // Some POMs depend on themselves, don't add this dependency: Ivy doesn't allow this!
         // Example: http://repo2.maven.org/maven2/net/jini/jsk-platform/2.1/jsk-platform-2.1.pom
         if (selector.getGroup().equals(descriptor.getComponentIdentifier().getGroup())
-            && selector.getName().equals(descriptor.getComponentIdentifier().getModule())) {
+            && selector.getName().equals(descriptor.getComponentIdentifier().getName())) {
             return;
         }
 
@@ -339,7 +339,7 @@ public class GradlePomModuleDescriptorBuilder {
         // since Ivy doesn't allow this!
         // Example: http://repo2.maven.org/maven2/com/atomikos/atomikos-util/3.6.4/atomikos-util-3.6.4.pom
         if (selector.getGroup().equals(descriptor.getComponentIdentifier().getGroup())
-            && selector.getName().equals(descriptor.getComponentIdentifier().getModule())) {
+            && selector.getName().equals(descriptor.getComponentIdentifier().getName())) {
             return;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -79,7 +79,7 @@ public class ModuleMetadataSerializer {
 
         private void writeId(ModuleComponentIdentifier componentIdentifier) throws IOException {
             writeString(componentIdentifier.getGroup());
-            writeString(componentIdentifier.getModule());
+            writeString(componentIdentifier.getName());
             writeString(componentIdentifier.getVersion());
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStore.java
@@ -77,7 +77,7 @@ public class ModuleMetadataStore {
     }
 
     private String getFilePath(ModuleComponentRepository repository, ModuleComponentIdentifier moduleComponentIdentifier) {
-        return moduleComponentIdentifier.getGroup() + "/" + moduleComponentIdentifier.getModule() + "/" + moduleComponentIdentifier.getVersion() + "/" + repository.getId() + "/descriptor.bin";
+        return moduleComponentIdentifier.getGroup() + "/" + moduleComponentIdentifier.getName() + "/" + moduleComponentIdentifier.getVersion() + "/" + repository.getId() + "/descriptor.bin";
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/publisher/IvyXmlModuleDescriptorWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/publisher/IvyXmlModuleDescriptorWriter.java
@@ -103,7 +103,7 @@ public class IvyXmlModuleDescriptorWriter implements IvyModuleDescriptorWriter {
         writer.startElement("info");
 
         writer.attribute("organisation", id.getGroup());
-        writer.attribute("module", id.getModule());
+        writer.attribute("module", id.getName());
         String branch = descriptor.getBranch();
         if (branch != null) {
             writer.attribute("branch", branch);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRules.java
@@ -152,7 +152,7 @@ public class DefaultComponentSelectionRules implements ComponentSelectionRulesIn
         }
 
         public boolean isSatisfiedBy(ComponentSelection selection) {
-            return selection.getCandidate().getGroup().equals(target.getGroup()) && selection.getCandidate().getModule().equals(target.getName());
+            return selection.getCandidate().getGroup().equals(target.getGroup()) && selection.getCandidate().getName().equals(target.getName());
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
@@ -53,7 +53,7 @@ public class ComponentIdentifierSerializer implements Serializer<ComponentIdenti
             ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier)value;
             encoder.writeByte(Implementation.MODULE.getId());
             encoder.writeString(moduleComponentIdentifier.getGroup());
-            encoder.writeString(moduleComponentIdentifier.getModule());
+            encoder.writeString(moduleComponentIdentifier.getName());
             encoder.writeString(moduleComponentIdentifier.getVersion());
         } else if(value instanceof DefaultProjectComponentIdentifier) {
             ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier)value;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -50,7 +50,7 @@ public class ComponentSelectorSerializer implements Serializer<ComponentSelector
             ModuleComponentSelector moduleComponentSelector = (ModuleComponentSelector) value;
             encoder.writeByte(Implementation.MODULE.getId());
             encoder.writeString(moduleComponentSelector.getGroup());
-            encoder.writeString(moduleComponentSelector.getModule());
+            encoder.writeString(moduleComponentSelector.getName());
             encoder.writeString(moduleComponentSelector.getVersion());
         } else if (value instanceof DefaultProjectComponentSelector) {
             ProjectComponentSelector projectComponentSelector = (ProjectComponentSelector) value;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
@@ -80,7 +80,7 @@ abstract class AbstractResourcePattern implements ResourcePattern {
     protected Map<String, String> toAttributes(ModuleComponentIdentifier componentIdentifier) {
         HashMap<String, String> attributes = new HashMap<String, String>();
         attributes.put(IvyPatternHelper.ORGANISATION_KEY, componentIdentifier.getGroup());
-        attributes.put(IvyPatternHelper.MODULE_KEY, componentIdentifier.getModule());
+        attributes.put(IvyPatternHelper.MODULE_KEY, componentIdentifier.getName());
         attributes.put(IvyPatternHelper.REVISION_KEY, componentIdentifier.getVersion());
         return attributes;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -202,7 +202,7 @@ public abstract class ExternalResourceResolver implements ModuleVersionPublisher
 
     private MutableModuleComponentResolveMetadata createMetaDataFromDefaultArtifact(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata overrideMetadata, ExternalResourceArtifactResolver artifactResolver, ResourceAwareResolveResult result) {
         Set<IvyArtifactName> artifacts = overrideMetadata.getArtifacts();
-        for (IvyArtifactName artifact : getDependencyArtifactNames(moduleComponentIdentifier.getModule(), artifacts)) {
+        for (IvyArtifactName artifact : getDependencyArtifactNames(moduleComponentIdentifier.getName(), artifacts)) {
             if (artifactResolver.artifactExists(new DefaultModuleComponentArtifactMetadata(moduleComponentIdentifier, artifact), result)) {
                 return createDefaultComponentResolveMetaData(moduleComponentIdentifier, artifacts);
             }
@@ -230,8 +230,8 @@ public abstract class ExternalResourceResolver implements ModuleVersionPublisher
         if (!expectedId.getGroup().equals(metadata.getId().getGroup())) {
             errors.add("bad group: expected='" + expectedId.getGroup() + "' found='" + metadata.getId().getGroup() + "'");
         }
-        if (!expectedId.getModule().equals(metadata.getId().getName())) {
-            errors.add("bad module name: expected='" + expectedId.getModule() + "' found='" + metadata.getId().getName() + "'");
+        if (!expectedId.getName().equals(metadata.getId().getName())) {
+            errors.add("bad module name: expected='" + expectedId.getName() + "' found='" + metadata.getId().getName() + "'");
         }
         if (!expectedId.getVersion().equals(metadata.getId().getVersion())) {
             errors.add("bad version: expected='" + expectedId.getVersion() + "' found='" + metadata.getId().getVersion() + "'");
@@ -253,7 +253,7 @@ public abstract class ExternalResourceResolver implements ModuleVersionPublisher
     }
 
     private ModuleDescriptorArtifactMetadata getMetaDataArtifactFor(ModuleComponentIdentifier moduleComponentIdentifier) {
-        IvyArtifactName ivyArtifactName = getMetaDataArtifactName(moduleComponentIdentifier.getModule());
+        IvyArtifactName ivyArtifactName = getMetaDataArtifactName(moduleComponentIdentifier.getName());
         DefaultModuleComponentArtifactMetadata defaultModuleComponentArtifactMetadata = new DefaultModuleComponentArtifactMetadata(moduleComponentIdentifier, ivyArtifactName);
         return new DefaultModuleDescriptorArtifactMetadata(defaultModuleComponentArtifactMetadata);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -213,7 +213,7 @@ public class MavenResolver extends ExternalResourceResolver {
             checkMetadataConsistency(snapshotComponentIdentifier.getSnapshotComponent(), metaData);
             // Use the requested id. Currently we're discarding the MavenUniqueSnapshotComponentIdentifier and replacing with DefaultModuleComponentIdentifier as pretty
             // much every consumer of the meta-data is expecting a DefaultModuleComponentIdentifier.
-            ModuleComponentIdentifier lossyId = DefaultModuleComponentIdentifier.newId(moduleComponentIdentifier.getGroup(), moduleComponentIdentifier.getModule(), moduleComponentIdentifier.getVersion());
+            ModuleComponentIdentifier lossyId = DefaultModuleComponentIdentifier.newId(moduleComponentIdentifier.getGroup(), moduleComponentIdentifier.getName(), moduleComponentIdentifier.getVersion());
             metaData.setComponentId(lossyId);
             metaData.setSnapshotTimestamp(snapshotComponentIdentifier.getTimestamp());
         } else {
@@ -287,7 +287,7 @@ public class MavenResolver extends ExternalResourceResolver {
 
     private MavenUniqueSnapshotComponentIdentifier composeSnapshotIdentifier(ModuleComponentIdentifier moduleComponentIdentifier, MavenUniqueSnapshotModuleSource uniqueSnapshotVersion) {
         return new MavenUniqueSnapshotComponentIdentifier(moduleComponentIdentifier.getGroup(),
-                moduleComponentIdentifier.getModule(),
+                moduleComponentIdentifier.getName(),
                 moduleComponentIdentifier.getVersion(),
                 uniqueSnapshotVersion.getTimestamp());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifier.java
@@ -30,7 +30,7 @@ public class MavenUniqueSnapshotComponentIdentifier extends DefaultModuleCompone
     }
 
     public MavenUniqueSnapshotComponentIdentifier(ModuleComponentIdentifier baseIdentifier, String timestamp) {
-        super(baseIdentifier.getGroup(), baseIdentifier.getModule(), baseIdentifier.getVersion());
+        super(baseIdentifier.getGroup(), baseIdentifier.getName(), baseIdentifier.getVersion());
         this.timestamp = timestamp;
     }
 
@@ -46,7 +46,7 @@ public class MavenUniqueSnapshotComponentIdentifier extends DefaultModuleCompone
 
     @Override
     public String getDisplayName() {
-        return String.format("%s:%s:%s:%s", getGroup(), getModule(), getSnapshotVersion(), timestamp);
+        return String.format("%s:%s:%s:%s", getGroup(), getName(), getSnapshotVersion(), timestamp);
     }
 
     public String getTimestamp() {
@@ -58,7 +58,7 @@ public class MavenUniqueSnapshotComponentIdentifier extends DefaultModuleCompone
     }
 
     public ModuleComponentIdentifier getSnapshotComponent() {
-        return DefaultModuleComponentIdentifier.newId(getGroup(), getModule(), getSnapshotVersion());
+        return DefaultModuleComponentIdentifier.newId(getGroup(), getName(), getSnapshotVersion());
     }
 
     public String getTimestampedVersion() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/composite/CompositeBuildDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/composite/CompositeBuildDependencySubstitutions.java
@@ -93,7 +93,7 @@ public class CompositeBuildDependencySubstitutions implements DependencySubstitu
         }
 
         public ProjectComponentIdentifier getReplacementFor(ModuleComponentSelector selector) {
-            ModuleIdentifier candidateId = DefaultModuleIdentifier.newId(selector.getGroup(), selector.getModule());
+            ModuleIdentifier candidateId = DefaultModuleIdentifier.newId(selector.getGroup(), selector.getName());
             Collection<ProjectComponentIdentifier> providingProjects = replacements.get(candidateId);
             if (providingProjects.isEmpty()) {
                 LOGGER.info("Found no composite build substitute for module '" + candidateId + "'.");

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/MutableModuleDescriptorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/MutableModuleDescriptorState.java
@@ -50,7 +50,7 @@ public class MutableModuleDescriptorState extends ModuleDescriptorState {
         }
 
         if (componentArtifacts.isEmpty()) {
-            IvyArtifactName defaultArtifact = new DefaultIvyArtifactName(componentIdentifier.getModule(), "jar", "jar");
+            IvyArtifactName defaultArtifact = new DefaultIvyArtifactName(componentIdentifier.getName(), "jar", "jar");
             moduleDescriptorState.addArtifact(defaultArtifact, Collections.singleton(org.gradle.api.artifacts.Dependency.DEFAULT_CONFIGURATION));
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifier.java
@@ -20,23 +20,23 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 
 public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifier {
     private final String group;
-    private final String module;
+    private final String name;
     private final String version;
 
-    public DefaultModuleComponentIdentifier(String group, String module, String version) {
+    public DefaultModuleComponentIdentifier(String group, String name, String version) {
         assert group != null : "group cannot be null";
-        assert module != null : "module cannot be null";
+        assert name != null : "name cannot be null";
         assert version != null : "version cannot be null";
         this.group = group;
-        this.module = module;
+        this.name = name;
         this.version = version;
     }
 
     public String getDisplayName() {
-        StringBuilder builder = new StringBuilder(group.length() + module.length() + version.length() + 2);
+        StringBuilder builder = new StringBuilder(group.length() + name.length() + version.length() + 2);
         builder.append(group);
         builder.append(":");
-        builder.append(module);
+        builder.append(name);
         builder.append(":");
         builder.append(version);
         return builder.toString();
@@ -46,8 +46,8 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
         return group;
     }
 
-    public String getModule() {
-        return module;
+    public String getName() {
+        return name;
     }
 
     public String getVersion() {
@@ -68,7 +68,7 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
         if (!group.equals(that.group)) {
             return false;
         }
-        if (!module.equals(that.module)) {
+        if (!name.equals(that.name)) {
             return false;
         }
         if (!version.equals(that.version)) {
@@ -81,7 +81,7 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
     @Override
     public int hashCode() {
         int result = group.hashCode();
-        result = 31 * result + module.hashCode();
+        result = 31 * result + name.hashCode();
         result = 31 * result + version.hashCode();
         return result;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -22,23 +22,23 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector;
 
 public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     private final String group;
-    private final String module;
+    private final String name;
     private final String version;
 
-    public DefaultModuleComponentSelector(String group, String module, String version) {
+    public DefaultModuleComponentSelector(String group, String name, String version) {
         assert group != null : "group cannot be null";
-        assert module != null : "module cannot be null";
+        assert name != null : "name cannot be null";
         assert version != null : "version cannot be null";
         this.group = group;
-        this.module = module;
+        this.name = name;
         this.version = version;
     }
 
     public String getDisplayName() {
-        StringBuilder builder = new StringBuilder(group.length() + module.length() + version.length() + 2);
+        StringBuilder builder = new StringBuilder(group.length() + name.length() + version.length() + 2);
         builder.append(group);
         builder.append(":");
-        builder.append(module);
+        builder.append(name);
         builder.append(":");
         builder.append(version);
         return builder.toString();
@@ -48,8 +48,8 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         return group;
     }
 
-    public String getModule() {
-        return module;
+    public String getName() {
+        return name;
     }
 
     public String getVersion() {
@@ -61,7 +61,7 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
 
         if(identifier instanceof ModuleComponentIdentifier) {
             ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier)identifier;
-            return module.equals(moduleComponentIdentifier.getModule())
+            return name.equals(moduleComponentIdentifier.getName())
                     && group.equals(moduleComponentIdentifier.getGroup())
                     && version.equals(moduleComponentIdentifier.getVersion());
         }
@@ -83,7 +83,7 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         if (!group.equals(that.group)) {
             return false;
         }
-        if (!module.equals(that.module)) {
+        if (!name.equals(that.name)) {
             return false;
         }
         if (!version.equals(that.version)) {
@@ -96,7 +96,7 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     @Override
     public int hashCode() {
         int result = group.hashCode();
-        result = 31 * result + module.hashCode();
+        result = 31 * result + name.hashCode();
         result = 31 * result + version.hashCode();
         return result;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultDependencyMetadata.java
@@ -97,7 +97,7 @@ public class DefaultDependencyMetadata implements DependencyMetadata {
 
     public DefaultDependencyMetadata(ModuleComponentIdentifier componentIdentifier) {
         this(
-            new DefaultModuleVersionSelector(componentIdentifier.getGroup(), componentIdentifier.getModule(), componentIdentifier.getVersion()),
+            new DefaultModuleVersionSelector(componentIdentifier.getGroup(), componentIdentifier.getName(), componentIdentifier.getVersion()),
             Collections.<String, List<String>>emptyMap(),
             Collections.<IvyArtifactName, Set<String>>emptyMap(),
             Collections.<Exclude, Set<String>>emptyMap(),
@@ -265,7 +265,7 @@ public class DefaultDependencyMetadata implements DependencyMetadata {
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
             ModuleComponentSelector moduleTarget = (ModuleComponentSelector) target;
-            ModuleVersionSelector requestedVersion = DefaultModuleVersionSelector.newSelector(moduleTarget.getGroup(), moduleTarget.getModule(), moduleTarget.getVersion());
+            ModuleVersionSelector requestedVersion = DefaultModuleVersionSelector.newSelector(moduleTarget.getGroup(), moduleTarget.getName(), moduleTarget.getVersion());
             if (requestedVersion.equals(requested)) {
                 return this;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -145,7 +145,7 @@ public class LocalComponentDependencyMetadata implements DependencyMetadata {
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
             ModuleComponentSelector moduleTarget = (ModuleComponentSelector) target;
-            ModuleVersionSelector requestedVersion = DefaultModuleVersionSelector.newSelector(moduleTarget.getGroup(), moduleTarget.getModule(), moduleTarget.getVersion());
+            ModuleVersionSelector requestedVersion = DefaultModuleVersionSelector.newSelector(moduleTarget.getGroup(), moduleTarget.getName(), moduleTarget.getVersion());
             return copyWithTarget(moduleTarget, requestedVersion);
         } else if (target instanceof ProjectComponentSelector) {
             return copyWithTarget(target, requested);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
@@ -55,15 +55,15 @@ public class ModuleVersionResolveException extends DefaultMultiCauseException {
     }
 
     public ModuleVersionResolveException(ModuleComponentIdentifier id, String messageFormat) {
-        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getModule(), id.getVersion()), messageFormat);
+        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getName(), id.getVersion()), messageFormat);
     }
 
     public ModuleVersionResolveException(ModuleComponentIdentifier id, Throwable cause) {
-        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getModule(), id.getVersion()), Arrays.asList(cause));
+        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getName(), id.getVersion()), Arrays.asList(cause));
     }
 
     public ModuleVersionResolveException(ModuleComponentIdentifier id, Iterable<? extends Throwable> causes) {
-        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getModule(), id.getVersion()), causes);
+        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getName(), id.getVersion()), causes);
     }
 
     public ModuleVersionResolveException(ModuleVersionSelector selector, Throwable cause) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
@@ -192,7 +192,7 @@ public class JsonProjectDependencyRenderer {
     private ModuleIdentifier getModuleIdentifier(RenderableDependency renderableDependency) {
         if (renderableDependency.getId() instanceof ModuleComponentIdentifier) {
             ModuleComponentIdentifier id = (ModuleComponentIdentifier) renderableDependency.getId();
-            return new DefaultModuleIdentifier(id.getGroup(), id.getModule());
+            return new DefaultModuleIdentifier(id.getGroup(), id.getName());
         }
         return null;
     }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/StrictDependencyResultSpec.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/StrictDependencyResultSpec.java
@@ -50,7 +50,7 @@ public class StrictDependencyResultSpec implements Spec<DependencyResult> {
         if (moduleIdentifier != null && requested instanceof ModuleComponentSelector) {
             ModuleComponentSelector requestedSelector = (ModuleComponentSelector) requested;
             return requestedSelector.getGroup().equals(moduleIdentifier.getGroup())
-                    && requestedSelector.getModule().equals(moduleIdentifier.getName());
+                    && requestedSelector.getName().equals(moduleIdentifier.getName());
         }
 
         return false;
@@ -62,7 +62,7 @@ public class StrictDependencyResultSpec implements Spec<DependencyResult> {
         if (moduleIdentifier != null && selected instanceof ModuleComponentIdentifier) {
             ModuleComponentIdentifier selectedModule = (ModuleComponentIdentifier) selected;
             return selectedModule.getGroup().equals(moduleIdentifier.getGroup())
-                    && selectedModule.getModule().equals(moduleIdentifier.getName());
+                    && selectedModule.getName().equals(moduleIdentifier.getName());
         }
 
         return false;

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpec.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpec.java
@@ -46,7 +46,7 @@ class DependencyResultSpec implements Spec<DependencyResult> {
 
         if(requested instanceof ModuleComponentSelector) {
             ModuleComponentSelector requestedModule = (ModuleComponentSelector)requested;
-            String requestedCandidate = requestedModule.getGroup() + ":" + requestedModule.getModule() + ":" + requestedModule.getVersion();
+            String requestedCandidate = requestedModule.getGroup() + ":" + requestedModule.getName() + ":" + requestedModule.getVersion();
             return requestedCandidate.contains(stringNotation);
         }
 
@@ -55,7 +55,7 @@ class DependencyResultSpec implements Spec<DependencyResult> {
 
     private boolean matchesSelected(ResolvedDependencyResult candidate) {
         ModuleVersionIdentifier selected = candidate.getSelected().getModuleVersion();
-        String selectedCandidate = selected.getGroup() + ":" + selected.getModule() + ":" + selected.getVersion();
+        String selectedCandidate = selected.getGroup() + ":" + selected.getName() + ":" + selected.getVersion();
         return selectedCandidate.contains(stringNotation);
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
@@ -56,7 +56,7 @@ public abstract class AbstractRenderableDependencyResult implements RenderableDe
      * @return Indicates whether version differs
      */
     private boolean isSameGroupAndModuleButDifferentVersion(ModuleComponentSelector requested, ModuleComponentIdentifier selected) {
-        return requested.getGroup().equals(selected.getGroup()) && requested.getModule().equals(selected.getModule()) && !requested.getVersion().equals(selected.getVersion());
+        return requested.getGroup().equals(selected.getGroup()) && requested.getName().equals(selected.getName()) && !requested.getVersion().equals(selected.getVersion());
     }
 
     /**

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResult.java
@@ -64,7 +64,7 @@ public class RenderableUnresolvedDependencyResult implements RenderableDependenc
             ModuleComponentSelector attemptedSelector = (ModuleComponentSelector)attempted;
 
             if(requestedSelector.getGroup().equals(attemptedSelector.getGroup())
-                    && requestedSelector.getModule().equals(attemptedSelector.getModule())
+                    && requestedSelector.getName().equals(attemptedSelector.getName())
                     && !requestedSelector.getVersion().equals(attemptedSelector.getVersion())) {
                 return requested.getDisplayName() + " -> " + ((ModuleComponentSelector) attempted).getVersion();
             }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
@@ -34,7 +34,7 @@ public class UnresolvedDependencyEdge implements DependencyEdge {
         this.dependency = dependency;
         // TODO:Prezi Is this cast safe? Can't this be a LibraryComponentSelector, say?
         ModuleComponentSelector attempted = (ModuleComponentSelector)dependency.getAttempted();
-        actual = DefaultModuleComponentIdentifier.newId(attempted.getGroup(), attempted.getModule(), attempted.getVersion());
+        actual = DefaultModuleComponentIdentifier.newId(attempted.getGroup(), attempted.getName(), attempted.getVersion());
     }
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorter.java
@@ -108,7 +108,7 @@ public class DependencyResultSorter {
                 return byGroup;
             }
 
-            int byModule = leftRequested.getModule().compareTo(rightRequested.getModule());
+            int byModule = leftRequested.getName().compareTo(rightRequested.getName());
             if (byModule != 0) {
                 return byModule;
             }
@@ -178,7 +178,7 @@ public class DependencyResultSorter {
                 return byGroup;
             }
 
-            int byModule = leftFrom.getModule().compareTo(rightFrom.getModule());
+            int byModule = leftFrom.getName().compareTo(rightFrom.getName());
             if (byModule != 0) {
                 return byModule;
             }


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

This is a trivial rename of a method in two incubating interfaces:

getName() is more in line with the existing naming in the module version
and related interfaces.