### PR TITLE
Deprecation warning should print location in build file

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.ExceptionAnalyser;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.StandardOutputListener;
+import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.configuration.BuildConfigurer;
 import org.gradle.deployment.internal.DeploymentRegistry;
 import org.gradle.execution.BuildConfigurationActionExecuter;
@@ -28,6 +29,7 @@ import org.gradle.execution.BuildExecuter;
 import org.gradle.internal.buildevents.BuildLogger;
 import org.gradle.internal.buildevents.TaskExecutionLogger;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.internal.featurelifecycle.ScriptUsageLocationReporter;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
@@ -145,6 +147,14 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         }
         ScriptUsageLocationReporter usageLocationReporter = new ScriptUsageLocationReporter();
         listenerManager.addListener(usageLocationReporter);
+        ShowStacktrace showStacktrace = startParameter.getShowStacktrace();
+        switch (showStacktrace) {
+            case ALWAYS:
+            case ALWAYS_FULL:
+                LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(true);
+            default:
+                LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(false);
+        }
         DeprecationLogger.useLocationReporter(usageLocationReporter);
 
         SettingsLoaderFactory settingsLoaderFactory = serviceRegistry.get(SettingsLoaderFactory.class);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -134,7 +134,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
     protected boolean noExplicitTmpDir;
     protected boolean noExplicitNativeServicesDir;
-    protected boolean noFullDeprecationStackTrace;
+    protected boolean fullDeprecationStackTrace = true;
 
     protected AbstractGradleExecuter(GradleDistribution distribution, TestDirectoryProvider testDirectoryProvider) {
         this.distribution = distribution;
@@ -262,8 +262,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         if (noExplicitNativeServicesDir) {
             executer.withNoExplicitNativeServicesDir();
         }
-        if (noFullDeprecationStackTrace) {
-            executer.withNoFullDeprecationStackTrace();
+        if (!fullDeprecationStackTrace) {
+            executer.withFullDeprecationStackTraceDisabled();
         }
         if (defaultLocale != null) {
             executer.withDefaultLocale(defaultLocale);
@@ -709,7 +709,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         if (!noExplicitNativeServicesDir) {
             properties.put(NativeServices.NATIVE_DIR_OVERRIDE, buildContext.getNativeServicesDir().getAbsolutePath());
         }
-        properties.put(LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME, ""+!noFullDeprecationStackTrace);
+        properties.put(LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME, ""+fullDeprecationStackTrace);
 
         if (!noExplicitTmpDir) {
             String tmpDirPath = getDefaultTmpDir().createDir().getAbsolutePath();
@@ -935,8 +935,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return this;
     }
 
-    public GradleExecuter withNoFullDeprecationStackTrace() {
-        noFullDeprecationStackTrace = true;
+    public GradleExecuter withFullDeprecationStackTraceDisabled() {
+        fullDeprecationStackTrace = false;
         return this;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -709,7 +709,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         if (!noExplicitNativeServicesDir) {
             properties.put(NativeServices.NATIVE_DIR_OVERRIDE, buildContext.getNativeServicesDir().getAbsolutePath());
         }
-        properties.put(LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME, ""+fullDeprecationStackTrace);
+        properties.put(LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME, Boolean.toString(fullDeprecationStackTrace));
 
         if (!noExplicitTmpDir) {
             String tmpDirPath = getDefaultTmpDir().createDir().getAbsolutePath();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.initialization.DefaultClassLoaderScope;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
@@ -42,7 +43,6 @@ import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.testfixtures.internal.NativeServicesTestFixture;
 import org.gradle.util.CollectionUtils;
-import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.io.IOException;
@@ -134,6 +134,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
     protected boolean noExplicitTmpDir;
     protected boolean noExplicitNativeServicesDir;
+    protected boolean noFullDeprecationStackTrace;
 
     protected AbstractGradleExecuter(GradleDistribution distribution, TestDirectoryProvider testDirectoryProvider) {
         this.distribution = distribution;
@@ -260,6 +261,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         }
         if (noExplicitNativeServicesDir) {
             executer.withNoExplicitNativeServicesDir();
+        }
+        if (noFullDeprecationStackTrace) {
+            executer.withNoFullDeprecationStackTrace();
         }
         if (defaultLocale != null) {
             executer.withDefaultLocale(defaultLocale);
@@ -705,7 +709,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         if (!noExplicitNativeServicesDir) {
             properties.put(NativeServices.NATIVE_DIR_OVERRIDE, buildContext.getNativeServicesDir().getAbsolutePath());
         }
-        properties.put(DeprecationLogger.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME, "true");
+        properties.put(LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME, ""+!noFullDeprecationStackTrace);
 
         if (!noExplicitTmpDir) {
             String tmpDirPath = getDefaultTmpDir().createDir().getAbsolutePath();
@@ -928,6 +932,11 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     @Override
     public GradleExecuter withNoExplicitNativeServicesDir() {
         noExplicitNativeServicesDir = true;
+        return this;
+    }
+
+    public GradleExecuter withNoFullDeprecationStackTrace() {
+        noFullDeprecationStackTrace = true;
         return this;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -182,7 +182,7 @@ public interface GradleExecuter {
     /**
      * Don't activate full deprecation stack trace.
      */
-    GradleExecuter withNoFullDeprecationStackTrace();
+    GradleExecuter withFullDeprecationStackTraceDisabled();
 
     /**
      * Specifies that the executer should only those JVM args explicitly requested using {@link #withBuildJvmOpts(String...)} and {@link #withCommandLineGradleOpts(String...)} (where appropriate) for

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -180,6 +180,11 @@ public interface GradleExecuter {
     GradleExecuter withNoExplicitNativeServicesDir();
 
     /**
+     * Don't activate full deprecation stack trace.
+     */
+    GradleExecuter withNoFullDeprecationStackTrace();
+
+    /**
      * Specifies that the executer should only those JVM args explicitly requested using {@link #withBuildJvmOpts(String...)} and {@link #withCommandLineGradleOpts(String...)} (where appropriate) for
      * the build JVM and not attempt to provide any others.
      */

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleHandle.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleHandle.java
@@ -19,7 +19,6 @@ package org.gradle.integtests.fixtures.executer;
 import org.gradle.api.Action;
 import org.gradle.internal.Factory;
 import org.gradle.process.internal.AbstractExecHandleBuilder;
-import org.gradle.util.SingleMessageLogger;
 
 import java.io.PipedOutputStream;
 import java.util.Arrays;
@@ -64,7 +63,7 @@ public class ParallelForkingGradleHandle extends ForkingGradleHandle {
         @Override
         public String getNormalizedOutput() {
             String output = super.getNormalizedOutput();
-            String parallelWarningPrefix = String.format(SingleMessageLogger.INCUBATION_MESSAGE, ".*");
+            String parallelWarningPrefix = ".* is an incubating feature.";
             return output.replaceFirst(format("(?m)%s.*$\n", parallelWarningPrefix), "");
         }
 

--- a/subprojects/logging/logging.gradle
+++ b/subprojects/logging/logging.gradle
@@ -17,6 +17,8 @@ dependencies {
     runtime libraries.log4j_to_slf4j
     runtime libraries.jcl_to_slf4j
 
+    testFixturesCompile project(":core")
+
     testCompile project(":internalTesting")
     testRuntime project(":jetty") // needed by DeprecationHandlingIntegrationTest
 }

--- a/subprojects/logging/logging.gradle
+++ b/subprojects/logging/logging.gradle
@@ -20,7 +20,6 @@ dependencies {
     testFixturesCompile project(":core")
 
     testCompile project(":internalTesting")
-    testRuntime project(":jetty") // needed by DeprecationHandlingIntegrationTest
 }
 
 useTestFixtures()

--- a/subprojects/logging/logging.gradle
+++ b/subprojects/logging/logging.gradle
@@ -14,10 +14,11 @@ dependencies {
     compile project(":messaging")
     compile project(":cli")
 
-    testCompile project(":internalTesting")
-
     runtime libraries.log4j_to_slf4j
     runtime libraries.jcl_to_slf4j
+
+    testCompile project(":internalTesting")
+    testRuntime project(":jetty") // needed by DeprecationHandlingIntegrationTest
 }
 
 useTestFixtures()

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -20,170 +20,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 
-    //@Ignore("This test will likely break with Gradle 4.0. Find some new deprecation in that case.")
-    def "jetty deprecation is detected - without full stacktrace."() {
-
-        buildFile << """
-apply plugin: 'jetty' // line 2
-"""
-        when:
-        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        run()
-
-        then:
-        output.contains('The Jetty plugin has been deprecated')
-        output.contains('build.gradle:2)')
-        output.count('\tat') == 1
-    }
-
-    //@Ignore("This test will likely break with Gradle 4.0. Find some new deprecation in that case.")
-    def "jetty deprecation is detected - with full stacktrace."() {
-
-        buildFile << """
-apply plugin: 'jetty' // line 2
-"""
-        when:
-        executer.expectDeprecationWarning()
-        run()
-
-        then:
-        output.contains('The Jetty plugin has been deprecated')
-        output.contains('build.gradle:2)')
-        output.count('\tat') > 1
-    }
-
-    //@Ignore("This test will likely break with Gradle 4.0. Find some new deprecation in that case.")
-    def "upToDateWhen deprecation is detected - without full stacktrace."() {
-        buildFile << """
-task binZip(type: Zip) {
-    outputs.file('build/some').upToDateWhen { false } // line 3
-    into('some')
-}
-"""
-        when:
-        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        run()
-
-        then:
-        output.contains('build.gradle:3)')
-        output.count('\tat') == 1
-    }
-
-    //@Ignore("This test will likely break with Gradle 4.0. Find some new deprecation in that case.")
-    def "upToDateWhen deprecation is detected - with full stacktrace."() {
-        buildFile << """
-task binZip(type: Zip) {
-    outputs.file('build/some').upToDateWhen { false } // line 3
-    into('some')
-}
-"""
-        when:
-        executer.expectDeprecationWarning()
-        run()
-
-        then:
-        output.contains('build.gradle:3)')
-        output.count('\tat') > 1
-    }
-
-    def "reports first usage of deprecated feature from a build script"() {
-        buildFile << """
-someFeature()
-someFeature()
-
-task broken(type: DeprecatedTask) {
-    otherFeature()
-}
-
-def someFeature() {
-    DeprecationLogger.nagUserOfDiscontinuedMethod("someFeature()") // line 10
-}
-
-class DeprecatedTask extends DefaultTask {
-    def otherFeature() {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("otherFeature()") // line 15
-    }
-}
-"""
-
-        when:
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
-        run()
-
-        then:
-        output.contains("Build file '$buildFile': line 10")
-        output.contains("Build file '$buildFile': line 15")
-        output.count("The someFeature() method has been deprecated") == 1
-        output.count("The otherFeature() method has been deprecated") == 1
-
-        // Run again to ensure logging is reset
-        when:
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
-        run()
-
-        then:
-        output.count("The someFeature() method has been deprecated") == 1
-        output.count("The otherFeature() method has been deprecated") == 1
-
-        // Not shown at quiet level
-        when:
-        executer.withArgument("--quiet")
-        run()
-
-        then:
-        output.count("The someFeature() method has been deprecated") == 0
-        output.count("The otherFeature() method has been deprecated") == 0
-        errorOutput == ""
-    }
-
-    def "reports usage of deprecated feature from an init script"() {
-        def initScript = file("init.gradle") << """
-allprojects {
-    someFeature()
-}
-
-def someFeature() {
-    DeprecationLogger.nagUserOfDiscontinuedMethod("someFeature()")
-}
-
-"""
-
-        when:
-        executer.expectDeprecationWarning().usingInitScript(initScript)
-        run()
-
-        then:
-        output.contains("Initialization script '$initScript': line 7")
-        output.count("The someFeature() method has been deprecated") == 1
-        errorOutput == ""
-    }
-
-    def "reports usage of deprecated feature from an applied script"() {
-        def script = file("project.gradle") << """
-
-def someFeature() {
-    DeprecationLogger.nagUserOfDiscontinuedMethod("someFeature()") // line 4
-}
-
-someFeature()
-"""
-        buildFile << "allprojects { apply from: 'project.gradle' }"
-
-        when:
-        executer.expectDeprecationWarning()
-        run()
-
-        then:
-        output.contains("Script '$script': line 4")
-        output.count("The someFeature() method has been deprecated") == 1
-        errorOutput == ""
-    }
-
     // ######################################################################
 
-    def "DeprecatedPlugin and DeprecatedTask - without full stacktrace."() {
+    def 'DeprecatedPlugin and DeprecatedTask - without full stacktrace.'() {
         given:
         buildFile << """import org.gradle.internal.deprecated.DeprecatedPlugin
 import org.gradle.internal.deprecated.DeprecatedTask
@@ -196,7 +35,6 @@ DeprecatedTask.someFeature()
 task broken(type: DeprecatedTask) << {
     otherFeature() // line 10
 }
-
 """
 
         when:
@@ -225,7 +63,7 @@ task broken(type: DeprecatedTask) << {
 
     // ######################################################################
 
-    def "DeprecatedPlugin and DeprecatedTask - with full stacktrace."() {
+    def 'DeprecatedPlugin and DeprecatedTask - with full stacktrace.'() {
         given:
         buildFile << """import org.gradle.internal.deprecated.DeprecatedPlugin
 import org.gradle.internal.deprecated.DeprecatedTask
@@ -238,7 +76,6 @@ DeprecatedTask.someFeature()
 task broken(type: DeprecatedTask) << {
     otherFeature() // line 10
 }
-
 """
 
         when:
@@ -265,7 +102,7 @@ task broken(type: DeprecatedTask) << {
 
     // ######################################################################
 
-    def "DeprecatedPlugin from init script - without full stacktrace."() {
+    def 'DeprecatedPlugin from init script - without full stacktrace.'() {
         given:
         def initScript = file("init.gradle") << """import org.gradle.internal.deprecated.DeprecatedPlugin
 allprojects {
@@ -289,7 +126,7 @@ allprojects {
 
     // ######################################################################
 
-    def "DeprecatedPlugin from applied script - without full stacktrace."() {
+    def 'DeprecatedPlugin from applied script - without full stacktrace.'() {
         given:
         file("project.gradle") << """import org.gradle.internal.deprecated.DeprecatedPlugin
 apply plugin:  DeprecatedPlugin // line 2
@@ -316,7 +153,7 @@ allprojects {
 
     // ######################################################################
 
-    def "DeprecatedPlugin from applied script - with full stacktrace."() {
+    def 'DeprecatedPlugin from applied script - with full stacktrace.'() {
         given:
         file("project.gradle") << """import org.gradle.internal.deprecated.DeprecatedPlugin
 apply plugin:  DeprecatedPlugin // line 2

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -97,7 +97,7 @@ task broken(type: DeprecatedTask) << {
         output.count('The deprecated task has been deprecated') == 1
 
         and:
-        output.count('\tat') > 4 // this should be 3
+        output.count('\tat') > 3
     }
 
     // ######################################################################

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -184,6 +184,7 @@ someFeature()
     // ######################################################################
 
     def "DeprecatedPlugin and DeprecatedTask - without full stacktrace."() {
+        given:
         buildFile << """import org.gradle.internal.deprecated.DeprecatedPlugin
 import org.gradle.internal.deprecated.DeprecatedTask
 
@@ -225,6 +226,7 @@ task broken(type: DeprecatedTask) << {
     // ######################################################################
 
     def "DeprecatedPlugin and DeprecatedTask - with full stacktrace."() {
+        given:
         buildFile << """import org.gradle.internal.deprecated.DeprecatedPlugin
 import org.gradle.internal.deprecated.DeprecatedTask
 
@@ -264,6 +266,7 @@ task broken(type: DeprecatedTask) << {
     // ######################################################################
 
     def "DeprecatedPlugin from init script - without full stacktrace."() {
+        given:
         def initScript = file("init.gradle") << """import org.gradle.internal.deprecated.DeprecatedPlugin
 allprojects {
     apply plugin: DeprecatedPlugin // line 3
@@ -287,6 +290,7 @@ allprojects {
     // ######################################################################
 
     def "DeprecatedPlugin from applied script - without full stacktrace."() {
+        given:
         file("project.gradle") << """import org.gradle.internal.deprecated.DeprecatedPlugin
 apply plugin:  DeprecatedPlugin // line 2
 """
@@ -313,6 +317,7 @@ allprojects {
     // ######################################################################
 
     def "DeprecatedPlugin from applied script - with full stacktrace."() {
+        given:
         file("project.gradle") << """import org.gradle.internal.deprecated.DeprecatedPlugin
 apply plugin:  DeprecatedPlugin // line 2
 """

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -27,7 +27,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 apply plugin: 'jetty' // line 2
 """
         when:
-        executer.expectDeprecationWarning().withNoFullDeprecationStackTrace()
+        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         run()
 
         then:
@@ -61,7 +61,7 @@ task binZip(type: Zip) {
 }
 """
         when:
-        executer.expectDeprecationWarning().withNoFullDeprecationStackTrace()
+        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         run()
 
         then:

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -42,14 +42,14 @@ task broken(type: DeprecatedTask) << {
         executer.expectDeprecationWarning()
         executer.expectDeprecationWarning()
         executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning() // TODO: this line should be removed
+        executer.expectDeprecationWarning()
         run('deprecated', 'broken')
 
         then:
         output.contains('build.gradle:4)')
         output.contains('build.gradle:6)')
         output.contains('build.gradle:10)')
-        output.contains('(Native Method)') // TODO: this should not be printed.
+        !output.contains('(Native Method)')
 
         and:
         output.count('The DeprecatedPlugin plugin has been deprecated') == 1
@@ -58,7 +58,7 @@ task broken(type: DeprecatedTask) << {
         output.count('The deprecated task has been deprecated') == 1
 
         and:
-        output.count('\tat') == 4 // TODO: this should be 3
+        output.count('\tat') == 3
     }
 
     // ######################################################################

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -21,6 +21,38 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 
     //@Ignore("This test will likely break with Gradle 4.0. Find some new deprecation in that case.")
+    def "jetty deprecation is detected - without full stacktrace."() {
+
+        buildFile << """
+apply plugin: 'jetty' // line 2
+"""
+        when:
+        executer.expectDeprecationWarning().withNoFullDeprecationStackTrace()
+        run()
+
+        then:
+        output.contains('The Jetty plugin has been deprecated')
+        output.contains('build.gradle:2)')
+        output.count('\tat') == 1
+    }
+
+    //@Ignore("This test will likely break with Gradle 4.0. Find some new deprecation in that case.")
+    def "jetty deprecation is detected - with full stacktrace."() {
+
+        buildFile << """
+apply plugin: 'jetty' // line 2
+"""
+        when:
+        executer.expectDeprecationWarning()
+        run()
+
+        then:
+        output.contains('The Jetty plugin has been deprecated')
+        output.contains('build.gradle:2)')
+        output.count('\tat') > 1
+    }
+
+    //@Ignore("This test will likely break with Gradle 4.0. Find some new deprecation in that case.")
     def "upToDateWhen deprecation is detected - without full stacktrace."() {
         buildFile << """
 task binZip(type: Zip) {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -29,12 +29,12 @@ task broken(type: DeprecatedTask) {
 }
 
 def someFeature() {
-    DeprecationLogger.nagUserOfDiscontinuedMethod("someFeature()")
+    DeprecationLogger.nagUserOfDiscontinuedMethod("someFeature()") // line 10
 }
 
 class DeprecatedTask extends DefaultTask {
     def otherFeature() {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("otherFeature()")
+        DeprecationLogger.nagUserOfDiscontinuedMethod("otherFeature()") // line 15
     }
 }
 """
@@ -45,9 +45,9 @@ class DeprecatedTask extends DefaultTask {
         run()
 
         then:
-        output.contains("Build file '$buildFile': line 3")
+        output.contains("Build file '$buildFile': line 10")
+        output.contains("Build file '$buildFile': line 15")
         output.count("The someFeature() method has been deprecated") == 1
-        output.contains("Build file '$buildFile': line 6")
         output.count("The otherFeature() method has been deprecated") == 1
 
         // Run again to ensure logging is reset
@@ -57,9 +57,7 @@ class DeprecatedTask extends DefaultTask {
         run()
 
         then:
-        output.contains("Build file '$buildFile': line 3")
         output.count("The someFeature() method has been deprecated") == 1
-        output.contains("Build file '$buildFile': line 6")
         output.count("The otherFeature() method has been deprecated") == 1
 
         // Not shown at quiet level
@@ -90,7 +88,7 @@ def someFeature() {
         run()
 
         then:
-        output.contains("Initialization script '$initScript': line 3")
+        output.contains("Initialization script '$initScript': line 7")
         output.count("The someFeature() method has been deprecated") == 1
         errorOutput == ""
     }
@@ -99,7 +97,7 @@ def someFeature() {
         def script = file("project.gradle") << """
 
 def someFeature() {
-    DeprecationLogger.nagUserOfDiscontinuedMethod("someFeature()")
+    DeprecationLogger.nagUserOfDiscontinuedMethod("someFeature()") // line 4
 }
 
 someFeature()
@@ -111,7 +109,7 @@ someFeature()
         run()
 
         then:
-        output.contains("Script '$script': line 7")
+        output.contains("Script '$script': line 4")
         output.count("The someFeature() method has been deprecated") == 1
         errorOutput == ""
     }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -17,8 +17,26 @@
 package org.gradle
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Ignore
 
 class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
+
+    @Ignore("This would break with Gradle 4.0.")
+    def "upToDateWhen deprecation is detected."() {
+        buildFile << """
+task binZip(type: Zip) {
+    outputs.file('build/some').upToDateWhen { false }
+    into('some')
+}
+"""
+        when:
+        executer.expectDeprecationWarning()
+        run()
+
+        then:
+        output.contains('build.gradle:3)')
+    }
+
     def "reports first usage of deprecated feature from a build script"() {
         buildFile << """
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -29,6 +29,7 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
     public static final String ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME = "org.gradle.deprecation.trace";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingDeprecatedFeatureHandler.class);
+    private static boolean traceLoggingEnabled;
     private final Set<String> messages = new HashSet<String>();
     private UsageLocationReporter locationReporter;
 
@@ -102,8 +103,24 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
         return false;
     }
 
-    private static boolean isTraceLoggingEnabled() {
-        return Boolean.getBoolean(ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME);
+    /**
+     * Whether or not deprecated features should print a full stack trace.
+     *
+     * This property can be overridden by setting the ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
+     * system property.
+     *
+     * @param traceLoggingEnabled if trace logging should be enabled.
+     */
+    public static void setTraceLoggingEnabled(boolean traceLoggingEnabled) {
+        LoggingDeprecatedFeatureHandler.traceLoggingEnabled = traceLoggingEnabled;
+    }
+
+    static boolean isTraceLoggingEnabled() {
+        String value = System.getProperty(ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME);
+        if(value == null) {
+            return traceLoggingEnabled;
+        }
+        return Boolean.parseBoolean(value);
     }
 
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -80,21 +80,6 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
                 return;
             }
         }
-
-        // there was no Gradle script stack trace element
-        // warning must have happened while executing an applied plugin
-        int elementCount = stack.size();
-        if (elementCount == 0) {
-            return; // or there is no stack information at all
-        }
-        if (elementCount >= 2) {
-            // this is the element above the method causing the deprecation warning
-            // it's the most reasonable heuristic we have at this point
-            appendStackTraceElement(stack.get(1), message, lineSeparator);
-            return;
-        }
-        // let's print what we got
-        appendStackTraceElement(stack.get(0), message, lineSeparator);
     }
 
     private static void appendStackTraceElement(StackTraceElement frame, StringBuilder message, String lineSeparator) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -59,7 +59,7 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
         }
     }
 
-    private static final String ELEMENT_PREFIX = "    ";
+    private static final String ELEMENT_PREFIX = "\tat ";
 
     private static void logTraceIfNecessary(List<StackTraceElement> stack, StringBuilder message) {
         final String lineSeperator = SystemProperties.getInstance().getLineSeparator();

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -47,7 +47,6 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
 
     public void deprecatedFeatureUsed(DeprecatedFeatureUsage usage) {
         if (messages.add(usage.getMessage())) {
-            usage = usage.withStackTrace();
             StringBuilder message = new StringBuilder();
             locationReporter.reportLocation(usage, message);
             if (message.length() > 0) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.featurelifecycle;
 
 import org.gradle.internal.SystemProperties;
-import org.gradle.util.SingleMessageLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +26,8 @@ import java.util.Locale;
 import java.util.Set;
 
 public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler {
+    public static final String ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME = "org.gradle.deprecation.trace";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingDeprecatedFeatureHandler.class);
     private final Set<String> messages = new HashSet<String>();
     private UsageLocationReporter locationReporter;
@@ -117,7 +118,7 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
     }
 
     private static boolean isTraceLoggingEnabled() {
-        return Boolean.getBoolean(SingleMessageLogger.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME);
+        return Boolean.getBoolean(ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME);
     }
 
 }

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -42,7 +42,6 @@ public class SingleMessageLogger {
         }
     };
 
-    public static final String ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME = "org.gradle.deprecation.trace";
     public static final String INCUBATION_MESSAGE = "%s is an incubating feature.";
 
     private static final Lock LOCK = new ReentrantLock();

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -42,8 +42,6 @@ public class SingleMessageLogger {
         }
     };
 
-    public static final String INCUBATION_MESSAGE = "%s is an incubating feature.";
-
     private static final Lock LOCK = new ReentrantLock();
     private static LoggingDeprecatedFeatureHandler handler = new LoggingDeprecatedFeatureHandler();
     private static String deprecationMessage;
@@ -203,7 +201,7 @@ public class SingleMessageLogger {
 
     public static void incubatingFeatureUsed(String incubatingFeature, String additionalWarning) {
         if (FEATURES.add(incubatingFeature)) {
-            String message = String.format(INCUBATION_MESSAGE, incubatingFeature);
+            String message = String.format("%s is an incubating feature.", incubatingFeature);
             if (additionalWarning != null) {
                 message = message + "\n" + additionalWarning;
             }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.featurelifecycle
 
+import org.gradle.api.logging.LogLevel
 import org.gradle.internal.logging.CollectingTestOutputEventListener
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.util.SetSystemProperties
@@ -48,6 +49,19 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         and:
         events[0].message == 'feature1'
         events[1].message == 'feature2'
+    }
+
+    def 'deprecations are logged at WARN level'() {
+        when:
+        handler.deprecatedFeatureUsed(new DeprecatedFeatureUsage('feature', []))
+
+        then:
+        outputEventListener.events.size() == 1
+
+        and:
+        def event = outputEventListener.events[0]
+        event.message == 'feature'
+        event.logLevel == LogLevel.WARN
     }
 
     @Unroll

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -291,4 +291,48 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         events.size() == 1
         events[0].message == TextUtil.toPlatformLineSeparators('location\nfeature')
     }
+
+    @Unroll
+    def 'Setting #deprecationTracePropertyName=#deprecationTraceProperty overrides setTraceLoggingEnabled value.'() {
+        given:
+        System.setProperty(deprecationTracePropertyName, deprecationTraceProperty)
+
+        when:
+        LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(true)
+
+        then:
+        LoggingDeprecatedFeatureHandler.isTraceLoggingEnabled() == expectedResult
+
+        when:
+        LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(false)
+
+        then:
+        LoggingDeprecatedFeatureHandler.isTraceLoggingEnabled() == expectedResult
+
+        where:
+        deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
+        deprecationTraceProperty << ['true', 'false', 'foo']
+        expectedResult << [true, false, false]
+    }
+
+    @Unroll
+    def 'Undefined #deprecationTracePropertyName does not influence setTraceLoggingEnabled value.'() {
+        given:
+        System.clearProperty(deprecationTracePropertyName)
+
+        when:
+        LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(true)
+
+        then:
+        LoggingDeprecatedFeatureHandler.isTraceLoggingEnabled()
+
+        when:
+        LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(false)
+
+        then:
+        !LoggingDeprecatedFeatureHandler.isTraceLoggingEnabled()
+
+        where:
+        deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
+    }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.featurelifecycle
 import org.gradle.internal.logging.CollectingTestOutputEventListener
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.util.SetSystemProperties
-import org.gradle.util.SingleMessageLogger
 import org.gradle.util.TextUtil
 import org.junit.Rule
 import spock.lang.Specification
@@ -85,7 +84,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
         where:
         deprecationTraceProperty << [true, false]
-        deprecationTracePropertyName = SingleMessageLogger.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
+        deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
         fakeStackTrace = [
             new StackTraceElement('org.gradle.internal.featurelifecycle.SimulatedJavaCallLocation', 'create', 'SimulatedJavaCallLocation.java', 25),
             new StackTraceElement('java.lang.reflect.Method', 'invoke', 'Method.java', 498),
@@ -132,7 +131,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
         where:
         deprecationTraceProperty << [true, false]
-        deprecationTracePropertyName = SingleMessageLogger.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
+        deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
         fakeStackTrace = [
             new StackTraceElement('org.gradle.internal.featurelifecycle.SimulatedJavaCallLocation', 'create', 'SimulatedJavaCallLocation.java', 25),
             new StackTraceElement('java.lang.reflect.Method', 'invoke', 'Method.java', 498),
@@ -177,7 +176,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
         where:
         deprecationTraceProperty << [true, false]
-        deprecationTracePropertyName = SingleMessageLogger.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
+        deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
         fakeStackTrace = [
             new StackTraceElement('org.gradle.internal.featurelifecycle.SimulatedJavaCallLocation', 'create', 'SimulatedJavaCallLocation.java', 25),
             new StackTraceElement('some.ArbitraryClass', 'withSource', 'ArbitraryClass.java', 42),
@@ -209,7 +208,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
         where:
         deprecationTraceProperty << [true, false]
-        deprecationTracePropertyName = SingleMessageLogger.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
+        deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
         fakeStackTrace = [
             new StackTraceElement('some.ArbitraryClass', 'withSource', 'ArbitraryClass.java', 42),
         ]
@@ -231,7 +230,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
         where:
         deprecationTraceProperty << [true, false]
-        deprecationTracePropertyName = SingleMessageLogger.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
+        deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
     }
 
     def "location reporter can prepend text"() {

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/deprecated/DeprecatedPlugin.java
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/deprecated/DeprecatedPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.deprecated;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.util.DeprecationLogger;
+
+public class DeprecatedPlugin  implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        DeprecationLogger.nagUserOfPluginReplacedWithExternalOne("DeprecatedPlugin", "Foobar");
+        project.getTasks().create("deprecated", DeprecatedTask.class);
+    }
+}

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/deprecated/DeprecatedTask.java
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/deprecated/DeprecatedTask.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.deprecated;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.util.DeprecationLogger;
+
+public class DeprecatedTask  extends DefaultTask {
+    @TaskAction
+    void causeDeprecationWarning() {
+        DeprecationLogger.nagUserOfReplacedTask("deprecated", "foobar");
+        System.out.println("DeprecatedTask.causeDeprecationWarning() executed.");
+    }
+
+    public static void someFeature() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("someFeature()");
+        System.out.println("DeprecatedTask.someFeature() executed.");
+    }
+
+    void otherFeature() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("otherFeature()", "Relax. This is just a test.");
+        System.out.println("DeprecatedTask.otherFeature() executed.");
+    }
+
+}

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/featurelifecycle/SimulatedDeprecationMessageLogger.java
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/featurelifecycle/SimulatedDeprecationMessageLogger.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.featurelifecycle;
+
+public class SimulatedDeprecationMessageLogger {
+    public static final String DIRECT_CALL = "direct call";
+    public static final String INDIRECT_CALL = "indirect call";
+    public static final String INDIRECT_CALL_2 = "second-level indirect call";
+
+    public static DeprecatedFeatureUsage indirectlySecondLevel(String message) {
+        return indirectly(message);
+    }
+
+    public static DeprecatedFeatureUsage indirectly(String message) {
+        return nagUserWith(message);
+    }
+
+    public static DeprecatedFeatureUsage nagUserWith(String message) {
+        return new DeprecatedFeatureUsage(message, SimulatedDeprecationMessageLogger.class);
+    }
+}

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/featurelifecycle/SimulatedGroovyCallLocation.groovy
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/featurelifecycle/SimulatedGroovyCallLocation.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.featurelifecycle
+
+/**
+ * This class is used to test proper call stack evaluation of Groovy classes.
+ */
+class SimulatedGroovyCallLocation {
+    static DeprecatedFeatureUsage create() {
+        return SimulatedDeprecationMessageLogger.nagUserWith(SimulatedDeprecationMessageLogger.DIRECT_CALL)
+    }
+
+    static DeprecatedFeatureUsage indirectly() {
+        return SimulatedDeprecationMessageLogger.indirectly(SimulatedDeprecationMessageLogger.INDIRECT_CALL)
+    }
+
+    static DeprecatedFeatureUsage indirectly2() {
+        return SimulatedDeprecationMessageLogger.indirectlySecondLevel(SimulatedDeprecationMessageLogger.INDIRECT_CALL_2)
+    }
+}

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/featurelifecycle/SimulatedJavaCallLocation.java
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/featurelifecycle/SimulatedJavaCallLocation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.featurelifecycle;
+
+/**
+ * This class is used to test proper call stack evaluation of Java classes.
+ */
+public class SimulatedJavaCallLocation {
+
+    static DeprecatedFeatureUsage create() {
+        return SimulatedDeprecationMessageLogger.nagUserWith(SimulatedDeprecationMessageLogger.DIRECT_CALL);
+    }
+
+    static DeprecatedFeatureUsage indirectly() {
+        return SimulatedDeprecationMessageLogger.indirectly(SimulatedDeprecationMessageLogger.INDIRECT_CALL);
+    }
+
+    static DeprecatedFeatureUsage indirectly2() {
+        return SimulatedDeprecationMessageLogger.indirectlySecondLevel(SimulatedDeprecationMessageLogger.INDIRECT_CALL_2);
+    }
+}

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/CollectingTestOutputEventListener.groovy
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/CollectingTestOutputEventListener.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging
+
+import org.gradle.internal.logging.events.LogEvent
+import org.gradle.internal.logging.events.OutputEvent
+import org.gradle.internal.logging.events.OutputEventListener
+
+class CollectingTestOutputEventListener implements OutputEventListener {
+    final List<LogEvent> events = new ArrayList<>()
+
+    void reset() {
+        events.clear()
+    }
+
+    @Override
+    synchronized void onOutput(OutputEvent event) {
+        LogEvent logEvent = event as LogEvent
+        events.add(logEvent)
+    }
+}


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, I started a discussion on the
[Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev)
or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I wrote a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.

This PR has been discussed in [Way to find root cause of a Gradle deprecation warning is arcane knowledge](https://discuss.gradle.org/t/way-to-find-root-cause-of-a-gradle-deprecation-warning-is-arcane-knowledge/18838).