### PR TITLE
Make Gretty plugin smoke test more stable

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -44,7 +44,7 @@ class GrettySmokeTest extends AbstractSmokeTest {
         """
 
         when:
-        def result = runner('checkContainerUp').forwardOutput().build()
+        def result = runner('checkContainerUp').build()
 
         then:
         result.task(':checkContainerUp').outcome == SUCCESS


### PR DESCRIPTION
The test occasionally failed with the following error message ([example of failed CI build](https://builds.gradle.org/viewLog.html?buildId=2024763&buildTypeId=Gradle_Branches_CoveragePhase_LinuxCoverage_LinuxJava18SmokeTestsAgainst3rdParty)):

    java.lang.Exception: Address already in use 

The time between allocation the port and using it left too much room for other code to potentially use the same port. Now we simply let the Jetty plugin determine the port at runtime, parse the used port from the logs and use it for the ping URL.