### PR TITLE
Increase number of warmups for daemon tests

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BuildExperimentRunner.java
@@ -217,7 +217,7 @@ public class BuildExperimentRunner {
             return experiment.getWarmUpCount();
         }
         if (usesDaemon(experiment)) {
-            return 14;
+            return 20;
         } else {
             return 4;
         }


### PR DESCRIPTION
Increase number of warmups 14 -> 20 .

Before recent changes, we had 20 measurements and 10 warmups for daemon tests ([see BuildExperimentRunner history](https://github.com/gradle/gradle/commits/master/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BuildExperimentRunner.java)).
Now this makes 10 measurements and 20 warmups for daemon tests.

