### PR TITLE
Annotate closure args in Project with @DelegatesTo.

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/StaticCompilationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/StaticCompilationTest.groovy
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class StaticCompilationTest extends AbstractIntegrationSpec {
+    def "static compilation uses information provided @DelegatesTo and @ClosureArgs in Project"() {
+        /*
+        This test contains many (seemingly meaningless) assignments such as
+        'Foo x = delegate'.  These serve two purposes.
+        1) If, in the above example, the type 'Foo' did not match the type 'delegate',
+           Groovy's static compiler would reject it as invalid.  This verifies the type
+           information provided by closures annotated with @DelegatesTo and @ClosureArgs
+           is being used by static compilation.
+        2) If, in the above example, 'it' was not _actually_ of type 'Foo', Groovy's run-
+           time would reject it at execution time as invalid.  This helps verify the type
+           information provided by closures annotated with @DelegatesTo and @ClosureArgs
+           is actually _correct_.
+        */
+        // TODO? How to validate @DelegatesTo strategy?
+
+        buildFile << """
+@groovy.transform.CompileStatic
+void setup(Project p) {
+    p.task("foo", type: DefaultTask) {
+        Task a = it
+        Task b = delegate
+    }
+    p.task("bar") {
+        Task a = it
+        Task b = delegate
+    }
+    p.project(":") {
+        Project a = it
+        Project b = delegate
+    }
+    p.files("build.gradle") {
+        ConfigurableFileCollection a = it
+        ConfigurableFileCollection b = delegate
+    }
+    p.fileTree(".") {
+        ConfigurableFileTree a = it
+        ConfigurableFileTree b = delegate
+    }
+    try {
+        p.javaexec {
+            // This block will run, but the execution will fail.
+            // That's okay - we're just using this for type checking.
+            // (A GroovyRuntimeException due to type-checking would
+            // be thrown here if we got the types wrong.)
+            JavaExecSpec a = it
+            JavaExecSpec b = delegate
+        }
+    } catch (IllegalStateException ex) {
+        // We don't have any Java to execute.
+    }
+    // Same as above, but for exec
+    try {
+        p.exec {
+            ExecSpec a = it
+            ExecSpec b = delegate
+        }
+    } catch (IllegalStateException ex) { }
+    p.ant {
+        AntBuilder a = it
+        AntBuilder b = delegate
+    }
+    p.configurations {
+        ConfigurationContainer a = it
+        ConfigurationContainer b = delegate
+    }
+    p.artifacts {
+        ArtifactHandler a = it
+        ArtifactHandler b = delegate
+    }
+    p.subprojects {
+        Project a = it
+        Project b = delegate
+        beforeEvaluate {
+            Project c = it
+        }
+    }
+    p.buildscript {
+        ScriptHandler a = it
+        ScriptHandler b = delegate
+    }
+    p.allprojects {
+        Project a = it
+        Project b = delegate
+    }
+    p.afterEvaluate {
+        Project a = it
+    }
+    p.repositories {
+        RepositoryHandler a = it
+        RepositoryHandler b = delegate
+    }
+    p.dependencies {
+        DependencyHandler a = it
+        DependencyHandler b = delegate
+    }
+    p.copy {
+        from "build.gradle"
+        into "foo.txt" // doesn't matter, but we have to provide something.
+        CopySpec a = it
+        CopySpec b = delegate
+    }
+    p.copySpec {
+        CopySpec a = it
+        CopySpec b = delegate
+    }
+    NamedDomainObjectContainer container = p.container(HashMap.class) {
+        String a = it
+        [name: it, cool: 'very']
+    }
+    container.create("foo") // Ensure container closure called so we check types.
+}
+setup(project)
+        """
+
+        settingsFile << """
+// Ensures 'subprojects' closure above is invoked
+include 'fauxSubproject'
+        """
+
+        expect:
+        succeeds("foo", "bar")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/java/org/gradle/api/Project.java
@@ -17,6 +17,7 @@
 package org.gradle.api;
 
 import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import groovy.lang.MissingPropertyException;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
@@ -477,7 +478,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @return The newly created task object
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      */
-    Task task(Map<String, ?> args, String name, Closure configureClosure);
+    Task task(Map<String, ?> args, String name, @DelegatesTo(Task.class) Closure configureClosure);
 
     /**
      * <p>Creates a {@link Task} with the given name and adds it to this project. Before the task is returned, the given
@@ -490,7 +491,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @return The newly created task object
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      */
-    Task task(String name, Closure configureClosure);
+    Task task(String name, @DelegatesTo(Task.class) Closure configureClosure);
 
     /**
      * <p>Returns the path of this project.  The path is the fully qualified name of the project.</p>
@@ -564,7 +565,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @return The project with the given path. Never returns null.
      * @throws UnknownProjectException If no project with the given path exists.
      */
-    Project project(String path, Closure configureClosure);
+    Project project(String path, @DelegatesTo(Project.class) Closure configureClosure);
 
     /**
      * <p>Returns a map of the tasks contained in this project, and optionally its subprojects.</p>
@@ -709,7 +710,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param configureClosure The closure to use to configure the file collection.
      * @return the configured file tree. Never returns null.
      */
-    ConfigurableFileCollection files(Object paths, Closure configureClosure);
+    ConfigurableFileCollection files(Object paths, @DelegatesTo(ConfigurableFileCollection.class) Closure configureClosure);
 
     /**
      * <p>Creates a new {@code ConfigurableFileTree} using the given base directory. The given baseDir path is evaluated
@@ -758,7 +759,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param configureClosure Closure to configure the {@code ConfigurableFileTree} object.
      * @return the configured file tree. Never returns null.
      */
-    ConfigurableFileTree fileTree(Object baseDir, Closure configureClosure);
+    ConfigurableFileTree fileTree(Object baseDir, @DelegatesTo(ConfigurableFileTree.class) Closure configureClosure);
 
     /**
      * <p>Creates a new {@code ConfigurableFileTree} using the provided map of arguments.  The map will be applied as
@@ -873,7 +874,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param closure The closure for configuring the execution.
      * @return the result of the execution
      */
-    ExecResult javaexec(Closure closure);
+    ExecResult javaexec(@DelegatesTo(JavaExecSpec.class) Closure closure);
 
     /**
      * Executes an external Java process.
@@ -892,7 +893,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param closure The closure for configuring the execution.
      * @return the result of the execution
      */
-    ExecResult exec(Closure closure);
+    ExecResult exec(@DelegatesTo(ExecSpec.class) Closure closure);
 
     /**
      * Executes an external command.
@@ -984,13 +985,13 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
 
     /**
      * <p>Executes the given closure against the <code>AntBuilder</code> for this project. You can use this in your
-     * build file to execute ant tasks. The <code>AntBuild</code> is passed to the closure as the closure's
+     * build file to execute ant tasks. The <code>AntBuilder</code> is passed to the closure as the closure's
      * delegate. See example in javadoc for {@link #getAnt()}</p>
      *
      * @param configureClosure The closure to execute against the <code>AntBuilder</code>.
      * @return The <code>AntBuilder</code>. Never returns null.
      */
-    AntBuilder ant(Closure configureClosure);
+    AntBuilder ant(@DelegatesTo(AntBuilder.class) Closure configureClosure);
 
     /**
      * Returns the configurations of this project.
@@ -1011,7 +1012,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the dependency configurations.
      */
-    void configurations(Closure configureClosure);
+    void configurations(@DelegatesTo(ConfigurationContainer.class) Closure configureClosure);
 
     /**
      * Returns a handler for assigning artifacts produced by the project to configurations.
@@ -1045,7 +1046,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the published artifacts.
      */
-    void artifacts(Closure configureClosure);
+    void artifacts(@DelegatesTo(ArtifactHandler.class) Closure configureClosure);
 
     /**
      * <p>Returns the {@link Convention} for this project.</p> <p/> <p>You can access this property in your build file
@@ -1096,7 +1097,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure The closure to execute.
      */
-    void subprojects(Closure configureClosure);
+    void subprojects(@DelegatesTo(Project.class) Closure configureClosure);
 
     /**
      * <p>Configures this project and each of its sub-projects.</p>
@@ -1115,7 +1116,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure The closure to execute.
      */
-    void allprojects(Closure configureClosure);
+    void allprojects(@DelegatesTo(Project.class) Closure configureClosure);
 
     /**
      * Adds an action to execute immediately before this project is evaluated.
@@ -1314,7 +1315,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the repositories.
      */
-    void repositories(Closure configureClosure);
+    void repositories(@DelegatesTo(RepositoryHandler.class) Closure configureClosure);
 
     /**
      * Returns the dependency handler of this project. The returned dependency handler instance can be used for adding
@@ -1339,7 +1340,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the dependencies.
      */
-    void dependencies(Closure configureClosure);
+    void dependencies(@DelegatesTo(DependencyHandler.class) Closure configureClosure);
 
     /**
      * Returns the build script handler for this project. You can use this handler to query details about the build
@@ -1357,7 +1358,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the build script classpath.
      */
-    void buildscript(Closure configureClosure);
+    void buildscript(@DelegatesTo(ScriptHandler.class) Closure configureClosure);
 
     /**
      * Copies the specified files.  The given closure is used to configure a {@link CopySpec}, which is then used to
@@ -1386,7 +1387,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param closure Closure to configure the CopySpec
      * @return {@link WorkResult} that can be used to check if the copy did any work.
      */
-    WorkResult copy(Closure closure);
+    WorkResult copy(@DelegatesTo(CopySpec.class) Closure closure);
 
     /**
      * Creates a {@link CopySpec} which can later be used to copy files or create an archive. The given closure is used
@@ -1407,7 +1408,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param closure Closure to configure the CopySpec
      * @return The CopySpec
      */
-    CopySpec copySpec(Closure closure);
+    CopySpec copySpec(@DelegatesTo(CopySpec.class) Closure closure);
 
     /**
      * Copies the specified files.  The given action is used to configure a {@link CopySpec}, which is then used to

--- a/subprojects/core/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/java/org/gradle/api/Project.java
@@ -19,6 +19,8 @@ package org.gradle.api;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.lang.MissingPropertyException;
+import groovy.transform.stc.ClosureParams;
+import groovy.transform.stc.SimpleType;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
@@ -30,6 +32,7 @@ import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DeleteSpec;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.initialization.dsl.ScriptHandler;
+import org.gradle.api.internal.ReturnType;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.LoggingManager;
@@ -478,7 +481,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @return The newly created task object
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      */
-    Task task(Map<String, ?> args, String name, @DelegatesTo(Task.class) Closure configureClosure);
+    Task task(Map<String, ?> args, String name, @DelegatesTo(value = Task.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(ReturnType.class) Closure configureClosure);
 
     /**
      * <p>Creates a {@link Task} with the given name and adds it to this project. Before the task is returned, the given
@@ -491,7 +494,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @return The newly created task object
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      */
-    Task task(String name, @DelegatesTo(Task.class) Closure configureClosure);
+    Task task(String name, @DelegatesTo(value = Task.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(ReturnType.class) Closure configureClosure);
 
     /**
      * <p>Returns the path of this project.  The path is the fully qualified name of the project.</p>
@@ -565,7 +568,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @return The project with the given path. Never returns null.
      * @throws UnknownProjectException If no project with the given path exists.
      */
-    Project project(String path, @DelegatesTo(Project.class) Closure configureClosure);
+    Project project(String path, @DelegatesTo(value = Project.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(ReturnType.class) Closure configureClosure);
 
     /**
      * <p>Returns a map of the tasks contained in this project, and optionally its subprojects.</p>
@@ -710,7 +713,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param configureClosure The closure to use to configure the file collection.
      * @return the configured file tree. Never returns null.
      */
-    ConfigurableFileCollection files(Object paths, @DelegatesTo(ConfigurableFileCollection.class) Closure configureClosure);
+    ConfigurableFileCollection files(Object paths, @DelegatesTo(value = ConfigurableFileCollection.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(ReturnType.class) Closure configureClosure);
 
     /**
      * <p>Creates a new {@code ConfigurableFileTree} using the given base directory. The given baseDir path is evaluated
@@ -759,7 +762,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param configureClosure Closure to configure the {@code ConfigurableFileTree} object.
      * @return the configured file tree. Never returns null.
      */
-    ConfigurableFileTree fileTree(Object baseDir, @DelegatesTo(ConfigurableFileTree.class) Closure configureClosure);
+    ConfigurableFileTree fileTree(Object baseDir, @DelegatesTo(value = ConfigurableFileTree.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(ReturnType.class) Closure configureClosure);
 
     /**
      * <p>Creates a new {@code ConfigurableFileTree} using the provided map of arguments.  The map will be applied as
@@ -874,7 +877,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param closure The closure for configuring the execution.
      * @return the result of the execution
      */
-    ExecResult javaexec(@DelegatesTo(JavaExecSpec.class) Closure closure);
+    ExecResult javaexec(@DelegatesTo(value = JavaExecSpec.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.process.JavaExecSpec"}) Closure closure);
 
     /**
      * Executes an external Java process.
@@ -893,7 +896,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param closure The closure for configuring the execution.
      * @return the result of the execution
      */
-    ExecResult exec(@DelegatesTo(ExecSpec.class) Closure closure);
+    ExecResult exec(@DelegatesTo(value = ExecSpec.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.process.ExecSpec"}) Closure closure);
 
     /**
      * Executes an external command.
@@ -991,7 +994,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param configureClosure The closure to execute against the <code>AntBuilder</code>.
      * @return The <code>AntBuilder</code>. Never returns null.
      */
-    AntBuilder ant(@DelegatesTo(AntBuilder.class) Closure configureClosure);
+    AntBuilder ant(@DelegatesTo(value = AntBuilder.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(ReturnType.class) Closure configureClosure);
 
     /**
      * Returns the configurations of this project.
@@ -1012,7 +1015,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the dependency configurations.
      */
-    void configurations(@DelegatesTo(ConfigurationContainer.class) Closure configureClosure);
+    void configurations(@DelegatesTo(value = ConfigurationContainer.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.api.artifacts.ConfigurationContainer"}) Closure configureClosure);
 
     /**
      * Returns a handler for assigning artifacts produced by the project to configurations.
@@ -1046,7 +1049,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the published artifacts.
      */
-    void artifacts(@DelegatesTo(ArtifactHandler.class) Closure configureClosure);
+    void artifacts(@DelegatesTo(value = ArtifactHandler.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.api.artifacts.dsl.ArtifactHandler"}) Closure configureClosure);
 
     /**
      * <p>Returns the {@link Convention} for this project.</p> <p/> <p>You can access this property in your build file
@@ -1097,7 +1100,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure The closure to execute.
      */
-    void subprojects(@DelegatesTo(Project.class) Closure configureClosure);
+    void subprojects(@DelegatesTo(value = Project.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.api.Project"}) Closure configureClosure);
 
     /**
      * <p>Configures this project and each of its sub-projects.</p>
@@ -1116,7 +1119,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure The closure to execute.
      */
-    void allprojects(@DelegatesTo(Project.class) Closure configureClosure);
+    void allprojects(@DelegatesTo(value = Project.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.api.Project"}) Closure configureClosure);
 
     /**
      * Adds an action to execute immediately before this project is evaluated.
@@ -1138,7 +1141,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param closure The closure to call.
      */
-    void beforeEvaluate(Closure closure);
+    void beforeEvaluate(@ClosureParams(value = SimpleType.class, options = {"org.gradle.api.Project"}) Closure closure);
 
     /**
      * <p>Adds a closure to be called immediately after this project has been evaluated. The project is passed to the
@@ -1149,7 +1152,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param closure The closure to call.
      */
-    void afterEvaluate(Closure closure);
+    void afterEvaluate(@ClosureParams(value = SimpleType.class, options = {"org.gradle.api.Project"}) Closure closure);
 
     /**
      * <p>Determines if this project has the given property. See <a href="#properties">here</a> for details of the
@@ -1315,7 +1318,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the repositories.
      */
-    void repositories(@DelegatesTo(RepositoryHandler.class) Closure configureClosure);
+    void repositories(@DelegatesTo(value = RepositoryHandler.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.api.artifacts.dsl.RepositoryHandler"}) Closure configureClosure);
 
     /**
      * Returns the dependency handler of this project. The returned dependency handler instance can be used for adding
@@ -1340,7 +1343,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the dependencies.
      */
-    void dependencies(@DelegatesTo(DependencyHandler.class) Closure configureClosure);
+    void dependencies(@DelegatesTo(value = DependencyHandler.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.api.artifacts.dsl.DependencyHandler"}) Closure configureClosure);
 
     /**
      * Returns the build script handler for this project. You can use this handler to query details about the build
@@ -1358,7 +1361,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param configureClosure the closure to use to configure the build script classpath.
      */
-    void buildscript(@DelegatesTo(ScriptHandler.class) Closure configureClosure);
+    void buildscript(@DelegatesTo(value = ScriptHandler.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.api.initialization.dsl.ScriptHandler"}) Closure configureClosure);
 
     /**
      * Copies the specified files.  The given closure is used to configure a {@link CopySpec}, which is then used to
@@ -1387,7 +1390,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param closure Closure to configure the CopySpec
      * @return {@link WorkResult} that can be used to check if the copy did any work.
      */
-    WorkResult copy(@DelegatesTo(CopySpec.class) Closure closure);
+    WorkResult copy(@DelegatesTo(value = CopySpec.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.api.file.CopySpec"}) Closure closure);
 
     /**
      * Creates a {@link CopySpec} which can later be used to copy files or create an archive. The given closure is used
@@ -1408,7 +1411,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param closure Closure to configure the CopySpec
      * @return The CopySpec
      */
-    CopySpec copySpec(@DelegatesTo(CopySpec.class) Closure closure);
+    CopySpec copySpec(@DelegatesTo(value = CopySpec.class, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType.class, options = {"org.gradle.api.file.CopySpec"}) Closure closure);
 
     /**
      * Copies the specified files.  The given action is used to configure a {@link CopySpec}, which is then used to
@@ -1478,7 +1481,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param <T> The type of objects for the container to contain.
      * @return The container.
      */
-    <T> NamedDomainObjectContainer<T> container(Class<T> type, Closure factoryClosure);
+    <T> NamedDomainObjectContainer<T> container(Class<T> type, @ClosureParams(value = SimpleType.class, options = {"java.lang.String"}) Closure factoryClosure);
 
     /**
      * Allows adding DSL extensions to the project. Useful for plugin authors.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/ReturnType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/ReturnType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal;
+
+import groovy.transform.stc.SingleSignatureClosureHint;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.SourceUnit;
+
+/**
+ * <p>A hint used to instruct the type checker to pick the return parameter type as the type of the
+ * sole argument to the closure. For example, imagine the method:</p>
+ *
+ * <p>R foo(A someArg, Closure c) {...}</p>
+ *
+ * <p>Here, the sole parameter for Closure c would be of type R, as R is the return type of foo.</p>
+ */
+public final class ReturnType extends SingleSignatureClosureHint {
+    @Override
+    public ClassNode[] getParameterTypes(MethodNode node, String[] options, SourceUnit sourceUnit, CompilationUnit unit, ASTNode usage) {
+        return new ClassNode[]{node.getReturnType()};
+    }
+}


### PR DESCRIPTION
Makes code completion in IDE less bad.  (also fixed a tiny typo)

Any of the checked boxes below indicate that I took action:

- [X] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [X] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [X] Ensured that basic checks pass: `./gradlew quickCheck`

I believe this is a very trivial change.  (No API changes or functionality changes.  Just a better IDE experience).  But, please let me know if more is needed.

![example](https://cloud.githubusercontent.com/assets/178348/20637511/59d8a5de-b358-11e6-89fe-94d6b7fa4720.png)
