### PR TITLE
Support partial attribute matching

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/AttributeMatchingStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/AttributeMatchingStrategy.java
@@ -15,6 +15,9 @@
  */
 package org.gradle.api;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * An attribute matching strategy is responsible for providing information about how an {@link Attribute}
  * is matched during dependency resolution. In particular, it will tell if a value, provided by a consumer,
@@ -32,4 +35,7 @@ public interface AttributeMatchingStrategy<T> {
      * @return true if the candidate value is <i>compatible with</i> the requested value
      */
     boolean isCompatible(T requestedValue, T candidateValue);
+
+    <K> List<K> selectClosestMatch(T requestedValue, Map<K, T> compatibleValues);
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/AttributeMatchingStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/AttributeMatchingStrategy.java
@@ -38,7 +38,7 @@ public interface AttributeMatchingStrategy<T> {
 
     /**
      * Selects the best matches from a list of compatible ones. The list of compatible sets
-     * is expressed a a {@link Map} which key is a candidate, and which value is the compatible value
+     * is expressed as a {@link Map} which key is a candidate, and which value is the compatible value
      * of this candidate. It is implied that this method is only called with compatible values, so
      * the objective of this method is to discriminate (or order) compatible values, and return only
      * the best ones.

--- a/subprojects/core/src/main/java/org/gradle/api/AttributeMatchingStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/AttributeMatchingStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api;
+
+/**
+ * An attribute matching strategy is responsible for providing information about how an {@link Attribute}
+ * is matched during dependency resolution. In particular, it will tell if a value, provided by a consumer,
+ * is compatible with a value provided by a candidate.
+ * @param <T> the type of the attribute
+ */
+@Incubating
+public interface AttributeMatchingStrategy<T> {
+    /**
+     * Tells if the candidate value is compatible with the requested value. Compatibility doesn't mean
+     * equality. A candidate value may be different from the requested value, but still compatible.
+     * For example, Java 6 classes are compatible with a Java 7 runtime.
+     * @param requestedValue the requested value
+     * @param candidateValue a candidate value
+     * @return true if the candidate value is <i>compatible with</i> the requested value
+     */
+    boolean isCompatible(T requestedValue, T candidateValue);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/AttributeMatchingStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/AttributeMatchingStrategy.java
@@ -36,6 +36,26 @@ public interface AttributeMatchingStrategy<T> {
      */
     boolean isCompatible(T requestedValue, T candidateValue);
 
+    /**
+     * Selects the best matches from a list of compatible ones. The list of compatible sets
+     * is expressed a a {@link Map} which key is a candidate, and which value is the compatible value
+     * of this candidate. It is implied that this method is only called with compatible values, so
+     * the objective of this method is to discriminate (or order) compatible values, and return only
+     * the best ones.
+     *
+     * The result of the selection process is going to depend on the result of this method: if it
+     * returns a single value, then there's a clear winner. If it returns more than one value, then
+     * it means that they are equivalent and that the strategy cannot discriminate between them.
+     *
+     * The result of this operation is never empty: since the map we pass only contains compatible
+     * values, it is an error to say that there's no best match in that list. Similarly, it is
+     * an error to return a value which is not contained in the key set of the candidates map.
+     *
+     * @param requestedValue the value to compare against
+     * @param compatibleValues the map of candidate values
+     * @param <K> the type of the candidate
+     * @return a list of best matches. Must never be empty.
+     */
     <K> List<K> selectClosestMatch(T requestedValue, Map<K, T> compatibleValues);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/AttributesSchema.java
+++ b/subprojects/core/src/main/java/org/gradle/api/AttributesSchema.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api;
+
+/**
+ * An attributes schema stores information about {@link Attribute attributes} and how they
+ * can be matched together.
+ */
+@Incubating
+public interface AttributesSchema {
+
+    /**
+     * Sets the attribute matching strategy of an attribute.
+     * @param attribute the attribute to set the strategy for
+     * @param strategy the strategy to assiociate with this attribute
+     * @param <T> the type of the attribute
+     */
+    <T> void setMatchingStrategy(Attribute<T> attribute, AttributeMatchingStrategy<T> strategy);
+
+    /**
+     * Returns the matching strategy for a given attribute.
+     * @param attribute the attribute
+     * @param <T> the type of the attribute
+     * @return the matching strategy for this attribute.
+     */
+    <T> AttributeMatchingStrategy<T> getMatchingStrategy(Attribute<T> attribute);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/AttributesSchema.java
+++ b/subprojects/core/src/main/java/org/gradle/api/AttributesSchema.java
@@ -38,4 +38,15 @@ public interface AttributesSchema {
      * @return the matching strategy for this attribute.
      */
     <T> AttributeMatchingStrategy<T> getMatchingStrategy(Attribute<T> attribute);
+
+    /**
+     * Configures the matching strategy for the provided attribute with a standard equality
+     * matching strategy: attribute values will be considered compatible if and only if they
+     * match using the {@link Object#equals(Object) equals method}.
+     *
+     * @param attribute the attribute for which to set the strategy
+     * @param <T> the type of the attribute
+     */
+    <T> void matchStrictly(Attribute<T> attribute);
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/java/org/gradle/api/Project.java
@@ -23,16 +23,23 @@ import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.component.SoftwareComponentContainer;
-import org.gradle.api.file.*;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.DeleteSpec;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.initialization.dsl.ScriptHandler;
-import org.gradle.internal.HasInternalProtocol;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.LoggingManager;
-import org.gradle.api.plugins.*;
+import org.gradle.api.plugins.Convention;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.PluginAware;
 import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.internal.HasInternalProtocol;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
@@ -1493,4 +1500,12 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      */
     @Incubating
     SoftwareComponentContainer getComponents();
+
+    /**
+     * Configures the configuration attributes schema. The action is passed a {@link AttributesSchema} instance.
+     * @param configureAction the configure action
+     * @return the configured schema
+     */
+    @Incubating
+    AttributesSchema configurationAttributesSchema(Action<? super AttributesSchema> configureAction);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultConfigurationAttributesSchema.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultConfigurationAttributesSchema.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.project;
+
+import com.google.common.collect.Maps;
+import org.gradle.api.Attribute;
+import org.gradle.api.AttributeMatchingStrategy;
+import org.gradle.internal.Cast;
+
+import java.util.Map;
+
+public class DefaultConfigurationAttributesSchema implements org.gradle.api.AttributesSchema {
+    private final Map<Attribute<?>, AttributeMatchingStrategy<?>> strategies = Maps.newHashMap();
+
+    @Override
+    public <T> void setMatchingStrategy(Attribute<T> attribute, AttributeMatchingStrategy<T> strategy) {
+        strategies.put(attribute, strategy);
+    }
+
+    @Override
+    public <T> AttributeMatchingStrategy<T> getMatchingStrategy(Attribute<T> attribute) {
+        AttributeMatchingStrategy<?> strategy = strategies.get(attribute);
+        if (strategy == null && String.class == attribute.getType()) {
+            strategy = StringMatchingStrategy.INSTANCE;
+        }
+        if (strategy == null) {
+            throw new IllegalArgumentException("Unable to find matching strategy for " + attribute);
+        }
+        return Cast.uncheckedCast(strategy);
+    }
+
+    private static class StringMatchingStrategy implements AttributeMatchingStrategy<String> {
+        private static final StringMatchingStrategy INSTANCE = new StringMatchingStrategy();
+
+        @Override
+        public boolean isCompatible(String requestedValue, String candidateValue) {
+            return requestedValue.equals(candidateValue);
+        }
+
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultConfigurationAttributesSchema.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultConfigurationAttributesSchema.java
@@ -15,11 +15,13 @@
  */
 package org.gradle.api.internal.project;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import org.gradle.api.Attribute;
 import org.gradle.api.AttributeMatchingStrategy;
 import org.gradle.internal.Cast;
 
+import java.util.List;
 import java.util.Map;
 
 public class DefaultConfigurationAttributesSchema implements org.gradle.api.AttributesSchema {
@@ -50,5 +52,9 @@ public class DefaultConfigurationAttributesSchema implements org.gradle.api.Attr
             return requestedValue.equals(candidateValue);
         }
 
+        @Override
+        public <K> List<K> selectClosestMatch(String requestedValue, Map<K, String> compatibleValues) {
+            return ImmutableList.copyOf(compatibleValues.keySet());
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -21,6 +21,7 @@ import groovy.lang.Closure;
 import groovy.lang.MissingPropertyException;
 import org.gradle.api.Action;
 import org.gradle.api.AntBuilder;
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.CircularReferenceException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
@@ -189,6 +190,8 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
 
     private final Path path;
 
+    private final AttributesSchema configurationAttributesSchema;
+
     public DefaultProject(String name,
                           ProjectInternal parent,
                           File projectDir,
@@ -227,6 +230,8 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
         extensibleDynamicObject.addObject(taskContainer.getTasksAsDynamicObject(), ExtensibleDynamicObject.Location.AfterConvention);
 
         evaluationListener.add(gradle.getProjectEvaluationBroadcaster());
+
+        configurationAttributesSchema = services.get(AttributesSchema.class);
 
         populateModelRegistry(services.get(ModelRegistry.class));
     }
@@ -1078,5 +1083,11 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     @Override
     public void fireDeferredConfiguration() {
         getDeferredProjectConfiguration().fire();
+    }
+
+    @Override
+    public AttributesSchema configurationAttributesSchema(Action<? super AttributesSchema> configureAction) {
+        configureAction.execute(configurationAttributesSchema);
+        return configurationAttributesSchema;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -18,7 +18,6 @@ package org.gradle.internal.service.scopes;
 
 import org.gradle.api.Action;
 import org.gradle.api.AntBuilder;
-import org.gradle.api.AttributesSchema;
 import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.ClassGenerator;
@@ -49,7 +48,6 @@ import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.plugins.PluginRegistry;
 import org.gradle.api.internal.plugins.RuleBasedPluginApplicator;
 import org.gradle.api.internal.project.DefaultAntBuilderFactory;
-import org.gradle.api.internal.project.DefaultConfigurationAttributesSchema;
 import org.gradle.api.internal.project.DeferredProjectConfiguration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ant.DefaultAntLoggingAdapterFactory;
@@ -217,10 +215,6 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
 
     protected TypeConverter createTypeConverter(PathToFileResolver fileResolver) {
         return new DefaultTypeConverter(fileResolver);
-    }
-
-    protected AttributesSchema createConfigurationAttributesSchema() {
-        return new DefaultConfigurationAttributesSchema();
     }
 
     private class ProjectBackedModuleMetaDataProvider implements DependencyMetaDataProvider {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -18,6 +18,7 @@ package org.gradle.internal.service.scopes;
 
 import org.gradle.api.Action;
 import org.gradle.api.AntBuilder;
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.ClassGenerator;
@@ -48,6 +49,7 @@ import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.plugins.PluginRegistry;
 import org.gradle.api.internal.plugins.RuleBasedPluginApplicator;
 import org.gradle.api.internal.project.DefaultAntBuilderFactory;
+import org.gradle.api.internal.project.DefaultConfigurationAttributesSchema;
 import org.gradle.api.internal.project.DeferredProjectConfiguration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ant.DefaultAntLoggingAdapterFactory;
@@ -215,6 +217,10 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
 
     protected TypeConverter createTypeConverter(PathToFileResolver fileResolver) {
         return new DefaultTypeConverter(fileResolver);
+    }
+
+    protected AttributesSchema createConfigurationAttributesSchema() {
+        return new DefaultConfigurationAttributesSchema();
     }
 
     private class ProjectBackedModuleMetaDataProvider implements DependencyMetaDataProvider {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultConfigurationAttributesSchemaTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultConfigurationAttributesSchemaTest.groovy
@@ -56,6 +56,25 @@ class DefaultConfigurationAttributesSchemaTest extends Specification {
         !strategy.isCompatible([a: 'foo', b: 'bar'], [a: 'foo', b: 'baz'])
     }
 
+    def "strategy is per attribute"() {
+        given:
+        schema.matchStrictly(Attribute.of('a', Map))
+
+        when:
+        schema.getMatchingStrategy(Attribute.of('someOther', Map))
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Unable to find matching strategy for someOther'
+
+        when:
+        schema.getMatchingStrategy(Attribute.of(Map))
+
+        then:
+        e = thrown(IllegalArgumentException)
+        e.message == 'Unable to find matching strategy for map'
+    }
+
     def "can set a custom matching strategy"() {
         def attr = Attribute.of(Map)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultConfigurationAttributesSchemaTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultConfigurationAttributesSchemaTest.groovy
@@ -44,6 +44,18 @@ class DefaultConfigurationAttributesSchemaTest extends Specification {
         e.message == 'Unable to find matching strategy for map'
     }
 
+    def "can set a basic equality match strategy"() {
+        given:
+        schema.matchStrictly(Attribute.of(Map))
+
+        when:
+        def strategy= schema.getMatchingStrategy(Attribute.of(Map))
+
+        then:
+        strategy.isCompatible([a: 'foo', b: 'bar'], [a: 'foo', b: 'bar'])
+        !strategy.isCompatible([a: 'foo', b: 'bar'], [a: 'foo', b: 'baz'])
+    }
+
     def "can set a custom matching strategy"() {
         def attr = Attribute.of(Map)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultConfigurationAttributesSchemaTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultConfigurationAttributesSchemaTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project
+
+import org.gradle.api.Attribute
+import org.gradle.api.AttributeMatchingStrategy
+import spock.lang.Specification
+
+class DefaultConfigurationAttributesSchemaTest extends Specification {
+    def schema = new DefaultConfigurationAttributesSchema()
+
+    def "has a reasonable default matching strategy for String attributes"() {
+        when:
+        def strategy = schema.getMatchingStrategy(Attribute.of(String))
+
+        then:
+        strategy.isCompatible("foo", "foo")
+        !strategy.isCompatible("foo", "bar")
+
+        and:
+        strategy.selectClosestMatch("foo", [a: "foo"]) == ['a']
+    }
+
+    def "fails if no strategy is declared for custom type"() {
+        when:
+        schema.getMatchingStrategy(Attribute.of(Map))
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Unable to find matching strategy for map'
+    }
+
+    def "can set a custom matching strategy"() {
+        def attr = Attribute.of(Map)
+
+        given:
+        schema.setMatchingStrategy(attr, new AttributeMatchingStrategy<Map>() {
+            @Override
+            boolean isCompatible(Map requestedValue, Map candidateValue) {
+                requestedValue.size() == candidateValue.size() // arbitrary, just for testing purposes
+            }
+
+            @Override
+            def <K> List<K> selectClosestMatch(Map requestedValue, Map<K, Map> compatibleValues) {
+                compatibleValues.findAll { it.value == requestedValue }*.getKey()
+            }
+        })
+
+        when:
+        def strategy = schema.getMatchingStrategy(attr)
+
+        then:
+        strategy.isCompatible([a: 'foo', b: 'bar'], [a: 'foo', b: 'bar'])
+        strategy.isCompatible([a: 'foo', b: 'bar'], [c: 'foo', d: 'bar'])
+
+        and:
+        strategy.selectClosestMatch([a: 'foo', b: 'bar'], [1: [a: 'foo', b: 'bar'], 2: [c: 'foo', d: 'bar'], 3: [a: 'foo', b: 'bar']]) == [1, 3]
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.project
 import org.apache.tools.ant.types.FileSet
 import org.gradle.api.Action
 import org.gradle.api.AntBuilder
+import org.gradle.api.AttributesSchema
 import org.gradle.api.CircularReferenceException
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
@@ -132,6 +133,7 @@ class DefaultProjectTest {
     PluginContainer pluginContainer = context.mock(PluginContainer.class)
     ManagedProxyFactory managedProxyFactory = context.mock(ManagedProxyFactory.class)
     AntLoggingAdapter antLoggingAdapter = context.mock(AntLoggingAdapter.class)
+    AttributesSchema attributesSchema = context.mock(AttributesSchema)
 
     ClassLoaderScope baseClassLoaderScope = new RootClassLoaderScope(getClass().classLoader, getClass().classLoader, new DummyClassLoaderCache())
     ClassLoaderScope rootProjectClassLoaderScope = baseClassLoaderScope.createChild("root-project")
@@ -186,6 +188,7 @@ class DefaultProjectTest {
             allowing(serviceRegistryMock).get((Type) ProjectConfigurationActionContainer); will(returnValue(configureActions))
             allowing(serviceRegistryMock).get((Type) PluginManagerInternal); will(returnValue(pluginManager))
             allowing(serviceRegistryMock).get(ManagedProxyFactory); will(returnValue(managedProxyFactory))
+            allowing(serviceRegistryMock).get(AttributesSchema) ; will(returnValue(attributesSchema))
             allowing(pluginManager).getPluginContainer(); will(returnValue(pluginContainer))
 
             allowing(serviceRegistryMock).get((Type) DeferredProjectConfiguration); will(returnValue(context.mock(DeferredProjectConfiguration)))

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StringConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StringConfigurationAttributesResolveIntegrationTest.groovy
@@ -26,16 +26,6 @@ class StringConfigurationAttributesResolveIntegrationTest extends AbstractConfig
     }
 
     @Override
-    String getFreeDebug() {
-        "buildType: 'debug', flavor: 'free'"
-    }
-
-    @Override
-    String getFreeRelease() {
-        "buildType: 'release', flavor: 'free'"
-    }
-
-    @Override
     String getDebug() {
         "buildType: 'debug'"
     }
@@ -43,5 +33,15 @@ class StringConfigurationAttributesResolveIntegrationTest extends AbstractConfig
     @Override
     String getFree() {
         "flavor: 'free'"
+    }
+
+    @Override
+    String getRelease() {
+        "buildType: 'release'"
+    }
+
+    @Override
+    String getPaid() {
+        "flavor: 'paid'"
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -37,6 +37,13 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
             def flavor = Attribute.of(Flavor)
             def buildType = Attribute.of(BuildType)
 
+            AttributeMatchingStrategy ms = { requested, candidate -> requested == candidate }
+            allprojects {
+               configurationAttributesSchema {
+                  setMatchingStrategy(flavor, ms)
+                  setMatchingStrategy(buildType, ms)
+               }
+            }
         '''
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -37,16 +37,10 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
             def flavor = Attribute.of(Flavor)
             def buildType = Attribute.of(BuildType)
 
-            AttributeMatchingStrategy ms = [
-                isCompatible: { requested, candidate -> requested == candidate },
-                selectClosestMatch: { requested, candidates ->
-                        candidates.keySet() as List
-                }
-            ] as AttributeMatchingStrategy
             project(':a') {
                configurationAttributesSchema {
-                  setMatchingStrategy(flavor, ms)
-                  setMatchingStrategy(buildType, ms)
+                  matchStrictly(flavor)
+                  matchStrictly(buildType)
                }
             }
         '''

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -38,7 +38,7 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
             def buildType = Attribute.of(BuildType)
 
             AttributeMatchingStrategy ms = { requested, candidate -> requested == candidate }
-            allprojects {
+            project(':a') {
                configurationAttributesSchema {
                   setMatchingStrategy(flavor, ms)
                   setMatchingStrategy(buildType, ms)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -284,4 +284,89 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
         failure.assertHasCause("Cannot choose between the following configurations: [foo2, foo3]. All of them match the client attributes {buildType=debug, flavor=free}")
 
     }
+
+    def "can select best compatible match when single best matches are found on individual attributes"() {
+        given:
+        file('settings.gradle') << "include 'a', 'b'"
+        buildFile << """
+            $typeDefs
+
+            project(':a') {
+               configurationAttributesSchema {
+                  setMatchingStrategy(flavor, [
+                    isCompatible: { requested, candidate -> requested.value.equalsIgnoreCase(candidate.value) },
+                    selectClosestMatch: { requested, candidates ->
+                        candidates.entrySet().findAll { it.value.value == requested.value }*.key
+                    }
+                  ] as AttributeMatchingStrategy)
+
+                  // for testing purposes, this strategy says that all build types are compatible, but returns the requested value as best
+                  setMatchingStrategy(buildType, [
+                    isCompatible: { requested, candidate -> true },
+                    selectClosestMatch: { requested, candidates ->
+                        candidates.entrySet().findAll { it.value == requested }*.key
+                    }
+                  ] as AttributeMatchingStrategy)
+               }
+            }
+
+            project(':a') {
+                configurations {
+                    _compileFreeDebug.attributes($freeDebug)
+                    _compileFreeRelease.attributes($freeRelease)
+                }
+                dependencies {
+                    _compileFreeDebug project(':b')
+                    _compileFreeRelease project(':b')
+                }
+                task checkDebug(dependsOn: configurations._compileFreeDebug) {
+                    doLast {
+                       assert configurations._compileFreeDebug.collect { it.name } == ['b-foo2.jar']
+                    }
+                }
+            }
+            project(':b') {
+                configurations {
+                    foo {
+                        attributes((buildType): BuildType.debug, (flavor): Flavor.of("FREE"))
+                    }
+                    foo2 {
+                        attributes((buildType): BuildType.debug, (flavor): Flavor.of("free"))
+                    }
+                    bar {
+                        attributes((buildType): BuildType.release, (flavor): Flavor.of("FREE"))
+                    }
+                    bar2 {
+                        attributes((buildType): BuildType.release, (flavor): Flavor.of("free"))
+                    }
+                }
+                task fooJar(type: Jar) {
+                   baseName = 'b-foo'
+                }
+                task foo2Jar(type: Jar) {
+                   baseName = 'b-foo2'
+                }
+                task barJar(type: Jar) {
+                   baseName = 'b-bar'
+                }
+                task bar2Jar(type: Jar) {
+                   baseName = 'b-bar2'
+                }
+                artifacts {
+                    foo fooJar
+                    foo2 foo2Jar
+                    bar barJar
+                    bar2 bar2Jar
+                }
+            }
+
+        """
+
+        when:
+        run ':a:checkDebug'
+
+        then:
+        executedAndNotSkipped ':b:foo2Jar'
+        notExecuted ':b:fooJar', ':b:barJar', ':b:bar2Jar'
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -47,16 +47,6 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
     }
 
     @Override
-    String getFreeDebug() {
-        '(buildType): BuildType.debug, (flavor): Flavor.of("free")'
-    }
-
-    @Override
-    String getFreeRelease() {
-        '(buildType): BuildType.release, (flavor): Flavor.of("free")'
-    }
-
-    @Override
     String getDebug() {
         '(buildType): BuildType.debug'
     }
@@ -64,6 +54,16 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
     @Override
     String getFree() {
         '(flavor): Flavor.of("free")'
+    }
+
+    @Override
+    String getRelease() {
+        '(buildType): BuildType.release'
+    }
+
+    @Override
+    String getPaid() {
+        '(flavor): Flavor.of("paid")'
     }
 
     // This documents the current behavior, not necessarily the one we would want. Maybe

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ArtifactDependencyResolver.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
@@ -29,5 +30,6 @@ public interface ArtifactDependencyResolver {
                  GlobalDependencyResolutionRules metadataHandler,
                  Spec<? super DependencyMetadata> edgeFilter,
                  DependencyGraphVisitor graphVisitor,
-                 DependencyArtifactsVisitor artifactsVisitor);
+                 DependencyArtifactsVisitor artifactsVisitor,
+                 AttributesSchema attributesSchema);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -60,6 +60,7 @@ import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore;
+import org.gradle.api.internal.project.DefaultConfigurationAttributesSchema;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
@@ -94,6 +95,10 @@ public class DefaultDependencyManagementServices implements DependencyManagement
     }
 
     private static class DependencyResolutionScopeServices {
+        AttributesSchema createConfigurationAttributesSchema() {
+            return new DefaultConfigurationAttributesSchema();
+        }
+
         BaseRepositoryFactory createBaseRepositoryFactory(LocalMavenRepositoryLocator localMavenRepositoryLocator, Instantiator instantiator, FileResolver fileResolver,
                                                           RepositoryTransportFactory repositoryTransportFactory, LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
                                                           ArtifactIdentifierFileStore artifactIdentifierFileStore,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.StartParameter;
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
@@ -169,7 +170,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                        ComponentIdentifierFactory componentIdentifierFactory,
                                                        CacheLockingManager cacheLockingManager,
                                                        ResolutionResultsStoreFactory resolutionResultsStoreFactory,
-                                                       StartParameter startParameter) {
+                                                       StartParameter startParameter,
+                                                       AttributesSchema attributesSchema) {
             return new ErrorHandlingConfigurationResolver(
                     new ShortCircuitEmptyConfigurationResolver(
                         new DefaultConfigurationResolver(
@@ -178,7 +180,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                             metadataHandler,
                             cacheLockingManager,
                             resolutionResultsStoreFactory,
-                            startParameter.isBuildProjectDependencies()),
+                            startParameter.isBuildProjectDependencies(), attributesSchema),
                         componentIdentifierFactory)
             );
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLockingArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLockingArtifactDependencyResolver.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice;
 
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.ResolveContext;
@@ -36,10 +37,10 @@ public class CacheLockingArtifactDependencyResolver implements ArtifactDependenc
     }
 
     @Override
-    public void resolve(final ResolveContext resolveContext, final List<? extends ResolutionAwareRepository> repositories, final GlobalDependencyResolutionRules metadataHandler, final Spec<? super DependencyMetadata> edgeFilter, final DependencyGraphVisitor graphVisitor, final DependencyArtifactsVisitor artifactsVisitor) {
+    public void resolve(final ResolveContext resolveContext, final List<? extends ResolutionAwareRepository> repositories, final GlobalDependencyResolutionRules metadataHandler, final Spec<? super DependencyMetadata> edgeFilter, final DependencyGraphVisitor graphVisitor, final DependencyArtifactsVisitor artifactsVisitor, final AttributesSchema attributesSchema) {
         lockingManager.useCache("resolve " + resolveContext, new Runnable() {
             public void run() {
-                resolver.resolve(resolveContext, repositories, metadataHandler, edgeFilter, graphVisitor, artifactsVisitor);
+                resolver.resolve(resolveContext, repositories, metadataHandler, edgeFilter, graphVisitor, artifactsVisitor, attributesSchema);
             }
         });
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
@@ -64,16 +65,18 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     private final CacheLockingManager cacheLockingManager;
     private final ResolutionResultsStoreFactory storeFactory;
     private final boolean buildProjectDependencies;
+    private final AttributesSchema attributesSchema;
 
     public DefaultConfigurationResolver(ArtifactDependencyResolver resolver, RepositoryHandler repositories,
                                         GlobalDependencyResolutionRules metadataHandler, CacheLockingManager cacheLockingManager,
-                                        ResolutionResultsStoreFactory storeFactory, boolean buildProjectDependencies) {
+                                        ResolutionResultsStoreFactory storeFactory, boolean buildProjectDependencies, AttributesSchema attributesSchema) {
         this.resolver = resolver;
         this.repositories = repositories;
         this.metadataHandler = metadataHandler;
         this.cacheLockingManager = cacheLockingManager;
         this.storeFactory = storeFactory;
         this.buildProjectDependencies = buildProjectDependencies;
+        this.attributesSchema = attributesSchema;
     }
 
     @Override
@@ -85,7 +88,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
             public boolean isSatisfiedBy(DependencyMetadata element) {
                 return element instanceof DslOriginDependencyMetadata && ((DslOriginDependencyMetadata) element).getSource() instanceof ProjectDependency;
             }
-        }, new CompositeDependencyGraphVisitor(localComponentsVisitor, fileDependenciesVisitor), new CompositeDependencyArtifactsVisitor());
+        }, new CompositeDependencyGraphVisitor(localComponentsVisitor, fileDependenciesVisitor), new CompositeDependencyArtifactsVisitor(), attributesSchema);
         result.graphResolved(localComponentsVisitor, fileDependenciesVisitor);
     }
 
@@ -111,7 +114,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         DependencyGraphVisitor graphVisitor = new CompositeDependencyGraphVisitor(oldModelVisitor, newModelBuilder, localComponentsVisitor, fileDependencyVisitor);
         DependencyArtifactsVisitor artifactsVisitor = new CompositeDependencyArtifactsVisitor(oldModelVisitor, artifactsBuilder);
 
-        resolver.resolve(configuration, resolutionAwareRepositories, metadataHandler, Specs.<DependencyMetadata>satisfyAll(), graphVisitor, artifactsVisitor);
+        resolver.resolve(configuration, resolutionAwareRepositories, metadataHandler, Specs.<DependencyMetadata>satisfyAll(), graphVisitor, artifactsVisitor, attributesSchema);
 
         results.graphResolved(newModelBuilder.complete(), localComponentsVisitor, fileDependencyVisitor);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
 import com.google.common.collect.Lists;
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.ResolveContext;
@@ -72,10 +73,10 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     }
 
     @Override
-    public void resolve(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler, Spec<? super DependencyMetadata> edgeFilter, DependencyGraphVisitor graphVisitor, DependencyArtifactsVisitor artifactsVisitor) {
+    public void resolve(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler, Spec<? super DependencyMetadata> edgeFilter, DependencyGraphVisitor graphVisitor, DependencyArtifactsVisitor artifactsVisitor, AttributesSchema attributesSchema) {
         LOGGER.debug("Resolving {}", resolveContext);
         ComponentResolvers resolvers = createResolvers(resolveContext, repositories, metadataHandler);
-        DependencyGraphBuilder builder = createDependencyGraphBuilder(resolvers, resolveContext.getResolutionStrategy(), metadataHandler, edgeFilter);
+        DependencyGraphBuilder builder = createDependencyGraphBuilder(resolvers, resolveContext.getResolutionStrategy(), metadataHandler, edgeFilter, attributesSchema);
 
         ArtifactResolver artifactResolver = new ErrorHandlingArtifactResolver(new CacheLockingArtifactResolver(cacheLockingManager, resolvers.getArtifactResolver()));
         DependencyGraphVisitor artifactsGraphVisitor = new ResolvedArtifactsGraphVisitor(artifactsVisitor, artifactResolver);
@@ -84,7 +85,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         builder.resolve(resolveContext, new CompositeDependencyGraphVisitor(graphVisitor, artifactsGraphVisitor));
     }
 
-    private DependencyGraphBuilder createDependencyGraphBuilder(ComponentResolvers componentSource, ResolutionStrategyInternal resolutionStrategy, GlobalDependencyResolutionRules globalRules, Spec<? super DependencyMetadata> edgeFilter) {
+    private DependencyGraphBuilder createDependencyGraphBuilder(ComponentResolvers componentSource, ResolutionStrategyInternal resolutionStrategy, GlobalDependencyResolutionRules globalRules, Spec<? super DependencyMetadata> edgeFilter, AttributesSchema attributesSchema) {
 
         DependencyToComponentIdResolver componentIdResolver = new DependencySubstitutionResolver(componentSource.getComponentIdResolver(), resolutionStrategy.getDependencySubstitutionRule());
         ComponentMetaDataResolver componentMetaDataResolver = new ClientModuleResolver(componentSource.getComponentResolver(), dependencyDescriptorFactory);
@@ -92,7 +93,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         ResolveContextToComponentResolver requestResolver = createResolveContextConverter();
         ConflictHandler conflictHandler = createConflictHandler(resolutionStrategy, globalRules);
 
-        return new DependencyGraphBuilder(componentIdResolver, componentMetaDataResolver, requestResolver, conflictHandler, edgeFilter);
+        return new DependencyGraphBuilder(componentIdResolver, componentMetaDataResolver, requestResolver, conflictHandler, edgeFilter, attributesSchema);
     }
 
     private ComponentResolversChain createResolvers(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyMetadata.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
@@ -101,7 +102,7 @@ public class IvyDependencyMetadata extends DefaultDependencyMetadata {
     }
 
     @Override
-    public Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent) {
+    public Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent, AttributesSchema attributesSchema) {
         // TODO - all this matching stuff is constant for a given DependencyMetadata instance
         Set<ConfigurationMetadata> targets = Sets.newLinkedHashSet();
         boolean matched = false;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MavenDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MavenDependencyMetadata.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.external.model;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
@@ -93,7 +94,7 @@ public class MavenDependencyMetadata extends DefaultDependencyMetadata {
     }
 
     @Override
-    public Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent) {
+    public Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent, AttributesSchema attributesSchema) {
         Set<ConfigurationMetadata> result = Sets.newLinkedHashSet();
         boolean requiresCompile = fromConfiguration.getName().equals("compile");
         if (!requiresCompile) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.local.model;
 
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
@@ -86,8 +87,8 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     }
 
     @Override
-    public Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent) {
-        return delegate.selectConfigurations(fromComponent, fromConfiguration, targetComponent);
+    public Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent, AttributesSchema attributesSchema) {
+        return delegate.selectConfigurations(fromComponent, fromConfiguration, targetComponent, attributesSchema);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.local.model;
 
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ComponentSelector;
@@ -60,8 +61,8 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
-    public Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent) {
-        return delegate.selectConfigurations(fromComponent, fromConfiguration, targetComponent);
+    public Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent, AttributesSchema attributesSchema) {
+        return delegate.selectConfigurations(fromComponent, fromConfiguration, targetComponent, attributesSchema);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.model;
 
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
@@ -65,7 +66,7 @@ public interface DependencyMetadata {
      * Select the target configurations for this dependency from the given target component.
      */
     // TODO:ADAM - fromComponent and fromConfiguration should be implicit in this metadata
-    Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent);
+    Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent, AttributesSchema attributesSchema);
 
     /**
      * Returns the set of source configurations that this dependency should be attached to.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -24,6 +24,7 @@ import org.gradle.api.Attribute;
 import org.gradle.api.AttributeContainer;
 import org.gradle.api.AttributeMatchingStrategy;
 import org.gradle.api.AttributesSchema;
+import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ComponentSelector;
@@ -127,7 +128,11 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
                         final Object requestedValue = fromConfigurationAttributes.getAttribute(key);
                         final Object candidateValue = dependencyAttributeContainer.getAttribute(key);
                         AttributeMatchingStrategy<Object> matchingStrategy = Cast.uncheckedCast(attributesSchema.getMatchingStrategy(key));
-                        containsAll = matchingStrategy.isCompatible(requestedValue, candidateValue);
+                        try {
+                            containsAll = matchingStrategy.isCompatible(requestedValue, candidateValue);
+                        } catch (Exception ex) {
+                            throw new GradleException("Unexpected error thrown when trying to match attribute values with " + matchingStrategy, ex);
+                        }
                         if (!containsAll) {
                             break;
                         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLockingArtifactDependencyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLockingArtifactDependencyResolverTest.groovy
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 package org.gradle.api.internal.artifacts.ivyservice
+
+import org.gradle.api.AttributesSchema
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository
 import org.gradle.api.specs.Spec
 import spock.lang.Specification
@@ -35,14 +37,15 @@ class CacheLockingArtifactDependencyResolverTest extends Specification {
         ConfigurationInternal configuration = Mock()
         def graphVisitor = Mock(DependencyGraphVisitor)
         def artifactVisitor = Mock(DependencyArtifactsVisitor)
+        def attributesSchema = Mock(AttributesSchema)
 
         when:
-        resolver.resolve(configuration, repositories, metadataHandler, spec, graphVisitor, artifactVisitor)
+        resolver.resolve(configuration, repositories, metadataHandler, spec, graphVisitor, artifactVisitor, attributesSchema)
 
         then:
         1 * lockingManager.useCache("resolve $configuration", !null) >> { String s, Runnable r ->
             r.run()
         }
-        1 * target.resolve(configuration, repositories, metadataHandler, spec, graphVisitor, artifactVisitor)
+        1 * target.resolve(configuration, repositories, metadataHandler, spec, graphVisitor, artifactVisitor, attributesSchema)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine
 
 import org.apache.ivy.core.module.id.ModuleRevisionId
+import org.gradle.api.AttributesSchema
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ModuleVersionSelector
@@ -63,6 +64,8 @@ class DependencyGraphBuilderTest extends Specification {
     def root = project('root', '1.0', ['root'])
     def moduleResolver = Mock(ResolveContextToComponentResolver)
     def moduleReplacements = Mock(ModuleReplacementsData)
+    def attributesSchema = Mock(AttributesSchema)
+
     DependencyGraphBuilder builder
 
     def setup() {
@@ -70,7 +73,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.path >> 'root'
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll(), attributesSchema)
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -497,7 +500,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.requested.name != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec)
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec, attributesSchema)
 
         def a = revision('a')
         def b = revision('b')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyMetadataTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.internal.component.model.DefaultDependencyMetadataTest
 import org.gradle.internal.component.model.Exclude
 
 class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
+
     @Override
     DefaultDependencyMetadata create(ModuleVersionSelector selector) {
         return new IvyDependencyMetadata(selector, ImmutableListMultimap.of())
@@ -99,7 +100,7 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, ImmutableListMultimap.of(), [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent).empty
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema).empty
     }
 
     def "selects configurations from target component that match configuration mappings"() {
@@ -119,7 +120,7 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1, toConfig2] // verify order as well
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1, toConfig2] // verify order as well
     }
 
     def "selects matching configurations for super-configurations"() {
@@ -139,7 +140,7 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1, toConfig2]
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1, toConfig2]
     }
 
     def "configuration mapping can use wildcard on LHS"() {
@@ -160,8 +161,8 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1, toConfig2]
-        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent) as List == [toConfig2]
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1, toConfig2]
+        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent, attributesSchema) as List == [toConfig2]
     }
 
     def "configuration mapping can use wildcard on RHS to select all public configurations"() {
@@ -187,7 +188,7 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1, toConfig2]
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1, toConfig2]
     }
 
     def "configuration mapping can use all-except-wildcard on LHS"() {
@@ -211,9 +212,9 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1]
-        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent) as List == [toConfig1]
-        metadata.selectConfigurations(fromComponent, fromConfig3, toComponent) as List == [toConfig2]
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1]
+        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent, attributesSchema) as List == [toConfig1]
+        metadata.selectConfigurations(fromComponent, fromConfig3, toComponent, attributesSchema) as List == [toConfig2]
     }
 
     def "configuration mapping can include fallback on LHS"() {
@@ -239,9 +240,9 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1, toConfig3]
-        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent) as List == [toConfig1, toConfig3]
-        metadata.selectConfigurations(fromComponent, fromConfig3, toComponent) as List == [toConfig2, toConfig3]
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1, toConfig3]
+        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent, attributesSchema) as List == [toConfig1, toConfig3]
+        metadata.selectConfigurations(fromComponent, fromConfig3, toComponent, attributesSchema) as List == [toConfig2, toConfig3]
     }
 
     def "configuration mapping can include fallback on RHS"() {
@@ -269,9 +270,9 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1, toConfig2]
-        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent) as List == [toConfig1]
-        metadata.selectConfigurations(fromComponent, fromConfig3, toComponent) as List == [toConfig2]
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1, toConfig2]
+        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent, attributesSchema) as List == [toConfig1]
+        metadata.selectConfigurations(fromComponent, fromConfig3, toComponent, attributesSchema) as List == [toConfig2]
     }
 
     def "configuration mapping can include self placeholder on RHS"() {
@@ -289,8 +290,8 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1]
-        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent) as List == [toConfig1]
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1]
+        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent, attributesSchema) as List == [toConfig1]
     }
 
     def "configuration mapping can include this placeholder on RHS"() {
@@ -312,8 +313,8 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1]
-        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent) as List == [toConfig2]
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1]
+        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent, attributesSchema) as List == [toConfig2]
     }
 
     def "configuration mapping can include wildcard on LHS and placeholder on RHS"() {
@@ -335,8 +336,8 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
 
         expect:
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1]
-        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent) as List == [toConfig2]
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) as List == [toConfig1]
+        metadata.selectConfigurations(fromComponent, fromConfig2, toComponent, attributesSchema) as List == [toConfig2]
 
         where:
         // these all map to the same thing
@@ -369,7 +370,7 @@ class IvyDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def metadata = new IvyDependencyMetadata(requested, "12", true, true, true, configMapping, [], [])
 
         when:
-        metadata.selectConfigurations(fromComponent, fromConfig, toComponent)
+        metadata.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema)
 
         then:
         ConfigurationNotFoundException e = thrown()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyMetadataTest.groovy
@@ -114,7 +114,7 @@ class MavenDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def dep = new MavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleVersionSelector), [], [])
 
         expect:
-        dep.selectConfigurations(fromComponent, fromCompile, toComponent) as List == [toCompile, toMaster]
+        dep.selectConfigurations(fromComponent, fromCompile, toComponent, attributesSchema) as List == [toCompile, toMaster]
     }
 
     def "selects compile, runtime and master configurations from target when traversing from other configuration"() {
@@ -135,8 +135,8 @@ class MavenDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def dep = new MavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleVersionSelector), [], [])
 
         expect:
-        dep.selectConfigurations(fromComponent, fromRuntime, toComponent) as List == [toRuntime, toCompile, toMaster]
-        dep.selectConfigurations(fromComponent, fromRuntime2, toComponent) as List == [toRuntime, toCompile, toMaster]
+        dep.selectConfigurations(fromComponent, fromRuntime, toComponent, attributesSchema) as List == [toRuntime, toCompile, toMaster]
+        dep.selectConfigurations(fromComponent, fromRuntime2, toComponent, attributesSchema) as List == [toRuntime, toCompile, toMaster]
     }
 
     def "selects runtime and master configurations from target when traversing from other configuration and target's runtime extends compile"() {
@@ -156,8 +156,8 @@ class MavenDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def dep = new MavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleVersionSelector), [], [])
 
         expect:
-        dep.selectConfigurations(fromComponent, fromRuntime, toComponent) as List == [toRuntime, toMaster]
-        dep.selectConfigurations(fromComponent, fromRuntime2, toComponent) as List == [toRuntime, toMaster]
+        dep.selectConfigurations(fromComponent, fromRuntime, toComponent, attributesSchema) as List == [toRuntime, toMaster]
+        dep.selectConfigurations(fromComponent, fromRuntime2, toComponent, attributesSchema) as List == [toRuntime, toMaster]
     }
 
     def "ignores missing master configuration"() {
@@ -173,7 +173,7 @@ class MavenDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def dep = new MavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleVersionSelector), [], [])
 
         expect:
-        dep.selectConfigurations(fromComponent, fromRuntime, toComponent) as List == [toRuntime]
+        dep.selectConfigurations(fromComponent, fromRuntime, toComponent, attributesSchema) as List == [toRuntime]
     }
 
     def "ignores empty master configuration"() {
@@ -190,7 +190,7 @@ class MavenDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def dep = new MavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleVersionSelector), [], [])
 
         expect:
-        dep.selectConfigurations(fromComponent, fromRuntime, toComponent) as List == [toRuntime]
+        dep.selectConfigurations(fromComponent, fromRuntime, toComponent, attributesSchema) as List == [toRuntime]
     }
 
     def "falls back to default configuration when compile is not defined in target component"() {
@@ -208,7 +208,7 @@ class MavenDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def dep = new MavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleVersionSelector), [], [])
 
         expect:
-        dep.selectConfigurations(fromComponent, fromCompile, toComponent) as List == [toDefault, toMaster]
+        dep.selectConfigurations(fromComponent, fromCompile, toComponent, attributesSchema) as List == [toDefault, toMaster]
     }
 
     def "falls back to default configuration when runtime is not defined in target component"() {
@@ -227,7 +227,7 @@ class MavenDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def dep = new MavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleVersionSelector), [], [])
 
         expect:
-        dep.selectConfigurations(fromComponent, fromRuntime, toComponent) as List == [toDefault, toMaster]
+        dep.selectConfigurations(fromComponent, fromRuntime, toComponent, attributesSchema) as List == [toDefault, toMaster]
     }
 
     def "fails when compile configuration is not defined in target component"() {
@@ -242,7 +242,7 @@ class MavenDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def dep = new MavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleVersionSelector), [], [])
 
         when:
-        dep.selectConfigurations(fromComponent, fromCompile, toComponent)
+        dep.selectConfigurations(fromComponent, fromCompile, toComponent, attributesSchema)
 
         then:
         thrown(ConfigurationNotFoundException)
@@ -260,7 +260,7 @@ class MavenDependencyMetadataTest extends DefaultDependencyMetadataTest {
         def dep = new MavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleVersionSelector), [], [])
 
         when:
-        dep.selectConfigurations(fromComponent, fromRuntime, toComponent)
+        dep.selectConfigurations(fromComponent, fromRuntime, toComponent, attributesSchema)
 
         then:
         thrown(ConfigurationNotFoundException)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/DefaultDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/DefaultDependencyMetadataTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.model
 
+import org.gradle.api.AttributesSchema
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
@@ -28,6 +29,8 @@ import spock.lang.Specification
 import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.newSelector
 
 abstract class DefaultDependencyMetadataTest extends Specification {
+    def attributesSchema = Mock(AttributesSchema)
+
     def requested = newSelector("org", "module", "1.2+")
     def id = DefaultModuleVersionIdentifier.newId("org", "module", "1.2+")
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -75,7 +75,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
         dep.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema) == [toConfig] as Set
     }
 
-    @Unroll("selects configuration '#expected' from target component")
+    @Unroll("selects configuration '#expected' from target component (#scenario)")
     def "selects the target configuration from target component which matches the attributes"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, null, [] as Set, [], false, false, true)
         def fromComponent = Stub(ComponentResolveMetadata)
@@ -109,11 +109,11 @@ class LocalComponentDependencyMetadataTest extends Specification {
         dep.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema)*.name as Set == [expected] as Set
 
         where:
-        queryAttributes                 | expected
-        [key: 'something']              | 'foo'
-        [key: 'something else']         | 'bar'
-        [key: 'other']                  | 'default'
-        [key: 'something', extra: 'no'] | 'default'
+        scenario               | queryAttributes                 | expected
+        'exact match'          | [key: 'something']              | 'foo'
+        'exact match'          | [key: 'something else']         | 'bar'
+        'no match'             | [key: 'other']                  | 'default'
+        'partial match on key' | [key: 'something', extra: 'no'] | 'foo'
     }
 
     def "fails to select target configuration when not present in the target component"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -116,6 +116,87 @@ class LocalComponentDependencyMetadataTest extends Specification {
         'partial match on key' | [key: 'something', extra: 'no'] | 'foo'
     }
 
+    @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy (#scenario)")
+    def "selects the target configuration from target component with Java proximity matching strategy"() {
+        def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, null, [] as Set, [], false, false, true)
+        def fromComponent = Stub(ComponentResolveMetadata)
+        def toComponent = Stub(ComponentResolveMetadata) {
+            getConfigurationNames() >> ['foo', 'bar']
+        }
+        def fromConfig = Stub(LocalConfigurationMetadata) {
+            getAttributes() >> attributes(queryAttributes)
+        }
+        fromConfig.hierarchy >> ["from"]
+        def defaultConfig = Stub(LocalConfigurationMetadata) {
+            getName() >> 'default'
+        }
+        def toFooConfig = Stub(LocalConfigurationMetadata) {
+            getName() >> 'foo'
+            getAttributes() >> attributes(fooAttributes)
+            isCanBeResolved() >> false
+            isCanBeConsumed() >> true
+        }
+        def toBarConfig = Stub(LocalConfigurationMetadata) {
+            getName() >> 'bar'
+            getAttributes() >> attributes(barAttributes)
+            isCanBeResolved() >> false
+            isCanBeConsumed() >> true
+        }
+        def attributeSchemaWithCompatibility = Mock(AttributesSchema) {
+            getMatchingStrategy(_) >> { args ->
+                def attr = args[0]
+                if (attr.name == 'platform') {
+                    return new JavaCompileVersionStrategy()
+                } else {
+                    return Mock(AttributeMatchingStrategy) {
+                        isCompatible(_, _) >> { req, cand -> req == cand }
+                        selectClosestMatch(_, _) >> { req, candidates -> candidates.keySet() as List }
+                    }
+                }
+            }
+        }
+
+        given:
+        toComponent.getConfiguration("default") >> defaultConfig
+        toComponent.getConfiguration("foo") >> toFooConfig
+        toComponent.getConfiguration("bar") >> toBarConfig
+
+        expect:
+        try {
+            def result = dep.selectConfigurations(fromComponent, fromConfig, toComponent, attributeSchemaWithCompatibility)*.name as Set
+            if (expected == null && result) {
+                throw new AssertionError("Expected an ambiguous result, but got $result")
+            }
+            assert result == [expected] as Set
+        } catch (IllegalArgumentException e) {
+            if (expected == null) {
+                assert e.message.startsWith('Cannot choose between the following configurations: [bar, foo]')
+            } else {
+                throw e
+            }
+        }
+
+        where:
+        scenario                                                    | queryAttributes                               | fooAttributes                                 | barAttributes                                 | expected
+        'exact match is found'                                      | [platform: JavaVersion.JAVA7]                 | [platform: JavaVersion.JAVA7]                 | [:]                                           | 'foo'
+        'exact match is found'                                      | [platform: JavaVersion.JAVA8]                 | [platform: JavaVersion.JAVA7]                 | [platform: JavaVersion.JAVA8]                 | 'bar'
+        'Java 7  is compatible with Java 8'                         | [platform: JavaVersion.JAVA8]                 | [platform: JavaVersion.JAVA7]                 | [:]                                           | 'foo'
+        'Java 7 is closer to Java 8'                                | [platform: JavaVersion.JAVA8]                 | [platform: JavaVersion.JAVA6]                 | [platform: JavaVersion.JAVA7]                 | 'bar'
+        'Java 8 is not compatible with Java 7'                      | [platform: JavaVersion.JAVA7]                 | [platform: JavaVersion.JAVA8]                 | [:]                                           | 'default'
+        'Java 8 is not compatible but Java 6 is'                    | [platform: JavaVersion.JAVA7]                 | [platform: JavaVersion.JAVA8]                 | [platform: JavaVersion.JAVA6]                 | 'bar'
+        'compatible platforms, but additional attributes unmatched' | [platform: JavaVersion.JAVA8]                 | [platform: JavaVersion.JAVA6, flavor: 'free'] | [platform: JavaVersion.JAVA6, flavor: 'paid'] | null
+        'compatible platforms, but one closer'                      | [platform: JavaVersion.JAVA8]                 | [platform: JavaVersion.JAVA6, flavor: 'free'] | [platform: JavaVersion.JAVA7, flavor: 'paid'] | 'bar'
+        'exact match and multiple attributes'                       | [platform: JavaVersion.JAVA8, flavor: 'free'] | [platform: JavaVersion.JAVA8, flavor: 'free'] | [platform: JavaVersion.JAVA7, flavor: 'free'] | 'foo'
+        'partial match and multiple attributes'                     | [platform: JavaVersion.JAVA8, flavor: 'free'] | [platform: JavaVersion.JAVA8]                 | [platform: JavaVersion.JAVA7]                 | 'foo'
+        'close match and multiple attributes'                       | [platform: JavaVersion.JAVA8, flavor: 'free'] | [platform: JavaVersion.JAVA6, flavor: 'free'] | [platform: JavaVersion.JAVA7, flavor: 'free'] | 'bar'
+        'close partial match and multiple attributes'               | [platform: JavaVersion.JAVA8, flavor: 'free'] | [platform: JavaVersion.JAVA6]                 | [platform: JavaVersion.JAVA7]                 | 'bar'
+        'exact match and partial match'                             | [platform: JavaVersion.JAVA8, flavor: 'free'] | [platform: JavaVersion.JAVA6]                 | [platform: JavaVersion.JAVA7, flavor: 'free'] | 'bar'
+        'no exact match but partial match'                          | [platform: JavaVersion.JAVA8, flavor: 'free'] | [platform: JavaVersion.JAVA6]                 | [platform: JavaVersion.JAVA7, flavor: 'paid'] | 'foo'
+        'no exact match but ambiguous partial match'                | [platform: JavaVersion.JAVA8, flavor: 'free'] | [platform: JavaVersion.JAVA6, extra: 'foo']   | [platform: JavaVersion.JAVA6, extra: 'bar']   | null
+        'no exact match but best partial match'                     | [platform: JavaVersion.JAVA8, flavor: 'free'] | [platform: JavaVersion.JAVA8, extra: 'foo']   | [platform: JavaVersion.JAVA6, extra: 'bar']   | 'foo'
+
+    }
+
     def "fails to select target configuration when not present in the target component"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, "to", [] as Set, [], false, false, true)
         def fromComponent = Stub(ComponentResolveMetadata)
@@ -261,11 +342,41 @@ class LocalComponentDependencyMetadataTest extends Specification {
         return config
     }
 
-    private AttributeContainer attributes(Map<String, String> src) {
+    private AttributeContainer attributes(Map<String, ?> src) {
+        def attributes = [:]
+        src.each { String name, Object value ->
+            def key = Attribute.of(name, value.class)
+            attributes[key] = value
+        }
         Mock(AttributeContainer) {
             isEmpty() >> src.isEmpty()
-            getAttribute(_) >> { args -> src[args[0].name] }
-            keySet() >> src.keySet().collect { Attribute.of(it, String) }
+            getAttribute(_) >> { args -> attributes[args[0]] }
+            keySet() >> {
+                attributes.keySet()
+            }
+        }
+    }
+
+    public enum JavaVersion {
+        JAVA5,
+        JAVA6,
+        JAVA7,
+        JAVA8,
+        JAVA9
+    }
+
+    public class JavaCompileVersionStrategy implements AttributeMatchingStrategy<JavaVersion> {
+
+        @Override
+        boolean isCompatible(JavaVersion requestedValue, JavaVersion candidateValue) {
+            candidateValue.ordinal() <= requestedValue.ordinal()
+        }
+
+        @Override
+        def <K> List<K> selectClosestMatch(JavaVersion requestedValue, Map<K, JavaVersion> compatibleValues) {
+            def maxCompat = compatibleValues.values().sort { it.ordinal() }.last()
+            def result = compatibleValues.findAll { it.value == maxCompat }*.key
+            result
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/language/java/plugins/JavaLanguagePlugin.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/plugins/JavaLanguagePlugin.java
@@ -186,7 +186,8 @@ public class JavaLanguagePlugin implements Plugin<Project> {
                 List<ResolutionAwareRepository> resolutionAwareRepositories = collect(repositories, Transformers.cast(ResolutionAwareRepository.class));
                 ModelSchema<? extends BinarySpec> schema = schemaStore.getSchema(((BinarySpecInternal) binary).getPublicType());
                 VariantsMetaData variantsMetaData = DefaultVariantsMetaData.extractFrom(binary, schema);
-                return new SourceSetDependencyResolvingClasspath((BinarySpecInternal) binary, javaSourceSet, dependencies, dependencyResolver, variantsMetaData, resolutionAwareRepositories);
+                AttributesSchema attributesSchema = serviceRegistry.get(AttributesSchema.class);
+                return new SourceSetDependencyResolvingClasspath((BinarySpecInternal) binary, javaSourceSet, dependencies, dependencyResolver, variantsMetaData, resolutionAwareRepositories, attributesSchema);
             }
 
             private static Iterable<DependencySpec> compileDependencies(BinarySpec binary, DependentSourceSet sourceSet) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.internal;
 
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
@@ -51,22 +52,24 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
     private final BinarySpecInternal binary;
     private final ArtifactDependencyResolver dependencyResolver;
     private final ResolveContext resolveContext;
-    private final String descriptor;
+    private final AttributesSchema attributesSchema;
 
+    private final String descriptor;
     private ResolveResult resolveResult;
 
     public DependencyResolvingClasspath(
-            BinarySpecInternal binarySpec,
-            String descriptor,
-            ArtifactDependencyResolver dependencyResolver,
-            List<ResolutionAwareRepository> remoteRepositories,
-            ResolveContext resolveContext
-            ) {
+        BinarySpecInternal binarySpec,
+        String descriptor,
+        ArtifactDependencyResolver dependencyResolver,
+        List<ResolutionAwareRepository> remoteRepositories,
+        ResolveContext resolveContext,
+        AttributesSchema attributesSchema) {
         this.binary = binarySpec;
         this.descriptor = descriptor;
         this.dependencyResolver = dependencyResolver;
         this.remoteRepositories = remoteRepositories;
         this.resolveContext = resolveContext;
+        this.attributesSchema = attributesSchema;
     }
 
     @Override
@@ -103,7 +106,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
 
     private ResolveResult resolve() {
         ResolveResult result = new ResolveResult();
-        dependencyResolver.resolve(resolveContext, remoteRepositories, globalRules, Specs.<DependencyMetadata>satisfyAll(), result, result);
+        dependencyResolver.resolve(resolveContext, remoteRepositories, globalRules, Specs.<DependencyMetadata>satisfyAll(), result, result, attributesSchema);
         return result;
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/SourceSetDependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/SourceSetDependencyResolvingClasspath.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.jvm.internal.resolve;
 
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.jvm.internal.DependencyResolvingClasspath;
@@ -27,17 +28,17 @@ import java.util.List;
 public class SourceSetDependencyResolvingClasspath extends DependencyResolvingClasspath {
 
     public SourceSetDependencyResolvingClasspath(
-            BinarySpecInternal binarySpec,
-            LanguageSourceSet sourceSet,
-            Iterable<DependencySpec> dependencies,
-            ArtifactDependencyResolver dependencyResolver,
-            VariantsMetaData binaryVariants,
-            List<ResolutionAwareRepository> remoteRepositories) {
+        BinarySpecInternal binarySpec,
+        LanguageSourceSet sourceSet,
+        Iterable<DependencySpec> dependencies,
+        ArtifactDependencyResolver dependencyResolver,
+        VariantsMetaData binaryVariants,
+        List<ResolutionAwareRepository> remoteRepositories, AttributesSchema attributesSchema) {
         super(binarySpec,
             "source set '" + sourceSet.getDisplayName() + "'",
             dependencyResolver,
             remoteRepositories,
-            new JvmLibraryResolveContext(binarySpec.getId(), binaryVariants, dependencies, UsageKind.API, sourceSet.getDisplayName()));
+            new JvmLibraryResolveContext(binarySpec.getId(), binaryVariants, dependencies, UsageKind.API, sourceSet.getDisplayName()), attributesSchema);
     }
 
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/jvm/plugins/JvmTestSuiteBasePlugin.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/jvm/plugins/JvmTestSuiteBasePlugin.java
@@ -18,6 +18,7 @@ package org.gradle.jvm.plugins;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang.WordUtils;
 import org.gradle.api.Action;
+import org.gradle.api.AttributesSchema;
 import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
@@ -106,11 +107,12 @@ public class JvmTestSuiteBasePlugin extends RuleSource {
         RepositoryHandler repositories = serviceRegistry.get(RepositoryHandler.class);
         List<ResolutionAwareRepository> resolutionAwareRepositories = CollectionUtils.collect(repositories, Transformers.cast(ResolutionAwareRepository.class));
         ModelSchema<? extends JvmTestSuiteBinarySpec> schema = Cast.uncheckedCast(modelSchemaStore.getSchema(((BinarySpecInternal) testBinary).getPublicType()));
-        testBinary.setRuntimeClasspath(configureRuntimeClasspath(testBinary, dependencyResolver, resolutionAwareRepositories, schema));
+        AttributesSchema attributesSchema = serviceRegistry.get(AttributesSchema.class);
+        testBinary.setRuntimeClasspath(configureRuntimeClasspath(testBinary, dependencyResolver, resolutionAwareRepositories, schema, attributesSchema));
     }
 
-    private static DependencyResolvingClasspath configureRuntimeClasspath(JvmTestSuiteBinarySpecInternal testBinary, ArtifactDependencyResolver dependencyResolver, List<ResolutionAwareRepository> resolutionAwareRepositories, ModelSchema<? extends JvmTestSuiteBinarySpec> schema) {
-        return new DependencyResolvingClasspath(testBinary, testBinary.getDisplayName(), dependencyResolver, resolutionAwareRepositories, createResolveContext(testBinary, schema));
+    private static DependencyResolvingClasspath configureRuntimeClasspath(JvmTestSuiteBinarySpecInternal testBinary, ArtifactDependencyResolver dependencyResolver, List<ResolutionAwareRepository> resolutionAwareRepositories, ModelSchema<? extends JvmTestSuiteBinarySpec> schema, AttributesSchema attributesSchema) {
+        return new DependencyResolvingClasspath(testBinary, testBinary.getDisplayName(), dependencyResolver, resolutionAwareRepositories, createResolveContext(testBinary, schema), attributesSchema);
     }
 
     private static JvmLibraryResolveContext createResolveContext(JvmTestSuiteBinarySpecInternal testBinary, ModelSchema<? extends JvmTestSuiteBinarySpec> schema) {


### PR DESCRIPTION
This pull request adds support for partial attribute matching during dependency resolution. It solves the following problems:

- tell if an attribute from a producer is _compatible with_ the value expected from a consumer
- when multiple _compatible_ values are found (that is to say, multiple configurations provide values which are compatible with the one the consumer wants), select the _closest_ match, and fail if multiple configurations are still compatible
- handle the case where an attribute is relevant to the consumer, but not to the producer, also known as _partial matches_: prefer full matches over partial matches, and prefer closes matches in case of partial matches.

This pull request basically covers step 1 to 3 of [the plan]( https://github.com/gradle/performance/issues/86#issuecomment-258351623).

This pull request supercedes gradle/gradle#807


