### PR TITLE
Add a chapter about Running or debugging gradle under Eclipse

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,9 +17,23 @@ git config user.email user@example.com
 You can generate the IntelliJ project by running
 ```
 ./gradlew idea       # *nix-based systems
-./gradlew.bat idea   # Windows
+gradlew idea         # Windows
 ```
-then "Open" it with IntelliJ. Unfortunately, Eclipse project import isn't straightforward so it's not recommended.
+then "Open" it with IntelliJ.
+
+You can generate the Eclipse projects by running
+```
+./gradlew eclipse   # *nix-based systems
+gradlew eclipse     # Windows
+```
+
+### Running or debugging gradle under Eclipse
+1. Create a `Java Application Run/Debug configuration as`
+2. Right click on `launcher/src/main/java/org.gradle.launcher.Main` and select `Run as->Run configuration`
+3. In the Arguments tab, enter: `--no-daemon -Dorg.gradle.appname=gradle`
+4. In the Working Directory tab: `enter you project's root directory`
+5. Apply/Run/Close as needed
+
 
 ## Choosing Tasks
 If you'd like to contribute to Gradle but aren't sure where, please look for issues [labelled help-wanted](https://github.com/gradle/gradle/labels/help-wanted). We have designated these issues as good candidates for easy contribution.


### PR DESCRIPTION
Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [ ] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [ ] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.

Add a chapter about Running or debugging gradle under Eclipse. Fix typo for invoking gradlew.bat under Windows.