### PR TITLE
Tooling API: Support jdkName from idea module model

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/IdeaModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/IdeaModelBuilder.java
@@ -164,6 +164,7 @@ public class IdeaModelBuilder implements ToolingModelBuilder {
             .setParent(ideaProject)
             .setGradleProject(rootGradleProject.findByPath(ideaModule.getProject().getPath()))
             .setContentRoots(Collections.singletonList(contentRoot))
+            .setJdkName(ideaModule.getJdkName())
             .setCompilerOutput(new DefaultIdeaCompilerOutput()
                 .setInheritOutputDirs(ideaModule.getInheritOutputDirs() != null ? ideaModule.getInheritOutputDirs() : false)
                 .setOutputDir(ideaModule.getOutputDir())

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/idea/DefaultIdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/idea/DefaultIdeaModule.java
@@ -39,6 +39,7 @@ public class DefaultIdeaModule implements Serializable, GradleProjectIdentity {
     private IdeaCompilerOutput compilerOutput;
 
     private DefaultIdeaJavaLanguageSettings javaLanguageSettings;
+    private String jdkName;
 
     public String getName() {
         return name;
@@ -112,6 +113,15 @@ public class DefaultIdeaModule implements Serializable, GradleProjectIdentity {
 
     public DefaultIdeaModule setJavaLanguageSettings(DefaultIdeaJavaLanguageSettings javaLanguageSettings) {
         this.javaLanguageSettings = javaLanguageSettings;
+        return this;
+    }
+
+    public String getJdkName() {
+        return jdkName;
+    }
+
+    public DefaultIdeaModule setJdkName(String jdkName) {
+        this.jdkName = jdkName;
         return this;
     }
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r34/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r34/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r34
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.model.UnsupportedMethodException
+import org.gradle.tooling.model.idea.IdeaProject
+
+class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
+    def setup(){
+        settingsFile << "rootProject.name = 'root'"
+    }
+
+    @ToolingApiVersion(">=3.4")
+    @TargetGradleVersion(">=3.4")
+    def "jdkName property from idea module model is available in the tooling API"() {
+        given:
+        settingsFile << "\ninclude 'root', 'child1', 'child2', 'child3'"
+        buildFile << """
+            allprojects {
+                apply plugin: 'idea'
+                apply plugin: 'java'
+            }
+
+            idea {
+                module {
+                    jdkName = 'MyJDK1'
+                }
+            }
+
+            project(':child1') {
+                idea {
+                    module {
+                        jdkName = 'MyJDK2'
+                    }
+                }
+            }
+
+            project(':child2') {
+                idea {
+                    module {
+                        jdkName = 'MyJDK3'
+                    }
+                }
+            }
+
+        """
+
+        when:
+        def ideaProject = withConnection { connection -> connection.getModel(IdeaProject) }
+
+        then:
+        ideaProject.modules.find { it.name == 'root' }.jdkName == 'MyJDK1'
+        ideaProject.modules.find { it.name == 'child1' }.jdkName == 'MyJDK2'
+        ideaProject.modules.find { it.name == 'child2' }.jdkName == 'MyJDK3'
+        ideaProject.modules.find { it.name == 'child3' }.jdkName == null
+    }
+
+    @ToolingApiVersion("current")
+    @TargetGradleVersion("<3.4")
+    def "jdkName property from idea module model is not available in the tooling before 3.4"() {
+        when:
+        def ideaProject = withConnection { connection -> connection.getModel(IdeaProject) }
+        ideaProject.modules.find { it.name == 'root' }.jdkName
+
+        then:
+        UnsupportedMethodException e = thrown()
+        e.message.startsWith("Unsupported method: IdeaModule.getJdkName()")
+    }
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaModule.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaModule.java
@@ -38,6 +38,14 @@ public interface IdeaModule extends HierarchicalElement, HasGradleProject {
     IdeaJavaLanguageSettings getJavaLanguageSettings() throws UnsupportedMethodException;
 
     /**
+     * Returns the name of the JDK.
+     *
+     * @return The name of the JDK.
+     * @since 3.3
+     */
+    String getJdkName() throws UnsupportedMethodException;
+
+    /**
      * All content roots. Most idea modules have a single content root.
      *
      * @return content roots

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaModule.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaModule.java
@@ -41,7 +41,7 @@ public interface IdeaModule extends HierarchicalElement, HasGradleProject {
      * Returns the name of the JDK.
      *
      * @return The name of the JDK.
-     * @since 3.3
+     * @since 3.4
      */
     String getJdkName() throws UnsupportedMethodException;
 


### PR DESCRIPTION
The information specified by

```gradle
idea {
    module {
	    jdkName = "My JDK"
	}
}
```

is not made available by the tooling API. In order to fix

https://youtrack.jetbrains.com/issue/IDEA-138526

this change is required first. The language level is already handled automatically in recent versions of IDEA. However, if modules have different language levels, the project JDK is not suitable for them and you have to be able to set a module-specific JDK.

- [ x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x ] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [ x] Ensured that basic checks pass: `./gradlew quickCheck`
