### PR TITLE
Add myself to mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -47,6 +47,7 @@ Rene Groeschke <rene@gradle.com> <rene.groeschke@gradleware.com>
 Rene Groeschke <rene@gradle.com> <rene@breskeby.com>
 Rene Groeschke <rene@gradle.com> <rgroeschke@builds.gradle.org>
 Rodrigo B. de Oliveira <rodrigo@gradle.com> <rbo@acm.org>
+Sebastian Schuberth <sschuberth@gmail.com> <sschuberth@users.noreply.github.com>
 Stefan Oehme <stefan@gradle.com> <st.oehme@gmail.com>
 Sterling Greene <sterling@gradle.com> <big-guy@users.noreply.github.com>
 Sterling Greene <sterling@gradle.com> <sterling.greene@gmail.com>


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

This is a trivial change that adds myself to the `.mailmap` file.