### PR TITLE
Fix some flakiness in DaemonReuseIntegrationTest

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonReuseIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonReuseIntegrationTest.groovy
@@ -84,7 +84,9 @@ class DaemonReuseIntegrationTest extends DaemonIntegrationSpec {
             task block {
                 doLast {
                     new URL("${getUrl('started')}").text
-                    java.util.concurrent.locks.LockSupport.park()
+
+                    // Block indefinitely for the daemon to appear busy
+                    new java.util.concurrent.Semaphore(0).acquireUninterruptibly()
                 }
             }
         """


### PR DESCRIPTION
The blocking task was using LockSupport.park() which is
interruptible and caused an assertion not related to the test
to fail (that the daemon was busy).

Change the test to use
`java.util.concurrent.Semaphore(0).acquireUninterruptibly()`
as other tests do.

Issue: gradle/gradle-private#396
