### PR TITLE
Show distributed performance tests in Teamcity

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/testing/CoordinatorBuild.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/CoordinatorBuild.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import groovy.transform.Immutable
+
+@Immutable
+class CoordinatorBuild {
+    String id
+    String lastChangeId
+    String buildTypeId
+}

--- a/buildSrc/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -139,9 +139,11 @@ class DistributedPerformanceTest extends PerformanceTest {
 
         createClient()
 
-        def lastChangeId = resolveLastChangeId()
+        def coordinatorBuild = resolveCoordinatorBuild()
+        testEventsGenerator.coordinatorBuild = coordinatorBuild
+
         scenarios.each {
-            schedule(it, lastChangeId)
+            schedule(it, coordinatorBuild?.lastChangeId)
         }
 
         scheduledBuilds.each {
@@ -216,11 +218,11 @@ class DistributedPerformanceTest extends PerformanceTest {
     }
 
     @TypeChecked(TypeCheckingMode.SKIP)
-    private String resolveLastChangeId() {
+    private CoordinatorBuild resolveCoordinatorBuild() {
         if (coordinatorBuildId) {
             def response = client.get(path: "builds/id:$coordinatorBuildId")
             if (response.success) {
-                return findLastChangeIdInXml(response.data)
+                return new CoordinatorBuild(id: coordinatorBuildId, lastChangeId: findLastChangeIdInXml(response.data), buildTypeId: response.data.@buildTypeId.text())
             }
         }
         return null

--- a/buildSrc/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -29,6 +29,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.testing.TestListener
+import org.gradle.api.tasks.testing.TestOutputListener
 import org.gradle.internal.IoActions
 
 import java.util.concurrent.TimeUnit
@@ -81,6 +83,22 @@ class DistributedPerformanceTest extends PerformanceTest {
     Map<String, List<File>> testResultFilesForBuild = [:]
     private File workerTestResultsTempDir
 
+    private final JUnitXmlTestEventsGenerator testEventsGenerator
+
+    DistributedPerformanceTest() {
+        this.testEventsGenerator = new JUnitXmlTestEventsGenerator(listenerManager.createAnonymousBroadcaster(TestListener.class), listenerManager.createAnonymousBroadcaster(TestOutputListener.class))
+    }
+
+    @Override
+    void addTestListener(TestListener listener) {
+        testEventsGenerator.addTestListener(listener)
+    }
+
+    @Override
+    void addTestOutputListener(TestOutputListener listener) {
+        testEventsGenerator.addTestOutputListener(listener)
+    }
+
     void setScenarioList(File scenarioList) {
         systemProperty "org.gradle.performance.scenario.list", scenarioList
         this.scenarioList = scenarioList
@@ -92,6 +110,7 @@ class DistributedPerformanceTest extends PerformanceTest {
         try {
             doExecuteTests()
         } finally {
+            testEventsGenerator.release()
             cleanTempFiles()
         }
     }
@@ -226,9 +245,18 @@ class DistributedPerformanceTest extends PerformanceTest {
         finishedBuilds += response.data
 
         try {
-            testResultFilesForBuild.put(jobId, fetchTestResults(jobId, response.data))
+            def results = fetchTestResults(jobId, response.data)
+            testResultFilesForBuild.put(jobId, results)
+            fireTestListener(results, response.data)
         } catch (e) {
             e.printStackTrace(System.err)
+        }
+    }
+
+    private void fireTestListener(List<File> results, Object build) {
+        def xmlFiles = results.findAll { it.name.endsWith('.xml') }
+        xmlFiles.each {
+            testEventsGenerator.processXmlFile(it, build)
         }
     }
 

--- a/buildSrc/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
@@ -33,6 +33,14 @@ import org.gradle.internal.event.ListenerBroadcast
 
 import javax.xml.datatype.DatatypeFactory
 
+/**
+ * This class is responsible for publishing events to {@link TestListener} and {@link TestOutputListener}
+ * from a JUnit xml file produced by the performance tests. The Teamcity test listeners need to be
+ * added for teamcity to discover the tests. We are ignoring the test listeners provided by Gradle itself
+ * in {@link JUnitXmlTestEventsGenerator#addTestListener(org.gradle.api.tasks.testing.TestListener)} and
+ * {@link JUnitXmlTestEventsGenerator#addTestOutputListener(org.gradle.api.tasks.testing.TestOutputListener)}
+ * in order to avoid problems with resources closed by the "actual" test execution (in particular {@code outputWriter}).
+ */
 class JUnitXmlTestEventsGenerator {
     private final ListenerBroadcast<TestListener> testListenerBroadcast
     private final ListenerBroadcast<TestOutputListener> testOutputListenerBroadcast
@@ -109,13 +117,18 @@ class JUnitXmlTestEventsGenerator {
         properties.find { it.@name == 'scenario' }.@value.text()
     }
 
-
+    /**
+     * Add a test listener. Gradle internal test listeners are ignored.
+     */
     void addTestListener(TestListener listener) {
         if (!listener.getClass().getName().startsWith('org.gradle.api.internal')) {
             testListenerBroadcast.add(listener)
         }
     }
 
+    /**
+     * Add a test output listener. Gradle internal test output listeners are ignored.
+     */
     void addTestOutputListener(TestOutputListener listener) {
         if (!listener.getClass().getName().startsWith('org.gradle.api.internal')) {
             testOutputListenerBroadcast.add(listener)

--- a/buildSrc/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import groovy.util.slurpersupport.GPathResult
+import groovy.util.slurpersupport.NodeChildren
+import org.gradle.api.internal.tasks.testing.DecoratingTestDescriptor
+import org.gradle.api.internal.tasks.testing.DefaultTestClassDescriptor
+import org.gradle.api.internal.tasks.testing.DefaultTestMethodDescriptor
+import org.gradle.api.internal.tasks.testing.DefaultTestOutputEvent
+import org.gradle.api.internal.tasks.testing.DefaultTestSuiteDescriptor
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
+import org.gradle.api.internal.tasks.testing.results.DefaultTestResult
+import org.gradle.api.tasks.testing.TestListener
+import org.gradle.api.tasks.testing.TestOutputEvent
+import org.gradle.api.tasks.testing.TestOutputListener
+import org.gradle.api.tasks.testing.TestResult
+import org.gradle.internal.event.ListenerBroadcast
+
+import javax.xml.datatype.DatatypeFactory
+
+class JUnitXmlTestEventsGenerator {
+    private final ListenerBroadcast<TestListener> testListenerBroadcast
+    private final ListenerBroadcast<TestOutputListener> testOutputListenerBroadcast
+
+    JUnitXmlTestEventsGenerator(ListenerBroadcast<TestListener> testListenerBroadcast, ListenerBroadcast<TestOutputListener> testOutputListenerListenerBroadcast) {
+        this.testOutputListenerBroadcast = testOutputListenerListenerBroadcast
+        this.testListenerBroadcast = testListenerBroadcast
+    }
+
+    void processXmlFile(File resultsFile, Object build) {
+        processXml(new XmlSlurper().parse(resultsFile), build)
+    }
+
+    void processXml(GPathResult testResult, Object build) {
+        String suiteName = testResult.@name.text()
+        def testSuiteDescriptor = new DecoratingTestDescriptor(new DefaultTestClassDescriptor(0, suiteName), createWorkerSuite())
+        testListener.beforeSuite(testSuiteDescriptor.parent.parent)
+        testListener.beforeSuite(testSuiteDescriptor.parent)
+        testListener.beforeSuite(testSuiteDescriptor)
+        String timestamp = testResult.@timestamp.text()
+        long startTime = DatatypeFactory.newInstance().newXMLGregorianCalendar(timestamp).toGregorianCalendar().getTimeInMillis()
+        testResult.testcase.each { testCase ->
+            String testCaseClassName = testCase.@classname.text()
+            String testMethodName = testCase.@name.text()
+            def testCaseDescriptor = new DecoratingTestDescriptor(new DefaultTestMethodDescriptor(0, testCaseClassName, testMethodName), testSuiteDescriptor)
+            def skipped = testCase.skipped
+            def failure = testCase.failure
+            long endTime = startTime + (testCase.@time.toDouble() * 1000).round()
+
+            if (failure.size() > 0) {
+                testListener.beforeTest(testCaseDescriptor)
+                publishAdditionalMetadata(testCaseDescriptor, build)
+                try {
+                    String systemErr = testResult."system-err".text()
+                    if (systemErr) {
+                        testOutputListener.onOutput(testCaseDescriptor, new DefaultTestOutputEvent(TestOutputEvent.Destination.StdErr, systemErr))
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace()
+                }
+                String failureText = failure.text()
+                failureText = failureText.replace("java.lang.AssertionError: ", "")
+                testListener.afterTest(testCaseDescriptor, new DefaultTestResult(TestResult.ResultType.FAILURE, startTime, endTime, 1, 0, 1, [new AssertionError(failureText)]))
+            } else if (!(skipped.size() > 0)) {
+                testListener.beforeTest(testCaseDescriptor)
+                publishAdditionalMetadata(testCaseDescriptor, build)
+                testListener.afterTest(testCaseDescriptor, new DefaultTestResult(TestResult.ResultType.SUCCESS, startTime, endTime, 1, 1, 0, []))
+            }
+        }
+        testListener.afterSuite(testSuiteDescriptor, new DefaultTestResult(TestResult.ResultType.SUCCESS, 0, 0, 0, 0, 0, []))
+        testListener.afterSuite(testSuiteDescriptor.parent, new DefaultTestResult(TestResult.ResultType.SUCCESS, 0, 0, 0, 0, 0, []))
+        testListener.afterSuite(testSuiteDescriptor.parent.parent, new DefaultTestResult(TestResult.ResultType.SUCCESS, 0, 0, 0, 0, 0, []))
+    }
+
+    private void publishAdditionalMetadata(DecoratingTestDescriptor testCaseDescriptor, Object build) {
+        def buildUrl = build.@webUrl
+        if (buildUrl) {
+            testOutputListener.onOutput(testCaseDescriptor, new DefaultTestOutputEvent(TestOutputEvent.Destination.StdOut,
+                """
+                    Scenario: ${getScenarioId(build)}
+                    Worker build url: ${buildUrl}
+                """.stripIndent())
+            )
+        }
+    }
+
+    private String getScenarioId(Object build) {
+        NodeChildren properties = build.properties.children()
+        properties.find { it.@name == 'scenario' }.@value.text()
+    }
+
+
+    void addTestListener(TestListener listener) {
+        if (!listener.getClass().getName().startsWith('org.gradle.api.internal')) {
+            testListenerBroadcast.add(listener)
+        }
+    }
+
+    void addTestOutputListener(TestOutputListener listener) {
+        if (!listener.getClass().getName().startsWith('org.gradle.api.internal')) {
+            testOutputListenerBroadcast.add(listener)
+        }
+    }
+
+    private TestListener getTestListener() {
+        testListenerBroadcast.getSource()
+    }
+
+    private TestOutputListener getTestOutputListener() {
+        testOutputListenerBroadcast.getSource()
+    }
+
+    void release() {
+        testListenerBroadcast.removeAll()
+        testOutputListenerBroadcast.removeAll()
+    }
+
+    private static TestDescriptorInternal createRootSuite() {
+        new DefaultTestSuiteDescriptor(0, "rootSuite")
+    }
+
+    private static TestDescriptorInternal createWorkerSuite() {
+        new DecoratingTestDescriptor(new DefaultTestSuiteDescriptor(0, "workerSuite"), createRootSuite())
+    }
+}

--- a/buildSrc/src/test/groovy/org/gradle/testing/JUnitXmlTestEventsGeneratorTest.groovy
+++ b/buildSrc/src/test/groovy/org/gradle/testing/JUnitXmlTestEventsGeneratorTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
+import org.gradle.api.tasks.testing.TestListener
+import org.gradle.api.tasks.testing.TestOutputListener
+import org.gradle.api.tasks.testing.TestResult
+import org.gradle.internal.event.ListenerBroadcast
+import spock.lang.Specification
+
+class JUnitXmlTestEventsGeneratorTest extends Specification {
+    def "uses correct failure message"() {
+        def xml = """
+            <testsuite name="org.gradle.performance.GradleScriptKotlinBuildPerformanceTest" tests="4" skipped="3" failures="1" errors="0" timestamp="2016-12-16T10:18:55" hostname="ubuntu47.buildfarm.gradle.org" time="1628.799">
+                <properties/>
+                <testcase name="configuration of ktsSmall" classname="org.gradle.performance.GradleScriptKotlinBuildPerformanceTest" time="0.001">
+                    <skipped/>
+                </testcase>
+                <testcase name="configuration of ktsSmall (--recompile-scripts)" classname="org.gradle.performance.GradleScriptKotlinBuildPerformanceTest" time="0.0">
+                    <skipped/>
+                </testcase>
+                <testcase name="configuration of ktsManyProjects" classname="org.gradle.performance.GradleScriptKotlinBuildPerformanceTest" time="0.001">
+                    <skipped/>
+                </testcase>
+                <testcase name="configuration of ktsManyProjects (--recompile-scripts)" classname="org.gradle.performance.GradleScriptKotlinBuildPerformanceTest" time="1628.796">
+                    <failure message="java.lang.AssertionError: Speed Results for test project 'ktsManyProjects' with tasks help: we're slower than 3.4-20161216000013+0000.&#10;Difference: 484 ms slower (484 ms), 2.51%, max regression: 116.443 ms&#10;  Current Gradle median: 19.778 s min: 19.684 s, max: 20.011 s, se: 86.89 ms, sem: 19.429 ms&#10;  &gt; [19.901 s, 19.792 s, 19.705 s, 20.011 s, 19.751 s, 19.756 s, 19.89 s, 19.877 s, 19.726 s, 19.684 s, 19.796 s, 19.764 s, 19.709 s, 19.833 s, 19.709 s, 19.822 s, 19.871 s, 19.694 s, 19.704 s, 19.876 s]&#10;  Gradle 3.4-20161216000013+0000 median: 19.294 s min: 19.159 s, max: 19.445 s, se: 79.75 ms, sem: 17.833 ms&#10;  &gt; [19.425 s, 19.275 s, 19.334 s, 19.402 s, 19.285 s, 19.303 s, 19.415 s, 19.309 s, 19.272 s, 19.445 s, 19.236 s, 19.28 s, 19.396 s, 19.159 s, 19.213 s, 19.262 s, 19.38 s, 19.225 s, 19.22 s, 19.372 s]&#10;&#10;" type="java.lang.AssertionError">java.lang.AssertionError: Speed Results for test project 'ktsManyProjects' with tasks help: we're slower than 3.4-20161216000013+0000.
+                Difference: 484 ms slower (484 ms), 2.51%, max regression: 116.443 ms
+                  Current Gradle median: 19.778 s min: 19.684 s, max: 20.011 s, se: 86.89 ms, sem: 19.429 ms
+                  &gt; [19.901 s, 19.792 s, 19.705 s, 20.011 s, 19.751 s, 19.756 s, 19.89 s, 19.877 s, 19.726 s, 19.684 s, 19.796 s, 19.764 s, 19.709 s, 19.833 s, 19.709 s, 19.822 s, 19.871 s, 19.694 s, 19.704 s, 19.876 s]
+                  Gradle 3.4-20161216000013+0000 median: 19.294 s min: 19.159 s, max: 19.445 s, se: 79.75 ms, sem: 17.833 ms
+                  &gt; [19.425 s, 19.275 s, 19.334 s, 19.402 s, 19.285 s, 19.303 s, 19.415 s, 19.309 s, 19.272 s, 19.445 s, 19.236 s, 19.28 s, 19.396 s, 19.159 s, 19.213 s, 19.262 s, 19.38 s, 19.225 s, 19.22 s, 19.372 s]
+                
+                
+                    at org.gradle.performance.results.CrossVersionPerformanceResults.throwAssertionErrorIfNotFlaky(CrossVersionPerformanceResults.groovy:101)
+                    at org.gradle.performance.results.CrossVersionPerformanceResults.assertCurrentVersionHasNotRegressed(CrossVersionPerformanceResults.groovy:93)
+                    at org.gradle.performance.fixture.CrossVersionPerformanceTestRunner.run(CrossVersionPerformanceTestRunner.groovy:121)
+                    at org.gradle.performance.GradleScriptKotlinBuildPerformanceTest.build(GradleScriptKotlinBuildPerformanceTest.groovy:37)
+                </failure>
+                </testcase>
+            </testsuite>""".stripIndent()
+        def gpath = new XmlSlurper().parseText(xml)
+        ListenerBroadcast<TestListener> testListenerBroadcast = Mock()
+        TestListener testListener = Mock()
+        ListenerBroadcast<TestOutputListener> testOutputListenerBroadcast = Mock()
+        TestOutputListener testOutputListener = Mock()
+        TestDescriptorInternal testDescriptor = null
+        TestResult testResult = null
+        Object build = new XmlSlurper().parseText("""<build webUrl="http://some.url"><properties><property name="scenario" value="configuration of ktsManyProjects (--recompile-scripts)" inherited="false"/></properties></build>""")
+
+        when:
+        new JUnitXmlTestEventsGenerator(testListenerBroadcast, testOutputListenerBroadcast).processXml(gpath, build)
+
+        then:
+        _ * testListenerBroadcast.getSource() >> testListener
+        _ * testOutputListenerBroadcast.getSource() >> testOutputListener
+        1 * testListener.afterTest(_, _) >> { arguments ->
+            testDescriptor = arguments[0]
+            testResult = arguments[1]
+        }
+
+        testDescriptor.name == 'configuration of ktsManyProjects (--recompile-scripts)'
+        testDescriptor.className == 'org.gradle.performance.GradleScriptKotlinBuildPerformanceTest'
+
+        testResult.resultType == TestResult.ResultType.FAILURE
+        testResult.exception.toString() startsWith """java.lang.AssertionError: Speed Results for test project 'ktsManyProjects' with tasks help: we're slower than 3.4-20161216000013+0000."""
+    }
+}


### PR DESCRIPTION
This change has the effect to show the distributed
performance tests as regular tests in Teamcity - with
duration and exception message.

Here is an example what it looks like: https://builds.gradle.org/viewLog.html?buildId=1956221&buildTypeId=Gradle_Branches_Performance_PerformanceTestCoordinatorLinux&tab=testsInfo

And here is a failing performance test: https://builds.gradle.org/viewLog.html?buildId=1952279&tab=buildResultsDiv&buildTypeId=Gradle_Branches_Performance_PerformanceTestCoordinatorLinux
