### PR TITLE
Increase build timeout if Gradle JARs need to be generated

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
@@ -16,7 +16,19 @@
 
 package org.gradle.launcher.continuous
 
+import org.gradle.api.internal.cache.GeneratedGradleJarCache
+import org.gradle.util.GradleVersion
+
 class BuildSrcContinuousIntegrationTest extends Java7RequiringContinuousIntegrationTest {
+
+    def setup() {
+        def generatedGradleJarCacheDir = new File(executer.gradleUserHomeDir, "caches/${GradleVersion.current().version}/$GeneratedGradleJarCache.CACHE_KEY")
+
+        // Increase build timeout if generated Gradle JARs do not exist yet (e.g. when bumping up the Gradle version)
+        if (!generatedGradleJarCacheDir.isDirectory()) {
+            buildTimeout = 60
+        }
+    }
 
     def "can build and reload a project with buildSrc"() {
         when:

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
@@ -16,28 +16,21 @@
 
 package org.gradle.launcher.continuous
 
-import org.gradle.api.internal.cache.GeneratedGradleJarCache
-import org.gradle.util.GradleVersion
-
 class BuildSrcContinuousIntegrationTest extends Java7RequiringContinuousIntegrationTest {
 
     def setup() {
-        def generatedGradleJarCacheDir = new File(executer.gradleUserHomeDir, "caches/${GradleVersion.current().version}/$GeneratedGradleJarCache.CACHE_KEY")
-
-        // Increase build timeout if generated Gradle JARs do not exist yet (e.g. when bumping up the Gradle version)
-        if (!generatedGradleJarCacheDir.isDirectory()) {
-            buildTimeout = 60
-        }
-    }
-
-    def "can build and reload a project with buildSrc"() {
-        when:
         file("buildSrc/src/main/groovy/Thing.groovy") << """
             class Thing {
               public static final String VALUE = "original"
             }
         """
 
+        // Trigger generation of Gradle JARs before executing any test case
+        succeeds("help")
+    }
+
+    def "can build and reload a project with buildSrc"() {
+        when:
         buildScript """
             task a {
               inputs.files "a"


### PR DESCRIPTION
Generating the Gradle JARs (e.g. Gradle API JAR) can add to the overall build time. In those situations the build time needs to be adjusted to avoid running into a timeout ([example of failing CI build](https://builds.gradle.org/viewLog.html?buildId=1996048)).