### PR TITLE
Fully reproducible archive tasks 

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
@@ -404,4 +404,26 @@ public class GUtil {
             throw UncheckedException.throwAsUncheckedException(e);
         }
     }
+
+    /**
+     * Note that setting the January 1st 1980 (or even worse, "0", as time) won't work due
+     * to Java 8 doing some interesting time processing: It checks if this date is before January 1st 1980
+     * and if it is it starts setting some extra fields in the zip. Java 7 does not do that - but in the
+     * zip not the milliseconds are saved but values for each of the date fields - but no time zone. And
+     * 1980 is the first year which can be saved.
+     * If you use January 1st 1980 then it is treated as a special flag in Java 8.
+     * Moreover, only even seconds can be stored in the zip file. Java 8 uses the upper half of
+     * some other long to store the remaining millis while Java 7 doesn't do that. So make sure
+     * that your seconds are even.
+     * Moreover, parsing happens via `new Date(millis)` in {@link java.util.zip.ZipUtils}#javaToDosTime() so we
+     * must use default timezone and locale.
+     *
+     * The date is 1980 February 1st.
+     */
+    public static final long CONSTANT_TIME_FOR_ZIP_ENTRIES = new GregorianCalendar(1980, Calendar.FEBRUARY, 1, 0, 0, 0).getTimeInMillis();
+
+    /**
+     * Tar files are simpler.  We can just use "0" as a timestamp.
+     */
+    public static final long CONSTANT_TIME_FOR_TAR_ENTRIES = 0;
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.apache.commons.io.FilenameUtils
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.archive.ArchiveTestFixture
+import org.gradle.test.fixtures.archive.TarTestFixture
+import org.gradle.test.fixtures.archive.ZipTestFixture
+import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Unroll
+
+class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
+
+    @Unroll
+    "reproducible #taskName for file order #files"() {
+        given:
+        createTestFiles()
+        buildFile << """
+            task ${taskName}(type: ${taskType}) {
+                sortedFileOrder = true
+                preserveFileTimestamps = false
+                from files(${files.collect { "'${it}'" }.join(',')})
+                destinationDir = buildDir
+                archiveName = 'test.${fileExtension}'
+            }
+            """
+
+        when:
+        succeeds taskName
+
+        then:
+        file("build/test.${fileExtension}").md5Hash == expectedHash
+
+        where:
+        input << [
+            ['dir1/file11.txt', 'dir2/file22.txt', 'dir3/file33.txt'].permutations(),
+            ['zip', 'tar']
+        ].combinations()
+        files = input[0]
+        taskName = input[1]
+        taskType = taskName.capitalize()
+        fileExtension = taskName
+        expectedHash = taskName == 'tar' ? '783922dfc025775c2f41dbe8a147cdad' : 'f56ce3c53ff5c8564bcf5d95cefb7846'
+    }
+
+    @Unroll
+    "timestamps are ignored in #taskName"() {
+        given:
+        createTestFiles()
+        buildFile << """
+            task ${taskName}(type: ${taskType}) {
+                sortedFileOrder = true
+                preserveFileTimestamps = false
+                from 'dir1'
+                destinationDir = buildDir
+                archiveName = 'test.${fileExtension}'
+            }
+            """
+
+        when:
+        succeeds taskName
+
+        def archive = file("build/test.${fileExtension}")
+        then:
+        def firstFileHash = archive.md5Hash
+
+        when:
+        file('dir1/file11.txt').makeOlder()
+        archive.delete()
+        succeeds taskName
+
+        then:
+        archive.md5Hash == firstFileHash
+
+        where:
+        taskName << ['tar', 'zip']
+        taskType = taskName.capitalize()
+        fileExtension = taskName
+    }
+
+    @Unroll
+    "#taskName can use zipTree and tarTree"() {
+        given:
+        createTestFiles()
+        buildFile << """
+            task aTar(type: Tar) {
+                from('dir1')
+                destinationDir = buildDir
+                archiveName = 'test.tar'
+            }
+            task aZip(type: Zip) {
+                from('dir2')
+                destinationDir = buildDir
+                archiveName = 'test.zip'
+            }
+
+            task ${taskName}(type: ${taskType}) {
+                sortedFileOrder = true
+                preserveFileTimestamps = false
+                destinationDir = buildDir
+                archiveName = 'combined.${fileExtension}'
+
+                from zipTree(aZip.archivePath)
+                from tarTree(aTar.archivePath)
+                dependsOn aZip, aTar
+            }
+        """
+
+        when:
+        succeeds taskName
+
+        then:
+        archive(file("build/combined.${fileExtension}")).hasDescendants(
+            'file11.txt',
+            'file12.txt',
+            'file13.txt',
+            'file14.txt',
+            'file21.txt',
+            'file22.txt',
+            'file23.txt',
+            'file24.txt')
+
+        where:
+        taskName << ['zip', 'tar']
+        taskType = taskName.capitalize()
+        fileExtension = taskName
+    }
+
+    @Unroll
+    "#taskName uses only first duplicate"() {
+        given:
+        duplicateEntriesInArchive(taskName, taskType, fileExtension)
+
+        buildFile << """
+            ${taskName} {
+                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            }
+        """
+
+        when:
+        succeeds taskName
+
+        then:
+        archive(file("build/test.${fileExtension}")).content('test.txt') == "from dir2"
+
+        where:
+        taskName << ['zip', 'tar']
+        taskType = taskName.capitalize()
+        fileExtension = taskName
+    }
+
+    @Unroll
+    "#taskName can fail for duplicate entries"() {
+        given:
+        duplicateEntriesInArchive(taskName, taskType, fileExtension)
+
+        buildFile << """
+            ${taskName} {
+                duplicatesStrategy = DuplicatesStrategy.FAIL
+            }
+        """
+
+        when:
+        fails taskName
+
+        then:
+        failure.assertHasCause('Encountered duplicate path "test.txt" during copy operation configured with DuplicatesStrategy.FAIL')
+
+        where:
+        taskName << ['zip', 'tar']
+        taskType = taskName.capitalize()
+        fileExtension = taskName
+    }
+
+    @Unroll
+    "#taskName supports filtered entries"() {
+
+        given:
+        file('dir1/test.txt').text = "Hello"
+        buildFile << """
+        task ${taskName}(type: ${taskType}) {
+            sortedFileOrder = true
+            preserveFileTimestamps = false
+            destinationDir = buildDir
+            archiveName = 'test.${fileExtension}'
+
+            from('dir1') {
+                filter { 'Goodbye' }
+            }
+        }
+        """
+
+        when:
+        succeeds taskName
+
+        then:
+        archive(file("build/test.${fileExtension}")).content('test.txt') == 'Goodbye'
+
+        where:
+        taskName << ['zip', 'tar']
+        taskType = taskName.capitalize()
+        fileExtension = taskName
+    }
+
+    @Unroll
+    "#taskName sorts by target file name"() {
+
+        given:
+        createDir('dir1') {
+            file('test1.txt') << 'test1'
+            file('test2.txt') << 'test2'
+        }
+        buildFile << """
+        task ${taskName}(type: ${taskType}) {
+            sortedFileOrder = true
+            preserveFileTimestamps = false
+            destinationDir = buildDir
+            archiveName = 'test.${fileExtension}'
+
+            from('dir1') {
+                rename { it == 'test1.txt' ? 'test4.txt' : 'test3.txt' }
+            }
+        }
+        """
+
+        when:
+        succeeds taskName
+
+        then:
+        def archiveFile = archive(file("build/test.${fileExtension}"))
+        archiveFile.hasDescendants('test3.txt', 'test4.txt')
+        archiveFile.content('test3.txt') == 'test2'
+        archiveFile.content('test4.txt') == 'test1'
+
+        where:
+        taskName << ['zip', 'tar']
+        taskType = taskName.capitalize()
+        fileExtension = taskName
+    }
+
+    private void duplicateEntriesInArchive(taskName, taskType, fileExtension) {
+        file('dir1/test.txt') << "from dir1"
+        file('dir2/test.txt') << "from dir2"
+
+        buildFile << """
+            task ${taskName}(type: ${taskType}) {
+                sortedFileOrder = true
+                preserveFileTimestamps = false
+                destinationDir = buildDir
+                archiveName = 'test.${fileExtension}'
+
+                from 'dir2'
+                from 'dir1'
+            }
+        """
+    }
+
+    ArchiveTestFixture archive(TestFile archiveFile) {
+        String type = FilenameUtils.getExtension(archiveFile.name)
+        if (type == 'zip') {
+            new ZipTestFixture(archiveFile)
+        } else {
+            new TarTestFixture(archiveFile)
+        }
+    }
+
+    def createTestFiles() {
+        createDir('dir1') {
+            file('file12.txt') << 'test2'
+            file('file11.txt') << 'test1'
+            file('file13.txt') << 'test3'
+            file('file14.txt') << 'test4'
+        }
+        createDir('dir2') {
+            file('file22.txt') << 'test2'
+            file('file21.txt') << 'test1'
+            file('file23.txt') << 'test3'
+            file('file24.txt') << 'test4'
+        }
+        createDir('dir3') {
+            file('file32.txt') << 'test2'
+            file('file31.txt') << 'test1'
+            file('file33.txt') << 'test3'
+            file('file34.txt') << 'test4'
+        }
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
@@ -94,6 +94,33 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
+    def "#compression compressed tar files are reproducible"() {
+        given:
+        createTestFiles()
+        buildFile << """
+            task tar(type: Tar) {
+                sortedFileOrder = true
+                preserveFileTimestamps = false  
+                compression = '${compression}'
+                from 'dir1', 'dir2', 'dir3'
+                destinationDir = buildDir
+                archiveName = 'test.tar.${compression}'
+            }
+            """
+
+        when:
+        succeeds 'tar'
+
+        then:
+        file("build/test.tar.${compression}").md5Hash == md5
+
+        where:
+        compression | md5
+        'gzip'      | '9981efce12fd025835922ce0f2961ab9'
+        'bzip2'     | '60f165136a27358d02926f26fb184c86'
+    }
+
+    @Unroll
     "#taskName can use zipTree and tarTree"() {
         given:
         createTestFiles()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/FileResolvingFileVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/FileResolvingFileVisitor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.archive;
+
+import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.file.FileVisitor;
+
+class FileResolvingFileVisitor implements FileVisitor {
+    private final FileVisitor delegate;
+
+    FileResolvingFileVisitor(FileVisitor delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void visitDir(FileVisitDetails dirDetails) {
+        dirDetails.getFile();
+        delegate.visitDir(dirDetails);
+    }
+
+    @Override
+    public void visitFile(FileVisitDetails fileDetails) {
+        fileDetails.getFile();
+        delegate.visitFile(fileDetails);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ReproducibleOrderingCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ReproducibleOrderingCopyActionDecorator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.archive;
+
+import com.google.common.collect.Maps;
+import org.gradle.api.file.RelativePath;
+import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
+import org.gradle.api.internal.file.copy.CopyAction;
+import org.gradle.api.internal.file.copy.CopyActionProcessingStream;
+import org.gradle.api.internal.file.copy.FileCopyDetailsInternal;
+import org.gradle.api.tasks.WorkResult;
+
+import java.util.Map;
+
+public class ReproducibleOrderingCopyActionDecorator implements CopyAction {
+    private final CopyAction delegate;
+
+    public ReproducibleOrderingCopyActionDecorator(CopyAction delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public WorkResult execute(final CopyActionProcessingStream stream) {
+        return delegate.execute(new CopyActionProcessingStream() {
+            public void process(final CopyActionProcessingStreamAction action) {
+                // Sort all of the files going into the underlying CopyAction
+                final Map<RelativePath, FileCopyDetailsInternal> files = Maps.newTreeMap();
+                stream.process(new CopyActionProcessingStreamAction() {
+                    public void processFile(FileCopyDetailsInternal details) {
+                        files.put(details.getRelativePath(), details);
+                    }
+                });
+                // Call the underlying CopyAction with the sorted collection of files
+                for (FileCopyDetailsInternal fileCopyDetailsInternal : files.values()) {
+                    action.processFile(fileCopyDetailsInternal);
+                }
+            }
+        });
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
@@ -143,6 +143,9 @@ public class TarFileTree implements MinimalFileTree, FileSystemMirroringFileTree
         public File getFile() {
             if (file == null) {
                 file = new File(tmpDir, entry.getName());
+                if (file.exists()) {
+                    GFileUtils.forceDelete(file);
+                }
                 copyTo(file);
             }
             return file;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.internal.IoActions;
+import org.gradle.util.GUtil;
 
 import java.io.File;
 
@@ -41,12 +42,14 @@ public class ZipCopyAction implements CopyAction {
     private final ZipCompressor compressor;
     private final DocumentationRegistry documentationRegistry;
     private final String encoding;
+    private final boolean preserveFileTimestamps;
 
-    public ZipCopyAction(File zipFile, ZipCompressor compressor, DocumentationRegistry documentationRegistry, String encoding) {
+    public ZipCopyAction(File zipFile, ZipCompressor compressor, DocumentationRegistry documentationRegistry, String encoding, boolean preserveFileTimestamps) {
         this.zipFile = zipFile;
         this.compressor = compressor;
         this.documentationRegistry = documentationRegistry;
         this.encoding = encoding;
+        this.preserveFileTimestamps = preserveFileTimestamps;
     }
 
     public WorkResult execute(final CopyActionProcessingStream stream) {
@@ -96,7 +99,7 @@ public class ZipCopyAction implements CopyAction {
         private void visitFile(FileCopyDetails fileDetails) {
             try {
                 ZipEntry archiveEntry = new ZipEntry(fileDetails.getRelativePath().getPathString());
-                archiveEntry.setTime(fileDetails.getLastModified());
+                archiveEntry.setTime(getArchiveTimeFor(fileDetails));
                 archiveEntry.setUnixMode(UnixStat.FILE_FLAG | fileDetails.getMode());
                 zipOutStr.putNextEntry(archiveEntry);
                 fileDetails.copyTo(zipOutStr);
@@ -110,7 +113,7 @@ public class ZipCopyAction implements CopyAction {
             try {
                 // Trailing slash in name indicates that entry is a directory
                 ZipEntry archiveEntry = new ZipEntry(dirDetails.getRelativePath().getPathString() + '/');
-                archiveEntry.setTime(dirDetails.getLastModified());
+                archiveEntry.setTime(getArchiveTimeFor(dirDetails));
                 archiveEntry.setUnixMode(UnixStat.DIR_FLAG | dirDetails.getMode());
                 zipOutStr.putNextEntry(archiveEntry);
                 zipOutStr.closeEntry();
@@ -118,5 +121,9 @@ public class ZipCopyAction implements CopyAction {
                 throw new GradleException(String.format("Could not add %s to ZIP '%s'.", dirDetails, zipFile), e);
             }
         }
+    }
+
+    private long getArchiveTimeFor(FileCopyDetails details) {
+        return preserveFileTimestamps ? details.getLastModified() : GUtil.CONSTANT_TIME_FOR_ZIP_ENTRIES;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
@@ -25,10 +25,15 @@ import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
 import org.gradle.api.internal.file.FileSystemSubset;
-import org.gradle.api.internal.file.collections.*;
+import org.gradle.api.internal.file.collections.DirectoryFileTree;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
+import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
+import org.gradle.api.internal.file.collections.MinimalFileTree;
+import org.gradle.api.internal.file.collections.SingletonFileTree;
 import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.nativeintegration.filesystem.Chmod;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+import org.gradle.util.GFileUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,6 +67,10 @@ public class ZipFileTree implements MinimalFileTree, FileSystemMirroringFileTree
     }
 
     public void visit(FileVisitor visitor) {
+        doVisit(new FileResolvingFileVisitor(visitor));
+    }
+
+    private void doVisit(FileVisitor visitor) {
         if (!zipFile.exists()) {
             throw new InvalidUserDataException(String.format("Cannot expand %s as it does not exist.", getDisplayName()));
         }
@@ -72,7 +81,7 @@ public class ZipFileTree implements MinimalFileTree, FileSystemMirroringFileTree
         AtomicBoolean stopFlag = new AtomicBoolean();
 
         try {
-            ZipFile zip = new ZipFile(zipFile);
+            CloseTrackingZipFile zip = new CloseTrackingZipFile(zipFile);
             try {
                 // The iteration order of zip.getEntries() is based on the hash of the zip entry. This isn't much use
                 // to us. So, collect the entries in a map and iterate over them in alphabetical order.
@@ -99,17 +108,36 @@ public class ZipFileTree implements MinimalFileTree, FileSystemMirroringFileTree
         }
     }
 
+    private static class CloseTrackingZipFile extends ZipFile {
+        private boolean closed;
+
+        public CloseTrackingZipFile(File f) throws IOException {
+            super(f);
+        }
+
+        private boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            closed = true;
+        }
+    }
+
     private File getBackingFile() {
         return zipFile;
     }
 
     private class DetailsImpl extends AbstractFileTreeElement implements FileVisitDetails {
         private final ZipEntry entry;
-        private final ZipFile zip;
+        private final CloseTrackingZipFile zip;
         private final AtomicBoolean stopFlag;
         private File file;
+        private boolean read;
 
-        public DetailsImpl(ZipEntry entry, ZipFile zip, AtomicBoolean stopFlag, Chmod chmod) {
+        public DetailsImpl(ZipEntry entry, CloseTrackingZipFile zip, AtomicBoolean stopFlag, Chmod chmod) {
             super(chmod);
             this.entry = entry;
             this.zip = zip;
@@ -145,6 +173,13 @@ public class ZipFileTree implements MinimalFileTree, FileSystemMirroringFileTree
         }
 
         public InputStream open() {
+            if (read && file != null) {
+                return GFileUtils.openInputStream(file);
+            }
+            if (read || zip.isClosed()) {
+                throw new UnsupportedOperationException(String.format("The contents of %s has already been read.", this));
+            }
+            read = true;
             try {
                 return zip.getInputStream(entry);
             } catch (IOException e) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
@@ -155,6 +155,9 @@ public class ZipFileTree implements MinimalFileTree, FileSystemMirroringFileTree
         public File getFile() {
             if (file == null) {
                 file = new File(tmpDir, entry.getName());
+                if (file.exists()) {
+                    GFileUtils.forceDelete(file);
+                }
                 copyTo(file);
             }
             return file;

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -15,10 +15,13 @@
  */
 package org.gradle.api.tasks.bundling;
 
+import com.google.common.collect.Ordering;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.RelativePath;
+import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.tasks.AbstractCopyTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -26,6 +29,7 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.util.GUtil;
 
 import java.io.File;
+import java.util.Comparator;
 
 /**
  * {@code AbstractArchiveTask} is the base class for all archive tasks.
@@ -260,5 +264,14 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      */
     public void setSortedFileOrder(boolean sortedFileOrder) {
         this.sortedFileOrder = sortedFileOrder;
+    }
+
+    @Override
+    protected CopyAction createCopyAction() {
+        return createCopyAction(Ordering.<RelativePath>natural());
+    }
+
+    protected CopyAction createCopyAction(Comparator<RelativePath> comparator) {
+        throw new UnsupportedOperationException("Override 'createCopyAction()' or 'createCopyAction(Comparator)' in your subclass");
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -17,8 +17,10 @@ package org.gradle.api.tasks.bundling;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.tasks.AbstractCopyTask;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.util.GUtil;
@@ -36,6 +38,8 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     private String version;
     private String extension;
     private String classifier = "";
+    private boolean preserveFileTimestamps = true;
+    private boolean sortedFileOrder;
 
     /**
      * Returns the archive name. If the name has not been explicitly set, the pattern for the name is:
@@ -207,5 +211,54 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     public CopySpec into(Object destPath, Action<? super CopySpec> copySpec) {
         super.into(destPath, copySpec);
         return this;
+    }
+
+    /**
+     * Returns whether file timestamps should be used preserved for archive entries
+     * If false, then a fixed timestamp will be used.
+     *
+     * @return whether file timestamps should be preserved for archive entries
+     */
+    @Input
+    @Incubating
+    public boolean isPreserveFileTimestamps() {
+        return preserveFileTimestamps;
+    }
+
+    /**
+     * Configures if file timestamps should be preserved in the archive.
+     * <p>
+     * When set to false this ensures that archive entries have the same time for builds between different machines,
+     * Java versions and operating systems.
+     *
+     * @param preserveFileTimestamps
+     */
+    @Incubating
+    public void setPreserveFileTimestamps(boolean preserveFileTimestamps) {
+        this.preserveFileTimestamps = preserveFileTimestamps;
+    }
+
+    /**
+     * Should the output files contained in the archive be stored in a sorted order?
+     * <p>
+     * Gradle will sort the files in the archive based on their <strong>destination</strong> path.
+     * </p>
+     *
+     * @return whether the files should be stored in the archive in a sorted order.
+     */
+    @Input
+    public boolean isSortedFileOrder() {
+        return sortedFileOrder;
+    }
+    /**
+     * Specifies if the files should be stored in the archive in a sorted order.
+     * <p>
+     * Enable this if the order of the files in the archive does not matter.
+     * This helps Gradle reliably produce byte-for-byte reproducible archives.
+     * </p>
+     * @param sortedFileOrder if the order should be reproducible
+     */
+    public void setSortedFileOrder(boolean sortedFileOrder) {
+        this.sortedFileOrder = sortedFileOrder;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -218,10 +218,12 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     }
 
     /**
-     * Returns whether file timestamps should be used preserved for archive entries
-     * If false, then a fixed timestamp will be used.
+     * Specifies whether file timestamps should be preserved in the archive.
+     * <p>
+     * If <tt>false</tt> this ensures that archive entries have the same time for builds between different machines, Java versions and operating systems.
+     * </p>
      *
-     * @return whether file timestamps should be preserved for archive entries
+     * @return <tt>true</tt> if file timestamps should be preserved for archive entries
      */
     @Input
     @Incubating
@@ -230,12 +232,12 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     }
 
     /**
-     * Configures if file timestamps should be preserved in the archive.
+     * Specifies whether file timestamps should be preserved in the archive.
      * <p>
-     * When set to false this ensures that archive entries have the same time for builds between different machines,
-     * Java versions and operating systems.
+     * If <tt>false</tt> this ensures that archive entries have the same time for builds between different machines, Java versions and operating systems.
+     * </p>
      *
-     * @param preserveFileTimestamps
+     * @param preserveFileTimestamps <tt>true</tt> if file timestamps should be preserved for archive entries
      */
     @Incubating
     public void setPreserveFileTimestamps(boolean preserveFileTimestamps) {
@@ -243,25 +245,31 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     }
 
     /**
-     * Should the output files contained in the archive be stored in a sorted order?
+     * Specifies whether the output files should be stored in the archive in a sorted order.
      * <p>
      * Gradle will sort the files in the archive based on their <strong>destination</strong> path.
+     * Enable this if the order of the files in the archive does not matter.
+     * This helps Gradle reliably produce byte-for-byte reproducible archives.
      * </p>
      *
-     * @return whether the files should be stored in the archive in a sorted order.
+     * @return <tt>true</tt> if the files should be stored in the archive in a sorted order.
      */
     @Input
+    @Incubating
     public boolean isSortedFileOrder() {
         return sortedFileOrder;
     }
     /**
-     * Specifies if the files should be stored in the archive in a sorted order.
+     * Specifies whether the output files should be stored in the archive in a sorted order.
      * <p>
+     * Gradle will sort the files in the archive based on their <strong>destination</strong> path.
      * Enable this if the order of the files in the archive does not matter.
      * This helps Gradle reliably produce byte-for-byte reproducible archives.
      * </p>
-     * @param sortedFileOrder if the order should be reproducible
+     *
+     * @param sortedFileOrder <tt>true</tt> if the files should be stored in the archive in a sorted order.
      */
+    @Incubating
     public void setSortedFileOrder(boolean sortedFileOrder) {
         this.sortedFileOrder = sortedFileOrder;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Tar.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Tar.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.bundling;
 
+import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.archive.ReproducibleOrderingCopyActionDecorator;
 import org.gradle.api.internal.file.archive.TarCopyAction;
 import org.gradle.api.internal.file.archive.compression.ArchiveOutputStreamFactory;
@@ -26,6 +27,7 @@ import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 
+import java.util.Comparator;
 import java.util.concurrent.Callable;
 
 /**
@@ -43,10 +45,10 @@ public class Tar extends AbstractArchiveTask {
     }
 
     @Override
-    protected CopyAction createCopyAction() {
+    protected CopyAction createCopyAction(Comparator<RelativePath> comparator) {
         TarCopyAction tarCopyAction = new TarCopyAction(getArchivePath(), getCompressor(), isPreserveFileTimestamps());
         if (isSortedFileOrder()) {
-            return new ReproducibleOrderingCopyActionDecorator(tarCopyAction);
+            return new ReproducibleOrderingCopyActionDecorator(tarCopyAction, comparator);
         }
         return tarCopyAction;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Tar.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Tar.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.bundling;
 
+import org.gradle.api.internal.file.archive.ReproducibleOrderingCopyActionDecorator;
 import org.gradle.api.internal.file.archive.TarCopyAction;
 import org.gradle.api.internal.file.archive.compression.ArchiveOutputStreamFactory;
 import org.gradle.api.internal.file.archive.compression.Bzip2Archiver;
@@ -43,7 +44,11 @@ public class Tar extends AbstractArchiveTask {
 
     @Override
     protected CopyAction createCopyAction() {
-        return new TarCopyAction(getArchivePath(), getCompressor());
+        TarCopyAction tarCopyAction = new TarCopyAction(getArchivePath(), getCompressor(), isPreserveFileTimestamps());
+        if (isSortedFileOrder()) {
+            return new ReproducibleOrderingCopyActionDecorator(tarCopyAction);
+        }
+        return tarCopyAction;
     }
 
     @Internal

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
@@ -19,6 +19,7 @@ import org.apache.tools.zip.ZipOutputStream;
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.file.archive.ReproducibleOrderingCopyActionDecorator;
 import org.gradle.api.internal.file.archive.ZipCopyAction;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.DefaultZipCompressor;
@@ -60,7 +61,11 @@ public class Zip extends AbstractArchiveTask {
     @Override
     protected CopyAction createCopyAction() {
         DocumentationRegistry documentationRegistry = getServices().get(DocumentationRegistry.class);
-        return new ZipCopyAction(getArchivePath(), getCompressor(), documentationRegistry, metadataCharset);
+        CopyAction zipCopyAction = new ZipCopyAction(getArchivePath(), getCompressor(), documentationRegistry, metadataCharset, isPreserveFileTimestamps());
+        if (isSortedFileOrder()) {
+            return new ReproducibleOrderingCopyActionDecorator(zipCopyAction);
+        }
+        return zipCopyAction;
     }
 
     /**
@@ -141,4 +146,5 @@ public class Zip extends AbstractArchiveTask {
         }
         this.metadataCharset = metadataCharset;
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
@@ -15,9 +15,11 @@
  */
 package org.gradle.api.tasks.bundling;
 
+import com.google.common.collect.Ordering;
 import org.apache.tools.zip.ZipOutputStream;
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.archive.ReproducibleOrderingCopyActionDecorator;
 import org.gradle.api.internal.file.archive.ZipCopyAction;
@@ -29,6 +31,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 
 import java.nio.charset.Charset;
+import java.util.Comparator;
 
 /**
  * Assembles a ZIP archive.
@@ -60,10 +63,14 @@ public class Zip extends AbstractArchiveTask {
 
     @Override
     protected CopyAction createCopyAction() {
+        return createCopyAction(Ordering.<RelativePath>natural());
+    }
+
+    protected CopyAction createCopyAction(Comparator<RelativePath> comparator) {
         DocumentationRegistry documentationRegistry = getServices().get(DocumentationRegistry.class);
         CopyAction zipCopyAction = new ZipCopyAction(getArchivePath(), getCompressor(), documentationRegistry, metadataCharset, isPreserveFileTimestamps());
         if (isSortedFileOrder()) {
-            return new ReproducibleOrderingCopyActionDecorator(zipCopyAction);
+            return new ReproducibleOrderingCopyActionDecorator(zipCopyAction, comparator);
         }
         return zipCopyAction;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarCopyActionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarCopyActionSpec.groovy
@@ -111,7 +111,7 @@ public class TarCopyActionSpec extends Specification {
     }
 
     private TestFile initializeTarFile(final TestFile tarFile, final ArchiveOutputStreamFactory compressor) {
-        action = new TarCopyAction(tarFile, compressor);
+        action = new TarCopyAction(tarFile, compressor, false);
         return tarFile;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
@@ -47,7 +47,7 @@ class ZipCopyActionTest extends Specification {
 
     def setup() {
         zipFile = tmpDir.getTestDirectory().file("test.zip")
-        visitor = new ZipCopyAction(zipFile, new DefaultZipCompressor(false, ZipOutputStream.STORED), new DocumentationRegistry(), encoding)
+        visitor = new ZipCopyAction(zipFile, new DefaultZipCompressor(false, ZipOutputStream.STORED), new DocumentationRegistry(), encoding, false)
     }
 
     void createsZipFile() {
@@ -81,9 +81,9 @@ class ZipCopyActionTest extends Specification {
         zip(dir("dir"), file("file"))
 
         when:
-        Map<String, Integer> expected = new HashMap<String, Integer>();
-        expected.put("dir", 2);
-        expected.put("file", 1);
+        Map<String, Integer> expected = new HashMap<String, Integer>()
+        expected.put("dir", 2)
+        expected.put("file", 1)
 
         then:
         assertVisitsPermissions(new ZipFileTree(zipFile, null, fileSystem(), directoryFileTreeFactory()), expected)
@@ -92,11 +92,11 @@ class ZipCopyActionTest extends Specification {
     void wrapsFailureToOpenOutputFile() {
         given:
         def invalidZipFile = tmpDir.createDir("test.zip")
-        visitor = new ZipCopyAction(invalidZipFile, new DefaultZipCompressor(false, ZipOutputStream.STORED), new DocumentationRegistry(), encoding)
+        visitor = new ZipCopyAction(invalidZipFile, new DefaultZipCompressor(false, ZipOutputStream.STORED), new DocumentationRegistry(), encoding, false)
 
         when:
         visitor.execute(new CopyActionProcessingStream() {
-            public void process(CopyActionProcessingStreamAction action) {
+            void process(CopyActionProcessingStreamAction action) {
                 // nothing
             }
         })
@@ -124,7 +124,7 @@ class ZipCopyActionTest extends Specification {
         1 * docRegistry.getDslRefForProperty(Zip, "zip64") >> "doc url"
         0 * docRegistry._
 
-        visitor = new ZipCopyAction(zipFile, compressor, docRegistry, encoding)
+        visitor = new ZipCopyAction(zipFile, compressor, docRegistry, encoding, false)
 
         when:
         zip(file("file2"))
@@ -135,7 +135,7 @@ class ZipCopyActionTest extends Specification {
     }
 
     @Test
-    public void wrapsFailureToAddElement() {
+    void wrapsFailureToAddElement() {
         given:
         Throwable failure = new RuntimeException("broken")
 
@@ -151,12 +151,12 @@ class ZipCopyActionTest extends Specification {
 
     private void zip(final FileCopyDetailsInternal... files) {
         visitor.execute(new CopyActionProcessingStream() {
-            public void process(CopyActionProcessingStreamAction action) {
+            void process(CopyActionProcessingStreamAction action) {
                 for (FileCopyDetailsInternal f : files) {
-                    action.processFile(f);
+                    action.processFile(f)
                 }
             }
-        });
+        })
     }
 
     private FileCopyDetailsInternal file(final String path) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
@@ -25,6 +25,7 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
+import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
@@ -34,6 +35,7 @@ import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.progress.PercentageProgressFormatter;
 import org.gradle.util.GFileUtils;
+import org.gradle.util.GUtil;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -54,10 +56,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -77,7 +77,6 @@ class RuntimeShadedJarCreator {
     private static final int BUFFER_SIZE = 8192;
     private static final String SERVICES_DIR_PREFIX = "META-INF/services/";
     private static final String CLASS_DESC = "Ljava/lang/Class;";
-    private static final long FIXED_TIME_FOR_ZIP_ENTRY = fixedTimeForZipEntry();
 
     private final ProgressLoggerFactory progressLoggerFactory;
     private final ImplementationDependencyRelocator remapper;
@@ -85,26 +84,6 @@ class RuntimeShadedJarCreator {
     public RuntimeShadedJarCreator(ProgressLoggerFactory progressLoggerFactory, ImplementationDependencyRelocator remapper) {
         this.progressLoggerFactory = progressLoggerFactory;
         this.remapper = remapper;
-    }
-
-    /**
-     * Note that setting the January 1st 1980 (or even worse, "0", as time) won't work due
-     * to Java 8 doing some interesting time processing: It checks if this date is before January 1st 1980
-     * and if it is it starts setting some extra fields in the zip. Java 7 does not do that - but in the
-     * zip not the milliseconds are saved but values for each of the date fields - but no time zone. And
-     * 1980 is the first year which can be saved.
-     * If you use January 1st 1980 then it is treated as a special flag in Java 8.
-     * Moreover, only even seconds can be stored in the zip file. Java 8 uses the upper half of
-     * some other long to store the remaining millis while Java 7 doesn't do that. So make sure
-     * that your seconds are even.
-     * Moreover, parsing happens via `new Date(millis)` in {@link java.util.zip.ZipUtils}#javaToDosTime() so we
-     * must use default timezone and locale.
-     */
-    private static long fixedTimeForZipEntry() {
-        Calendar calendar = new GregorianCalendar();
-        calendar.clear();
-        calendar.set(1980, Calendar.FEBRUARY, 1, 0, 0, 0);
-        return calendar.getTimeInMillis();
     }
 
     public void create(final File outputJar, final Iterable<? extends File> files) {
@@ -335,7 +314,7 @@ class RuntimeShadedJarCreator {
 
     private ZipEntry newZipEntryWithFixedTime(String name) {
         ZipEntry entry = new ZipEntry(name);
-        entry.setTime(FIXED_TIME_FOR_ZIP_ENTRY);
+        entry.setTime(GUtil.CONSTANT_TIME_FOR_ZIP_ENTRIES);
         return entry;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
@@ -25,7 +25,6 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
-import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
@@ -40,6 +40,14 @@
                 <td>destinationDir</td>
                 <td><literal>project.distsDir</literal></td>
             </tr>
+            <tr>
+                <td>preserveFileTimestamps</td>
+                <td><literal>true</literal></td>
+            </tr>
+            <tr>
+                <td>sortedFileOrder</td>
+                <td><literal>false</literal></td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
@@ -23,9 +23,6 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.file.RelativePath;
-import org.gradle.api.internal.DocumentationRegistry;
-import org.gradle.api.internal.file.archive.ReproducibleOrderingCopyActionDecorator;
-import org.gradle.api.internal.file.archive.ZipCopyAction;
 import org.gradle.api.internal.file.collections.FileTreeAdapter;
 import org.gradle.api.internal.file.collections.MapFileTree;
 import org.gradle.api.internal.file.copy.CopyAction;
@@ -100,12 +97,7 @@ public class Jar extends Zip {
 
     @Override
     protected CopyAction createCopyAction() {
-        DocumentationRegistry documentationRegistry = getServices().get(DocumentationRegistry.class);
-        CopyAction zipCopyAction = new ZipCopyAction(getArchivePath(), getCompressor(), documentationRegistry, getMetadataCharset(), isPreserveFileTimestamps());
-        if (isSortedFileOrder()) {
-            return new ReproducibleOrderingCopyActionDecorator(zipCopyAction, new JarContentsComparator());
-        }
-        return zipCopyAction;
+        return createCopyAction(new JarContentsComparator());
     }
 
     /**
@@ -152,8 +144,8 @@ public class Jar extends Zip {
      * The character set used to encode the manifest content.
      *
      * @param manifestContentCharset the character set used to encode the manifest content
-     * @since 2.14
      * @see #getManifestContentCharset()
+     * @since 2.14
      */
     @Incubating
     public void setManifestContentCharset(String manifestContentCharset) {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/tasks/JarTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/tasks/JarTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.tasks
 
+import org.gradle.api.file.RelativePath
 import org.gradle.api.java.archives.internal.DefaultManifest
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.bundling.AbstractArchiveTaskTest
@@ -60,5 +61,22 @@ class JarTest extends AbstractArchiveTaskTest {
 
         then:
         jar.manifest.attributes.key == 'value'
+    }
+
+    def "comparator sorts manifest first"() {
+        expect:
+        List<RelativePath> sorted = [new RelativePath(false, 'META-INF')] +
+            ['ABB.MF', 'AAA.META', 'MANIFEST.MF'].collect { new RelativePath(true, 'META-INF', it)} +
+            ['Some.class', 'AaaClass.class'].collect { new RelativePath(true, it)}
+        sorted.sort(true, Jar.JAR_CONTENTS_COMPARATOR)
+        sorted*.pathString ==
+            [
+                    'META-INF',
+                    'META-INF/MANIFEST.MF',
+                    'META-INF/AAA.META',
+                    'META-INF/ABB.MF',
+                    'AaaClass.class',
+                    'Some.class',
+            ]
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
@@ -79,6 +79,29 @@ class JarIntegrationTest extends AbstractIntegrationSpec {
         jar.assertContainsFile('dir1/file1.txt')
     }
 
+    def "manifest is the first file in the Jar"() {
+        given:
+        createDir('meta-inf') {
+            file('AAA.META') << 'Some custom metadata'
+        }
+        buildFile << """
+            task jar(type: Jar) {
+                metaInf {
+                    from 'meta-inf'
+                }
+                destinationDir = buildDir
+                archiveName = 'test.jar'
+            }
+        """
+
+        when:
+        succeeds 'jar'
+
+        then:
+        def jar = new JarTestFixture(file('build/test.jar'))
+        jar.assertContainsFile('META-INF/AAA.META')
+    }
+
     def metaInfSpecsAreIndependentOfOtherSpec() {
         given:
         createDir('test') {


### PR DESCRIPTION
This is a refactoring of https://github.com/gradle/gradle/pull/1009

Only the archive tasks have new properties (`sortedFileOrder` and `preserveFileTimestamps`), instead of `Copy` tasks also having `sortedFileOrder`.  This uses a global sort instead of a per-CopySpec sort by wrapping the `ZipCopyAction` or `TarCopyAction`.  

I fixed `TarFileTree` and `ZipFileTree` so we can visit their content multiple times.

The unrelated changes from the PR were merged to master already (e.g. adding `md5sum` to `TestFile`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gradle/gradle/1053)
<!-- Reviewable:end -->
