### PR TITLE
Register classloaders as parallelCapable

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
@@ -32,7 +32,11 @@ public class CachingClassLoader extends ClassLoader implements ClassLoaderHierar
          * This classloader is thread-safe and ClassLoader is parallel capable,
          * so register as such to reduce contention when running multithreaded builds
         */
-        ClassLoader.registerAsParallelCapable();
+        try {
+            ClassLoader.registerAsParallelCapable();
+        } catch (NoSuchMethodError ignore) {
+            // Not using Java 7+, just ignore it
+        }
     }
 
     public CachingClassLoader(ClassLoader parent) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
@@ -27,6 +27,14 @@ public class CachingClassLoader extends ClassLoader implements ClassLoaderHierar
     private final ConcurrentMap<String, Object> loadedClasses = new MapMaker().weakValues().makeMap();
     private final ClassLoader parent;
 
+    static {
+        /*
+         * This classloader is thread-safe and ClassLoader is parallel capable,
+         * so register as such to reduce contention when running multithreaded builds
+        */
+        ClassLoader.registerAsParallelCapable();
+    }
+
     public CachingClassLoader(ClassLoader parent) {
         super(parent);
         this.parent = parent;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -67,7 +67,11 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
          * This classloader is thread-safe (all hashsets are read-only from here on) andClassLoader is parallel capable,
          * so register as such to reduce contention when running multithreaded builds
         */
-        ClassLoader.registerAsParallelCapable();
+        try {
+            ClassLoader.registerAsParallelCapable();
+        } catch (NoSuchMethodError ignore) {
+            // Not using Java 7+, just ignore it
+        }
     }
 
     public FilteringClassLoader(ClassLoader parent, Spec spec) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -62,6 +62,12 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
         for (Package p : systemPackages) {
             SYSTEM_PACKAGES.add(p.getName());
         }
+
+        /*
+         * This classloader is thread-safe (all hashsets are read-only from here on) andClassLoader is parallel capable,
+         * so register as such to reduce contention when running multithreaded builds
+        */
+        ClassLoader.registerAsParallelCapable();
     }
 
     public FilteringClassLoader(ClassLoader parent, Spec spec) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
@@ -43,6 +43,14 @@ public class MultiParentClassLoader extends ClassLoader implements ClassLoaderHi
 
     private final List<ClassLoader> parents;
 
+    static {
+        /*
+         * This classloader is thread-safe and ClassLoader is parallel capable,
+         * so register as such to reduce contention when running multithreaded builds
+        */
+        ClassLoader.registerAsParallelCapable();
+    }
+
     public MultiParentClassLoader(ClassLoader... parents) {
         this(Arrays.asList(parents));
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
@@ -48,7 +48,11 @@ public class MultiParentClassLoader extends ClassLoader implements ClassLoaderHi
          * This classloader is thread-safe and ClassLoader is parallel capable,
          * so register as such to reduce contention when running multithreaded builds
         */
-        ClassLoader.registerAsParallelCapable();
+        try {
+            ClassLoader.registerAsParallelCapable();
+        } catch (NoSuchMethodError ignore) {
+            // Not using Java 7+, just ignore it
+        }
     }
 
     public MultiParentClassLoader(ClassLoader... parents) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformingClassLoader.java
@@ -30,6 +30,15 @@ import java.security.cert.Certificate;
 import java.util.Collection;
 
 public abstract class TransformingClassLoader extends VisitableURLClassLoader {
+    static {
+        /*
+         * This classloader is thread-safe and VisitableURLClassLoader is parallel capable,
+         * so register as such to reduce contention when running multithreaded builds.
+         * Notice, concrete classes extending this one still need to register as parallel capable
+        */
+        ClassLoader.registerAsParallelCapable();
+    }
+
     public TransformingClassLoader(ClassLoader parent, ClassPath classPath) {
         super(parent, classPath);
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformingClassLoader.java
@@ -36,7 +36,11 @@ public abstract class TransformingClassLoader extends VisitableURLClassLoader {
          * so register as such to reduce contention when running multithreaded builds.
          * Notice, concrete classes extending this one still need to register as parallel capable
         */
-        ClassLoader.registerAsParallelCapable();
+        try {
+            ClassLoader.registerAsParallelCapable();
+        } catch (NoSuchMethodError ignore) {
+            // Not using Java 7+, just ignore it
+        }
     }
 
     public TransformingClassLoader(ClassLoader parent, ClassPath classPath) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
@@ -30,7 +30,11 @@ public class VisitableURLClassLoader extends URLClassLoader implements ClassLoad
          * This classloader is thread-safe and URLClassLoader is parallel capable,
          * so register as such to reduce contention when running multithreaded builds
         */
-        ClassLoader.registerAsParallelCapable();
+        try {
+            ClassLoader.registerAsParallelCapable();
+        } catch (NoSuchMethodError ignore) {
+            // Not using Java 7+, just ignore it
+        }
     }
 
     public VisitableURLClassLoader(ClassLoader parent, Collection<URL> urls) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
@@ -25,6 +25,14 @@ import java.util.Collection;
 import java.util.List;
 
 public class VisitableURLClassLoader extends URLClassLoader implements ClassLoaderHierarchy {
+    static {
+        /*
+         * This classloader is thread-safe and URLClassLoader is parallel capable,
+         * so register as such to reduce contention when running multithreaded builds
+        */
+        ClassLoader.registerAsParallelCapable();
+    }
+
     public VisitableURLClassLoader(ClassLoader parent, Collection<URL> urls) {
         super(urls.toArray(new URL[0]), parent);
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
@@ -78,7 +78,11 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
          * This classloader is thread-safe and TransformingClassLoader is parallel capable,
          * so register as such to reduce contention when running multithreaded builds
         */
-        ClassLoader.registerAsParallelCapable();
+        try {
+            ClassLoader.registerAsParallelCapable();
+        } catch (NoSuchMethodError ignore) {
+            // Not using Java 7+, just ignore it
+        }
     }
 
     public MixInLegacyTypesClassLoader(ClassLoader parent, ClassPath classPath, LegacyTypesSupport legacyTypesSupport) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
@@ -73,6 +73,14 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
 
     private LegacyTypesSupport legacyTypesSupport;
 
+    static {
+        /*
+         * This classloader is thread-safe and TransformingClassLoader is parallel capable,
+         * so register as such to reduce contention when running multithreaded builds
+        */
+        ClassLoader.registerAsParallelCapable();
+    }
+
     public MixInLegacyTypesClassLoader(ClassLoader parent, ClassPath classPath, LegacyTypesSupport legacyTypesSupport) {
         super(parent, classPath);
         this.legacyTypesSupport = legacyTypesSupport;

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompileTransformingClassLoader.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompileTransformingClassLoader.java
@@ -36,7 +36,11 @@ class GroovyCompileTransformingClassLoader extends TransformingClassLoader {
          * This classloader is thread-safe and TransformingClassLoader is parallel capable,
          * so register as such to reduce contention when running multithreaded builds
         */
-        ClassLoader.registerAsParallelCapable();
+        try {
+            ClassLoader.registerAsParallelCapable();
+        } catch (NoSuchMethodError ignore) {
+            // Not using Java 7+, just ignore it
+        }
     }
 
     public GroovyCompileTransformingClassLoader(ClassLoader parent, ClassPath classPath) {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompileTransformingClassLoader.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompileTransformingClassLoader.java
@@ -31,6 +31,14 @@ import java.util.List;
 class GroovyCompileTransformingClassLoader extends TransformingClassLoader {
     private static final String ANNOTATION_DESCRIPTOR = Type.getType(GroovyASTTransformationClass.class).getDescriptor();
 
+    static {
+        /*
+         * This classloader is thread-safe and TransformingClassLoader is parallel capable,
+         * so register as such to reduce contention when running multithreaded builds
+        */
+        ClassLoader.registerAsParallelCapable();
+    }
+
     public GroovyCompileTransformingClassLoader(ClassLoader parent, ClassPath classPath) {
         super(parent, classPath);
     }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/ClientSidePayloadClassLoaderFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/ClientSidePayloadClassLoaderFactory.java
@@ -53,6 +53,14 @@ public class ClientSidePayloadClassLoaderFactory implements PayloadClassLoaderFa
     }
 
     private static class MixInClassLoader extends TransformingClassLoader {
+        static {
+            /*
+             * This classloader is thread-safe and TransformingClassLoader is parallel capable,
+             * so register as such to reduce contention when running multithreaded builds
+            */
+            ClassLoader.registerAsParallelCapable();
+        }
+
         public MixInClassLoader(ClassLoader parent, List<URL> classPath) {
             super(parent, classPath);
         }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/ClientSidePayloadClassLoaderFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/ClientSidePayloadClassLoaderFactory.java
@@ -58,7 +58,11 @@ public class ClientSidePayloadClassLoaderFactory implements PayloadClassLoaderFa
              * This classloader is thread-safe and TransformingClassLoader is parallel capable,
              * so register as such to reduce contention when running multithreaded builds
             */
-            ClassLoader.registerAsParallelCapable();
+            try {
+                ClassLoader.registerAsParallelCapable();
+            } catch (NoSuchMethodError ignore) {
+                // Not using Java 7+, just ignore it
+            }
         }
 
         public MixInClassLoader(ClassLoader parent, List<URL> classPath) {


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:
- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`
  - Since Java 1.7, classloaders can register as parallel capable.
    When doing so, if ALL parent classes are parallel capable, class
    loading will be synchronized aginst a unique lock per class-name
    instead of locking the whole classloader. This reduces contention
    under multi-thread environments. Single-thread builds still perform
    the lock on either case, and the JVM usually optimizes it away.
  - Fixes #749
