### PR TITLE
Do not use Guava's `Throwables.propagate()`

### DIFF
--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/DefaultTemplateLibraryVersionProvider.java
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/DefaultTemplateLibraryVersionProvider.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.buildinit.plugins.internal;
 
-import com.google.common.base.Throwables;
+import org.gradle.api.UncheckedIOException;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -28,7 +28,7 @@ public class DefaultTemplateLibraryVersionProvider implements TemplateLibraryVer
         try {
             this.libraryVersions.load(getClass().getResourceAsStream("/org/gradle/buildinit/tasks/templates/library-versions.properties"));
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/AntBuilderDelegate.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/AntBuilderDelegate.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.project.antbuilder;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import groovy.util.BuilderSupport;
 import groovy.util.Node;
@@ -24,6 +23,7 @@ import groovy.util.XmlParser;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.internal.DynamicObjectUtil;
 import org.gradle.internal.Cast;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.metaobject.DynamicObject;
 
 import java.io.InputStream;
@@ -55,7 +55,7 @@ public class AntBuilderDelegate extends BuilderSupport {
                 String className = args.get("classname");
                 addTaskDefinition(name, className);
             } catch (ClassNotFoundException ex) {
-                throw Throwables.propagate(ex);
+                throw new RuntimeException(ex);
             }
         } else if (argNames.equals(Collections.singleton("resource"))) {
             InputStream instr = antlibClassLoader.getResourceAsStream(args.get("resource"));
@@ -68,7 +68,7 @@ public class AntBuilderDelegate extends BuilderSupport {
                     addTaskDefinition(name, className);
                 }
             } catch (Exception ex) {
-                throw Throwables.propagate(ex);
+                throw UncheckedException.throwAsUncheckedException(ex);
             } finally {
                 IOUtils.closeQuietly(instr);
             }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -19,7 +19,6 @@ package org.gradle.plugin.devel.tasks;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -30,6 +29,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
@@ -139,9 +139,9 @@ public class ValidateTaskProperties extends DefaultTask implements VerificationT
             Class<?> validatorClass = classLoader.loadClass("org.gradle.api.internal.project.taskfactory.TaskPropertyValidationAccess");
             validatorMethod = validatorClass.getMethod("collectTaskValidationProblems", Class.class, Map.class);
         } catch (ClassNotFoundException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         } catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
 
         getServices().get(DirectoryFileTreeFactory.class).create(getClassesDir()).visit(new FileVisitor() {
@@ -158,7 +158,7 @@ public class ValidateTaskProperties extends DefaultTask implements VerificationT
                 try {
                     reader = new Java9ClassReader(Files.asByteSource(fileDetails.getFile()).read());
                 } catch (IOException e) {
-                    throw Throwables.propagate(e);
+                    throw new UncheckedIOException(e);
                 }
                 List<String> classNames = Lists.newArrayList();
                 reader.accept(new TaskNameCollectorVisitor(classNames), ClassReader.SKIP_CODE);
@@ -186,9 +186,9 @@ public class ValidateTaskProperties extends DefaultTask implements VerificationT
                     try {
                         validatorMethod.invoke(null, taskClass, taskValidationProblems);
                     } catch (IllegalAccessException e) {
-                        throw Throwables.propagate(e);
+                        throw new RuntimeException(e);
                     } catch (InvocationTargetException e) {
-                        throw Throwables.propagate(e);
+                        throw new RuntimeException(e);
                     }
                 }
             }


### PR DESCRIPTION
It is going to be deprecated in Guava 20. Explanation: https://github.com/google/guava/wiki/ThrowablesExplained#uses-for-throwablespropagate

---

Any of the checked boxes below indicate that I took action:
- [ ] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [ ] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [ ] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:
- [ ] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
    the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I considered writing a design document. A design document can be
  brief but explains the use case or problem you are trying to solve,
  touches on the planned implementation approach as well as the test cases
  that verify the behavior. Optimally, design documents should be submitted
  as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
  can be found in the Gradle GitHub repository. Please let us know if you need help with
  creating the design document. We are happy to help!
- [ ] The pull request contains an appropriate level of unit and integration
  test coverage to verify the behavior. Before submitting the pull request
  I ran a build on your local machine via the command
  `./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
  DSL reference and Javadocs where applicable.
