### PR TITLE
Fixing README link for 'contributing to Gradle'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ And so on.
 
 ## Contributing
 
-If you're looking to contribute to Gradle or provide a patch/pull request, you can find info on how to get in touch with the developers at http://gradle.org/development.
+If you're looking to contribute to Gradle or provide a patch/pull request, you can find more info [here](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
 
 ### Contributing Code
 


### PR DESCRIPTION
The Readme link to [gradle.org/development](https://gradle.org/development) redirects back to itself; linking to CONTRIBUTING.md seems more helpful.

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

N/A
