### PR TITLE
Fix local file dependency leak in IDE model

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarAndWebAndEjbProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarAndWebAndEjbProjectIntegrationTest.groovy
@@ -52,6 +52,7 @@ project(':java') {
 
     dependencies {
         compile 'com.google.guava:guava:18.0'
+        compile files('foo')
         compile 'javax.servlet:javax.servlet-api:3.1.0'
         testCompile "junit:junit:4.12"
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
@@ -167,7 +167,7 @@ public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
         List<IdeLocalFileDependency> ideLocalFileDependencies = new ArrayList<IdeLocalFileDependency>();
 
         for (SelfResolvingDependency externalDependency : externalDependencies) {
-            Set<File> resolvedFiles = externalDependency.resolve();
+            Set<File> resolvedFiles = externalDependency.resolve(configuration.isTransitive());
 
             for (File resolvedFile : resolvedFiles) {
                 IdeLocalFileDependency ideLocalFileDependency = new IdeLocalFileDependency(resolvedFile);
@@ -188,7 +188,7 @@ public class DefaultIdeDependencyResolver implements IdeDependencyResolver {
         for (Dependency dependency : configuration.getAllDependencies()) {
             if(!visited.contains(dependency)){
                 visited.add(dependency);
-                if(dependency instanceof ProjectDependency) {
+                if(dependency instanceof ProjectDependency && configuration.isTransitive()) {
                     findAllExternalDependencies(externalDependencies, visited, getTargetConfiguration((ProjectDependency) dependency));
                 } else if (dependency instanceof SelfResolvingDependency) {
                     externalDependencies.add((SelfResolvingDependency) dependency);


### PR DESCRIPTION
The IDE dependency resolver was always leaking local file
dependencies into dependent projects, even if the target
configuration was marked as transitive=false. This broke
things like EAR projects depending on a WAR project with
a local file dependency.