### PR TITLE
Fix cache corruption resulting from cache reuse problem

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
@@ -15,7 +15,10 @@
  */
 package org.gradle.cache.internal;
 
+import com.google.common.base.Objects;
 import net.jcip.annotations.ThreadSafe;
+import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -25,14 +28,18 @@ import org.gradle.cache.internal.cacheops.CacheAccessOperationsStack;
 import org.gradle.cache.internal.filelock.LockOptions;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
+import org.gradle.internal.SystemProperties;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.StoppableExecutor;
 import org.gradle.internal.serialize.Serializer;
 
 import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -48,7 +55,7 @@ public class DefaultCacheAccess implements CacheCoordinator {
     private final FileLockManager lockManager;
     private final ExecutorFactory executorFactory;
     private final FileAccess fileAccess = new UnitOfWorkFileAccess();
-    private final Set<MultiProcessSafePersistentIndexedCache> caches = new HashSet<MultiProcessSafePersistentIndexedCache>();
+    private final Map<String, IndexedCacheEntry> caches = new HashMap<String, IndexedCacheEntry>();
     private final AbstractCrossProcessCacheAccess crossProcessCacheAccess;
     private final LockOptions lockOptions;
 
@@ -311,38 +318,43 @@ public class DefaultCacheAccess implements CacheCoordinator {
     }
 
     public <K, V> MultiProcessSafePersistentIndexedCache<K, V> newCache(final PersistentIndexedCacheParameters<K, V> parameters) {
-        final File cacheFile = new File(baseDir, parameters.getCacheName() + ".bin");
-        LOG.info("Creating new cache for {}, path {}, access {}", parameters.getCacheName(), cacheFile, this);
-        Factory<BTreePersistentIndexedCache<K, V>> indexedCacheFactory = new Factory<BTreePersistentIndexedCache<K, V>>() {
-            public BTreePersistentIndexedCache<K, V> create() {
-                return doCreateCache(cacheFile, parameters.getKeySerializer(), parameters.getValueSerializer());
-            }
-        };
-
-        MultiProcessSafePersistentIndexedCache<K, V> indexedCache = new DefaultMultiProcessSafePersistentIndexedCache<K, V>(indexedCacheFactory, fileAccess);
-        CacheDecorator decorator = parameters.getCacheDecorator();
-        if (decorator != null) {
-            indexedCache = decorator.decorate(cacheFile.getAbsolutePath(), parameters.getCacheName(), indexedCache, crossProcessCacheAccess, getCacheAccessWorker());
-            if (fileLock == null) {
-                useCache("Initial operation", new Runnable() {
-                    @Override
-                    public void run() {
-                        // Empty initial operation to trigger onStartWork calls
-                    }
-                });
-            }
-        }
-
         lock.lock();
+        IndexedCacheEntry entry = caches.get(parameters.getCacheName());
         try {
-            caches.add(indexedCache);
-            if (fileLock != null) {
-                indexedCache.afterLockAcquire(stateAtOpen);
+            if (entry == null) {
+                final File cacheFile = new File(baseDir, parameters.getCacheName() + ".bin");
+                LOG.info("Creating new cache for {}, path {}, access {}", parameters.getCacheName(), cacheFile, this);
+                Factory<BTreePersistentIndexedCache<K, V>> indexedCacheFactory = new Factory<BTreePersistentIndexedCache<K, V>>() {
+                    public BTreePersistentIndexedCache<K, V> create() {
+                        return doCreateCache(cacheFile, parameters.getKeySerializer(), parameters.getValueSerializer());
+                    }
+                };
+
+                MultiProcessSafePersistentIndexedCache<K, V> indexedCache = new DefaultMultiProcessSafePersistentIndexedCache<K, V>(indexedCacheFactory, fileAccess);
+                CacheDecorator decorator = parameters.getCacheDecorator();
+                if (decorator != null) {
+                    indexedCache = decorator.decorate(cacheFile.getAbsolutePath(), parameters.getCacheName(), indexedCache, crossProcessCacheAccess, getCacheAccessWorker());
+                    if (fileLock == null) {
+                        useCache("Initial operation", new Runnable() {
+                            @Override
+                            public void run() {
+                                // Empty initial operation to trigger onStartWork calls
+                            }
+                        });
+                    }
+                }
+                entry = new IndexedCacheEntry(parameters, indexedCache);
+                caches.put(parameters.getCacheName(), entry);
+                if (fileLock != null) {
+                    indexedCache.afterLockAcquire(stateAtOpen);
+                }
+            } else {
+                entry.assertCompatibleCacheParameters(parameters);
             }
         } finally {
             lock.unlock();
         }
-        return indexedCache;
+        return entry.getCache();
     }
 
     @Override
@@ -365,8 +377,8 @@ public class DefaultCacheAccess implements CacheCoordinator {
         this.stateAtOpen = fileLock.getState();
         takeOwnershipNow("initialise caches");
         try {
-            for (UnitOfWorkParticipant cache : caches) {
-                cache.afterLockAcquire(stateAtOpen);
+            for (IndexedCacheEntry entry : caches.values()) {
+                entry.getCache().afterLockAcquire(stateAtOpen);
             }
         } finally {
             releaseOwnership();
@@ -386,14 +398,14 @@ public class DefaultCacheAccess implements CacheCoordinator {
             takeOwnershipNow("release caches");
             try {
                 // Notify caches that lock is to be released. The caches may do work on the cache files during this
-                for (MultiProcessSafePersistentIndexedCache cache : caches) {
-                    cache.finishWork();
+                for (IndexedCacheEntry entry : caches.values()) {
+                    entry.getCache().finishWork();
                 }
 
                 // Snapshot the state and notify the caches
                 FileLock.State state = fileLock.getState();
-                for (MultiProcessSafePersistentIndexedCache cache : caches) {
-                    cache.beforeLockRelease(state);
+                for (IndexedCacheEntry entry : caches.values()) {
+                    entry.getCache().beforeLockRelease(state);
                 }
             } finally {
                 releaseOwnership();
@@ -498,6 +510,76 @@ public class DefaultCacheAccess implements CacheCoordinator {
 
     FileAccess getFileAccess() {
         return fileAccess;
+    }
+
+    protected static class IndexedCacheEntry {
+        private final MultiProcessSafePersistentIndexedCache cache;
+        private final PersistentIndexedCacheParameters parameters;
+
+        public IndexedCacheEntry(PersistentIndexedCacheParameters parameters, MultiProcessSafePersistentIndexedCache cache) {
+            this.parameters = parameters;
+            this.cache = cache;
+        }
+
+        public MultiProcessSafePersistentIndexedCache getCache() {
+            return cache;
+        }
+
+        public PersistentIndexedCacheParameters getParameters() {
+            return parameters;
+        }
+
+        public void assertCompatibleCacheParameters(PersistentIndexedCacheParameters parameters) {
+            List<String> faultMessages = new ArrayList<String>();
+
+            assertCacheNameMatch(faultMessages, parameters.getCacheName());
+            assertCompatibleKeySerializer(faultMessages, parameters.getKeySerializer());
+            assertCompatibleValueSerializer(faultMessages, parameters.getValueSerializer());
+            assertCompatibleCacheDecorator(faultMessages, parameters.getCacheDecorator());
+
+            if (!faultMessages.isEmpty()) {
+                String lineSeparator = SystemProperties.getInstance().getLineSeparator();
+                String faultMessage = StringUtils.join(faultMessages, lineSeparator);
+                throw new InvalidCacheReuseException(
+                    "The cache couldn't be reuse because of the following mismatch:" + lineSeparator + faultMessage);
+            }
+        }
+
+        private void assertCacheNameMatch(Collection<String> faultMessages, String cacheName) {
+            if (!Objects.equal(cacheName, parameters.getCacheName())) {
+                faultMessages.add(
+                    String.format(" * Requested cache name (%s) doesn't match current cache name (%s)", cacheName,
+                        parameters.getCacheName()));
+            }
+        }
+
+        private void assertCompatibleKeySerializer(Collection<String> faultMessages, Serializer keySerializer) {
+            if (!Objects.equal(keySerializer.getClass(), parameters.getKeySerializer().getClass())) {
+                faultMessages.add(
+                    String.format(" * Requested key serializer type (%s) doesn't match current cache type (%s)",
+                        keySerializer.getClass().getCanonicalName(),
+                        parameters.getKeySerializer().getClass().getCanonicalName()));
+            }
+        }
+
+        private void assertCompatibleValueSerializer(Collection<String> faultMessages, Serializer valueSerializer) {
+            if (!Objects.equal(valueSerializer.getClass(), parameters.getValueSerializer().getClass())) {
+                faultMessages.add(
+                    String.format(" * Requested value serializer type (%s) doesn't match current cache type (%s)",
+                        valueSerializer.getClass().getCanonicalName(),
+                        parameters.getValueSerializer().getClass().getCanonicalName()));
+            }
+        }
+
+        private void assertCompatibleCacheDecorator(Collection<String> faultMessages, CacheDecorator cacheDecorator) {
+            String requestClassName = ClassUtils.getShortCanonicalName(cacheDecorator, "null");
+            String currentClassName = ClassUtils.getShortCanonicalName(parameters.getCacheDecorator(), "null");
+            if (!Objects.equal(requestClassName, currentClassName)) {
+                faultMessages.add(
+                    String.format(" * Requested cache decorator type (%s) doesn't match current cache type (%s)",
+                        requestClassName, currentClassName));
+            }
+        }
     }
 
     private static class InvalidCacheReuseException extends IllegalArgumentException {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
@@ -573,9 +573,9 @@ public class DefaultCacheAccess implements CacheCoordinator {
         }
 
         private void checkCompatibleCacheDecorator(Collection<String> faultMessages, CacheDecorator cacheDecorator) {
-            String requestClassName = ClassUtils.getShortCanonicalName(cacheDecorator, null);
-            String currentClassName = ClassUtils.getShortCanonicalName(parameters.getCacheDecorator(), null);
-            if (!Objects.equal(requestClassName, currentClassName)) {
+            if (!Objects.equal(cacheDecorator, parameters.getCacheDecorator())) {
+                String requestClassName = ClassUtils.getShortCanonicalName(cacheDecorator, null);
+                String currentClassName = ClassUtils.getShortCanonicalName(parameters.getCacheDecorator(), null);
                 faultMessages.add(
                     String.format(" * Requested cache decorator type (%s) doesn't match current cache type (%s)",
                         requestClassName, currentClassName));

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
@@ -499,4 +499,10 @@ public class DefaultCacheAccess implements CacheCoordinator {
     FileAccess getFileAccess() {
         return fileAccess;
     }
+
+    private static class InvalidCacheReuseException extends IllegalArgumentException {
+        public InvalidCacheReuseException(String message) {
+            super(message);
+        }
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
@@ -698,19 +698,15 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
 
     def "returns the same cache object when cache decorator match"() {
         def access = newAccess(None)
-        def decorator1 = Mock(CacheDecorator)
-        def decorator2 = Mock(CacheDecorator)
+        def decorator = Mock(CacheDecorator)
         lockManager.lock(lockFile, mode(Exclusive), "<display-name>") >> lock
-        decorator1.decorate(_, _, _, _, _) >> { String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess ->
-            persistentCache
-        }
-        decorator2.decorate(_, _, _, _, _) >> { String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess ->
+        decorator.decorate(_, _, _, _, _) >> { String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess ->
             persistentCache
         }
 
         when:
-        def cache1 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class).cacheDecorator(decorator1))
-        def cache2 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class).cacheDecorator(decorator2))
+        def cache1 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class).cacheDecorator(decorator))
+        def cache2 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class).cacheDecorator(decorator))
 
         then:
         noExceptionThrown()

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.cache.PersistentIndexedCacheParameters
 import org.gradle.cache.internal.FileLockManager.LockMode
 import org.gradle.cache.internal.btree.BTreePersistentIndexedCache
 import org.gradle.internal.Factory
+import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.internal.serialize.Serializer
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -29,6 +30,8 @@ import static org.gradle.cache.internal.FileLockManager.LockMode.*
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 
 class DefaultCacheAccessTest extends ConcurrentSpec {
+    private static final BaseSerializerFactory SERIALIZER_FACTORY = new BaseSerializerFactory()
+
     @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     final FileLockManager lockManager = Mock()
     final CacheInitializationAction initializationAction = Mock()
@@ -627,6 +630,121 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
 
         then:
         1 * lock.close()
+
+        cleanup:
+        access?.close()
+    }
+
+    def "returns the same cache object when using same cache parameters"() {
+        def access = newAccess(None)
+
+        when:
+        def cache1 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class))
+        def cache2 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class))
+
+        then:
+        cache1 == cache2
+
+        cleanup:
+        access?.close()
+    }
+
+    def "throws InvalidCacheReuseException when cache value type differs"() {
+        def access = newAccess(None)
+
+        when:
+        access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class))
+        access.newCache(new PersistentIndexedCacheParameters('cache', String.class, String.class))
+
+        then:
+        thrown(DefaultCacheAccess.InvalidCacheReuseException)
+
+        cleanup:
+        access?.close()
+    }
+
+    def "throws InvalidCacheReuseException when cache key type differs"() {
+        def access = newAccess(None)
+
+        when:
+        access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class))
+        access.newCache(new PersistentIndexedCacheParameters('cache', Integer.class, Integer.class))
+
+        then:
+        thrown(DefaultCacheAccess.InvalidCacheReuseException)
+
+        cleanup:
+        access?.close()
+    }
+
+    def "throws InvalidCacheReuseException when cache decorator differs"() {
+        def access = newAccess(None)
+        def decorator = Mock(CacheDecorator)
+        lockManager.lock(lockFile, mode(Exclusive), "<display-name>") >> lock
+        decorator.decorate(_, _, _, _, _) >> { String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess ->
+            persistentCache
+        }
+
+        when:
+        access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class))
+        access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class).cacheDecorator(decorator))
+
+        then:
+        thrown(DefaultCacheAccess.InvalidCacheReuseException)
+
+        cleanup:
+        access?.close()
+    }
+
+    def "returns the same cache object when cache decorator match"() {
+        def access = newAccess(None)
+        def decorator1 = Mock(CacheDecorator)
+        def decorator2 = Mock(CacheDecorator)
+        lockManager.lock(lockFile, mode(Exclusive), "<display-name>") >> lock
+        decorator1.decorate(_, _, _, _, _) >> { String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess ->
+            persistentCache
+        }
+        decorator2.decorate(_, _, _, _, _) >> { String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess ->
+            persistentCache
+        }
+
+        when:
+        def cache1 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class).cacheDecorator(decorator1))
+        def cache2 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class).cacheDecorator(decorator2))
+
+        then:
+        noExceptionThrown()
+        cache1 == cache2
+
+        cleanup:
+        access?.close()
+    }
+
+    def "returns the same cache object when using compatible value serializer"() {
+        def access = newAccess(None)
+
+        when:
+        def cache1 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class))
+        def cache2 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, SERIALIZER_FACTORY.getSerializerFor(Integer.class)))
+
+        then:
+        noExceptionThrown()
+        cache1 == cache2
+
+        cleanup:
+        access?.close()
+    }
+
+    def "returns the same cache object when using compatible key serializer"() {
+        def access = newAccess(None)
+
+        when:
+        def cache1 = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class))
+        def cache2 = access.newCache(new PersistentIndexedCacheParameters('cache', SERIALIZER_FACTORY.getSerializerFor(String.class), SERIALIZER_FACTORY.getSerializerFor(Integer.class)))
+
+        then:
+        noExceptionThrown()
+        cache1 == cache2
 
         cleanup:
         access?.close()


### PR DESCRIPTION
This PR fix issue gradle/gradle#933 by using a deep knowledge of the inner working of Gradle. It assumes the parameters for the cache won't change between the embedded run of Gradle through `GradleBuild` type task or other.