### PR TITLE
Making the pluginRepositories avaliable in the init scripts

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
@@ -75,7 +75,7 @@ class InitScriptIntegrationTest extends AbstractIntegrationSpec {
         output.contains("Task helloFromBuildSrc executed")
     }
 
-    def 'init script can apply custom plugin'() {
+    def 'init script can specify plugin repositories'() {
         executer.requireOwnGradleUserHomeDir()
         new TestFile(executer.gradleUserHomeDir, "init.gradle") << "gradle.pluginRepositories { maven { it.url '${getMavenRepo().getRootDir().absolutePath}'} }"
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
@@ -17,9 +17,13 @@
 package org.gradle.initialization
 
 import groovy.transform.NotYetImplemented
+import org.gradle.api.execution.TaskExecutionAdapter
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.ArtifactBuilder
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.maven.MavenModule
+import spock.lang.IgnoreRest
 import spock.lang.Issue
 
 @LeaksFileHandles
@@ -72,6 +76,44 @@ class InitScriptIntegrationTest extends AbstractIntegrationSpec {
         then:
         output.contains("Task hello executed")
         output.contains("Task helloFromBuildSrc executed")
+    }
+
+    def 'init script can apply custom plugin'() {
+        executer.requireOwnGradleUserHomeDir()
+        new TestFile(executer.gradleUserHomeDir, "init.gradle") << "gradle.pluginRepositories { maven { it.url '${getMavenRepo().getRootDir().absolutePath}'} }"
+
+        buildPluginJar()
+
+        buildScript """
+        plugins { 
+            id 'custom' version '1.0'
+        }
+        """
+
+        when:
+        succeeds 'help'
+
+        then:
+        noExceptionThrown()
+    }
+
+    private void buildPluginJar() {
+        ArtifactBuilder builder = artifactBuilder()
+        builder.sourceFile('CustomPlugin.java') << """
+import org.gradle.api.*;
+import org.gradle.api.initialization.*;
+public class CustomPlugin implements Plugin<Project> {
+    public void apply(Project t) {
+        
+    }
+}
+"""
+        builder.resourceFile('META-INF/gradle-plugins/custom.properties') << '''
+implementation-class=CustomPlugin
+'''
+        def module = mavenRepo.module("custom", "custom.gradle.plugin").publish()
+        module.artifactFile.delete()
+        builder.buildJar(module.artifactFile)
     }
 
     private String initScript() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
@@ -77,7 +77,7 @@ class InitScriptIntegrationTest extends AbstractIntegrationSpec {
 
     def 'init script can specify plugin repositories'() {
         executer.requireOwnGradleUserHomeDir()
-        new TestFile(executer.gradleUserHomeDir, "init.gradle") << "gradle.pluginRepositories { maven { it.url '${getMavenRepo().getRootDir().absolutePath}'} }"
+        new TestFile(executer.gradleUserHomeDir, "init.gradle") << "gradle.pluginRepositories { maven { it.url '${getMavenRepo().getRootDir().toURI().toURL().toString()}'} }"
 
         def pluginBuilder = new PluginBuilder(new TestFile(executer.testDirectoryProvider.testDirectory, 'plugin-repo'))
         pluginBuilder.addPlugin("", 'custom')
@@ -98,8 +98,8 @@ class InitScriptIntegrationTest extends AbstractIntegrationSpec {
 
     def 'when plugins come from multiple repos, it will pick the first'() {
         executer.requireOwnGradleUserHomeDir()
-        new TestFile(executer.gradleUserHomeDir, "init.gradle") << "gradle.pluginRepositories { maven { it.url '${getMavenRepo().getRootDir().absolutePath}'} }"
-        new TestFile(executer.testDirectoryProvider.testDirectory, "settings.gradle") << "pluginRepositories { ivy { it.url '${getIvyRepo().getRootDir().absolutePath}'} }"
+        new TestFile(executer.gradleUserHomeDir, "init.gradle") << "gradle.pluginRepositories { maven { it.url '${getMavenRepo().getRootDir().toURI().toURL().toString()}'} }"
+        new TestFile(executer.testDirectoryProvider.testDirectory, "settings.gradle") << "pluginRepositories { ivy { it.url '${getIvyRepo().getRootDir().absolutePath.toURI().toURL().toString()}'} }"
 
         def pluginBuilder1 = new PluginBuilder(new TestFile(executer.testDirectoryProvider.testDirectory, 'plugin1-repo'))
         pluginBuilder1.addPlugin("", 'custom')

--- a/subprojects/core/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -187,19 +187,9 @@ public interface Gradle extends PluginAware {
      * Adds a action to be called to configure {@code PluginRepositoriesSpec}
      *
      * @param pluginSettings The action to execute
-     * @throws IllegalStateException when settings are evaluated
+     * @throws IllegalStateException if a plugin has already been applied with the <code>plugins { }</code> block.
      */
-    void pluginRepositories(Action<PluginRepositoriesSpec> pluginSettings);
-
-    /**
-     * Adds a closure to be called to configure pluginRepositories.
-     *
-     * This {@code PluginRepositoriesSpec} instance is passed to the closure as the first parameter.
-     *
-     * @param closure The closure to execute.
-     * @throws IllegalStateException when settings are evaluated
-     */
-    void pluginRepositories(Closure closure);
+    void pluginRepositories(Action<? super PluginRepositoriesSpec> pluginSettings);
 
     /**
      * Adds a closure to be called when the build settings have been loaded and evaluated.

--- a/subprojects/core/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -28,6 +28,7 @@ import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.plugins.PluginAware;
 import org.gradle.internal.HasInternalProtocol;
+import org.gradle.plugin.repository.PluginRepositoriesSpec;
 
 import java.io.File;
 import java.util.Collection;
@@ -181,6 +182,24 @@ public interface Gradle extends PluginAware {
      * @param action The action to execute.
      */
     void buildStarted(Action<? super Gradle> action);
+     
+    /**
+     * Adds a action to be called to configure {@code PluginRepositoriesSpec}
+     *
+     * @param pluginSettings The action to execute
+     * @throws IllegalStateException when settings are evaluated
+     */
+    void pluginRepositories(Action<PluginRepositoriesSpec> pluginSettings);
+
+    /**
+     * Adds a closure to be called to configure pluginRepositories.
+     *
+     * This {@code PluginRepositoriesSpec} instance is passed to the closure as the first parameter.
+     *
+     * @param closure The closure to execute.
+     * @throws IllegalStateException when settings are evaluated
+     */
+    void pluginRepositories(Closure closure);
 
     /**
      * Adds a closure to be called when the build settings have been loaded and evaluated.

--- a/subprojects/core/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -182,7 +182,7 @@ public interface Gradle extends PluginAware {
      * @param action The action to execute.
      */
     void buildStarted(Action<? super Gradle> action);
-     
+
     /**
      * Adds a action to be called to configure {@code PluginRepositoriesSpec}
      *
@@ -190,6 +190,14 @@ public interface Gradle extends PluginAware {
      * @throws IllegalStateException if a plugin has already been applied with the <code>plugins { }</code> block.
      */
     void pluginRepositories(Action<? super PluginRepositoriesSpec> pluginSettings);
+
+    /**
+     * Adds a action to be called to configure {@code PluginRepositoriesSpec}
+     *
+     * @param pluginSettings The action to execute
+     * @throws IllegalStateException if a plugin has already been applied with the <code>plugins { }</code> block.
+     */
+    void pluginRepositories(Closure pluginSettings);
 
     /**
      * Adds a closure to be called when the build settings have been loaded and evaluated.

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -50,6 +50,11 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.listener.ActionBroadcast;
 import org.gradle.listener.ClosureBackedMethodInvocationDispatch;
+import org.gradle.plugin.repository.PluginRepositoriesSpec;
+import org.gradle.plugin.repository.internal.DefaultPluginRepositoriesSpec;
+import org.gradle.plugin.repository.internal.PluginRepositoryFactory;
+import org.gradle.plugin.repository.internal.PluginRepositoryRegistry;
+import org.gradle.util.ConfigureUtil;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.Path;
 
@@ -241,6 +246,19 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     @Override
     public void buildStarted(Action<? super Gradle> action) {
         buildListenerBroadcast.add("buildStarted", action);
+    }
+
+    @Override
+    public void pluginRepositories(Action<PluginRepositoriesSpec> pluginSettings) {
+        PluginRepositoryFactory pluginRepositoryFactory = getServices().get(PluginRepositoryFactory.class);
+        PluginRepositoryRegistry pluginRepositoryRegistry = getServices().get(PluginRepositoryRegistry.class);
+        DefaultPluginRepositoriesSpec spec = new DefaultPluginRepositoriesSpec(pluginRepositoryFactory, pluginRepositoryRegistry, getFileResolver());
+        pluginSettings.execute(spec);
+    }
+
+    @Override
+    public void pluginRepositories(Closure closure) {
+        pluginRepositories(ConfigureUtil.<PluginRepositoriesSpec>configureUsing(closure));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -249,7 +249,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     }
 
     @Override
-    public void pluginRepositories(Action<PluginRepositoriesSpec> pluginSettings) {
+    public void pluginRepositories(Action<? super PluginRepositoriesSpec> pluginSettings) {
         PluginRepositoryFactory pluginRepositoryFactory = getServices().get(PluginRepositoryFactory.class);
         PluginRepositoryRegistry pluginRepositoryRegistry = getServices().get(PluginRepositoryRegistry.class);
         DefaultPluginRepositoriesSpec spec = new DefaultPluginRepositoriesSpec(pluginRepositoryFactory, pluginRepositoryRegistry, getFileResolver());
@@ -262,6 +262,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     }
 
     @Override
+    
     public void settingsEvaluated(Closure closure) {
         buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("settingsEvaluated", closure));
     }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -262,7 +262,6 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     }
 
     @Override
-    
     public void settingsEvaluated(Closure closure) {
         buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("settingsEvaluated", closure));
     }

--- a/subprojects/core/src/main/java/org/gradle/plugin/repository/PluginRepositoriesSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/repository/PluginRepositoriesSpec.java
@@ -24,6 +24,10 @@ import org.gradle.api.Incubating;
  * <p>
  * Plugin repositories added via this interface will used to resolve plugins specified
  * in the <code>plugins {}</code> block.
+ *
+ * When defining multiple <code>pluginRepository {}</code> blocks (like possible with
+ * init scripts), the order in which they are applied is the order in which Gradle will
+ * search for the plugin.
  */
 @Incubating
 public interface PluginRepositoriesSpec {

--- a/subprojects/core/src/main/java/org/gradle/plugin/repository/PluginRepositoriesSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/repository/PluginRepositoriesSpec.java
@@ -24,10 +24,6 @@ import org.gradle.api.Incubating;
  * <p>
  * Plugin repositories added via this interface will used to resolve plugins specified
  * in the <code>plugins {}</code> block.
- *
- * When defining multiple <code>pluginRepository {}</code> blocks (like possible with
- * init scripts), the order in which they are applied is the order in which Gradle will
- * search for the plugin.
  */
 @Incubating
 public interface PluginRepositoriesSpec {

--- a/subprojects/docs/src/docs/userguide/plugins.xml
+++ b/subprojects/docs/src/docs/userguide/plugins.xml
@@ -273,10 +273,10 @@
                     which actually implement the plugin. For more information on publishing plugins to custom repositories read <xref linkend="javaGradle_plugin" />.
                 </para>
                 <para>
-                    It is also possible to add a custom plugin repositories using an <link linkend="init_scripts">Init Script</link> using
-                    then <apilink class="org.gradle.api.invocation.Gradle" method="pluginRepositories"/> method. When using both an init script and
-                    <code>settings.gradle</code> the order in which they apply will be the order Gradle searches for the plugin. Once a plugin is applied using
-                    <code>plugins {}</code> DSL, you can no longer add custom plugin repositories.
+                    It is also possible to add a custom plugin repositories using an <link linkend="init_scripts">Init Script</link> with
+                    a <apilink class="org.gradle.api.invocation.Gradle" method="pluginRepositories"/> block. Plugin repositories added this way will be applied
+                    before those in <code>settings.gradle</code>. Once a plugin is applied using the <code>plugins {}</code> DSL, you can no longer add custom
+                    plugin repositories.
                 </para>
                 <para>
                     See <apilink class="org.gradle.plugin.repository.PluginRepositoriesSpec" /> for complete documentation for using the

--- a/subprojects/docs/src/docs/userguide/plugins.xml
+++ b/subprojects/docs/src/docs/userguide/plugins.xml
@@ -268,9 +268,15 @@
                     omit the <code>gradlePluginPortal()</code> line. Finally, the Ivy repository at <literal>ivy-repo</literal> will be checked.
                 </para>
                 <para>
-                    The <code>pluginRepositories {}</code> block may only appear in the <code>settings.gradle</code> file, and must be the first block in the file.
+                    The <code>pluginRepositories {}</code> when in the <code>settings.gradle</code> file must be the first block in the file.
                     Custom Maven and Ivy plugin repositories must contain <link linkend="sec:plugin_markers">plugin marker artifacts</link> in addition to the artifacts
                     which actually implement the plugin. For more information on publishing plugins to custom repositories read <xref linkend="javaGradle_plugin" />.
+                </para>
+                <para>
+                    It is also possible to add a custom plugin repositories using an <link linkend="init_scripts">Init Script</link> using
+                    then <apilink class="org.gradle.api.invocation.Gradle" method="pluginRepositories"/> method. When using both an init script and
+                    <code>settings.gradle</code> the order in which they apply will be the order Gradle searches for the plugin. Once a plugin is applied using
+                    <code>plugins {}</code> DSL, you can no longer add custom plugin repositories.
                 </para>
                 <para>
                     See <apilink class="org.gradle.plugin.repository.PluginRepositoriesSpec" /> for complete documentation for using the

--- a/subprojects/docs/src/docs/userguide/plugins.xml
+++ b/subprojects/docs/src/docs/userguide/plugins.xml
@@ -274,7 +274,7 @@
                 </para>
                 <para>
                     It is also possible to add a custom plugin repositories using an <link linkend="init_scripts">Init Script</link> with
-                    a <apilink class="org.gradle.api.invocation.Gradle" method="pluginRepositories"/> block. Plugin repositories added this way will be applied
+                    a <apilink class="org.gradle.api.invocation.Gradle" method="pluginRepositories(org.gradle.api.Action)"/> block. Plugin repositories added this way will be applied
                     before those in <code>settings.gradle</code>. Once a plugin is applied using the <code>plugins {}</code> DSL, you can no longer add custom
                     plugin repositories.
                 </para>


### PR DESCRIPTION
Given this feature users the ability to configure their
pluginRepositories though an init script to make it easier for orgs to
load all plugin repositories up.

This was talked about as part of #883.