### PR TITLE
Revalidate that selected configurations match the requested attributes

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -81,7 +81,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         String declaredConfiguration = getTargetConfiguration();
         Configuration selectedConfiguration = dependencyConfigurations.getByName(GUtil.elvis(declaredConfiguration, Dependency.DEFAULT_CONFIGURATION));
         if (!selectedConfiguration.isCanBeConsumed()) {
-            throw new ConfigurationNotConsumableException(dependencyProject.toString(), selectedConfiguration.getName());
+            throw new ConfigurationNotConsumableException(dependencyProject.getDisplayName(), selectedConfiguration.getName());
         }
         return selectedConfiguration;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -81,7 +81,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         String declaredConfiguration = getTargetConfiguration();
         Configuration selectedConfiguration = dependencyConfigurations.getByName(GUtil.elvis(declaredConfiguration, Dependency.DEFAULT_CONFIGURATION));
         if (!selectedConfiguration.isCanBeConsumed()) {
-            throw new ConfigurationNotConsumableException(selectedConfiguration.getName());
+            throw new ConfigurationNotConsumableException(dependencyProject.toString(), selectedConfiguration.getName());
         }
         return selectedConfiguration;
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/ConfigurationNotConsumableException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/ConfigurationNotConsumableException.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.exceptions;
 
 public class ConfigurationNotConsumableException extends IllegalArgumentException {
-    public ConfigurationNotConsumableException(String configurationName) {
-        super("Selected configuration '" + configurationName + "' but it can't be used as a project dependency because it isn't intended for consumption by other components.");
+    public ConfigurationNotConsumableException(String targetComponent, String configurationName) {
+        super("Selected configuration '" + configurationName + "' on '" + targetComponent + "' but it can't be used as a project dependency because it isn't intended for consumption by other components.");
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -138,7 +138,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
 
         then:
         def e = thrown(ConfigurationNotConsumableException)
-        e.message == "Selected configuration 'conf' but it can't be used as a project dependency because it isn't intended for consumption by other components."
+        e.message == "Selected configuration 'conf' on 'root project 'test'' but it can't be used as a project dependency because it isn't intended for consumption by other components."
     }
 
     void "does not build project dependencies if configured so"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousConfigurationSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousConfigurationSelectionException.java
@@ -25,6 +25,12 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.AttributeMatchingStrategy;
+import org.gradle.api.attributes.AttributeValue;
+import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.attributes.CompatibilityCheckDetails;
+import org.gradle.api.internal.attributes.CompatibilityRuleChainInternal;
+import org.gradle.internal.Cast;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 
@@ -48,11 +54,14 @@ public class AmbiguousConfigurationSelectionException extends IllegalArgumentExc
         }
     };
 
-    public AmbiguousConfigurationSelectionException(AttributeContainer fromConfigurationAttributes, List<ConfigurationMetadata> matches, ComponentResolveMetadata targetComponent) {
-        super(generateMessage(fromConfigurationAttributes, matches, targetComponent));
+    public AmbiguousConfigurationSelectionException(AttributeContainer fromConfigurationAttributes,
+                                                    AttributesSchema consumerSchema,
+                                                    List<ConfigurationMetadata> matches,
+                                                    ComponentResolveMetadata targetComponent) {
+        super(generateMessage(fromConfigurationAttributes, consumerSchema, matches, targetComponent));
     }
 
-    private static String generateMessage(AttributeContainer fromConfigurationAttributes, List<ConfigurationMetadata> matches, ComponentResolveMetadata targetComponent) {
+    private static String generateMessage(AttributeContainer fromConfigurationAttributes, AttributesSchema consumerSchema, List<ConfigurationMetadata> matches, ComponentResolveMetadata targetComponent) {
         Set<String> ambiguousConfigurations = Sets.newTreeSet(Lists.transform(matches, CONFIG_NAME));
         Set<String> requestedAttributes = Sets.newTreeSet(Iterables.transform(fromConfigurationAttributes.keySet(), ATTRIBUTE_NAME));
         StringBuilder sb = new StringBuilder("Cannot choose between the following configurations on '" + targetComponent + "' : ");
@@ -63,12 +72,12 @@ public class AmbiguousConfigurationSelectionException extends IllegalArgumentExc
         // We're sorting the names of the configurations and later attributes
         // to make sure the output is consistently the same between invocations
         for (final String ambiguousConf : ambiguousConfigurations) {
-            formatConfiguration(sb, fromConfigurationAttributes, matches, requestedAttributes, maxConfLength, ambiguousConf);
+            formatConfiguration(sb, fromConfigurationAttributes, consumerSchema, matches, requestedAttributes, maxConfLength, ambiguousConf);
         }
         return sb.toString();
     }
 
-    static void formatConfiguration(StringBuilder sb, AttributeContainer fromConfigurationAttributes, List<ConfigurationMetadata> matches, Set<String> requestedAttributes, int maxConfLength, final String conf) {
+    static void formatConfiguration(StringBuilder sb, AttributeContainer fromConfigurationAttributes, AttributesSchema consumerSchema, List<ConfigurationMetadata> matches, Set<String> requestedAttributes, int maxConfLength, final String conf) {
         ConfigurationMetadata match = Iterables.find(matches, new Predicate<ConfigurationMetadata>() {
             @Override
             public boolean apply(ConfigurationMetadata input) {
@@ -84,22 +93,44 @@ public class AmbiguousConfigurationSelectionException extends IllegalArgumentExc
         sb.append("   ").append("- Configuration '").append(StringUtils.rightPad(conf + "'", maxConfLength + 1)).append(" :");
         List<Attribute<?>> sortedAttributes = Ordering.usingToString().sortedCopy(allAttributes);
         List<String> values = new ArrayList<String>(sortedAttributes.size());
-        formatAttributes(sb, fromConfigurationAttributes, producerAttributes, commonAttributes, consumerOnlyAttributes, sortedAttributes, values);
+        formatAttributes(sb, fromConfigurationAttributes, consumerSchema, producerAttributes, commonAttributes, consumerOnlyAttributes, sortedAttributes, values);
     }
 
-    private static void formatAttributes(StringBuilder sb, AttributeContainer fromConfigurationAttributes, AttributeContainer producerAttributes, Set<String> commonAttributes, Set<String> consumerOnlyAttributes, List<Attribute<?>> sortedAttributes, List<String> values) {
+    private static void formatAttributes(StringBuilder sb, AttributeContainer fromConfigurationAttributes, AttributesSchema consumerSchema, AttributeContainer producerAttributes, Set<String> commonAttributes, Set<String> consumerOnlyAttributes, List<Attribute<?>> sortedAttributes, final List<String> values) {
         for (Attribute<?> attribute : sortedAttributes) {
-            String attributeName = attribute.getName();
-            String label;
+            final String attributeName = attribute.getName();
             if (commonAttributes.contains(attributeName)) {
-                label = "      - " + "Required " + attributeName + " '" + fromConfigurationAttributes.getAttribute(attribute) + "' and found compatible value '" + producerAttributes.getAttribute(attribute) + "'.";
-            } else if (consumerOnlyAttributes.contains(attributeName)) {
-                label = "      - " + "Required " + attributeName + " '" + fromConfigurationAttributes.getAttribute(attribute) + "' but no value provided.";
-            } else {
-                label = "      - " + "Found " + attributeName + " '" + producerAttributes.getAttribute(attribute) + "' but wasn't required.";
-            }
-            values.add(label);
+                AttributeMatchingStrategy<?> strategy = consumerSchema.getMatchingStrategy(attribute);
+                CompatibilityRuleChainInternal<Object> compatibilityRules = Cast.uncheckedCast(strategy.getCompatibilityRules());
+                final Object consumerValue = fromConfigurationAttributes.getAttribute(attribute);
+                final Object producerValue = producerAttributes.getAttribute(attribute);
+                compatibilityRules.execute(new CompatibilityCheckDetails<Object>() {
+                    @Override
+                    public AttributeValue<Object> getConsumerValue() {
+                        return AttributeValue.of(consumerValue);
+                    }
 
+                    @Override
+                    public AttributeValue<Object> getProducerValue() {
+                        return AttributeValue.of(producerValue);
+                    }
+
+                    @Override
+                    public void compatible() {
+                        values.add("      - " + "Required " + attributeName + " '" + consumerValue + "' and found compatible value '" + producerValue + "'.");
+                    }
+
+                    @Override
+                    public void incompatible() {
+                        values.add("      - " + "Required " + attributeName + " '" + consumerValue + "' and found incompatible value '" + producerValue + "'.");
+                    }
+                });
+
+            } else if (consumerOnlyAttributes.contains(attributeName)) {
+                values.add("      - " + "Required " + attributeName + " '" + fromConfigurationAttributes.getAttribute(attribute) + "' but no value provided.");
+            } else {
+                values.add("      - " + "Found " + attributeName + " '" + producerAttributes.getAttribute(attribute) + "' but wasn't required.");
+            }
         }
         sb.append("\n");
         sb.append(Joiner.on("\n").join(values));

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -16,13 +16,14 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine
 
 import org.apache.ivy.core.module.id.ModuleRevisionId
-import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
+import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
@@ -61,10 +62,13 @@ class DependencyGraphBuilderTest extends Specification {
     def conflictResolver = Mock(ModuleConflictResolver)
     def idResolver = Mock(DependencyToComponentIdResolver)
     def metaDataResolver = Mock(ComponentMetaDataResolver)
+    def attributesSchema = Mock(AttributesSchema)
+    def attributes = Mock(AttributeContainer) {
+        isEmpty() >> true
+    }
     def root = project('root', '1.0', ['root'])
     def moduleResolver = Mock(ResolveContextToComponentResolver)
     def moduleReplacements = Mock(ModuleReplacementsData)
-    def attributesSchema = Mock(AttributesSchema)
 
     DependencyGraphBuilder builder
 
@@ -943,16 +947,16 @@ class DependencyGraphBuilderTest extends Specification {
         // TODO Shouldn't really be using the local component implementation here
         def id = newId("group", name, revision)
         def metaData = new DefaultLocalComponentMetadata(id, DefaultModuleComponentIdentifier.newId(id), "release", attributesSchema)
-        metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ["default"] as Set<String>, true, true, null, true, true)
+        metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ["default"] as Set<String>, true, true, attributes, true, true)
         metaData.addArtifacts("default", [new DefaultPublishArtifact("art1", "zip", "art", null, new Date(), new File("art1.zip"))])
         return metaData
     }
 
     def project(String name, String revision = '1.0', List<String> extraConfigs = []) {
         def metaData = new DefaultLocalComponentMetadata(newId("group", name, revision), newProjectId(":${name}"), "release", attributesSchema)
-        metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ["default"] as Set<String>, true, true, null, true, true)
+        metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ["default"] as Set<String>, true, true, attributes, true, true)
         extraConfigs.each { String config ->
-            metaData.addConfiguration(config, "${config}Config", ["default"] as Set<String>, ["default", config] as Set<String>, true, true, null, true, true)
+            metaData.addConfiguration(config, "${config}Config", ["default"] as Set<String>, ["default", config] as Set<String>, true, true, attributes, true, true)
         }
         metaData.addArtifacts("default", [new DefaultPublishArtifact("art1", "zip", "art", null, new Date(), new File("art1.zip"))])
         return metaData


### PR DESCRIPTION
This commit changes the behavior of dependency resolution in case a selected configuration doesn't match
the requested attributes. It could happen in two cases:

- in case no matching configuration is found, we fallback to the `default` configuration, which could have attributes
that did *not* match (it was part of the selection, but in the end since no configuration was matching, it was selected
anyway).
- in case an explicit configuration was chosen. In that case, we didn't check that the selected configuration matched
the consumer attributes.

Error messages have been improved as part of this story. It's worth noting that this commit does NOT change the
selection algorithm, and we will always fallback to the `default` configuration in case no match is found. The only
thing it does is really revalidating that this fallback is compatible.

See gradle/performance#233