### PR TITLE
Add TimeProvider.currentTimeForDuration and use it

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/TimeProvider.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/TimeProvider.java
@@ -21,4 +21,5 @@ public interface TimeProvider extends Serializable {
 
     long getCurrentTime();
 
+    long getCurrentTimeForDuration();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/TrueTimeProvider.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/TrueTimeProvider.java
@@ -16,10 +16,16 @@
 
 package org.gradle.internal;
 
-public class TrueTimeProvider implements TimeProvider {
+import java.util.concurrent.TimeUnit;
 
+public class TrueTimeProvider implements TimeProvider {
+    @Override
     public long getCurrentTime() {
         return System.currentTimeMillis();
     }
 
+    @Override
+    public long getCurrentTimeForDuration() {
+        return TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+    }
 }

--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/fixture/BuildScanPerformanceTestRunner.groovy
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/fixture/BuildScanPerformanceTestRunner.groovy
@@ -40,7 +40,7 @@ class BuildScanPerformanceTestRunner extends CrossBuildPerformanceTestRunner {
             versionUnderTest: GradleVersion.current().getVersion(),
             vcsBranch: Git.current().branchName,
             vcsCommits: [Git.current().commitId, pluginCommitSha],
-            startTime: System.currentTimeMillis(),
+            startTime: timeProvider.getCurrentTimeForDuration(),
             channel: determineChannel()
         )
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -28,6 +28,7 @@ import org.gradle.configuration.BuildConfigurer;
 import org.gradle.deployment.internal.DeploymentRegistry;
 import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.execution.BuildExecuter;
+import org.gradle.internal.TimeProvider;
 import org.gradle.internal.buildevents.BuildLogger;
 import org.gradle.internal.buildevents.CacheStatisticsReporter;
 import org.gradle.internal.buildevents.TaskExecutionLogger;
@@ -61,10 +62,13 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
     private final GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry;
     private final NestedBuildTracker tracker;
     private final BuildProgressLogger buildProgressLogger;
+    private final TimeProvider timeProvider;
 
-    public DefaultGradleLauncherFactory(ListenerManager listenerManager, ProgressLoggerFactory progressLoggerFactory, GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry) {
+    public DefaultGradleLauncherFactory(
+        ListenerManager listenerManager, ProgressLoggerFactory progressLoggerFactory, GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry, TimeProvider timeProvider) {
         this.listenerManager = listenerManager;
         this.userHomeDirServiceRegistry = userHomeDirServiceRegistry;
+        this.timeProvider = timeProvider;
         tracker = new NestedBuildTracker();
 
         // Register default loggers
@@ -105,7 +109,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         }
 
         ServiceRegistry services = tracker.getCurrentBuild().getServices();
-        BuildRequestMetaData requestMetaData = new DefaultBuildRequestMetaData(services.get(BuildClientMetaData.class), System.currentTimeMillis());
+        BuildRequestMetaData requestMetaData = new DefaultBuildRequestMetaData(services.get(BuildClientMetaData.class), timeProvider.getCurrentTimeForDuration());
         BuildCancellationToken cancellationToken = services.get(BuildCancellationToken.class);
         BuildEventConsumer buildEventConsumer = services.get(BuildEventConsumer.class);
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -77,6 +77,8 @@ import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.initialization.JdkToolsInitializer;
 import org.gradle.initialization.LegacyTypesSupport;
 import org.gradle.internal.Factory;
+import org.gradle.internal.TimeProvider;
+import org.gradle.internal.TrueTimeProvider;
 import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.classloader.ClassLoaderHasher;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
@@ -160,8 +162,8 @@ public class GlobalScopeServices {
         }
     }
 
-    GradleLauncherFactory createGradleLauncherFactory(ListenerManager listenerManager, ProgressLoggerFactory progressLoggerFactory, GradleUserHomeScopeServiceRegistry userHomeScopeServiceRegistry) {
-        return new DefaultGradleLauncherFactory(listenerManager, progressLoggerFactory, userHomeScopeServiceRegistry);
+    GradleLauncherFactory createGradleLauncherFactory(ListenerManager listenerManager, ProgressLoggerFactory progressLoggerFactory, GradleUserHomeScopeServiceRegistry userHomeScopeServiceRegistry, TimeProvider timeProvider) {
+        return new DefaultGradleLauncherFactory(listenerManager, progressLoggerFactory, userHomeScopeServiceRegistry, timeProvider);
     }
 
     TemporaryFileProvider createTemporaryFileProvider() {
@@ -383,5 +385,9 @@ public class GlobalScopeServices {
 
     GradleUserHomeScopeServiceRegistry createGradleUserHomeScopeServiceRegistry(ServiceRegistry globalServices) {
         return new DefaultGradleUserHomeScopeServiceRegistry(globalServices, new GradleUserHomeScopeServices(globalServices));
+    }
+
+    TimeProvider createTimeProvider() {
+        return new TrueTimeProvider();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/util/Clock.java
+++ b/subprojects/core/src/main/java/org/gradle/util/Clock.java
@@ -50,11 +50,11 @@ public class Clock {
     }
 
     public long getTimeInMs() {
-        return Math.max(timeProvider.getCurrentTime() - start, 0);
+        return Math.max(timeProvider.getCurrentTimeForDuration() - start, 0);
     }
 
     public void reset() {
-        start = timeProvider.getCurrentTime();
+        start = timeProvider.getCurrentTimeForDuration();
     }
 
     public long getStartTime() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/antbuilder/AntBuilderMemoryLeakTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/antbuilder/AntBuilderMemoryLeakTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.api.internal.DefaultClassPathProvider
 import org.gradle.api.internal.DefaultClassPathRegistry
 import org.gradle.api.internal.classpath.DefaultModuleRegistry
 import org.gradle.api.internal.classpath.ModuleRegistry
+import org.gradle.internal.TimeProvider
+import org.gradle.internal.TrueTimeProvider
 import org.gradle.internal.classloader.DefaultClassLoaderFactory
 import org.gradle.internal.installation.CurrentGradleInstallation
 import spock.lang.Ignore
@@ -39,6 +41,9 @@ class AntBuilderMemoryLeakTest extends Specification {
 
     @Shared
     private DefaultClassLoaderFactory classLoaderFactory = new DefaultClassLoaderFactory()
+
+    @Shared
+    private TimeProvider timeProvider = new TrueTimeProvider()
 
     def "should release cache when cleanup is called"() {
         classLoaderFactory = new DefaultClassLoaderFactory()
@@ -71,9 +76,9 @@ class AntBuilderMemoryLeakTest extends Specification {
         when:
         int i = 0
         // time out after 10 minutes
-        long maxTime = System.currentTimeMillis() + 10 * 60 * 1000
+        long maxTime = timeProvider.getCurrentTimeForDuration() + 10 * 60 * 1000
         try {
-            while (System.currentTimeMillis() < maxTime) {
+            while (timeProvider.getCurrentTimeForDuration() < maxTime) {
                 builder.withClasspath([new File("foo$i")]).execute {
 
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherFactoryTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.initialization
 
 import org.gradle.StartParameter
+import org.gradle.internal.TrueTimeProvider
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
@@ -40,7 +41,7 @@ class DefaultGradleLauncherFactoryTest extends Specification {
     final ListenerManager listenerManager = globalServices.get(ListenerManager)
     final ProgressLoggerFactory progressLoggerFactory = globalServices.get(ProgressLoggerFactory)
     final GradleUserHomeScopeServiceRegistry userHomeScopeServiceRegistry = globalServices.get(GradleUserHomeScopeServiceRegistry)
-    final DefaultGradleLauncherFactory factory = new DefaultGradleLauncherFactory(listenerManager, progressLoggerFactory, userHomeScopeServiceRegistry)
+    final DefaultGradleLauncherFactory factory = new DefaultGradleLauncherFactory(listenerManager, progressLoggerFactory, userHomeScopeServiceRegistry, new TrueTimeProvider());
 
     def "makes services from build context available as build scoped services"() {
         def cancellationToken = Stub(BuildCancellationToken)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GlobalScopeServicesTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GlobalScopeServicesTest.java
@@ -43,6 +43,8 @@ import org.gradle.initialization.DefaultClassLoaderRegistry;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.DefaultGradleLauncherFactory;
 import org.gradle.initialization.GradleLauncherFactory;
+import org.gradle.internal.TimeProvider;
+import org.gradle.internal.TrueTimeProvider;
 import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.classloader.ClassPathSnapshotter;
 import org.gradle.internal.classloader.DefaultHashingClassLoaderFactory;
@@ -204,4 +206,8 @@ public class GlobalScopeServicesTest {
         assertThat(registry().get(ClassLoaderCache.class), instanceOf(DefaultClassLoaderCache.class));
     }
 
+    @Test
+    public void providesATimeProvider() throws Exception {
+        assertThat(registry().get(TimeProvider.class), instanceOf(TrueTimeProvider.class));
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/util/ClockTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/util/ClockTest.java
@@ -19,10 +19,11 @@ import org.gradle.internal.TimeProvider;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JMock;
 import org.jmock.integration.junit4.JUnit4Mockery;
-import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(JMock.class)
 public class ClockTest {
@@ -80,7 +81,7 @@ public class ClockTest {
 
     private void returnFromTimeProvider(final long time) {
         context.checking(new Expectations(){{
-            one(timeProvider).getCurrentTime();
+            one(timeProvider).getCurrentTimeForDuration();
             will(returnValue(time));
         }});
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/MockTimeProvider.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/MockTimeProvider.java
@@ -40,4 +40,10 @@ public class MockTimeProvider implements TimeProvider {
         current += 10L;
         return current;
     }
+
+    /** Increments the time by 10ms and returns it. */
+    @Override
+    public long getCurrentTimeForDuration() {
+        return getCurrentTime();
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/AbstractDaemonFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/AbstractDaemonFixture.groovy
@@ -17,16 +17,19 @@
 package org.gradle.integtests.fixtures.daemon
 
 import org.gradle.integtests.fixtures.ProcessFixture
+import org.gradle.internal.TimeProvider
+import org.gradle.internal.TrueTimeProvider
 import org.gradle.launcher.daemon.context.DaemonContext
 
-import static org.gradle.launcher.daemon.server.api.DaemonStateControl.*
-import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.*
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State
 
 abstract class AbstractDaemonFixture implements DaemonFixture {
     public static final int STATE_CHANGE_TIMEOUT = 20000
     final DaemonContext context
+    final TimeProvider timeProvider
 
     AbstractDaemonFixture(File daemonLog) {
+        this.timeProvider = new TrueTimeProvider()
         this.context = DaemonContextParser.parseFrom(daemonLog.text)
         if(!this.context) {
             println "Could not parse daemon log: \n$daemonLog.text"

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/LegacyDaemon.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/LegacyDaemon.groovy
@@ -16,15 +16,17 @@
 
 package org.gradle.integtests.fixtures.daemon
 
+import org.gradle.internal.TrueTimeProvider
 import org.gradle.util.GradleVersion
 
-import static org.gradle.launcher.daemon.server.api.DaemonStateControl.*
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State
 
 class LegacyDaemon extends AbstractDaemonFixture {
     private final DaemonLogFileStateProbe logFileProbe
 
     LegacyDaemon(File daemonLog, String version) {
         super(daemonLog)
+        timeProvider = new TrueTimeProvider()
         if (GradleVersion.version(version).baseVersion >= GradleVersion.version("2.2")) {
             logFileProbe = new DaemonLogFileStateProbe(daemonLog, context)
         } else {
@@ -33,9 +35,9 @@ class LegacyDaemon extends AbstractDaemonFixture {
     }
 
     protected void waitForState(State state) {
-        def expiry = System.currentTimeMillis() + STATE_CHANGE_TIMEOUT
+        def expiry = timeProvider.getCurrentTimeForDuration() + STATE_CHANGE_TIMEOUT
         def lastLogState = logFileProbe.currentState
-        while (expiry > System.currentTimeMillis() && lastLogState != state) {
+        while (expiry > timeProvider.getCurrentTimeForDuration() && lastLogState != state) {
             Thread.sleep(200)
             lastLogState = logFileProbe.currentState
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/TestableDaemon.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/TestableDaemon.groovy
@@ -31,10 +31,10 @@ class TestableDaemon extends AbstractDaemonFixture {
     }
 
     protected void waitForState(State state) {
-        def expiry = System.currentTimeMillis() + STATE_CHANGE_TIMEOUT
+        def expiry = timeProvider.getCurrentTimeForDuration() + STATE_CHANGE_TIMEOUT
         def lastRegistryState = registryProbe.currentState
         def lastLogState = logFileProbe.currentState
-        while (expiry > System.currentTimeMillis() && (lastRegistryState != state || lastLogState != state)) {
+        while (expiry > timeProvider.getCurrentTimeForDuration() && (lastRegistryState != state || lastLogState != state)) {
             Thread.sleep(200)
             lastRegistryState = registryProbe.currentState
             lastLogState = logFileProbe.currentState

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -40,6 +40,7 @@ import org.gradle.initialization.NoOpBuildEventConsumer;
 import org.gradle.initialization.ReportedException;
 import org.gradle.internal.Factory;
 import org.gradle.internal.SystemProperties;
+import org.gradle.internal.TrueTimeProvider;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.exceptions.LocationAwareException;
@@ -290,7 +291,7 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
     private BuildRequestContext createBuildRequestContext(StandardOutputListener outputListener, StandardOutputListener errorListener) {
         return new DefaultBuildRequestContext(
-            new DefaultBuildRequestMetaData(new GradleLauncherMetaData(), System.currentTimeMillis()),
+            new DefaultBuildRequestMetaData(new GradleLauncherMetaData(), new TrueTimeProvider().getCurrentTimeForDuration()),
             new DefaultBuildCancellationToken(),
             new NoOpBuildEventConsumer(),
             outputListener, errorListener);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.groovy
@@ -17,6 +17,7 @@
 
 package org.gradle.test.fixtures.server.http
 
+import org.gradle.internal.TrueTimeProvider
 import org.junit.rules.ExternalResource
 import org.mortbay.jetty.Server
 import org.mortbay.jetty.handler.AbstractHandler
@@ -123,7 +124,7 @@ server state: ${server.dump()}
                 return
             }
 
-            Date expiry = new Date(System.currentTimeMillis() + 30000)
+            Date expiry = new Date(new TrueTimeProvider().getCurrentTimeForDuration() + 30000)
             lock.lock()
             try {
                 if (shortCircuit) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -24,6 +24,8 @@ import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.integtests.tooling.fixture.ToolingApi
 import org.gradle.integtests.tooling.fixture.ToolingApiClasspathProvider
 import org.gradle.integtests.tooling.fixture.ToolingApiDistributionResolver
+import org.gradle.internal.TimeProvider
+import org.gradle.internal.TrueTimeProvider
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
@@ -116,6 +118,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
     }
 
     private class Measurement implements ToolingApiClasspathProvider {
+        private final TimeProvider timeProvider = new TrueTimeProvider();
 
         private CrossVersionPerformanceResults run() {
             def testId = experimentSpec.displayName
@@ -134,7 +137,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
                 versionUnderTest: GradleVersion.current().getVersion(),
                 vcsBranch: Git.current().branchName,
                 vcsCommits: [Git.current().commitId],
-                startTime: System.currentTimeMillis(),
+                startTime: timeProvider.getCurrentTimeForDuration(),
                 tasks: [],
                 args: [],
                 gradleOpts: [],
@@ -168,7 +171,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
                 resolver.stop()
             }
 
-            results.endTime = System.currentTimeMillis();
+            results.endTime = timeProvider.getCurrentTimeForDuration()
 
             results.assertEveryBuildSucceeds()
             resultStore.report(results)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractGradleBuildPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractGradleBuildPerformanceTestRunner.groovy
@@ -18,6 +18,8 @@ package org.gradle.performance.fixture
 
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution
+import org.gradle.internal.TimeProvider
+import org.gradle.internal.TrueTimeProvider
 import org.gradle.performance.results.DataReporter
 import org.gradle.performance.results.MeasuredOperationList
 import org.gradle.performance.results.PerformanceTestResult
@@ -29,6 +31,7 @@ abstract class AbstractGradleBuildPerformanceTestRunner<R extends PerformanceTes
     final GradleDistribution gradleDistribution = new UnderDevelopmentGradleDistribution()
     final BuildExperimentRunner experimentRunner
     final TestProjectLocator testProjectLocator = new TestProjectLocator()
+    final TimeProvider timeProvider = new TrueTimeProvider()
 
     String testId
     String testGroup
@@ -91,7 +94,7 @@ abstract class AbstractGradleBuildPerformanceTestRunner<R extends PerformanceTes
 
         runAllSpecifications(results)
 
-        results.endTime = System.currentTimeMillis()
+        results.endTime = timeProvider.getCurrentTimeForDuration()
 
         results.assertEveryBuildSucceeds()
         reporter.report(results)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossBuildPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossBuildPerformanceTestRunner.groovy
@@ -59,7 +59,7 @@ class CrossBuildPerformanceTestRunner extends AbstractGradleBuildPerformanceTest
             versionUnderTest: GradleVersion.current().getVersion(),
             vcsBranch: Git.current().branchName,
             vcsCommits: [Git.current().commitId],
-            startTime: System.currentTimeMillis(),
+            startTime: timeProvider.getCurrentTimeForDuration(),
             channel: determineChannel()
         )
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
@@ -23,6 +23,8 @@ import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.GradleExecuterDecorator
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
+import org.gradle.internal.TimeProvider
+import org.gradle.internal.TrueTimeProvider
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.performance.measure.MeasuredOperation
@@ -46,6 +48,7 @@ public class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
     TestProjectLocator testProjectLocator = new TestProjectLocator()
     final BuildExperimentRunner experimentRunner
     final ReleasedVersionDistributions releases
+    final TimeProvider timeProvider = new TrueTimeProvider()
 
     String testProject
     File workingDir
@@ -99,7 +102,7 @@ public class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
             versionUnderTest: GradleVersion.current().getVersion(),
             vcsBranch: Git.current().branchName,
             vcsCommits: [Git.current().commitId],
-            startTime: System.currentTimeMillis(),
+            startTime: timeProvider.getCurrentTimeForDuration(),
             channel: ResultsStoreHelper.determineChannel()
         )
 
@@ -112,7 +115,7 @@ public class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
             runVersion(buildContext.distribution(baselineVersion.version), perVersionWorkingDirectory(baselineVersion.version), baselineVersion.results)
         }
 
-        results.endTime = System.currentTimeMillis()
+        results.endTime = timeProvider.getCurrentTimeForDuration()
 
         results.assertEveryBuildSucceeds()
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
@@ -90,7 +90,7 @@ class GradleVsMavenPerformanceTestRunner extends AbstractGradleBuildPerformanceT
             versionUnderTest: GradleVersion.current().getVersion(),
             vcsBranch: Git.current().branchName,
             vcsCommits: [Git.current().commitId],
-            startTime: System.currentTimeMillis(),
+            startTime: timeProvider.getCurrentTimeForDuration(),
             channel: determineChannel()
         )
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/WaitingReader.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/WaitingReader.java
@@ -16,6 +16,9 @@
 
 package org.gradle.performance.fixture;
 
+import org.gradle.internal.TimeProvider;
+import org.gradle.internal.TrueTimeProvider;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 
@@ -35,6 +38,7 @@ public class WaitingReader {
     private final BufferedReader reader;
     private final int timeoutMs;
     private final int clockTick;
+    private final TimeProvider timeProvider = new TrueTimeProvider();
 
     //for testing
     int retriedCount;
@@ -50,13 +54,13 @@ public class WaitingReader {
     }
 
     String readLine() throws IOException {
-        long upTo = System.currentTimeMillis() + timeoutMs;
+        long upTo = timeProvider.getCurrentTimeForDuration() + timeoutMs;
         reader.mark(READAHEAD_BUFFER_SIZE);
         int character = EOF;
         while (character != NEW_LINE && character != CARRIAGE_RETURN) {
             character = reader.read();
             if (character == EOF) {
-                if (System.currentTimeMillis() >= upTo) {
+                if (timeProvider.getCurrentTimeForDuration() >= upTo) {
                     break;
                 }
                 try {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
@@ -598,14 +598,6 @@ model {
         return toolChain.meets(ToolChainRequirement.GCC) && (sourceType == "C" || sourceType == "Cpp")
     }
 
-    private void maybeWait() {
-        if (toolChain.visualCpp) {
-            def now = System.currentTimeMillis()
-            def nextSecond = now % 1000
-            Thread.sleep(1200 - nextSecond)
-        }
-    }
-
     static boolean rename(TestFile sourceFile) {
         final newFile = new File(sourceFile.getParentFile(), "changed_${sourceFile.name}")
         newFile << sourceFile.text

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativePreCompiledHeaderIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativePreCompiledHeaderIntegrationTest.groovy
@@ -520,14 +520,6 @@ abstract class AbstractNativePreCompiledHeaderIntegrationTest extends AbstractIn
         true
     }
 
-    private void maybeWait() {
-        if (toolChain.visualCpp) {
-            def now = System.currentTimeMillis()
-            def nextSecond = now % 1000
-            Thread.sleep(1200 - nextSecond)
-        }
-    }
-
     String getSuffix() {
         return toolChain.typeDisplayName == "visual c++" ? "pch" : "h.gch"
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonIdleTimeoutExpirationStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonIdleTimeoutExpirationStrategy.java
@@ -21,6 +21,7 @@ import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.internal.TrueTimeProvider;
 import org.gradle.launcher.daemon.server.expiry.DaemonExpirationResult;
 import org.gradle.launcher.daemon.server.expiry.DaemonExpirationStrategy;
 
@@ -46,7 +47,7 @@ public class DaemonIdleTimeoutExpirationStrategy implements DaemonExpirationStra
 
     @Override
     public DaemonExpirationResult checkExpiration() {
-        long idleMillis = daemon.getStateCoordinator().getIdleMillis(System.currentTimeMillis());
+        long idleMillis = daemon.getStateCoordinator().getIdleMillis(new TrueTimeProvider().getCurrentTimeForDuration());
         boolean idleTimeoutExceeded = idleMillis > idleTimeout.apply(null);
         if (idleTimeoutExceeded) {
             LOG.info("Idle timeout: daemon has been idle for {} milliseconds. Expiring.", idleMillis);

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerTest.groovy
@@ -19,11 +19,14 @@ package org.gradle.internal.logging.slf4j
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.internal.TimeProvider
 import org.gradle.internal.logging.events.LogEvent
 import org.gradle.internal.logging.events.OutputEventListener
 import org.slf4j.Marker
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit
 
 import static org.gradle.api.logging.LogLevel.*
 import static org.slf4j.Logger.ROOT_LOGGER_NAME
@@ -32,8 +35,19 @@ import static org.slf4j.Logger.ROOT_LOGGER_NAME
 class OutputEventListenerBackedLoggerTest extends Specification {
 
     final List<LogEvent> events = []
-    final long now = System.currentTimeMillis()
-    final OutputEventListenerBackedLoggerContext context = new OutputEventListenerBackedLoggerContext(System.out, System.err, { now })
+    final long now = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS)
+    final TimeProvider timeProvider = new TimeProvider() {
+        @Override
+        long getCurrentTime() {
+            return now
+        }
+
+        @Override
+        long getCurrentTimeForDuration() {
+            return now
+        }
+    }
+    final OutputEventListenerBackedLoggerContext context = new OutputEventListenerBackedLoggerContext(System.out, System.err, timeProvider)
 
     def setup() {
         context.outputEventListener = Mock(OutputEventListener) {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/Slf4jLoggingConfigurerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/Slf4jLoggingConfigurerTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.internal.logging.slf4j
 
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
+import org.gradle.internal.TrueTimeProvider
 import org.gradle.internal.logging.events.OutputEventListener
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -26,7 +27,7 @@ class Slf4jLoggingConfigurerTest extends Specification {
     Logger logger = LoggerFactory.getLogger("cat1")
     OutputEventListener listener = Mock()
     Slf4jLoggingConfigurer configurer = new Slf4jLoggingConfigurer(listener)
-    
+
     def cleanup() {
         def context = (OutputEventListenerBackedLoggerContext) LoggerFactory.getILoggerFactory()
         context.reset()
@@ -53,7 +54,7 @@ class Slf4jLoggingConfigurerTest extends Specification {
         1 * listener.onOutput({it.category == 'cat1' && it.message == 'message' && it.logLevel == LogLevel.INFO && it.throwable == failure})
         0 * listener._
     }
-    
+
     def mapsSlf4jLogLevelsToGradleLogLevels() {
         when:
         configurer.configure(LogLevel.DEBUG)
@@ -91,7 +92,7 @@ class Slf4jLoggingConfigurerTest extends Specification {
         logger.info('message')
 
         then:
-        1 * listener.onOutput({it.timestamp >= System.currentTimeMillis() - 300})
+        1 * listener.onOutput({it.timestamp >= new TrueTimeProvider().getCurrentTimeForDuration() - 300})
         0 * listener._
     }
 

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.nativeplatform.fixtures
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.TrueTimeProvider
 import org.gradle.internal.hash.HashUtil
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingScheme
@@ -77,6 +78,14 @@ allprojects { p ->
                         .withOutputBaseFolder(file(rootObjectFilesDir))
                         .map(sourceFile)
         return file(getTestDirectory().toURI().relativize(objectFile.toURI()));
+    }
+
+    protected void maybeWait() {
+        if (toolChain.visualCpp) {
+            def now = new TrueTimeProvider().getCurrentTimeForDuration()
+            def nextSecond = now % 1000
+            Thread.sleep(1200 - nextSecond)
+        }
     }
 
     String hashFor(File inputFile){

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/ExclusiveFileAccessManager.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/ExclusiveFileAccessManager.java
@@ -22,6 +22,7 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 public class ExclusiveFileAccessManager {
 
@@ -46,10 +47,10 @@ public class ExclusiveFileAccessManager {
         FileChannel channel = null;
         try {
 
-            long startAt = System.currentTimeMillis();
+            long startAt = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
             FileLock lock = null;
 
-            while (lock == null && System.currentTimeMillis() < startAt + timeoutMs) {
+            while (lock == null && TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS) < startAt + timeoutMs) {
                 randomAccessFile = new RandomAccessFile(lockFile, "rw");
                 channel = randomAccessFile.getChannel();
                 lock = channel.tryLock();


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`
https://scans.gradle.com/s/7clpw3wlkqabk
- [x] Also ran the integration tests for core.
https://gradle.com/s/ndrhqrcc572mc

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [x] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [x] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.

There were many places we were measuring a duration by comparing
`System.currentTimeMillis()` at some start and end times. This is a
known anti-pattern which is subject to incorrect duration measurements
due to how clock skew affects the implementation of that function.

The new `currentTimeForDuration()` method uses `System.nanoTime()` which
is much more reliable for measuring durations within a single thread of
control in a single process.

Replacing our uses of `System.currentTimeMillis()` with
`currentTimeForDuration()` will make Gradle and our tests much more
reliable.

In service of issue #740