### PR TITLE
Adds missing strongly typed overloads to SourceSets

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultGroovySourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultGroovySourceSet.java
@@ -18,9 +18,9 @@ package org.gradle.api.internal.tasks;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.tasks.GroovySourceSet;
-import org.gradle.util.ConfigureUtil;
 
 public class DefaultGroovySourceSet implements GroovySourceSet {
     private final SourceDirectorySet groovy;
@@ -39,8 +39,7 @@ public class DefaultGroovySourceSet implements GroovySourceSet {
     }
 
     public GroovySourceSet groovy(Closure configureClosure) {
-        ConfigureUtil.configure(configureClosure, getGroovy());
-        return this;
+        return groovy(ClosureBackedAction.of(configureClosure));
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultGroovySourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultGroovySourceSet.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.tasks.GroovySourceSet;
@@ -39,6 +40,12 @@ public class DefaultGroovySourceSet implements GroovySourceSet {
 
     public GroovySourceSet groovy(Closure configureClosure) {
         ConfigureUtil.configure(configureClosure, getGroovy());
+        return this;
+    }
+
+    @Override
+    public GroovySourceSet groovy(Action<? super SourceDirectorySet> configureAction) {
+        configureAction.execute(getGroovy());
         return this;
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -21,12 +21,12 @@ import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.internal.jvm.ClassDirectoryBinaryNamingScheme;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
-import org.gradle.util.ConfigureUtil;
 import org.gradle.util.GUtil;
 
 public class DefaultSourceSet implements SourceSet {
@@ -161,8 +161,7 @@ public class DefaultSourceSet implements SourceSet {
     }
 
     public SourceSet java(Closure configureClosure) {
-        ConfigureUtil.configure(configureClosure, getJava());
-        return this;
+        return java(ClosureBackedAction.of(configureClosure));
     }
 
     @Override
@@ -180,8 +179,7 @@ public class DefaultSourceSet implements SourceSet {
     }
 
     public SourceSet resources(Closure configureClosure) {
-        ConfigureUtil.configure(configureClosure, getResources());
-        return this;
+        return resources(ClosureBackedAction.of(configureClosure));
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.tasks;
 
 import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
+import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.SourceDirectorySet;
@@ -164,6 +165,12 @@ public class DefaultSourceSet implements SourceSet {
         return this;
     }
 
+    @Override
+    public SourceSet java(Action<? super SourceDirectorySet> configureAction) {
+        configureAction.execute(getJava());
+        return this;
+    }
+
     public SourceDirectorySet getAllJava() {
         return allJavaSource;
     }
@@ -174,6 +181,12 @@ public class DefaultSourceSet implements SourceSet {
 
     public SourceSet resources(Closure configureClosure) {
         ConfigureUtil.configure(configureClosure, getResources());
+        return this;
+    }
+
+    @Override
+    public SourceSet resources(Action<? super SourceDirectorySet> configureAction) {
+        configureAction.execute(getResources());
         return this;
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/GroovySourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/GroovySourceSet.java
@@ -16,6 +16,7 @@
 package org.gradle.api.tasks;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 
 /**
@@ -40,6 +41,16 @@ public interface GroovySourceSet {
      * @return this
      */
     GroovySourceSet groovy(Closure configureClosure);
+
+    /**
+     * Configures the Groovy source for this set.
+     *
+     * <p>The given action is used to configure the {@link SourceDirectorySet} which contains the Groovy source.
+     *
+     * @param configureAction The action to use to configure the Groovy source.
+     * @return this
+     */
+    GroovySourceSet groovy(Action<? super SourceDirectorySet> configureAction);
 
     /**
      * All Groovy source for this source set.

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
@@ -16,6 +16,7 @@
 package org.gradle.api.tasks;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
@@ -119,6 +120,16 @@ public interface SourceSet {
     SourceSet resources(Closure configureClosure);
 
     /**
+     * Configures the non-Java resources for this set.
+     *
+     * <p>The given action is used to configure the {@link SourceDirectorySet} which contains the resources.
+     *
+     * @param configureAction The action to use to configure the resources.
+     * @return this
+     */
+    SourceSet resources(Action<? super SourceDirectorySet> configureAction);
+
+    /**
      * Returns the Java source which is to be compiled by the Java compiler into the class output directory.
      *
      * @return the Java source. Never returns null.
@@ -134,6 +145,16 @@ public interface SourceSet {
      * @return this
      */
     SourceSet java(Closure configureClosure);
+
+    /**
+     * Configures the Java source for this set.
+     *
+     * <p>The given action is used to configure the {@link SourceDirectorySet} which contains the Java source.
+     *
+     * @param configureAction The action to use to configure the Java source.
+     * @return this
+     */
+    SourceSet java(Action<? super SourceDirectorySet> configureAction);
 
     /**
      * All Java source files for this source set. This includes, for example, source which is directly compiled, and

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultGroovySourceSetTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultGroovySourceSetTest.groovy
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.internal.tasks
 
+import org.gradle.api.Action
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.file.DefaultSourceDirectorySet
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -55,6 +57,17 @@ class DefaultGroovySourceSetTest {
     @Test
     public void canConfigureGroovySource() {
         sourceSet.groovy { srcDir 'src/groovy' }
+        assertThat(sourceSet.groovy.srcDirs, equalTo([tmpDir.file("src/groovy")] as Set))
+    }
+
+    @Test
+    public void canConfigureGroovySourceUsingAnAction() {
+        sourceSet.groovy(new Action<SourceDirectorySet>() {
+            @Override
+            void execute(SourceDirectorySet set) {
+                set.srcDir 'src/groovy'
+            }
+        })
         assertThat(sourceSet.groovy.srcDirs, equalTo([tmpDir.file("src/groovy")] as Set))
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
@@ -15,7 +15,9 @@
  */
 package org.gradle.api.internal.tasks
 
+import org.gradle.api.Action
 import org.gradle.api.Task
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.file.DefaultSourceDirectorySet
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TestFiles
@@ -139,9 +141,31 @@ class DefaultSourceSetTest {
         assertThat(sourceSet.resources.srcDirs, equalTo([tmpDir.file('src/resources')] as Set))
     }
 
+    @Test public void canConfigureResourcesUsingAnAction() {
+        SourceSet sourceSet = sourceSet('main')
+        sourceSet.resources(new Action<SourceDirectorySet>() {
+            @Override
+            void execute(SourceDirectorySet set) {
+                set.srcDir 'src/resources'
+            }
+        })
+        assertThat(sourceSet.resources.srcDirs, equalTo([tmpDir.file('src/resources')] as Set))
+    }
+
     @Test public void canConfigureJavaSource() {
         SourceSet sourceSet = sourceSet('main')
         sourceSet.java { srcDir 'src/java' }
+        assertThat(sourceSet.java.srcDirs, equalTo([tmpDir.file('src/java')] as Set))
+    }
+
+    @Test public void canConfigureJavaSourceUsingAnAction() {
+        SourceSet sourceSet = sourceSet('main')
+        sourceSet.java(new Action<SourceDirectorySet>() {
+            @Override
+            void execute(SourceDirectorySet set) {
+                set.srcDir 'src/java'
+            }
+        })
         assertThat(sourceSet.java.srcDirs, equalTo([tmpDir.file('src/java')] as Set))
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.tasks.ScalaSourceSet;
@@ -39,6 +40,12 @@ public class DefaultScalaSourceSet implements ScalaSourceSet {
 
     public ScalaSourceSet scala(Closure configureClosure) {
         ConfigureUtil.configure(configureClosure, getScala());
+        return this;
+    }
+
+    @Override
+    public ScalaSourceSet scala(Action<? super SourceDirectorySet> configureAction) {
+        configureAction.execute(getScala());
         return this;
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
@@ -18,9 +18,9 @@ package org.gradle.api.internal.tasks;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.tasks.ScalaSourceSet;
-import org.gradle.util.ConfigureUtil;
 
 public class DefaultScalaSourceSet implements ScalaSourceSet {
     private final SourceDirectorySet scala;
@@ -39,8 +39,7 @@ public class DefaultScalaSourceSet implements ScalaSourceSet {
     }
 
     public ScalaSourceSet scala(Closure configureClosure) {
-        ConfigureUtil.configure(configureClosure, getScala());
-        return this;
+        return scala(ClosureBackedAction.of(configureClosure));
     }
 
     @Override

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaSourceSet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaSourceSet.java
@@ -16,6 +16,7 @@
 package org.gradle.api.tasks;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 
 /**
@@ -40,6 +41,16 @@ public interface ScalaSourceSet {
      * @return this
      */
     ScalaSourceSet scala(Closure configureClosure);
+
+    /**
+     * Configures the Scala source for this set.
+     *
+     * <p>The given action is used to configure the {@link SourceDirectorySet} which contains the Scala source.
+     *
+     * @param configureAction The action to use to configure the Scala source.
+     * @return this
+     */
+    ScalaSourceSet scala(Action<? super SourceDirectorySet> configureAction);
 
     /**
      * All Scala source for this source set.

--- a/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/DefaultScalaSourceSetTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/DefaultScalaSourceSetTest.groovy
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.internal.tasks
 
+import org.gradle.api.Action
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.file.DefaultSourceDirectorySet
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -56,6 +58,17 @@ class DefaultScalaSourceSetTest {
     @Test
     public void canConfigureScalaSource() {
         sourceSet.scala { srcDir 'src/scala' }
+        assertThat(sourceSet.scala.srcDirs, equalTo([tmpDir.file('src/scala')] as Set))
+    }
+
+    @Test
+    public void canConfigureScalaSourceUsingAnAction() {
+        sourceSet.scala(new Action<SourceDirectorySet>() {
+            @Override
+            void execute(SourceDirectorySet set) {
+                set.srcDir 'src/scala'
+            }
+        })
         assertThat(sourceSet.scala.srcDirs, equalTo([tmpDir.file('src/scala')] as Set))
     }
 }


### PR DESCRIPTION
This PR adds the following missing strongly typed overloads to SourceTrees:
- `SourceSet#resources(Action<? super SourceDirectorySet>)`
- `SourceSet#java(Action<? super SourceDirectorySet>)`
- `GroovySourceSet#groovy(Action<? super SourceDirectorySet>)`
- `ScalaSourceSet#scala(Action<? super SourceDirectorySet>)`

See gradle/gradle-script-kotlin#124