### PR TITLE
Take all Javadoc options into account as task inputs

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -91,7 +91,7 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 ### Javadoc options should not be overwritten
 
-`Javadoc.setOptions(MinimalJavadocOptions)` is now deprecated. Use `setOptions(StandardJavadocDocletOptions)` instead.
+`Javadoc.setOptions(MinimalJavadocOptions)` is now deprecated.
 
 <!--
 ### Example deprecation

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -89,6 +89,10 @@ in the next major Gradle version (Gradle 4.0). See the User guide section on the
 
 The following are the newly deprecated items in this Gradle release. If you have concerns about a deprecation, please raise it via the [Gradle Forums](https://discuss.gradle.org).
 
+### Javadoc options should not be overwritten
+
+`Javadoc.setOptions(MinimalJavadocOptions)` is now deprecated. Use `setOptions(StandardJavadocDocletOptions)` instead.
+
 <!--
 ### Example deprecation
 -->
@@ -102,6 +106,10 @@ Please see <a href="#improved-feedback-when-skipping-tasks-with-no-source-input"
 ### new NO_SOURCE task outcome when testing with GradleRunner
 
 Please see <a href="#improved-feedback-when-skipping-tasks-with-no-source-input">Improved feedback when skipping tasks with no source input</a>.
+
+### Setting Javadoc options
+
+When the now deprecated `Javadoc.setOptions(MinimalJavadocOptions)` method is called with a `StandardJavadocDocletOptions`, it replaces the task's own `options` value. However, calling the method with a parameter that is not a `StandardJavadocDocletOptions` will only copy the values declared by the object, but won't replace the `options` object itself.
 
 ## External contributions
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -97,4 +97,43 @@ Joe!""")
         then:
         file("build/javadoc/Foo.html").exists()
     }
+
+    def "changing standard doclet options makes task out-of-date"() {
+        buildFile << """
+            task javadoc(type: Javadoc) {
+                destinationDir = file("build/javadoc")
+                source "src/main/java"
+                options {
+                    windowTitle = "Window title"
+                }
+            }
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when:
+        run "javadoc"
+        then:
+        nonSkippedTasks == [":javadoc"]
+
+        when:
+        run "javadoc"
+        then:
+        skippedTasks as List == [":javadoc"]
+
+        when:
+        buildFile.text = """
+            task javadoc(type: Javadoc) {
+                destinationDir = file("build/javadoc")
+                source "src/main/java"
+                options {
+                    windowTitle = "Window title changed"
+                }
+            }
+        """
+        run "javadoc"
+
+        then:
+        nonSkippedTasks == [":javadoc"]
+    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -106,7 +106,7 @@ public class Javadoc extends SourceTask {
     protected void generate() {
         final File destinationDir = getDestinationDir();
 
-        StandardJavadocDocletOptions options = getOptions().duplicate();
+        StandardJavadocDocletOptions options = new StandardJavadocDocletOptions(getOptions());
 
         if (options.getDestinationDirectory() == null) {
             options.destinationDirectory(destinationDir);

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks.javadoc;
 
-import com.google.common.collect.Lists;
 import groovy.lang.Closure;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
@@ -310,35 +309,10 @@ public class Javadoc extends SourceTask {
     @Deprecated
     public void setOptions(MinimalJavadocOptions options) {
         DeprecationLogger.nagUserOfDiscontinuedMethod("Javadoc.setOptions(MinimalJavadocOptions)");
-        if (options == null || options instanceof StandardJavadocDocletOptions) {
+        if (options instanceof StandardJavadocDocletOptions) {
             this.options = (StandardJavadocDocletOptions) options;
         } else {
-            this.options.setOverview(options.getOverview());
-            this.options.setMemberLevel(options.getMemberLevel());
-            this.options.setDoclet(options.getDoclet());
-            this.options.setDocletpath(copyOrNull(options.getDocletpath()));
-            this.options.setSource(options.getSource());
-            this.options.setClasspath(copyOrNull(options.getClasspath()));
-            this.options.setBootClasspath(copyOrNull(options.getBootClasspath()));
-            this.options.setExtDirs(copyOrNull(options.getExtDirs()));
-            this.options.setOutputLevel(options.getOutputLevel());
-            this.options.setBreakIterator(options.isBreakIterator());
-            this.options.setLocale(options.getLocale());
-            this.options.setEncoding(options.getEncoding());
-            this.options.setJFlags(copyOrNull(options.getJFlags()));
-            this.options.setOptionFiles(copyOrNull(options.getOptionFiles()));
-            this.options.setDestinationDirectory(options.getDestinationDirectory());
-            this.options.setWindowTitle(options.getWindowTitle());
-            this.options.setHeader(options.getHeader());
-            this.options.setSourceNames(copyOrNull(options.getSourceNames()));
-        }
-    }
-
-    private static <T> List<T> copyOrNull(List<T> items) {
-        if (items == null) {
-            return null;
-        } else {
-            return Lists.newArrayList(items);
+            this.options = new StandardJavadocDocletOptions(options);
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -105,7 +105,7 @@ public class Javadoc extends SourceTask {
     protected void generate() {
         final File destinationDir = getDestinationDir();
 
-        StandardJavadocDocletOptions options = new StandardJavadocDocletOptions(getOptions());
+        StandardJavadocDocletOptions options = new StandardJavadocDocletOptions((StandardJavadocDocletOptions) getOptions());
 
         if (options.getDestinationDirectory() == null) {
             options.destinationDirectory(destinationDir);
@@ -297,7 +297,7 @@ public class Javadoc extends SourceTask {
      * @return The options. Never returns null.
      */
     @Nested
-    public StandardJavadocDocletOptions getOptions() {
+    public MinimalJavadocOptions getOptions() {
         return options;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -309,9 +309,9 @@ public class Javadoc extends SourceTask {
      */
     @Deprecated
     public void setOptions(MinimalJavadocOptions options) {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("Javadoc.setOptions(MinimalJavadocOptions)", "Use setOptions(StandardJavadocDocletOptions) instead.");
+        DeprecationLogger.nagUserOfDiscontinuedMethod("Javadoc.setOptions(MinimalJavadocOptions)");
         if (options == null || options instanceof StandardJavadocDocletOptions) {
-            setOptions((StandardJavadocDocletOptions) options);
+            this.options = (StandardJavadocDocletOptions) options;
         } else {
             this.options.setOverview(options.getOverview());
             this.options.setMemberLevel(options.getMemberLevel());
@@ -332,10 +332,6 @@ public class Javadoc extends SourceTask {
             this.options.setHeader(options.getHeader());
             this.options.setSourceNames(copyOrNull(options.getSourceNames()));
         }
-    }
-
-    public void setOptions(StandardJavadocDocletOptions options) {
-        this.options = options;
     }
 
     private static <T> List<T> copyOrNull(List<T> items) {

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
@@ -56,6 +56,25 @@ public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
         sourceNames = optionFile.getSourceNames();
     }
 
+    protected CoreJavadocOptions(CoreJavadocOptions original, JavadocOptionFile optionFile) {
+        this.optionFile = optionFile;
+
+        overview = optionFile.getOption("overview");
+        memberLevel = optionFile.getOption("memberLevel");
+        doclet = optionFile.getOption("doclet");
+        docletpath = optionFile.getOption("docletpath");
+        source = optionFile.getOption("source");
+        classpath = optionFile.getOption("classpath");
+        bootClasspath = optionFile.getOption("bootclasspath");
+        extDirs = optionFile.getOption("extdirs");
+        outputLevel = optionFile.getOption("outputLevel");
+        breakIterator = optionFile.getOption("breakiterator");
+        locale = optionFile.getOption("locale");
+        encoding = optionFile.getOption("encoding");
+
+        sourceNames = optionFile.getSourceNames();
+    }
+
     /**
      * -overview  path\filename
      * Specifies that javadoc should retrieve the text for the overview documentation from

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
@@ -31,7 +31,7 @@ import java.util.List;
  * Provides the core Javadoc Options. That is, provides the options which are not doclet specific.
  */
 public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
-    private final JavadocOptionFile optionFile;
+    protected final JavadocOptionFile optionFile;
 
     public CoreJavadocOptions() {
         this(new JavadocOptionFile());

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/JavadocOfflineLink.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/JavadocOfflineLink.java
@@ -16,12 +16,13 @@
 
 package org.gradle.external.javadoc;
 
+import java.io.Serializable;
 
 /**
  * This class is used to hold the information that can be provided to the javadoc executable via the -linkoffline
  * option.
  */
-public class JavadocOfflineLink {
+public class JavadocOfflineLink implements Serializable {
     private final String extDocUrl;
     private final String packagelistLoc;
 

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/JavadocOfflineLink.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/JavadocOfflineLink.java
@@ -16,6 +16,8 @@
 
 package org.gradle.external.javadoc;
 
+import com.google.common.base.Objects;
+
 import java.io.Serializable;
 
 /**
@@ -37,6 +39,24 @@ public class JavadocOfflineLink implements Serializable {
 
     public String getPackagelistLoc() {
         return packagelistLoc;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JavadocOfflineLink that = (JavadocOfflineLink) o;
+        return Objects.equal(extDocUrl, that.extDocUrl)
+            && Objects.equal(packagelistLoc, that.packagelistLoc);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(extDocUrl, packagelistLoc);
     }
 
     public String toString() {

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/JavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/JavadocOptionFileOption.java
@@ -23,4 +23,7 @@ package org.gradle.external.javadoc;
  */
 public interface JavadocOptionFileOption<T> extends OptionLessJavadocOptionFileOption<T> {
     String getOption();
+
+    @Override
+    JavadocOptionFileOption<T> duplicate();
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
@@ -22,6 +22,8 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.process.ExecSpec;
 
 import java.io.File;
@@ -91,7 +93,7 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions bootClasspath(File ... bootClasspath);
 
-    @Optional @InputFiles
+    @Optional @PathSensitive(PathSensitivity.RELATIVE) @InputFiles
     List<File> getExtDirs();
 
     void setExtDirs(List<File> extDirs);
@@ -140,7 +142,7 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions jFlags(String ... jFlags);
 
-    @Optional @InputFiles
+    @Optional @PathSensitive(PathSensitivity.NONE) @InputFiles
     List<File> getOptionFiles();
 
     void setOptionFiles(List<File> optionFiles);

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/OptionLessJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/OptionLessJavadocOptionFileOption.java
@@ -31,4 +31,6 @@ public interface OptionLessJavadocOptionFileOption<T> {
     void setValue(T value);
 
     void write(JavadocOptionFileWriterContext writerContext) throws IOException;
+
+    OptionLessJavadocOptionFileOption<T> duplicate();
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
@@ -16,6 +16,13 @@
 
 package org.gradle.external.javadoc;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
 import org.gradle.external.javadoc.internal.GroupsJavadocOptionFileOption;
 import org.gradle.external.javadoc.internal.JavadocOptionFile;
 import org.gradle.external.javadoc.internal.LinksOfflineJavadocOptionFileOption;
@@ -24,6 +31,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import static org.gradle.api.tasks.PathSensitivity.NONE;
 
 /**
  * Provides the options for the standard Javadoc doclet.
@@ -48,9 +57,9 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         footer = addStringOption("footer");
         bottom = addStringOption("bottom");
         links = addMultilineStringsOption("link");
-        linksOffline = addOption(new LinksOfflineJavadocOptionFileOption("linkoffline"));
+        linksOffline = addOption(new LinksOfflineJavadocOptionFileOption("linkoffline", Lists.<JavadocOfflineLink>newArrayList()));
         linkSource = addBooleanOption("linksource");
-        groups = addOption(new GroupsJavadocOptionFileOption("group"));
+        groups = addOption(new GroupsJavadocOptionFileOption("group", Maps.<String, List<String>>newLinkedHashMap()));
         noDeprecated = addBooleanOption("nodeprecated");
         noDeprecatedList = addBooleanOption("nodeprecatedlist");
         noSince = addBooleanOption("nosince");
@@ -72,6 +81,10 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         noQualifiers = addStringsOption("noqualifier", ":");
         noTimestamp = addBooleanOption("notimestamp");
         noComment = addBooleanOption("nocomment");
+    }
+
+    public StandardJavadocDocletOptions duplicate() {
+        return new StandardJavadocDocletOptions(optionFile.duplicate());
     }
 
     /**
@@ -122,6 +135,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> use;
 
+    @Input
     public boolean isUse() {
         return use.getValue();
     }
@@ -146,6 +160,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> version;
 
+    @Input
     public boolean isVersion() {
         return version.getValue();
     }
@@ -169,6 +184,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> author;
 
+    @Input
     public boolean isAuthor() {
         return author.getValue();
     }
@@ -193,6 +209,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> splitIndex;
 
+    @Input
     public boolean isSplitIndex() {
         return splitIndex.getValue();
     }
@@ -272,6 +289,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<String> docTitle;
 
+    @Optional @Input
     public String getDocTitle() {
         return docTitle.getValue();
     }
@@ -293,6 +311,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<String> footer;
 
+    @Optional @Input
     public String getFooter() {
         return footer.getValue();
     }
@@ -315,6 +334,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<String> bottom;
 
+    @Optional @Input
     public String getBottom() {
         return bottom.getValue();
     }
@@ -348,6 +368,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<List<String>> links;
 
+    @Optional @Input
     public List<String> getLinks() {
         return links.getValue();
     }
@@ -391,6 +412,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<List<JavadocOfflineLink>> linksOffline;
 
+    @Optional @Input
     public List<JavadocOfflineLink> getLinksOffline() {
         return linksOffline.getValue();
     }
@@ -423,6 +445,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> linkSource;
 
+    @Input
     public boolean isLinkSource() {
         return linkSource.getValue();
     }
@@ -476,6 +499,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Map<String, List<String>>> groups;
 
+    @Optional @Input
     public Map<String, List<String>> getGroups() {
         return groups.getValue();
     }
@@ -510,6 +534,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> noDeprecated;
 
+    @Input
     public boolean isNoDeprecated() {
         return noDeprecated.getValue();
     }
@@ -536,6 +561,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> noDeprecatedList;
 
+    @Input
     public boolean isNoDeprecatedList() {
         return noDeprecatedList.getValue();
     }
@@ -559,6 +585,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> noSince;
 
+    @Input
     public boolean isNoSince() {
         return noSince.getValue();
     }
@@ -584,6 +611,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> noTree;
 
+    @Input
     public boolean isNoTree() {
         return noTree.getValue();
     }
@@ -607,6 +635,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> noIndex;
 
+    @Input
     public boolean isNoIndex() {
         return noIndex.getValue();
     }
@@ -630,6 +659,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> noHelp;
 
+    @Input
     public boolean isNoHelp() {
         return noHelp.getValue();
     }
@@ -656,6 +686,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> noNavBar;
 
+    @Input
     public boolean isNoNavBar() {
         return noNavBar.getValue();
     }
@@ -681,6 +712,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<File> helpFile;
 
+    @Optional @PathSensitive(NONE) @InputFile
     public File getHelpFile() {
         return helpFile.getValue();
     }
@@ -702,6 +734,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<File> stylesheetFile;
 
+    @Optional @PathSensitive(NONE) @InputFile
     public File getStylesheetFile() {
         return stylesheetFile.getValue();
     }
@@ -724,6 +757,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> serialWarn;
 
+    @Input
     public boolean isSerialWarn() {
         return serialWarn.getValue();
     }
@@ -757,6 +791,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<String> charSet;
 
+    @Optional @Input
     public String getCharSet() {
         return charSet.getValue();
     }
@@ -780,6 +815,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<String> docEncoding;
 
+    @Optional @Input
     public String getDocEncoding() {
         return docEncoding.getValue();
     }
@@ -798,6 +834,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> keyWords;
 
+    @Input
     public boolean isKeyWords() {
         return keyWords.getValue();
     }
@@ -820,6 +857,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<List<String>> tags;
 
+    @Optional @Input
     public List<String> getTags() {
         return tags.getValue();
     }
@@ -846,6 +884,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<List<String>> taglets;
 
+    @Optional @Input
     public List<String> getTaglets() {
         return taglets.getValue();
     }
@@ -868,6 +907,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<List<File>> tagletPath;
 
+    @Optional @PathSensitive(NONE) @InputFiles
     public List<File> getTagletPath() {
         return tagletPath.getValue();
     }
@@ -890,6 +930,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> docFilesSubDirs;
 
+    @Input
     public boolean isDocFilesSubDirs() {
         return docFilesSubDirs.getValue();
     }
@@ -912,6 +953,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<List<String>> excludeDocFilesSubDir;
 
+    @Optional @Input
     public List<String> getExcludeDocFilesSubDir() {
         return excludeDocFilesSubDir.getValue();
     }
@@ -934,6 +976,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<List<String>> noQualifiers;
 
+    @Optional @Input
     public List<String> getNoQualifiers() {
         return noQualifiers.getValue();
     }
@@ -953,6 +996,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
 
     public final JavadocOptionFileOption<Boolean> noTimestamp;
 
+    @Input
     public boolean isNoTimestamp() {
         return noTimestamp.getValue();
     }
@@ -975,6 +1019,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<Boolean> noComment;
 
+    @Input
     public boolean isNoComment() {
         return noComment.getValue();
     }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
@@ -84,7 +84,78 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
     }
 
     public StandardJavadocDocletOptions(StandardJavadocDocletOptions original) {
-        this(new JavadocOptionFile(original.optionFile));
+        this(original, new JavadocOptionFile(original.optionFile));
+    }
+
+    public StandardJavadocDocletOptions(StandardJavadocDocletOptions original, JavadocOptionFile optionFile) {
+        super(original, optionFile);
+
+        destinationDirectory = optionFile.getOption("d");
+        use = optionFile.getOption("use");
+        version = optionFile.getOption("version");
+        author = optionFile.getOption("author");
+        splitIndex = optionFile.getOption("splitindex");
+        header = optionFile.getOption("header");
+        windowTitle = optionFile.getOption("windowtitle");
+        docTitle = optionFile.getOption("doctitle");
+        footer = optionFile.getOption("footer");
+        bottom = optionFile.getOption("bottom");
+        links = optionFile.getOption("link");
+        linksOffline = optionFile.getOption("linkoffline");
+        linkSource = optionFile.getOption("linksource");
+        groups = optionFile.getOption("group");
+        noDeprecated = optionFile.getOption("nodeprecated");
+        noDeprecatedList = optionFile.getOption("nodeprecatedlist");
+        noSince = optionFile.getOption("nosince");
+        noTree = optionFile.getOption("notree");
+        noIndex = optionFile.getOption("noindex");
+        noHelp = optionFile.getOption("nohelp");
+        noNavBar = optionFile.getOption("nonavbar");
+        helpFile = optionFile.getOption("helpfile");
+        stylesheetFile = optionFile.getOption("stylesheetfile");
+        serialWarn = optionFile.getOption("serialwarn");
+        charSet = optionFile.getOption("charset");
+        docEncoding = optionFile.getOption("docencoding");
+        keyWords = optionFile.getOption("keywords");
+        tags = optionFile.getOption("tag");
+        taglets = optionFile.getOption("taglet");
+        tagletPath = optionFile.getOption("tagletpath");
+        docFilesSubDirs = optionFile.getOption("docfilessubdirs");
+        excludeDocFilesSubDir = optionFile.getOption("excludedocfilessubdir");
+        noQualifiers = optionFile.getOption("noqualifier");
+        noTimestamp = optionFile.getOption("notimestamp");
+        noComment = optionFile.getOption("nocomment");
+    }
+
+    public StandardJavadocDocletOptions(MinimalJavadocOptions original) {
+        this();
+
+        setOverview(original.getOverview());
+        setMemberLevel(original.getMemberLevel());
+        setDoclet(original.getDoclet());
+        setDocletpath(copyOrNull(original.getDocletpath()));
+        setSource(original.getSource());
+        setClasspath(copyOrNull(original.getClasspath()));
+        setBootClasspath(copyOrNull(original.getBootClasspath()));
+        setExtDirs(copyOrNull(original.getExtDirs()));
+        setOutputLevel(original.getOutputLevel());
+        setBreakIterator(original.isBreakIterator());
+        setLocale(original.getLocale());
+        setEncoding(original.getEncoding());
+        setJFlags(copyOrNull(original.getJFlags()));
+        setOptionFiles(copyOrNull(original.getOptionFiles()));
+        setDestinationDirectory(original.getDestinationDirectory());
+        setWindowTitle(original.getWindowTitle());
+        setHeader(original.getHeader());
+        setSourceNames(copyOrNull(original.getSourceNames()));
+    }
+
+    private static <T> List<T> copyOrNull(List<T> items) {
+        if (items == null) {
+            return null;
+        } else {
+            return Lists.newArrayList(items);
+        }
     }
 
     /**

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
@@ -18,9 +18,9 @@ package org.gradle.external.javadoc;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.external.javadoc.internal.GroupsJavadocOptionFileOption;
@@ -907,7 +907,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<List<File>> tagletPath;
 
-    @Optional @PathSensitive(NONE) @InputFiles
+    @Optional @Classpath
     public List<File> getTagletPath() {
         return tagletPath.getValue();
     }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
@@ -83,8 +83,8 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         noComment = addBooleanOption("nocomment");
     }
 
-    public StandardJavadocDocletOptions duplicate() {
-        return new StandardJavadocDocletOptions(optionFile.duplicate());
+    public StandardJavadocDocletOptions(StandardJavadocDocletOptions original) {
+        this(new JavadocOptionFile(original.optionFile));
     }
 
     /**

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.gradle.api.tasks.PathSensitivity.NONE;
+import static org.gradle.api.tasks.PathSensitivity.NAME_ONLY;
 
 /**
  * Provides the options for the standard Javadoc doclet.
@@ -712,7 +712,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<File> helpFile;
 
-    @Optional @PathSensitive(NONE) @InputFile
+    @Optional @PathSensitive(NAME_ONLY) @InputFile
     public File getHelpFile() {
         return helpFile.getValue();
     }
@@ -734,7 +734,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      */
     private final JavadocOptionFileOption<File> stylesheetFile;
 
-    @Optional @PathSensitive(NONE) @InputFile
+    @Optional @PathSensitive(NAME_ONLY) @InputFile
     public File getStylesheetFile() {
         return stylesheetFile.getValue();
     }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/AbstractJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/AbstractJavadocOptionFileOption.java
@@ -27,10 +27,6 @@ public abstract class AbstractJavadocOptionFileOption<T> implements JavadocOptio
     protected final String option;
     protected T value;
 
-    protected AbstractJavadocOptionFileOption(String option) {
-        this(option, null);
-    }
-
     protected AbstractJavadocOptionFileOption(String option, T value) {
         if (option == null) {
             throw new IllegalArgumentException("option == null!");

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/AbstractListJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/AbstractListJavadocOptionFileOption.java
@@ -25,12 +25,7 @@ import java.util.List;
  * @param <T> The type which this option represents.
  */
 public abstract class AbstractListJavadocOptionFileOption<T extends List<?>> extends AbstractJavadocOptionFileOption<T> {
-    protected String joinBy;
-
-    protected AbstractListJavadocOptionFileOption(String option, String joinBy) {
-        super(option);
-        this.joinBy = joinBy;
-    }
+    protected final String joinBy;
 
     protected AbstractListJavadocOptionFileOption(String option, T value, String joinBy) {
         super(option, value);

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/BooleanJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/BooleanJavadocOptionFileOption.java
@@ -22,11 +22,7 @@ import java.io.IOException;
  * A {@link org.gradle.external.javadoc.JavadocOptionFileOption} whose value is a boolean.
  */
 public class BooleanJavadocOptionFileOption extends AbstractJavadocOptionFileOption<Boolean> {
-    protected BooleanJavadocOptionFileOption(String option) {
-        super(option);
-    }
-
-    protected BooleanJavadocOptionFileOption(String option, Boolean value) {
+    public BooleanJavadocOptionFileOption(String option, Boolean value) {
         super(option, value);
     }
 
@@ -35,5 +31,10 @@ public class BooleanJavadocOptionFileOption extends AbstractJavadocOptionFileOpt
         if (value != null && value) {
             writerContext.writeOption(option);
         }
+    }
+
+    @Override
+    public BooleanJavadocOptionFileOption duplicate() {
+        return new BooleanJavadocOptionFileOption(option, value);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/EnumJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/EnumJavadocOptionFileOption.java
@@ -39,10 +39,6 @@ import java.util.Locale;
  * @param <T> The type which this option represents.
  */
 public class EnumJavadocOptionFileOption<T> extends AbstractJavadocOptionFileOption<T> {
-    public EnumJavadocOptionFileOption(String option) {
-        super(option);
-    }
-
     public EnumJavadocOptionFileOption(String option, T value) {
         super(option, value);
     }
@@ -53,5 +49,10 @@ public class EnumJavadocOptionFileOption<T> extends AbstractJavadocOptionFileOpt
             // See https://issues.gradle.org/browse/GRADLE-3470
             writerContext.writeOption(value.toString().toLowerCase(Locale.ENGLISH));
         }
+    }
+
+    @Override
+    public EnumJavadocOptionFileOption<T> duplicate() {
+        return new EnumJavadocOptionFileOption<T>(option, value);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/FileJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/FileJavadocOptionFileOption.java
@@ -23,11 +23,7 @@ import java.io.IOException;
  * A {@link org.gradle.external.javadoc.JavadocOptionFileOption} whose value is a file.
  */
 public class FileJavadocOptionFileOption extends AbstractJavadocOptionFileOption<File> {
-    protected FileJavadocOptionFileOption(String option) {
-        super(option);
-    }
-
-    protected FileJavadocOptionFileOption(String option, File value) {
+    public FileJavadocOptionFileOption(String option, File value) {
         super(option, value);
     }
 
@@ -36,5 +32,10 @@ public class FileJavadocOptionFileOption extends AbstractJavadocOptionFileOption
         if (value != null) {
             writerContext.writeValueOption(option, value.getAbsolutePath());
         }
+    }
+
+    @Override
+    public FileJavadocOptionFileOption duplicate() {
+        return new FileJavadocOptionFileOption(option, value);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/GroupsJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/GroupsJavadocOptionFileOption.java
@@ -16,10 +16,11 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.gradle.util.CollectionUtils;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,8 +29,8 @@ import java.util.Map;
  * option.
  */
 public class GroupsJavadocOptionFileOption extends AbstractJavadocOptionFileOption<Map<String, List<String>>> {
-    public GroupsJavadocOptionFileOption(String option) {
-        super(option, new LinkedHashMap<String, List<String>>());
+    public GroupsJavadocOptionFileOption(String option, Map<String, List<String>> value) {
+        super(option, value);
     }
 
     @Override
@@ -46,5 +47,14 @@ public class GroupsJavadocOptionFileOption extends AbstractJavadocOptionFileOpti
                     .newLine();
             }
         }
+    }
+
+    @Override
+    public GroupsJavadocOptionFileOption duplicate() {
+        Map<String, List<String>> duplicateValue = Maps.newLinkedHashMap();
+        for (Map.Entry<String, List<String>> entry : value.entrySet()) {
+            duplicateValue.put(entry.getKey(), Lists.newArrayList(entry.getValue()));
+        }
+        return new GroupsJavadocOptionFileOption(option, duplicateValue);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
@@ -16,12 +16,13 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.gradle.external.javadoc.JavadocOptionFileOption;
 import org.gradle.external.javadoc.OptionLessJavadocOptionFileOption;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,8 +34,21 @@ public class JavadocOptionFile {
     private final OptionLessJavadocOptionFileOption<List<String>> sourceNames;
 
     public JavadocOptionFile() {
-        options = new LinkedHashMap<String, JavadocOptionFileOption<?>>();
-        sourceNames = new OptionLessStringsJavadocOptionFileOption();
+        this(new LinkedHashMap<String, JavadocOptionFileOption<?>>(), new OptionLessStringsJavadocOptionFileOption(Lists.<String>newArrayList()));
+    }
+
+    private JavadocOptionFile(Map<String, JavadocOptionFileOption<?>> options, OptionLessJavadocOptionFileOption<List<String>> sourceNames) {
+        this.options = options;
+        this.sourceNames = sourceNames;
+    }
+
+    public JavadocOptionFile duplicate() {
+        Map<String, JavadocOptionFileOption<?>> duplicateOptions = Maps.newLinkedHashMap();
+        for (Map.Entry<String, JavadocOptionFileOption<?>> entry : options.entrySet()) {
+            duplicateOptions.put(entry.getKey(), entry.getValue().duplicate());
+        }
+        OptionLessJavadocOptionFileOption<List<String>> duplicateSourceNames = sourceNames.duplicate();
+        return new JavadocOptionFile(duplicateOptions, duplicateSourceNames);
     }
 
     public OptionLessJavadocOptionFileOption<List<String>> getSourceNames() {
@@ -76,7 +90,7 @@ public class JavadocOptionFile {
     }
 
     public JavadocOptionFileOption<List<File>> addPathOption(String option, String joinBy) {
-        return addOption(new PathJavadocOptionFileOption(option, joinBy));
+        return addOption(new PathJavadocOptionFileOption(option, Lists.<File>newArrayList(), joinBy));
     }
 
     public JavadocOptionFileOption<List<String>> addStringsOption(String option) {
@@ -84,11 +98,11 @@ public class JavadocOptionFile {
     }
 
     public JavadocOptionFileOption<List<String>> addStringsOption(String option, String joinBy) {
-        return addOption(new StringsJavadocOptionFileOption(option, new ArrayList<String>(), joinBy));
+        return addOption(new StringsJavadocOptionFileOption(option, Lists.<String>newArrayList(), joinBy));
     }
 
     public JavadocOptionFileOption<List<String>> addMultilineStringsOption(String option) {
-        return addOption(new MultilineStringsJavadocOptionFileOption(option, new ArrayList<String>()));
+        return addOption(new MultilineStringsJavadocOptionFileOption(option, Lists.<String>newArrayList()));
     }
 
     public JavadocOptionFileOption<Boolean> addBooleanOption(String option) {

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
@@ -42,13 +42,16 @@ public class JavadocOptionFile {
         this.sourceNames = sourceNames;
     }
 
-    public JavadocOptionFile duplicate() {
+    public JavadocOptionFile(JavadocOptionFile original) {
+        this(duplicateOptions(original.options), original.sourceNames.duplicate());
+    }
+
+    private static Map<String, JavadocOptionFileOption<?>> duplicateOptions(Map<String, JavadocOptionFileOption<?>> original) {
         Map<String, JavadocOptionFileOption<?>> duplicateOptions = Maps.newLinkedHashMap();
-        for (Map.Entry<String, JavadocOptionFileOption<?>> entry : options.entrySet()) {
+        for (Map.Entry<String, JavadocOptionFileOption<?>> entry : original.entrySet()) {
             duplicateOptions.put(entry.getKey(), entry.getValue().duplicate());
         }
-        OptionLessJavadocOptionFileOption<List<String>> duplicateSourceNames = sourceNames.duplicate();
-        return new JavadocOptionFile(duplicateOptions, duplicateSourceNames);
+        return duplicateOptions;
     }
 
     public OptionLessJavadocOptionFileOption<List<String>> getSourceNames() {

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.gradle.external.javadoc.JavadocOptionFileOption;
 import org.gradle.external.javadoc.OptionLessJavadocOptionFileOption;
+import org.gradle.internal.Cast;
 
 import java.io.File;
 import java.io.IOException;
@@ -132,5 +133,13 @@ public class JavadocOptionFile {
         final JavadocOptionFileWriter optionFileWriter = new JavadocOptionFileWriter(this);
 
         optionFileWriter.write(optionFile);
+    }
+
+    public <T> JavadocOptionFileOption<T> getOption(String option) {
+        JavadocOptionFileOption<?> foundOption = options.get(option);
+        if (foundOption == null) {
+            throw new IllegalArgumentException("Cannot find option " + option);
+        }
+        return Cast.uncheckedCast(foundOption);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/LinksOfflineJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/LinksOfflineJavadocOptionFileOption.java
@@ -16,15 +16,15 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
 import org.gradle.external.javadoc.JavadocOfflineLink;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class LinksOfflineJavadocOptionFileOption extends AbstractJavadocOptionFileOption<List<JavadocOfflineLink>> {
-    public LinksOfflineJavadocOptionFileOption(String option) {
-        super(option, new ArrayList<JavadocOfflineLink>());
+    public LinksOfflineJavadocOptionFileOption(String option, List<JavadocOfflineLink> value) {
+        super(option, value);
     }
 
     @Override
@@ -34,5 +34,11 @@ public class LinksOfflineJavadocOptionFileOption extends AbstractJavadocOptionFi
                 writerContext.writeValueOption(option, offlineLink.toString());
             }
         }
+    }
+
+    @Override
+    public LinksOfflineJavadocOptionFileOption duplicate() {
+        List<JavadocOfflineLink> duplicateValue = Lists.newArrayList(value);
+        return new LinksOfflineJavadocOptionFileOption(option, duplicateValue);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/MultilineStringsJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/MultilineStringsJavadocOptionFileOption.java
@@ -16,8 +16,9 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
+
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class MultilineStringsJavadocOptionFileOption extends AbstractListJavadocOptionFileOption<List<String>> {
@@ -25,11 +26,7 @@ public class MultilineStringsJavadocOptionFileOption extends AbstractListJavadoc
     // We should never attempt to join strings so if you see this, there's a problem
     private static final String JOIN_BY = "Not Used!";
 
-    protected MultilineStringsJavadocOptionFileOption(String option) {
-        super(option, new ArrayList<String>(), JOIN_BY);
-    }
-
-    protected MultilineStringsJavadocOptionFileOption(String option, List<String> value) {
+    public MultilineStringsJavadocOptionFileOption(String option, List<String> value) {
         super(option, value, JOIN_BY);
     }
 
@@ -38,5 +35,11 @@ public class MultilineStringsJavadocOptionFileOption extends AbstractListJavadoc
         if (value != null && !value.isEmpty()) {
             writerContext.writeMultilineValuesOption(option, value);
         }
+    }
+
+    @Override
+    public MultilineStringsJavadocOptionFileOption duplicate() {
+        List<String> duplicateValue = Lists.newArrayList(value);
+        return new MultilineStringsJavadocOptionFileOption(option, duplicateValue);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/OptionLessStringsJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/OptionLessStringsJavadocOptionFileOption.java
@@ -16,21 +16,22 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
 import org.gradle.external.javadoc.OptionLessJavadocOptionFileOption;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class OptionLessStringsJavadocOptionFileOption implements OptionLessJavadocOptionFileOption<List<String>> {
     private List<String> value;
 
-    public OptionLessStringsJavadocOptionFileOption() {
-        value = new ArrayList<String>();
-    }
-
     public OptionLessStringsJavadocOptionFileOption(List<String> value) {
         this.value = value;
+    }
+
+    @Override
+    public OptionLessStringsJavadocOptionFileOption duplicate() {
+        return new OptionLessStringsJavadocOptionFileOption(Lists.newArrayList(value));
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/PathJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/PathJavadocOptionFileOption.java
@@ -16,16 +16,13 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class PathJavadocOptionFileOption extends AbstractListJavadocOptionFileOption<List<File>> {
-
-    public PathJavadocOptionFileOption(String option, String joinBy) {
-        super(option, new ArrayList<File>(), joinBy);
-    }
 
     public PathJavadocOptionFileOption(String option, List<File> value, String joinBy) {
         super(option, value, joinBy);
@@ -34,5 +31,11 @@ public class PathJavadocOptionFileOption extends AbstractListJavadocOptionFileOp
     @Override
     public void writeCollectionValue(JavadocOptionFileWriterContext writerContext) throws IOException {
         writerContext.writePathOption(option, value, joinBy);
+    }
+
+    @Override
+    public PathJavadocOptionFileOption duplicate() {
+        List<File> duplicateValue = Lists.newArrayList(value);
+        return new PathJavadocOptionFileOption(option, duplicateValue, joinBy);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/StringJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/StringJavadocOptionFileOption.java
@@ -19,10 +19,6 @@ package org.gradle.external.javadoc.internal;
 import java.io.IOException;
 
 public class StringJavadocOptionFileOption extends AbstractJavadocOptionFileOption<String> {
-    public StringJavadocOptionFileOption(String option) {
-        super(option);
-    }
-
     public StringJavadocOptionFileOption(String option, String value) {
         super(option, value);
     }
@@ -32,5 +28,10 @@ public class StringJavadocOptionFileOption extends AbstractJavadocOptionFileOpti
         if (value != null) {
             writerContext.writeValueOption(option, value);
         }
+    }
+
+    @Override
+    public StringJavadocOptionFileOption duplicate() {
+        return new StringJavadocOptionFileOption(option, value);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/StringsJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/StringsJavadocOptionFileOption.java
@@ -16,21 +16,24 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
+
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class StringsJavadocOptionFileOption extends AbstractListJavadocOptionFileOption<List<String>> {
-    protected StringsJavadocOptionFileOption(String option, String joinBy) {
-        super(option, new ArrayList<String>(), joinBy);
-    }
-
-    protected StringsJavadocOptionFileOption(String option, List<String> value, String joinBy) {
+    public StringsJavadocOptionFileOption(String option, List<String> value, String joinBy) {
         super(option, value, joinBy);
     }
 
     @Override
     public void writeCollectionValue(JavadocOptionFileWriterContext writerContext) throws IOException {
         writerContext.writeValuesOption(option, value, joinBy);
+    }
+
+    @Override
+    public StringsJavadocOptionFileOption duplicate() {
+        List<String> duplicateValue = Lists.newArrayList(value);
+        return new StringsJavadocOptionFileOption(option, duplicateValue, joinBy);
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks.javadoc
 
 import org.gradle.api.internal.file.collections.SimpleFileCollection
-import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal
 import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.platform.base.internal.toolchain.ToolProvider
@@ -28,10 +27,7 @@ import org.gradle.util.WrapUtil
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.hamcrest.Matchers.equalTo
-import static org.junit.Assert.assertThat
-
-public class JavadocTest extends Specification {
+class JavadocTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def testDir = tmpDir.getTestDirectory()
@@ -45,7 +41,7 @@ public class JavadocTest extends Specification {
     def executable = "somepath";
     private Javadoc task = TestUtil.create(tmpDir).task(Javadoc)
 
-    public void setup() {
+    void setup() {
         task.setClasspath(configurationMock);
         task.setExecutable(executable);
         task.setToolChain(toolChain);
@@ -80,24 +76,5 @@ public class JavadocTest extends Specification {
         1 * toolChain.select(_) >> toolProvider
         1 * toolProvider.newCompiler(!null) >> generator
         1 * generator.execute(_)
-    }
-
-    def setsTheWindowAndDocTitleIfNotSet() {
-        when:
-        task.setDestinationDir(destDir);
-        task.source(srcDir);
-        task.setTitle("title");
-
-        task.execute();
-
-        then:
-        1 * toolChain.select(_) >> toolProvider
-        1 * toolProvider.newCompiler(!null) >> generator
-        1 * generator.execute(_)
-
-        and:
-        StandardJavadocDocletOptions options = (StandardJavadocDocletOptions) task.getOptions();
-        assertThat(options.getDocTitle(), equalTo("title"));
-        assertThat(options.getWindowTitle(), equalTo("title"));
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/StandardJavadocDocletOptionsTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/StandardJavadocDocletOptionsTest.java
@@ -16,6 +16,8 @@
 
 package org.gradle.external.javadoc;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.gradle.external.javadoc.internal.GroupsJavadocOptionFileOption;
 import org.gradle.external.javadoc.internal.JavadocOptionFile;
 import org.gradle.external.javadoc.internal.LinksOfflineJavadocOptionFileOption;
@@ -130,9 +132,9 @@ public class StandardJavadocDocletOptionsTest {
             oneOf(optionFileMock).addStringOption("footer");
             oneOf(optionFileMock).addStringOption("bottom");
             oneOf(optionFileMock).addStringOption("link");
-            allowing(optionFileMock).addOption(new LinksOfflineJavadocOptionFileOption("linkoffline"));
+            allowing(optionFileMock).addOption(new LinksOfflineJavadocOptionFileOption("linkoffline", Lists.<JavadocOfflineLink>newArrayList()));
             oneOf(optionFileMock).addBooleanOption("linksource");
-            oneOf(optionFileMock).addOption(new GroupsJavadocOptionFileOption("group"));
+            oneOf(optionFileMock).addOption(new GroupsJavadocOptionFileOption("group", Maps.<String, List<String>>newLinkedHashMap()));
             oneOf(optionFileMock).addBooleanOption("nodeprecated");
             oneOf(optionFileMock).addBooleanOption("nodeprecatedlist");
             oneOf(optionFileMock).addBooleanOption("nosince");

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/BooleanJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/BooleanJavadocOptionFileOptionTest.java
@@ -35,7 +35,7 @@ public class BooleanJavadocOptionFileOptionTest {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
 
-        booleanOption = new BooleanJavadocOptionFileOption(optionName);
+        booleanOption = new BooleanJavadocOptionFileOption(optionName, null);
     }
 
     @Test

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/EnumJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/EnumJavadocOptionFileOptionTest.java
@@ -36,7 +36,7 @@ public class EnumJavadocOptionFileOptionTest {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
 
-        enumOption = new EnumJavadocOptionFileOption<JavadocMemberLevel>(optionName);
+        enumOption = new EnumJavadocOptionFileOption<JavadocMemberLevel>(optionName, null);
     }
 
     @Test

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/FileJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/FileJavadocOptionFileOptionTest.java
@@ -36,7 +36,7 @@ public class FileJavadocOptionFileOptionTest {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
 
-        fileOption = new FileJavadocOptionFileOption(optionName);
+        fileOption = new FileJavadocOptionFileOption(optionName, null);
     }
 
     @Test

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/GroupsJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/GroupsJavadocOptionFileOptionTest.java
@@ -16,6 +16,7 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Maps;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
@@ -38,7 +39,7 @@ public class GroupsJavadocOptionFileOptionTest {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
 
-        groupsFile = new GroupsJavadocOptionFileOption(optionName);
+        groupsFile = new GroupsJavadocOptionFileOption(optionName, Maps.<String, List<String>>newLinkedHashMap());
     }
 
     @Test

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/JavadocOptionFileWriterTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/JavadocOptionFileWriterTest.groovy
@@ -36,7 +36,7 @@ class JavadocOptionFileWriterTest extends Specification {
         def optionsMap = createOptionsMap()
         when:
         _ * optionfile.options >> optionsMap
-        _ * optionfile.getSourceNames() >> new OptionLessStringsJavadocOptionFileOption();
+        _ * optionfile.getSourceNames() >> new OptionLessStringsJavadocOptionFileOption([]);
         javadocOptionFileWriter.write(tempFile)
         then:
         tempFile.text == toPlatformLineSeparators("""-key1 'value1'

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/LinksOfflineJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/LinksOfflineJavadocOptionFileOptionTest.java
@@ -16,6 +16,7 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
 import org.gradle.external.javadoc.JavadocOfflineLink;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnit4Mockery;
@@ -37,7 +38,7 @@ public class LinksOfflineJavadocOptionFileOptionTest {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
 
-        linksOfflineOption = new LinksOfflineJavadocOptionFileOption(optionName);
+        linksOfflineOption = new LinksOfflineJavadocOptionFileOption(optionName, Lists.<JavadocOfflineLink>newArrayList());
     }
 
     @Test

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/MultilineStringsJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/MultilineStringsJavadocOptionFileOptionTest.java
@@ -16,6 +16,7 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
@@ -37,7 +38,7 @@ public class MultilineStringsJavadocOptionFileOptionTest {
     public void setUp() {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
-        linksOption = new MultilineStringsJavadocOptionFileOption(optionName);
+        linksOption = new MultilineStringsJavadocOptionFileOption(optionName, Lists.<String>newArrayList());
     }
 
     @Test

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/OptionLessStringsJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/OptionLessStringsJavadocOptionFileOptionTest.java
@@ -16,6 +16,7 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
@@ -37,7 +38,7 @@ public class OptionLessStringsJavadocOptionFileOptionTest {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
 
-        optionLessStringsOption = new OptionLessStringsJavadocOptionFileOption();
+        optionLessStringsOption = new OptionLessStringsJavadocOptionFileOption(Lists.<String>newArrayList());
     }
 
     @Test

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/PathJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/PathJavadocOptionFileOptionTest.java
@@ -16,6 +16,7 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
@@ -39,7 +40,7 @@ public class PathJavadocOptionFileOptionTest {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
 
-        pathOption = new PathJavadocOptionFileOption(optionName, joinBy);
+        pathOption = new PathJavadocOptionFileOption(optionName, Lists.<File>newArrayList(), joinBy);
     }
 
     @Test

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/StringJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/StringJavadocOptionFileOptionTest.java
@@ -36,7 +36,7 @@ public class StringJavadocOptionFileOptionTest {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
 
-        stringOption = new StringJavadocOptionFileOption(optionName);
+        stringOption = new StringJavadocOptionFileOption(optionName, null);
     }
 
     @Test

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/StringsJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/StringsJavadocOptionFileOptionTest.java
@@ -16,6 +16,7 @@
 
 package org.gradle.external.javadoc.internal;
 
+import com.google.common.collect.Lists;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
@@ -38,7 +39,7 @@ public class StringsJavadocOptionFileOptionTest {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         writerContextMock = context.mock(JavadocOptionFileWriterContext.class);
 
-        stringsOption = new StringsJavadocOptionFileOption(optionName, joinBy);
+        stringsOption = new StringsJavadocOptionFileOption(optionName, Lists.<String>newArrayList(), joinBy);
     }
 
     @Test


### PR DESCRIPTION
Previously the type of Javadoc’s options property was MinimalJavadocOptions, which declared a few nested properties. However, the real value was a StandardJavadocDocletOptions, which contains several other properties that are not declared as inputs. Now these are taken into account as well.

This commit also stops the Javadoc task from modifying its inputs during execution.

Any of the checked boxes below indicate that I took action:

- [ ] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [ ] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [ ] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [ ] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [ ] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
