### PR TITLE
Handle missing/unknown attributes on compatiblity chain

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/attributes/CompatibilityCheckDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/attributes/CompatibilityCheckDetails.java
@@ -31,13 +31,13 @@ public interface CompatibilityCheckDetails<T> {
      * The value of the attribute as found on the consumer side.
      * @return the value from the consumer
      */
-    AttributeValue<T> getConsumerValue();
+    T getConsumerValue();
 
     /**
      * The value of the attribute as found on the producer side.
      * @return the value from the producer
      */
-    AttributeValue<T> getProducerValue();
+    T getProducerValue();
 
     /**
      * Calling this method will indicate that the attributes are compatible.

--- a/subprojects/core/src/main/java/org/gradle/api/attributes/CompatibilityRuleChain.java
+++ b/subprojects/core/src/main/java/org/gradle/api/attributes/CompatibilityRuleChain.java
@@ -58,7 +58,7 @@ public interface CompatibilityRuleChain<T> {
 
     /**
      * <p>Adds an arbitrary compatibility rule to the chain.</p>
-     * <p>A compatibility rule can tell if two {@link AttributeValue values} are compatible.
+     * <p>A compatibility rule can tell if two values are compatible.
      * Compatibility doesn't mean equality. Typically two different Java platforms can be
      * compatible, without being equal.</p>
      *

--- a/subprojects/core/src/main/java/org/gradle/api/attributes/DisambiguationRuleChain.java
+++ b/subprojects/core/src/main/java/org/gradle/api/attributes/DisambiguationRuleChain.java
@@ -26,7 +26,7 @@ import java.util.Comparator;
  * <p>A chain of disambiguation rules. By default the chain is empty and will not do any disambiguation.</p>
  *
  * <p>For a given set of rules, the execution is done <i>in order</i>, and interrupts as soon as a rule
- * selected at least one candidate (through {@link MultipleCandidatesDetails#closestMatch(AttributeValue)}).
+ * selected at least one candidate (through {@link MultipleCandidatesDetails#closestMatch(T)}).
  * </p>
  *
  * <p>If the end of the rule chain is reached and that no rule selected a candidate then the candidate list is returned
@@ -40,9 +40,9 @@ public interface DisambiguationRuleChain<T> {
 
     /**
      * <p>Adds an arbitrary disambiguation rule to the chain.</p>
-     * <p>A disambiguation rule can select the best match from a list of {@link AttributeValue candidate}.</p>
+     * <p>A disambiguation rule can select the best match from a list of candidates.</p>
      *
-     * <p>A rule <i>can</i> express an preference by calling the @{link {@link MultipleCandidatesDetails#closestMatch(AttributeValue)}
+     * <p>A rule <i>can</i> express an preference by calling the @{link {@link MultipleCandidatesDetails#closestMatch(T)}
      * method to tell that a candidate is the best one.</p>
      *
      * <p>It is not mandatory for a rule to choose, and it is not an error to select multiple candidates.</p>

--- a/subprojects/core/src/main/java/org/gradle/api/attributes/MultipleCandidatesDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/attributes/MultipleCandidatesDetails.java
@@ -30,16 +30,16 @@ import java.util.Set;
 @Incubating
 public interface MultipleCandidatesDetails<T> {
     /**
-     * The value of the attribute on the consumer side. All possible outcomes are valid (present, missing, unknown)
+     * The value of the attribute on the consumer side
      * @return the value of the attribute as found on the consumer side
      */
-    AttributeValue<T> getConsumerValue();
+    T getConsumerValue();
 
     /**
      * A set of candidate values.
      * @return the set of candidates
      */
-    Set<AttributeValue<T>> getCandidateValues();
+    Set<T> getCandidateValues();
 
     /**
      * Calling this method indicates that the candidate is the closest match. It is allowed to call this method several times with
@@ -47,6 +47,6 @@ public interface MultipleCandidatesDetails<T> {
      *
      * @param candidate the closest match
      */
-    void closestMatch(AttributeValue<T> candidate);
+    void closestMatch(T candidate);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/attributes/MultipleCandidatesDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/attributes/MultipleCandidatesDetails.java
@@ -21,19 +21,12 @@ import java.util.Set;
 
 /**
  * Provides context about candidates for an attribute. In particular, this class gives access to
- * the value of an attribute as found on the consumer, but also a list of candidates for the same
- * attribute on the producer side. It is possible to determine what to do in case an attribute is
- * missing, or unknown, on both the consumer and producer sides.
+ * the list of candidates on the producer side.
  *
  * @param <T> the concrete type of the attribute
  */
 @Incubating
 public interface MultipleCandidatesDetails<T> {
-    /**
-     * The value of the attribute on the consumer side
-     * @return the value of the attribute as found on the consumer side
-     */
-    T getConsumerValue();
 
     /**
      * A set of candidate values.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeMatchingRules.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeMatchingRules.java
@@ -25,17 +25,6 @@ import java.util.Comparator;
 
 public abstract class AttributeMatchingRules {
     private static final EqualityCompatibilityRule EQUALITY_RULE = new EqualityCompatibilityRule();
-    private static final Action<CompatibilityCheckDetails<?>> ASSUME_COMPATIBLE_WHEN_MISSING = new Action<CompatibilityCheckDetails<?>>() {
-        @Override
-        public void execute(CompatibilityCheckDetails<?> details) {
-            if (details.getProducerValue().isMissing()
-                || details.getProducerValue().isUnknown()
-                || details.getConsumerValue().isMissing()
-                || details.getConsumerValue().isUnknown()) {
-                details.compatible();
-            }
-        }
-    };
 
     public static <T> Action<? super CompatibilityCheckDetails<T>> equalityCompatibility() {
         return Cast.uncheckedCast(EQUALITY_RULE);
@@ -47,9 +36,5 @@ public abstract class AttributeMatchingRules {
 
     public static <T> Action<? super MultipleCandidatesDetails<T>> orderedDisambiguation(Comparator<? super T> comparator, boolean pickFirst) {
         return new DefaultOrderedDisambiguationRule<T>(comparator, pickFirst);
-    }
-
-    public static <T> Action<? super CompatibilityCheckDetails<T>> assumeCompatibleWhenMissing() {
-        return Cast.uncheckedCast(ASSUME_COMPATIBLE_WHEN_MISSING);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
@@ -17,8 +17,6 @@
 package org.gradle.api.internal.attributes;
 
 import org.gradle.api.InvalidUserCodeException;
-import org.gradle.api.attributes.AttributeMatchingStrategy;
-import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.internal.Cast;
 
 import java.util.NoSuchElementException;
@@ -27,13 +25,13 @@ import java.util.NoSuchElementException;
  * Represents an optional attribute value, as found in an attribute container. There are 3 possible cases:
  * <ul>
  *     <li><i>present</i> is the default, and represents an attribute with an actual value</li>
- *     <li><i>missing</i> used whenever an attribute is known of the {@link AttributesSchema} of a consumer,
+ *     <li><i>missing</i> used whenever an attribute is known of the {@link org.gradle.api.attributes.AttributesSchema} of a consumer,
  *     no value was provided.</li>
- *     <li><i>unknown</i> used whenever an attribute is unknown of the {@link AttributesSchema} of a consumer,
+ *     <li><i>unknown</i> used whenever an attribute is unknown of the {@link org.gradle.api.attributes.AttributesSchema} of a consumer,
  *     implying that no value was provided. It is different from the missing case in the sense that the consumer
  *     had no chance to provide a value here.</li>
  * </ul>
- * During attribute matching, this can be used to implement various {@link AttributeMatchingStrategy strategies}.
+ * During attribute matching, this can be used to implement various {@link org.gradle.api.attributes.AttributeMatchingStrategy strategies}.
  * @param <T> the type of the attribute
  *
  * @since 3.3

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.api.attributes;
+package org.gradle.api.internal.attributes;
 
 import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.attributes.AttributeMatchingStrategy;
+import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.internal.Cast;
 
 import java.util.NoSuchElementException;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/CompatibilityRuleChainInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/CompatibilityRuleChainInternal.java
@@ -20,4 +20,5 @@ import org.gradle.api.attributes.CompatibilityCheckDetails;
 import org.gradle.api.attributes.CompatibilityRuleChain;
 
 public interface CompatibilityRuleChainInternal<T> extends CompatibilityRuleChain<T>, Action<CompatibilityCheckDetails<T>> {
+    boolean isCompatibleWhenMissing();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.attributes;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
-import org.gradle.api.attributes.AttributeValue;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
 
 import java.util.Comparator;
@@ -26,6 +25,8 @@ import java.util.List;
 public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChainInternal<T> {
 
     private final List<Action<? super CompatibilityCheckDetails<T>>> rules = Lists.newArrayList();
+
+    private boolean assumeCompatibleWhenMissing;
 
     @Override
     public void ordered(Comparator<? super T> comparator) {
@@ -46,8 +47,12 @@ public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChainI
 
     @Override
     public void assumeCompatibleWhenMissing() {
-        Action<? super CompatibilityCheckDetails<T>> rule = AttributeMatchingRules.assumeCompatibleWhenMissing();
-        add(rule);
+        assumeCompatibleWhenMissing = true;
+    }
+
+    @Override
+    public boolean isCompatibleWhenMissing() {
+        return assumeCompatibleWhenMissing;
     }
 
     @Override
@@ -78,12 +83,12 @@ public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChainI
         }
 
         @Override
-        public AttributeValue<T> getConsumerValue() {
+        public T getConsumerValue() {
             return delegate.getConsumerValue();
         }
 
         @Override
-        public AttributeValue<T> getProducerValue() {
+        public T getProducerValue() {
             return delegate.getProducerValue();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.attributes;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
-import org.gradle.api.attributes.AttributeValue;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 
 import java.util.Comparator;
@@ -69,17 +68,17 @@ public class DefaultDisambiguationRuleChain<T> implements DisambiguationRuleChai
         }
 
         @Override
-        public AttributeValue<T> getConsumerValue() {
+        public T getConsumerValue() {
             return delegate.getConsumerValue();
         }
 
         @Override
-        public Set<AttributeValue<T>> getCandidateValues() {
+        public Set<T> getCandidateValues() {
             return delegate.getCandidateValues();
         }
 
         @Override
-        public void closestMatch(AttributeValue<T> candidate) {
+        public void closestMatch(T candidate) {
             determined = true;
             delegate.closestMatch(candidate);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
@@ -68,11 +68,6 @@ public class DefaultDisambiguationRuleChain<T> implements DisambiguationRuleChai
         }
 
         @Override
-        public T getConsumerValue() {
-            return delegate.getConsumerValue();
-        }
-
-        @Override
         public Set<T> getCandidateValues() {
             return delegate.getCandidateValues();
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultOrderedCompatibilityRule.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultOrderedCompatibilityRule.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.attributes;
 
 import org.gradle.api.Action;
-import org.gradle.api.attributes.AttributeValue;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
 
 import java.util.Comparator;
@@ -32,20 +31,16 @@ public class DefaultOrderedCompatibilityRule<T> implements Action<CompatibilityC
 
     @Override
     public void execute(CompatibilityCheckDetails<T> details) {
-        AttributeValue<T> consumerValue = details.getConsumerValue();
-        AttributeValue<T> producerValue = details.getProducerValue();
-        if (consumerValue.isPresent() && producerValue.isPresent()) {
-            T consumerPresent = consumerValue.get();
-            T producerPresent = producerValue.get();
-            int cmp = comparator.compare(consumerPresent, producerPresent);
-            if (reverse) {
-                cmp = -cmp;
-            }
-            if (cmp >= 0) {
-                details.compatible();
-            } else {
-                details.incompatible();
-            }
+        T consumerValue = details.getConsumerValue();
+        T producerValue = details.getProducerValue();
+        int cmp = comparator.compare(consumerValue, producerValue);
+        if (reverse) {
+            cmp = -cmp;
+        }
+        if (cmp >= 0) {
+            details.compatible();
+        } else {
+            details.incompatible();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultOrderedDisambiguationRule.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultOrderedDisambiguationRule.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.attributes;
 
 import org.gradle.api.Action;
-import org.gradle.api.attributes.AttributeValue;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 
 import java.util.Collection;
@@ -33,24 +32,23 @@ public class DefaultOrderedDisambiguationRule<T> implements Action<MultipleCandi
 
     @Override
     public void execute(MultipleCandidatesDetails<T> details) {
-        Collection<AttributeValue<T>> values = details.getCandidateValues();
+        Collection<T> values = details.getCandidateValues();
         T min = null;
         T max = null;
-        for (AttributeValue<T> value : values) {
-            if (value.isPresent()) {
-                T v = value.get();
-                if (min == null || comparator.compare(v, min) < 0) {
-                    min = v;
-                }
-                if (max == null || comparator.compare(v, max) > 0) {
-                    max = v;
-                }
+        for (T value : values) {
+
+            if (min == null || comparator.compare(value, min) < 0) {
+                min = value;
             }
+            if (max == null || comparator.compare(value, max) > 0) {
+                max = value;
+            }
+
         }
         T cmp = pickFirst ? min : max;
         if (cmp != null) {
-            for (AttributeValue<T> value : details.getCandidateValues()) {
-                if (value.isPresent() && value.get().equals(cmp)) {
+            for (T value : details.getCandidateValues()) {
+                if (value.equals(cmp)) {
                     details.closestMatch(value);
                 }
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/EqualityCompatibilityRule.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/EqualityCompatibilityRule.java
@@ -16,21 +16,16 @@
 package org.gradle.api.internal.attributes;
 
 import org.gradle.api.Action;
-import org.gradle.api.attributes.AttributeValue;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
 
 public class EqualityCompatibilityRule<T> implements Action<CompatibilityCheckDetails<T>> {
 
     @Override
     public void execute(CompatibilityCheckDetails<T> details) {
-        AttributeValue<T> consumerValue = details.getConsumerValue();
-        AttributeValue<T> producerValue = details.getProducerValue();
-        if (consumerValue.isPresent() && producerValue.isPresent()) {
-            if (consumerValue.equals(producerValue)) {
-                details.compatible();
-            } else {
-                details.incompatible();
-            }
+        if (details.getConsumerValue().equals(details.getProducerValue())) {
+            details.compatible();
+        } else {
+            details.incompatible();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/SelectAllCompatibleRule.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/SelectAllCompatibleRule.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.attributes;
 
 import org.gradle.api.Action;
-import org.gradle.api.attributes.AttributeValue;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 
 class SelectAllCompatibleRule<T> implements Action<MultipleCandidatesDetails<T>> {
@@ -31,7 +30,7 @@ class SelectAllCompatibleRule<T> implements Action<MultipleCandidatesDetails<T>>
 
     @Override
     public void execute(MultipleCandidatesDetails<T> details) {
-        for (AttributeValue<T> candidate : details.getCandidateValues()) {
+        for (T candidate : details.getCandidateValues()) {
             details.closestMatch(candidate);
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.attributes
 
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.attributes.AttributeValue
 import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.MultipleCandidatesDetails
 import spock.lang.Specification

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
@@ -115,33 +115,21 @@ class DefaultAttributesSchemaTest extends Specification {
             it.compatibilityRules.add { CompatibilityCheckDetails<Map> details ->
                 def producerValue = details.producerValue
                 def consumerValue = details.consumerValue
-                if (producerValue.present && consumerValue.present) {
-                    if (producerValue.get().size() == consumerValue.get().size()) {
-                        // arbitrary, just for testing purposes
-                        details.compatible()
-                    }
+                if (producerValue.size() == consumerValue.size()) {
+                    // arbitrary, just for testing purposes
+                    details.compatible()
                 }
             }
-            it.disambiguationRules.add { MultipleCandidatesDetails<Map> details ->
-                def optionalAttribute = details.consumerValue
-                def candidateValues = details.candidateValues
-                if (optionalAttribute.present) {
-                    candidateValues.findAll { it == optionalAttribute }.each {
-                        details.closestMatch(it)
-                    }
-                } else if (optionalAttribute.missing) {
-                    details.closestMatch(candidateValues.first())
-                } else {
-                    candidateValues.each { details.closestMatch(it) }
-                }
+            it.disambiguationRules.add { details ->
+                details.closestMatch(details.candidateValues.first())
             }
         }
         def strategy = schema.getMatchingStrategy(attr)
         def checkDetails = Mock(CompatibilityCheckDetails)
         def candidateDetails = Mock(MultipleCandidatesDetails)
 
-        def aFoo_bBar = AttributeValue.of([a: 'foo', b: 'bar'])
-        def cFoo_dBar = AttributeValue.of([c: 'foo', d: 'bar'])
+        def aFoo_bBar = [a: 'foo', b: 'bar']
+        def cFoo_dBar = [c: 'foo', d: 'bar']
 
         when:
         checkDetails.getConsumerValue() >> aFoo_bBar
@@ -162,7 +150,6 @@ class DefaultAttributesSchemaTest extends Specification {
         0 * checkDetails.incompatible()
 
         when:
-        candidateDetails.consumerValue >> aFoo_bBar
         candidateDetails.candidateValues >> [aFoo_bBar, cFoo_dBar]
         strategy.disambiguationRules.execute(candidateDetails)
 
@@ -170,23 +157,5 @@ class DefaultAttributesSchemaTest extends Specification {
         1 * candidateDetails.closestMatch(aFoo_bBar)
         0 * candidateDetails._
 
-        when:
-        candidateDetails.consumerValue >> AttributeValue.missing()
-        candidateDetails.candidateValues >> [aFoo_bBar, cFoo_dBar]
-        strategy.disambiguationRules.execute(candidateDetails)
-
-        then:
-        1 * candidateDetails.closestMatch(aFoo_bBar)
-        0 * candidateDetails._
-
-        when:
-        candidateDetails.consumerValue >> AttributeValue.unknown()
-        candidateDetails.candidateValues >> [aFoo_bBar, cFoo_dBar]
-        strategy.disambiguationRules.execute(candidateDetails)
-
-        then:
-        1 * candidateDetails.closestMatch(aFoo_bBar)
-        1 * candidateDetails.closestMatch(cFoo_dBar)
-        0 * candidateDetails._
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousConfigurationSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousConfigurationSelectionException.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
-import org.gradle.api.attributes.AttributeValue;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
 import org.gradle.api.internal.attributes.CompatibilityRuleChainInternal;
@@ -109,13 +108,13 @@ public class AmbiguousConfigurationSelectionException extends IllegalArgumentExc
                 final Object producerValue = producerAttributes.getAttribute(attribute);
                 compatibilityRules.execute(new CompatibilityCheckDetails<Object>() {
                     @Override
-                    public AttributeValue<Object> getConsumerValue() {
-                        return AttributeValue.of(consumerValue);
+                    public Object getConsumerValue() {
+                        return consumerValue;
                     }
 
                     @Override
-                    public AttributeValue<Object> getProducerValue() {
-                        return AttributeValue.of(producerValue);
+                    public Object getProducerValue() {
+                        return producerValue;
                     }
 
                     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentAttributeMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentAttributeMatcher.java
@@ -24,7 +24,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
-import org.gradle.api.attributes.AttributeValue;
+import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
 import org.gradle.api.attributes.HasAttributes;
@@ -69,7 +69,7 @@ public class ComponentAttributeMatcher {
             MatchDetails details = entry.getValue();
             AttributeContainer producerAttributesContainer = key.getAttributes();
             Set<Attribute<Object>> dependencyAttributes = Cast.uncheckedCast(producerAttributesContainer.keySet());
-            Set<Attribute<Object>> filter = Cast.uncheckedCast(attributesToConsider != null ? attributesToConsider.keySet() : null);
+            Set<Attribute<Object>> filter = Cast.uncheckedCast(attributesToConsider);
             Set<Attribute<Object>> allAttributes = filter != null ? filter : Sets.union(requestedAttributes, dependencyAttributes);
             for (Attribute<Object> attribute : allAttributes) {
                 AttributeValue<Object> consumerValue = attributeValue(attribute, consumerAttributeSchema, consumerAttributesContainer);
@@ -102,55 +102,7 @@ public class ComponentAttributeMatcher {
 
     private List<HasAttributes> disambiguateUsingClosestMatch(List<HasAttributes> matchs) {
         if (matchs.size() > 1) {
-            List<HasAttributes> remainingMatches = selectClosestMatches(matchs);
-            if (remainingMatches != null) {
-                return disambiguateUsingProducerSchema(remainingMatches);
-            }
-        }
-        return matchs;
-    }
-
-    private List<HasAttributes> disambiguateUsingProducerSchema(List<HasAttributes> matchs) {
-        if (matchs.size() < 2 || producerAttributeSchema == null) {
-            return matchs;
-        }
-        // If we are reaching this point, it means that we have more than one match, so we need to
-        // ask the producer if it has any preference: so far only the consumer schema was used. Now
-        // we need to take into consideration the producer schema
-        Set<Attribute<?>> producerOnlyAttributes = Sets.newHashSet();
-        for (HasAttributes match : matchs) {
-            AttributeContainer attributes = match.getAttributes();
-            for (Attribute<?> attribute : attributes.keySet()) {
-                if (!consumerAttributesContainer.contains(attribute)) {
-                    producerOnlyAttributes.add(attribute);
-                }
-            }
-        }
-        Set<Attribute<?>> consumerAttributes = consumerAttributeSchema.getAttributes();
-        List<HasAttributes> remainingMatches = Lists.newArrayList(matchs);
-        List<HasAttributes> best = Lists.newArrayListWithCapacity(matchs.size());
-        final ListMultimap<AttributeValue<Object>, HasAttributes> candidatesByValue = ArrayListMultimap.create();
-        for (Attribute<?> attribute : producerOnlyAttributes) {
-            for (HasAttributes match : matchs) {
-                Object maybeProvided = match.getAttributes().getAttribute(attribute);
-                if (maybeProvided != null) {
-                    candidatesByValue.put(AttributeValue.of(maybeProvided), match);
-                }
-            }
-            if (!candidatesByValue.isEmpty()) {
-                final AttributeValue<Object> absent = consumerAttributes.contains(attribute) ? AttributeValue.missing() : AttributeValue.unknown();
-                disambiguate(remainingMatches, candidatesByValue, absent, producerAttributeSchema.getMatchingStrategy(attribute), best);
-                if (remainingMatches.isEmpty()) {
-                    // the intersection is empty, so we cannot choose
-                    return matchs;
-                }
-                candidatesByValue.clear();
-                best.clear();
-            }
-        }
-        if (!remainingMatches.isEmpty()) {
-            // there's a subset (or not) of best matches
-            return remainingMatches;
+            return selectClosestMatches(matchs);
         }
         return matchs;
     }
@@ -162,15 +114,17 @@ public class ComponentAttributeMatcher {
         // then see if there's a non-empty intersection.
         List<HasAttributes> remainingMatches = Lists.newArrayList(fullMatches);
         List<HasAttributes> best = Lists.newArrayListWithCapacity(fullMatches.size());
-        final ListMultimap<AttributeValue<Object>, HasAttributes> candidatesByValue = ArrayListMultimap.create();
+        final ListMultimap<Object, HasAttributes> candidatesByValue = ArrayListMultimap.create();
         for (Attribute<?> attribute : requestedAttributes) {
             Object requestedValue = consumerAttributesContainer.getAttribute(attribute);
             for (HasAttributes match : fullMatches) {
-                Map<Attribute<Object>, AttributeValue<Object>> matchedAttributes = matchDetails.get(match).matchesByAttribute;
-                candidatesByValue.put(matchedAttributes.get(attribute), match);
+                Map<Attribute<Object>, Object> matchedAttributes = matchDetails.get(match).matchesByAttribute;
+                Object val = matchedAttributes.get(attribute);
+                if (val != null) {
+                    candidatesByValue.put(val, match);
+                }
             }
-            final AttributeValue<Object> requested = AttributeValue.of(requestedValue);
-            disambiguate(remainingMatches, candidatesByValue, requested, consumerAttributeSchema.getMatchingStrategy(attribute), best);
+            disambiguate(remainingMatches, candidatesByValue, requestedValue, consumerAttributeSchema.getMatchingStrategy(attribute), best);
             if (remainingMatches.isEmpty()) {
                 // the intersection is empty, so we cannot choose
                 return fullMatches;
@@ -186,10 +140,14 @@ public class ComponentAttributeMatcher {
     }
 
     private static void disambiguate(List<HasAttributes> remainingMatches,
-                                     ListMultimap<AttributeValue<Object>, HasAttributes> candidatesByValue,
-                                     AttributeValue<Object> requested,
+                                     ListMultimap<Object, HasAttributes> candidatesByValue,
+                                     Object requested,
                                      AttributeMatchingStrategy<?> matchingStrategy,
                                      List<HasAttributes> best) {
+        if (candidatesByValue.isEmpty()) {
+            // missing or unknown
+            return;
+        }
         AttributeMatchingStrategy<Object> ms = Cast.uncheckedCast(matchingStrategy);
         MultipleCandidatesDetails<Object> details = new CandidateDetails(requested, candidatesByValue, best);
         DisambiguationRuleChainInternal<Object> disambiguationRules = (DisambiguationRuleChainInternal<Object>) ms.getDisambiguationRules();
@@ -198,30 +156,40 @@ public class ComponentAttributeMatcher {
     }
 
     private static class MatchDetails {
-        private final Map<Attribute<Object>, AttributeValue<Object>> matchesByAttribute = Maps.newHashMap();
+        private final Map<Attribute<Object>, Object> matchesByAttribute = Maps.newHashMap();
 
         private boolean compatible = true;
 
         private void update(final Attribute<Object> attribute, final AttributesSchema consumerSchema, final AttributesSchema producerSchema, final AttributeValue<Object> consumerValue, final AttributeValue<Object> producerValue) {
             AttributesSchema schemaToUse = consumerSchema;
+            boolean missingOrUnknown = false;
             if (consumerValue.isUnknown() || consumerValue.isMissing()) {
                 // We need to use the producer schema in this case
                 schemaToUse = producerSchema;
+                missingOrUnknown = true;
+            } else if (producerValue.isUnknown() || producerValue.isMissing()) {
+                missingOrUnknown = true;
+            }
+            AttributeMatchingStrategy<Object> strategy = schemaToUse.getMatchingStrategy(attribute);
+            CompatibilityRuleChainInternal<Object> compatibilityRules = (CompatibilityRuleChainInternal<Object>) strategy.getCompatibilityRules();
+            if (missingOrUnknown) {
+                compatible &= compatibilityRules.isCompatibleWhenMissing();
+                return;
             }
             CompatibilityCheckDetails<Object> details = new CompatibilityCheckDetails<Object>() {
                 @Override
-                public AttributeValue<Object> getConsumerValue() {
-                    return consumerValue;
+                public Object getConsumerValue() {
+                    return consumerValue.get();
                 }
 
                 @Override
-                public AttributeValue<Object> getProducerValue() {
-                    return producerValue;
+                public Object getProducerValue() {
+                    return producerValue.get();
                 }
 
                 @Override
                 public void compatible() {
-                    matchesByAttribute.put(attribute, producerValue);
+                    matchesByAttribute.put(attribute, producerValue.get());
                 }
 
                 @Override
@@ -229,8 +197,6 @@ public class ComponentAttributeMatcher {
                     compatible = false;
                 }
             };
-            AttributeMatchingStrategy<Object> strategy = schemaToUse.getMatchingStrategy(attribute);
-            CompatibilityRuleChainInternal<Object> compatibilityRules = (CompatibilityRuleChainInternal<Object>) strategy.getCompatibilityRules();
             try {
                 compatibilityRules.execute(details);
             } catch (Exception ex) {
@@ -240,28 +206,28 @@ public class ComponentAttributeMatcher {
     }
 
     private static class CandidateDetails implements MultipleCandidatesDetails<Object> {
-        private final AttributeValue<Object> consumerValue;
-        private final ListMultimap<AttributeValue<Object>, HasAttributes> candidatesByValue;
+        private final Object consumerValue;
+        private final ListMultimap<Object, HasAttributes> candidatesByValue;
         private final List<HasAttributes> best;
 
-        public CandidateDetails(AttributeValue<Object> consumerValue, ListMultimap<AttributeValue<Object>, HasAttributes> candidatesByValue, List<HasAttributes> best) {
+        public CandidateDetails(Object consumerValue, ListMultimap<Object, HasAttributes> candidatesByValue, List<HasAttributes> best) {
             this.consumerValue = consumerValue;
             this.candidatesByValue = candidatesByValue;
             this.best = best;
         }
 
         @Override
-        public AttributeValue<Object> getConsumerValue() {
+        public Object getConsumerValue() {
             return consumerValue;
         }
 
         @Override
-        public Set<AttributeValue<Object>> getCandidateValues() {
+        public Set<Object> getCandidateValues() {
             return candidatesByValue.keySet();
         }
 
         @Override
-        public void closestMatch(AttributeValue<Object> candidate) {
+        public void closestMatch(Object candidate) {
             List<HasAttributes> hasAttributes = candidatesByValue.get(candidate);
             for (HasAttributes attributes : hasAttributes) {
                 best.add(attributes);


### PR DESCRIPTION
This PR is a follow up to #953 and changes the handling of missing/unknown attributes, not allowing them to be used in rules.

The consequence is a simplified API, at the cost of more limited expressiveness (cannot disambiguate the case where the consumer doesn't provide a value anymore).

See gradle/performance#237