### PR TITLE
Do not require password for truststore

### DIFF
--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/DefaultSslContextFactory.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/DefaultSslContextFactory.java
@@ -100,7 +100,7 @@ public class DefaultSslContextFactory implements SslContextFactory {
                         String trustStorePassword = props.get("javax.net.ssl.trustStorePassword");
                         FileInputStream instream = new FileInputStream(trustStoreFile);
                         try {
-                            trustStore.load(instream, trustStorePassword != null ? trustStorePassword.toCharArray() : EMPTY_PASSWORD);
+                            trustStore.load(instream, trustStorePassword != null ? trustStorePassword.toCharArray() : null);
                         } finally {
                             instream.close();
                         }

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/DefaultSslContextFactoryTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/DefaultSslContextFactoryTest.groovy
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http
+
+import org.apache.http.ssl.SSLInitializationException
+
+import org.gradle.internal.SystemProperties
+
+import spock.lang.Specification
+
+/**
+ * Tests loading of keystores and truststores corresponding to system
+ * properties specified.
+ */
+class DefaultSslContextFactoryTest extends Specification {
+    def props
+    def loader
+
+    void setup() {
+        props = ['java.home': SystemProperties.getInstance().javaHomeDir.path]
+        loader = new DefaultSslContextFactory.SslContextCacheLoader()
+    }
+
+    void 'no properties specified'() {
+        when:
+        loader.load(props)
+
+        then:
+        notThrown(SSLInitializationException)
+    }
+
+    void 'non-existent truststore file'() {
+        given:
+        props['javax.net.ssl.trustStore'] = 'will-not-exist'
+
+        when:
+        loader.load(props)
+
+        then:
+        thrown(SSLInitializationException)
+    }
+
+    void 'valid truststore file without specifying password'() {
+        given:
+        props['javax.net.ssl.trustStore'] = getDefaultTrustStore()
+
+        when:
+        loader.load(props)
+
+        // NOTE: This should not fail, as a password is only necessary for
+        //       integrity checking, not accessing trusted public certificates
+        //       contained within a keystore
+        then:
+        notThrown(SSLInitializationException)
+    }
+
+    void 'valid truststore file with incorrect password'() {
+        given:
+        props['javax.net.ssl.trustStore'] = getDefaultTrustStore()
+        props['javax.net.ssl.trustStorePassword'] = 'totally-wrong'
+
+        when:
+        loader.load(props)
+
+        then:
+        thrown(SSLInitializationException)
+    }
+
+    void 'valid truststore file with correct password'() {
+        given:
+        props['javax.net.ssl.trustStore'] = getDefaultTrustStore()
+        props['javax.net.ssl.trustStorePassword'] = 'changeit'
+
+        when:
+        loader.load(props)
+
+        then:
+        notThrown(SSLInitializationException)
+    }
+
+    void 'non-existent keystore file'() {
+        given:
+        props['javax.net.ssl.keyStore'] = 'will-not-exist'
+
+        when:
+        loader.load(props)
+
+        then:
+        thrown(SSLInitializationException)
+    }
+
+    void 'valid keystore file without specifying password'() {
+        given:
+        props['javax.net.ssl.keyStore'] = getDefaultTrustStore()
+
+        when:
+        loader.load(props)
+
+        // NOTE: This should fail, as the private keys password must match
+        //       the keystore password, so a password is necessary
+        then:
+        thrown(SSLInitializationException)
+    }
+
+    void 'valid keystore file with incorrect password'() {
+        given:
+        props['javax.net.ssl.keyStore'] = getDefaultTrustStore()
+        props['javax.net.ssl.keyStorePassword'] = 'totally-wrong'
+
+        when:
+        loader.load(props)
+
+        then:
+        thrown(SSLInitializationException)
+    }
+
+    void 'valid keystore file with correct password'() {
+        given:
+        props['javax.net.ssl.keyStore'] = getDefaultTrustStore()
+        props['javax.net.ssl.keyStorePassword'] = 'changeit'
+
+        when:
+        loader.load(props)
+
+        then:
+        notThrown(SSLInitializationException)
+    }
+
+    // NOTE: A keystore and a truststore are generally both simmply a JKS
+    //       file.  A default "keystore" is always shipped with the JRE and
+    //       it contains simply trusted public certificates, and it is the
+    //       default truststore used when one is not explicitly specified.
+    String getDefaultTrustStore() {
+        File keyStore = new File(props['java.home'], 'lib/security/jssecacerts')
+
+        if (!keyStore.exists()) {
+            keyStore = new File(props['java.home'], 'lib/security/cacerts')
+        }
+
+        keyStore.path
+    }
+}


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [X] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [X] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [X] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [X] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
https://discuss.gradle.org/t/truststorepassword-is-required-because-of-a-bug-in-org-apache-httpcomponents-httpclient/17621
- [X] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [N/A] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
(Technically it'd be nice to have something create client keystores/truststores and server
keystores/truststores to do the comparison as part of a dynamic test, but that would be
significantly more difficult to implement right now)
- [N/A] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
(Shouldn't need to change anything with this, as it will now function as other Java
applications)

Because it throws an apache http SSLInitializationException it was
misleading as to what was really the cause of a password being
required for the use of a custom truststore.