### PR TITLE
Re-wire configurations for improved backwards compatibility

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -54,6 +54,8 @@
     <!-- Protocol types may only define constants in interfaces -->
     <suppress checks="InterfaceIsTypeCheck"
               files=".*[/\\]subprojects[/\\]tooling-api[/\\]src[/\\]main[/\\]java[/\\]org[/\\]gradle[/\\]tooling[/\\]internal[/\\]protocol.+"/>
+    <suppress checks="InterfaceIsTypeCheck"
+              files=".*[/\\]subprojects[/\\]plugins[/\\]src[/\\]main[/\\]java[/\\]org[/\\]gradle[/\\]api[/\\]plugins[/\\]JavaBasePlugin.+"/>
 
 
 </suppressions>

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -33,7 +33,6 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
 
     void removeMutationValidator(MutationValidator validator);
 
-
     /**
      * Locks a configuration, making it effectively immutable. Any attempt to mutate this configuration
      * will throw an exception with the provided error message.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -33,11 +33,4 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
 
     void removeMutationValidator(MutationValidator validator);
 
-    /**
-     * Locks a configuration, making it effectively immutable. Any attempt to mutate this configuration
-     * will throw an exception with the provided error message.
-     * @param message the message to be sent to the user when an attempt to mutate the configuration is done.
-     */
-    void lock(String message);
-
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
@@ -18,12 +18,12 @@ package org.gradle.api.internal.artifacts.configurations;
 import org.gradle.api.artifacts.Configuration;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class Configurations {
     public static Set<String> getNames(Collection<Configuration> configurations) {
-        Set<String> names = new HashSet<String>(configurations.size());
+        Set<String> names = new LinkedHashSet<String>(configurations.size());
         for (Configuration configuration : configurations) {
             names.add(configuration.getName());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -145,7 +145,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private boolean canBeConsumed = true;
     private boolean canBeResolved = true;
     private final DefaultAttributeContainer configurationAttributes = new DefaultAttributeContainer();
-    private String lockMessage;
 
     public DefaultConfiguration(Path identityPath, String path, String name,
                                 ConfigurationsProvider configurationsProvider,
@@ -675,10 +674,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         childMutationValidators.remove(validator);
     }
 
-    @Override
-    public void lock(String message) {
-        this.lockMessage = message;
-    }
 
     private void validateParentMutation(MutationType type) {
         // Strategy changes in a parent configuration do not affect this configuration, or any of its children, in any way
@@ -698,9 +693,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     public void validateMutation(MutationType type) {
-        if (lockMessage != null) {
-            throw new InvalidUserDataException(lockMessage);
-        }
         if (resolvedState == ARTIFACTS_RESOLVED) {
             // The public result for the configuration has been calculated.
             // It is an error to change anything that would change the dependencies or artifacts

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -281,7 +281,7 @@ rootProject.name = 'root'
 
         then:
         output.contains """
-compile - Dependencies for source set 'main'.
+compile - Dependencies for source set 'main' (deprecated, use 'implementation ' instead).
 +--- project :a
 |    \\--- foo:bar:1.0 -> 3.0
 |         \\--- foo:baz:5.0
@@ -662,7 +662,7 @@ rootProject.name = 'root'
 
         then:
         output.contains """
-compile - Dependencies for source set 'main'.
+compile - Dependencies for source set 'main' (deprecated, use 'implementation ' instead).
 +--- project :a
 |    \\--- foo:bar:1.0 -> 2.0
 +--- project :b

--- a/subprojects/docs/src/samples/ivypublish/build.gradle
+++ b/subprojects/docs/src/samples/ivypublish/build.gradle
@@ -48,7 +48,10 @@ uploadArchives {
         def ns = new groovy.xml.Namespace("http://ant.apache.org/ivy/maven", 'm')
         def root = new XmlParser().parse(new File(repoDir, 'ivy.xml'))
         assert root.publications.artifact.find { it.@name == 'ivypublishSource' }.attribute(ns.classifier) == 'src'
-        assert (root.configurations.conf.collect { it.@name } as Set) == ['archives', 'compile', 'default', 'runtime', 'testCompile', 'testRuntime', 'compileOnly', 'testCompileOnly', 'compileClasspath', 'testCompileClasspath'] as Set
+        assert (root.configurations.conf.collect { it.@name } as Set) == ['archives', 'compile', 'compileClasspath', 'compileOnly', 'default',
+                                                                          'implementation', 'runtime', 'runtimeClasspath', 'runtimeElements',
+                                                                          'runtimeOnly', 'testCompile', 'testCompileClasspath', 'testCompileOnly',
+                                                                          'testImplementation', 'testRuntime', 'testRuntimeClasspath', 'testRuntimeOnly'] as Set
         assert root.dependencies.dependency.find { it.@org == 'junit' }.attributes() == [org: 'junit', name: 'junit', rev: '4.12', conf: 'compile->default']
         assert root.dependencies.dependency.find { it.@org == 'ivypublish' }.attributes() == [org: 'ivypublish', name: 'subproject', rev: 'unspecified',
                 conf: 'compile->default']

--- a/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyRemoteLegacyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyRemoteLegacyPublishIntegrationTest.groovy
@@ -93,7 +93,7 @@ uploadArchives {
         then:
         module.assertIvyAndJarFilePublished()
         module.jarFile.assertIsCopyOf(file('build/libs/publish-2.jar'))
-        module.parsedIvy.expectArtifact("publish", "jar").hasAttributes("jar", "jar", ["archives", "runtime"], null)
+        module.parsedIvy.expectArtifact("publish", "jar").hasAttributes("jar", "jar", ["archives", "runtime", "runtimeElements"], null)
 
         with (module.parsedIvy) {
             dependencies.size() == 6

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -317,4 +317,118 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         then:
         noExceptionThrown()
     }
+
+    def "test runtime classpath includes implementation dependencies"() {
+        given:
+        buildFile << '''
+            apply plugin: 'java'
+
+            repositories {
+                jcenter()
+            }
+
+            dependencies {
+                implementation 'org.apache.commons:commons-lang3:3.4'
+                testCompile 'junit:junit:4.12' // not using testImplementation intentionaly, that's not what we want to test
+            }
+        '''
+        file('src/main/java/Text.java') << '''import org.apache.commons.lang3.StringUtils;
+            public class Text {
+                public static String sayHello(String name) { return "Hello, " + StringUtils.capitalize(name); }
+            }
+        '''
+        file('src/test/java/TextTest.java') << '''
+            import org.junit.Test;
+            import static org.junit.Assert.*;
+
+            public class TextTest {
+                @Test
+                public void testGreeting() {
+                    assertEquals("Hello, Cedric", Text.sayHello("cedric"));
+                }
+            }
+        '''
+
+        when:
+        run 'test'
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "test runtime classpath includes test implementation dependencies"() {
+        given:
+        buildFile << '''
+            apply plugin: 'java'
+
+            repositories {
+                jcenter()
+            }
+
+            dependencies {
+                implementation 'org.apache.commons:commons-lang3:3.4'
+                testImplementation 'junit:junit:4.12'
+            }
+        '''
+        file('src/main/java/Text.java') << '''import org.apache.commons.lang3.StringUtils;
+            public class Text {
+                public static String sayHello(String name) { return "Hello, " + StringUtils.capitalize(name); }
+            }
+        '''
+        file('src/test/java/TextTest.java') << '''
+            import org.junit.Test;
+            import static org.junit.Assert.*;
+
+            public class TextTest {
+                @Test
+                public void testGreeting() {
+                    assertEquals("Hello, Cedric", Text.sayHello("cedric"));
+                }
+            }
+        '''
+
+        when:
+        run 'test'
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "test compile classpath includes implementation dependencies"() {
+        given:
+        buildFile << '''
+            apply plugin: 'java'
+
+            repositories {
+                jcenter()
+            }
+
+            dependencies {
+                implementation 'org.apache.commons:commons-lang3:3.4'
+                testImplementation 'junit:junit:4.12'
+            }
+        '''
+        file('src/main/java/Text.java') << '''import org.apache.commons.lang3.StringUtils;
+            public class Text {
+                public static String sayHello(String name) { return "Hello, " + StringUtils.capitalize(name); }
+            }
+        '''
+        file('src/test/java/TextTest.java') << '''import org.apache.commons.lang3.StringUtils;
+            import org.junit.Test;
+            import static org.junit.Assert.*;
+
+            public class TextTest {
+                @Test
+                public void testGreeting() {
+                    assertEquals(StringUtils.capitalize("hello, Cedric"), Text.sayHello("cedric"));
+                }
+            }
+        '''
+
+        when:
+        run 'test'
+
+        then:
+        noExceptionThrown()
+    }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
@@ -137,23 +137,6 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         notExecuted ':b:processResources', ':b:classes', ':b:jar'
     }
 
-    def "doesn't allow declaring dependencies using the 'compile' configuration"() {
-        file('settings.gradle') << 'include "b"'
-        buildFile << '''
-            apply plugin: 'java-library'
-
-            dependencies {
-                compile project(':b')
-            }
-        '''
-
-        when:
-        fails 'tasks'
-
-        then:
-        failure.assertHasCause "The 'compile' configuration should not be used to declare dependencies. Please use 'api' or 'implementation' instead."
-    }
-
     def "recompiles consumer if API dependency of producer changed"() {
         def shared10 = mavenRepo.module('org.gradle.test', 'shared', '1.0').publish()
         def shared11 = mavenRepo.module('org.gradle.test', 'shared', '1.1').publish()

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -112,35 +112,55 @@ public class DefaultSourceSet implements SourceSet {
     }
 
     public String getCompileConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.COMPILE_CONFIGURATION_NAME));
+        String compileConfigurationName = JavaPlugin.COMPILE_CONFIGURATION_NAME;
+        return configurationNameOf(compileConfigurationName);
+    }
+
+    private String configurationNameOf(String baseName) {
+        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(baseName));
     }
 
     public String getRuntimeConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.RUNTIME_CONFIGURATION_NAME));
+        return configurationNameOf(JavaPlugin.RUNTIME_CONFIGURATION_NAME);
     }
 
     public String getCompileOnlyConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME));
+        return configurationNameOf(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
     }
 
     @Override
     public String getCompileClasspathConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+        return configurationNameOf(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
     }
 
     @Override
     public String getApiConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.API_CONFIGURATION_NAME));
+        return configurationNameOf(JavaPlugin.API_CONFIGURATION_NAME);
     }
 
     @Override
     public String getImplementationConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
+        return configurationNameOf(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME);
     }
 
     @Override
     public String getApiCompileConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.API_COMPILE_CONFIGURATION_NAME));
+        return configurationNameOf(JavaPlugin.API_COMPILE_CONFIGURATION_NAME);
+    }
+
+    @Override
+    public String getRuntimeOnlyConfigurationName() {
+        return configurationNameOf(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME);
+    }
+
+    @Override
+    public String getRuntimeClasspathConfigurationName() {
+        return configurationNameOf(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+    }
+
+    @Override
+    public String getRuntimeElementsConfigurationName() {
+        return configurationNameOf(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME);
     }
 
     public SourceSetOutput getOutput() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -135,7 +135,7 @@ public class DefaultSourceSet implements SourceSet {
 
     @Override
     public String getImplementationConfigurationName() {
-        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.IMPL_CONFIGURATION_NAME));
+        return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -144,8 +144,8 @@ public class DefaultSourceSet implements SourceSet {
     }
 
     @Override
-    public String getApiCompileConfigurationName() {
-        return configurationNameOf(JavaPlugin.API_COMPILE_CONFIGURATION_NAME);
+    public String getApiElementsConfigurationName() {
+        return configurationNameOf(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME);
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -469,6 +469,11 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         }
     }
 
+    /**
+     * Represents the usage of a configuration. Typical usages include compilation or runtime.
+     * This interface allows the user to customize usages by implementing this interface, or
+     * simply calling the {@link #usage(String)} method.
+     */
     public interface Usage extends Named {
         Attribute<Usage> USAGE_ATTRIBUTE = Attribute.of(Usage.class);
 
@@ -477,6 +482,11 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
 
     }
 
+    /**
+     * Creates a simple named usage.
+     * @param usage the usage name
+     * @return a usage with the provided name
+     */
     public static Usage usage(final String usage) {
         return new UsageImpl(usage);
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -241,7 +241,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         Configuration runtimeConfiguration = configurations.maybeCreate(sourceSet.getRuntimeConfigurationName());
         runtimeConfiguration.setVisible(false);
         runtimeConfiguration.extendsFrom(compileConfiguration);
-        runtimeConfiguration.setDescription("Runtime dependencies for " + sourceSet + ".");
+        runtimeConfiguration.setDescription("Runtime dependencies for " + sourceSet + " (deprecated, use '" + sourceSet.getRuntimeClasspathConfigurationName() + " ' instead).");
 
         Configuration compileOnlyConfiguration = configurations.maybeCreate(sourceSet.getCompileOnlyConfigurationName());
         compileOnlyConfiguration.setVisible(false);
@@ -256,6 +256,19 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
 
         sourceSet.setCompileClasspath(compileClasspathConfiguration);
         sourceSet.setRuntimeClasspath(sourceSet.getOutput().plus(runtimeConfiguration));
+
+        Configuration runtimeOnlyConfiguration = configurations.maybeCreate(sourceSet.getRuntimeOnlyConfigurationName());
+        runtimeOnlyConfiguration.setVisible(false);
+        runtimeOnlyConfiguration.setCanBeConsumed(false);
+        runtimeOnlyConfiguration.setCanBeResolved(false);
+        runtimeOnlyConfiguration.setDescription("Runtime only dependencies for " + sourceSet + ".");
+
+        Configuration runtimeClasspathConfiguration = configurations.maybeCreate(sourceSet.getRuntimeClasspathConfigurationName());
+        runtimeClasspathConfiguration.setVisible(false);
+        runtimeClasspathConfiguration.setCanBeConsumed(false);
+        runtimeClasspathConfiguration.setCanBeResolved(true);
+        runtimeClasspathConfiguration.setDescription("Runtime classpath of " + sourceSet + ".");
+        runtimeClasspathConfiguration.extendsFrom(runtimeOnlyConfiguration, runtimeConfiguration);
     }
 
     public void configureForSourceSet(final SourceSet sourceSet, AbstractCompile compile) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -254,9 +254,6 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSet + ".");
         compileClasspathConfiguration.setCanBeConsumed(false);
 
-        sourceSet.setCompileClasspath(compileClasspathConfiguration);
-        sourceSet.setRuntimeClasspath(sourceSet.getOutput().plus(runtimeConfiguration));
-
         Configuration runtimeOnlyConfiguration = configurations.maybeCreate(sourceSet.getRuntimeOnlyConfigurationName());
         runtimeOnlyConfiguration.setVisible(false);
         runtimeOnlyConfiguration.setCanBeConsumed(false);
@@ -269,6 +266,10 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         runtimeClasspathConfiguration.setCanBeResolved(true);
         runtimeClasspathConfiguration.setDescription("Runtime classpath of " + sourceSet + ".");
         runtimeClasspathConfiguration.extendsFrom(runtimeOnlyConfiguration, runtimeConfiguration);
+
+        sourceSet.setCompileClasspath(compileClasspathConfiguration);
+        sourceSet.setRuntimeClasspath(sourceSet.getOutput().plus(runtimeClasspathConfiguration));
+
     }
 
     public void configureForSourceSet(final SourceSet sourceSet, AbstractCompile compile) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -241,7 +241,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         Configuration runtimeConfiguration = configurations.maybeCreate(sourceSet.getRuntimeConfigurationName());
         runtimeConfiguration.setVisible(false);
         runtimeConfiguration.extendsFrom(compileConfiguration);
-        runtimeConfiguration.setDescription("Runtime dependencies for " + sourceSet + " (deprecated, use '" + sourceSet.getRuntimeClasspathConfigurationName() + " ' instead).");
+        runtimeConfiguration.setDescription("Runtime dependencies for " + sourceSet + " (deprecated, use '" + sourceSet.getRuntimeOnlyConfigurationName() + " ' instead).");
 
         Configuration compileOnlyConfiguration = configurations.maybeCreate(sourceSet.getCompileOnlyConfigurationName());
         compileOnlyConfiguration.setVisible(false);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -119,10 +119,10 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         configureTest(project, javaConvention);
         configureBuildNeeded(project);
         configureBuildDependents(project);
-        registerProcessingAspect(project);
+        configureSchema(project);
     }
 
-    private void registerProcessingAspect(ProjectInternal project) {
+    private void configureSchema(ProjectInternal project) {
         project.getAttributesSchema().matchStrictly(Usage.USAGE_ATTRIBUTE);
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -21,7 +21,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
 
@@ -74,8 +73,5 @@ public class JavaLibraryPlugin implements Plugin<Project> {
 
         Configuration compileConfiguration = configurations.findByName(sourceSet.getCompileConfigurationName());
         apiConfiguration.extendsFrom(compileConfiguration);
-        ((ConfigurationInternal) compileConfiguration).lock(
-            "The '" + compileConfiguration.getName() + "' configuration should not be used to declare dependencies. Please use '" + sourceSet.getApiConfigurationName()
-                + "' or '" + implementationConfiguration.getName() + "' instead.");
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -25,8 +25,6 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
 
-import static org.gradle.api.plugins.JavaPlugin.USAGE;
-
 /**
  * <p>A {@link Plugin} which extends the capabilities of the {@link JavaPlugin Java plugin} by cleanly separating
  * the API and implementation dependencies of a library.</p>
@@ -68,18 +66,14 @@ public class JavaLibraryPlugin implements Plugin<Project> {
         apiCompileConfiguration.setCanBeResolved(false);
         apiCompileConfiguration.setCanBeConsumed(true);
         apiCompileConfiguration.setTransitive(false);
-        apiCompileConfiguration.attribute(USAGE, "api");
+        apiCompileConfiguration.attribute(JavaBasePlugin.Usage.USAGE_ATTRIBUTE, JavaBasePlugin.Usage.FOR_COMPILE);
         apiCompileConfiguration.extendsFrom(apiConfiguration);
 
         Configuration implementationConfiguration = configurations.maybeCreate(sourceSet.getImplementationConfigurationName());
-        implementationConfiguration.setVisible(false);
-        implementationConfiguration.setDescription("Implementation only dependencies for " + sourceSet + ".");
-        implementationConfiguration.setCanBeConsumed(false);
-        implementationConfiguration.setCanBeResolved(false);
         implementationConfiguration.extendsFrom(apiConfiguration);
 
         Configuration compileConfiguration = configurations.findByName(sourceSet.getCompileConfigurationName());
-        compileConfiguration.extendsFrom(implementationConfiguration);
+        apiConfiguration.extendsFrom(compileConfiguration);
         ((ConfigurationInternal) compileConfiguration).lock(
             "The '" + compileConfiguration.getName() + "' configuration should not be used to declare dependencies. Please use '" + sourceSet.getApiConfigurationName()
                 + "' or '" + implementationConfiguration.getName() + "' instead.");

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -45,7 +45,7 @@ public class JavaLibraryPlugin implements Plugin<Project> {
             public void execute(SourceSet sourceSet) {
                 defineApiConfigurationsForSourceSet(sourceSet, configurations);
                 JavaCompile javaCompile = (JavaCompile) project.getTasks().findByName(sourceSet.getCompileJavaTaskName());
-                project.getArtifacts().add(sourceSet.getApiCompileConfigurationName(), ImmutableMap.of(
+                project.getArtifacts().add(sourceSet.getApiElementsConfigurationName(), ImmutableMap.of(
                     "file", javaCompile.getDestinationDir(),
                     "builtBy", javaCompile));
             }
@@ -59,14 +59,14 @@ public class JavaLibraryPlugin implements Plugin<Project> {
         apiConfiguration.setCanBeResolved(false);
         apiConfiguration.setCanBeConsumed(false);
 
-        Configuration apiCompileConfiguration = configurations.maybeCreate(sourceSet.getApiCompileConfigurationName());
-        apiCompileConfiguration.setVisible(false);
-        apiCompileConfiguration.setDescription("API compile classpath for " + sourceSet + ".");
-        apiCompileConfiguration.setCanBeResolved(false);
-        apiCompileConfiguration.setCanBeConsumed(true);
-        apiCompileConfiguration.setTransitive(false);
-        apiCompileConfiguration.attribute(JavaBasePlugin.Usage.USAGE_ATTRIBUTE, JavaBasePlugin.Usage.FOR_COMPILE);
-        apiCompileConfiguration.extendsFrom(apiConfiguration);
+        Configuration apiElementsConfiguration = configurations.maybeCreate(sourceSet.getApiElementsConfigurationName());
+        apiElementsConfiguration.setVisible(false);
+        apiElementsConfiguration.setDescription("API compile classpath for " + sourceSet + ".");
+        apiElementsConfiguration.setCanBeResolved(false);
+        apiElementsConfiguration.setCanBeConsumed(true);
+        apiElementsConfiguration.setTransitive(false);
+        apiElementsConfiguration.attribute(JavaBasePlugin.Usage.USAGE_ATTRIBUTE, JavaBasePlugin.Usage.FOR_COMPILE);
+        apiElementsConfiguration.extendsFrom(apiConfiguration);
 
         Configuration implementationConfiguration = configurations.maybeCreate(sourceSet.getImplementationConfigurationName());
         implementationConfiguration.extendsFrom(apiConfiguration);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -97,7 +97,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
 
         SourceSet test = pluginConvention.getSourceSets().create(SourceSet.TEST_SOURCE_SET_NAME);
         test.setCompileClasspath(project.files(main.getOutput(), project.getConfigurations().getByName(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME)));
-        test.setRuntimeClasspath(project.files(test.getOutput(), main.getOutput(), project.getConfigurations().getByName(TEST_RUNTIME_CONFIGURATION_NAME)));
+        test.setRuntimeClasspath(project.files(test.getOutput(), main.getOutput(), project.getConfigurations().getByName(TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)));
     }
 
     private void configureJavaDoc(final JavaPluginConvention pluginConvention) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -151,12 +151,13 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     void configureConfigurations(Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration implementationConfiguration = configurations.getByName(IMPLEMENTATION_CONFIGURATION_NAME);
+        Configuration testImplementationConfiguration = configurations.getByName(TEST_IMPLEMENTATION_CONFIGURATION_NAME);
         Configuration runtimeConfiguration = configurations.getByName(RUNTIME_CONFIGURATION_NAME);
 
         Configuration compileTestsConfiguration = configurations.getByName(TEST_COMPILE_CONFIGURATION_NAME);
         compileTestsConfiguration.extendsFrom(implementationConfiguration);
 
-        configurations.getByName(TEST_RUNTIME_CONFIGURATION_NAME).extendsFrom(runtimeConfiguration, compileTestsConfiguration);
+        configurations.getByName(TEST_RUNTIME_CONFIGURATION_NAME).extendsFrom(runtimeConfiguration, compileTestsConfiguration, testImplementationConfiguration);
 
         configurations.getByName(Dependency.DEFAULT_CONFIGURATION).extendsFrom(runtimeConfiguration);
         configurations.getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).attribute(USAGE_ATTRIBUTE, FOR_COMPILE);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -59,7 +59,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
 
     public static final String API_CONFIGURATION_NAME = "api";
     public static final String IMPLEMENTATION_CONFIGURATION_NAME = "implementation";
-    public static final String API_COMPILE_CONFIGURATION_NAME = "apiCompile";
+    public static final String API_ELEMENTS_CONFIGURATION_NAME = "apiElements";
     public static final String COMPILE_CONFIGURATION_NAME = "compile";
     public static final String COMPILE_ONLY_CONFIGURATION_NAME = "compileOnly";
     public static final String RUNTIME_CONFIGURATION_NAME = "runtime";

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -120,8 +120,10 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
 
         ArchivePublishArtifact jarArtifact = new ArchivePublishArtifact(jar);
         Configuration runtimeConfiguration = project.getConfigurations().getByName(RUNTIME_CONFIGURATION_NAME);
+        Configuration runtimeElementsConfiguration = project.getConfigurations().getByName(RUNTIME_ELEMENTS_CONFIGURATION_NAME);
 
         runtimeConfiguration.getArtifacts().add(jarArtifact);
+        runtimeElementsConfiguration.getArtifacts().add(jarArtifact);
         project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(jarArtifact);
         project.getComponents().add(new JavaLibrary(jarArtifact, runtimeConfiguration.getAllDependencies()));
     }
@@ -161,6 +163,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         // the following is not strictly required now, but it will once we remove the deprecated configurations. More work today, less later!
         testImplementationConfiguration.extendsFrom(implementationConfiguration);
         Configuration runtimeConfiguration = configurations.getByName(RUNTIME_CONFIGURATION_NAME);
+        Configuration runtimeClasspathConfiguration = configurations.maybeCreate(RUNTIME_CLASSPATH_CONFIGURATION_NAME);
 
         Configuration compileTestsConfiguration = configurations.getByName(TEST_COMPILE_CONFIGURATION_NAME);
         compileTestsConfiguration.extendsFrom(implementationConfiguration);
@@ -176,10 +179,9 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
 
         configurations.getByName(Dependency.DEFAULT_CONFIGURATION).extendsFrom(runtimeConfiguration);
         configurations.getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).attribute(USAGE_ATTRIBUTE, FOR_COMPILE);
-        configurations.getByName(RUNTIME_ELEMENTS_CONFIGURATION_NAME).attribute(USAGE_ATTRIBUTE, FOR_RUNTIME);
-        configurations.getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME).attribute(USAGE_ATTRIBUTE, FOR_RUNTIME);
+        runtimeElementsConfiguration.attribute(USAGE_ATTRIBUTE, FOR_RUNTIME);
+        runtimeClasspathConfiguration.attribute(USAGE_ATTRIBUTE, FOR_RUNTIME);
 
-        Configuration runtimeClasspathConfiguration = configurations.maybeCreate(RUNTIME_CLASSPATH_CONFIGURATION_NAME);
         runtimeClasspathConfiguration.extendsFrom(runtimeElementsConfiguration);
 
         // the following is not strictly required now, but it will once we remove the deprecated configurations. More work today, less later!

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -17,7 +17,6 @@
 package org.gradle.api.plugins;
 
 import org.gradle.api.Action;
-import org.gradle.api.Attribute;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -40,6 +39,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
+import static org.gradle.api.plugins.JavaBasePlugin.Usage.FOR_COMPILE;
+import static org.gradle.api.plugins.JavaBasePlugin.Usage.USAGE_ATTRIBUTE;
+
 /**
  * <p>A {@link Plugin} which compiles and tests Java source, and assembles it into a JAR file.</p>
  */
@@ -55,17 +57,17 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     public static final String JAVADOC_TASK_NAME = "javadoc";
 
     public static final String API_CONFIGURATION_NAME = "api";
-    public static final String IMPL_CONFIGURATION_NAME = "implementation";
+    public static final String IMPLEMENTATION_CONFIGURATION_NAME = "implementation";
     public static final String API_COMPILE_CONFIGURATION_NAME = "apiCompile";
     public static final String COMPILE_CONFIGURATION_NAME = "compile";
     public static final String COMPILE_ONLY_CONFIGURATION_NAME = "compileOnly";
     public static final String RUNTIME_CONFIGURATION_NAME = "runtime";
     public static final String COMPILE_CLASSPATH_CONFIGURATION_NAME = "compileClasspath";
     public static final String TEST_COMPILE_CONFIGURATION_NAME = "testCompile";
+    public static final String TEST_IMPLEMENTATION_CONFIGURATION_NAME = "testImplementation";
     public static final String TEST_COMPILE_ONLY_CONFIGURATION_NAME = "testCompileOnly";
     public static final String TEST_RUNTIME_CONFIGURATION_NAME = "testRuntime";
     public static final String TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME = "testCompileClasspath";
-    public static final Attribute<String> USAGE = Attribute.of("org.gradle.usage", String.class);
 
     public void apply(ProjectInternal project) {
         project.getPluginManager().apply(JavaBasePlugin.class);
@@ -148,16 +150,16 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
 
     void configureConfigurations(Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
-        Configuration compileConfiguration = configurations.getByName(COMPILE_CONFIGURATION_NAME);
+        Configuration implementationConfiguration = configurations.getByName(IMPLEMENTATION_CONFIGURATION_NAME);
         Configuration runtimeConfiguration = configurations.getByName(RUNTIME_CONFIGURATION_NAME);
 
         Configuration compileTestsConfiguration = configurations.getByName(TEST_COMPILE_CONFIGURATION_NAME);
-        compileTestsConfiguration.extendsFrom(compileConfiguration);
+        compileTestsConfiguration.extendsFrom(implementationConfiguration);
 
         configurations.getByName(TEST_RUNTIME_CONFIGURATION_NAME).extendsFrom(runtimeConfiguration, compileTestsConfiguration);
 
         configurations.getByName(Dependency.DEFAULT_CONFIGURATION).extendsFrom(runtimeConfiguration);
-        configurations.getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).attribute(USAGE, "api");
+        configurations.getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).attribute(USAGE_ATTRIBUTE, FOR_COMPILE);
 
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
@@ -279,4 +279,33 @@ public interface SourceSet {
      */
     @Incubating
     String getApiCompileConfigurationName();
+
+    /**
+     * Returns the name of the configuration that contains dependencies that are only required
+     * at runtime of the component. Dependencies found in this configuration are visible to
+     * the runtime classpath of the component, but not to consumers.
+     *
+     * @return the runtime only configuration name
+     */
+    @Incubating
+    String getRuntimeOnlyConfigurationName();
+
+    /**
+     * Returns the name of the runtime classpath configuration of this component: the runtime
+     * classpath contains elements of the implementation, as well as runtime only elements.
+     *
+     * @return the name of the runtime classpath configuration
+     */
+    @Incubating
+    String getRuntimeClasspathConfigurationName();
+
+    /**
+     * Returns the name of the configuration containing elements that are stricly required
+     * at runtime. Consumers of this configuration will get all the mandatory elements for
+     * this component to execute at runtime.
+     *
+     * @return the name of the runtime elements configuration.
+     */
+    @Incubating
+    String getRuntimeElementsConfigurationName();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
@@ -278,7 +278,7 @@ public interface SourceSet {
      * @since 3.3
      */
     @Incubating
-    String getApiCompileConfigurationName();
+    String getApiElementsConfigurationName();
 
     /**
      * Returns the name of the configuration that contains dependencies that are only required

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
@@ -117,7 +117,7 @@ class DefaultSourceSetTest {
         assertThat(sourceSet.compileOnlyConfigurationName, equalTo("setNameCompileOnly"))
         assertThat(sourceSet.compileClasspathConfigurationName, equalTo("setNameCompileClasspath"))
         assertThat(sourceSet.apiConfigurationName, equalTo("setNameApi"))
-        assertThat(sourceSet.apiCompileConfigurationName, equalTo("setNameApiCompile"))
+        assertThat(sourceSet.apiElementsConfigurationName, equalTo("setNameApiCompile"))
     }
 
     @Test public void mainSourceSetUsesSpecialCaseNames() {
@@ -136,7 +136,7 @@ class DefaultSourceSetTest {
         assertThat(sourceSet.compileOnlyConfigurationName, equalTo("compileOnly"))
         assertThat(sourceSet.compileClasspathConfigurationName, equalTo("compileClasspath"))
         assertThat(sourceSet.apiConfigurationName, equalTo("api"))
-        assertThat(sourceSet.apiCompileConfigurationName, equalTo("apiCompile"))
+        assertThat(sourceSet.apiElementsConfigurationName, equalTo("apiElements"))
     }
 
     @Test public void canConfigureResources() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
@@ -117,7 +117,7 @@ class DefaultSourceSetTest {
         assertThat(sourceSet.compileOnlyConfigurationName, equalTo("setNameCompileOnly"))
         assertThat(sourceSet.compileClasspathConfigurationName, equalTo("setNameCompileClasspath"))
         assertThat(sourceSet.apiConfigurationName, equalTo("setNameApi"))
-        assertThat(sourceSet.apiElementsConfigurationName, equalTo("setNameApiCompile"))
+        assertThat(sourceSet.apiElementsConfigurationName, equalTo("setNameApiElements"))
     }
 
     @Test public void mainSourceSetUsesSpecialCaseNames() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
@@ -39,12 +39,21 @@ class GroovyPluginTest extends AbstractProjectBuilderSpec {
         groovyPlugin.apply(project)
 
         when:
-        def configuration = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
+        def compile = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
 
         then:
-        configuration.extendsFrom == [] as Set
-        !configuration.visible
-        configuration.transitive
+        compile.extendsFrom == [] as Set
+        !compile.visible
+        compile.transitive
+
+        when:
+        def implementation = project.configurations.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
+
+        then:
+        implementation.extendsFrom == [compile] as Set
+        !implementation.visible
+        !implementation.canBeConsumed
+        !implementation.canBeResolved
     }
 
     def "adds Groovy convention to each source set"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -213,7 +213,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         def sourceSetRuntimeClasspath = sourceSet.runtimeClasspath
         def sourceSetCompileClasspath = sourceSet.compileClasspath
         sourceSetCompileClasspath == compileClasspath
-        sourceSetRuntimeClasspath sameCollection(sourceSet.output + runtime)
+        sourceSetRuntimeClasspath sameCollection(sourceSet.output + runtimeClasspath)
     }
 
     void appliesMappingsToTasksDefinedByBuildScript() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -175,7 +175,25 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         runtime.transitive
         !runtime.visible
         runtime.extendsFrom == [compile] as Set
-        runtime.description == "Runtime dependencies for source set 'custom'."
+        runtime.description == "Runtime dependencies for source set 'custom' (deprecated, use 'customRuntimeClasspath ' instead)."
+
+        and:
+        def runtimeOnly = project.configurations.customRuntimeOnly
+        runtimeOnly.transitive
+        !runtimeOnly.visible
+        !runtimeOnly.canBeConsumed
+        !runtimeOnly.canBeResolved
+        runtimeOnly.extendsFrom == [] as Set
+        runtimeOnly.description == "Runtime only dependencies for source set 'custom'."
+
+        and:
+        def runtimeClasspath = project.configurations.customRuntimeClasspath
+        runtimeClasspath.transitive
+        !runtimeClasspath.visible
+        !runtimeClasspath.canBeConsumed
+        runtimeClasspath.canBeResolved
+        runtimeClasspath.extendsFrom == [runtimeOnly, runtime] as Set
+        runtimeClasspath.description == "Runtime classpath of source set 'custom'."
 
         and:
         def compileOnly = project.configurations.customCompileOnly

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -175,7 +175,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         runtime.transitive
         !runtime.visible
         runtime.extendsFrom == [compile] as Set
-        runtime.description == "Runtime dependencies for source set 'custom' (deprecated, use 'customRuntimeClasspath ' instead)."
+        runtime.description == "Runtime dependencies for source set 'custom' (deprecated, use 'customRuntimeOnly ' instead)."
 
         and:
         def runtimeOnly = project.configurations.customRuntimeOnly

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -160,7 +160,15 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         compile.transitive
         !compile.visible
         compile.extendsFrom == [] as Set
-        compile.description == "Dependencies for source set 'custom'."
+        compile.description == "Dependencies for source set 'custom' (deprecated, use 'customImplementation ' instead)."
+
+        then:
+        def implementation = project.configurations.customImplementation
+        !implementation.visible
+        implementation.extendsFrom == [compile] as Set
+        implementation.description == "Implementation only dependencies for source set 'custom'."
+        !implementation.canBeConsumed
+        !implementation.canBeResolved
 
         and:
         def runtime = project.configurations.customRuntime
@@ -173,7 +181,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         def compileOnly = project.configurations.customCompileOnly
         compileOnly.transitive
         !compileOnly.visible
-        compileOnly.extendsFrom == [compile] as Set
+        compileOnly.extendsFrom == [implementation] as Set
         compileOnly.description == "Compile dependencies for source set 'custom'."
 
         and:

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.plugins
 
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.Dependency
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
@@ -184,21 +183,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         defaultConfig.extendsFrom == toSet(runtime)
-    }
-
-    def "cannot add dependencies to `compile` configuration"() {
-        given:
-        def commonProject = TestUtil.createChildProject(project, "common")
-        javaLibraryPlugin.apply(project)
-
-        when:
-        project.dependencies {
-            compile commonProject
-        }
-
-        then:
-        def e = thrown(InvalidUserDataException)
-        e.message == "The 'compile' configuration should not be used to declare dependencies. Please use 'api' or 'implementation' instead."
     }
 
     def "can declare API and implementation dependencies"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -83,6 +83,36 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         runtime.transitive
 
         when:
+        def runtimeOnly = project.configurations.getByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME)
+
+        then:
+        runtimeOnly.transitive
+        !runtimeOnly.visible
+        !runtimeOnly.canBeConsumed
+        !runtimeOnly.canBeResolved
+        runtimeOnly.extendsFrom == [] as Set
+
+        when:
+        def runtimeElements = project.configurations.getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
+
+        then:
+        runtimeElements.transitive
+        !runtimeElements.visible
+        runtimeElements.canBeConsumed
+        !runtimeElements.canBeResolved
+        runtimeElements.extendsFrom == [implementation] as Set
+
+        when:
+        def runtimeClasspath = project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+
+        then:
+        runtimeClasspath.transitive
+        !runtimeClasspath.visible
+        !runtimeClasspath.canBeConsumed
+        runtimeClasspath.canBeResolved
+        runtimeClasspath.extendsFrom == [runtimeOnly, runtime, runtimeElements] as Set
+
+        when:
         def compileOnly = project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
 
         then:
@@ -107,21 +137,31 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         testCompile.transitive
 
         when:
+        def testImplementation = project.configurations.getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME)
+
+        then:
+        testImplementation.extendsFrom == toSet(testCompile, implementation)
+        !testImplementation.visible
+        !testImplementation.canBeConsumed
+        !testImplementation.canBeResolved
+
+        when:
         def testRuntime = project.configurations.getByName(JavaPlugin.TEST_RUNTIME_CONFIGURATION_NAME)
 
         then:
-        testRuntime.extendsFrom == toSet(runtime, testCompile)
+        testRuntime.extendsFrom == toSet(runtime, testCompile, testImplementation)
         !testRuntime.visible
         testRuntime.transitive
 
         when:
-        def testImplementation = project.configurations.getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME)
+        def testRuntimeOnly = project.configurations.getByName(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME)
 
         then:
-        testImplementation.extendsFrom == toSet(testCompile)
-        !testImplementation.visible
-        !testImplementation.canBeConsumed
-        !testImplementation.canBeResolved
+        testRuntimeOnly.transitive
+        !testRuntimeOnly.visible
+        !testRuntimeOnly.canBeConsumed
+        !testRuntimeOnly.canBeResolved
+        testRuntimeOnly.extendsFrom == [] as Set
 
         when:
         def testCompileOnly = project.configurations.getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -40,11 +40,19 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         javaLibraryPlugin.apply(project)
 
         when:
+        def compile = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
+
+        then:
+        compile.extendsFrom == [] as Set
+        !compile.visible
+        compile.transitive
+
+        when:
         def api = project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME)
 
         then:
         !api.visible
-        api.extendsFrom == [] as Set
+        api.extendsFrom == [compile] as Set
         !api.canBeConsumed
         !api.canBeResolved
 
@@ -58,21 +66,13 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         !apiCompile.canBeResolved
 
         when:
-        def implementation = project.configurations.getByName(JavaPlugin.IMPL_CONFIGURATION_NAME)
+        def implementation = project.configurations.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
 
         then:
         !implementation.visible
-        implementation.extendsFrom == [api] as Set
+        implementation.extendsFrom == [api, compile] as Set
         !implementation.canBeConsumed
         !implementation.canBeResolved
-
-        when:
-        def compile = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
-
-        then:
-        compile.extendsFrom == [implementation] as Set
-        !compile.visible
-        compile.transitive
 
         when:
         def runtime = project.configurations.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME)
@@ -86,7 +86,7 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         def compileOnly = project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
 
         then:
-        compileOnly.extendsFrom == toSet(compile)
+        compileOnly.extendsFrom == toSet(implementation)
         !compileOnly.visible
         compileOnly.transitive
 
@@ -102,7 +102,7 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         def testCompile = project.configurations.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME)
 
         then:
-        testCompile.extendsFrom == toSet(compile)
+        testCompile.extendsFrom == toSet(implementation)
         !testCompile.visible
         testCompile.transitive
 
@@ -115,10 +115,19 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         testRuntime.transitive
 
         when:
+        def testImplementation = project.configurations.getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME)
+
+        then:
+        testImplementation.extendsFrom == toSet(testCompile)
+        !testImplementation.visible
+        !testImplementation.canBeConsumed
+        !testImplementation.canBeResolved
+
+        when:
         def testCompileOnly = project.configurations.getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME)
 
         then:
-        testCompileOnly.extendsFrom == toSet(testCompile)
+        testCompileOnly.extendsFrom == toSet(testImplementation)
         !testCompileOnly.visible
         testCompileOnly.transitive
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -56,13 +56,13 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         !api.canBeResolved
 
         when:
-        def apiCompile = project.configurations.getByName(JavaPlugin.API_COMPILE_CONFIGURATION_NAME)
+        def apiElements = project.configurations.getByName(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME)
 
         then:
-        !apiCompile.visible
-        apiCompile.extendsFrom == [api] as Set
-        apiCompile.canBeConsumed
-        !apiCompile.canBeResolved
+        !apiElements.visible
+        apiElements.extendsFrom == [api] as Set
+        apiElements.canBeConsumed
+        !apiElements.canBeResolved
 
         when:
         def implementation = project.configurations.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -85,6 +85,36 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         runtime.transitive
 
         when:
+        def runtimeOnly = project.configurations.getByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME)
+
+        then:
+        runtimeOnly.transitive
+        !runtimeOnly.visible
+        !runtimeOnly.canBeConsumed
+        !runtimeOnly.canBeResolved
+        runtimeOnly.extendsFrom == [] as Set
+
+        when:
+        def runtimeElements = project.configurations.getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
+
+        then:
+        runtimeElements.transitive
+        !runtimeElements.visible
+        runtimeElements.canBeConsumed
+        !runtimeElements.canBeResolved
+        runtimeElements.extendsFrom == [implementation] as Set
+
+        when:
+        def runtimeClasspath = project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+
+        then:
+        runtimeClasspath.transitive
+        !runtimeClasspath.visible
+        !runtimeClasspath.canBeConsumed
+        runtimeClasspath.canBeResolved
+        runtimeClasspath.extendsFrom == [runtimeOnly, runtime, runtimeElements] as Set
+
+        when:
         def compileOnly = project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
 
         then:
@@ -109,20 +139,30 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         testCompile.transitive
 
         when:
+        def testImplementation = project.configurations.getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME)
+
+        then:
+        testImplementation.extendsFrom == toSet(testCompile, implementation)
+        !testImplementation.visible
+        testImplementation.transitive
+
+        when:
         def testRuntime = project.configurations.getByName(JavaPlugin.TEST_RUNTIME_CONFIGURATION_NAME)
 
         then:
-        testRuntime.extendsFrom == toSet(runtime, testCompile)
+        testRuntime.extendsFrom == toSet(runtime, testCompile, testImplementation)
         !testRuntime.visible
         testRuntime.transitive
 
         when:
-        def testImplementation = project.configurations.getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME)
+        def testRuntimeOnly = project.configurations.getByName(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME)
 
         then:
-        testImplementation.extendsFrom == toSet(testCompile)
-        !testImplementation.visible
-        testImplementation.transitive
+        testRuntimeOnly.transitive
+        !testRuntimeOnly.visible
+        !testRuntimeOnly.canBeConsumed
+        !testRuntimeOnly.canBeResolved
+        testRuntimeOnly.extendsFrom == [] as Set
 
         when:
         def testCompileOnly = project.configurations.getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME)
@@ -139,6 +179,16 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         testCompileClasspath.extendsFrom == toSet(testCompileOnly)
         !testCompileClasspath.visible
         testCompileClasspath.transitive
+
+        when:
+        def testRuntimeClasspath = project.configurations.getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+
+        then:
+        testRuntimeClasspath.extendsFrom == toSet(testRuntime, testRuntimeOnly, testImplementation)
+        !testRuntimeClasspath.visible
+        testRuntimeClasspath.transitive
+        !testRuntimeClasspath.canBeConsumed
+        testRuntimeClasspath.canBeResolved
 
         when:
         def defaultConfig = project.configurations.getByName(Dependency.DEFAULT_CONFIGURATION)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -241,7 +241,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.output.classesDir == new File(project.buildDir, 'classes/main')
         set.output.resourcesDir == new File(project.buildDir, 'resources/main')
         set.getOutput() builtBy(JavaPlugin.CLASSES_TASK_NAME)
-        set.runtimeClasspath.sourceCollections.contains(project.configurations.runtime)
+        set.runtimeClasspath.sourceCollections.contains(project.configurations.runtimeClasspath)
         set.runtimeClasspath.contains(new File(project.buildDir, 'classes/main'))
 
         when:
@@ -255,7 +255,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.output.classesDir == new File(project.buildDir, 'classes/test')
         set.output.resourcesDir == new File(project.buildDir, 'resources/test')
         set.getOutput() builtBy(JavaPlugin.TEST_CLASSES_TASK_NAME)
-        set.runtimeClasspath.sourceCollections.contains(project.configurations.testRuntime)
+        set.runtimeClasspath.sourceCollections.contains(project.configurations.testRuntimeClasspath)
         set.runtimeClasspath.contains(new File(project.buildDir, 'classes/main'))
         set.runtimeClasspath.contains(new File(project.buildDir, 'classes/test'))
     }
@@ -273,7 +273,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.compileClasspath.is(project.configurations.customCompileClasspath)
         set.output.classesDir == new File(project.buildDir, 'classes/custom')
         set.getOutput() builtBy('customClasses')
-        Assert.assertThat(set.runtimeClasspath, sameCollection(set.output + project.configurations.customRuntime))
+        Assert.assertThat(set.runtimeClasspath, sameCollection(set.output + project.configurations.customRuntimeClasspath))
     }
 
     def createsStandardTasksAndAppliesMappings() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -68,6 +68,15 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         compile.transitive
 
         when:
+        def implementation = project.configurations.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
+
+        then:
+        implementation.extendsFrom == toSet(compile)
+        !implementation.visible
+        !implementation.canBeConsumed
+        !implementation.canBeResolved
+
+        when:
         def runtime = project.configurations.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME)
 
         then:
@@ -79,7 +88,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         def compileOnly = project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
 
         then:
-        compileOnly.extendsFrom == toSet(compile)
+        compileOnly.extendsFrom == toSet(implementation)
         !compileOnly.visible
         compileOnly.transitive
 
@@ -95,7 +104,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         def testCompile = project.configurations.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME)
 
         then:
-        testCompile.extendsFrom == toSet(compile)
+        testCompile.extendsFrom == toSet(implementation)
         !testCompile.visible
         testCompile.transitive
 
@@ -108,10 +117,18 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         testRuntime.transitive
 
         when:
+        def testImplementation = project.configurations.getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME)
+
+        then:
+        testImplementation.extendsFrom == toSet(testCompile)
+        !testImplementation.visible
+        testImplementation.transitive
+
+        when:
         def testCompileOnly = project.configurations.getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME)
 
         then:
-        testCompileOnly.extendsFrom == toSet(testCompile)
+        testCompileOnly.extendsFrom == toSet(testImplementation)
         !testCompileOnly.visible
         testCompileOnly.transitive
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -129,7 +129,7 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         def task = project.tasks[WarPlugin.WAR_TASK_NAME]
-        task.classpath.files as List == [project.sourceSets.main.output.classesDir, project.sourceSets.main.output.resourcesDir, runtimeJar, compileJar]
+        task.classpath.files as List == [project.sourceSets.main.output.classesDir, project.sourceSets.main.output.resourcesDir, compileJar, runtimeJar]
     }
 
     def "applies mappings to archive tasks"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -129,7 +129,7 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         def task = project.tasks[WarPlugin.WAR_TASK_NAME]
-        task.classpath.files as List == [project.sourceSets.main.output.classesDir, project.sourceSets.main.output.resourcesDir, compileJar, runtimeJar]
+        task.classpath.files as List == [project.sourceSets.main.output.classesDir, project.sourceSets.main.output.resourcesDir, runtimeJar, compileJar]
     }
 
     def "applies mappings to archive tasks"() {


### PR DESCRIPTION
This pull request improves the setup of the configurations, for 2 reasons:

- improving backwards compatibility, and making the semantics of the "old" java plugin as close as possible as the one from `java-library`
- improve compile avoidance by not leaking runtime classpath to upstream dependencies if we use the `implementation` configuration

# Impact on the `java` plugin

For the `java` plugin, the starting point in 3.2 is:

![java-current](https://cloud.githubusercontent.com/assets/316357/20632594/112348ee-b33f-11e6-92f5-22c694b06ee7.png)

With this pull request, it is now:

![java-after](https://cloud.githubusercontent.com/assets/316357/20632601/1b751476-b33f-11e6-92e2-9cc7e44ac06c.png)

And eventually, once we remove the deprecated configurations, it will look like this:

![java-no-deprecations](https://cloud.githubusercontent.com/assets/316357/20632608/28c453c6-b33f-11e6-933a-4edd341697e1.png)

# Impact on the `java-library` plugin

The `java-library` plugin adds an additional `api` configuration and supports exporting dependencies through the `apiCompile` configuration:

![library](https://cloud.githubusercontent.com/assets/316357/20632650/7ccb9664-b33f-11e6-95e5-a355d551e2b2.png)

And it will eventually look like this once the deprecated configurations are removed:

![library-no-deprecated](https://cloud.githubusercontent.com/assets/316357/20632659/8bc5ab46-b33f-11e6-8f3d-4f33f1a31fe2.png)

# Open questions

Currently `compileOnly` extends from `compile`, and represents dependencies which are only required at compile time (typically, dependencies that would be shaded somehow). There are 2 issues with it:

- why does it extend `compile`? Wouldn't it have been better to have `compileClasspath` extend from both `compile` and `compileOnly` (like the new `runtimeClasspath` setup)
- should we introduce `implementationOnly` for that purpose, and make the new setup consistent in naming and setup?

See: gradle/performance#180