### PR TITLE
Use median in performance statistics

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BuildExperimentRunner.java
@@ -201,11 +201,7 @@ public class BuildExperimentRunner {
         if (experiment.getInvocationCount() != null) {
             return experiment.getInvocationCount();
         }
-        if (usesDaemon(experiment)) {
-            return 10;
-        } else {
-            return 14;
-        }
+        return 20;
     }
 
     protected int warmupsForExperiment(BuildExperimentSpec experiment) {
@@ -219,7 +215,7 @@ public class BuildExperimentRunner {
         if (usesDaemon(experiment)) {
             return 20;
         } else {
-            return 4;
+            return 1;
         }
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/measure/DataSeries.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/measure/DataSeries.java
@@ -16,14 +16,19 @@
 
 package org.gradle.performance.measure;
 
+import com.google.common.collect.Lists;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A collection of measurements of some given units.
  */
 public class DataSeries<Q> extends ArrayList<Amount<Q>> {
     private final Amount<Q> average;
+    private final Amount<Q> median;
     private final Amount<Q> max;
     private final Amount<Q> min;
     // https://en.wikipedia.org/wiki/Standard_error
@@ -40,6 +45,7 @@ public class DataSeries<Q> extends ArrayList<Amount<Q>> {
 
         if (isEmpty()) {
             average = null;
+            median = null;
             max = null;
             min = null;
             standardError = null;
@@ -56,6 +62,11 @@ public class DataSeries<Q> extends ArrayList<Amount<Q>> {
             min = min.compareTo(amount) <= 0 ? min : amount;
             max = max.compareTo(amount) >= 0 ? max : amount;
         }
+        List<Amount<Q>> sorted = Lists.newArrayList(this);
+        Collections.sort(sorted);
+        Amount<Q> medianLeft = sorted.get((sorted.size() - 1) / 2);
+        Amount<Q> medianRight = sorted.get((sorted.size() - 1) / 2 + 1 - sorted.size() % 2);
+        median = medianLeft.plus(medianRight).div(2);
         average = total.div(size());
         this.min = min;
         this.max = max;
@@ -79,6 +90,10 @@ public class DataSeries<Q> extends ArrayList<Amount<Q>> {
 
     public Amount<Q> getAverage() {
         return average;
+    }
+
+    public Amount<Q> getMedian() {
+        return median;
     }
 
     public Amount<Q> getMin() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
@@ -39,35 +39,35 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
     protected void headSection(Html html) {
         String rootDir = getDepth() == 0 ? "" : "../";
         html.meta()
-                .httpEquiv("Content-Type")
-                .content("text/html; charset=utf-8");
+            .httpEquiv("Content-Type")
+            .content("text/html; charset=utf-8");
         html.link()
-                .rel("stylesheet")
-                .type("text/css")
-                .href(rootDir + "css/style.css")
-                .end();
+            .rel("stylesheet")
+            .type("text/css")
+            .href(rootDir + "css/style.css")
+            .end();
         html.script()
-                .src(rootDir + "js/jquery.min-1.11.0.js")
-                .end();
+            .src(rootDir + "js/jquery.min-1.11.0.js")
+            .end();
         html.script()
-                .src(rootDir + "js/flot-0.8.1-min.js")
-                .end();
+            .src(rootDir + "js/flot-0.8.1-min.js")
+            .end();
         html.script()
-                .src(rootDir + "js/flot.selection.min.js")
-                .end();
+            .src(rootDir + "js/flot.selection.min.js")
+            .end();
         html.script()
-                .src(rootDir + "js/report.js")
-                .end();
+            .src(rootDir + "js/report.js")
+            .end();
         html.script()
-                .src(rootDir + "js/performanceGraph.js")
-                .end();
+            .src(rootDir + "js/performanceGraph.js")
+            .end();
     }
 
     protected void footer(Html html) {
         html.div()
-                .id("footer")
-                .text(String.format("Generated at %s by %s", format.executionTimestamp(), GradleVersion.current()))
-                .end();
+            .id("footer")
+            .text(String.format("Generated at %s by %s", format.executionTimestamp(), GradleVersion.current()))
+            .end();
     }
 
     public static class NavigationItem {
@@ -153,7 +153,7 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
                 if (data.isEmpty()) {
                     values.add(null);
                 } else {
-                    Amount<T> value = data.getAverage();
+                    Amount<T> value = data.getMedian();
                     values.add(data);
                     if (min == null || value.compareTo(min) < 0) {
                         min = value;
@@ -173,7 +173,7 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
                     td().text("").end();
                     td().text("").end();
                 } else {
-                    Amount<T> value = data.getAverage();
+                    Amount<T> value = data.getMedian();
                     Amount<T> stddev = data.getStandardError();
                     String classAttr = "numeric";
                     if (value.equals(min)) {
@@ -184,13 +184,13 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
                     }
                     td()
                         .classAttr(classAttr)
-                        .title("avg: " + value + ", min: " + data.getMin() + ", max: " + data.getMax() + ", stddev: " + stddev + ", values: " + data)
+                        .title("median: " + value + ", min: " + data.getMin() + ", max: " + data.getMax() + ", stddev: " + stddev + ", values: " + data)
                         .text(value.format())
-                    .end();
+                        .end();
                     td()
                         .classAttr("numeric more-detail")
                         .text("s: " + stddev.format())
-                    .end();
+                        .end();
                 }
             }
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/MeasuredOperationList.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/MeasuredOperationList.groovy
@@ -75,7 +75,7 @@ public class MeasuredOperationList extends LinkedList<MeasuredOperation> {
     }
 
     private String format(DataSeries<?> measurement) {
-        """  ${name} avg: ${measurement.average.format()} min: ${measurement.min.format()}, max: ${measurement.max.format()}, se: ${measurement.standardError.format()}, sem: ${measurement.standardErrorOfMean.format()}
+        """  ${name} median: ${measurement.median.format()} min: ${measurement.min.format()}, max: ${measurement.max.format()}, se: ${measurement.standardError.format()}, sem: ${measurement.standardErrorOfMean.format()}
   > ${measurement.collect { it.format() }}
 """
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
@@ -56,44 +56,44 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
         out.print("\"totalTime\":");
         render(testHistory, new Transformer<String, MeasuredOperationList>() {
             public String transform(MeasuredOperationList original) {
-                return format.seconds(original.getTotalTime().getAverage());
+                return format.seconds(original.getTotalTime().getMedian());
             }
         }, out);
         out.println(",");
         out.print("\"configurationTime\":");
         render(testHistory, new Transformer<String, MeasuredOperationList>() {
             public String transform(MeasuredOperationList original) {
-                return format.seconds(original.getConfigurationTime().getAverage());
+                return format.seconds(original.getConfigurationTime().getMedian());
             }
         }, out);
         out.println(",");
         out.print("\"executionTime\":");
         render(testHistory, new Transformer<String, MeasuredOperationList>() {
             public String transform(MeasuredOperationList original) {
-                return format.seconds(original.getExecutionTime().getAverage());
+                return format.seconds(original.getExecutionTime().getMedian());
             }
         }, out);
         out.println(",");
         out.print("\"compileTotalTime\":");
         render(testHistory, new Transformer<String, MeasuredOperationList>() {
             public String transform(MeasuredOperationList original) {
-                return format.seconds(original.getCompileTotalTime().getAverage());
+                return format.seconds(original.getCompileTotalTime().getMedian());
             }
         }, out);
         out.println(",");
         out.print("\"gcTotalTime\":");
         render(testHistory, new Transformer<String, MeasuredOperationList>() {
             public String transform(MeasuredOperationList original) {
-                return format.seconds(original.getGcTotalTime().getAverage());
+                return format.seconds(original.getGcTotalTime().getMedian());
             }
         }, out);
         out.println(",");
         out.print("\"miscTime\":");
         render(testHistory, new Transformer<String, MeasuredOperationList>() {
             public String transform(MeasuredOperationList original) {
-                Amount<Duration> miscTime = original.getTotalTime().getAverage()
-                    .minus(original.getConfigurationTime().getAverage())
-                    .minus(original.getExecutionTime().getAverage());
+                Amount<Duration> miscTime = original.getTotalTime().getMedian()
+                    .minus(original.getConfigurationTime().getMedian())
+                    .minus(original.getExecutionTime().getMedian());
                 return format.seconds(miscTime);
             }
         }, out);
@@ -101,7 +101,7 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
         out.print("\"heapUsage\":");
         render(testHistory, new Transformer<String, MeasuredOperationList>() {
             public String transform(MeasuredOperationList original) {
-                return format.megabytes(original.getTotalMemoryUsed().getAverage());
+                return format.megabytes(original.getTotalMemoryUsed().getMedian());
             }
         }, out);
         out.println("}");

--- a/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
+++ b/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
@@ -32,6 +32,7 @@
             legend: {
                 noColumns: 0,
                 margin: 1,
+                position: "se",
                 labelFormatter:
                     function(label, series) {
                        return '<a href="#" class="chart-legend" onClick="performanceTests.togglePlot(\''+chartId+'\', \''+label+'\'); return false;">'+label+'</a>';

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestExecutionTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestExecutionTest.groovy
@@ -56,7 +56,7 @@ class CrossVersionPerformanceTestExecutionTest extends ResultSpecification {
         result.assertCurrentVersionHasNotRegressed()
     }
 
-    def "fails when average execution time for current release is larger than average execution time for previous releases"() {
+    def "fails when median execution time for current release is larger than median execution time for previous releases"() {
         given:
         result.baseline("1.0").results << operation(totalTime: 100)
         result.baseline("1.0").results << operation(totalTime: 100)
@@ -77,7 +77,7 @@ class CrossVersionPerformanceTestExecutionTest extends ResultSpecification {
         then:
         AssertionError e = thrown()
         e.message.startsWith("Speed ${result.displayName}: we're slower than 1.0.")
-        e.message.contains('Difference: 10.333 ms slower (10.333 ms), 10.33%')
+        e.message.contains('Difference: 10 ms slower (1E+1 ms), 10.00%, max regression: 0.848 ms')
         !e.message.contains('1.3')
     }
 
@@ -121,7 +121,7 @@ class CrossVersionPerformanceTestExecutionTest extends ResultSpecification {
         then:
         AssertionError e = thrown()
         e.message.startsWith("Memory ${result.displayName}: we need more memory than 1.2.")
-        e.message.contains('Difference: 0.667 B more (0.667 B), 0.07%')
+        e.message.contains('Difference: 1 B more (1 B), 0.10%, max regression: 0.848 B')
         !e.message.contains('than 1.0')
     }
 
@@ -146,9 +146,9 @@ class CrossVersionPerformanceTestExecutionTest extends ResultSpecification {
         then:
         AssertionError e = thrown()
         e.message.contains("Speed ${result.displayName}: we're slower than 1.2.")
-        e.message.contains('Difference: 10.333 ms slower (10.333 ms)')
+        e.message.contains('Difference: 10 ms slower (1E+1 ms), 10.00%, max regression: 0.848 ms')
         e.message.contains("Memory ${result.displayName}: we need more memory than 1.2.")
-        e.message.contains('Difference: 100.333 B more (100.333 B)')
+        e.message.contains('Difference: 100 B more (1E+2 B), 10.00%, max regression: 0.848 B')
         !e.message.contains('than 1.0')
     }
 

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/measure/DataSeriesTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/measure/DataSeriesTest.groovy
@@ -27,6 +27,7 @@ class DataSeriesTest extends Specification {
 
         expect:
         series.average == v2
+        series.median == v2
         series.min == v1
         series.max == v3
         series.standardError == DataAmount.bytes(8360.92)
@@ -42,6 +43,7 @@ class DataSeriesTest extends Specification {
         expect:
         series.size() == 3
         series.average == v2
+        series.average == v2
         series.min == v1
         series.max == v3
     }
@@ -52,6 +54,7 @@ class DataSeriesTest extends Specification {
         expect:
         series.empty
         series.average == null
+        series.median == null
         series.min == null
         series.max == null
         series.standardError == null


### PR DESCRIPTION
With this change, our performance tests and reports will use the median instead of the mean to display and compare data series. The median is more stable in the presence of a few outliers (e.g. garbage collection, JIT compilation).