### PR TITLE
Zinc compiler enhacements

### DIFF
--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -43,7 +43,8 @@ import java.io.File;
 import java.util.Arrays;
 
 public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends AbstractDaemonCompiler<T> {
-    private static final Iterable<String> SHARED_PACKAGES = Arrays.asList("scala", "com.typesafe.zinc", "xsbti", "com.sun.tools.javac");
+    private static final Iterable<String> SHARED_PACKAGES =
+            Arrays.asList("scala", "com.typesafe.zinc", "xsbti", "com.sun.tools.javac", "sbt");
     private final Iterable<File> zincClasspath;
 
     public DaemonScalaCompiler(File daemonWorkingDir, Compiler<T> delegate, CompilerDaemonFactory daemonFactory, Iterable<File> zincClasspath) {

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincCompilerServices.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincCompilerServices.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.scala;
+
+import org.gradle.cache.internal.CacheRepositoryServices;
+import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.internal.service.DefaultServiceRegistry;
+import org.gradle.internal.service.scopes.GlobalScopeServices;
+
+import java.io.File;
+
+class ZincCompilerServices extends DefaultServiceRegistry {
+    private static ZincCompilerServices instance;
+
+    private ZincCompilerServices(File gradleUserHome) {
+        super(NativeServices.getInstance());
+
+        addProvider(new GlobalScopeServices(true));
+        addProvider(new CacheRepositoryServices(gradleUserHome, null));
+    }
+
+    public static ZincCompilerServices getInstance(File gradleUserHome) {
+        if (instance == null) {
+            NativeServices.initialize(gradleUserHome);
+            instance = new ZincCompilerServices(gradleUserHome);
+        }
+        return instance;
+    }
+}

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
@@ -17,43 +17,26 @@
 package org.gradle.api.internal.tasks.scala;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.typesafe.zinc.*;
 import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.internal.tasks.compile.CompilationFailedException;
-import org.gradle.cache.CacheRepository;
-import org.gradle.cache.PersistentCache;
-import org.gradle.cache.internal.*;
-import org.gradle.internal.Factory;
-import org.gradle.internal.SystemProperties;
-import org.gradle.internal.nativeintegration.services.NativeServices;
-import org.gradle.internal.service.DefaultServiceRegistry;
-import org.gradle.internal.service.scopes.GlobalScopeServices;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.util.GFileUtils;
 import scala.Option;
-import xsbti.F0;
 
 import java.io.File;
 import java.io.Serializable;
 import java.util.List;
-
-import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
 public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec>, Serializable {
     private static final Logger LOGGER = Logging.getLogger(ZincScalaCompiler.class);
     private final Iterable<File> scalaClasspath;
     private Iterable<File> zincClasspath;
     private final File gradleUserHome;
-
-    public static final String ZINC_CACHE_HOME_DIR_SYSTEM_PROPERTY = "org.gradle.zinc.home.dir";
-    private static final String ZINC_DIR_SYSTEM_PROPERTY = "zinc.dir";
-    public static final String ZINC_DIR_IGNORED_MESSAGE = "In order to guarantee parallel safe Scala compilation, Gradle does not support the '" + ZINC_DIR_SYSTEM_PROPERTY + "' system property and ignores any value provided.";
 
     public ZincScalaCompiler(Iterable<File> scalaClasspath, Iterable<File> zincClasspath, File gradleUserHome) {
         this.scalaClasspath = scalaClasspath;
@@ -74,7 +57,7 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec>, S
 
             final xsbti.Logger logger = new SbtLoggerAdapter();
 
-            com.typesafe.zinc.Compiler compiler = createParallelSafeCompiler(scalaClasspath, zincClasspath, logger, gradleUserHome);
+            com.typesafe.zinc.Compiler compiler = ZincScalaCompilerFactory.createParallelSafeCompiler(scalaClasspath, zincClasspath, logger, gradleUserHome);
 
             List<String> scalacOptions = new ZincScalaCompilerArgumentsGenerator().generate(spec);
             List<String> javacOptions = new JavaCompilerArgumentsBuilder(spec).includeClasspath(false).build();
@@ -115,91 +98,32 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec>, S
             return options;
         }
 
-        static com.typesafe.zinc.Compiler createCompiler(Iterable<File> scalaClasspath, Iterable<File> zincClasspath, xsbti.Logger logger) {
-            ScalaLocation scalaLocation = ScalaLocation.fromPath(Lists.newArrayList(scalaClasspath));
-            SbtJars sbtJars = SbtJars.fromPath(Lists.newArrayList(zincClasspath));
-            Setup setup = Setup.create(scalaLocation, sbtJars, Jvm.current().getJavaHome(), true);
-            if (LOGGER.isDebugEnabled()) {
-                Setup.debug(setup, logger);
-            }
-            com.typesafe.zinc.Compiler compiler = com.typesafe.zinc.Compiler.getOrCreate(setup, logger);
-            return compiler;
-        }
-
-        static com.typesafe.zinc.Compiler createParallelSafeCompiler(final Iterable<File> scalaClasspath, final Iterable<File> zincClasspath, final xsbti.Logger logger, File gradleUserHome) {
-            File zincCacheHomeDir = new File(System.getProperty(ZINC_CACHE_HOME_DIR_SYSTEM_PROPERTY, gradleUserHome.getAbsolutePath()));
-            CacheRepository cacheRepository = ZincCompilerServices.getInstance(zincCacheHomeDir).get(CacheRepository.class);
-            final PersistentCache zincCache = cacheRepository.cache("zinc")
-                                                            .withDisplayName("Zinc compiler cache")
-                                                            .withLockOptions(mode(FileLockManager.LockMode.Exclusive))
-                                                            .open();
-            final File cacheDir = zincCache.getBaseDir();
-
-            final String userSuppliedZincDir = System.getProperty("zinc.dir");
-            if (userSuppliedZincDir != null && !userSuppliedZincDir.equals(cacheDir.getAbsolutePath())) {
-                LOGGER.warn(ZINC_DIR_IGNORED_MESSAGE);
-            }
-
-            com.typesafe.zinc.Compiler compiler = SystemProperties.getInstance().withSystemProperty(ZINC_DIR_SYSTEM_PROPERTY, cacheDir.getAbsolutePath(), new Factory<com.typesafe.zinc.Compiler>() {
-                @Override
-                public com.typesafe.zinc.Compiler create() {
-                    return zincCache.useCache("initialize", new Factory<com.typesafe.zinc.Compiler>() {
-                        @Override
-                        public com.typesafe.zinc.Compiler create() {
-                            return createCompiler(scalaClasspath, zincClasspath, logger);
-                        }
-                    });
-                }
-            });
-            zincCache.close();
-
-            return compiler;
-        }
     }
 
     private static class SbtLoggerAdapter implements xsbti.Logger {
         @Override
-        public void error(F0<String> msg) {
+        public void error(xsbti.F0<String> msg) {
             LOGGER.error(msg.apply());
         }
 
         @Override
-        public void warn(F0<String> msg) {
+        public void warn(xsbti.F0<String> msg) {
             LOGGER.warn(msg.apply());
         }
 
         @Override
-        public void info(F0<String> msg) {
+        public void info(xsbti.F0<String> msg) {
             LOGGER.info(msg.apply());
         }
 
         @Override
-        public void debug(F0<String> msg) {
+        public void debug(xsbti.F0<String> msg) {
             LOGGER.debug(msg.apply());
         }
 
         @Override
-        public void trace(F0<Throwable> exception) {
+        public void trace(xsbti.F0<Throwable> exception) {
             LOGGER.trace(exception.apply().toString());
-        }
-    }
-
-    private static class ZincCompilerServices extends DefaultServiceRegistry {
-        private static ZincCompilerServices instance;
-
-        private ZincCompilerServices(File gradleUserHome) {
-            super(NativeServices.getInstance());
-
-            addProvider(new GlobalScopeServices(true));
-            addProvider(new CacheRepositoryServices(gradleUserHome, null));
-        }
-
-        public static ZincCompilerServices getInstance(File gradleUserHome) {
-            if (instance == null) {
-                NativeServices.initialize(gradleUserHome);
-                instance = new ZincCompilerServices(gradleUserHome);
-            }
-            return instance;
         }
     }
 }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.scala;
+
+import com.google.common.collect.Lists;
+import com.typesafe.zinc.Compiler;
+import com.typesafe.zinc.SbtJars;
+import com.typesafe.zinc.ScalaLocation;
+import com.typesafe.zinc.Setup;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.cache.CacheRepository;
+import org.gradle.cache.PersistentCache;
+import org.gradle.cache.internal.FileLockManager;
+import org.gradle.internal.Factory;
+import org.gradle.internal.SystemProperties;
+import org.gradle.util.GFileUtils;
+import sbt.ScalaInstance;
+import sbt.compiler.AnalyzingCompiler;
+import xsbti.compile.JavaCompiler;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
+
+class ZincScalaCompilerFactory {
+    private static final Logger LOGGER = Logging.getLogger(ZincScalaCompilerFactory.class);
+
+    private static final String ZINC_CACHE_HOME_DIR_SYSTEM_PROPERTY = "org.gradle.zinc.home.dir";
+    private static final String ZINC_DIR_SYSTEM_PROPERTY = "zinc.dir";
+    private static final String ZINC_DIR_IGNORED_MESSAGE = "In order to guarantee parallel safe Scala compilation, Gradle does not support the '" + ZINC_DIR_SYSTEM_PROPERTY + "' system property and ignores any value provided.";
+
+    static Compiler createParallelSafeCompiler(final Iterable<File> scalaClasspath, final Iterable<File> zincClasspath, final xsbti.Logger logger, File gradleUserHome) {
+        File zincCacheHomeDir = new File(System.getProperty(ZINC_CACHE_HOME_DIR_SYSTEM_PROPERTY, gradleUserHome.getAbsolutePath()));
+        CacheRepository cacheRepository = ZincCompilerServices.getInstance(zincCacheHomeDir).get(CacheRepository.class);
+
+        String zincVersion = Setup.zincVersion().published();
+        String zincCacheKey = String.format("zinc-%s", zincVersion);
+        String zincCacheName = String.format("Zinc %s compiler cache", zincVersion);
+        final PersistentCache zincCache = cacheRepository.cache(zincCacheKey)
+                .withDisplayName(zincCacheName)
+                .withLockOptions(mode(FileLockManager.LockMode.Exclusive))
+                .open();
+        final File cacheDir = zincCache.getBaseDir();
+
+        final String userSuppliedZincDir = System.getProperty("zinc.dir");
+        if (userSuppliedZincDir != null && !userSuppliedZincDir.equals(cacheDir.getAbsolutePath())) {
+            LOGGER.warn(ZINC_DIR_IGNORED_MESSAGE);
+        }
+
+        Compiler compiler = SystemProperties.getInstance().withSystemProperty(ZINC_DIR_SYSTEM_PROPERTY, cacheDir.getAbsolutePath(), new Factory<Compiler>() {
+            @Override
+            public Compiler create() {
+                Setup zincSetup = createZincSetup(scalaClasspath, zincClasspath, logger);
+                return createCompiler(zincSetup, zincCache, logger);
+            }
+        });
+        zincCache.close();
+
+        return compiler;
+    }
+
+    private static Compiler createCompiler(final Setup setup, final PersistentCache zincCache, final xsbti.Logger logger) {
+        return Compiler.compilerCache().get(setup, new scala.runtime.AbstractFunction0<Compiler>() {
+            public Compiler apply() {
+                ScalaInstance instance = Compiler.scalaInstance(setup);
+                File interfaceJar = getCompilerInterface(setup, instance, zincCache, logger);
+                AnalyzingCompiler scalac = Compiler.newScalaCompiler(instance, interfaceJar, logger);
+                JavaCompiler javac = Compiler.newJavaCompiler(instance, setup.javaHome(), setup.forkJava());
+                return new Compiler(scalac, javac);
+            }
+        });
+    }
+
+    // parallel safe version of Compiler.compilerInterface()
+    private static File getCompilerInterface(final Setup setup, final ScalaInstance instance, PersistentCache zincCache, final xsbti.Logger logger) {
+        String sbtInterfaceFileName =
+            String.format("compiler-interface-%s.jar", Compiler.interfaceId(instance.actualVersion()));
+        final File compilerInterface = new File(setup.cacheDir(), sbtInterfaceFileName);
+        if (compilerInterface.exists()) {
+            return compilerInterface;
+        }
+
+        try {
+            // Let's try to compile the interface to a temp file and then copy it to the cache folder.
+            // Compiling an interface is an expensive operation which affects performance on machines
+            // with many CPUs and we don't want to block while compiling.
+            final File tempFile = File.createTempFile("zinc", ".jar");
+            sbt.compiler.IC.compileInterfaceJar(
+                    sbtInterfaceFileName,
+                    setup.compilerInterfaceSrc(),
+                    tempFile,
+                    setup.sbtInterface(),
+                    instance,
+                    logger);
+            return zincCache.useCache("coping sbt interface", new Factory<File>() {
+                public File create() {
+                    GFileUtils.copyFile(tempFile, compilerInterface);
+                    return compilerInterface;
+                }
+            });
+        } catch (IOException e) {
+            // fall back to the default logic
+            return zincCache.useCache("compiling sbt interface", new Factory<File>() {
+                public File create() {
+                    return Compiler.compilerInterface(setup, instance, logger);
+                }
+            });
+        }
+    }
+
+    private static Setup createZincSetup(Iterable<File> scalaClasspath, Iterable<File> zincClasspath, xsbti.Logger logger) {
+        ScalaLocation scalaLocation = ScalaLocation.fromPath(Lists.newArrayList(scalaClasspath));
+        SbtJars sbtJars = SbtJars.fromPath(Lists.newArrayList(zincClasspath));
+        Setup setup = Setup.create(scalaLocation, sbtJars, null, false);
+        if (LOGGER.isDebugEnabled()) {
+            Setup.debug(setup, logger);
+        }
+        return setup;
+    }
+}


### PR DESCRIPTION
Take number 3 after #666 and #671 on fixing timeout while locking Zinc cache.

# Background

See #666 and #671  for details.

TLDR: We have a project with 450+ project where ~100 of them in Scala. On a cold compilation where no caches are presented and we are compiling with max parallelism we see TimeoutExceptions while waiting for a zinc lock.

# Solution

I've refactored scala compilation to use direct in-memory java compiler and use separate caches for different Zinc versions. 

But most importantly I've refactored how the lock is used. Before it was acquired even on checking 
local caches. Also compilation of sbt compiler interface was wrapped in the lock which led to the timeout. Now this compilation will be take place in a temp folder and a lock will be acquired only on coping the compiler interface to the cache folder.

# Testing

I've ran v3.1.0 with this fix on our repo multiple times successfully. In our case it also dropped the overall compilation time by ~10%.

to: @ghale
cc: @eriwen @bmuschko