### PR TITLE
Change daemon soak test to not check build success for expiration tests

### DIFF
--- a/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringSoakTest.groovy
@@ -178,14 +178,15 @@ class DaemonPerformanceMonitoringSoakTest extends DaemonMultiJdkIntegrationTest 
             for (int i = 0; i < maxBuilds; i++) {
                 executer.noExtraLogging()
                 executer.withBuildJvmOpts("-D${DaemonMemoryStatus.ENABLE_PERFORMANCE_MONITORING}=true", "-Xmx${heapSize}", "-Dorg.gradle.daemon.performance.logging=true")
-                def r = run()
-                if (r.output ==~ /(?s).*Starting build in new daemon \[memory: [0-9].*/) {
+                GradleHandle gradle = executer.start()
+                gradle.waitForExit()
+                if (gradle.standardOutput ==~ /(?s).*Starting build in new daemon \[memory: [0-9].*/) {
                     newDaemons++;
                 }
                 if (newDaemons > 1) {
                     return true
                 }
-                def lines = r.output.readLines()
+                def lines = gradle.standardOutput.readLines()
                 dataFile << lines[lines.findLastIndexOf { it.startsWith "Starting" }]
                 dataFile << "  " + lines[lines.findLastIndexOf { it.contains "Total time:" }]
                 dataFile << "\n"


### PR DESCRIPTION
The success or failure of the build is not important for what we are trying to test here - only that the daemon is expired when GC rates are high.