### PR TITLE
Set implementation version in the manifest to the base version

### DIFF
--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -49,7 +49,7 @@ testTasks.all { task ->
 jarTasks.all { jar ->
     jar.manifest.mainAttributes(
         (Attributes.Name.IMPLEMENTATION_TITLE.toString()): 'Gradle',
-        (Attributes.Name.IMPLEMENTATION_VERSION.toString()): version,
+        (Attributes.Name.IMPLEMENTATION_VERSION.toString()): versionBase
     )
 }
 

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -34,6 +34,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
     @Rule public final PreconditionVerifier preconditionVerifier = new PreconditionVerifier()
 
     @Shared String version = GradleVersion.current().version
+    @Shared String baseVersion = GradleVersion.current().baseVersion.version
 
     abstract String getDistributionLabel()
 
@@ -150,7 +151,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
     protected void assertIsGradleJar(TestFile jar) {
         jar.assertIsFile()
-        assertThat(jar.manifest.mainAttributes.getValue('Implementation-Version'), equalTo(version))
+        assertThat(jar.manifest.mainAttributes.getValue('Implementation-Version'), equalTo(baseVersion))
         assertThat(jar.manifest.mainAttributes.getValue('Implementation-Title'), equalTo('Gradle'))
     }
 }

--- a/subprojects/launcher/launcher.gradle
+++ b/subprojects/launcher/launcher.gradle
@@ -42,11 +42,15 @@ integTestTasks.all {
     }
 }
 
-jar {
-    manifest.mainAttributes('Main-Class': "org.gradle.launcher.GradleMain")
-    doFirst {
+task configureJar {
+    doLast {
         jar.manifest.mainAttributes('Class-Path': "${project(':core').jar.archivePath.name} ${project(':baseServices').jar.archivePath.name}")
     }
+}
+
+jar {
+    dependsOn configureJar
+    manifest.mainAttributes('Main-Class': "org.gradle.launcher.GradleMain")
 }
 
 task startScripts(type: StartScriptGenerator) {


### PR DESCRIPTION
This is one step to improving cacheability of the Gradle build. Note that I had to create a separate task to configure the jar manifest in `launcher` since the build failed using a cached version without the right `Class-Path` attribute in the Manifest causing the distribution to be broken ([build scan](https://e.grdev.net/s/bs2zgiq45kj2o)).

That is one of the parts of #754.