### PR TITLE
Check that an existing sftp connection is still connected before reuse

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/sftp/SFTPServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/sftp/SFTPServer.groovy
@@ -88,12 +88,12 @@ class SFTPServer extends ServerWithExpectations implements RepositoryServer {
         restart()
     }
 
-    protected void before(int sftpPort = 0) throws Throwable {
+    protected void before() throws Throwable {
         baseDir = testDirectoryProvider.getTestDirectory().createDir("sshd/files")
         configDir = testDirectoryProvider.getTestDirectory().createDir("sshd/config")
 
         // Set the port to 0 to have it automatically assign a port
-        sshd = setupConfiguredTestSshd(sftpPort)
+        sshd = setupConfiguredTestSshd(0)
         sshd.start()
         port = sshd.getPort()
         allowInit()
@@ -105,7 +105,13 @@ class SFTPServer extends ServerWithExpectations implements RepositoryServer {
 
     public void restart() {
         stop(true)
-        before(port)
+        before()
+    }
+
+    public void clearSessions() {
+        sshd.activeSessions.each { session ->
+            session.close(true)
+        }
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/sftp/SFTPServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/sftp/SFTPServer.groovy
@@ -88,12 +88,12 @@ class SFTPServer extends ServerWithExpectations implements RepositoryServer {
         restart()
     }
 
-    protected void before() throws Throwable {
+    protected void before(int sftpPort = 0) throws Throwable {
         baseDir = testDirectoryProvider.getTestDirectory().createDir("sshd/files")
         configDir = testDirectoryProvider.getTestDirectory().createDir("sshd/config")
 
         // Set the port to 0 to have it automatically assign a port
-        sshd = setupConfiguredTestSshd(0)
+        sshd = setupConfiguredTestSshd(sftpPort)
         sshd.start()
         port = sshd.getPort()
         allowInit()
@@ -105,7 +105,7 @@ class SFTPServer extends ServerWithExpectations implements RepositoryServer {
 
     public void restart() {
         stop(true)
-        before()
+        before(port)
     }
 
     @Override

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/SftpClientReuseIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/SftpClientReuseIntegrationTest.groovy
@@ -52,7 +52,7 @@ class SftpClientReuseIntegrationTest extends AbstractIntegrationSpec {
         coordinator.waitFor()
 
         then:
-        sftpServer.restart()
+        sftpServer.clearSessions()
         sftpServer.expectLstat("/")
 
         when:

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/SftpClientReuseIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/SftpClientReuseIntegrationTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.resource.sftp
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.server.http.CyclicBarrierHttpServer
+import org.gradle.test.fixtures.server.sftp.SFTPServer
+import org.junit.Rule
+
+class SftpClientReuseIntegrationTest extends AbstractIntegrationSpec {
+    @Rule final SFTPServer sftpServer = new SFTPServer(temporaryFolder)
+    @Rule final CyclicBarrierHttpServer coordinator = new CyclicBarrierHttpServer()
+
+    def "does not attempt to reuse a client that has been disconnected"() {
+        buildFile << """
+            ${sftpTask}
+            
+            task firstUse(type: SftpTask) {
+                credentials = creds
+            }
+            
+            task block {
+                doLast {
+                    new URL("${coordinator.uri}").text
+                }
+                dependsOn firstUse
+            }
+            
+            task reuseClient(type: SftpTask) {
+                credentials = creds
+                dependsOn block
+            }
+        """
+        sftpServer.expectLstat("/")
+
+        when:
+        def gradle = executer.withTasks('reuseClient').start()
+        coordinator.waitFor()
+
+        then:
+        sftpServer.restart()
+        sftpServer.expectLstat("/")
+
+        when:
+        coordinator.release()
+
+        then:
+        gradle.waitForFinish()
+    }
+
+    String getSftpTask() {
+        return """
+            import javax.inject.Inject
+            import org.gradle.internal.resource.transport.sftp.SftpClientFactory
+            import org.gradle.api.artifacts.repositories.PasswordCredentials
+            import org.gradle.api.internal.artifacts.repositories.DefaultPasswordCredentials
+            
+            PasswordCredentials creds = new DefaultPasswordCredentials('sftp', 'sftp')
+            
+            class SftpTask extends DefaultTask {
+                PasswordCredentials credentials 
+
+                @Inject
+                SftpClientFactory getSftpClientFactory() {
+                    throw new UnsupportedOperationException()
+                }
+                
+                @TaskAction
+                void sftpTest() {
+                    def client = sftpClientFactory.createSftpClient(new URI("${sftpServer.uri}"), credentials)
+                    client.sftpClient.lstat("/")
+                    sftpClientFactory.releaseSftpClient(client)
+                }
+            }
+        """
+    }
+}

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/LockableSftpClient.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/LockableSftpClient.java
@@ -22,4 +22,5 @@ import org.gradle.internal.concurrent.Stoppable;
 public interface LockableSftpClient extends Stoppable {
     SftpHost getHost();
     ChannelSftp getSftpClient();
+    boolean isConnected();
 }

--- a/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpClientFactory.java
+++ b/subprojects/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpClientFactory.java
@@ -18,6 +18,7 @@ package org.gradle.internal.resource.transport.sftp;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
 import com.jcraft.jsch.*;
 import net.jcip.annotations.ThreadSafe;
 import org.gradle.api.artifacts.repositories.PasswordCredentials;
@@ -36,7 +37,8 @@ public class SftpClientFactory implements Stoppable {
 
     private SftpClientCreator sftpClientCreator = new SftpClientCreator();
     private final Object lock = new Object();
-    private final ListMultimap<SftpHost, LockableSftpClient> clients = ArrayListMultimap.create();
+    private final List<LockableSftpClient> allClients = Lists.newArrayList();
+    private final ListMultimap<SftpHost, LockableSftpClient> idleClients = ArrayListMultimap.create();
 
     public LockableSftpClient createSftpClient(URI uri, PasswordCredentials credentials) {
         synchronized (lock) {
@@ -46,21 +48,21 @@ public class SftpClientFactory implements Stoppable {
     }
 
     private LockableSftpClient acquireClient(SftpHost sftpHost) {
-        return clients.containsKey(sftpHost) ? reuseExistingOrCreateNewClient(sftpHost) : sftpClientCreator.createNewClient(sftpHost);
+        return idleClients.containsKey(sftpHost) ? reuseExistingOrCreateNewClient(sftpHost) : createNewClient(sftpHost);
     }
 
     private LockableSftpClient reuseExistingOrCreateNewClient(SftpHost sftpHost) {
-        List<LockableSftpClient> clientsByHost = clients.get(sftpHost);
+        List<LockableSftpClient> clientsByHost = idleClients.get(sftpHost);
 
         LockableSftpClient client = null;
         if (clientsByHost.isEmpty()) {
             LOGGER.debug("No existing sftp clients.  Creating a new one.");
-            client = sftpClientCreator.createNewClient(sftpHost);
+            client = createNewClient(sftpHost);
         } else {
             client = clientsByHost.remove(0);
             if (!client.isConnected()) {
-                LOGGER.debug("Tried to reuse an existing sftp client, but unexpectedly found it disconnected.  Discarding and trying again.");
-                client.stop();
+                LOGGER.info("Tried to reuse an existing sftp client, but unexpectedly found it disconnected.  Discarding and trying again.");
+                discard(client);
                 client = reuseExistingOrCreateNewClient(sftpHost);
             } else {
                 LOGGER.debug("Reusing an existing sftp client.");
@@ -68,6 +70,20 @@ public class SftpClientFactory implements Stoppable {
         }
 
         return client;
+    }
+
+    private LockableSftpClient createNewClient(SftpHost sftpHost) {
+        LockableSftpClient client = sftpClientCreator.createNewClient(sftpHost);
+        allClients.add(client);
+        return client;
+    }
+
+    private void discard(LockableSftpClient client) {
+        try {
+            client.stop();
+        } finally {
+            allClients.remove(client);
+        }
     }
 
     private static class SftpClientCreator {
@@ -138,20 +154,17 @@ public class SftpClientFactory implements Stoppable {
 
     public void releaseSftpClient(LockableSftpClient sftpClient) {
         synchronized (lock) {
-            clients.put(sftpClient.getHost(), sftpClient);
+            idleClients.put(sftpClient.getHost(), sftpClient);
         }
     }
 
     public void stop() {
         synchronized (lock) {
             try {
-                CompositeStoppable stoppable = new CompositeStoppable();
-                for (LockableSftpClient client : clients.values()) {
-                    stoppable.add(client);
-                }
-                stoppable.stop();
+                CompositeStoppable.stoppable(allClients).stop();
             } finally {
-                clients.clear();
+                allClients.clear();
+                idleClients.clear();
             }
         }
     }

--- a/subprojects/resources-sftp/src/test/groovy/org/gradle/internal/resource/transport/sftp/SftpClientFactoryTest.groovy
+++ b/subprojects/resources-sftp/src/test/groovy/org/gradle/internal/resource/transport/sftp/SftpClientFactoryTest.groovy
@@ -42,14 +42,15 @@ class SftpClientFactoryTest extends ConcurrentSpec {
 
         then:
         sftpClientCreator.createNewClient(new SftpHost(uri, credentials)) >> mockSftpClient
-        sftpClientFactory.clients.size() == 0
+        sftpClientFactory.idleClients.size() == 0
 
         when:
         sftpClientFactory.releaseSftpClient(actualClient)
 
         then:
         1 * mockSftpClient.host >> new SftpHost(uri, credentials)
-        sftpClientFactory.clients.size() == 1
+        sftpClientFactory.idleClients.size() == 1
+        sftpClientFactory.allClients.size() == 1
         List<SftpHost> clientsByHost = getClientsForSftpHost(uri, credentials)
         clientsByHost.size() == 1
         clientsByHost.get(0) == actualClient
@@ -68,14 +69,15 @@ class SftpClientFactoryTest extends ConcurrentSpec {
 
         then:
         sftpClientCreator.createNewClient(new SftpHost(uri, credentials)) >> mockInitialSftpClient
-        sftpClientFactory.clients.size() == 0
+        sftpClientFactory.idleClients.size() == 0
 
         when:
         LockableSftpClient newClient = sftpClientFactory.createSftpClient(uri, credentials)
 
         then:
         sftpClientCreator.createNewClient(new SftpHost(uri, credentials)) >> mockNewSftpClient
-        sftpClientFactory.clients.size() == 0
+        sftpClientFactory.idleClients.size() == 0
+        sftpClientFactory.allClients.size() == 2
         initialClient != newClient
     }
 
@@ -93,7 +95,7 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         then:
         1 * mockSftpClient.host >> new SftpHost(uri, credentials)
         sftpClientCreator.createNewClient(new SftpHost(uri, credentials)) >> mockSftpClient
-        sftpClientFactory.clients.size() == 1
+        sftpClientFactory.idleClients.size() == 1
         List<SftpHost> clientsByHost = getClientsForSftpHost(uri, credentials)
         clientsByHost.size() == 1
         clientsByHost.get(0) == initialClient
@@ -105,7 +107,8 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         then:
         1 * mockSftpClient.host >> new SftpHost(uri, credentials)
         1 * mockSftpClient.connected >> true
-        sftpClientFactory.clients.size() == 1
+        sftpClientFactory.idleClients.size() == 1
+        sftpClientFactory.allClients.size() == 1
         clientsByHost.size() == 1
         clientsByHost.get(0) == reusedClient
         initialClient == reusedClient
@@ -128,7 +131,7 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         then:
         sftpClientCreator.createNewClient(new SftpHost(uri1, credentials1)) >> mockSftpClient1
         sftpClientCreator.createNewClient(new SftpHost(uri2, credentials2)) >> mockSftpClient2
-        sftpClientFactory.clients.size() == 0
+        sftpClientFactory.idleClients.size() == 0
 
         when:
         sftpClientFactory.releaseSftpClient(client1)
@@ -137,7 +140,8 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         then:
         1 * mockSftpClient1.host >> new SftpHost(uri1, credentials1)
         1 * mockSftpClient2.host >> new SftpHost(uri2, credentials2)
-        sftpClientFactory.clients.size() == 2
+        sftpClientFactory.idleClients.size() == 2
+        sftpClientFactory.allClients.size() == 2
         List<SftpHost> clientsByHost1 = getClientsForSftpHost(uri1, credentials1)
         clientsByHost1.size() == 1
         clientsByHost1.get(0) == client1
@@ -163,7 +167,8 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         then:
         sftpClientCreator.createNewClient(new SftpHost(uri, credentials)) >> mockSftpClient
         1 * mockSftpClient.host >> new SftpHost(uri, credentials)
-        sftpClientFactory.clients.size() == 0
+        sftpClientFactory.idleClients.size() == 0
+        sftpClientFactory.allClients.size() == 0
         1 * mockSftpClient.stop()
     }
 
@@ -191,7 +196,8 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         sftpClientCreator.createNewClient(new SftpHost(uri2, credentials2)) >> mockSftpClient2
         1 * mockSftpClient1.host >> new SftpHost(uri1, credentials1)
         1 * mockSftpClient2.host >> new SftpHost(uri2, credentials2)
-        sftpClientFactory.clients.size() == 0
+        sftpClientFactory.idleClients.size() == 0
+        sftpClientFactory.allClients.size() == 0
         1 * mockSftpClient1.stop()
         1 * mockSftpClient2.stop()
     }
@@ -217,7 +223,8 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         then:
         sftpClientCreator.createNewClient(new SftpHost(uri, credentials)) >> mockSftpClient
         mockSftpClient.host >> new SftpHost(uri, credentials)
-        sftpClientFactory.clients.size() > 0
+        sftpClientFactory.idleClients.size() > 0
+        sftpClientFactory.allClients.size() == sftpClientFactory.idleClients.size()
     }
 
     def "Creates new client if currently in use by different thread"() {
@@ -252,7 +259,8 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         1 * sftpClientCreator.createNewClient(new SftpHost(uri, credentials)) >> mockSftpClient2
         1 * mockSftpClient1.host >> new SftpHost(uri, credentials)
         1 * mockSftpClient2.host >> new SftpHost(uri, credentials)
-        sftpClientFactory.clients.size() == 2
+        sftpClientFactory.idleClients.size() == 2
+        sftpClientFactory.allClients.size() == 2
         actualClient1 != actualClient2
     }
 
@@ -278,7 +286,8 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         1 * mockSftpClient2.host >> new SftpHost(uri, credentials)
         1 * mockSftpClient1.connected >> false
         1 * mockSftpClient2.connected >> false
-        sftpClientFactory.clients.size() == 0
+        sftpClientFactory.idleClients.size() == 0
+        sftpClientFactory.allClients.size() == 1
         client3 == mockSftpClient3
     }
 
@@ -303,11 +312,41 @@ class SftpClientFactoryTest extends ConcurrentSpec {
         1 * mockSftpClient2.host >> new SftpHost(uri, credentials)
         1 * mockSftpClient1.connected >> false
         1 * mockSftpClient2.connected >> true
-        sftpClientFactory.clients.size() == 0
+        sftpClientFactory.idleClients.size() == 0
+        sftpClientFactory.allClients.size() == 1
         client3 == mockSftpClient2
     }
 
+    def "all clients are stopped even if they are not released"() {
+        def mockSftpClient1 = Mock(LockableSftpClient)
+        def mockSftpClient2 = Mock(LockableSftpClient)
+
+        given:
+        URI uri1 = new URI('http://localhost:22/repo1')
+        URI uri2 = new URI('http://localhost:22/repo2')
+        PasswordCredentials credentials1 = new DefaultPasswordCredentials('sftp1', 'sftp1')
+        PasswordCredentials credentials2 = new DefaultPasswordCredentials('sftp2', 'sftp2')
+
+        when:
+        LockableSftpClient client1 = sftpClientFactory.createSftpClient(uri1, credentials1)
+        LockableSftpClient client2 = sftpClientFactory.createSftpClient(uri2, credentials2)
+
+        and:
+        sftpClientFactory.releaseSftpClient(client1)
+        // client2 has not been released
+        sftpClientFactory.stop()
+
+        then:
+        sftpClientCreator.createNewClient(new SftpHost(uri1, credentials1)) >> mockSftpClient1
+        sftpClientCreator.createNewClient(new SftpHost(uri2, credentials2)) >> mockSftpClient2
+        1 * mockSftpClient1.host >> new SftpHost(uri1, credentials1)
+        sftpClientFactory.idleClients.size() == 0
+        sftpClientFactory.allClients.size() == 0
+        1 * mockSftpClient1.stop()
+        1 * mockSftpClient2.stop()
+    }
+
     private List<SftpHost> getClientsForSftpHost(URI uri, PasswordCredentials credentials) {
-        sftpClientFactory.clients.get(new SftpHost(uri, credentials))
+        sftpClientFactory.idleClients.get(new SftpHost(uri, credentials))
     }
 }


### PR DESCRIPTION
This addresses an issue where we could attempt to reuse a client that was connected to an sftp server that has dropped the connection for some reason (e.g. restart).