### PR TITLE
First steps towards backporting compile avoidance to current model

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -32,4 +32,11 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
     void addMutationValidator(MutationValidator validator);
 
     void removeMutationValidator(MutationValidator validator);
+
+    /**
+     * Locks a configuration, making it effectively immutable. Any attempt to mutate this configuration
+     * will throw an exception with the provided error message.
+     * @param message the message to be sent to the user when an attempt to mutate the configuration is done.
+     */
+    void lock(String message);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -141,6 +141,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private boolean canBeConsumed = true;
     private boolean canBeResolved = true;
     private final DefaultAttributeContainer configurationAttributes = new DefaultAttributeContainer();
+    private String lockMessage;
 
     public DefaultConfiguration(String path, String name, ConfigurationsProvider configurationsProvider,
                                 ConfigurationResolver resolver, ListenerManager listenerManager,
@@ -670,6 +671,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         childMutationValidators.remove(validator);
     }
 
+    @Override
+    public void lock(String message) {
+        this.lockMessage = message;
+    }
+
     private void validateParentMutation(MutationType type) {
         // Strategy changes in a parent configuration do not affect this configuration, or any of its children, in any way
         if (type == MutationType.STRATEGY) {
@@ -688,6 +694,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     public void validateMutation(MutationType type) {
+        if (lockMessage != null) {
+            throw new InvalidUserDataException(lockMessage);
+        }
         if (resolvedState == ARTIFACTS_RESOLVED) {
             // The public result for the configuration has been calculated.
             // It is an error to change anything that would change the dependencies or artifacts

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
@@ -24,7 +24,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         given:
         subproject('a') {
             'build.gradle'('''
-                apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+                apply plugin: 'java-library'
                 dependencies {
                     api project(':b')
                 }
@@ -40,7 +40,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         subproject('b') {
             'build.gradle'('''
-                apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+                apply plugin: 'java-library'
             ''')
             src {
                 main {
@@ -63,7 +63,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         given:
         subproject('a') {
             'build.gradle'('''
-                apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+                apply plugin: 'java-library'
                 dependencies {
                     api project(':b')
                 }
@@ -118,7 +118,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         subproject('b') {
             'build.gradle'('''
-                apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+                apply plugin: 'java-library'
             ''')
             src {
                 main {
@@ -140,7 +140,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
     def "doesn't allow declaring dependencies using the 'compile' configuration"() {
         file('settings.gradle') << 'include "b"'
         buildFile << '''
-            apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+            apply plugin: 'java-library'
 
             dependencies {
                 compile project(':b')

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
@@ -137,6 +137,23 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         notExecuted ':b:processResources', ':b:classes', ':b:jar'
     }
 
+    def "doesn't allow declaring dependencies using the 'compile' configuration"() {
+        file('settings.gradle') << 'include "b"'
+        buildFile << '''
+            apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+
+            dependencies {
+                compile project(':b')
+            }
+        '''
+
+        when:
+        fails 'tasks'
+
+        then:
+        failure.assertHasCause "The 'compile' configuration should not be used to declare dependencies. Please use 'api' or 'implementation' instead."
+    }
+
     private void subproject(String name, @DelegatesTo(value=FileTreeBuilder, strategy = Closure.DELEGATE_FIRST) Closure<Void> config) {
         file("settings.gradle") << "include '$name'\n"
         def subprojectDir = file(name)

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
+
+    def "project can declare an API dependency"() {
+        given:
+        subproject('a') {
+            'build.gradle'('''
+                apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+                dependencies {
+                    api project(':b')
+                }
+            ''')
+            src {
+                main {
+                    java {
+                        'ToolImpl.java'('public class ToolImpl implements Tool { public void execute() {} }')
+                    }
+                }
+            }
+        }
+
+        subproject('b') {
+            'build.gradle'('''
+                apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+            ''')
+            src {
+                main {
+                    java {
+                        'Tool.java'('public interface Tool { void execute(); }')
+                    }
+                }
+            }
+        }
+
+        when:
+        succeeds 'a:compileJava'
+
+        then:
+        executedAndNotSkipped ':b:compileJava'
+        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+    }
+
+    def "uses the default configuration when producer is not a library"() {
+        given:
+        subproject('a') {
+            'build.gradle'('''
+                apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+                dependencies {
+                    api project(':b')
+                }
+            ''')
+            src {
+                main {
+                    java {
+                        'ToolImpl.java'('public class ToolImpl implements Tool { public void execute() {} }')
+                    }
+                }
+            }
+        }
+
+        subproject('b') {
+            'build.gradle'('''
+                apply plugin: 'java'
+            ''')
+            src {
+                main {
+                    java {
+                        'Tool.java'('public interface Tool { void execute(); }')
+                    }
+                }
+            }
+        }
+
+        when:
+        succeeds 'a:compileJava'
+
+        then:
+        executedAndNotSkipped ':b:compileJava', ':b:classes', ':b:jar'
+        skipped ':b:processResources'
+    }
+
+    def "uses the API configuration when compiling a project against a library"() {
+        given:
+        subproject('a') {
+            'build.gradle'('''
+                apply plugin: 'java'
+                dependencies {
+                    compile project(':b')
+                }
+            ''')
+            src {
+                main {
+                    java {
+                        'ToolImpl.java'('public class ToolImpl implements Tool { public void execute() {} }')
+                    }
+                }
+            }
+        }
+
+        subproject('b') {
+            'build.gradle'('''
+                apply plugin: org.gradle.api.plugins.JavaLibraryPlugin
+            ''')
+            src {
+                main {
+                    java {
+                        'Tool.java'('public interface Tool { void execute(); }')
+                    }
+                }
+            }
+        }
+
+        when:
+        succeeds 'a:compileJava'
+
+        then:
+        executedAndNotSkipped ':b:compileJava'
+        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+    }
+
+    private void subproject(String name, @DelegatesTo(value=FileTreeBuilder, strategy = Closure.DELEGATE_FIRST) Closure<Void> config) {
+        file("settings.gradle") << "include '$name'\n"
+        def subprojectDir = file(name)
+        subprojectDir.mkdirs()
+        FileTreeBuilder builder = new FileTreeBuilder(subprojectDir)
+        config.setDelegate(builder)
+        config.resolveStrategy = Closure.DELEGATE_FIRST
+        config.call()
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -24,6 +24,7 @@ import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.internal.jvm.ClassDirectoryBinaryNamingScheme;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
@@ -111,20 +112,30 @@ public class DefaultSourceSet implements SourceSet {
     }
 
     public String getCompileConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + "Compile");
+        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.COMPILE_CONFIGURATION_NAME));
     }
 
     public String getRuntimeConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + "Runtime");
+        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.RUNTIME_CONFIGURATION_NAME));
     }
 
     public String getCompileOnlyConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + "CompileOnly");
+        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME));
     }
 
     @Override
     public String getCompileClasspathConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + "CompileClasspath");
+        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+    }
+
+    @Override
+    public String getApiConfigurationName() {
+        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.API_CONFIGURATION_NAME));
+    }
+
+    @Override
+    public String getApiCompileConfigurationName() {
+        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.API_COMPILE_CONFIGURATION_NAME));
     }
 
     public SourceSetOutput getOutput() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -134,6 +134,11 @@ public class DefaultSourceSet implements SourceSet {
     }
 
     @Override
+    public String getImplementationConfigurationName() {
+        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.IMPL_CONFIGURATION_NAME));
+    }
+
+    @Override
     public String getApiCompileConfigurationName() {
         return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.API_COMPILE_CONFIGURATION_NAME));
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -220,9 +220,25 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     }
 
     private void defineConfigurationsForSourceSet(SourceSet sourceSet, ConfigurationContainer configurations) {
+        Configuration apiConfiguration = configurations.maybeCreate(sourceSet.getApiConfigurationName());
+        apiConfiguration.setVisible(false);
+        apiConfiguration.setDescription("API dependencies for " + sourceSet + ".");
+        apiConfiguration.setCanBeResolved(false);
+        apiConfiguration.setCanBeConsumed(false);
+        apiConfiguration.setTransitive(false);
+
+        Configuration apiCompileConfiguration = configurations.maybeCreate(sourceSet.getApiCompileConfigurationName());
+        apiCompileConfiguration.setVisible(false);
+        apiCompileConfiguration.setDescription("API compile classpath for " + sourceSet + ".");
+        apiCompileConfiguration.setCanBeResolved(true);
+        apiCompileConfiguration.setCanBeConsumed(true);
+        apiCompileConfiguration.setTransitive(false);
+        apiCompileConfiguration.extendsFrom(apiConfiguration);
+
         Configuration compileConfiguration = configurations.maybeCreate(sourceSet.getCompileConfigurationName());
         compileConfiguration.setVisible(false);
         compileConfiguration.setDescription("Dependencies for " + sourceSet + ".");
+        compileConfiguration.extendsFrom(apiConfiguration);
 
         Configuration runtimeConfiguration = configurations.maybeCreate(sourceSet.getRuntimeConfigurationName());
         runtimeConfiguration.setVisible(false);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -220,25 +220,9 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     }
 
     private void defineConfigurationsForSourceSet(SourceSet sourceSet, ConfigurationContainer configurations) {
-        Configuration apiConfiguration = configurations.maybeCreate(sourceSet.getApiConfigurationName());
-        apiConfiguration.setVisible(false);
-        apiConfiguration.setDescription("API dependencies for " + sourceSet + ".");
-        apiConfiguration.setCanBeResolved(false);
-        apiConfiguration.setCanBeConsumed(false);
-        apiConfiguration.setTransitive(false);
-
-        Configuration apiCompileConfiguration = configurations.maybeCreate(sourceSet.getApiCompileConfigurationName());
-        apiCompileConfiguration.setVisible(false);
-        apiCompileConfiguration.setDescription("API compile classpath for " + sourceSet + ".");
-        apiCompileConfiguration.setCanBeResolved(true);
-        apiCompileConfiguration.setCanBeConsumed(true);
-        apiCompileConfiguration.setTransitive(false);
-        apiCompileConfiguration.extendsFrom(apiConfiguration);
-
         Configuration compileConfiguration = configurations.maybeCreate(sourceSet.getCompileConfigurationName());
         compileConfiguration.setVisible(false);
         compileConfiguration.setDescription("Dependencies for " + sourceSet + ".");
-        compileConfiguration.extendsFrom(apiConfiguration);
 
         Configuration runtimeConfiguration = configurations.maybeCreate(sourceSet.getRuntimeConfigurationName());
         runtimeConfiguration.setVisible(false);
@@ -254,6 +238,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         compileClasspathConfiguration.setVisible(false);
         compileClasspathConfiguration.extendsFrom(compileOnlyConfiguration);
         compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSet + ".");
+        compileClasspathConfiguration.setCanBeConsumed(false);
 
         sourceSet.setCompileClasspath(compileClasspathConfiguration);
         sourceSet.setRuntimeClasspath(sourceSet.getOutput().plus(runtimeConfiguration));

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -25,6 +25,10 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
 
+/**
+ * <p>A {@link Plugin} which extends the capabilities of the {@link JavaPlugin Java plugin} by cleanly separating
+ * the API and implementation dependencies of a library.</p>
+ */
 public class JavaLibraryPlugin implements Plugin<Project> {
 
     @Override
@@ -44,7 +48,7 @@ public class JavaLibraryPlugin implements Plugin<Project> {
                 JavaCompile javaCompile = (JavaCompile) project.getTasks().findByName(sourceSet.getCompileJavaTaskName());
                 project.getArtifacts().add(sourceSet.getApiCompileConfigurationName(), ImmutableMap.of(
                     "file", javaCompile.getDestinationDir(),
-                    "builtBy", javaCompile ));
+                    "builtBy", javaCompile));
             }
         });
     }
@@ -75,8 +79,8 @@ public class JavaLibraryPlugin implements Plugin<Project> {
 
         Configuration compileConfiguration = configurations.findByName(sourceSet.getCompileConfigurationName());
         compileConfiguration.extendsFrom(implementationConfiguration);
-        ((ConfigurationInternal)compileConfiguration).lock(
-            "The '" + compileConfiguration.getName() +"' configuration should not be used to declare dependencies. Please use '" + sourceSet.getApiConfigurationName()
+        ((ConfigurationInternal) compileConfiguration).lock(
+            "The '" + compileConfiguration.getName() + "' configuration should not be used to declare dependencies. Please use '" + sourceSet.getApiConfigurationName()
                 + "' or '" + implementationConfiguration.getName() + "' instead.");
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -25,6 +25,8 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
 
+import static org.gradle.api.plugins.JavaPlugin.USAGE;
+
 /**
  * <p>A {@link Plugin} which extends the capabilities of the {@link JavaPlugin Java plugin} by cleanly separating
  * the API and implementation dependencies of a library.</p>
@@ -67,7 +69,7 @@ public class JavaLibraryPlugin implements Plugin<Project> {
         apiCompileConfiguration.setCanBeResolved(true);
         apiCompileConfiguration.setCanBeConsumed(true);
         apiCompileConfiguration.setTransitive(false);
-        apiCompileConfiguration.attribute("usage", "api");
+        apiCompileConfiguration.attribute(USAGE, "api");
         apiCompileConfiguration.extendsFrom(apiConfiguration);
 
         Configuration implementationConfiguration = configurations.maybeCreate(sourceSet.getImplementationConfigurationName());

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -61,7 +61,6 @@ public class JavaLibraryPlugin implements Plugin<Project> {
         apiConfiguration.setDescription("API dependencies for " + sourceSet + ".");
         apiConfiguration.setCanBeResolved(false);
         apiConfiguration.setCanBeConsumed(false);
-        apiConfiguration.setTransitive(false);
 
         Configuration apiCompileConfiguration = configurations.maybeCreate(sourceSet.getApiCompileConfigurationName());
         apiCompileConfiguration.setVisible(false);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -21,6 +21,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
 
@@ -74,6 +75,8 @@ public class JavaLibraryPlugin implements Plugin<Project> {
 
         Configuration compileConfiguration = configurations.findByName(sourceSet.getCompileConfigurationName());
         compileConfiguration.extendsFrom(implementationConfiguration);
-
+        ((ConfigurationInternal)compileConfiguration).lock(
+            "The '" + compileConfiguration.getName() +"' configuration should not be used to declare dependencies. Please use '" + sourceSet.getApiConfigurationName()
+                + "' or '" + implementationConfiguration.getName() + "' instead.");
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins;
+
+import com.google.common.collect.ImmutableMap;
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+public class JavaLibraryPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(final Project project) {
+        project.getPluginManager().apply(JavaPlugin.class);
+
+        JavaPluginConvention convention = (JavaPluginConvention) project.getConvention().getPlugins().get("java");
+        final ConfigurationContainer configurations = project.getConfigurations();
+        addApiToMainSourceSet(project, convention, configurations);
+    }
+
+    private void addApiToMainSourceSet(final Project project, JavaPluginConvention convention, final ConfigurationContainer configurations) {
+        convention.getSourceSets().getByName("main", new Action<SourceSet>() {
+            @Override
+            public void execute(SourceSet sourceSet) {
+                defineApiConfigurationsForSourceSet(sourceSet, configurations);
+                JavaCompile javaCompile = (JavaCompile) project.getTasks().findByName(sourceSet.getCompileJavaTaskName());
+                project.getArtifacts().add(sourceSet.getApiCompileConfigurationName(), ImmutableMap.of(
+                    "file", javaCompile.getDestinationDir(),
+                    "builtBy", javaCompile ));
+            }
+        });
+    }
+
+    private void defineApiConfigurationsForSourceSet(SourceSet sourceSet, ConfigurationContainer configurations) {
+        Configuration apiConfiguration = configurations.maybeCreate(sourceSet.getApiConfigurationName());
+        apiConfiguration.setVisible(false);
+        apiConfiguration.setDescription("API dependencies for " + sourceSet + ".");
+        apiConfiguration.setCanBeResolved(false);
+        apiConfiguration.setCanBeConsumed(false);
+        apiConfiguration.setTransitive(false);
+
+        Configuration apiCompileConfiguration = configurations.maybeCreate(sourceSet.getApiCompileConfigurationName());
+        apiCompileConfiguration.setVisible(false);
+        apiCompileConfiguration.setDescription("API compile classpath for " + sourceSet + ".");
+        apiCompileConfiguration.setCanBeResolved(true);
+        apiCompileConfiguration.setCanBeConsumed(true);
+        apiCompileConfiguration.setTransitive(false);
+        apiCompileConfiguration.attribute("usage", "api");
+        apiCompileConfiguration.extendsFrom(apiConfiguration);
+
+        Configuration implementationConfiguration = configurations.maybeCreate(sourceSet.getImplementationConfigurationName());
+        implementationConfiguration.setVisible(false);
+        implementationConfiguration.setDescription("Implementation only dependencies for " + sourceSet + ".");
+        implementationConfiguration.setCanBeConsumed(false);
+        implementationConfiguration.setCanBeResolved(false);
+        implementationConfiguration.extendsFrom(apiConfiguration);
+
+        Configuration compileConfiguration = configurations.findByName(sourceSet.getCompileConfigurationName());
+        compileConfiguration.extendsFrom(implementationConfiguration);
+
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -65,7 +65,7 @@ public class JavaLibraryPlugin implements Plugin<Project> {
         Configuration apiCompileConfiguration = configurations.maybeCreate(sourceSet.getApiCompileConfigurationName());
         apiCompileConfiguration.setVisible(false);
         apiCompileConfiguration.setDescription("API compile classpath for " + sourceSet + ".");
-        apiCompileConfiguration.setCanBeResolved(true);
+        apiCompileConfiguration.setCanBeResolved(false);
         apiCompileConfiguration.setCanBeConsumed(true);
         apiCompileConfiguration.setTransitive(false);
         apiCompileConfiguration.attribute(USAGE, "api");

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -53,10 +53,13 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     public static final String JAR_TASK_NAME = "jar";
     public static final String JAVADOC_TASK_NAME = "javadoc";
 
+    public static final String API_CONFIGURATION_NAME = "api";
+    public static final String API_COMPILE_CONFIGURATION_NAME = "apiCompile";
     public static final String COMPILE_CONFIGURATION_NAME = "compile";
     public static final String COMPILE_ONLY_CONFIGURATION_NAME = "compileOnly";
     public static final String RUNTIME_CONFIGURATION_NAME = "runtime";
     public static final String COMPILE_CLASSPATH_CONFIGURATION_NAME = "compileClasspath";
+    public static final String TEST_API_CONFIGURATION_NAME = "testApi";
     public static final String TEST_COMPILE_CONFIGURATION_NAME = "testCompile";
     public static final String TEST_COMPILE_ONLY_CONFIGURATION_NAME = "testCompileOnly";
     public static final String TEST_RUNTIME_CONFIGURATION_NAME = "testRuntime";

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -54,12 +54,12 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     public static final String JAVADOC_TASK_NAME = "javadoc";
 
     public static final String API_CONFIGURATION_NAME = "api";
+    public static final String IMPL_CONFIGURATION_NAME = "implementation";
     public static final String API_COMPILE_CONFIGURATION_NAME = "apiCompile";
     public static final String COMPILE_CONFIGURATION_NAME = "compile";
     public static final String COMPILE_ONLY_CONFIGURATION_NAME = "compileOnly";
     public static final String RUNTIME_CONFIGURATION_NAME = "runtime";
     public static final String COMPILE_CLASSPATH_CONFIGURATION_NAME = "compileClasspath";
-    public static final String TEST_API_CONFIGURATION_NAME = "testApi";
     public static final String TEST_COMPILE_CONFIGURATION_NAME = "testCompile";
     public static final String TEST_COMPILE_ONLY_CONFIGURATION_NAME = "testCompileOnly";
     public static final String TEST_RUNTIME_CONFIGURATION_NAME = "testRuntime";
@@ -155,6 +155,8 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         configurations.getByName(TEST_RUNTIME_CONFIGURATION_NAME).extendsFrom(runtimeConfiguration, compileTestsConfiguration);
 
         configurations.getByName(Dependency.DEFAULT_CONFIGURATION).extendsFrom(runtimeConfiguration);
+        configurations.getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).attribute("usage", "api");
+
     }
 
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins;
 
 import org.gradle.api.Action;
+import org.gradle.api.Attribute;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -64,6 +65,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     public static final String TEST_COMPILE_ONLY_CONFIGURATION_NAME = "testCompileOnly";
     public static final String TEST_RUNTIME_CONFIGURATION_NAME = "testRuntime";
     public static final String TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME = "testCompileClasspath";
+    public static final Attribute<String> USAGE = Attribute.of("org.gradle.usage", String.class);
 
     public void apply(ProjectInternal project) {
         project.getPluginManager().apply(JavaBasePlugin.class);
@@ -155,7 +157,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         configurations.getByName(TEST_RUNTIME_CONFIGURATION_NAME).extendsFrom(runtimeConfiguration, compileTestsConfiguration);
 
         configurations.getByName(Dependency.DEFAULT_CONFIGURATION).extendsFrom(runtimeConfiguration);
-        configurations.getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).attribute("usage", "api");
+        configurations.getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).attribute(USAGE, "api");
 
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
@@ -245,4 +245,29 @@ public interface SourceSet {
      */
     @Incubating
     String getCompileClasspathConfigurationName();
+
+    /**
+     * Returns the name of the API configuration for this source set. The API configuration
+     * contains dependencies which are exported by this source set, and is not transitive
+     * by default. This configuration is not meant to be resolved and should only contain
+     * dependencies that are required when compiling against this component.
+     *
+     * @return The API configuration name
+     *
+     * @since 3.3
+     */
+    @Incubating
+    String getApiConfigurationName();
+
+    /**
+     * Returns the name of the configuration that should be used when compiling against the API
+     * of this component. This configuration is meant to be consumed by other components when
+     * they need to compile against it.
+     *
+     * @return The API compile configuration name
+     *
+     * @since 3.3
+     */
+    @Incubating
+    String getApiCompileConfigurationName();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
@@ -260,6 +260,15 @@ public interface SourceSet {
     String getApiConfigurationName();
 
     /**
+     * Returns the name of the implementation configuration for this source set. The implementation
+     * configuration should contain dependencies which are specific to the implementation of the component
+     * (internal APIs).
+     * @return The configuration name
+     */
+    @Incubating
+    String getImplementationConfigurationName();
+
+    /**
      * Returns the name of the configuration that should be used when compiling against the API
      * of this component. This configuration is meant to be consumed by other components when
      * they need to compile against it.

--- a/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.java-library.properties
+++ b/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.java-library.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=org.gradle.api.plugins.JavaLibraryPlugin

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
@@ -116,6 +116,8 @@ class DefaultSourceSetTest {
         assertThat(sourceSet.runtimeConfigurationName, equalTo("setNameRuntime"))
         assertThat(sourceSet.compileOnlyConfigurationName, equalTo("setNameCompileOnly"))
         assertThat(sourceSet.compileClasspathConfigurationName, equalTo("setNameCompileClasspath"))
+        assertThat(sourceSet.apiConfigurationName, equalTo("setNameApi"))
+        assertThat(sourceSet.apiCompileConfigurationName, equalTo("setNameApiCompile"))
     }
 
     @Test public void mainSourceSetUsesSpecialCaseNames() {
@@ -133,6 +135,8 @@ class DefaultSourceSetTest {
         assertThat(sourceSet.runtimeConfigurationName, equalTo("runtime"))
         assertThat(sourceSet.compileOnlyConfigurationName, equalTo("compileOnly"))
         assertThat(sourceSet.compileClasspathConfigurationName, equalTo("compileClasspath"))
+        assertThat(sourceSet.apiConfigurationName, equalTo("api"))
+        assertThat(sourceSet.apiCompileConfigurationName, equalTo("apiCompile"))
     }
 
     @Test public void canConfigureResources() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
@@ -37,13 +37,12 @@ class GroovyPluginTest extends AbstractProjectBuilderSpec {
     def "adds groovy configuration to the project"() {
         given:
         groovyPlugin.apply(project)
-        def apiConfiguration = project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME)
 
         when:
         def configuration = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
 
         then:
-        configuration.extendsFrom == [apiConfiguration] as Set
+        configuration.extendsFrom == [] as Set
         !configuration.visible
         configuration.transitive
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
@@ -16,95 +16,107 @@
 
 package org.gradle.api.plugins
 
-import org.gradle.api.Project
-import org.gradle.api.internal.artifacts.configurations.Configurations
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.javadoc.Groovydoc
-import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.Matchers
-import org.gradle.util.TestUtil
-import org.junit.Rule
-import org.junit.Test
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 import static org.gradle.api.tasks.TaskDependencyMatchers.dependsOn
-import static org.gradle.util.WrapUtil.toLinkedSet
-import static org.hamcrest.Matchers.*
-import static org.junit.Assert.*
 
-class GroovyPluginTest {
-    @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
-    private final Project project = TestUtil.create(tmpDir).rootProject()
+class GroovyPluginTest extends AbstractProjectBuilderSpec {
     private final GroovyPlugin groovyPlugin = new GroovyPlugin()
 
-    @Test
-    public void appliesTheJavaPluginToTheProject() {
+    def "applies the java plugin to the project"() {
+        when:
         groovyPlugin.apply(project)
 
-        assertTrue(project.getPlugins().hasPlugin(JavaPlugin));
+        then:
+        project.plugins.hasPlugin(JavaPlugin)
     }
 
-    @Test
-    public void addsGroovyConfigurationToTheProject() {
+    def "adds groovy configuration to the project"() {
+        given:
         groovyPlugin.apply(project)
+        def apiConfiguration = project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME)
 
+        when:
         def configuration = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
-        assertThat(Configurations.getNames(configuration.extendsFrom), Matchers.isEmpty())
-        assertFalse(configuration.visible)
-        assertTrue(configuration.transitive)
+
+        then:
+        configuration.extendsFrom == [apiConfiguration] as Set
+        !configuration.visible
+        configuration.transitive
     }
 
-    @Test
-    public void addsGroovyConventionToEachSourceSet() {
+    def "adds Groovy convention to each source set"() {
+        given:
         groovyPlugin.apply(project)
 
+        when:
         def sourceSet = project.sourceSets.main
-        assertThat(sourceSet.groovy.displayName, equalTo("main Groovy source"))
-        assertThat(sourceSet.groovy.srcDirs, equalTo(toLinkedSet(project.file("src/main/groovy"))))
 
+        then:
+        sourceSet.groovy.displayName == "main Groovy source"
+        sourceSet.groovy.srcDirs == [project.file("src/main/groovy")] as Set
+
+        when:
         sourceSet = project.sourceSets.test
-        assertThat(sourceSet.groovy.displayName, equalTo("test Groovy source"))
-        assertThat(sourceSet.groovy.srcDirs, equalTo(toLinkedSet(project.file("src/test/groovy"))))
+
+        then:
+        sourceSet.groovy.displayName == "test Groovy source"
+        sourceSet.groovy.srcDirs == [project.file("src/test/groovy")] as Set
     }
 
-    @Test
-    public void addsCompileTaskForEachSourceSet() {
+    def "adds compile task for each source set"() {
+        given:
         groovyPlugin.apply(project)
 
+        when:
         def task = project.tasks['compileGroovy']
-        assertThat(task, instanceOf(GroovyCompile.class))
-        assertThat(task.description, equalTo('Compiles the main Groovy source.'))
-        assertThat(task, dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME))
 
+        then:
+        task instanceof GroovyCompile
+        task.description == 'Compiles the main Groovy source.'
+        dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME).matches(task)
+
+        when:
         task = project.tasks['compileTestGroovy']
-        assertThat(task, instanceOf(GroovyCompile.class))
-        assertThat(task.description, equalTo('Compiles the test Groovy source.'))
-        assertThat(task, dependsOn(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaPlugin.CLASSES_TASK_NAME))
+
+        then:
+        task instanceof GroovyCompile
+        task.description == 'Compiles the test Groovy source.'
+        dependsOn(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaPlugin.CLASSES_TASK_NAME).matches(task)
     }
 
-    @Test
-    public void dependenciesOfJavaPluginTasksIncludeGroovyCompileTasks() {
+    def "dependencies of Java plugin tasks include Groovy compile tasks"() {
+        given:
         groovyPlugin.apply(project)
 
+        when:
         def task = project.tasks[JavaPlugin.CLASSES_TASK_NAME]
-        assertThat(task, dependsOn(hasItem('compileGroovy')))
+        then:
+        dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaPlugin.PROCESS_RESOURCES_TASK_NAME, 'compileGroovy').matches(task)
 
+        when:
         task = project.tasks[JavaPlugin.TEST_CLASSES_TASK_NAME]
-        assertThat(task, dependsOn(hasItem('compileTestGroovy')))
+        then:
+        dependsOn(JavaPlugin.PROCESS_TEST_RESOURCES_TASK_NAME, JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, 'compileTestGroovy').matches(task)
     }
 
-    @Test
-    public void addsStandardTasksToTheProject() {
+    def "adds standard tasks to the project"() {
+        given:
         groovyPlugin.apply(project)
 
-        project.sourceSets.main.groovy.srcDirs(tmpDir.getTestDirectory())
-        tmpDir.file("SomeFile.groovy").touch()
+        when:
+        project.sourceSets.main.groovy.srcDirs(temporaryFolder.getTestDirectory())
+        temporaryFolder.file("SomeFile.groovy").touch()
         def task = project.tasks[GroovyPlugin.GROOVYDOC_TASK_NAME]
-        assertThat(task, instanceOf(Groovydoc.class))
-        assertThat(task.destinationDir, equalTo(new File(project.docsDir, 'groovydoc')))
-        assertThat(task.source.files, equalTo(project.sourceSets.main.groovy.files))
-        assertThat(task.docTitle, equalTo(project.extensions.getByType(ReportingExtension).apiDocTitle))
-        assertThat(task.windowTitle, equalTo(project.extensions.getByType(ReportingExtension).apiDocTitle))
+
+        then:
+        task instanceof Groovydoc
+        task.destinationDir == new File(project.docsDir, 'groovydoc')
+        task.source.files == project.sourceSets.main.groovy.files
+        task.docTitle == project.extensions.getByType(ReportingExtension).apiDocTitle
+        task.windowTitle == project.extensions.getByType(ReportingExtension).apiDocTitle
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -156,10 +156,24 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         def sourceSet = project.sourceSets.create('custom')
 
         then:
+        def api = project.configurations.customApi
+        !api.transitive
+        !api.visible
+        api.extendsFrom == [] as Set
+        api.description == "API dependencies for source set 'custom'."
+
+        and:
+        def apiCompile = project.configurations.customApiCompile
+        !apiCompile.transitive
+        !apiCompile.visible
+        apiCompile.extendsFrom == [api] as Set
+        apiCompile.description == "API compile classpath for source set 'custom'."
+
+        and:
         def compile = project.configurations.customCompile
         compile.transitive
         !compile.visible
-        compile.extendsFrom == [] as Set
+        compile.extendsFrom == [api] as Set
         compile.description == "Dependencies for source set 'custom'."
 
         and:

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -156,24 +156,10 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         def sourceSet = project.sourceSets.create('custom')
 
         then:
-        def api = project.configurations.customApi
-        !api.transitive
-        !api.visible
-        api.extendsFrom == [] as Set
-        api.description == "API dependencies for source set 'custom'."
-
-        and:
-        def apiCompile = project.configurations.customApiCompile
-        !apiCompile.transitive
-        !apiCompile.visible
-        apiCompile.extendsFrom == [api] as Set
-        apiCompile.description == "API compile classpath for source set 'custom'."
-
-        and:
         def compile = project.configurations.customCompile
         compile.transitive
         !compile.visible
-        compile.extendsFrom == [api] as Set
+        compile.extendsFrom == [] as Set
         compile.description == "Dependencies for source set 'custom'."
 
         and:
@@ -187,14 +173,14 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         def compileOnly = project.configurations.customCompileOnly
         compileOnly.transitive
         !compileOnly.visible
-        compileOnly.extendsFrom ==  [compile] as Set
+        compileOnly.extendsFrom == [compile] as Set
         compileOnly.description == "Compile dependencies for source set 'custom'."
 
         and:
         def compileClasspath = project.configurations.customCompileClasspath
         compileClasspath.transitive
         !compileClasspath.visible
-        compileClasspath.extendsFrom ==  [compileOnly] as Set
+        compileClasspath.extendsFrom == [compileOnly] as Set
         compileClasspath.description == "Compile classpath for source set 'custom'."
 
         and:

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -55,7 +55,7 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         !apiCompile.visible
         apiCompile.extendsFrom == [api] as Set
         apiCompile.canBeConsumed
-        apiCompile.canBeResolved
+        !apiCompile.canBeResolved
 
         when:
         def implementation = project.configurations.getByName(JavaPlugin.IMPL_CONFIGURATION_NAME)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.artifacts.Dependency
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+import org.gradle.util.TestUtil
+
+import static org.gradle.util.WrapUtil.toSet
+
+class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
+    private final def javaLibraryPlugin = new JavaLibraryPlugin()
+    private final def javaPlugin = new JavaPlugin()
+
+    def "applies Java plugin"() {
+        when:
+        javaLibraryPlugin.apply(project)
+
+        then:
+        project.plugins.findPlugin(JavaPlugin)
+    }
+
+    def "adds configurations to the project"() {
+        given:
+        javaLibraryPlugin.apply(project)
+
+        when:
+        def api = project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME)
+
+        then:
+        !api.visible
+        api.extendsFrom == [] as Set
+        !api.canBeConsumed
+        !api.canBeResolved
+
+        when:
+        def apiCompile = project.configurations.getByName(JavaPlugin.API_COMPILE_CONFIGURATION_NAME)
+
+        then:
+        !apiCompile.visible
+        apiCompile.extendsFrom == [api] as Set
+        apiCompile.canBeConsumed
+        apiCompile.canBeResolved
+
+        when:
+        def implementation = project.configurations.getByName(JavaPlugin.IMPL_CONFIGURATION_NAME)
+
+        then:
+        !implementation.visible
+        implementation.extendsFrom == [api] as Set
+        !implementation.canBeConsumed
+        !implementation.canBeResolved
+
+        when:
+        def compile = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
+
+        then:
+        compile.extendsFrom == [implementation] as Set
+        !compile.visible
+        compile.transitive
+
+        when:
+        def runtime = project.configurations.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME)
+
+        then:
+        runtime.extendsFrom == toSet(compile)
+        !runtime.visible
+        runtime.transitive
+
+        when:
+        def compileOnly = project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
+
+        then:
+        compileOnly.extendsFrom == toSet(compile)
+        !compileOnly.visible
+        compileOnly.transitive
+
+        when:
+        def compileClasspath = project.configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+
+        then:
+        compileClasspath.extendsFrom == toSet(compileOnly)
+        !compileClasspath.visible
+        compileClasspath.transitive
+
+        when:
+        def testCompile = project.configurations.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME)
+
+        then:
+        testCompile.extendsFrom == toSet(compile)
+        !testCompile.visible
+        testCompile.transitive
+
+        when:
+        def testRuntime = project.configurations.getByName(JavaPlugin.TEST_RUNTIME_CONFIGURATION_NAME)
+
+        then:
+        testRuntime.extendsFrom == toSet(runtime, testCompile)
+        !testRuntime.visible
+        testRuntime.transitive
+
+        when:
+        def testCompileOnly = project.configurations.getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME)
+
+        then:
+        testCompileOnly.extendsFrom == toSet(testCompile)
+        !testCompileOnly.visible
+        testCompileOnly.transitive
+
+        when:
+        def testCompileClasspath = project.configurations.getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME)
+
+        then:
+        testCompileClasspath.extendsFrom == toSet(testCompileOnly)
+        !testCompileClasspath.visible
+        testCompileClasspath.transitive
+
+        when:
+        def defaultConfig = project.configurations.getByName(Dependency.DEFAULT_CONFIGURATION)
+
+        then:
+        defaultConfig.extendsFrom == toSet(runtime)
+    }
+
+    def "cannot add dependencies to `compile` configuration"() {
+        given:
+        def commonProject = TestUtil.createChildProject(project, "common")
+        javaLibraryPlugin.apply(project)
+
+        when:
+        project.dependencies {
+            compile commonProject
+        }
+
+        then:
+        def e = thrown(InvalidUserDataException)
+        e.message == "The 'compile' configuration should not be used to declare dependencies. Please use 'api' or 'implementation' instead."
+    }
+
+    def "can declare API and implementation dependencies"() {
+        given:
+        def commonProject = TestUtil.createChildProject(project, "common")
+        def toolsProject = TestUtil.createChildProject(project, "tools")
+        def internalProject = TestUtil.createChildProject(project, "internal")
+
+        javaPlugin.apply(project)
+        javaLibraryPlugin.apply(commonProject)
+        javaLibraryPlugin.apply(toolsProject)
+        javaLibraryPlugin.apply(internalProject)
+
+        when:
+        project.dependencies {
+            compile commonProject
+        }
+        commonProject.dependencies {
+            api toolsProject
+            implementation internalProject
+        }
+
+        def task = project.tasks.compileJava
+
+        then:
+        task.taskDependencies.getDependencies(task)*.path as Set == [':common:compileJava', ':tools:compileJava'] as Set
+
+        when:
+        task = commonProject.tasks.compileJava
+
+        then:
+        task.taskDependencies.getDependencies(task)*.path as Set == [':tools:compileJava', ':internal:compileJava'] as Set
+    }
+}

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -60,30 +60,10 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         javaPlugin.apply(project)
 
         when:
-        def api = project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME)
-
-        then:
-        api.extendsFrom == toSet()
-        !api.visible
-        !api.transitive
-        !api.canBeResolved
-        !api.canBeConsumed
-
-        when:
-        def apiCompile = project.configurations.getByName(JavaPlugin.API_COMPILE_CONFIGURATION_NAME)
-
-        then:
-        apiCompile.extendsFrom == toSet(api)
-        !apiCompile.visible
-        !apiCompile.transitive
-        apiCompile.canBeConsumed
-        apiCompile.canBeResolved
-
-        when:
         def compile = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
 
         then:
-        compile.extendsFrom == toSet(api)
+        compile.extendsFrom == toSet()
         !compile.visible
         compile.transitive
 
@@ -112,11 +92,10 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         compileClasspath.transitive
 
         when:
-        def testApi = project.configurations.getByName(JavaPlugin.TEST_API_CONFIGURATION_NAME)
         def testCompile = project.configurations.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME)
 
         then:
-        testCompile.extendsFrom == toSet(testApi, compile)
+        testCompile.extendsFrom == toSet(compile)
         !testCompile.visible
         testCompile.transitive
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -60,10 +60,30 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         javaPlugin.apply(project)
 
         when:
+        def api = project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME)
+
+        then:
+        api.extendsFrom == toSet()
+        !api.visible
+        !api.transitive
+        !api.canBeResolved
+        !api.canBeConsumed
+
+        when:
+        def apiCompile = project.configurations.getByName(JavaPlugin.API_COMPILE_CONFIGURATION_NAME)
+
+        then:
+        apiCompile.extendsFrom == toSet(api)
+        !apiCompile.visible
+        !apiCompile.transitive
+        apiCompile.canBeConsumed
+        apiCompile.canBeResolved
+
+        when:
         def compile = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
 
         then:
-        compile.extendsFrom == toSet()
+        compile.extendsFrom == toSet(api)
         !compile.visible
         compile.transitive
 
@@ -92,10 +112,11 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         compileClasspath.transitive
 
         when:
+        def testApi = project.configurations.getByName(JavaPlugin.TEST_API_CONFIGURATION_NAME)
         def testCompile = project.configurations.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME)
 
         then:
-        testCompile.extendsFrom == toSet(compile)
+        testCompile.extendsFrom == toSet(testApi, compile)
         !testCompile.visible
         testCompile.transitive
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -17,79 +17,96 @@
 package org.gradle.api.plugins
 
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
-import org.gradle.api.internal.artifacts.configurations.Configurations
 import org.gradle.api.tasks.bundling.War
-import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
 
 import static org.gradle.api.tasks.TaskDependencyMatchers.dependsOn
-import static org.gradle.util.WrapUtil.toSet
-import static org.hamcrest.Matchers.*
-import static org.junit.Assert.*
 
-class WarPluginTest {
-    private Project project // = TestUtil.createRootProject()
-    private WarPlugin warPlugin// = new WarPlugin()
-    @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+class WarPluginTest extends AbstractProjectBuilderSpec {
+    private final WarPlugin warPlugin = new WarPlugin()
 
-    @Before
-    public void setUp() {
-        project = TestUtil.create(tmpDir).rootProject()
-        warPlugin = new WarPlugin()
-    }
-
-    @Test public void appliesJavaPluginAndAddsConvention() {
+    def "applies Java plugin and adds convention"() {
+        when:
         warPlugin.apply(project)
 
-        assertTrue(project.getPlugins().hasPlugin(JavaPlugin));
-        assertThat(project.convention.plugins.war, instanceOf(WarPluginConvention))
+        then:
+        project.getPlugins().hasPlugin(JavaPlugin)
+        project.convention.plugins.war instanceof WarPluginConvention
     }
 
-    @Test public void createsConfigurations() {
+    def "creates configurations"() {
+        given:
         warPlugin.apply(project)
 
-        def configuration = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
-        assertThat(Configurations.getNames(configuration.extendsFrom), equalTo(toSet(WarPlugin.PROVIDED_COMPILE_CONFIGURATION_NAME)))
-        assertFalse(configuration.visible)
-        assertTrue(configuration.transitive)
+        when:
+        def providedCompileConfiguration = project.configurations.getByName(WarPlugin.PROVIDED_COMPILE_CONFIGURATION_NAME)
 
-        configuration = project.configurations.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME)
-        assertThat(Configurations.getNames(configuration.extendsFrom), equalTo(toSet(JavaPlugin.COMPILE_CONFIGURATION_NAME, WarPlugin.PROVIDED_RUNTIME_CONFIGURATION_NAME)))
-        assertFalse(configuration.visible)
-        assertTrue(configuration.transitive)
+        then:
+        providedCompileConfiguration.extendsFrom  == [] as Set
+        !providedCompileConfiguration.visible
+        providedCompileConfiguration.transitive
 
-        configuration = project.configurations.getByName(WarPlugin.PROVIDED_COMPILE_CONFIGURATION_NAME)
-        assertThat(Configurations.getNames(configuration.extendsFrom), equalTo(toSet()))
-        assertFalse(configuration.visible)
-        assertTrue(configuration.transitive)
+        when:
+        def apiConfiguration = project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME)
 
-        configuration = project.configurations.getByName(WarPlugin.PROVIDED_RUNTIME_CONFIGURATION_NAME)
-        assertThat(Configurations.getNames(configuration.extendsFrom), equalTo(toSet(WarPlugin.PROVIDED_COMPILE_CONFIGURATION_NAME)))
-        assertFalse(configuration.visible)
-        assertTrue(configuration.transitive)
+        then:
+        apiConfiguration.extendsFrom == [] as Set
+        !apiConfiguration.visible
+        !apiConfiguration.transitive
+        !apiConfiguration.canBeResolved
+        !apiConfiguration.canBeConsumed
+
+        when:
+        def compileConfiguration = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
+
+        then:
+        compileConfiguration.extendsFrom  == [apiConfiguration, providedCompileConfiguration] as Set
+        !compileConfiguration.visible
+        compileConfiguration.transitive
+
+        when:
+        def providedRuntimeConfiguration = project.configurations.getByName(WarPlugin.PROVIDED_RUNTIME_CONFIGURATION_NAME)
+
+        then:
+        providedRuntimeConfiguration.extendsFrom == [providedCompileConfiguration] as Set
+        !providedRuntimeConfiguration.visible
+        providedRuntimeConfiguration.transitive
+
+        when:
+        def runtimeConfiguration = project.configurations.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME)
+
+        then:
+        runtimeConfiguration.extendsFrom == [compileConfiguration, providedRuntimeConfiguration] as Set
+        !runtimeConfiguration.visible
+        runtimeConfiguration.transitive
+
+
     }
 
-    @Test public void addsTasks() {
+    def "adds tasks"() {
+        when:
         warPlugin.apply(project)
 
+        then:
         def task = project.tasks[WarPlugin.WAR_TASK_NAME]
-        assertThat(task, instanceOf(War))
-        assertThat(task, dependsOn(JavaPlugin.CLASSES_TASK_NAME))
-        assertThat(task.destinationDir, equalTo(project.libsDir))
+        task instanceof War
+        dependsOn(JavaPlugin.CLASSES_TASK_NAME).matches(task)
+        task.destinationDir == project.libsDir
 
+        when:
         task = project.tasks[BasePlugin.ASSEMBLE_TASK_NAME]
-        assertThat(task, dependsOn(WarPlugin.WAR_TASK_NAME))
+
+        then:
+        dependsOn(WarPlugin.WAR_TASK_NAME).matches(task)
     }
 
-    @Test public void dependsOnRuntimeConfig() {
+    def "depends on runtime config"() {
+        given:
         warPlugin.apply(project)
 
+        when:
         Project childProject = TestUtil.createChildProject(project, 'child')
         JavaPlugin javaPlugin = new JavaPlugin()
         javaPlugin.apply(childProject)
@@ -98,11 +115,13 @@ class WarPluginTest {
             runtime project(path: childProject.path, configuration: 'archives')
         }
 
+        then:
         def task = project.tasks[WarPlugin.WAR_TASK_NAME]
-        assertThat(task.taskDependencies.getDependencies(task)*.path as Set, hasItem(':child:jar'))
+        ':child:jar' in task.taskDependencies.getDependencies(task)*.path
     }
 
-    @Test public void usesRuntimeClasspathExcludingProvidedAsClasspath() {
+    def "uses runtime classpath excluding provided as classpath"() {
+        given:
         File compileJar = project.file('compile.jar')
         File compileOnlyJar = project.file('compileOnly.jar')
         File runtimeJar = project.file('runtime.jar')
@@ -110,6 +129,7 @@ class WarPluginTest {
 
         warPlugin.apply(project)
 
+        when:
         project.dependencies {
             providedCompile project.files(providedJar)
             compile project.files(compileJar)
@@ -117,23 +137,31 @@ class WarPluginTest {
             runtime project.files(runtimeJar)
         }
 
+        then:
         def task = project.tasks[WarPlugin.WAR_TASK_NAME]
-        assertThat(task.classpath.files as List, equalTo([project.sourceSets.main.output.classesDir, project.sourceSets.main.output.resourcesDir, runtimeJar, compileJar]))
+        task.classpath.files as List == [project.sourceSets.main.output.classesDir, project.sourceSets.main.output.resourcesDir, runtimeJar, compileJar]
     }
 
-    @Test public void appliesMappingsToArchiveTasks() {
+    def "applies mappings to archive tasks"() {
         warPlugin.apply(project)
 
+        when:
         def task = project.task('customWar', type: War)
-        assertThat(task, dependsOn(hasItems(JavaPlugin.CLASSES_TASK_NAME)))
-        assertThat(task.destinationDir, equalTo(project.libsDir))
+
+        then:
+        dependsOn(JavaPlugin.CLASSES_TASK_NAME).matches(task)
+        task.destinationDir == project.libsDir
     }
 
-    @Test public void replacesJarAsPublication() {
+    def "replaces jar as publication"() {
+        given:
         warPlugin.apply(project)
 
-        Configuration archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION);
-        assertThat(archiveConfiguration.getAllArtifacts().size(), equalTo(1));
-        assertThat(archiveConfiguration.getAllArtifacts().iterator().next().getType(), equalTo("war"));
+        when:
+        def archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)
+
+        then:
+        archiveConfiguration.getAllArtifacts().size() == 1
+        archiveConfiguration.getAllArtifacts()[0].type == "war"
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -49,20 +49,10 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
         providedCompileConfiguration.transitive
 
         when:
-        def apiConfiguration = project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME)
-
-        then:
-        apiConfiguration.extendsFrom == [] as Set
-        !apiConfiguration.visible
-        !apiConfiguration.transitive
-        !apiConfiguration.canBeResolved
-        !apiConfiguration.canBeConsumed
-
-        when:
         def compileConfiguration = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
 
         then:
-        compileConfiguration.extendsFrom  == [apiConfiguration, providedCompileConfiguration] as Set
+        compileConfiguration.extendsFrom  == [providedCompileConfiguration] as Set
         !compileConfiguration.visible
         compileConfiguration.transitive
 


### PR DESCRIPTION
Note: this pull request is done against the long living `cc-java-library-plugin` branch, which will contain the whole Java library compile avoidance plugin and documentation, and will only be merged when it's done. As such, all iterations will be done as pull requests on this branch.

This is the first step towards compile avoidance for the current model. This pull request introduces a new plugin, called `java-library`, which adds a different type of "component" for the current Java model. Libraries separate API from implementation. Therefore, the `compile` configuration is **not** used, and replaced by two distinct configurations holding dependencies: `api` and `implementation`.

Consumers of libraries will depend on the `apiCompile` configuration, so we end up with the following schema:

![configurations dot](https://cloud.githubusercontent.com/assets/316357/20492192/209e7ed4-b014-11e6-8cde-9c0bc7352295.png)

Adding a dependency to the `compile` configuration for a library is a failure.

Backwards compatibility works in both directions: a library can depend on a classic, legacy `java` project. And a `java` project can consume a `library` (in which case compile avoidance works as expected).

See: gradle/performance#180