### PR TITLE
Update docs to indicate use of HTTPS maven central

### DIFF
--- a/subprojects/docs/src/docs/userguide/depMngmt.xml
+++ b/subprojects/docs/src/docs/userguide/depMngmt.xml
@@ -689,16 +689,12 @@
 
         <section id="sub:maven_central">
             <title>Maven central repository</title>
-            <para>To add the central Maven 2 repository (<ulink url='http://repo1.maven.org/maven2'/>) simply add this to your build script:
+            <para>To add the central Maven 2 repository (<ulink url='https://repo1.maven.org/maven2'/>) simply add this to your build script:
             </para>
             <sample id="mavenCentral" dir="userguide/artifacts/defineRepository" title="Adding central Maven repository">
                 <sourcefile file="build.gradle" snippet="maven-central"/>
             </sample>
             <para>Now Gradle will look for your dependencies in this repository.</para>
-            <para>
-                <emphasis>Warning:</emphasis> Be aware that the central Maven 2 repository is HTTP only and
-                HTTPS is not supported. If you need a public HTTPS enabled central repository, you can use the <ulink url='http://jcenter.bintray.com'>JCenter</ulink> public repository (see <xref linkend="sub:maven_jcenter"/>).
-            </para>
         </section>
 
         <section id="sub:maven_jcenter">


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:
- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#contribution-workflow).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).

Maven Central has been available over HTTPS since 2014, and gradle has defaulted to it since 2.1 (see [1])

[1] https://github.com/gradle/gradle/blob/REL_2.1/subprojects/core/src/main/groovy/org/gradle/api/artifacts/ArtifactRepositoryContainer.java#L50
