### PR TITLE
Prevent usage of Worker Daemons from custom threads

### DIFF
--- a/subprojects/workers/src/main/java/org/gradle/process/internal/daemon/WorkerDaemonClient.java
+++ b/subprojects/workers/src/main/java/org/gradle/process/internal/daemon/WorkerDaemonClient.java
@@ -33,7 +33,7 @@ class WorkerDaemonClient implements WorkerDaemon, Stoppable {
     public <T extends WorkSpec> WorkerDaemonResult execute(WorkerDaemonAction<T> action, T spec) {
         // currently we just allow a single compilation thread at a time (per compiler daemon)
         // one problem to solve when allowing multiple threads is how to deal with memory requirements specified by compile tasks
-        BuildOperationWorkerRegistry.Completion workerLease = buildOperationWorkerRegistry.operationStart();
+        BuildOperationWorkerRegistry.Completion workerLease = buildOperationWorkerRegistry.getCurrent().operationStart();
         try {
             return workerProcess.execute(action, spec);
         } finally {


### PR DESCRIPTION
When a task action starts a thread that calls execute() and the task action blocks waiting for the thread to complete, we can deadlock due to running out of leases, for example, if this is run with --max-workers=1.

Given that we don't have great visibility about how tasks and threads are related, we simply have execute() throw an exception if not used from a thread we know about, ie a thread that does not have a build operation associated with it.