### PR TITLE
Use configuration attributes for artifact filtering in dependency resolution

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -168,26 +168,6 @@ public interface Configuration extends FileCollection {
     Configuration setTransitive(boolean t);
 
     /**
-     * Returns the format of this configuration.
-     *
-     * @return the format or null if not specified.
-     * @since 3.3
-     */
-    @Incubating @Nullable
-    String getFormat();
-
-    /**
-     * Sets the format of the artifacts this configuration is handling. Can be null if this configuration does not deal with a
-     * specific format.
-     *
-     * @param format the format id
-     * @return this configuration
-     * @since 3.3
-     */
-    @Incubating
-    Configuration setFormat(@Nullable String format);
-
-    /**
      * Returns the description for this configuration.
      *
      * @return the description. May be null.

--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -21,7 +21,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Attribute;
 import org.gradle.api.AttributeContainer;
 import org.gradle.api.Incubating;
-import org.gradle.api.Nullable;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskDependency;

--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/PublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/PublishArtifact.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.AttributeContainer;
 import org.gradle.api.Buildable;
 
 import java.io.File;
@@ -75,5 +74,4 @@ public interface PublishArtifact extends Buildable {
      */
     Date getDate();
 
-    AttributeContainer getAttributes();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/ResolvableDependencies.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/ResolvableDependencies.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.file.FileCollection;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -60,12 +61,12 @@ public interface ResolvableDependencies {
     FileCollection getFiles();
 
     /**
-     * Returns a view of this set containing files with the given format.
+     * Returns a view of this set containing files matching the requested attributes.
      *
      * @since 3.3
      */
     @Incubating
-    FileCollection getFiles(String format);
+    FileCollection getFiles(Map<?, ?> attributes);
 
     /**
      * Returns the set of dependencies which will be resolved.

--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/ResolvedArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/ResolvedArtifact.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.artifacts;
 
+import org.gradle.api.AttributeContainer;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 
@@ -43,4 +44,7 @@ public interface ResolvedArtifact {
 
     @Incubating
     ComponentArtifactIdentifier getId();
+
+    @Incubating
+    AttributeContainer getAttributes();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultAttributeContainer.java
@@ -96,4 +96,10 @@ public class DefaultAttributeContainer implements AttributeContainerInternal {
         return new ImmutableAttributes(attributes);
     }
 
+    public DefaultAttributeContainer copy() {
+        DefaultAttributeContainer container = new DefaultAttributeContainer();
+        container.ensureAttributes();
+        container.attributes.putAll(this.attributes);
+        return container;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/AbstractPublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/AbstractPublishArtifact.java
@@ -15,20 +15,16 @@
  */
 package org.gradle.api.internal.artifacts.publish;
 
-import org.gradle.api.AttributeContainer;
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.internal.DefaultAttributeContainer;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.tasks.TaskDependency;
 
 public abstract class AbstractPublishArtifact implements PublishArtifact {
     private final DefaultTaskDependency taskDependency;
-    private final AttributeContainer attributes;
 
     public AbstractPublishArtifact(Object... tasks) {
         taskDependency = new DefaultTaskDependency();
         taskDependency.add(tasks);
-        this.attributes = new DefaultAttributeContainer();
     }
 
     public TaskDependency getBuildDependencies() {
@@ -38,11 +34,6 @@ public abstract class AbstractPublishArtifact implements PublishArtifact {
     public AbstractPublishArtifact builtBy(Object... tasks) {
         taskDependency.add(tasks);
         return this;
-    }
-
-    @Override
-    public AttributeContainer getAttributes() {
-        return attributes;
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/DefaultPublishArtifactTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/DefaultPublishArtifactTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.publish
 
-import org.gradle.api.Attribute
 import org.gradle.api.Task
 
 public class DefaultPublishArtifactTest extends AbstractPublishArtifactTest {
@@ -55,32 +54,6 @@ public class DefaultPublishArtifactTest extends AbstractPublishArtifactTest {
 
         then:
         publishArtifact.buildDependencies.getDependencies(null) == [task] as Set
-    }
-
-    def "can add attributes to artifact"() {
-        given:
-        def publishArtifact = new DefaultPublishArtifact("name", "extension", "type", null, null, null)
-        def artifactType = Attribute.of('artifactType', String)
-
-        when:
-        publishArtifact.attributes.attribute(artifactType, 'jar')
-
-        then:
-        publishArtifact.attributes.contains(artifactType)
-        publishArtifact.attributes.getAttribute(artifactType) == 'jar'
-    }
-
-    def "can add strongly-typed attributes to artifact"() {
-        given:
-        def publishArtifact = new DefaultPublishArtifact("name", "extension", "type", null, null, null)
-        def artifactType = Attribute.of(ArtifactType)
-
-        when:
-        publishArtifact.attributes.attribute(artifactType, ArtifactType.JAR)
-
-        then:
-        publishArtifact.attributes.contains(artifactType)
-        publishArtifact.attributes.getAttribute(artifactType) == ArtifactType.JAR
     }
 
     enum ArtifactType {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -96,7 +96,7 @@ allprojects {
             project(':app') {
                 configurations {
                     compile {
-                        format = 'jar'
+                        attributes type: 'jar'
                     }
                 }
 
@@ -172,7 +172,7 @@ allprojects {
             project(':app') {
                 configurations {
                     compile {
-                        format = 'jar'
+                        attributes type: 'jar'
                     }
                 }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -96,7 +96,7 @@ allprojects {
             project(':app') {
                 configurations {
                     compile {
-                        attributes type: 'jar'
+                        attributes artifactType: 'jar'
                     }
                 }
 
@@ -123,7 +123,7 @@ allprojects {
                         assert configurations.compile.resolvedConfiguration.lenientConfiguration.getFiles { true }.collect { it.name } == ['lib-util.jar', 'lib.jar', 'some-jar-1.0.jar']
                         
                         // Get a view specifying the default type
-                        assert configurations.compile.incoming.getFiles(type: 'jar').collect { it.name } == ['lib-util.jar', 'lib.jar', 'some-jar-1.0.jar']
+                        assert configurations.compile.incoming.getFiles(artifactType: 'jar').collect { it.name } == ['lib-util.jar', 'lib.jar', 'some-jar-1.0.jar']
                         
                         // Get a view without overriding the type
                         assert configurations.compile.incoming.getFiles(otherAttribute: 'anything').collect { it.name } == ['lib-util.jar', 'lib.jar', 'some-jar-1.0.jar']
@@ -178,7 +178,7 @@ allprojects {
             project(':app') {
                 configurations {
                     compile {
-                        attributes type: 'jar'
+                        attributes artifactType: 'jar'
                     }
                 }
 
@@ -187,7 +187,7 @@ allprojects {
                 }
 
                 task resolve {
-                    def files = configurations.compile.incoming.getFiles(type: 'classes')
+                    def files = configurations.compile.incoming.getFiles(artifactType: 'classes')
                     inputs.files files
                     doLast {
                         assert files.collect { it.name } == ['lib-util.classes', 'lib.classes', 'some-classes-1.0.classes']

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -121,6 +121,12 @@ allprojects {
                         assert configurations.compile.resolvedConfiguration.getFiles { true }.collect { it.name } == ['lib-util.jar', 'lib.jar', 'some-jar-1.0.jar']
                         assert configurations.compile.resolvedConfiguration.lenientConfiguration.files.collect { it.name } == ['lib-util.jar', 'lib.jar', 'some-jar-1.0.jar']
                         assert configurations.compile.resolvedConfiguration.lenientConfiguration.getFiles { true }.collect { it.name } == ['lib-util.jar', 'lib.jar', 'some-jar-1.0.jar']
+                        
+                        // Get a view specifying the default type
+                        assert configurations.compile.incoming.getFiles(type: 'jar').collect { it.name } == ['lib-util.jar', 'lib.jar', 'some-jar-1.0.jar']
+                        
+                        // Get a view without overriding the type
+                        assert configurations.compile.incoming.getFiles(otherAttribute: 'anything').collect { it.name } == ['lib-util.jar', 'lib.jar', 'some-jar-1.0.jar']
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -181,7 +181,7 @@ allprojects {
                 }
 
                 task resolve {
-                    def files = configurations.compile.incoming.getFiles('classes')
+                    def files = configurations.compile.incoming.getFiles(type: 'classes')
                     inputs.files files
                     doLast {
                         assert files.collect { it.name } == ['lib-util.classes', 'lib.classes', 'some-classes-1.0.classes']

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/AbstractAARFilterAndTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/AbstractAARFilterAndTransformIntegrationTest.groovy
@@ -370,7 +370,7 @@ abstract public class AbstractAARFilterAndTransformIntegrationTest extends Abstr
             return ""
         }
         """
-        format = '$formatName'
+        attributes type: '$formatName'
         """
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/AbstractAARFilterAndTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/AbstractAARFilterAndTransformIntegrationTest.groovy
@@ -370,7 +370,7 @@ abstract public class AbstractAARFilterAndTransformIntegrationTest extends Abstr
             return ""
         }
         """
-        attributes type: '$formatName'
+        attributes artifactType: '$formatName'
         """
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -218,7 +218,7 @@ class FileSizer extends ArtifactTransform {
                 }
                 configurations {
                     compile {
-                        attributes type: 'size'
+                        attributes artifactType: 'size'
                         resolutionStrategy.registerTransform(FileSizer) {
                             outputDirectory = project.file("\${buildDir}/transformed")
                         }
@@ -297,7 +297,7 @@ class FileSizer extends ArtifactTransform {
                 }
                 configurations {
                     compile {
-                        attributes type: 'size'
+                        attributes artifactType: 'size'
                         resolutionStrategy.registerTransform(FileSizer) {
                             outputDirectory = project.file("\${buildDir}/transformed")
                         }
@@ -505,7 +505,7 @@ class FileSizer extends ArtifactTransform {
         """
             configurations {
                 compile {
-                    attributes type: 'size'
+                    attributes artifactType: 'size'
                     resolutionStrategy.registerTransform($transformImplementation) {
                         outputDirectory = project.file("\${buildDir}/transformed")
                     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -218,7 +218,7 @@ class FileSizer extends ArtifactTransform {
                 }
                 configurations {
                     compile {
-                        format = 'size'
+                        attributes type: 'size'
                         resolutionStrategy.registerTransform(FileSizer) {
                             outputDirectory = project.file("\${buildDir}/transformed")
                         }
@@ -297,7 +297,7 @@ class FileSizer extends ArtifactTransform {
                 }
                 configurations {
                     compile {
-                        format = 'size'
+                        attributes type: 'size'
                         resolutionStrategy.registerTransform(FileSizer) {
                             outputDirectory = project.file("\${buildDir}/transformed")
                         }
@@ -505,7 +505,7 @@ class FileSizer extends ArtifactTransform {
         """
             configurations {
                 compile {
-                    format = 'size'
+                    attributes type: 'size'
                     resolutionStrategy.registerTransform($transformImplementation) {
                         outputDirectory = project.file("\${buildDir}/transformed")
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedArtifact.java
@@ -15,10 +15,12 @@
  */
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.AttributeContainer;
 import org.gradle.api.Buildable;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
+import org.gradle.api.internal.artifacts.attributes.DefaultArtifactAttributes;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.dynamicversions.DefaultResolvedModuleVersion;
 import org.gradle.api.tasks.TaskDependency;
@@ -32,6 +34,7 @@ public class DefaultResolvedArtifact implements ResolvedArtifact, Buildable {
     private final IvyArtifactName artifact;
     private final ComponentArtifactIdentifier artifactId;
     private final TaskDependency buildDependencies;
+    private final AttributeContainer attributes;
     private Factory<File> artifactSource;
     private File file;
 
@@ -41,6 +44,7 @@ public class DefaultResolvedArtifact implements ResolvedArtifact, Buildable {
         this.artifactId = artifactId;
         this.buildDependencies = buildDependencies;
         this.artifactSource = artifactSource;
+        this.attributes = DefaultArtifactAttributes.forIvyArtifactName(artifact);
     }
 
     @Override
@@ -93,6 +97,11 @@ public class DefaultResolvedArtifact implements ResolvedArtifact, Buildable {
 
     public String getClassifier() {
         return artifact.getClassifier();
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return attributes;
     }
 
     public File getFile() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/attributes/DefaultArtifactAttributes.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/attributes/DefaultArtifactAttributes.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.attributes;
+
+import org.gradle.api.Attribute;
+import org.gradle.api.AttributeContainer;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.DefaultAttributeContainer;
+import org.gradle.internal.component.model.IvyArtifactName;
+
+public class DefaultArtifactAttributes {
+
+    public static final String TYPE_ATTRIBUTE = "artifactType";
+    public static final String EXTENSION_ATTRIBUTE = "artifactExtension";
+    public static final String CLASSIFIER_ATTRIBUTE = "artifactClassifier";
+
+    public static AttributeContainer forIvyArtifactName(IvyArtifactName ivyArtifactName) {
+        return createAttributes(ivyArtifactName.getName(), ivyArtifactName.getType(), ivyArtifactName.getExtension(), ivyArtifactName.getClassifier());
+    }
+
+    public static AttributeContainer forPublishArtifact(PublishArtifact artifact) {
+        return createAttributes(artifact.getName(), artifact.getType(), artifact.getExtension(), artifact.getClassifier());
+    }
+
+    private static AttributeContainer createAttributes(String name, String type, String extension, String classifier) {
+        AttributeContainer attributes = new DefaultAttributeContainer();
+        attributes.attribute(attributeType(TYPE_ATTRIBUTE), type);
+        if (extension != null) {
+            attributes.attribute(attributeType(EXTENSION_ATTRIBUTE), extension);
+        }
+        if (classifier != null) {
+            attributes.attribute(attributeType(CLASSIFIER_ATTRIBUTE), classifier);
+        }
+        return attributes;
+    }
+
+    private static Attribute<String> attributeType(String artifactName) {
+        return Attribute.of(artifactName, String.class);
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -33,5 +33,4 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
 
     void removeMutationValidator(MutationValidator validator);
 
-    String getFormat();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -32,4 +32,6 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
     void addMutationValidator(MutationValidator validator);
 
     void removeMutationValidator(MutationValidator validator);
+
+    String getFormat();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -798,13 +798,17 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     @Override
     public Configuration attributes(Map<?, ?> attributes) {
         validateMutation(MutationType.ATTRIBUTES);
+        populateAttributesFromMap(attributes, configurationAttributes);
+        return this;
+    }
+
+    private void populateAttributesFromMap(Map<?, ?> attributes, AttributeContainer attributeContainer) {
         for (Map.Entry<?, ?> entry : attributes.entrySet()) {
             Object rawKey = entry.getKey();
             Attribute<Object> key = uncheckedCast(asAttribute(rawKey));
             Object value = entry.getValue();
-            configurationAttributes.attribute(key, value);
+            attributeContainer.attribute(key, value);
         }
-        return this;
     }
 
     private static Attribute<?> asAttribute(Object rawKey) {
@@ -911,7 +915,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
 
         @Override
-        public FileCollection getFiles(String format) {
+        public FileCollection getFiles(Map<?, ?> attributes) {
+            AttributeContainer attributeContainer = new DefaultAttributeContainer();
+            populateAttributesFromMap(attributes, attributeContainer);
+            String format = attributeContainer.getAttribute(stringAttribute("type"));
             return new ConfigurationFileCollection(Specs.<Dependency>satisfyAll(), format);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -124,7 +124,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     private boolean visible = true;
     private boolean transitive = true;
-    private String format;
     private Set<Configuration> extendsFrom = new LinkedHashSet<Configuration>();
     private String description;
     private ConfigurationsProvider configurationsProvider;
@@ -273,15 +272,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         return this;
     }
 
-    @Override
     public String getFormat() {
-        return format;
-    }
-
-    @Override
-    public Configuration setFormat(String format) {
-        this.format = format;
-        return this;
+        return configurationAttributes.getAttribute(stringAttribute("type"));
     }
 
     public String getDescription() {
@@ -340,7 +332,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     public Set<File> getFiles() {
-        return doGetFiles(Specs.<Dependency>satisfyAll(), format);
+        return doGetFiles(Specs.<Dependency>satisfyAll(), getFormat());
     }
 
     public Set<File> files(Dependency... dependencies) {
@@ -468,7 +460,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     public TaskDependency getBuildDependencies() {
         assertResolvingAllowed();
-        return doGetTaskDependency(Specs.<Dependency>satisfyAll(), format);
+        return doGetTaskDependency(Specs.<Dependency>satisfyAll(), getFormat());
     }
 
     private TaskDependency doGetTaskDependency(Spec<? super Dependency> dependencySpec, @Nullable String format) {
@@ -747,7 +739,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         @Override
         public TaskDependency getBuildDependencies() {
-            return doGetTaskDependency(dependencySpec, format != null ? format : DefaultConfiguration.this.format);
+            return doGetTaskDependency(dependencySpec, format != null ? format : DefaultConfiguration.this.getFormat());
         }
 
         public Spec<? super Dependency> getDependencySpec() {
@@ -759,7 +751,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
 
         public Set<File> getFiles() {
-            return doGetFiles(dependencySpec, format != null ? format : DefaultConfiguration.this.format);
+            return doGetFiles(dependencySpec, format != null ? format : DefaultConfiguration.this.getFormat());
         }
     }
 
@@ -951,7 +943,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         @Override
         public Set<ResolvedArtifactResult> getArtifacts() {
             resolveToStateOrLater(ARTIFACTS_RESOLVED);
-            return cachedResolverResults.getVisitedArtifacts().select(Specs.<Dependency>satisfyAll(), format).collectArtifacts(new LinkedHashSet<ResolvedArtifactResult>());
+            return cachedResolverResults.getVisitedArtifacts().select(Specs.<Dependency>satisfyAll(), getFormat()).collectArtifacts(new LinkedHashSet<ResolvedArtifactResult>());
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -912,7 +912,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         @Override
         public FileCollection getFiles(Map<?, ?> attributeMap) {
-            AttributeContainerInternal attributes = new DefaultAttributeContainer();
+            AttributeContainerInternal attributes = configurationAttributes.copy();
             populateAttributesFromMap(attributeMap, attributes);
             return new ConfigurationFileCollection(Specs.<Dependency>satisfyAll(), attributes);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactTransformer.java
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.io.Files;
+import org.gradle.api.Attribute;
+import org.gradle.api.AttributeContainer;
 import org.gradle.api.Buildable;
 import org.gradle.api.Nullable;
 import org.gradle.api.Transformer;
@@ -46,9 +48,10 @@ public class ArtifactTransformer {
     }
 
     /**
-     * Returns a spec that selects artifacts with the given format, or which can be transformed into the given format.
+     * Returns a spec that selects artifacts matching the supplied attributes, or which can be transformed to match.
      */
-    public Spec<ResolvedArtifact> select(@Nullable final String format) {
+    public Spec<ResolvedArtifact> select(AttributeContainer attributes) {
+        final String format = getTypeAttribute(attributes);
         if (format == null) {
             return Specs.satisfyAll();
         }
@@ -61,9 +64,11 @@ public class ArtifactTransformer {
     }
 
     /**
-     * Returns a visitor that transforms files and artifacts to the given format and then forwards the results to the given visitor.
+     * Returns a visitor that transforms files and artifacts to match the requested attributes
+     * and then forwards the results to the given visitor.
      */
-    public ArtifactVisitor visitor(final ArtifactVisitor visitor, @Nullable final String format) {
+    public ArtifactVisitor visitor(final ArtifactVisitor visitor, AttributeContainer attributes) {
+        final String format = getTypeAttribute(attributes);
         if (format == null) {
             return visitor;
         }
@@ -125,5 +130,11 @@ public class ArtifactTransformer {
                 }
             }
         };
+    }
+
+    // TODO:DAZ This String attribute doesn't match the strongly typed ArtifactType attribute produced for `ResolvedArtifact`
+    private String getTypeAttribute(AttributeContainer attributes) {
+        Attribute<String> typeAttribute = Attribute.of("type", String.class);
+        return attributes.getAttribute(typeAttribute);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -135,7 +135,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
 
         ArtifactTransformer transformer = new ArtifactTransformer(configuration.getResolutionStrategy());
         DefaultLenientConfiguration result = new DefaultLenientConfiguration(configuration, cacheLockingManager, graphResults.getUnresolvedDependencies(), artifactResults, resolveState.fileDependencyResults, transientConfigurationResultsFactory, transformer);
-        results.artifactsResolved(new DefaultResolvedConfiguration(result), result);
+        results.artifactsResolved(new DefaultResolvedConfiguration(result, configuration.getAttributes()), result);
     }
 
     private static class ArtifactResolveState {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -134,8 +134,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         Factory<TransientConfigurationResults> transientConfigurationResultsFactory = new TransientConfigurationResultsLoader(transientConfigurationResultsBuilder, graphResults, artifactResults);
 
         ArtifactTransformer transformer = new ArtifactTransformer(configuration.getResolutionStrategy());
-        DefaultLenientConfiguration result = new DefaultLenientConfiguration(configuration, configuration.getFormat(), cacheLockingManager, graphResults.getUnresolvedDependencies(), artifactResults, resolveState.fileDependencyResults, transientConfigurationResultsFactory, transformer);
-        results.artifactsResolved(new DefaultResolvedConfiguration(result, configuration.getFormat()), result);
+        DefaultLenientConfiguration result = new DefaultLenientConfiguration(configuration, cacheLockingManager, graphResults.getUnresolvedDependencies(), artifactResults, resolveState.fileDependencyResults, transientConfigurationResultsFactory, transformer);
+        results.artifactsResolved(new DefaultResolvedConfiguration(result), result);
     }
 
     private static class ArtifactResolveState {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.collect.Sets;
-import org.gradle.api.Attribute;
 import org.gradle.api.AttributeContainer;
 import org.gradle.api.Nullable;
 import org.gradle.api.artifacts.Configuration;
@@ -261,9 +260,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
      * @param dependencySpec dependency spec
      */
     private void visitArtifacts(Spec<? super Dependency> dependencySpec, AttributeContainer attributes, ArtifactVisitor visitor) {
-        Attribute<String> typeAttribute = Attribute.of("type", String.class);
-        String format = attributes.getAttribute(typeAttribute);
-        visitor = artifactTransformer.visitor(visitor, format);
+        visitor = artifactTransformer.visitor(visitor, attributes);
 
         //this is not very nice might be good enough until we get rid of ResolvedConfiguration and friends
         //avoid traversing the graph causing the full ResolvedDependency graph to be loaded for the most typical scenario

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -71,15 +71,20 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     private final Factory<TransientConfigurationResults> transientConfigurationResultsFactory;
     private final ArtifactTransformer artifactTransformer;
 
-    public DefaultLenientConfiguration(ConfigurationInternal configuration, String format, CacheLockingManager cacheLockingManager, Set<UnresolvedDependency> unresolvedDependencies, VisitedArtifactsResults artifactResults, VisitedFileDependencyResults fileDependencyResults, Factory<TransientConfigurationResults> transientConfigurationResultsLoader, ArtifactTransformer artifactTransformer) {
+    public DefaultLenientConfiguration(ConfigurationInternal configuration, CacheLockingManager cacheLockingManager, Set<UnresolvedDependency> unresolvedDependencies, VisitedArtifactsResults artifactResults, VisitedFileDependencyResults fileDependencyResults, Factory<TransientConfigurationResults> transientConfigurationResultsLoader, ArtifactTransformer artifactTransformer) {
         this.configuration = configuration;
-        this.format = format;
         this.cacheLockingManager = cacheLockingManager;
         this.unresolvedDependencies = unresolvedDependencies;
         this.artifactResults = artifactResults;
         this.fileDependencyResults = fileDependencyResults;
         this.transientConfigurationResultsFactory = transientConfigurationResultsLoader;
         this.artifactTransformer = artifactTransformer;
+        // TODO:DAZ Should use attributes here
+        this.format = configuration.getFormat();
+    }
+
+    public String getFormat() {
+        return format;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice;
 
-import org.gradle.api.Nullable;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ResolveException;
@@ -33,9 +32,10 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
     private final DefaultLenientConfiguration configuration;
     private final String format;
 
-    public DefaultResolvedConfiguration(DefaultLenientConfiguration configuration, @Nullable String format) {
+    public DefaultResolvedConfiguration(DefaultLenientConfiguration configuration) {
         this.configuration = configuration;
-        this.format = format;
+        // TODO:DAZ Should use attributes here.
+        this.format = configuration.getFormat();
     }
 
     public boolean hasError() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice;
 
+import org.gradle.api.AttributeContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ResolveException;
@@ -30,12 +31,11 @@ import java.util.Set;
 
 public class DefaultResolvedConfiguration implements ResolvedConfiguration {
     private final DefaultLenientConfiguration configuration;
-    private final String format;
+    private final AttributeContainer attributes;
 
-    public DefaultResolvedConfiguration(DefaultLenientConfiguration configuration) {
+    public DefaultResolvedConfiguration(DefaultLenientConfiguration configuration, AttributeContainer attributes) {
         this.configuration = configuration;
-        // TODO:DAZ Should use attributes here.
-        this.format = configuration.getFormat();
+        this.attributes = attributes;
     }
 
     public boolean hasError() {
@@ -57,7 +57,7 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
 
     public Set<File> getFiles(final Spec<? super Dependency> dependencySpec) throws ResolveException {
         rethrowFailure();
-        return configuration.select(dependencySpec, format).collectFiles(new LinkedHashSet<File>());
+        return configuration.select(dependencySpec, attributes).collectFiles(new LinkedHashSet<File>());
     }
 
     public Set<ResolvedDependency> getFirstLevelModuleDependencies() throws ResolveException {
@@ -73,7 +73,7 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
     public Set<ResolvedArtifact> getResolvedArtifacts() throws ResolveException {
         rethrowFailure();
         ArtifactCollectingVisitor visitor = new ArtifactCollectingVisitor();
-        configuration.select(Specs.<Dependency>satisfyAll(), format).visitArtifacts(visitor);
+        configuration.select(Specs.<Dependency>satisfyAll(), attributes).visitArtifacts(visitor);
         return visitor.artifacts;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.AttributeContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ResolveException;
@@ -349,7 +350,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         }
 
         @Override
-        public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, String format) {
+        public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainer attributes) {
             return this;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice;
 
+import org.gradle.api.AttributeContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -92,7 +93,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
 
     private static class EmptyResults implements VisitedArtifactSet, SelectedArtifactSet {
         @Override
-        public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, String format) {
+        public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainer attributes) {
             return this;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
@@ -16,7 +16,8 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import org.gradle.api.Nullable;
+import org.gradle.api.Attribute;
+import org.gradle.api.AttributeContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
@@ -40,7 +41,8 @@ public class BuildDependenciesOnlyVisitedArtifactSet implements VisitedArtifactS
     }
 
     @Override
-    public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, @Nullable String format) {
+    public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainer attributes) {
+        String format = attributes.getAttribute(Attribute.of("type", String.class));
         Spec<ResolvedArtifact> spec = artifactTransformer.select(format);
         ResolvedArtifactSet selectedArtifacts;
         ResolvedArtifactSet selectedFiles;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import org.gradle.api.Attribute;
 import org.gradle.api.AttributeContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ResolveException;
@@ -42,8 +41,7 @@ public class BuildDependenciesOnlyVisitedArtifactSet implements VisitedArtifactS
 
     @Override
     public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainer attributes) {
-        String format = attributes.getAttribute(Attribute.of("type", String.class));
-        Spec<ResolvedArtifact> spec = artifactTransformer.select(format);
+        Spec<ResolvedArtifact> spec = artifactTransformer.select(attributes);
         ResolvedArtifactSet selectedArtifacts;
         ResolvedArtifactSet selectedFiles;
         if (spec == Specs.<ResolvedArtifact>satisfyAll()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactSet.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import org.gradle.api.Nullable;
+import org.gradle.api.AttributeContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.specs.Spec;
 
@@ -30,7 +30,7 @@ public interface VisitedArtifactSet {
      * Not every query is available on the value returned from this method. Details are progressively refined during resolution and more queries become available.
      *
      * @param dependencySpec Select only those artifacts reachable from first level dependencies that match the given spec.
-     * @param format When not null, select only those artifacts which have the given format.
+     * @param attributes Select only those artifacts that match the provided attributes.
      */
-    SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, @Nullable String format);
+    SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainer attributes);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.configurations
 
 import org.gradle.api.Action
 import org.gradle.api.Attribute
+import org.gradle.api.AttributeContainer
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Named
 import org.gradle.api.Project
@@ -1426,7 +1427,7 @@ All Artifacts:
     private visitedArtifacts() {
         def visitedArtifactSet = new VisitedArtifactSet() {
             @Override
-            SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, String format) {
+            SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainer attributes) {
                 return new SelectedArtifactSet() {
                     @Override
                     def <T extends Collection<Object>> T collectBuildDependencies(T dest) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
@@ -33,7 +33,7 @@ class DefaultLenientConfigurationTest extends Specification {
     def "should resolve first level dependencies in tree"() {
         given:
         TransientConfigurationResults transientConfigurationResults = Mock(TransientConfigurationResults)
-        DefaultLenientConfiguration lenientConfiguration = new DefaultLenientConfiguration(null, "format", null, null, null, null, { transientConfigurationResults } as Factory, transformer)
+        DefaultLenientConfiguration lenientConfiguration = new DefaultLenientConfiguration(null, null, null, null, null, { transientConfigurationResults } as Factory, transformer)
         def rootNode = new TestResolvedDependency()
         def child = new TestResolvedDependency()
         rootNode.children.add(child)
@@ -51,7 +51,7 @@ class DefaultLenientConfigurationTest extends Specification {
     def "should resolve and filter first level dependencies in tree"() {
         given:
         TransientConfigurationResults transientConfigurationResults = Mock(TransientConfigurationResults)
-        DefaultLenientConfiguration lenientConfiguration = new DefaultLenientConfiguration(null, "format", null, null, null, null, { transientConfigurationResults } as Factory, transformer)
+        DefaultLenientConfiguration lenientConfiguration = new DefaultLenientConfiguration(null, null, null, null, null, { transientConfigurationResults } as Factory, transformer)
         def spec = Mock(Spec)
         def node1 = new TestResolvedDependency()
         def node2 = new TestResolvedDependency()
@@ -74,7 +74,7 @@ class DefaultLenientConfigurationTest extends Specification {
     def "should flatten all resolved dependencies in dependency tree"() {
         given:
         TransientConfigurationResults transientConfigurationResults = Mock(TransientConfigurationResults)
-        DefaultLenientConfiguration lenientConfiguration = new DefaultLenientConfiguration(null, "format", null, null, null, null, { transientConfigurationResults } as Factory, transformer)
+        DefaultLenientConfiguration lenientConfiguration = new DefaultLenientConfiguration(null, null, null, null, null, { transientConfigurationResults } as Factory, transformer)
 
         def (expected, root) = generateDependenciesWithChildren(treeStructure)
 


### PR DESCRIPTION
This PR removes the separate 'format' property on `Configuration` and instead allows a consumer to define the required artifact types via an 'artifactType' attribute. This attribute is automatically produced for each `ResolvedArtifact` based on the `type` property.

By removing the separate 'format' property, this provides a consistent mechanism for a consuming `Configuration` to specify all aspects of the variant required. However, the current implementation is hard-wired to only consider the 'artifactType' attribute.

At this stage, the artifact attributes are not modelled in any way in the producing configuration: we simply map existing artifact properties to a fixed set of attributes on `ResolvedArtifact`. For external dependencies this is likely to be close to what we want, since we are limited in the set of metadata available. For local dependencies we'll probably want to eventually support custom artifact attributes on the producing configuration. However I'd like to see this requirement driven by real use cases.

I think this is a good step forward for gradle/performance#201, and it should not be too difficult to merge the relevant changes from #887 as well as other commits for this issue (e.g. https://github.com/gradle/gradle/commit/4033969872cde5adb94a841c66a01a8d31cdbe76). 

I think this PR is OK to merge into master as-is (it's not a spike), or we could keep working on it until gradle/performance#201 is complete. Over to you @jjohannes .

