### PR TITLE
Change test to block until expiration to fix flakiness

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
@@ -22,7 +22,7 @@ import spock.lang.Unroll
 
 class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
     static final EXPIRATION_CHECK_FREQUENCY = 50
-    static final EXPIRATION_CHECK_WAIT = 500
+    public static final String EXPIRATION_EVENT = "expiration_event.txt"
 
     def "should capture basic data via the service registry"() {
         given:
@@ -78,14 +78,14 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
            ${imports()}
            ${registerTestExpirationStrategy()}
            ${registerExpirationListener()}
-           ${delayTask()}
+           ${waitForExpirationTask()}
         """
 
         when:
-        def delayResult = executer.withArguments(continuous ? ['delay', '--continuous'] : ['delay']).run()
+        executer.withArguments(continuous ? ['waitForExpiration', '--continuous'] : ['waitForExpiration']).run()
 
         then:
-        delayResult.assertOutputContains("onExpirationEvent fired with: expiring daemon with TestExpirationStrategy")
+        file(EXPIRATION_EVENT).text.startsWith "onExpirationEvent fired with: expiring daemon with TestExpirationStrategy uuid:"
 
         where:
         continuous << [true, false]
@@ -97,24 +97,28 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
            ${imports()}
            ${registerTestExpirationStrategy()}
            ${registerExpirationListener()}
-           ${delayTask()}
+           ${waitForExpirationTask()}
         """
 
         when:
-        def delayResult = executer.withArguments('delay').run()
+        executer.withArguments('waitForExpiration').run()
 
         then:
-        delayResult.assertOutputContains('onExpirationEvent fired with: expiring daemon with TestExpirationStrategy')
+        file(EXPIRATION_EVENT).text.startsWith "onExpirationEvent fired with: expiring daemon with TestExpirationStrategy uuid:"
 
         when:
+        file(EXPIRATION_EVENT).delete()
         buildFile.text = """
            ${imports()}
-           ${delayTask()}
+           ${waitForExpirationTask()}
         """
-        delayResult = executer.withArguments('delay').run()
+        def waitForExpirationResult = executer.withArguments('waitForExpiration').runWithFailure()
 
         then:
-        !delayResult.output.contains('onExpirationEvent fired with: expiring daemon with TestExpirationStrategy')
+        waitForExpirationResult.assertHasCause("Timed out waiting for expiration event")
+
+        and:
+        !file(EXPIRATION_EVENT).exists()
     }
 
     def "a daemon expiration listener receives expiration reasons when daemons run in the foreground"() {
@@ -123,16 +127,15 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
            ${imports()}
            ${registerTestExpirationStrategy()}
            ${registerExpirationListener()}
-           ${delayTask()}
+           ${waitForExpirationTask()}
         """
 
         when:
         startAForegroundDaemon()
-        def delayResult = executer.withTasks('delay').run()
+        executer.withTasks('waitForExpiration').run()
 
         then:
-        delayResult.assertOutputContains("onExpirationEvent fired with: expiring daemon with TestExpirationStrategy")
-
+        file(EXPIRATION_EVENT).text.startsWith "onExpirationEvent fired with: expiring daemon with TestExpirationStrategy uuid:"
     }
 
     static String captureTask(String name, int buildCount, int daemonCount) {
@@ -162,11 +165,13 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
         """
     }
 
-    static String delayTask() {
+    static String waitForExpirationTask() {
         """
-        task delay {
+        task waitForExpiration {
             doFirst {
-             sleep(${EXPIRATION_CHECK_WAIT})
+                if (!latch.await(2, TimeUnit.SECONDS)) {
+                    throw new GradleException("Timed out waiting for expiration event")
+                }
             }
         }
         """
@@ -180,6 +185,8 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
             @Override
             public void execute(String s) {
                   println "onExpirationEvent fired with: \${s}"
+                  file("${EXPIRATION_EVENT}").text = "onExpirationEvent fired with: \${s}"
+                  latch.countDown()
             }
         })
         """
@@ -217,6 +224,10 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
         import org.gradle.launcher.daemon.context.*
         import org.gradle.launcher.daemon.server.*
         import org.gradle.launcher.daemon.server.expiry.*
+        import java.util.concurrent.CountDownLatch
+        import java.util.concurrent.TimeUnit
+            
+        def latch = new CountDownLatch(1)
         """
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.launcher.daemon.server.scaninfo
 
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.util.GFileUtils
 import spock.lang.Unroll
 
 class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
@@ -107,7 +108,7 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
         file(EXPIRATION_EVENT).text.startsWith "onExpirationEvent fired with: expiring daemon with TestExpirationStrategy uuid:"
 
         when:
-        file(EXPIRATION_EVENT).delete()
+        GFileUtils.forceDelete(file(EXPIRATION_EVENT))
         buildFile.text = """
            ${imports()}
            ${waitForExpirationTask()}


### PR DESCRIPTION
Looks like these failures are due to the async expiration event arriving late. I've fixed this so that we block for a longer timeout while waiting for the event rather than having a fixed "delay". I've also changed the verification to use files instead of output to avoid any flakiness due to output arriving after the build.