### PR TITLE
Checkstyle supports file properties

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
@@ -204,6 +204,23 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         !file("build/tmp/checkstyleMain/main.xml").exists()
     }
 
+    def "can configure file properties"() {
+        given:
+        goodCode()
+        buildFile << '''
+            checkstyleMain {
+                configProperties = ['checkstyle.cache.file': file("${buildDir}/checkstyle-main.cache")]
+            }
+        '''
+
+        when:
+        succeeds 'checkstyleMain'
+
+        then:
+        file("build/reports/checkstyle/main.xml").exists()
+        file("build/checkstyle-main.cache").exists()
+    }
+
     private goodCode() {
         file('src/main/java/org/gradle/Class1.java') << 'package org.gradle; class Class1 { }'
         file('src/test/java/org/gradle/TestClass1.java') << 'package org.gradle; class TestClass1 { }'

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleInvoker.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleInvoker.groovy
@@ -63,7 +63,11 @@ abstract class CheckstyleInvoker {
                 }
 
                 configProperties.each { key, value ->
-                    property(key: key, value: value.toString())
+                    if (value in File) {
+                        property(key: key, file: value.toString())
+                    } else {
+                        property(key: key, value: value.toString())
+                    }
                 }
             }
 


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

As per http://checkstyle.sourceforge.net/anttask.html#Nested_Elements, properties can be either values or files. This is needed to configure properties such as 'checkstyle.cache.file'