### PR TITLE
Eclipse resource filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ atlassian-ide-plugin.xml
 # Emacs
 # -----
 *~
+\#*\#
+.\#*
 
 # Textmate
 # --------

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -91,6 +91,7 @@ libraries += [
         jcip: "net.jcip:jcip-annotations:1.0@jar",
         junit: 'junit:junit:4.12@jar',
         xmlunit: 'xmlunit:xmlunit:1.3',
+        equalsVerifier: 'nl.jqno.equalsverifier:equalsverifier:2.1.6',
         nekohtml: 'net.sourceforge.nekohtml:nekohtml:1.9.14',
         xbean: 'org.apache.xbean:xbean-reflect:3.4@jar', //required by maven3 classes
         nativePlatform: 'net.rubygrapefruit:native-platform:0.13',

--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.eclipse.model.EclipseProject.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.eclipse.model.EclipseProject.xml
@@ -36,6 +36,10 @@
                 <td>file</td>
                 <td/>
             </tr>
+            <tr>
+                <td>resourceFilters</td>
+                <td>[]</td>
+            </tr>
         </table>
     </section>
     <section>
@@ -60,6 +64,9 @@
             </tr>
             <tr>
                 <td>file</td>
+            </tr>
+            <tr>
+                <td>resourceFilter</td>
             </tr>
         </table>
     </section>

--- a/subprojects/ide/ide.gradle
+++ b/subprojects/ide/ide.gradle
@@ -30,6 +30,7 @@ dependencies {
     compile libraries.inject
 
     testCompile libraries.xmlunit
+    testCompile libraries.equalsVerifier
     testCompile project(':dependencyManagement')
 
 }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectFixture.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectFixture.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.plugins.ide.eclipse
 
+import groovy.xml.XmlUtil
+import org.custommonkey.xmlunit.XMLUnit
 import org.gradle.test.fixtures.file.TestFile
 
 class EclipseProjectFixture {
@@ -40,10 +42,25 @@ class EclipseProjectFixture {
         return this.project.'comment'.text()
     }
 
+    Node getFilteredResourcesNode() {
+        def r = this.project.filteredResources
+        return r ? r[0] : null
+    }
+
     void assertHasReferencedProjects(String... referencedProjects) {
         assert this.project.projects.project*.text() == referencedProjects as List
     }
 
+    void assertHasResourceFilterXml(String expectedFilteredResourcesXml) {
+        def actualFilteredResourcesXml = XmlUtil.serialize(this.project.filteredResources[0])
+        def xmlUnitIgnoreWhitespaceOriginal = XMLUnit.getIgnoreWhitespace()
+        XMLUnit.setIgnoreWhitespace(true)
+        try {
+            assert XMLUnit.compareXML(expectedFilteredResourcesXml, actualFilteredResourcesXml).similar()
+        } finally {
+            XMLUnit.setIgnoreWhitespace(xmlUnitIgnoreWhitespaceOriginal)
+        }
+    }
 
     void assertHasJavaFacetNatures() {
         assertHasNatures("org.eclipse.jdt.core.javanature",

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectIntegrationTest.groovy
@@ -78,6 +78,540 @@ eclipse {
         assert jdt.contains('source=1.4')
     }
 
+    void "allows custom matcher resource filter"() {
+        given:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    resourceFilter {
+      appliesTo = 'FILES_AND_FOLDERS'
+      type = 'EXCLUDE_ALL'
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'foobar'
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>30</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+    }
+
+    void "allows configuring multiple resource filters"() {
+        given:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    resourceFilter {
+      appliesTo = 'FILES_AND_FOLDERS'
+      type = 'EXCLUDE_ALL'
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'foobar'
+      }
+    }
+    resourceFilter {
+      appliesTo = 'FILES_AND_FOLDERS'
+      type = 'EXCLUDE_ALL'
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'barfoo'
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>30</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+                <filter>
+                        <id>2</id>
+                        <type>30</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>barfoo</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+    }
+
+    void "allows custom matcher resource filter"() {
+        given:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    resourceFilter {
+      appliesTo = 'FILES_AND_FOLDERS'
+      type = 'EXCLUDE_ALL'
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'foobar'
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>30</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+    }
+
+    void "allows 'include only' type resource filter"() {
+        given:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    resourceFilter {
+      appliesTo = 'FILES_AND_FOLDERS'
+      type = 'INCLUDE_ONLY'
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'foobar'
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>29</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+    }
+
+    void "allows resource filter for files"() {
+        given:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    resourceFilter {
+      appliesTo = 'FILES'
+      type = 'INCLUDE_ONLY'
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'foobar'
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>21</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+    }
+
+    void "allows resource filter for folders"() {
+        given:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    resourceFilter {
+      appliesTo = 'FOLDERS'
+      type = 'INCLUDE_ONLY'
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'foobar'
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>25</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+    }
+
+    void "allows non-recursive resource filter"() {
+        given:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    resourceFilter {
+      appliesTo = 'FOLDERS'
+      type = 'INCLUDE_ONLY'
+      recursive = false
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'foobar'
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>9</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+    }
+
+    void "existing resource filters are not duplicated"() {
+        given:
+        def projectFile = file('.project')
+        projectFile << '''<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+        <name>root</name>
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>9</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+</projectDescription>'''
+
+        and:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    // this filter is equivalent to the one that exists in .project already
+    resourceFilter {
+      appliesTo = 'FOLDERS'
+      type = 'INCLUDE_ONLY'
+      recursive = false
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'foobar'
+      }
+    }
+    resourceFilter {
+      appliesTo = 'FILES_AND_FOLDERS'
+      type = 'EXCLUDE_ALL'
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'barfoo'
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>9</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+                <filter>
+                        <id>2</id>
+                        <type>30</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>barfoo</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+    }
+
+    void "existing project file with equivalent resource filters is unchanged"() {
+        given:
+        def projectFile = file('.project')
+        def projectFileOriginalText = '''<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>root</name>
+	<comment></comment>
+	<projects/>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments/>
+		</buildCommand>
+	</buildSpec>
+	<linkedResources/>
+	<filteredResources>
+		<filter>
+			<id>1</id>
+			<type>9</type>
+			<name/>
+			<matcher>
+				<id>org.eclipse.some.custom.matcher</id>
+				<arguments>foobar</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>2</id>
+			<type>30</type>
+			<name/>
+			<matcher>
+				<id>org.eclipse.some.custom.matcher</id>
+				<arguments>barfoo</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>
+'''
+
+        projectFile << projectFileOriginalText
+
+        and:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    // these filters are equivalent to those already in the .project
+    resourceFilter {
+      appliesTo = 'FOLDERS'
+      type = 'INCLUDE_ONLY'
+      recursive = false
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'foobar'
+      }
+    }
+    resourceFilter {
+      appliesTo = 'FILES_AND_FOLDERS'
+      type = 'EXCLUDE_ALL'
+      matcher {
+        id = 'org.eclipse.some.custom.matcher'
+        arguments = 'barfoo'
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>9</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>foobar</arguments>
+                        </matcher>
+                </filter>
+                <filter>
+                        <id>2</id>
+                        <type>30</type>
+                        <name/>
+                        <matcher>
+                                <id>org.eclipse.some.custom.matcher</id>
+                                <arguments>barfoo</arguments>
+                        </matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+        projectFileOriginalText == projectFile.text.normalize()
+    }
+
+    void "allows nested matcher"() {
+        given:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    resourceFilter {
+      appliesTo = 'FOLDERS'
+      type = 'INCLUDE_ONLY'
+      recursive = false
+      matcher {
+        id = 'org.eclipse.ui.ide.orFilterMatcher'
+        matcher {
+          id = 'org.eclipse.ui.ide.multiFilter'
+          arguments = '1.0-name-matches-false-false-node_modules'
+        }
+        matcher {
+          id = 'org.eclipse.ui.ide.multiFilter'
+          arguments = '1.0-name-matches-false-false-target'
+        }
+      }
+    }
+  }
+}
+        """
+        when:
+        run("eclipse")
+        then:
+
+        def resourceFilterXml = '''
+        <filteredResources>
+                <filter>
+                        <id>1</id>
+                        <type>9</type>
+                        <name/>
+			<matcher>
+				<id>org.eclipse.ui.ide.orFilterMatcher</id>
+				<arguments>
+					<matcher>
+						<id>org.eclipse.ui.ide.multiFilter</id>
+						<arguments>1.0-name-matches-false-false-node_modules</arguments>
+					</matcher>
+					<matcher>
+						<id>org.eclipse.ui.ide.multiFilter</id>
+						<arguments>1.0-name-matches-false-false-target</arguments>
+					</matcher>
+				</arguments>
+			</matcher>
+                </filter>
+        </filteredResources>
+
+        '''
+        project.assertHasResourceFilterXml(resourceFilterXml)
+    }
+
     void enablesBeforeAndWhenHooksForProject() {
         given:
         def projectFile = file('.project')

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiProject.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiProject.xml
@@ -23,4 +23,5 @@
 		</buildCommand>
 	</buildSpec>
 	<linkedResources/>
+	<filteredResources/>
 </projectDescription>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonProject.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonProject.xml
@@ -23,4 +23,5 @@
 		</buildCommand>
 	</buildSpec>
 	<linkedResources/>
+	<filteredResources/>
 </projectDescription>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectProject.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectProject.xml
@@ -13,4 +13,5 @@
 		</buildCommand>
 	</buildSpec>
 	<linkedResources/>
+	<filteredResources/>
 </projectDescription>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/javabaseprojectProject.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/javabaseprojectProject.xml
@@ -12,4 +12,5 @@
 		</buildCommand>
 	</buildSpec>
 	<linkedResources/>
+	<filteredResources/>
 </projectDescription>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/masterProject.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/masterProject.xml
@@ -5,4 +5,5 @@
 	<natures/>
 	<buildSpec/>
 	<linkedResources/>
+	<filteredResources/>
 </projectDescription>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Project.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Project.xml
@@ -23,4 +23,5 @@
 		</buildCommand>
 	</buildSpec>
 	<linkedResources/>
+	<filteredResources/>
 </projectDescription>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsProject.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsProject.xml
@@ -23,4 +23,5 @@
 		</buildCommand>
 	</buildSpec>
 	<linkedResources/>
+	<filteredResources/>
 </projectDescription>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceProject.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceProject.xml
@@ -23,4 +23,5 @@
 		</buildCommand>
 	</buildSpec>
 	<linkedResources/>
+	<filteredResources/>
 </projectDescription>

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilter.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilter.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model;
+
+import com.google.common.base.Objects;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.internal.ClosureBackedAction;
+
+/**
+ * The gradle DSL model of an Eclipse resource filter.
+ *
+ * This allows specifying a filter with a custom matcher and configuring
+ * whether it is an include/exclude filter that applies to files, folders,
+ * or both.  The following example excludes the 'node_modules' folder.
+ *
+ * <pre autoTested=''>
+ * apply plugin: 'java'
+ * apply plugin: 'eclipse'
+ *
+ * eclipse {
+ *   project {
+ *     resourceFilter {
+ *       appliesTo = 'FOLDERS'
+ *       type = 'EXCLUDE_ALL'
+ *       matcher {
+ *         id = 'org.eclipse.ui.ide.multiFilter'
+ *         // to find out which arguments to use, configure the desired
+ *         // filter with Eclipse's UI and copy the arguments string over
+ *         arguments = '1.0-name-matches-false-false-node_modules'
+ *       }
+ *     }
+ *   }
+ * }
+ * </pre>
+ *
+ * @since 3.5
+ */
+public final class ResourceFilter {
+    private ResourceFilterAppliesTo appliesTo = ResourceFilterAppliesTo.FILES_AND_FOLDERS;
+    private ResourceFilterType type = ResourceFilterType.EXCLUDE_ALL;
+    private boolean recursive = true;
+    private ResourceFilterMatcher matcher;
+
+    public ResourceFilter() {
+    }
+
+    public ResourceFilter(ResourceFilterAppliesTo appliesTo, ResourceFilterType type, boolean recursive, ResourceFilterMatcher matcher) {
+        this();
+        setAppliesTo(appliesTo);
+        setType(type);
+        setRecursive(recursive);
+        setMatcher(matcher);
+    }
+
+    /**
+     * Indicates whether this ResourceFilter applies to files, folders, or both.  Default is FILES_AND_FOLDERS
+     */
+    public ResourceFilterAppliesTo getAppliesTo() {
+        return appliesTo;
+    }
+    
+    /**
+     * Indicates whether this ResourceFilter applies to files, folders, or both.  Default is FILES_AND_FOLDERS
+     * 
+     * @throws InvalidUserDataException if appliesTo is null.
+     */
+    public void setAppliesTo(ResourceFilterAppliesTo appliesTo) {
+        if (appliesTo == null) {
+            throw new InvalidUserDataException("appliesTo must not be null");
+        }
+        this.appliesTo = appliesTo;
+    }
+    
+    /**
+     * Specifies whether this ResourceFilter is including or excluding resources.  Default is EXCLUDE_ALL
+     */
+    public ResourceFilterType getType() {
+        return type;
+    }
+
+    /**
+     * Sets the ResourceFilterType
+     * 
+     * @throws InvalidUserDataException if type is null.
+     */
+    public void setType(ResourceFilterType type) {
+        if (type == null) {
+            throw new InvalidUserDataException("type must not be null");
+        }
+        this.type = type;
+    }
+
+    /**
+     * Indicates whether this ResourceFilter applies recursively to all children of the project it is created on.  Default is true.
+     */
+    public boolean getRecursive() {
+        return recursive;
+    }
+
+    /**
+     * Sets whether this ResourceFilter applies recursively or not.
+     */
+    public void setRecursive(boolean recursive) {
+        this.recursive = recursive;
+    }
+
+    /**
+     * Gets the matcher of this ResourceFilter.
+     */
+    public ResourceFilterMatcher getMatcher() {
+        return matcher;
+    }
+
+    /**
+     * Sets the matcher of this ResourceFilter.
+     */
+    public void setMatcher(ResourceFilterMatcher matcher) {
+        this.matcher = matcher;
+    }
+
+    /**
+     * Configures the matcher of this resource filter.  Will create the matcher if it does not yet exist, or configure the existing matcher if it already exists.
+     *
+     * @param configureClosure The closure to use to configure the matcher.
+     */
+    public ResourceFilterMatcher matcher(@DelegatesTo(value=ResourceFilterMatcher.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
+        return matcher(new ClosureBackedAction<ResourceFilterMatcher>(configureClosure));
+    }
+
+    /**
+     * Configures the matcher of this resource filter.  Will create the matcher if it does not yet exist, or configure the existing matcher if it already exists.
+     *
+     * @param configureAction The action to use to configure the matcher.
+     */
+    public ResourceFilterMatcher matcher(Action<? super ResourceFilterMatcher> configureAction) {
+        if (this.matcher == null) {
+            this.matcher = new ResourceFilterMatcher();
+        }
+        configureAction.execute(this.matcher);
+        return this.matcher;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (!getClass().equals(o.getClass())) {
+            return false;
+        }
+        ResourceFilter resourceFilter = (ResourceFilter) o;
+        return Objects.equal(appliesTo, resourceFilter.appliesTo)
+            && Objects.equal(type, resourceFilter.type)
+            && Objects.equal(recursive, resourceFilter.recursive)
+            && Objects.equal(matcher, resourceFilter.matcher);
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        result = appliesTo != null ? appliesTo.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + Boolean.valueOf(recursive).hashCode();
+        result = 31 * result + (matcher != null ? matcher.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceFilter{"
+            + "appliesTo='" + appliesTo + '\''
+            + ", type='" + type + '\''
+            + ", recursive='" + recursive + '\''
+            + ", matcher='" + matcher + '\''            
+            + '}';
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterAppliesTo.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterAppliesTo.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model;
+
+/**
+ * Specifies the type of resource that the Eclipse {@link ResourceFilter} applies to.
+ *
+ * @since 3.5
+ */
+public enum ResourceFilterAppliesTo {
+    FILES,
+    FOLDERS,
+    FILES_AND_FOLDERS;
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcher.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcher.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Sets;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Nullable;
+import org.gradle.api.internal.ClosureBackedAction;
+
+import java.util.Set;
+
+/**
+ * The model of an Eclipse resource filter matcher.
+ * <p>
+ * The matcher decides when the containing filter (or containing matcher) applies.  The
+ * matcher configures things like whether this ResourceFilter matches resources by
+ * name, project relative path, location, last modified, etc.  Eclipse has many types
+ * of built-in matchers and it is possible to specify the id and arguments for custom
+ * matchers using this model.
+ * <p>
+ * A matcher must have an id.  It may have either a custom string argument or a set of nested
+ * child matchers (e.g. an 'or' matcher will have several nested condition matchers).
+ * <p>
+ * For more documentation on usage with examples, see {@link ResourceFilter}.
+ *
+ * @since 3.5
+ */
+public final class ResourceFilterMatcher {
+    private String id;
+    private String arguments;
+    private Set<ResourceFilterMatcher> children = Sets.newLinkedHashSet();
+
+    public ResourceFilterMatcher() {
+    }
+
+    public ResourceFilterMatcher(String id, String arguments, Set<ResourceFilterMatcher> children) {
+        this();
+        this.id = id;
+        this.arguments = arguments;
+        this.children = children;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public String getArguments() {
+        return arguments;
+    }
+
+    public void setArguments(String arguments) {
+        this.arguments = arguments;
+    }
+
+    public Set<ResourceFilterMatcher> getChildren() {
+        return children;
+    }
+
+    public void setChildren(Set<ResourceFilterMatcher> children) {
+        if (children == null) {
+            throw new InvalidUserDataException("children must not be null");
+        }
+        this.children = children;
+    }    
+
+    /**
+     * Adds a child/nested matcher to this matcher.
+     *
+     * @param configureClosure The closure to use to configure the matcher.
+     */
+    public ResourceFilterMatcher matcher(@DelegatesTo(value=ResourceFilterMatcher.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
+        return matcher(new ClosureBackedAction<ResourceFilterMatcher>(configureClosure));
+    }
+
+    /**
+     * Adds a child/nested matcher to this matcher.
+     *
+     * @param configureAction The action to use to configure the matcher.
+     */
+    public ResourceFilterMatcher matcher(Action<? super ResourceFilterMatcher> configureAction) {
+        ResourceFilterMatcher m = new ResourceFilterMatcher();
+        configureAction.execute(m);
+        children.add(m);
+        return m;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (!getClass().equals(o.getClass())) {
+            return false;
+        }
+        ResourceFilterMatcher resourceFilterMatcher = (ResourceFilterMatcher) o;
+        return Objects.equal(id, resourceFilterMatcher.id)
+            && Objects.equal(arguments, resourceFilterMatcher.arguments)
+            && Objects.equal(children, resourceFilterMatcher.children);
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (arguments != null ? arguments.hashCode() : 0);
+        result = 31 * result + (children != null ? children.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceFilterMatcher{"
+            + "id='" + id + '\''
+            + ", arguments='" + arguments + '\''
+            + ", children='" + children + '\''
+            + '}';
+    }    
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterType.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model;
+
+/**
+ * Specifies whether an Eclipse {@link ResourceFilter} is including or excluding resources.
+ *
+ * @since 3.5
+ */
+public enum ResourceFilterType {
+    INCLUDE_ONLY,
+    EXCLUDE_ALL;
+}

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ProjectTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ProjectTest.groovy
@@ -26,6 +26,9 @@ public class ProjectTest extends Specification {
     def static final CUSTOM_BUILD_COMMANDS = [new BuildCommand('org.eclipse.jdt.core.scalabuilder', [climate: 'cold'])]
     def static final CUSTOM_NATURES = ['org.eclipse.jdt.core.scalanature'] 
     def static final CUSTOM_LINKED_RESOURCES = [new Link('somename', 'sometype', 'somelocation', '')] as Set
+    def static final CUSTOM_RESOURCE_FILTERS = [
+        new ResourceFilter(ResourceFilterAppliesTo.FILES_AND_FOLDERS, ResourceFilterType.EXCLUDE_ALL, true, new ResourceFilterMatcher('org.eclipse.some.custom.matcher', 'foobar', [] as LinkedHashSet)),
+        new ResourceFilter(ResourceFilterAppliesTo.FOLDERS, ResourceFilterType.INCLUDE_ONLY, false, new ResourceFilterMatcher('org.eclipse.ui.ide.orFilterMatcher', null, [new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet))] as LinkedHashSet
 
     @Rule
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
@@ -42,6 +45,7 @@ public class ProjectTest extends Specification {
         project.buildCommands == CUSTOM_BUILD_COMMANDS
         project.natures == CUSTOM_NATURES
         project.linkedResources == CUSTOM_LINKED_RESOURCES
+        project.resourceFilters == CUSTOM_RESOURCE_FILTERS
     }
 
     def configureMergesValues() {
@@ -52,6 +56,9 @@ public class ProjectTest extends Specification {
         eclipseProject.buildCommands = [new BuildCommand('constructorbuilder')]
         eclipseProject.natures = ['constructorNature']
         eclipseProject.linkedResources = [new Link('constructorName', 'constructorType', 'constructorLocation', '')] as Set
+        eclipseProject.resourceFilters = [
+            new ResourceFilter(ResourceFilterAppliesTo.FILES, ResourceFilterType.INCLUDE_ONLY, false, new ResourceFilterMatcher('matcherId', 'matcherArgs', [] as LinkedHashSet)),
+            new ResourceFilter(ResourceFilterAppliesTo.FILES_AND_FOLDERS, ResourceFilterType.EXCLUDE_ALL, true, new ResourceFilterMatcher('org.eclipse.ui.ide.orFilterMatcher', null, [new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet)] as LinkedHashSet))] as LinkedHashSet
 
         when:
         project.load(customProjectReader)
@@ -64,6 +71,7 @@ public class ProjectTest extends Specification {
         project.buildCommands == CUSTOM_BUILD_COMMANDS + eclipseProject.buildCommands
         project.natures == CUSTOM_NATURES + eclipseProject.natures
         project.linkedResources == eclipseProject.linkedResources + CUSTOM_LINKED_RESOURCES
+        project.resourceFilters == eclipseProject.resourceFilters + CUSTOM_RESOURCE_FILTERS
     }
 
     def loadDefaults() {
@@ -77,6 +85,7 @@ public class ProjectTest extends Specification {
         project.buildCommands == []
         project.natures == []
         project.linkedResources == [] as Set
+        project.resourceFilters == [] as Set
     }
 
     def toXml_shouldContainCustomValues() {
@@ -84,6 +93,7 @@ public class ProjectTest extends Specification {
         eclipseProject.name = 'constructorName'
         eclipseProject.comment = 'constructorComment'
         eclipseProject.referencedProjects = ['constructorRefProject'] as LinkedHashSet
+        eclipseProject.resourceFilters = [new ResourceFilter(ResourceFilterAppliesTo.FOLDERS, ResourceFilterType.INCLUDE_ONLY, true, new ResourceFilterMatcher('matcherId2', 'matcherArgs2', [] as LinkedHashSet))] as LinkedHashSet
 
         when:
         project.load(customProjectReader)

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcherTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcherTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model;
+
+
+import nl.jqno.equalsverifier.EqualsVerifier
+import nl.jqno.equalsverifier.Warning
+import spock.lang.Specification
+
+public class ResourceFilterMatcherTest extends Specification {
+    def "ResourceFilterMatcher equals and hashCode satisfies contract"() {
+        when:
+        EqualsVerifier.forClass(ResourceFilterMatcher.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withPrefabValues(Set.class, [new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet, [] as LinkedHashSet)
+                .verify()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ResourceFilterTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ResourceFilterTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model;
+
+
+import nl.jqno.equalsverifier.EqualsVerifier
+import nl.jqno.equalsverifier.Warning
+import spock.lang.Specification
+
+public class ResourceFilterTest extends Specification {
+    def "ResourceFilter equals and hashCode satisfies contract"() {
+        when:
+        EqualsVerifier.forClass(ResourceFilter.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withPrefabValues(Set.class, [new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet, [] as LinkedHashSet)
+                .verify()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/subprojects/ide/src/test/resources/org/gradle/plugins/ide/eclipse/model/customProject.xml
+++ b/subprojects/ide/src/test/resources/org/gradle/plugins/ide/eclipse/model/customProject.xml
@@ -26,4 +26,33 @@
             <location>somelocation</location>
         </link>
     </linkedResources>
+    <filteredResources>
+        <filter>
+            <id>1</id>
+            <type>30</type>
+            <name/>
+            <matcher>
+                <id>org.eclipse.some.custom.matcher</id>
+                <arguments>foobar</arguments>
+            </matcher>
+        </filter>
+        <filter>
+            <id>1</id>
+            <type>9</type>
+            <name/>
+            <matcher>
+                <id>org.eclipse.ui.ide.orFilterMatcher</id>
+                <arguments>
+                    <matcher>
+                        <id>org.eclipse.ui.ide.multiFilter</id>
+                        <arguments>1.0-name-matches-false-false-node_modules</arguments>
+                    </matcher>
+                    <matcher>
+                        <id>org.eclipse.ui.ide.multiFilter</id>
+                        <arguments>1.0-name-matches-false-false-target</arguments>
+                    </matcher>
+                </arguments>
+            </matcher>
+        </filter>
+    </filteredResources>
 </projectDescription>


### PR DESCRIPTION
Hi @oehme ! This is a draft pull request for the first phase of the eclipse resource filters, adding the EclipseProject DSL support for filters with a basic custom matcher.  I am still cleaning up the documentation, but I wanted to open this so you could start to take a look.

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, I started a discussion on the [Gradle eclipse Buildship plugin bug tracker](https://bugs.eclipse.org/bugs/show_bug.cgi?id=495799)
- [x] Design document: https://github.com/gradle/gradle/tree/master/design-docs/features/ide-integration/richer-eclipse-model/resource-filters
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [x] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
