### PR TITLE
Add missing strongly typed overloads to FileTree

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/file/FileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/file/FileTree.java
@@ -16,6 +16,7 @@
 package org.gradle.api.file;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -51,6 +52,20 @@ public interface FileTree extends FileCollection {
      * <p>Restricts the contents of this tree to those files matching the given filter. The filtered tree is live, so
      * that any changes to this tree are reflected in the filtered tree.</p>
      *
+     * <p>The given action is used to configure the filter. A {@link org.gradle.api.tasks.util.PatternFilterable} is
+     * passed to the action. Only files which match the specified include patterns will be included in
+     * the filtered tree. Any files which match the specified exclude patterns will be excluded from the filtered
+     * tree.</p>
+     *
+     * @param filterConfigAction Action to use to configure the filter.
+     * @return The filtered tree.
+     */
+    FileTree matching(Action<PatternFilterable> filterConfigAction);
+
+    /**
+     * <p>Restricts the contents of this tree to those files matching the given filter. The filtered tree is live, so
+     * that any changes to this tree are reflected in the filtered tree.</p>
+     *
      * <p>The given pattern set is used to configure the filter. Only files which match the specified include patterns
      * will be included in the filtered tree. Any files which match the specified exclude patterns will be excluded from
      * the filtered tree.</p>
@@ -78,6 +93,16 @@ public interface FileTree extends FileCollection {
      * @return this
      */
     FileTree visit(Closure visitor);
+
+    /**
+     * Visits the files and directories in this file tree. Files are visited in depth-first prefix order, so that a directory
+     * is visited before its children. The file/directory to be visited is passed to the given action as a {@link
+     * FileVisitDetails}
+     *
+     * @param visitor The visitor.
+     * @return this
+     */
+    FileTree visit(Action<FileVisitDetails> visitor);
 
     /**
      * Returns a {@code FileTree} which contains the union of this tree and the given tree. The returned tree is live,

--- a/subprojects/core/src/main/java/org/gradle/api/file/FileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/file/FileTree.java
@@ -60,7 +60,7 @@ public interface FileTree extends FileCollection {
      * @param filterConfigAction Action to use to configure the filter.
      * @return The filtered tree.
      */
-    FileTree matching(Action<PatternFilterable> filterConfigAction);
+    FileTree matching(Action<? super PatternFilterable> filterConfigAction);
 
     /**
      * <p>Restricts the contents of this tree to those files matching the given filter. The filtered tree is live, so
@@ -102,7 +102,7 @@ public interface FileTree extends FileCollection {
      * @param visitor The visitor.
      * @return this
      */
-    FileTree visit(Action<FileVisitDetails> visitor);
+    FileTree visit(Action<? super FileVisitDetails> visitor);
 
     /**
      * Returns a {@code FileTree} which contains the union of this tree and the given tree. The returned tree is live,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -16,15 +16,14 @@
 package org.gradle.api.internal.file;
 
 import groovy.lang.Closure;
-import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.gradle.api.Action;
 import org.gradle.api.file.*;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Cast;
-import org.gradle.util.ConfigureUtil;
 
 import java.io.File;
 import java.util.LinkedHashMap;
@@ -57,9 +56,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
     }
 
     public FileTree matching(Closure filterConfigClosure) {
-        PatternSet patternSet = new PatternSet();
-        ConfigureUtil.configure(filterConfigClosure, patternSet);
-        return matching(patternSet);
+        return matching(ClosureBackedAction.<PatternFilterable>of(filterConfigClosure));
     }
 
     @Override
@@ -118,7 +115,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
     }
 
     public FileTree visit(Closure closure) {
-        return visit(DefaultGroovyMethods.asType(closure, FileVisitor.class));
+        return visit(ClosureBackedAction.<FileVisitDetails>of(closure));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -60,7 +60,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
     }
 
     @Override
-    public FileTree matching(Action<PatternFilterable> filterConfigAction) {
+    public FileTree matching(Action<? super PatternFilterable> filterConfigAction) {
         PatternSet patternSet = new PatternSet();
         filterConfigAction.execute(patternSet);
         return matching(patternSet);
@@ -119,7 +119,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
     }
 
     @Override
-    public FileTree visit(final Action<FileVisitDetails> visitor) {
+    public FileTree visit(final Action<? super FileVisitDetails> visitor) {
         return visit(new FileVisitor() {
             @Override
             public void visitDir(FileVisitDetails dirDetails) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.file;
 
 import groovy.lang.Closure;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.gradle.api.Action;
 import org.gradle.api.file.*;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskDependency;
@@ -58,6 +59,13 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
     public FileTree matching(Closure filterConfigClosure) {
         PatternSet patternSet = new PatternSet();
         ConfigureUtil.configure(filterConfigClosure, patternSet);
+        return matching(patternSet);
+    }
+
+    @Override
+    public FileTree matching(Action<PatternFilterable> filterConfigAction) {
+        PatternSet patternSet = new PatternSet();
+        filterConfigAction.execute(patternSet);
         return matching(patternSet);
     }
 
@@ -111,6 +119,21 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
 
     public FileTree visit(Closure closure) {
         return visit(DefaultGroovyMethods.asType(closure, FileVisitor.class));
+    }
+
+    @Override
+    public FileTree visit(final Action<FileVisitDetails> visitor) {
+        return visit(new FileVisitor() {
+            @Override
+            public void visitDir(FileVisitDetails dirDetails) {
+                visitor.execute(dirDetails);
+            }
+
+            @Override
+            public void visitFile(FileVisitDetails fileDetails) {
+                visitor.execute(fileDetails);
+            }
+        });
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/CompositeFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/CompositeFileTree.java
@@ -46,7 +46,7 @@ public abstract class CompositeFileTree extends CompositeFileCollection implemen
     }
 
     @Override
-    public FileTree matching(Action<PatternFilterable> filterConfigAction) {
+    public FileTree matching(Action<? super PatternFilterable> filterConfigAction) {
         return new FilteredFileTree(filterConfigAction);
     }
 
@@ -59,7 +59,7 @@ public abstract class CompositeFileTree extends CompositeFileCollection implemen
     }
 
     @Override
-    public FileTree visit(Action<FileVisitDetails> visitor) {
+    public FileTree visit(Action<? super FileVisitDetails> visitor) {
         for (FileTree tree : getSourceCollections()) {
             tree.visit(visitor);
         }
@@ -84,7 +84,7 @@ public abstract class CompositeFileTree extends CompositeFileCollection implemen
     }
 
     private class FilteredFileTree extends CompositeFileTree {
-        private final Action<PatternFilterable> action;
+        private final Action<? super PatternFilterable> action;
         private final PatternFilterable patterns;
 
         public FilteredFileTree(PatternFilterable patterns) {
@@ -92,7 +92,7 @@ public abstract class CompositeFileTree extends CompositeFileCollection implemen
             action = null;
         }
 
-        public FilteredFileTree(Action<PatternFilterable> action) {
+        public FilteredFileTree(Action<? super PatternFilterable> action) {
             this.action = action;
             patterns = null;
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
@@ -15,11 +15,13 @@
  */
 package org.gradle.api.internal.file
 
+import org.gradle.api.Action
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.file.RelativePath
 import org.gradle.api.tasks.TaskDependency
+import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
 
@@ -56,6 +58,30 @@ public class AbstractFileTreeTest extends Specification {
 
         when:
         def filtered = tree.matching { include '*.txt' }
+        filtered.visit(visitor)
+
+        then:
+        1 * visitor.visitFile(file1)
+        0 * visitor._
+    }
+
+    def canFilterTreeUsingAction() {
+        FileVisitDetails file1 = Mock()
+        FileVisitDetails file2 = Mock()
+        FileVisitor visitor = Mock()
+        def tree = new TestFileTree([file1, file2])
+
+        given:
+        _ * file1.relativePath >> new RelativePath(true, 'a.txt')
+        _ * file2.relativePath >> new RelativePath(true, 'b.html')
+
+        when:
+        def filtered = tree.matching(new Action<PatternFilterable>() {
+            @Override
+            void execute(PatternFilterable patternFilterable) {
+                patternFilterable.include '*.txt'
+            }
+        })
         filtered.visit(visitor)
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileTreeTest.java
@@ -16,10 +16,14 @@
 package org.gradle.api.internal.file;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
+import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Actions;
 import org.gradle.testfixtures.internal.NativeServicesTestFixture;
 import org.gradle.util.JUnit4GroovyMockery;
 import org.gradle.util.TestUtil;
@@ -79,6 +83,26 @@ public class CompositeFileTreeTest {
     }
 
     @Test
+    public void matchingWithActionReturnsUnionOfFilteredSets() {
+        final Action<PatternFilterable> action = Actions.doNothing();
+        final FileTreeInternal filtered1 = context.mock(FileTreeInternal.class);
+        final FileTreeInternal filtered2 = context.mock(FileTreeInternal.class);
+
+        context.checking(new Expectations() {{
+            oneOf(source1).matching(action);
+            will(returnValue(filtered1));
+            oneOf(source2).matching(action);
+            will(returnValue(filtered2));
+        }});
+
+        FileTree filtered = tree.matching(action);
+        assertThat(filtered, instanceOf(CompositeFileTree.class));
+        CompositeFileTree filteredCompositeSet = (CompositeFileTree) filtered;
+
+        assertThat(toList(filteredCompositeSet.getSourceCollections()), equalTo(toList(filtered1, filtered2)));
+    }
+
+    @Test
     public void matchingWithPatternSetReturnsUnionOfFilteredSets() {
         final PatternSet patternSet = new PatternSet();
         final FileTreeInternal filtered1 = context.mock(FileTreeInternal.class);
@@ -123,6 +147,18 @@ public class CompositeFileTreeTest {
     @Test
     public void visitsEachTreeWithClosure() {
         final Closure visitor = TestUtil.TEST_CLOSURE;
+
+        context.checking(new Expectations() {{
+            oneOf(source1).visit(visitor);
+            oneOf(source2).visit(visitor);
+        }});
+
+        tree.visit(visitor);
+    }
+
+    @Test
+    public void visitsEachTreeWithAction() {
+        final Action<FileVisitDetails> visitor = Actions.doNothing();
 
         context.checking(new Expectations() {{
             oneOf(source1).visit(visitor);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileTreeTest.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
@@ -65,13 +66,14 @@ public class CompositeFileTreeTest {
     @Test
     public void matchingWithClosureReturnsUnionOfFilteredSets() {
         final Closure closure = TestUtil.TEST_CLOSURE;
+        final Action<PatternFilterable> action = ClosureBackedAction.of(closure);
         final FileTreeInternal filtered1 = context.mock(FileTreeInternal.class);
         final FileTreeInternal filtered2 = context.mock(FileTreeInternal.class);
 
         context.checking(new Expectations() {{
-            oneOf(source1).matching(closure);
+            oneOf(source1).matching(action);
             will(returnValue(filtered1));
-            oneOf(source2).matching(closure);
+            oneOf(source2).matching(action);
             will(returnValue(filtered2));
         }});
 
@@ -147,10 +149,11 @@ public class CompositeFileTreeTest {
     @Test
     public void visitsEachTreeWithClosure() {
         final Closure visitor = TestUtil.TEST_CLOSURE;
+        final Action<FileVisitDetails> action = ClosureBackedAction.of(visitor);
 
         context.checking(new Expectations() {{
-            oneOf(source1).visit(visitor);
-            oneOf(source2).visit(visitor);
+            oneOf(source1).visit(action);
+            oneOf(source2).visit(action);
         }});
 
         tree.visit(visitor);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecResolutionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecResolutionTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
@@ -154,7 +155,7 @@ public class DefaultCopySpecResolutionTest {
             one(fileResolver).resolveFilesAsTree(['a', 'b'] as Set)
             def tree = context.mock(FileTreeInternal, 'source')
             will(returnValue(tree))
-            one(tree).matching(withParam(equalTo(parentSpec.patternSet)))
+            one(tree).matching((PatternFilterable)withParam(equalTo(parentSpec.patternSet)))
             will(returnValue(filteredTree))
         }
 


### PR DESCRIPTION
This PR adds the following missing strongly typed overloads to `FileTree`:
- `FileTree#matching(Action<? super PatternFilterable>)`
- `FileTree#visit(Action<? super FileVisitDetails>)`

See https://github.com/gradle/gradle-script-kotlin/issues/126