### PR TITLE
Issue: #951 Fix NPE when excluding transitive dependencies in dependency configuration

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultExcludeRuleConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultExcludeRuleConverter.java
@@ -24,6 +24,7 @@ public class DefaultExcludeRuleConverter implements ExcludeRuleConverter {
     public DefaultExclude convertExcludeRule(String configurationName, ExcludeRule excludeRule) {
         String org = GUtil.elvis(excludeRule.getGroup(), PatternMatchers.ANY_EXPRESSION);
         String module = GUtil.elvis(excludeRule.getModule(), PatternMatchers.ANY_EXPRESSION);
-        return new DefaultExclude(org, module, new String[] {configurationName}, PatternMatchers.EXACT);
+        String[] configurationNames = GUtil.isTrue(configurationName) ? new String[]{configurationName} : new String[0];
+        return new DefaultExclude(org, module, configurationNames, PatternMatchers.EXACT);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultExcludeRuleConverterTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultExcludeRuleConverterTest.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.Patte
 import org.gradle.internal.component.model.Exclude;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import spock.lang.Issue;
 
 import java.util.Collections;
 
@@ -46,5 +47,49 @@ public class DefaultExcludeRuleConverterTest {
                 Matchers.equalTo(PatternMatchers.EXACT));
         assertThat(exclude.getConfigurations(),
                 Matchers.equalTo(Collections.singleton(configurationName)));
+    }
+
+    @Test
+    @Issue("gradle/gradle#951")
+    public void testCreateExcludeRuleNullConfigurationName() {
+        String configurationName = null;
+        final String someOrg = "someOrg";
+        final String someModule = "someModule";
+        Exclude exclude =
+            new DefaultExcludeRuleConverter().convertExcludeRule(configurationName, new DefaultExcludeRule(someOrg, someModule));
+        assertThat(exclude.getModuleId().getGroup(),
+            Matchers.equalTo(someOrg));
+        assertThat(exclude.getModuleId().getName(),
+            Matchers.equalTo(someModule));
+        assertThat(exclude.getArtifact().getExtension(),
+            Matchers.equalTo(PatternMatchers.ANY_EXPRESSION));
+        assertThat(exclude.getArtifact().getType(),
+            Matchers.equalTo(PatternMatchers.ANY_EXPRESSION));
+        assertThat(exclude.getMatcher(),
+            Matchers.equalTo(PatternMatchers.EXACT));
+        assertThat(exclude.getConfigurations(),
+            Matchers.equalTo(Collections.<String>emptySet()));
+    }
+
+    @Test
+    @Issue("gradle/gradle#951")
+    public void testCreateExcludeRuleEmptyConfigurationName() {
+        String configurationName = "";
+        final String someOrg = "someOrg";
+        final String someModule = "someModule";
+        Exclude exclude =
+            new DefaultExcludeRuleConverter().convertExcludeRule(configurationName, new DefaultExcludeRule(someOrg, someModule));
+        assertThat(exclude.getModuleId().getGroup(),
+            Matchers.equalTo(someOrg));
+        assertThat(exclude.getModuleId().getName(),
+            Matchers.equalTo(someModule));
+        assertThat(exclude.getArtifact().getExtension(),
+            Matchers.equalTo(PatternMatchers.ANY_EXPRESSION));
+        assertThat(exclude.getArtifact().getType(),
+            Matchers.equalTo(PatternMatchers.ANY_EXPRESSION));
+        assertThat(exclude.getMatcher(),
+            Matchers.equalTo(PatternMatchers.EXACT));
+        assertThat(exclude.getConfigurations(),
+            Matchers.equalTo(Collections.<String>emptySet()));
     }
 }


### PR DESCRIPTION
Translating a null configuration name into an empty set of configuration names in an Exclude to fix NPE when excluding transitive dependencies in dependency configuration

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
