### PR TITLE
Disable output capturing in performance tests

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -151,6 +151,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private boolean cleanTempDirOnShutdown;
     private DurationMeasurement durationMeasurement;
     private boolean reuseUserHomeServices;
+    private boolean outputCapturingEnabled = true;
 
     protected AbstractGradleExecuter(GradleDistribution distribution, TestDirectoryProvider testDirectoryProvider) {
         this(distribution, testDirectoryProvider, GradleVersion.current());
@@ -1129,6 +1130,16 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     @Override
     public GradleExecuter withReuseUserHomeServices(boolean flag) {
         this.reuseUserHomeServices = flag;
+        return this;
+    }
+
+    protected boolean isOutputCapturingEnabled() {
+        return outputCapturingEnabled;
+    }
+
+    @Override
+    public GradleExecuter withOutputCapturing(boolean flag) {
+        this.outputCapturingEnabled = flag;
         return this;
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ForkingGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ForkingGradleExecuter.java
@@ -188,7 +188,7 @@ public class ForkingGradleExecuter extends AbstractGradleExecuter {
     }
 
     protected ForkingGradleHandle createGradleHandle(Action<ExecutionResult> resultAssertion, String encoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory) {
-        return new ForkingGradleHandle(getStdinPipe(), isUseDaemon(), resultAssertion, encoding, execHandleFactory, getDurationMeasurement());
+        return new ForkingGradleHandle(getStdinPipe(), isUseDaemon(), resultAssertion, encoding, execHandleFactory, getDurationMeasurement(), isOutputCapturingEnabled());
     }
 
     protected ExecutionResult doRun() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ForkingGradleHandle.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ForkingGradleHandle.java
@@ -16,43 +16,38 @@
 package org.gradle.integtests.fixtures.executer;
 
 import com.google.common.base.Joiner;
-import org.apache.commons.io.output.CloseShieldOutputStream;
-import org.apache.commons.io.output.TeeOutputStream;
 import org.gradle.api.Action;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.internal.Factory;
-import org.gradle.internal.UncheckedException;
 import org.gradle.process.ExecResult;
 import org.gradle.process.internal.AbstractExecHandleBuilder;
 import org.gradle.process.internal.ExecHandle;
 import org.gradle.process.internal.ExecHandleState;
 import org.gradle.util.TextUtil;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PipedOutputStream;
-import java.io.UnsupportedEncodingException;
 
 class ForkingGradleHandle extends OutputScrapingGradleHandle {
     final private Factory<? extends AbstractExecHandleBuilder> execHandleFactory;
 
-    final private ByteArrayOutputStream standardOutput = new ByteArrayOutputStream();
-    final private ByteArrayOutputStream errorOutput = new ByteArrayOutputStream();
+    private final OutputCapturer standardOutputCapturer;
+    private final OutputCapturer errorOutputCapturer;
     private final Action<ExecutionResult> resultAssertion;
     private final PipedOutputStream stdinPipe;
     private final boolean isDaemon;
 
     private ExecHandle execHandle;
-    private final String outputEncoding;
     private final DurationMeasurement durationMeasurement;
 
     public ForkingGradleHandle(PipedOutputStream stdinPipe, boolean isDaemon, Action<ExecutionResult> resultAssertion, String outputEncoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory, DurationMeasurement durationMeasurement) {
         this.resultAssertion = resultAssertion;
         this.execHandleFactory = execHandleFactory;
-        this.outputEncoding = outputEncoding;
         this.isDaemon = isDaemon;
         this.stdinPipe = stdinPipe;
         this.durationMeasurement = durationMeasurement;
+        this.standardOutputCapturer = new OutputCapturer(System.out, outputEncoding);
+        this.errorOutputCapturer = new OutputCapturer(System.err, outputEncoding);
     }
 
     @Override
@@ -61,19 +56,11 @@ class ForkingGradleHandle extends OutputScrapingGradleHandle {
     }
 
     public String getStandardOutput() {
-        try {
-            return standardOutput.toString(outputEncoding);
-        } catch (UnsupportedEncodingException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        }
+        return standardOutputCapturer.getOutputAsString();
     }
 
     public String getErrorOutput() {
-        try {
-            return errorOutput.toString(outputEncoding);
-        } catch (UnsupportedEncodingException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        }
+        return errorOutputCapturer.getOutputAsString();
     }
 
     public GradleHandle start() {
@@ -82,8 +69,8 @@ class ForkingGradleHandle extends OutputScrapingGradleHandle {
         }
 
         AbstractExecHandleBuilder execBuilder = execHandleFactory.create();
-        execBuilder.setStandardOutput(new CloseShieldOutputStream(new TeeOutputStream(System.out, standardOutput)));
-        execBuilder.setErrorOutput(new CloseShieldOutputStream(new TeeOutputStream(System.err, errorOutput)));
+        execBuilder.setStandardOutput(standardOutputCapturer.getOutputStream());
+        execBuilder.setErrorOutput(errorOutputCapturer.getOutputStream());
         execHandle = execBuilder.build();
 
         System.out.println("Starting build with: " + execHandle.getCommand() + " " + Joiner.on(" ").join(execHandle.getArguments()));

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -410,4 +410,10 @@ public interface GradleExecuter extends Stoppable {
      * Returns true if this executer uses a daemon
      */
     boolean isUseDaemon();
+
+    /**
+     * Sets flag for output capturing, defaults to true
+     *
+     */
+    GradleExecuter withOutputCapturing(boolean flag);
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -170,7 +170,7 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
     @Override
     protected GradleHandle doStart() {
-        return new ForkingGradleHandle(getStdinPipe(), isUseDaemon(), getResultAssertion(), getDefaultCharacterEncoding(), getJavaExecBuilder(), getDurationMeasurement()).start();
+        return new ForkingGradleHandle(getStdinPipe(), isUseDaemon(), getResultAssertion(), getDefaultCharacterEncoding(), getJavaExecBuilder(), getDurationMeasurement(), isOutputCapturingEnabled()).start();
     }
 
     private Factory<JavaExecHandleBuilder> getJavaExecBuilder() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputCapturer.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputCapturer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer;
+
+import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.apache.commons.io.output.TeeOutputStream;
+import org.gradle.internal.UncheckedException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+class OutputCapturer {
+    private final ByteArrayOutputStream buffer;
+    private final OutputStream outputStream;
+    private final String outputEncoding;
+
+    public OutputCapturer(OutputStream standardStream, String outputEncoding) {
+        this.buffer = new ByteArrayOutputStream();
+        this.outputStream = new CloseShieldOutputStream(new TeeOutputStream(standardStream, buffer));
+        this.outputEncoding = outputEncoding;
+    }
+
+    public OutputStream getOutputStream() {
+        return outputStream;
+    }
+
+    public String getOutputAsString() {
+        try {
+            return buffer.toString(outputEncoding);
+        } catch (UnsupportedEncodingException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleExecuter.java
@@ -47,6 +47,6 @@ class ParallelForkingGradleExecuter extends ForkingGradleExecuter {
 
     @Override
     protected ForkingGradleHandle createGradleHandle(Action<ExecutionResult> resultAssertion, String encoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory) {
-        return new ParallelForkingGradleHandle(getStdinPipe(), isUseDaemon(), resultAssertion, encoding, execHandleFactory, getDurationMeasurement());
+        return new ParallelForkingGradleHandle(getStdinPipe(), isUseDaemon(), resultAssertion, encoding, execHandleFactory, getDurationMeasurement(), isOutputCapturingEnabled());
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleHandle.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleHandle.java
@@ -32,8 +32,8 @@ import static org.junit.Assert.assertThat;
 
 public class ParallelForkingGradleHandle extends ForkingGradleHandle {
 
-    public ParallelForkingGradleHandle(PipedOutputStream stdinPipe, boolean isDaemon, Action<ExecutionResult> resultAssertion, String outputEncoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory, DurationMeasurement durationMeasurement) {
-        super(stdinPipe, isDaemon, resultAssertion, outputEncoding, execHandleFactory, durationMeasurement);
+    public ParallelForkingGradleHandle(PipedOutputStream stdinPipe, boolean isDaemon, Action<ExecutionResult> resultAssertion, String outputEncoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory, DurationMeasurement durationMeasurement, boolean outputCapturingEnabled) {
+        super(stdinPipe, isDaemon, resultAssertion, outputEncoding, execHandleFactory, durationMeasurement, outputCapturingEnabled);
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleExecuterBackedSession.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleExecuterBackedSession.groovy
@@ -82,12 +82,11 @@ class GradleExecuterBackedSession implements GradleSession {
     private GradleExecuter createExecuter(BuildExperimentInvocationInfo invocationInfo, InvocationCustomizer invocationCustomizer) {
         def invocation = invocationCustomizer ? invocationCustomizer.customize(invocationInfo, this.invocation) : this.invocation
 
+        def createNewExecuter = {
+            invocation.gradleDistribution.executer(testDirectoryProvider, integrationTestBuildContext)
+        }
         if (executer == null) {
-            def createNewExecuter = {
-                invocation.gradleDistribution.executer(testDirectoryProvider, integrationTestBuildContext)
-            }
             executer = createNewExecuter()
-            executerForStopping = createNewExecuter()
         } else {
             executer.reset()
         }
@@ -121,7 +120,10 @@ class GradleExecuterBackedSession implements GradleSession {
 
         // must make a copy of argument for executer to use for stopping since arguments must match when stopping the daemons
         // executer instance's reset method gets called after execution and the arguments aren't preserved there
-        executer.copyTo(executerForStopping)
+        if (executerForStopping == null) {
+            executerForStopping = createNewExecuter()
+            executer.copyTo(executerForStopping)
+        }
 
         executer
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleExecuterBackedSession.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleExecuterBackedSession.groovy
@@ -100,7 +100,8 @@ class GradleExecuterBackedSession implements GradleSession {
             withStackTraceChecksDisabled().
             withArgument('-u').
             inDirectory(invocation.workingDirectory).
-            withTasks(invocation.tasksToRun)
+            withTasks(invocation.tasksToRun).
+            withOutputCapturing(false)
 
         executer.withBuildJvmOpts(invocation.jvmOpts)
 


### PR DESCRIPTION
- the output isn't inspected in performance tests and since capturing could affect the measurements, it's better to simply not do it.

- this PR also has an unrelated change that fixes a problem in GradleExecuterBackedSession.cleanup