### PR TITLE
Only report performance measurements from current branch

### DIFF
--- a/gradle/performanceTest.gradle
+++ b/gradle/performanceTest.gradle
@@ -196,18 +196,25 @@ tasks.withType(DistributedPerformanceTest) {
     teamCityUrl = "https://builds.gradle.org/"
     teamCityUsername = project.findProperty("teamCityUsername")
     teamCityPassword = project.findProperty("teamCityPassword")
+    afterEvaluate { p ->
+      if (branchName) {
+        channel = channel + "-" + branchName
+      }
+    }
 }
 
 task distributedPerformanceTest(type: DistributedPerformanceTest) {
     options {
         excludeCategories 'org.gradle.performance.categories.Experiment'
     }
+    channel = 'commits'
 }
 
 task distributedPerformanceExperiment(type: DistributedPerformanceTest) {
     options {
         includeCategories 'org.gradle.performance.categories.Experiment'
     }
+    channel = 'experiments'
 }
 
 task distributedFullPerformanceTest(type: DistributedPerformanceTest) {


### PR DESCRIPTION
Our performance graphs are currently showing all the results from
all branches in one graph, which makes them very confusing to read,
because the test configuration itself can vary from branch to branch.

It also leads to way too many lines, so the graphs would be hard to decipher
even if the results were the same on all branches.

This change assigns a different channel for each branch so we only report
results that were measured on that branch.