### PR TITLE
Update eclipse.gradle for importing gradle without compile errors into Eclipse 

### DIFF
--- a/subprojects/internal-android-performance-testing/internal-android-performance-testing.gradle
+++ b/subprojects/internal-android-performance-testing/internal-android-performance-testing.gradle
@@ -12,9 +12,12 @@ task renameAndroidTools(type: Copy) {
 // workaround for idea not triggering the resolution of the `androidTools`
 tasks.ideaModule.dependsOn(renameAndroidTools)
 
+def renamedAndroidLibs = files({ -> files(renameAndroidTools).asFileTree.files.sort() })
+renamedAndroidLibs.builtBy(renameAndroidTools)
+
 dependencies {
     compile project(':toolingApi')
-    compile files({ -> files(renameAndroidTools).asFileTree.files.sort()})
+    compile renamedAndroidLibs
     androidTools('com.android.tools.build:gradle:2.2.0-beta2') {
         exclude group: 'org.gradle'
     }


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

Hi

This PR is a fix to the gradle/eclipse.gradle script. It permits to import later on all gradle projects with no compile errors in all src/main/java classes and most of all but few src/test/groovy classes.
By adding the build/generated-resource/main to the classpath of each project, gradle can run as a simple non daemon java application ready to be debugged under the Eclipse JDT debugger.

Using the JavaSE-1.8 is mandatory since JavaSE-1.7 compiles some gradle java classes with errors.
