### PR TITLE
Use only baseVersion in jar files

### DIFF
--- a/gradle/buildReceipt.gradle
+++ b/gradle/buildReceipt.gradle
@@ -108,7 +108,7 @@ task determineCommitId {
 task createBuildReceipt(dependsOn: determineCommitId) {
     ext.receiptFile = file("$buildDir/$buildReceiptFileName")
     inputs.property "version", { version }
-    inputs.property "versionBase", { versionBase }
+    inputs.property "baseVersion", { baseVersion }
     inputs.property "isSnapshot", { isSnapshot }
     inputs.property "buildTimestamp", { buildTimestamp }
     inputs.property "commitId", { devBuild ? "HEAD" : determineCommitId.commitId }
@@ -118,7 +118,7 @@ task createBuildReceipt(dependsOn: determineCommitId) {
         def data = [
                 commitId: devBuild ? "HEAD" : determineCommitId.commitId,
                 versionNumber: version,
-                versionBase: versionBase,
+                baseVersion: baseVersion,
                 isSnapshot: isSnapshot,
                 buildTimestamp: buildTimestamp,
         ]

--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -129,7 +129,7 @@ def removeDaemonLogFiles(File dir) {
 /**
  * Removes state for versions that we're unlikely to ever need again, such as old snapshot versions.
  */
-def removeOldVersionsFromDir(File dir, def shouldDelete, def dirPrefix = "", def dirSuffix = "") {
+def removeOldVersionsFromDir(File dir, shouldDelete, dirPrefix = "", dirSuffix = "") {
     if (dir.directory) {
 
         for (File cacheDir : dir.listFiles()) {
@@ -187,13 +187,13 @@ project(":") {
             def testedVersion = GradleVersion.version(versionProps.versionNumber)
 
             // Expire .gradle cache where major version is older than executing version
-            def expireTaskCache = { def candidateVersion ->
+            def expireTaskCache = { candidateVersion ->
                 return candidateVersion.baseVersion < executingVersion.baseVersion
             }
 
             // Expire intTestImage cache snapshots that are older than the tested version
             // Also expire version-specific cache snapshots when they can't be re-used (for 'snapshot-1' developer builds)
-            def expireIntegTestCache = { def candidateVersion ->
+            def expireIntegTestCache = { candidateVersion ->
                 return (candidateVersion.snapshot && candidateVersion < testedVersion) || candidateVersion.version.endsWith('-snapshot-1')
             }
 

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -47,10 +47,10 @@ testTasks.all { task ->
 }
 
 jarTasks.all { jar ->
-    jar.version = versionBase
+    jar.version = baseVersion
     jar.manifest.mainAttributes(
         (Attributes.Name.IMPLEMENTATION_TITLE.toString()): 'Gradle',
-        (Attributes.Name.IMPLEMENTATION_VERSION.toString()): versionBase
+        (Attributes.Name.IMPLEMENTATION_VERSION.toString()): baseVersion
     )
 }
 

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -47,6 +47,7 @@ testTasks.all { task ->
 }
 
 jarTasks.all { jar ->
+    jar.version = versionBase
     jar.manifest.mainAttributes(
         (Attributes.Name.IMPLEMENTATION_TITLE.toString()): 'Gradle',
         (Attributes.Name.IMPLEMENTATION_VERSION.toString()): versionBase

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -20,12 +20,12 @@ if ((milestoneNumber != null && rcNumber != null) ||
 
 
 if (incomingDistributionsBuildReceipt) {
-    ext.versionBase = incomingDistributionsBuildReceipt.versionBase
+    ext.baseVersion = incomingDistributionsBuildReceipt.baseVersion
     ext.buildTimestamp = incomingDistributionsBuildReceipt.buildTimestamp
     ext.devBuild = false
 } else {
     ext.devBuild = milestoneNumber == null && rcNumber == null && !finalRelease && !timestampedVersion;
-    ext.versionBase = rootProject.file("version.txt").text.trim()
+    ext.baseVersion = rootProject.file("version.txt").text.trim()
 
     if (devBuild) {
         ext.buildTimestamp = "unknown";
@@ -60,7 +60,7 @@ if (incomingDistributionsBuildReceipt) {
     }
 }
 
-version = versionBase
+version = baseVersion
 
 ext.isSnapshot = false
 if (finalRelease) {
@@ -78,5 +78,5 @@ if (finalRelease) {
 }
 
 if (buildTypes.promotionBuild.active) {
-    logger.lifecycle "Version: $version (version base: $versionBase, timestamp: $buildTimestamp, snapshot: $isSnapshot, dev build: $devBuild)"
+    logger.lifecycle "Version: $version (base version: $baseVersion, timestamp: $buildTimestamp, snapshot: $isSnapshot, dev build: $devBuild)"
 }

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -116,30 +116,30 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
         assert coreLibs.size() == 19
         coreLibs.each { assertIsGradleJar(it) }
 
-        def toolingApiJar = contentsDir.file("lib/gradle-tooling-api-${version}.jar")
+        def toolingApiJar = contentsDir.file("lib/gradle-tooling-api-${baseVersion}.jar")
         toolingApiJar.assertIsFile()
-        assert toolingApiJar.length() < 340 * 1024; // tooling api jar is the small plain tooling api jar version and not the fat jar.
+        assert toolingApiJar.length() < 340 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
 
         // Plugins
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-dependency-management-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-plugins-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-ide-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-scala-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-code-quality-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-antlr-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-announce-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-jetty-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-maven-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-osgi-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-signing-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-ear-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-platform-native-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-ide-native-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-language-native-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-platform-jvm-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-language-jvm-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-language-java-${version}.jar"))
-        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-language-groovy-${version}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-dependency-management-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-plugins-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-ide-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-scala-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-code-quality-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-antlr-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-announce-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-jetty-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-maven-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-osgi-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-signing-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-ear-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-platform-native-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-ide-native-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-language-native-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-platform-jvm-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-language-jvm-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-language-java-${baseVersion}.jar"))
+        assertIsGradleJar(contentsDir.file("lib/plugins/gradle-language-groovy-${baseVersion}.jar"))
 
         // Docs
         contentsDir.file('getting-started.html').assertIsFile()

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -423,7 +423,7 @@ task releaseNotes(type: Copy) {
     into "$docsDir"
     from releaseNotesMarkdown
     jsoup.plugins "src/transforms/release-notes.gradle"
-    filter(ReplaceTokens, tokens: [version: project.version.toString(), versionBase: rootProject.versionBase])
+    filter(ReplaceTokens, tokens: [version: project.version.toString(), baseVersion: rootProject.baseVersion])
     ext.entryPoint = file("$docsDir/$fileName")
 }
 

--- a/subprojects/docs/src/docs/release/content/script.js
+++ b/subprojects/docs/src/docs/release/content/script.js
@@ -43,25 +43,25 @@ $(function() {
   });
 
   injectIssues(
-    "https://services.gradle.org/fixed-issues/@versionBase@",
-    $("h2#fixed-issues"), 
-    "fixed-issues", 
-    "Retrieving the fixed issue information for @versionBase@", 
+    "https://services.gradle.org/fixed-issues/@baseVersion@",
+    $("h2#fixed-issues"),
+    "fixed-issues",
+    "Retrieving the fixed issue information for @baseVersion@",
     function(i) {
-      return i + " issues have been fixed in Gradle @versionBase@.";
+      return i + " issues have been fixed in Gradle @baseVersion@.";
     }
   );
-  
+
   injectIssues(
-    "https://services.gradle.org/known-issues/@versionBase@",
-    $("h2#known-issues").next("p"), 
-    "known-issues", 
-    "Retrieving the known issue information for @versionBase@", 
+    "https://services.gradle.org/known-issues/@baseVersion@",
+    $("h2#known-issues").next("p"),
+    "known-issues",
+    "Retrieving the known issue information for @baseVersion@",
     function(i) {
       if (i > 0) {
-        return i + " issues are known to affect Gradle @versionBase@.";
+        return i + " issues are known to affect Gradle @baseVersion@.";
       } else {
-        return "There are no known issues of Gradle @versionBase@ at this time.";
+        return "There are no known issues of Gradle @baseVersion@ at this time.";
       }
     }
   );

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
@@ -74,7 +74,7 @@ public class IntegrationTestBuildContext {
 
     public TestFile getFatToolingApiJar() {
         TestFile toolingApiShadedJarDir = file("integTest.toolingApiShadedJarDir", "subprojects/tooling-api/build/shaded-jar");
-        TestFile fatToolingApiJar = new TestFile(toolingApiShadedJarDir, String.format("gradle-tooling-api-shaded-%s.jar", getVersion().getVersion()));
+        TestFile fatToolingApiJar = new TestFile(toolingApiShadedJarDir, String.format("gradle-tooling-api-shaded-%s.jar", getVersion().getBaseVersion().getVersion()));
 
         if (!fatToolingApiJar.exists()) {
             throw new IllegalStateException(String.format("The fat Tooling API JAR file does not exist: %s", fatToolingApiJar.getAbsolutePath()));

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
@@ -45,13 +45,13 @@ class CrossVersionPerformanceTestRunnerTest extends ResultSpecification {
         'org.gradle.performance.db.url': "jdbc:h2:${tmpDir.testDirectory}"
     )
 
-    final buildContext = IntegrationTestBuildContext.INSTANCE;
+    final buildContext = IntegrationTestBuildContext.INSTANCE
     final experimentRunner = Mock(BuildExperimentRunner)
     final reporter = Mock(ReporterAndStore)
     final testProjectLocator = Stub(TestProjectLocator)
     final currentGradle = Stub(GradleDistribution)
     final releases = Stub(ReleasedVersionDistributions)
-    final currentVersionBase = GradleVersion.current().baseVersion.version
+    final currentBaseVersion = GradleVersion.current().baseVersion.version
 
     def setup() {
         releases.all >> [
@@ -178,7 +178,7 @@ class CrossVersionPerformanceTestRunnerTest extends ResultSpecification {
 
         when:
         System.setProperty('org.gradle.performance.baselines', 'defaults')
-        def results = runner.run()
+        runner.run()
 
         then:
         thrown(IllegalArgumentException)
@@ -207,7 +207,7 @@ class CrossVersionPerformanceTestRunnerTest extends ResultSpecification {
     def "ignores baseline version if it has the same base as the version under test"() {
         given:
         def runner = runner()
-        runner.targetVersions = ['1.0', currentVersionBase, MOST_RECENT_RELEASE, 'last']
+        runner.targetVersions = ['1.0', currentBaseVersion, MOST_RECENT_RELEASE, 'last']
 
         when:
         def results = runner.run()

--- a/subprojects/tooling-api/tooling-api.gradle
+++ b/subprojects/tooling-api/tooling-api.gradle
@@ -54,7 +54,7 @@ task shadedJar(type: ShadedJar) {
     sourceFiles = jar.inputs.files + files {(configurations.runtime - configurations.publishCompile).collect { zipTree(it) } }
     analysisFile = file("$outputDir/analysis.txt")
     classesDir = file("$outputDir/classes")
-    jarFile = file("$outputDir/gradle-tooling-api-shaded-${version}.jar")
+    jarFile = file("$outputDir/gradle-tooling-api-shaded-${versionBase}.jar")
     keepPackages = ["org.gradle.tooling"]
     unshadedPackages = ["org.gradle", "org.slf4j"]
     ignorePackages = ["org.gradle.tooling.provider.model"]

--- a/subprojects/tooling-api/tooling-api.gradle
+++ b/subprojects/tooling-api/tooling-api.gradle
@@ -54,7 +54,7 @@ task shadedJar(type: ShadedJar) {
     sourceFiles = jar.inputs.files + files {(configurations.runtime - configurations.publishCompile).collect { zipTree(it) } }
     analysisFile = file("$outputDir/analysis.txt")
     classesDir = file("$outputDir/classes")
-    jarFile = file("$outputDir/gradle-tooling-api-shaded-${versionBase}.jar")
+    jarFile = file("$outputDir/gradle-tooling-api-shaded-${baseVersion}.jar")
     keepPackages = ["org.gradle.tooling"]
     unshadedPackages = ["org.gradle", "org.slf4j"]
     ignorePackages = ["org.gradle.tooling.provider.model"]


### PR DESCRIPTION
Another change to improve caching of the Gradle build.
This is due to various places where the name of the jar file is used
 - classpath in the manifest of the launcher
 - name of jar files in the distribution