### PR TITLE
Spike sorting artifacts in `ArtifactCollection`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -287,9 +287,26 @@ public interface ResolutionStrategy {
     ResolutionStrategy dependencySubstitution(Action<? super DependencySubstitutions> action);
 
     /**
-     * Specifies that any artifacts for a consuming component should appear before artifacts for it's dependents.
-     * A best attempt will be made to sort artifacts in this way. No guarantees will be made in the presence of dependency cycles.
+     * Specifies the ordering for resolved artifacts. Options are:
+     * <ul>
+     * <li>{@link SortOrder#DEFAULT} : Don't specify the sort order. Gradle will provide artifacts in the default order.</li>
+     * <li>{@link SortOrder#CONSUMER_FIRST} : Artifacts for a consuming component should appear before artifacts for it's dependents.</li>
+     * <li>{@link SortOrder#DEPENDENT_FIRST} : Artifacts for a consuming component should appear after artifacts for it's dependents.</li>
+     * </ul>
+     * A best attempt will be made to sort artifacts according the supplied {@link SortOrder}, but no guarantees will be made in the presence of dependency cycles.
+     *
+     * NOTE: For a particular Gradle version, artifact ordering will be consistent. Multiple resolves for the same inputs will result in the
+     * same outputs in the same order.
      */
     @Incubating
-    void sortConsumerFirst();
+    void sortArtifacts(SortOrder sortOrder);
+
+    /**
+     * Defines the sort order for components and artifacts produced by the configuration.
+     * @see #sortArtifacts(SortOrder)
+     */
+    @Incubating
+    enum SortOrder {
+        DEFAULT, CONSUMER_FIRST, DEPENDENT_FIRST
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -285,4 +285,11 @@ public interface ResolutionStrategy {
      */
     @Incubating
     ResolutionStrategy dependencySubstitution(Action<? super DependencySubstitutions> action);
+
+    /**
+     * Specifies that any artifacts for a consuming component should appear before artifacts for it's dependents.
+     * A best attempt will be made to sort artifacts in this way. No guarantees will be made in the presence of dependency cycles.
+     */
+    @Incubating
+    void sortConsumerFirst();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactCollectionOrderingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactCollectionOrderingIntegrationTest.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+
+class ArtifactCollectionOrderingIntegrationTest extends AbstractHttpDependencyResolutionTest {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+"""
+        buildFile << """
+            version = '1.0'
+            repositories {
+                maven { url '$mavenRepo.uri' }
+            }
+            configurations {
+                compile
+            }
+            dependencies {
+                compile "org.test:A:1.0"
+            }
+            
+            def artifacts = configurations.compile.incoming.artifacts
+
+            task checkArtifacts {
+                doLast {
+                    assert configurations.compile.collect { it.name } == ['A-1.0.jar', 'B-1.0.jar', 'C-1.0.jar', 'D-1.0.jar']
+                }
+            }
+"""
+    }
+
+    def "artifact collection has resolved artifact files and metadata 1"() {
+        when:
+        def moduleD = mavenRepo.module("org.test", "D").publish()
+        def moduleC = mavenRepo.module("org.test", "C").dependsOn(moduleD).publish()
+        def moduleB = mavenRepo.module("org.test", "B").dependsOn(moduleD).publish()
+        mavenRepo.module("org.test", "A").dependsOn(moduleB).dependsOn(moduleC).publish()
+
+        then:
+        succeeds "checkArtifacts"
+    }
+
+    def "artifact collection has resolved artifact files and metadata 2"() {
+        when:
+        def moduleD = mavenRepo.module("org.test", "D").publish()
+        def moduleC = mavenRepo.module("org.test", "C").dependsOn(moduleD).publish()
+        def moduleB = mavenRepo.module("org.test", "B").dependsOn(moduleC).publish()
+        mavenRepo.module("org.test", "A").dependsOn(moduleB).dependsOn(moduleD).publish()
+
+        then:
+        succeeds "checkArtifacts"
+    }
+
+    def "artifact collection has resolved artifact files and metadata 3"() {
+        when:
+        def moduleD = mavenRepo.module("org.test", "D").publish()
+        def moduleC = mavenRepo.module("org.test", "C").dependsOn(moduleD).publish()
+        def moduleB = mavenRepo.module("org.test", "B").dependsOn(moduleC).publish()
+        mavenRepo.module("org.test", "A").dependsOn(moduleD).dependsOn(moduleB).publish()
+
+        then:
+        succeeds "checkArtifacts"
+    }
+
+    def "artifact collection has resolved artifact files and metadata 4"() {
+        when:
+        def moduleD = mavenRepo.module("org.test", "D").publish()
+        def moduleC = mavenRepo.module("org.test", "C").dependsOn(moduleD).publish()
+        def moduleB = mavenRepo.module("org.test", "B").dependsOn(moduleD).publish()
+        mavenRepo.module("org.test", "A").dependsOn(moduleB).dependsOn(moduleD).dependsOn(moduleC).publish()
+
+        then:
+        succeeds "checkArtifacts"
+    }
+
+    def "artifact collection has resolved artifact files and metadata 5"() {
+        when:
+        def moduleD = mavenRepo.module("org.test", "D").publish()
+        def moduleC = mavenRepo.module("org.test", "C").dependsOn(moduleD).publish()
+        def moduleB = mavenRepo.module("org.test", "B").dependsOn(moduleD).publish()
+        mavenRepo.module("org.test", "A").dependsOn(moduleB).dependsOn(moduleC).dependsOn(moduleD).publish()
+
+        then:
+        succeeds "checkArtifacts"
+    }
+
+    def "artifact collection has resolved artifact files and metadata 6"() {
+        when:
+        def moduleD = mavenRepo.module("org.test", "D").publish()
+        def moduleC = mavenRepo.module("org.test", "C").dependsOn(moduleD).publish()
+        def moduleB = mavenRepo.module("org.test", "B").dependsOn(moduleD).publish()
+        mavenRepo.module("org.test", "A").dependsOn(moduleD).dependsOn(moduleB).dependsOn(moduleC).publish()
+
+        then:
+        succeeds "checkArtifacts"
+    }
+
+    def "artifact collection has resolved artifact files and metadata cycle"() {
+        when:
+        def moduleD = mavenRepo.module("org.test", "D")
+        def moduleC = mavenRepo.module("org.test", "C").dependsOn(moduleD).publish()
+        def moduleB = mavenRepo.module("org.test", "B").dependsOn(moduleC).publish()
+        moduleD.dependsOn(moduleB).publish()
+        mavenRepo.module("org.test", "A").dependsOn(moduleB).publish()
+
+        then:
+        succeeds "checkArtifacts"
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactOrderingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactOrderingIntegrationTest.groovy
@@ -16,10 +16,11 @@
 
 package org.gradle.integtests.resolve
 
+import com.google.common.collect.Lists
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.test.fixtures.maven.MavenModule
 
-class ArtifactCollectionOrderingIntegrationTest extends AbstractHttpDependencyResolutionTest {
+class ResolvedArtifactOrderingIntegrationTest extends AbstractHttpDependencyResolutionTest {
 
     def setup() {
         settingsFile << """
@@ -32,18 +33,22 @@ class ArtifactCollectionOrderingIntegrationTest extends AbstractHttpDependencyRe
             }
             configurations {
                 unordered
-                ordered
+                consumerFirst
+                dependentFirst
             }
             dependencies {
                 unordered "org.test:A:1.0"
-                ordered "org.test:A:1.0"
+                consumerFirst "org.test:A:1.0"
+                dependentFirst "org.test:A:1.0"
             }
-            configurations.ordered.resolutionStrategy.sortConsumerFirst()
+            configurations.consumerFirst.resolutionStrategy.sortArtifacts(ResolutionStrategy.SortOrder.CONSUMER_FIRST)
+            configurations.dependentFirst.resolutionStrategy.sortArtifacts(ResolutionStrategy.SortOrder.DEPENDENT_FIRST)
 """
     }
 
     private void checkOrdered(List<MavenModule> ordered) {
-        checkArtifacts("ordered", ordered)
+        checkArtifacts("consumerFirst", ordered)
+        checkArtifacts("dependentFirst", Lists.reverse(ordered))
     }
 
     private void checkUnordered(List<MavenModule> unordered) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -61,7 +61,7 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
      */
     boolean resolveGraphToDetermineTaskDependencies();
 
-    boolean isSortConsumerFirst();
+    SortOrder getSortOrder();
 
     DependencySubstitutionsInternal getDependencySubstitution();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -61,6 +61,8 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
      */
     boolean resolveGraphToDetermineTaskDependencies();
 
+    boolean isSortConsumerFirst();
+
     DependencySubstitutionsInternal getDependencySubstitution();
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -93,7 +93,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults result) {
         ResolutionStrategyInternal resolutionStrategy = configuration.getResolutionStrategy();
         FileDependencyCollectingGraphVisitor fileDependenciesVisitor = new FileDependencyCollectingGraphVisitor();
-        DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(buildProjectDependencies, resolutionStrategy.isSortConsumerFirst());
+        DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(buildProjectDependencies, resolutionStrategy.getSortOrder());
         resolver.resolve(configuration, ImmutableList.<ResolutionAwareRepository>of(), metadataHandler, IS_LOCAL_EDGE, fileDependenciesVisitor, artifactsVisitor, attributesSchema);
         result.graphResolved(new BuildDependenciesOnlyVisitedArtifactSet(artifactsVisitor.complete(), fileDependenciesVisitor, artifactTransforms));
     }
@@ -114,7 +114,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
 
         ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor();
 
-        DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(buildProjectDependencies, configuration.getResolutionStrategy().isSortConsumerFirst());
+        DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(buildProjectDependencies, configuration.getResolutionStrategy().getSortOrder());
         FileDependencyCollectingGraphVisitor fileDependencyVisitor = new FileDependencyCollectingGraphVisitor();
 
         DependencyGraphVisitor graphVisitor = new CompositeDependencyGraphVisitor(oldModelVisitor, newModelBuilder, localComponentsVisitor, fileDependencyVisitor);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildDependenciesOnlyVisitedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DefaultResolvedArtifactsBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
@@ -90,8 +91,9 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
 
     @Override
     public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults result) {
+        ResolutionStrategyInternal resolutionStrategy = configuration.getResolutionStrategy();
         FileDependencyCollectingGraphVisitor fileDependenciesVisitor = new FileDependencyCollectingGraphVisitor();
-        DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(buildProjectDependencies);
+        DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(buildProjectDependencies, resolutionStrategy.isSortConsumerFirst());
         resolver.resolve(configuration, ImmutableList.<ResolutionAwareRepository>of(), metadataHandler, IS_LOCAL_EDGE, fileDependenciesVisitor, artifactsVisitor, attributesSchema);
         result.graphResolved(new BuildDependenciesOnlyVisitedArtifactSet(artifactsVisitor.complete(), fileDependenciesVisitor, artifactTransforms));
     }
@@ -112,7 +114,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
 
         ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor();
 
-        DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(buildProjectDependencies);
+        DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(buildProjectDependencies, configuration.getResolutionStrategy().isSortConsumerFirst());
         FileDependencyCollectingGraphVisitor fileDependencyVisitor = new FileDependencyCollectingGraphVisitor();
 
         DependencyGraphVisitor graphVisitor = new CompositeDependencyGraphVisitor(oldModelVisitor, newModelBuilder, localComponentsVisitor, fileDependencyVisitor);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -59,7 +59,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private MutationValidator mutationValidator = MutationValidator.IGNORE;
 
     private boolean assumeFluidDependencies;
-    private boolean sortConsumerFirst;
+    private SortOrder sortOrder = SortOrder.DEFAULT;
     private static final String ASSUME_FLUID_DEPENDENCIES = "org.gradle.resolution.assumeFluidDependencies";
 
     public DefaultResolutionStrategy(DependencySubstitutionRules globalDependencySubstitutionRules, ComponentIdentifierFactory componentIdentifierFactory) {
@@ -99,13 +99,14 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         }
     }
 
-    public void sortConsumerFirst() {
-        this.sortConsumerFirst = true;
+    @Override
+    public void sortArtifacts(SortOrder sortOrder) {
+        this.sortOrder = sortOrder;
     }
 
     @Override
-    public boolean isSortConsumerFirst() {
-        return sortConsumerFirst;
+    public SortOrder getSortOrder() {
+        return sortOrder;
     }
 
     public ConflictResolution getConflictResolution() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -59,6 +59,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private MutationValidator mutationValidator = MutationValidator.IGNORE;
 
     private boolean assumeFluidDependencies;
+    private boolean sortConsumerFirst;
     private static final String ASSUME_FLUID_DEPENDENCIES = "org.gradle.resolution.assumeFluidDependencies";
 
     public DefaultResolutionStrategy(DependencySubstitutionRules globalDependencySubstitutionRules, ComponentIdentifierFactory componentIdentifierFactory) {
@@ -96,6 +97,15 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         if (this.conflictResolution instanceof LatestConflictResolution) {
             this.conflictResolution = new PreferProjectModulesConflictResolution();
         }
+    }
+
+    public void sortConsumerFirst() {
+        this.sortConsumerFirst = true;
+    }
+
+    @Override
+    public boolean isSortConsumerFirst() {
+        return sortConsumerFirst;
     }
 
     public ConflictResolution getConflictResolution() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DependencyArtifactsVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DependencyArtifactsVisitor.java
@@ -19,6 +19,8 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 
 public interface DependencyArtifactsVisitor {
+    // TODO:DAZ Performing the topo-sort for nodes shouldn't be done in a DependencyArtifactsVisitor
+    void startArtifacts(DependencyGraphNode root);
     void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, ArtifactSet artifacts);
     void finishArtifacts();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
@@ -58,6 +58,7 @@ public class ResolvedArtifactsGraphVisitor implements DependencyGraphVisitor {
 
     @Override
     public void start(DependencyGraphNode root) {
+        artifactResults.startArtifacts(root);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyArtifactsVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyArtifactsVisitor.java
@@ -30,6 +30,13 @@ public class CompositeDependencyArtifactsVisitor implements DependencyArtifactsV
     }
 
     @Override
+    public void startArtifacts(DependencyGraphNode root) {
+        for (DependencyArtifactsVisitor visitor : visitors) {
+            visitor.startArtifacts(root);
+        }
+    }
+
+    @Override
     public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, ArtifactSet artifacts) {
         for (DependencyArtifactsVisitor visitor : visitors) {
             visitor.visitArtifacts(from, to, artifacts);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
@@ -203,7 +203,7 @@ public class DependencyGraphBuilder {
             }
         }
 
-        visitor.finish(resolveState.root);
+        visitor.finish(resolveState.root);  
     }
 
     /**
@@ -338,6 +338,11 @@ public class DependencyGraphBuilder {
                 return ((DslOriginDependencyMetadata) dependencyMetadata).getSource();
             }
             return null;
+        }
+
+        @Override
+        public Iterable<? extends DependencyGraphNode> getTargets() {
+            return targetConfigurations;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
@@ -44,4 +44,6 @@ public interface DependencyGraphEdge extends DependencyResult {
 
     @Nullable
     ModuleDependency getModuleDependency();
+
+    Iterable<? extends DependencyGraphNode> getTargets();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationDependencyGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationDependencyGraphVisitor.java
@@ -76,6 +76,10 @@ public class ResolvedConfigurationDependencyGraphVisitor implements DependencyGr
     }
 
     @Override
+    public void startArtifacts(DependencyGraphNode root) {
+    }
+
+    @Override
     public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, ArtifactSet artifacts) {
         builder.addChild(from, to, artifacts.getId());
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -170,6 +170,10 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
         }
 
         @Override
+        public void startArtifacts(DependencyGraphNode root) {
+        }
+
+        @Override
         public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, ArtifactSet artifacts) {
             artifactsBuilder.visitArtifacts(from, to, artifacts);
         }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -140,7 +140,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
 
     class ResolveResult implements DependencyGraphVisitor, DependencyArtifactsVisitor {
         public final List<Throwable> notFound = new LinkedList<Throwable>();
-        public DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(true, false);
+        public DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(true);
         public SelectedArtifactResults artifactsResults;
 
         @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -140,7 +140,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
 
     class ResolveResult implements DependencyGraphVisitor, DependencyArtifactsVisitor {
         public final List<Throwable> notFound = new LinkedList<Throwable>();
-        public DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(true);
+        public DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(true, false);
         public SelectedArtifactResults artifactsResults;
 
         @Override


### PR DESCRIPTION
This spike allows users to specify a sort order when constructing a view on a configuration. The artifacts in the view can be ordered as follows:

- `CONSUMER_FIRST` ensures that artifacts for a component will appear before artifacts for any of that components dependencies
- `DEPENDENCY_FIRST` is the opposite ordering to `CONSUMER_FIRST`
- `DEFAULT` makes no guarantees about ordering (but ensures consistent ordering given a set of dependencies for a particular version of Gradle)

The way this is currently implemented, we perform a topological sort of the resolved dependency graph, whether it will be needed or not.