### PR TITLE
Fail build if `default` configuration is not consumable

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -80,7 +80,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         ConfigurationContainer dependencyConfigurations = getDependencyProject().getConfigurations();
         String declaredConfiguration = getTargetConfiguration();
         Configuration selectedConfiguration = dependencyConfigurations.getByName(GUtil.elvis(declaredConfiguration, Dependency.DEFAULT_CONFIGURATION));
-        if (declaredConfiguration!=null && !selectedConfiguration.isCanBeConsumed()) {
+        if (!selectedConfiguration.isCanBeConsumed()) {
             throw new ConfigurationNotConsumableException(declaredConfiguration);
         }
         return selectedConfiguration;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.initialization.ProjectAccessListener;
+import org.gradle.internal.exceptions.ConfigurationNotConsumableException;
 import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GUtil;
 
@@ -80,7 +81,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         String declaredConfiguration = getTargetConfiguration();
         Configuration selectedConfiguration = dependencyConfigurations.getByName(GUtil.elvis(declaredConfiguration, Dependency.DEFAULT_CONFIGURATION));
         if (declaredConfiguration!=null && !selectedConfiguration.isCanBeConsumed()) {
-            throw new IllegalArgumentException("Configuration '" + declaredConfiguration+"' cannot be used in a project dependency");
+            throw new ConfigurationNotConsumableException(declaredConfiguration);
         }
         return selectedConfiguration;
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/ConfigurationNotConsumableException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/ConfigurationNotConsumableException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.exceptions;
+
+public class ConfigurationNotConsumableException extends IllegalArgumentException {
+    public ConfigurationNotConsumableException(String configurationName) {
+        super("Selected configuration '" + configurationName + "' but it can't be used as a project dependency because it isn't intended for consumption by other components.");
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.DependencyResolveContext
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.initialization.ProjectAccessListener
+import org.gradle.internal.exceptions.ConfigurationNotConsumableException
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 import static org.gradle.api.internal.artifacts.dependencies.AbstractModuleDependencySpec.assertDeepCopy
@@ -121,6 +122,23 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
         1 * context.add({it.is(conf.allArtifacts)})
         1 * listener.beforeResolvingProjectDependency(project)
         0 * _
+    }
+
+    void "doesn't allow selection of configuration is not consumable"() {
+        def context = Mock(TaskDependencyResolveContext)
+
+        def conf = project.configurations.create('conf') {
+            canBeConsumed = false
+        }
+        def listener = Mock(ProjectAccessListener)
+        projectDependency = new DefaultProjectDependency(project, 'conf', listener, true)
+
+        when:
+        projectDependency.buildDependencies.visitDependencies(context)
+
+        then:
+        def e = thrown(ConfigurationNotConsumableException)
+        e.message == "Selected configuration 'conf' but it can't be used as a project dependency because it isn't intended for consumption by other components."
     }
 
     void "does not build project dependencies if configured so"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.Modul
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.component.AmbiguousConfigurationSelectionException;
+import org.gradle.internal.exceptions.ConfigurationNotConsumableException;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import org.gradle.internal.component.local.model.LocalConfigurationMetadata;
@@ -126,8 +127,8 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         if (toConfiguration == null) {
             throw new ConfigurationNotFoundException(fromComponent.getComponentId(), moduleConfiguration, targetConfiguration, targetComponent.getComponentId());
         }
-        if (dependencyConfiguration != null && !toConfiguration.isCanBeConsumed()) {
-            throw new IllegalArgumentException("Configuration '" + dependencyConfiguration + "' cannot be used in a project dependency");
+        if (!toConfiguration.isCanBeConsumed()) {
+            throw new ConfigurationNotConsumableException(toConfiguration.getName());
         }
         ConfigurationMetadata delegate = toConfiguration;
         if (useConfigurationAttributes) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -89,6 +89,8 @@ class LocalComponentDependencyMetadataTest extends Specification {
         fromConfig.hierarchy >> ["from"]
         def defaultConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'default'
+            isCanBeResolved() >> true
+            isCanBeConsumed() >> true
         }
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -130,6 +132,8 @@ class LocalComponentDependencyMetadataTest extends Specification {
         fromConfig.hierarchy >> ["from"]
         def defaultConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'default'
+            isCanBeResolved() >> true
+            isCanBeConsumed() >> true
         }
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -251,6 +255,8 @@ class LocalComponentDependencyMetadataTest extends Specification {
         fromConfig.hierarchy >> ["from"]
         def defaultConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'default'
+            isCanBeResolved() >> true
+            isCanBeConsumed() >> true
         }
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -303,6 +309,8 @@ class LocalComponentDependencyMetadataTest extends Specification {
         fromConfig.hierarchy >> ["from"]
         def defaultConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'default'
+            isCanBeResolved() >> true
+            isCanBeConsumed() >> true
         }
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'


### PR DESCRIPTION
This PR fixes the configuration selection process to make sure that any selected configuration is consumable, including the `default` one. If not, an error is thrown.