### PR TITLE
Expose javac diagnostics as part of CompilerOptions

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -57,6 +57,6 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         CompileOptions compileOptions = spec.getCompileOptions();
         StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, compileOptions.getEncoding() != null ? Charset.forName(compileOptions.getEncoding()) : null);
         Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(spec.getSource());
-        return compiler.getTask(null, null, null, options, null, compilationUnits);
+        return compiler.getTask(null, null, compileOptions.getDiagnosticListener(), options, null, compilationUnits);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -30,6 +30,9 @@ import org.gradle.util.SingleMessageLogger;
 import java.util.List;
 import java.util.Map;
 
+import javax.tools.DiagnosticListener;
+import javax.tools.JavaFileObject;
+
 /**
  * Main options for Java compilation.
  */
@@ -72,6 +75,8 @@ public class CompileOptions extends AbstractOptions {
     private boolean incremental;
 
     private FileCollection sourcepath;
+
+    private DiagnosticListener<? super JavaFileObject> diagnosticListener;
 
     /**
      * Tells whether to fail the build when compilation fails. Defaults to {@code true}.
@@ -444,6 +449,34 @@ public class CompileOptions extends AbstractOptions {
     @Incubating
     public void setSourcepath(FileCollection sourcepath) {
         this.sourcepath = sourcepath;
+    }
+
+    /**
+     * A diagnostic listener to attach to the compilation task.
+     * <p>
+     * The default value for the diagnostic listener is {@code null}, which indicates that the compiler's default error reporting method will be used.
+     * Note that this parameter is ONLY supported for the in-process Java compiler; the command-line compiler does not expose any way to declare a listener.
+     * Accordingly, this parameter will be ignored entirely when {@link #isFork} is true.
+     * <p>
+     * @return the diagnostic listener
+     * @see #setDiagnosticListener(DiagnosticListener)
+     */
+    @Input
+    @Optional
+    @Incubating
+    public DiagnosticListener<? super JavaFileObject> getDiagnosticListener() {
+        return diagnosticListener;
+    }
+
+    /**
+     * Sets a diagnostic listener to be passed to the Java compiler.
+     *
+     * @param diagnosticListener a diagnostic listener; if {@code null},
+     * use the compiler's default method for reporting diagnostics
+     */
+    @Incubating
+    public void setDiagnosticListener(DiagnosticListener<? super JavaFileObject> diagnosticListener) {
+        this.diagnosticListener = diagnosticListener;
     }
 }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/JavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/JavaCompilerIntegrationSpec.groovy
@@ -58,6 +58,26 @@ abstract class JavaCompilerIntegrationSpec extends BasicJavaCompilerIntegrationS
         file("build/classes/main/compile/test/Person.class").exists()
     }
 
+    def compileWithCustomDiagnosticListener() {
+        given:
+        goodCode()
+
+        and:
+        buildFile << '''
+            compileJava.options.diagnosticListener = new DiagnosticListener<JavaFileObject>() {
+                void report(Diagnostic<? extends JavaFileObject> diagnostic) {
+                    file("build/diagnostics.out").text = diagnostic.toString()
+                }
+            }
+        '''
+
+        expect:
+        succeeds("compileJava")
+        output.contains(logStatement())
+        !errorOutput
+        file("build/diagnostics.out").exists()
+    }
+
     def compileWithCustomHeapSettings() {
         given:
         goodCode()


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:
- [ ] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
        I did not do this. However, I think it is fair to describe this change as trivial'.
- [x] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
       Again, I think it is fair to describe this change as trivial.
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [x] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.


This allows build scripts to declare listeners which handle particular
errors in more sophisticated ways than just "capture stderr and grep for
things that look like line numbers / hope for the best."
For example, pushing this plumbing all the way through allows me to:
    Pipe errors to a quickfix buffer in Vim and jump to lines from there.
    Post precise errors on pull requests & CRs in near-real time.
    Generally avoid scrolling past a thousand lines of irrelevancies to
        find a meaningful issue.

Change-Id: I62b02237699fc0353ab7f57fd6077ffb5d4a2801