### PR TITLE
Reduce memory for performance scenarios

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -103,9 +103,8 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
         }
     }
 
-    protected List<String> createDefaultJvmOptions(String heapSize = '1g') {
-        List<String> jvmOptions = PerformanceTestJvmOptions.customizeJvmOptions(["-Xms${heapSize}", "-Xmx${heapSize}"])
-        return jvmOptions
+    protected List<String> customizeJvmOptions(List<String> jvmOptionns) {
+        PerformanceTestJvmOptions.customizeJvmOptions(jvmOptionns)
     }
 
     @InheritConstructors

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestJvmOptions.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestJvmOptions.groovy
@@ -22,12 +22,12 @@ import org.gradle.api.JavaVersion
 
 @CompileStatic
 class PerformanceTestJvmOptions {
-    static List<String> customizeJvmOptions(List<String> jvmOptions) {
-        commonJvmOptions(jvmOptions, ['-Xms2g', '-Xmx2g'])
+    static List<String> customizeJvmOptions(List<? extends CharSequence> jvmOptions) {
+        commonJvmOptions(jvmOptions, ['-Xms1g', '-Xmx1g'])
     }
 
     // JVM default options for both build JVM and the daemon client (launcher) JVM
-    private static List<String> commonJvmOptions(List<String> originalJvmOptions, List<String> defaultOptions = []) {
+    private static List<String> commonJvmOptions(List<? extends CharSequence> originalJvmOptions, List<String> defaultOptions = []) {
         List<String> jvmOptions
         if (!originalJvmOptions) {
             jvmOptions = defaultOptions

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/DependencyReportPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/DependencyReportPerformanceTest.groovy
@@ -29,6 +29,7 @@ class DependencyReportPerformanceTest extends AbstractCrossVersionPerformanceTes
         runner.testProject = testProject
         runner.tasksToRun = ['dependencyReport']
         runner.targetVersions = targetVersions
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -37,9 +38,9 @@ class DependencyReportPerformanceTest extends AbstractCrossVersionPerformanceTes
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject       | targetVersions
-        "small"           | ['3.3-20161028000018+0000']
-        "multi"           | ['3.3-20161028000018+0000']
-        "lotDependencies" | ['3.3-20161028000018+0000']
+        testProject       | targetVersions              | maxMemory
+        "small"           | ['3.3-20161028000018+0000'] | '128m'
+        "multi"           | ['3.3-20161028000018+0000'] | '256m'
+        "lotDependencies" | ['3.3-20161028000018+0000'] | '256g'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/DependencyResolutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/DependencyResolutionPerformanceTest.groovy
@@ -30,6 +30,7 @@ class DependencyResolutionPerformanceTest extends AbstractCrossVersionPerformanc
         runner.tasksToRun = ['resolveDependencies']
         runner.targetVersions = targetVersions
         runner.useDaemon = true
+        runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
 
         when:
         def result = runner.run()
@@ -39,10 +40,7 @@ class DependencyResolutionPerformanceTest extends AbstractCrossVersionPerformanc
 
         where:
         testProject              | repoType | targetVersions
-        // TODO(pepper): Revert this to 'last' when 3.2 is released
-        // The regression was determined acceptable in this discussion:
-        // https://issues.gradle.org/browse/GRADLE-1346
         "lotDependencies"        | 'local'  | ['3.3-20161028000018+0000']
-        "lotProjectDependencies" | 'local'  | ['3.2-rc-1']
+        "lotProjectDependencies" | 'local'  | ['3.2']
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/IdeIntegrationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/IdeIntegrationPerformanceTest.groovy
@@ -30,6 +30,7 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest 
         runner.tasksToRun = ['eclipse']
         runner.targetVersions = targetVersions
         runner.useDaemon = true
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -38,10 +39,10 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest 
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject       | targetVersions
-        "small"           | ['3.3-20161028000018+0000']
-        "multi"           | ['3.3-20161028000018+0000']
-        "lotDependencies" | ['3.3-20161028000018+0000']
+        testProject       | targetVersions              | maxMemory
+        "small"           | ['3.3-20161028000018+0000'] | '128m'
+        "multi"           | ['3.3-20161028000018+0000'] | '256m'
+        "lotDependencies" | ['3.3-20161028000018+0000'] | '256m'
     }
 
     @Unroll("Project '#testProject' idea")
@@ -52,6 +53,7 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest 
         runner.tasksToRun = ['idea']
         runner.targetVersions = targetVersions
         runner.useDaemon = true
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -60,9 +62,9 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest 
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject       | targetVersions
-        "small"           | ['3.3-20161028000018+0000']
-        "multi"           | ['3.3-20161028000018+0000']
-        "lotDependencies" | ['3.3-20161028000018+0000']
+        testProject       | targetVersions              | maxMemory
+        "small"           | ['3.3-20161028000018+0000'] | '128m'
+        "multi"           | ['3.3-20161028000018+0000'] | '256m'
+        "lotDependencies" | ['3.3-20161028000018+0000'] | '256m'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaCleanDaemonPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaCleanDaemonPerformanceTest.groovy
@@ -57,7 +57,7 @@ class JavaCleanDaemonPerformanceTest extends AbstractCrossVersionPerformanceTest
         runner.useDaemon = true
         runner.tasksToRun = ["clean"]
         runner.targetVersions = targetVersions
-        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -66,12 +66,9 @@ class JavaCleanDaemonPerformanceTest extends AbstractCrossVersionPerformanceTest
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject            | targetVersions
-        "bigOldJava"           | ['2.8', 'last']
-        // TODO(pepper): Revert this to 'last' when 3.2 is released
-        // The regression was determined acceptable in this discussion:
-        // https://issues.gradle.org/browse/GRADLE-1346
-        "mediumOldJava"        | ['3.2-rc-1']
-        "smallOldJava"         | ['3.2-rc-1']
+        testProject            | targetVersions     | maxMemory
+        "bigOldJava"           | ['2.8', 'last']    | '512m'
+        "mediumOldJava"        | ['3.2-rc-1']       | '256m'
+        "smallOldJava"         | ['3.2-rc-1']       | '128m'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaConfigurationDaemonPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaConfigurationDaemonPerformanceTest.groovy
@@ -55,7 +55,7 @@ class JavaConfigurationDaemonPerformanceTest extends AbstractCrossVersionPerform
         runner.tasksToRun = ['help']
         runner.targetVersions = targetVersions
         runner.useDaemon = true
-        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -64,9 +64,9 @@ class JavaConfigurationDaemonPerformanceTest extends AbstractCrossVersionPerform
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject     | targetVersions
-        "bigOldJava"    | ['3.3-20161028000018+0000']
-        "mediumOldJava" | ['3.3-20161028000018+0000']
-        "smallOldJava"  | ['3.3-20161028000018+0000']
+        testProject     | targetVersions                | maxMemory
+        "bigOldJava"    | ['3.3-20161028000018+0000']   | '512m'
+        "mediumOldJava" | ['3.3-20161028000018+0000']   | '256m'
+        "smallOldJava"  | ['3.3-20161028000018+0000']   | '128m'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaConfigurationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaConfigurationPerformanceTest.groovy
@@ -30,6 +30,7 @@ class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.testProject = testProject
         runner.tasksToRun = ['help']
         runner.targetVersions = targetVersions
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -38,10 +39,10 @@ class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTe
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject       | targetVersions
-        "small"           | ['3.3-20161028000018+0000']
-        "multi"           | ['3.3-20161028000018+0000']
-        "lotDependencies" | ['3.3-20161028000018+0000']
-        "bigOldJava"      | ['3.3-20161028000018+0000']
+        testProject       | targetVersions              | maxMemory
+        "small"           | ['3.3-20161028000018+0000'] | '128m'
+        "multi"           | ['3.3-20161028000018+0000'] | '256m'
+        "lotDependencies" | ['3.3-20161028000018+0000'] | '256m'
+        "bigOldJava"      | ['3.3-20161028000018+0000'] | '512m'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaFullAssembleDaemonPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaFullAssembleDaemonPerformanceTest.groovy
@@ -64,7 +64,7 @@ class JavaFullAssembleDaemonPerformanceTest extends AbstractCrossVersionPerforma
         runner.useDaemon = true
         runner.tasksToRun = ["clean", "assemble"]
         runner.targetVersions = targetVersions
-        runner.gradleOpts = ["-Xms2g", "-Xmx2g"]
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -73,13 +73,10 @@ class JavaFullAssembleDaemonPerformanceTest extends AbstractCrossVersionPerforma
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject            | targetVersions
-        // TODO(pepper): Revert this to 'last' when 3.2 is released
-        // The regression was determined acceptable in this discussion:
-        // https://issues.gradle.org/browse/GRADLE-1346
-        "bigOldJavaMoreSource" | ['3.2-rc-1']
-        "bigOldJava"           | ['3.2-rc-1']
-        "mediumOldJava"        | ['3.2-rc-1']
-        "smallOldJava"         | ['3.2-rc-1']
+        testProject            | targetVersions | maxMemory
+        "bigOldJavaMoreSource" | ['3.2-rc-1']   | '1g'
+        "bigOldJava"           | ['3.2-rc-1']   | '512m'
+        "mediumOldJava"        | ['3.2-rc-1']   | '256m'
+        "smallOldJava"         | ['3.2-rc-1']   | '128m'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaFullBuildDaemonPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaFullBuildDaemonPerformanceTest.groovy
@@ -31,7 +31,7 @@ class JavaFullBuildDaemonPerformanceTest extends AbstractCrossVersionPerformance
         runner.useDaemon = true
         runner.tasksToRun = ['clean', 'build']
         runner.targetVersions = targetVersions
-        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -40,11 +40,8 @@ class JavaFullBuildDaemonPerformanceTest extends AbstractCrossVersionPerformance
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject | targetVersions
-        // TODO(pepper): Revert this to 'last' when 3.2 is released
-        // The regression was determined acceptable in this discussion:
-        // https://issues.gradle.org/browse/GRADLE-1346
-        "small"     | ['3.2-rc-1']
-        "multi"     | ['3.2-rc-1']
+        testProject | targetVersions    | maxMemory
+        "small"     | ['3.2-rc-1']      | '128m'
+        "multi"     | ['3.2-rc-1']      | '256m'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaPartialAssembleDaemonPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaPartialAssembleDaemonPerformanceTest.groovy
@@ -33,7 +33,7 @@ class JavaPartialAssembleDaemonPerformanceTest extends AbstractCrossVersionPerfo
         runner.useDaemon = true
         runner.tasksToRun = [":project1:clean", ":project1:assemble"]
         runner.targetVersions = targetVersions
-        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.gradleOpts = ["-Xms512m", "-Xmx512m"]
 
         when:
         def result = runner.run()
@@ -56,12 +56,10 @@ class JavaPartialAssembleDaemonPerformanceTest extends AbstractCrossVersionPerfo
         }
         runner.testProject = testProject
         runner.useDaemon = true
+        runner.warmUpRuns = 25
         runner.tasksToRun = [":project1:clean", ":project1:assemble"]
-        // TODO(pepper): Revert this to 'last' when 3.2 is released
-        // The regression was determined acceptable in this discussion:
-        // https://issues.gradle.org/browse/GRADLE-1346
-        runner.targetVersions = ['3.2-rc-1']
-        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.targetVersions = ['3.2']
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -70,6 +68,9 @@ class JavaPartialAssembleDaemonPerformanceTest extends AbstractCrossVersionPerfo
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject << ["bigOldJavaMoreSource", "bigOldJava", "mediumOldJava"]
+        testProject             | maxMemory
+        "bigOldJavaMoreSource"  | '512m'
+        "bigOldJava"            | '512m'
+        "mediumOldJava"         | '256m'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaTestExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaTestExecutionPerformanceTest.groovy
@@ -27,7 +27,7 @@ class JavaTestExecutionPerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.tasksToRun = gradleTasks
         runner.targetVersions = targetVersions
         runner.useDaemon = true
-        runner.gradleOpts = ['-Xms1G', '-Xmx1G']
+        runner.gradleOpts = ['-Xms256m', '-Xmx256m']
 
         when:
         def result = runner.run()
@@ -49,7 +49,7 @@ class JavaTestExecutionPerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.tasksToRun = gradleTasks
         runner.targetVersions = ['2.11', '3.3-20161028000018+0000']
         runner.useDaemon = true
-        runner.gradleOpts = ['-Xms1G', '-Xmx1G']
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
         runner.buildExperimentListener = new JavaOldModelSourceFileUpdater(10)
 
         when:
@@ -59,8 +59,8 @@ class JavaTestExecutionPerformanceTest extends AbstractCrossVersionPerformanceTe
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        template          | size     | description              | gradleTasks
-        'mediumWithJUnit' | 'medium' | 'incremental test build' | ['test']
-        'largeWithJUnit'  | 'large'  | 'incremental test build' | ['test']
+        template          | size     | description              | gradleTasks   | maxMemory
+        'mediumWithJUnit' | 'medium' | 'incremental test build' | ['test']      | '256m'
+        'largeWithJUnit'  | 'large'  | 'incremental test build' | ['test']      | '512m'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaUpToDateFullBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/JavaUpToDateFullBuildPerformanceTest.groovy
@@ -30,6 +30,7 @@ class JavaUpToDateFullBuildPerformanceTest extends AbstractCrossVersionPerforman
         runner.testProject = testProject
         runner.tasksToRun = ['build']
         runner.targetVersions = targetVersions
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
 
         when:
         def result = runner.run()
@@ -38,10 +39,10 @@ class JavaUpToDateFullBuildPerformanceTest extends AbstractCrossVersionPerforman
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject       | targetVersions
-        "small"           | ['3.3-20161028000018+0000']
-        "multi"           | ['3.3-20161028000018+0000']
-        "lotDependencies" | ['3.3-20161028000018+0000']
+        testProject       | targetVersions              | maxMemory
+        "small"           | ['3.3-20161028000018+0000'] | '128m'
+        "multi"           | ['3.3-20161028000018+0000'] | '256m'
+        "lotDependencies" | ['3.3-20161028000018+0000'] | '256m'
     }
 
     @Unroll("Up-to-date full build (daemon) - #testProject")
@@ -50,7 +51,7 @@ class JavaUpToDateFullBuildPerformanceTest extends AbstractCrossVersionPerforman
         runner.testId = "up-to-date full build Java build $testProject (daemon)"
         runner.testProject = testProject
         runner.tasksToRun = ['build']
-        runner.gradleOpts = ["-Xms2g", "-Xmx2g"]
+        runner.gradleOpts = ["-Xms${maxMemory}", "-Xmx${maxMemory}"]
         runner.targetVersions = ['3.3-20161028000018+0000']
         runner.useDaemon = true
         when:
@@ -59,6 +60,8 @@ class JavaUpToDateFullBuildPerformanceTest extends AbstractCrossVersionPerforman
         then:
         result.assertCurrentVersionHasNotRegressed()
         where:
-        testProject << ["bigOldJava", "lotDependencies"]
+        testProject       |  maxMemory
+        "bigOldJava"      | '1G'
+        "lotDependencies" | '256m'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/LocalTaskOutputCacheJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/LocalTaskOutputCacheJavaPerformanceTest.groovy
@@ -31,7 +31,7 @@ class LocalTaskOutputCacheJavaPerformanceTest extends AbstractCrossVersionPerfor
         runner.tasksToRun = tasks
         runner.useDaemon = true
         runner.targetVersions = ['last']
-        runner.gradleOpts = ["-Xms8g", "-Xmx8g"]
+        runner.gradleOpts = ["-Xms1G", "-Xmx1G"]
         runner.args = ['-Dorg.gradle.cache.tasks=true']
         runner.setupCleanupOnOddRounds()
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/ManyEmptyProjectsHelpPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/ManyEmptyProjectsHelpPerformanceTest.groovy
@@ -28,6 +28,7 @@ class ManyEmptyProjectsHelpPerformanceTest extends AbstractCrossVersionPerforman
         runner.testProject = "bigEmpty"
         runner.tasksToRun = ['help']
         runner.targetVersions = ['3.0', 'last']
+        runner.gradleOpts = ['-Xms1g', '-Xmx1g']
 
         when:
         def result = runner.run()
@@ -42,6 +43,7 @@ class ManyEmptyProjectsHelpPerformanceTest extends AbstractCrossVersionPerforman
         runner.testProject = "bigEmpty"
         runner.tasksToRun = ['help']
         runner.targetVersions = ['3.3-20161028000018+0000', 'last']
+        runner.gradleOpts = ['-Xms1g', '-Xmx1g']
         runner.useDaemon = true
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/ProjectDependenciesPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/ProjectDependenciesPerformanceTest.groovy
@@ -28,12 +28,8 @@ class ProjectDependenciesPerformanceTest extends AbstractCrossVersionPerformance
         runner.testProject = "lotProjectDependencies"
         runner.tasksToRun = ['resolveDependencies']
         runner.useDaemon = true
-        // TODO(pepper): Revert this to 'last' when 3.2 is released
-        // The regression was introduced by some code which makes parallel
-        // execution and cases work much better. That is currently a more
-        // important use case, so we are accepting the performance regression
-        // in these non-parallel case.
-        runner.targetVersions = ['3.2-rc-1']
+        runner.gradleOpts = ['-Xms256m', '-Xmx256m']
+        runner.targetVersions = ['3.2']
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/RealLifeAndroidStudioMockupPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/RealLifeAndroidStudioMockupPerformanceTest.groovy
@@ -30,7 +30,7 @@ class RealLifeAndroidStudioMockupPerformanceTest extends AbstractAndroidStudioMo
 
         experiment(template, "simulate Android Studio $template synchronization") {
             action('org.gradle.performance.android.SyncAction') {
-                jvmArguments = createDefaultJvmOptions("2g")
+                jvmArguments = customizeJvmOptions(["-Xms2g", "-Xmx2g"])
             }
         }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/RealWorldNativePluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/RealWorldNativePluginPerformanceTest.groovy
@@ -37,8 +37,9 @@ class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionPerforman
         runner.tasksToRun = ['build']
         runner.targetVersions = ['last']
         runner.useDaemon = true
-        runner.gradleOpts = ["-Xms4g", "-Xmx4g"]
-        runner.warmUpRuns = 6
+        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.warmUpRuns = 9
+        runner.runs = 10
 
         if (parallelWorkers) {
             runner.args += ["--parallel", "--max-workers=$parallelWorkers".toString()]
@@ -53,9 +54,9 @@ class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionPerforman
         where:
         testProject                   | parallelWorkers
         "nativeMonolithic"            | 0
-        "nativeMonolithic"            | 4
+        "nativeMonolithic"            | 12
         "nativeMonolithicOverlapping" | 0
-        "nativeMonolithicOverlapping" | 4
+        "nativeMonolithicOverlapping" | 12
     }
 
     @Unroll('Project #buildSize native build #changeType')
@@ -64,11 +65,11 @@ class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionPerforman
         runner.testId = "native build ${buildSize} ${changeType}"
         runner.testProject = "${buildSize}NativeMonolithic"
         runner.tasksToRun = ['build']
-        runner.args = ["--parallel", "--max-workers=4"]
+        runner.args = ["--parallel", "--max-workers=12"]
         runner.targetVersions = targetVersions
         runner.useDaemon = true
-        runner.gradleOpts = ["-Xms4g", "-Xmx4g"]
-        runner.warmUpRuns = 6
+        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.warmUpRuns = 9
         //the content changing code below assumes an even number of runs
         runner.runs = 10
         if (runner.honestProfiler.enabled) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/TasksReportPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/TasksReportPerformanceTest.groovy
@@ -35,6 +35,7 @@ class TasksReportPerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testId = "$reportType.description $testProject"
         runner.testProject = testProject
         runner.tasksToRun = reportType.tasks
+        runner.gradleOpts = ['-Xms256m', '-Xmx256m']
         runner.targetVersions = ['3.3-20161028000018+0000']
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/TestExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/TestExecutionPerformanceTest.groovy
@@ -29,10 +29,8 @@ class TestExecutionPerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testProject = testProject
         runner.tasksToRun = ['cleanTest', 'test']
         runner.args = ['-q']
-        // TODO(pepper): Revert this to 'last' when 3.2 is released
-        // The regression was determined acceptable in this discussion:
-        // https://issues.gradle.org/browse/GRADLE-1346
         runner.targetVersions = ['3.2-rc-1']
+        runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
         runner.useDaemon = true
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/ToolingApiIdeModelCrossVersionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/ToolingApiIdeModelCrossVersionPerformanceTest.groovy
@@ -40,7 +40,7 @@ class ToolingApiIdeModelCrossVersionPerformanceTest extends AbstractToolingApiCr
             targetVersions = ['3.2-rc-1']
             action {
                 def model = model(tapiClass(EclipseProject))
-                    .setJvmArguments(createDefaultJvmOptions()).get()
+                    .setJvmArguments(customizeJvmOptions(["-Xms$maxMemory", "-Xmx$maxMemory"])).get()
                 // we must actually do something to highlight some performance issues
                 forEachEclipseProject(model) {
                     buildCommands.each {
@@ -86,7 +86,11 @@ class ToolingApiIdeModelCrossVersionPerformanceTest extends AbstractToolingApiCr
         results.assertCurrentVersionHasNotRegressed()
 
         where:
-        template << ["smallOldJava", "mediumOldJava", "bigOldJava", "lotDependencies"]
+        template            | maxMemory
+        "smallOldJava"      | '128m'
+        "mediumOldJava"     | '256m'
+        "bigOldJava"        | '512m'
+        "lotDependencies"   | '256m'
     }
 
     private static void sendCommand(String command, int port) {
@@ -134,11 +138,12 @@ class ToolingApiIdeModelCrossVersionPerformanceTest extends AbstractToolingApiCr
             }*/
             warmUpCount = 20
             invocationCount = 30
-            targetVersions = targetGradleVersions
+            targetVersions = ['3.2']
+
             action {
                 def version = tapiClass(GradleVersion).current().version
                 def model = model(tapiClass(IdeaProject))
-                    .setJvmArguments(createDefaultJvmOptions()).get()
+                    .setJvmArguments(customizeJvmOptions(["-Xms$maxMemory", "-Xmx$maxMemory"])).get()
                 // we must actually do something to highlight some performance issues
                 model.with {
                     name
@@ -181,12 +186,11 @@ class ToolingApiIdeModelCrossVersionPerformanceTest extends AbstractToolingApiCr
         results.assertCurrentVersionHasNotRegressed()
 
         where:
-        // rebaselined because of https://github.com/gra
-        template          | targetGradleVersions
-        "smallOldJava"    | ['3.2-rc-1']
-        "mediumOldJava"   | ['3.2-rc-1']
-        "bigOldJava"      | ['3.2-rc-1']
-        "lotDependencies" | ['3.2-rc-1']
+        template            | maxMemory
+        "smallOldJava"      | '128m'
+        "mediumOldJava"     | '256m'
+        "bigOldJava"        | '512m'
+        "lotDependencies"   | '256m'
     }
 
     private static void forEachEclipseProject(def elm, @DelegatesTo(value=EclipseProject) Closure<?> action) {


### PR DESCRIPTION
The scenarios should only have an amount of memory that is
"reasonable" for what they are doing. This serves two purposes.
It allows us to detect large memory regressions, as a reasonable
upper limit will lead to lots of GC time if that limit is breached.
It also makes test results more predictable, as too much memory means
that many test runs will not need garbage collection at all while other
test runs will have large GC cycles.