### PR TITLE
Rework ImmutableAttributes API

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultArtifactTransformTargets.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultArtifactTransformTargets.java
@@ -20,16 +20,22 @@ import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.transform.ArtifactTransformTargets;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.DefaultAttributeContainer;
+import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 
 import java.util.List;
 
 public class DefaultArtifactTransformTargets implements ArtifactTransformTargets {
+    private final ImmutableAttributesFactory cache;
 
     private List<AttributeContainerInternal> newTargets;
 
+    public DefaultArtifactTransformTargets(ImmutableAttributesFactory cache) {
+        this.cache = cache;
+    }
+
     public AttributeContainer newTarget() {
-        AttributeContainerInternal to = new DefaultAttributeContainer();
+        AttributeContainerInternal to = new DefaultMutableAttributeContainer(cache);
         if (newTargets == null) {
             newTargets = Lists.newArrayList();
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeContainerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeContainerInternal.java
@@ -16,62 +16,9 @@
 
 package org.gradle.api.internal.attributes;
 
-import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 
-import java.util.Collections;
-import java.util.Set;
-
 public interface AttributeContainerInternal extends AttributeContainer {
-    /**
-     * An immutable empty configuration attributes map.
-     */
-    AttributeContainerInternal EMPTY = new AttributeContainerInternal() {
-        @Override
-        public String toString() {
-            return "{}";
-        }
-
-        @Override
-        public Set<Attribute<?>> keySet() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public <T> AttributeContainer attribute(Attribute<T> key, T value) {
-            throw new UnsupportedOperationException("Mutation of attributes is not allowed");
-        }
-
-        @Override
-        public <T> T getAttribute(Attribute<T> key) {
-            return null;
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return true;
-        }
-
-        @Override
-        public boolean contains(Attribute<?> key) {
-            return false;
-        }
-
-        @Override
-        public AttributeContainerInternal asImmutable() {
-            return this;
-        }
-
-        @Override
-        public AttributeContainerInternal copy() {
-            return new DefaultAttributeContainer();
-        }
-
-        @Override
-        public AttributeContainer getAttributes() {
-            return this;
-        }
-    };
 
     /**
      * Returns an immutable copy of this attribute set. Implementations are not required to return a distinct instance for each call.
@@ -79,7 +26,7 @@ public interface AttributeContainerInternal extends AttributeContainer {
      *
      * @return an immutable view of this container.
      */
-    AttributeContainerInternal asImmutable();
+    ImmutableAttributes asImmutable();
 
     /**
      * Returns a mutable copy of this attribute set.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributeContainer.java
@@ -114,33 +114,41 @@ public class DefaultAttributeContainer implements AttributeContainerInternal {
         return attributes != null && attributes.containsKey(key) || parent != null && parent.contains(key);
     }
 
-    public AttributeContainerInternal asImmutable() {
+    public ImmutableAttributes asImmutable() {
         if (isEmpty()) {
-            return EMPTY;
+            return ImmutableAttributes.EMPTY;
         }
         if (parent == null) {
             return ImmutableAttributes.of(attributes);
+        } else {
+            if (attributes == null) {
+                return parent.asImmutable();
+            }
+            return ImmutableAttributes.concat(parent, ImmutableAttributes.of(attributes));
         }
-        return copy().asImmutable();
     }
 
     public AttributeContainerInternal copy() {
         if (isEmpty()) {
             return new DefaultAttributeContainer();
         }
-        AttributeContainerInternal copy;
-        if (parent != null) {
-            copy = parent.copy();
+        DefaultAttributeContainer copy;
+        if (parent!=null) {
+            copy = new DefaultAttributeContainer(parent.copy());
         } else {
             copy = new DefaultAttributeContainer();
         }
         if (attributes != null) {
-            for (Map.Entry<Attribute<?>, Object> entry : attributes.entrySet()) {
-                Attribute<Object> attribute = Cast.uncheckedCast(entry.getKey());
-                copy.attribute(attribute, entry.getValue());
-            }
+            putAllAttributes(attributes, copy);
         }
         return copy;
+    }
+
+    protected void putAllAttributes(Map<Attribute<?>, Object> attributes, AttributeContainerInternal copy) {
+        for (Map.Entry<Attribute<?>, Object> entry : attributes.entrySet()) {
+            Attribute<Object> attribute = Cast.uncheckedCast(entry.getKey());
+            copy.attribute(attribute, entry.getValue());
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.attributes;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.gradle.api.attributes.Attribute;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultImmutableAttributesFactory implements ImmutableAttributesFactory {
+    private final ImmutableAttributes root;
+    private final Map<ImmutableAttributes, List<ImmutableAttributes>> children;
+
+    public DefaultImmutableAttributesFactory() {
+        this.root = new ImmutableAttributes(this);
+        this.children = Maps.newHashMap();
+        children.put(root, new ArrayList<ImmutableAttributes>());
+    }
+
+    public int size() {
+        return children.size();
+    }
+
+    @Override
+    public Builder builder() {
+        return root.builder;
+    }
+
+    @Override
+    public Builder builder(ImmutableAttributes from) {
+        return from.builder != null ? from.builder : new Builder(from);
+    }
+
+    @Override
+    public ImmutableAttributes of(Attribute<?> key, Object value) {
+        return concat(root, key, value);
+    }
+
+    @Override
+    public ImmutableAttributes fromPolymorphicMap(Map<?, ?> attributes) {
+        if (attributes.isEmpty()) {
+            return root;
+        }
+        Builder builder = builder(root);
+        for (Map.Entry<?, ?> entry : attributes.entrySet()) {
+            builder = builder.addAny(entry.getKey(), entry.getValue());
+        }
+        return builder.get();
+    }
+
+    @Override
+    public ImmutableAttributes concat(ImmutableAttributes node, Attribute<?> key, Object value) {
+        List<ImmutableAttributes> nodeChildren = children.get(node);
+        if (nodeChildren == null) {
+            nodeChildren = Lists.newArrayList();
+            children.put(node, nodeChildren);
+        }
+        for (ImmutableAttributes child : nodeChildren) {
+            if (child.attribute.equals(key) && child.value.equals(value)) {
+                return child;
+            }
+        }
+        ImmutableAttributes child = new ImmutableAttributes(node, key, value, this);
+        nodeChildren.add(child);
+        return child;
+    }
+
+    public ImmutableAttributes getRoot() {
+        return root;
+    }
+
+    @Override
+    public ImmutableAttributes concat(ImmutableAttributes attributes, ImmutableAttributes state) {
+        Builder builder = new Builder(attributes);
+        for (Attribute<?> attribute : state.keySet()) {
+            builder = builder.addAttribute(attribute, state.getAttribute(attribute));
+        }
+        return builder.get();
+    }
+
+    public class Builder {
+        private final ImmutableAttributes node;
+
+        public Builder(ImmutableAttributes from) {
+            node = from;
+        }
+
+        public Builder addAttribute(Attribute<?> attribute, Object value) {
+            ImmutableAttributes cur = node;
+            if (!cur.contains(attribute)) {
+                cur = concat(cur, attribute, value);
+            }
+            return cur.builder;
+        }
+
+        public Builder addAny(Object key, Object value) {
+            return addAttribute(asAttribute(key), value);
+        }
+
+        public ImmutableAttributes get() {
+            return node;
+        }
+
+        private Attribute<?> asAttribute(Object rawKey) {
+            if (rawKey instanceof Attribute) {
+                return (Attribute<?>) rawKey;
+            }
+            return Attribute.of(rawKey.toString(), String.class);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.attributes;
+
+import org.gradle.api.attributes.Attribute;
+
+import java.util.Map;
+
+public interface ImmutableAttributesFactory {
+    DefaultImmutableAttributesFactory.Builder builder();
+
+    DefaultImmutableAttributesFactory.Builder builder(ImmutableAttributes from);
+
+    ImmutableAttributes of(Attribute<?> key, Object value);
+
+    ImmutableAttributes fromPolymorphicMap(Map<?, ?> attributes);
+
+    ImmutableAttributes concat(ImmutableAttributes node, Attribute<?> key, Object value);
+
+    ImmutableAttributes concat(ImmutableAttributes attributes, ImmutableAttributes state);
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -122,7 +122,7 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion);
     }
 
-    ImmutableAttributesFactory createAttributesCache() {
+    ImmutableAttributesFactory createImmutableAttributesFactory() {
         return new DefaultImmutableAttributesFactory();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -21,6 +21,8 @@ import org.gradle.api.Action;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.DefaultClassPathProvider;
 import org.gradle.api.internal.DefaultClassPathRegistry;
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.cache.DefaultGeneratedGradleJarCache;
 import org.gradle.api.internal.cache.GeneratedGradleJarCache;
 import org.gradle.api.internal.classpath.ModuleRegistry;
@@ -118,5 +120,9 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
     GeneratedGradleJarCache createGeneratedGradleJarCache(CacheRepository cacheRepository) {
         String gradleVersion = GradleVersion.current().getVersion();
         return new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion);
+    }
+
+    ImmutableAttributesFactory createAttributesCache() {
+        return new DefaultImmutableAttributesFactory();
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributeContainerTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.HasAttributes
 import spock.lang.Specification
 
-import static org.gradle.api.internal.attributes.AttributeContainerInternal.EMPTY
+import static org.gradle.api.internal.attributes.ImmutableAttributes.EMPTY
 
 class DefaultAttributeContainerTest extends Specification {
     def "can query contents of container"() {
@@ -74,49 +74,21 @@ class DefaultAttributeContainerTest extends Specification {
         copy.getAttribute(Attribute.of("a2", String)) == "2"
     }
 
-    def "A copy of an immutable attribute container is mutable and contains the same attributes and the same values as the original"() {
-        given:
-        AttributeContainerInternal container = new DefaultAttributeContainer()
-        container.attribute(Attribute.of("a1", Integer), 1)
-        container.attribute(Attribute.of("a2", String), "2")
-        container = container.asImmutable()
-
-        when:
-        AttributeContainerInternal copy = container.copy()
-        copy.attribute(Attribute.of("a3", String), "3")
-
-        then:
-        copy.keySet().size() == 3
-        copy.getAttribute(Attribute.of("a1", Integer)) == 1
-        copy.getAttribute(Attribute.of("a2", String)) == "2"
-        copy.getAttribute(Attribute.of("a3", String)) == "3"
-    }
-
     def "changes to attribute container are not seen by immutable copy"() {
         given:
         AttributeContainerInternal container = new DefaultAttributeContainer()
         container.attribute(Attribute.of("a1", Integer), 1)
         container.attribute(Attribute.of("a2", String), "2")
-        def copy = container.asImmutable()
+        def immutable = container.asImmutable()
 
         when:
         container.attribute(Attribute.of("a1", Integer), 2)
         container.attribute(Attribute.of("a3", String), "3")
 
         then:
-        copy.keySet().size() == 2
-        copy.getAttribute(Attribute.of("a1", Integer)) == 1
-        copy.getAttribute(Attribute.of("a2", String)) == "2"
-    }
-
-    def "A copy of an empty attribute container is a modifiable container which is empty"() {
-        when:
-        def copy = EMPTY.copy()
-        copy.attribute(Attribute.of("a1", Integer), 1)
-
-        then:
-        copy.keySet().size() == 1
-        copy.getAttribute(Attribute.of("a1", Integer)) == 1
+        immutable.keySet().size() == 2
+        immutable.getAttribute(Attribute.of("a1", Integer)) == 1
+        immutable.getAttribute(Attribute.of("a2", String)) == "2"
     }
 
     def "immutable copy of empty attribute container is EMPTY"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
@@ -24,6 +24,7 @@ import spock.lang.Specification
 
 class DefaultAttributesSchemaTest extends Specification {
     def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher())
+    def factory = new DefaultImmutableAttributesFactory()
 
     def "fails if no strategy is declared for custom type"() {
         when:
@@ -168,9 +169,9 @@ class DefaultAttributesSchemaTest extends Specification {
         def a1 = Attribute.of("a1", String)
         def a2 = Attribute.of("a2", Integer)
         def candidates = [
-            new DefaultAttributeContainer().attribute(a1, "A").attribute(a2, 1),
-            new DefaultAttributeContainer().attribute(a1, "B").attribute(a2, 1)]
-        def consumer = new DefaultAttributeContainer().attribute(a1, "A").attribute(a2, 1)
+            new DefaultMutableAttributeContainer(factory).attribute(a1, "A").attribute(a2, 1),
+            new DefaultMutableAttributeContainer(factory).attribute(a1, "B").attribute(a2, 1)]
+        def consumer = new DefaultMutableAttributeContainer(factory).attribute(a1, "A").attribute(a2, 1)
 
         when:
         schema.getMatches(schema, candidates, consumer)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes
+
+import org.gradle.api.attributes.Attribute
+import spock.lang.Specification
+
+class DefaultImmutableAttributesFactoryTest extends Specification {
+    private static final Attribute<String> FOO = Attribute.of("foo", String)
+    private static final Attribute<String> BAR = Attribute.of("bar", String)
+    private static final Attribute<String> BAZ = Attribute.of("baz", String)
+
+    ImmutableAttributesFactory factory = new DefaultImmutableAttributesFactory()
+
+    def "can create empty attributes"() {
+        when:
+        def attributes = factory.builder().get()
+
+        then:
+        attributes.empty
+    }
+
+    def "can create immutable attributes"() {
+        when:
+        def attributes = factory.builder()
+            .addAttribute(FOO, "foo")
+            .get()
+
+        then:
+        attributes.keySet() == [FOO] as Set
+
+        and:
+        attributes.getAttribute(FOO) == 'foo'
+    }
+
+    def "can concatenate immutable attributes sets"() {
+        when:
+        def set1 = factory.builder()
+            .addAttribute(FOO, "foo")
+            .get()
+        def set2 = factory.builder()
+            .addAttribute(BAR, "bar")
+            .get()
+        def union = factory.concat(set1, set2)
+
+        then:
+        union.keySet() == [FOO, BAR] as Set
+
+        and:
+        union.getAttribute(FOO) == 'foo'
+        union.getAttribute(BAR) == 'bar'
+    }
+
+    def "can concatenate an immutable attribute set with a new value"() {
+        when:
+        def set1 = factory.builder()
+            .addAttribute(FOO, "foo")
+            .get()
+        def set2 = factory.concat(set1, BAR, "bar")
+        def union = factory.concat(set1, set2)
+
+        then:
+        union.keySet() == [FOO, BAR] as Set
+
+        and:
+        union.getAttribute(FOO) == 'foo'
+        union.getAttribute(BAR) == 'bar'
+    }
+
+    def "can create a single entry immutable set"() {
+        when:
+        def attributes = factory.of(FOO, "foo")
+
+        then:
+        attributes.keySet() == [FOO] as Set
+
+        and:
+        attributes.getAttribute(FOO) == 'foo'
+    }
+
+    def "can create an immutable set from a polymorphic key map"() {
+        when:
+        def attributes = factory.fromPolymorphicMap(
+            foo: 'foo', // stringy key
+            (BAR): 'bar' // attribute key
+        )
+
+        then:
+        attributes.keySet() == [FOO, BAR] as Set
+
+        and:
+        attributes.getAttribute(FOO) == 'foo'
+        attributes.getAttribute(BAR) == 'bar'
+    }
+
+    def "can start a build chain from another set"() {
+        given:
+        def attributes = factory.of(FOO, 'foo')
+
+        when:
+        def set = factory.builder(attributes)
+            .addAttribute(BAR, 'bar')
+            .addAttribute(BAZ, 'baz')
+            .get()
+
+        then:
+        set.keySet() == [FOO, BAR, BAZ] as Set
+        set.getAttribute(FOO) == 'foo'
+        set.getAttribute(BAR) == 'bar'
+        set.getAttribute(BAZ) == 'baz'
+
+    }
+
+    def "order of entries is not significant in equality"() {
+        when:
+        def set1 = factory.builder()
+            .addAttribute(FOO, "foo")
+            .addAttribute(BAR, "bar")
+            .get()
+        def set2 = factory.builder()
+            .addAttribute(BAR, "bar")
+            .addAttribute(FOO, "foo")
+            .get()
+
+        then:
+        set1 == set2
+    }
+
+    def "can compare attribute sets created by two different factories"() {
+        given:
+        def otherFactory = new DefaultImmutableAttributesFactory()
+
+        when:
+        def set1 = factory.builder()
+            .addAttribute(FOO, "foo")
+            .addAttribute(BAR, "bar")
+            .get()
+        def set2 = otherFactory.builder()
+            .addAttribute(BAR, "bar")
+            .addAttribute(FOO, "foo")
+            .get()
+
+        then:
+        set1 == set2
+    }
+
+    def "can start a build chain from another set created with a different factory"() {
+        given:
+        def otherFactory = new DefaultImmutableAttributesFactory()
+        def attributes = otherFactory.of(FOO, 'foo')
+
+        when:
+        def set = factory.builder(attributes)
+            .addAttribute(BAR, 'bar')
+            .addAttribute(BAZ, 'baz')
+            .get()
+
+        then:
+        set.keySet() == [FOO, BAR, BAZ] as Set
+        set.getAttribute(FOO) == 'foo'
+        set.getAttribute(BAR) == 'bar'
+        set.getAttribute(BAZ) == 'baz'
+
+    }
+
+    def "can concatenate immutable attributes sets from different factories"() {
+        given:
+        def otherFactory = new DefaultImmutableAttributesFactory()
+        def yetAnotherFactory = new DefaultImmutableAttributesFactory()
+
+        when:
+        def set1 = factory.builder()
+            .addAttribute(FOO, "foo")
+            .get()
+        def set2 = otherFactory.builder()
+            .addAttribute(BAR, "bar")
+            .get()
+        def union = factory.concat(set1, set2)
+
+        then:
+        union.keySet() == [FOO, BAR] as Set
+
+        and:
+        union.getAttribute(FOO) == 'foo'
+        union.getAttribute(BAR) == 'bar'
+
+        and:
+        union == yetAnotherFactory.fromPolymorphicMap(
+            'foo': 'foo',
+            'bar': 'bar'
+        )
+    }
+
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -61,6 +61,7 @@ import org.gradle.api.internal.artifacts.transform.ArtifactAttributeMatchingCach
 import org.gradle.api.internal.artifacts.transform.DefaultArtifactTransformRegistrations;
 import org.gradle.api.internal.artifacts.transform.DefaultArtifactTransforms;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
@@ -105,8 +106,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultAttributesSchema.class, new ComponentAttributeMatcher());
         }
 
-        ArtifactTransformRegistrations createArtifactTransformRegistrations(Instantiator instantiator) {
-            return instantiator.newInstance(DefaultArtifactTransformRegistrations.class);
+        ArtifactTransformRegistrations createArtifactTransformRegistrations(Instantiator instantiator, ImmutableAttributesFactory attributesFactory) {
+            return instantiator.newInstance(DefaultArtifactTransformRegistrations.class, attributesFactory);
         }
 
         BaseRepositoryFactory createBaseRepositoryFactory(LocalMavenRepositoryLocator localMavenRepositoryLocator, Instantiator instantiator, FileResolver fileResolver,
@@ -135,7 +136,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         ConfigurationContainerInternal createConfigurationContainer(Instantiator instantiator, ConfigurationResolver configurationResolver, DomainObjectContext domainObjectContext,
                                                                     ListenerManager listenerManager, DependencyMetaDataProvider metaDataProvider, ProjectAccessListener projectAccessListener,
                                                                     ProjectFinder projectFinder, ConfigurationComponentMetaDataBuilder metaDataBuilder, FileCollectionFactory fileCollectionFactory,
-                                                                    GlobalDependencyResolutionRules globalDependencyResolutionRules, ComponentIdentifierFactory componentIdentifierFactory, BuildOperationExecutor buildOperationExecutor) {
+                                                                    GlobalDependencyResolutionRules globalDependencyResolutionRules, ComponentIdentifierFactory componentIdentifierFactory,
+                                                                    BuildOperationExecutor buildOperationExecutor, ImmutableAttributesFactory attributesFactory) {
             return instantiator.newInstance(DefaultConfigurationContainer.class,
                     configurationResolver,
                     instantiator,
@@ -148,7 +150,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                     fileCollectionFactory,
                     globalDependencyResolutionRules.getDependencySubstitutionRules(),
                     componentIdentifierFactory,
-                    buildOperationExecutor
+                    buildOperationExecutor,
+                    attributesFactory
                 );
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedArtifact.java
@@ -24,6 +24,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.attributes.DefaultArtifactAttributes;
 import org.gradle.api.internal.artifacts.ivyservice.dynamicversions.DefaultResolvedModuleVersion;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -39,21 +40,21 @@ public class DefaultResolvedArtifact implements ResolvedArtifact, Buildable {
     private Factory<File> artifactSource;
     private File file;
 
-    public DefaultResolvedArtifact(ModuleVersionIdentifier owner, IvyArtifactName artifact, ComponentArtifactIdentifier artifactId, TaskDependency buildDependencies, Factory<File> artifactSource, AttributeContainerInternal parentAttributes) {
+    public DefaultResolvedArtifact(ModuleVersionIdentifier owner, IvyArtifactName artifact, ComponentArtifactIdentifier artifactId, TaskDependency buildDependencies, Factory<File> artifactSource, AttributeContainerInternal parentAttributes, ImmutableAttributesFactory attributesFactory) {
         this.owner = owner;
         this.artifact = artifact;
         this.artifactId = artifactId;
         this.buildDependencies = buildDependencies;
         this.artifactSource = artifactSource;
-        this.attributes = DefaultArtifactAttributes.forIvyArtifactName(artifact, parentAttributes);
+        this.attributes = DefaultArtifactAttributes.forIvyArtifactName(artifact, parentAttributes, attributesFactory);
     }
 
-    public DefaultResolvedArtifact(ModuleVersionIdentifier owner, IvyArtifactName artifact, ComponentArtifactIdentifier artifactId, TaskDependency buildDependencies, File artifactFile, AttributeContainerInternal parentAttributes) {
+    public DefaultResolvedArtifact(ModuleVersionIdentifier owner, IvyArtifactName artifact, ComponentArtifactIdentifier artifactId, TaskDependency buildDependencies, File artifactFile, AttributeContainerInternal parentAttributes, ImmutableAttributesFactory attributesFactory) {
         this.owner = owner;
         this.artifact = artifact;
         this.artifactId = artifactId;
         this.buildDependencies = buildDependencies;
-        this.attributes = DefaultArtifactAttributes.forIvyArtifactName(artifact, parentAttributes);
+        this.attributes = DefaultArtifactAttributes.forIvyArtifactName(artifact, parentAttributes, attributesFactory);
         this.file = artifactFile;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -62,6 +62,7 @@ import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenSettingsProvide
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
 import org.gradle.api.internal.artifacts.mvnsettings.MavenSettingsProvider;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.cache.GeneratedGradleJarCache;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.TemporaryFileProvider;
@@ -250,13 +251,15 @@ class DependencyManagementBuildScopeServices {
                                                                 DependencyDescriptorFactory dependencyDescriptorFactory,
                                                                 CacheLockingManager cacheLockingManager,
                                                                 VersionComparator versionComparator,
-                                                                ServiceRegistry serviceRegistry) {
+                                                                ServiceRegistry serviceRegistry,
+                                                                ImmutableAttributesFactory cache) {
         ArtifactDependencyResolver resolver = new DefaultArtifactDependencyResolver(
             serviceRegistry,
             resolveIvyFactory,
             dependencyDescriptorFactory,
             cacheLockingManager,
-            versionComparator
+            versionComparator,
+            cache
         );
         return new CacheLockingArtifactDependencyResolver(cacheLockingManager, resolver);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/attributes/DefaultArtifactAttributes.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/attributes/DefaultArtifactAttributes.java
@@ -16,12 +16,11 @@
 
 package org.gradle.api.internal.artifacts.attributes;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
-import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.io.File;
@@ -30,21 +29,19 @@ import static org.gradle.api.internal.artifacts.ArtifactAttributes.*;
 
 public class DefaultArtifactAttributes {
 
-    public static AttributeContainer forIvyArtifactName(IvyArtifactName ivyArtifactName, AttributeContainerInternal parentAttributes) {
-        return createAttributes(ivyArtifactName.getType(), ivyArtifactName.getExtension(), ivyArtifactName.getClassifier(), parentAttributes);
+    public static AttributeContainer forIvyArtifactName(IvyArtifactName ivyArtifactName, AttributeContainerInternal parentAttributes, ImmutableAttributesFactory attributesFactory) {
+        return createAttributes(ivyArtifactName.getType(), ivyArtifactName.getExtension(), ivyArtifactName.getClassifier(), parentAttributes, attributesFactory);
     }
 
-    public static AttributeContainer forFile(File file) {
+    public static AttributeContainer forFile(File file, ImmutableAttributesFactory attributesFactory) {
         String extension = Files.getFileExtension(file.getName());
-        return createAttributes(extension, extension, "", ImmutableAttributes.EMPTY);
+        return createAttributes(extension, extension, "", ImmutableAttributes.EMPTY, attributesFactory);
     }
 
-    private static AttributeContainer createAttributes(String type, String extension, String classifier, AttributeContainerInternal parentAttributes) {
-        return ImmutableAttributes.concat(parentAttributes, ImmutableAttributes.of(
-            ImmutableMap.<Attribute<?>, Object>of(
-                ARTIFACT_FORMAT, type == null ? "" : type,
-                ARTIFACT_EXTENSION, extension == null ? "" : extension,
-                ARTIFACT_CLASSIFIER, classifier == null ? "" : classifier)
-        ));
+    private static AttributeContainer createAttributes(String type, String extension, String classifier, AttributeContainerInternal parentAttributes, ImmutableAttributesFactory attributesFactory) {
+        return attributesFactory.builder(parentAttributes.asImmutable())
+            .addAttribute(ARTIFACT_FORMAT, type == null ? "" : type)
+            .addAttribute(ARTIFACT_EXTENSION, extension == null ? "" : extension)
+            .addAttribute(ARTIFACT_CLASSIFIER, classifier == null ? "" : classifier).get();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/attributes/DefaultArtifactAttributes.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/attributes/DefaultArtifactAttributes.java
@@ -16,17 +16,17 @@
 
 package org.gradle.api.internal.artifacts.attributes;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.DefaultAttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.io.File;
 
-import static org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT;
-import static org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_EXTENSION;
-import static org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_CLASSIFIER;
+import static org.gradle.api.internal.artifacts.ArtifactAttributes.*;
 
 public class DefaultArtifactAttributes {
 
@@ -36,14 +36,15 @@ public class DefaultArtifactAttributes {
 
     public static AttributeContainer forFile(File file) {
         String extension = Files.getFileExtension(file.getName());
-        return createAttributes(extension, extension, "", AttributeContainerInternal.EMPTY);
+        return createAttributes(extension, extension, "", ImmutableAttributes.EMPTY);
     }
 
     private static AttributeContainer createAttributes(String type, String extension, String classifier, AttributeContainerInternal parentAttributes) {
-        AttributeContainerInternal attributes = new DefaultAttributeContainer(parentAttributes);
-        attributes.attribute(ARTIFACT_FORMAT, type == null ? "" : type);
-        attributes.attribute(ARTIFACT_EXTENSION, extension == null ? "" : extension);
-        attributes.attribute(ARTIFACT_CLASSIFIER, classifier == null ? "" : classifier);
-        return attributes.asImmutable();
+        return ImmutableAttributes.concat(parentAttributes, ImmutableAttributes.of(
+            ImmutableMap.<Attribute<?>, Object>of(
+                ARTIFACT_FORMAT, type == null ? "" : type,
+                ARTIFACT_EXTENSION, extension == null ? "" : extension,
+                ARTIFACT_CLASSIFIER, classifier == null ? "" : classifier)
+        ));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.configurations;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 
 public interface ConfigurationInternal extends ResolveContext, Configuration, DependencyMetaDataProvider {
     enum InternalState {UNRESOLVED, GRAPH_RESOLVED, ARTIFACTS_RESOLVED}
@@ -43,8 +44,7 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
      */
     OutgoingVariant convertToOutgoingVariant();
 
-    /**
-     * Make the attributes effectively immutable.
-     */
+    ImmutableAttributesFactory getAttributesCache();
+
     void lockAttributes();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -42,4 +42,9 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
      * Converts this configuration to an {@link OutgoingVariant} view. The view may not necessarily be immutable.
      */
     OutgoingVariant convertToOutgoingVariant();
+
+    /**
+     * Make the attributes effectively immutable.
+     */
+    void lockAttributes();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.ConfigurationComponentMetaDataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.event.ListenerManager;
@@ -57,6 +58,7 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
     private final ComponentIdentifierFactory componentIdentifierFactory;
     private final BuildOperationExecutor buildOperationExecutor;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
+    private final ImmutableAttributesFactory attributesFactory;
 
     private int detachedConfigurationDefaultNameCounter = 1;
 
@@ -65,7 +67,8 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
                                          DependencyMetaDataProvider dependencyMetaDataProvider, ProjectAccessListener projectAccessListener,
                                          ProjectFinder projectFinder, ConfigurationComponentMetaDataBuilder configurationComponentMetaDataBuilder,
                                          FileCollectionFactory fileCollectionFactory, DependencySubstitutionRules globalDependencySubstitutionRules,
-                                         ComponentIdentifierFactory componentIdentifierFactory, BuildOperationExecutor buildOperationExecutor) {
+                                         ComponentIdentifierFactory componentIdentifierFactory, BuildOperationExecutor buildOperationExecutor,
+                                         ImmutableAttributesFactory attributesFactory) {
         super(Configuration.class, instantiator, new Configuration.Namer());
         this.resolver = resolver;
         this.instantiator = instantiator;
@@ -80,6 +83,7 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         this.componentIdentifierFactory = componentIdentifierFactory;
         this.buildOperationExecutor = buildOperationExecutor;
         this.artifactNotationParser = new PublishArtifactNotationParserFactory(instantiator, dependencyMetaDataProvider).create();
+        this.attributesFactory = attributesFactory;
     }
 
     @Override
@@ -87,7 +91,7 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         DefaultResolutionStrategy resolutionStrategy = instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, componentIdentifierFactory);
         return instantiator.newInstance(DefaultConfiguration.class, context.identityPath(name), context.projectPath(name), name, this, resolver,
                 listenerManager, dependencyMetaDataProvider, resolutionStrategy, projectAccessListener, projectFinder,
-                configurationComponentMetaDataBuilder, fileCollectionFactory, componentIdentifierFactory, buildOperationExecutor, instantiator, artifactNotationParser);
+                configurationComponentMetaDataBuilder, fileCollectionFactory, componentIdentifierFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory);
     }
 
     public Set<? extends ConfigurationInternal> getAll() {
@@ -115,7 +119,7 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         DefaultConfiguration detachedConfiguration = instantiator.newInstance(DefaultConfiguration.class,
                 context.identityPath(name), context.projectPath(name), name, detachedConfigurationsProvider, resolver,
                 listenerManager, dependencyMetaDataProvider, new DefaultResolutionStrategy(globalDependencySubstitutionRules, componentIdentifierFactory), projectAccessListener, projectFinder,
-                configurationComponentMetaDataBuilder, fileCollectionFactory, componentIdentifierFactory, buildOperationExecutor, instantiator, artifactNotationParser);
+                configurationComponentMetaDataBuilder, fileCollectionFactory, componentIdentifierFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory);
         DomainObjectSet<Dependency> detachedDependencies = detachedConfiguration.getDependencies();
         for (Dependency dependency : dependencies) {
             detachedDependencies.add(dependency.copy());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
@@ -40,14 +41,16 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
     private final Instantiator instantiator;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
     private final FileCollectionFactory fileCollectionFactory;
+    private final ImmutableAttributesFactory attributesFactory;
     private FactoryNamedDomainObjectContainer<ConfigurationVariant> variants;
 
-    public DefaultConfigurationPublications(PublishArtifactSet artifacts, final AttributeContainerInternal parentAttributes, final Instantiator instantiator, final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser, final FileCollectionFactory fileCollectionFactory) {
+    public DefaultConfigurationPublications(PublishArtifactSet artifacts, final AttributeContainerInternal parentAttributes, final Instantiator instantiator, final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser, final FileCollectionFactory fileCollectionFactory, ImmutableAttributesFactory attributesFactory) {
         this.artifacts = artifacts;
         this.parentAttributes = parentAttributes;
         this.instantiator = instantiator;
         this.artifactNotationParser = artifactNotationParser;
         this.fileCollectionFactory = fileCollectionFactory;
+        this.attributesFactory = attributesFactory;
     }
 
     public OutgoingVariant convertToOutgoingVariant() {
@@ -100,7 +103,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
             variants = new FactoryNamedDomainObjectContainer<ConfigurationVariant>(ConfigurationVariant.class, instantiator, new NamedDomainObjectFactory<ConfigurationVariant>() {
                 @Override
                 public ConfigurationVariant create(String name) {
-                    return instantiator.newInstance(DefaultVariant.class, name, parentAttributes, artifactNotationParser, fileCollectionFactory);
+                    return instantiator.newInstance(DefaultVariant.class, name, parentAttributes, artifactNotationParser, fileCollectionFactory, attributesFactory);
                 }
             });
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -26,7 +26,8 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.DefaultAttributeContainer;
+import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -39,9 +40,13 @@ public class DefaultVariant implements ConfigurationVariant {
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
     private final PublishArtifactSet artifacts;
 
-    public DefaultVariant(String name, AttributeContainerInternal parentAttributes, NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser, FileCollectionFactory fileCollectionFactory) {
+    public DefaultVariant(String name,
+                          AttributeContainerInternal parentAttributes,
+                          NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
+                          FileCollectionFactory fileCollectionFactory,
+                          ImmutableAttributesFactory cache) {
         this.name = name;
-        attributes = new DefaultAttributeContainer(parentAttributes);
+        attributes = new DefaultMutableAttributeContainer(cache, parentAttributes);
         this.artifactNotationParser = artifactNotationParser;
         artifacts = new DefaultPublishArtifactSet(name + " artifacts", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact.class), fileCollectionFactory);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -277,7 +277,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
      * @param dependencySpec dependency spec
      */
     private void visitArtifacts(Spec<? super Dependency> dependencySpec, AttributeContainerInternal requestedAttributes, SelectedArtifactResults artifactResults, SelectedFileDependencyResults fileDependencyResults, ArtifactVisitor visitor) {
-        ArtifactVisitor transformingVisitor = artifactTransforms.visitor(visitor, requestedAttributes);
+        ArtifactVisitor transformingVisitor = artifactTransforms.visitor(visitor, requestedAttributes, configuration.getAttributesCache());
 
         //this is not very nice might be good enough until we get rid of ResolvedConfiguration and friends
         //avoid traversing the graph causing the full ResolvedDependency graph to be loaded for the most typical scenario

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 
@@ -58,7 +59,7 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
 
     public Set<File> getFiles(final Spec<? super Dependency> dependencySpec) throws ResolveException {
         rethrowFailure();
-        return configuration.select(dependencySpec, AttributeContainerInternal.EMPTY, Specs.<ComponentIdentifier>satisfyAll()).collectFiles(new LinkedHashSet<File>());
+        return configuration.select(dependencySpec, ImmutableAttributes.EMPTY, Specs.<ComponentIdentifier>satisfyAll()).collectFiles(new LinkedHashSet<File>());
     }
 
     public Set<ResolvedDependency> getFirstLevelModuleDependencies() throws ResolveException {
@@ -74,7 +75,7 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
     public Set<ResolvedArtifact> getResolvedArtifacts() throws ResolveException {
         rethrowFailure();
         ArtifactCollectingVisitor visitor = new ArtifactCollectingVisitor();
-        configuration.select(Specs.<Dependency>satisfyAll(), AttributeContainerInternal.EMPTY, Specs.<ComponentIdentifier>satisfyAll()).visitArtifacts(visitor);
+        configuration.select(Specs.<Dependency>satisfyAll(), ImmutableAttributes.EMPTY, Specs.<ComponentIdentifier>satisfyAll()).visitArtifacts(visitor);
         return visitor.artifacts;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationComponentMetaDataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationComponentMetaDataBuilder.java
@@ -33,6 +33,7 @@ public class DefaultConfigurationComponentMetaDataBuilder implements Configurati
 
     public void addConfigurations(BuildableLocalComponentMetadata metaData, Collection<? extends ConfigurationInternal> configurations) {
         for (ConfigurationInternal configuration : configurations) {
+            configuration.lockAttributes();
             addConfiguration(metaData, configuration);
             dependenciesConverter.addDependencyDescriptors(metaData, configuration);
             OutgoingVariant outgoingVariant = configuration.convertToOutgoingVariant();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationComponentMetaDataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationComponentMetaDataBuilder.java
@@ -33,7 +33,6 @@ public class DefaultConfigurationComponentMetaDataBuilder implements Configurati
 
     public void addConfigurations(BuildableLocalComponentMetadata metaData, Collection<? extends ConfigurationInternal> configurations) {
         for (ConfigurationInternal configuration : configurations) {
-            configuration.lockAttributes();
             addConfiguration(metaData, configuration);
             dependenciesConverter.addDependencyDescriptors(metaData, configuration);
             OutgoingVariant outgoingVariant = configuration.convertToOutgoingVariant();
@@ -45,6 +44,7 @@ public class DefaultConfigurationComponentMetaDataBuilder implements Configurati
     }
 
     private void addConfiguration(BuildableLocalComponentMetadata metaData, ConfigurationInternal configuration) {
+        configuration.lockAttributes();
         Set<String> hierarchy = Configurations.getNames(configuration.getHierarchy());
         Set<String> extendsFrom = Configurations.getNames(configuration.getExtendsFrom());
         metaData.addConfiguration(configuration.getName(),
@@ -53,7 +53,7 @@ public class DefaultConfigurationComponentMetaDataBuilder implements Configurati
             hierarchy,
             configuration.isVisible(),
             configuration.isTransitive(),
-            configuration.getAttributes().asImmutable(),
+            configuration.getAttributes(),
             configuration.isCanBeConsumed(),
             configuration.isCanBeResolved());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependenciesToModuleDescriptorConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependenciesToModuleDescriptorConverter.java
@@ -45,7 +45,7 @@ public class DefaultDependenciesToModuleDescriptorConverter implements Dependenc
     }
 
     private void addDependencies(BuildableLocalComponentMetadata metaData, ConfigurationInternal configuration) {
-        AttributeContainerInternal attributes = configuration.getAttributes().asImmutable();
+        AttributeContainerInternal attributes = configuration.getAttributes();
         for (Dependency dependency : configuration.getDependencies()) {
             if (dependency instanceof ModuleDependency) {
                 ModuleDependency moduleDependency = (ModuleDependency) dependency;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -42,6 +42,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.ConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultConflictHandler;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -62,14 +63,16 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     private final ResolveIvyFactory ivyFactory;
     private final CacheLockingManager cacheLockingManager;
     private final VersionComparator versionComparator;
+    private final ImmutableAttributesFactory attributesFactory;
 
     public DefaultArtifactDependencyResolver(ServiceRegistry serviceRegistry, ResolveIvyFactory ivyFactory, DependencyDescriptorFactory dependencyDescriptorFactory,
-                                             CacheLockingManager cacheLockingManager, VersionComparator versionComparator) {
+                                             CacheLockingManager cacheLockingManager, VersionComparator versionComparator, ImmutableAttributesFactory attributesFactory) {
         this.serviceRegistry = serviceRegistry;
         this.ivyFactory = ivyFactory;
         this.dependencyDescriptorFactory = dependencyDescriptorFactory;
         this.cacheLockingManager = cacheLockingManager;
         this.versionComparator = versionComparator;
+        this.attributesFactory = attributesFactory;
     }
 
     @Override
@@ -79,7 +82,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         DependencyGraphBuilder builder = createDependencyGraphBuilder(resolvers, resolveContext.getResolutionStrategy(), metadataHandler, edgeFilter, attributesSchema);
 
         ArtifactResolver artifactResolver = new ErrorHandlingArtifactResolver(new CacheLockingArtifactResolver(cacheLockingManager, resolvers.getArtifactResolver()));
-        DependencyGraphVisitor artifactsGraphVisitor = new ResolvedArtifactsGraphVisitor(artifactsVisitor, artifactResolver);
+        DependencyGraphVisitor artifactsGraphVisitor = new ResolvedArtifactsGraphVisitor(artifactsVisitor, artifactResolver, attributesFactory);
 
         // Resolve the dependency graph
         builder.resolve(resolveContext, new CompositeDependencyGraphVisitor(graphVisitor, artifactsGraphVisitor));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -21,12 +21,13 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.internal.artifacts.DefaultResolvedArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.DefaultAttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -36,6 +37,7 @@ import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -87,9 +89,8 @@ public class DefaultArtifactSet implements ArtifactSet {
             // Add artifact type as an implicit attribute when there is a single artifact
             AttributeContainerInternal attributes = variant.getAttributes();
             if (artifacts.size() == 1 && !attributes.contains(ArtifactAttributes.ARTIFACT_FORMAT)) {
-                DefaultAttributeContainer implicitAttributes = new DefaultAttributeContainer(attributes);
-                implicitAttributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, artifacts.iterator().next().getName().getType());
-                attributes = implicitAttributes.asImmutable();
+                Map<Attribute<?>, Object> implicitAttributes = Collections.<Attribute<?>, Object>singletonMap(ArtifactAttributes.ARTIFACT_FORMAT, artifacts.iterator().next().getName().getType());
+                attributes = ImmutableAttributes.concat(attributes, implicitAttributes);
             }
 
             for (ComponentArtifactMetadata artifact : artifacts) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
@@ -25,7 +25,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -90,7 +90,7 @@ public class ResolvedArtifactsGraphVisitor implements DependencyGraphVisitor {
 
         Set<? extends ComponentArtifactMetadata> artifacts = dependency.getArtifacts(configuration);
         if (!artifacts.isEmpty()) {
-            Set<DefaultVariantMetadata> variants = ImmutableSet.of(new DefaultVariantMetadata(AttributeContainerInternal.EMPTY, artifacts));
+            Set<DefaultVariantMetadata> variants = ImmutableSet.of(new DefaultVariantMetadata(ImmutableAttributes.EMPTY, artifacts));
             return new DefaultArtifactSet(component.getComponentId(), component.getId(), component.getSource(), ModuleExclusions.excludeNone(), variants, artifactResolver, allResolvedArtifacts, id);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -48,12 +49,13 @@ public class ResolvedArtifactsGraphVisitor implements DependencyGraphVisitor {
     private final Map<Long, ArtifactSet> artifactSetsByConfiguration = Maps.newHashMap();
     private final Map<ComponentArtifactIdentifier, ResolvedArtifact> allResolvedArtifacts = Maps.newHashMap();
     private final ArtifactResolver artifactResolver;
-
+    private final ImmutableAttributesFactory attributesFactory;
     private final DependencyArtifactsVisitor artifactResults;
 
-    public ResolvedArtifactsGraphVisitor(DependencyArtifactsVisitor artifactsBuilder, ArtifactResolver artifactResolver) {
+    public ResolvedArtifactsGraphVisitor(DependencyArtifactsVisitor artifactsBuilder, ArtifactResolver artifactResolver, ImmutableAttributesFactory attributesFactory) {
         this.artifactResults = artifactsBuilder;
         this.artifactResolver = artifactResolver;
+        this.attributesFactory = attributesFactory;
     }
 
     @Override
@@ -91,14 +93,14 @@ public class ResolvedArtifactsGraphVisitor implements DependencyGraphVisitor {
         Set<? extends ComponentArtifactMetadata> artifacts = dependency.getArtifacts(configuration);
         if (!artifacts.isEmpty()) {
             Set<DefaultVariantMetadata> variants = ImmutableSet.of(new DefaultVariantMetadata(ImmutableAttributes.EMPTY, artifacts));
-            return new DefaultArtifactSet(component.getComponentId(), component.getId(), component.getSource(), ModuleExclusions.excludeNone(), variants, artifactResolver, allResolvedArtifacts, id);
+            return new DefaultArtifactSet(component.getComponentId(), component.getId(), component.getSource(), ModuleExclusions.excludeNone(), variants, artifactResolver, allResolvedArtifacts, id, attributesFactory);
         }
 
         ArtifactSet configurationArtifactSet = artifactSetsByConfiguration.get(toConfiguration.getNodeId());
         if (configurationArtifactSet == null) {
             Set<? extends VariantMetadata> variants = doResolve(component, configuration);
 
-            configurationArtifactSet = new DefaultArtifactSet(component.getComponentId(), component.getId(), component.getSource(), dependency.getExclusions(), variants, artifactResolver, allResolvedArtifacts, id);
+            configurationArtifactSet = new DefaultArtifactSet(component.getComponentId(), component.getId(), component.getSource(), dependency.getExclusions(), variants, artifactResolver, allResolvedArtifacts, id, attributesFactory);
 
             // Only share an ArtifactSet if the artifacts are not filtered by the dependency
             if (!dependency.getExclusions().mayExcludeArtifacts()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransforms.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransforms.java
@@ -20,6 +20,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 
 import java.util.Collection;
 
@@ -27,5 +28,5 @@ public interface ArtifactTransforms {
 
     <T extends HasAttributes> Transformer<T, Collection<? extends T>> variantSelector(final AttributeContainerInternal attributes);
 
-    ArtifactVisitor visitor(ArtifactVisitor visitor, AttributeContainerInternal requestedAttributes);
+    ArtifactVisitor visitor(ArtifactVisitor visitor, AttributeContainerInternal requestedAttributes, ImmutableAttributesFactory attributesFactory);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformRegistrations.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformRegistrations.java
@@ -20,13 +20,19 @@ import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.DefaultAttributeContainer;
+import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.reflect.DirectInstantiator;
 
 import java.util.List;
 
 public class DefaultArtifactTransformRegistrations implements ArtifactTransformRegistrationsInternal {
     private final List<ArtifactTransformRegistration> transforms = Lists.newArrayList();
+    private final ImmutableAttributesFactory immutableAttributesFactory;
+
+    public DefaultArtifactTransformRegistrations(ImmutableAttributesFactory immutableAttributesFactory) {
+        this.immutableAttributesFactory = immutableAttributesFactory;
+    }
 
     public void registerTransform(Class<? extends ArtifactTransform> type, Action<? super ArtifactTransform> config) {
         for (ArtifactTransformRegistration transformRegistration : transforms) {
@@ -35,9 +41,9 @@ public class DefaultArtifactTransformRegistrations implements ArtifactTransformR
             }
         }
         ArtifactTransform artifactTransform = DirectInstantiator.INSTANCE.newInstance(type);
-        AttributeContainerInternal from = new DefaultAttributeContainer();
+        AttributeContainerInternal from = new DefaultMutableAttributeContainer(immutableAttributesFactory);
 
-        org.gradle.api.internal.artifacts.dsl.dependencies.DefaultArtifactTransformTargets registry = new org.gradle.api.internal.artifacts.dsl.dependencies.DefaultArtifactTransformTargets();
+        org.gradle.api.internal.artifacts.dsl.dependencies.DefaultArtifactTransformTargets registry = new org.gradle.api.internal.artifacts.dsl.dependencies.DefaultArtifactTransformTargets(immutableAttributesFactory);
         artifactTransform.configure(from, registry);
 
         for (AttributeContainerInternal to : registry.getNewTargets()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformTargets.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformTargets.java
@@ -17,19 +17,26 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.Lists;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.artifacts.transform.ArtifactTransformTargets;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.DefaultAttributeContainer;
+import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 
 import java.util.List;
 
 public class DefaultArtifactTransformTargets implements ArtifactTransformTargets {
 
+    private final ImmutableAttributesFactory cache;
+
     private List<AttributeContainerInternal> newTargets;
 
+    public DefaultArtifactTransformTargets(ImmutableAttributesFactory cache) {
+        this.cache = cache;
+    }
+
     public AttributeContainer newTarget() {
-        AttributeContainerInternal to = new DefaultAttributeContainer();
+        AttributeContainerInternal to = new DefaultMutableAttributeContainer(cache);
         if (newTargets == null) {
             newTargets = Lists.newArrayList();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformTargets.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformTargets.java
@@ -27,16 +27,16 @@ import java.util.List;
 
 public class DefaultArtifactTransformTargets implements ArtifactTransformTargets {
 
-    private final ImmutableAttributesFactory cache;
+    private final ImmutableAttributesFactory attributesFactory;
 
     private List<AttributeContainerInternal> newTargets;
 
-    public DefaultArtifactTransformTargets(ImmutableAttributesFactory cache) {
-        this.cache = cache;
+    public DefaultArtifactTransformTargets(ImmutableAttributesFactory attributesFactory) {
+        this.attributesFactory = attributesFactory;
     }
 
     public AttributeContainer newTarget() {
-        AttributeContainerInternal to = new DefaultMutableAttributeContainer(cache);
+        AttributeContainerInternal to = new DefaultMutableAttributeContainer(attributesFactory);
         if (newTargets == null) {
             newTargets = Lists.newArrayList();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.external.descriptor.ModuleDescriptorState;
@@ -302,7 +303,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
 
         @Override
         public AttributeContainerInternal getAttributes() {
-            return AttributeContainerInternal.EMPTY;
+            return ImmutableAttributes.EMPTY;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/FixedComponentArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/FixedComponentArtifacts.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentArtifacts;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -42,6 +42,6 @@ public class FixedComponentArtifacts implements ComponentArtifacts {
 
     @Override
     public Set<? extends VariantMetadata> getVariantsFor(ConfigurationMetadata configuration) {
-        return ImmutableSet.of(new DefaultVariantMetadata(AttributeContainerInternal.EMPTY, artifacts));
+        return ImmutableSet.of(new DefaultVariantMetadata(ImmutableAttributes.EMPTY, artifacts));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.artifacts.configurations.OutgoingVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
@@ -266,7 +267,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         public Set<? extends VariantMetadata> getVariants() {
             Set<DefaultVariantMetadata> variants = allVariants.get(name);
             if (variants.isEmpty()) {
-                variants = ImmutableSet.of(new DefaultVariantMetadata(AttributeContainerInternal.EMPTY, getArtifacts()));
+                variants = ImmutableSet.of(new DefaultVariantMetadata(ImmutableAttributes.EMPTY, getArtifacts()));
             }
             return variants;
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedArtifactTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedArtifactTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.internal.Factory
 import org.gradle.internal.component.model.IvyArtifactName
@@ -34,11 +35,12 @@ class DefaultResolvedArtifactTest extends Specification {
         def artifactId = Stub(ComponentArtifactIdentifier)
         def otherArtifactId = Stub(ComponentArtifactIdentifier)
         def buildDependencies = Stub(TaskDependency)
+        def factory = new DefaultImmutableAttributesFactory()
 
-        def artifact = new DefaultResolvedArtifact(dependency, ivyArt, artifactId, buildDependencies, artifactSource, ImmutableAttributes.EMPTY)
-        def equalArtifact = new DefaultResolvedArtifact(dependencySameModule, Stub(IvyArtifactName), artifactId, Stub(TaskDependency), Stub(Factory), ImmutableAttributes.EMPTY)
-        def differentModule = new DefaultResolvedArtifact(dependency2, ivyArt, artifactId, buildDependencies, artifactSource, ImmutableAttributes.EMPTY)
-        def differentId = new DefaultResolvedArtifact(dependency, ivyArt, otherArtifactId, buildDependencies, artifactSource, ImmutableAttributes.EMPTY)
+        def artifact = new DefaultResolvedArtifact(dependency, ivyArt, artifactId, buildDependencies, artifactSource, ImmutableAttributes.EMPTY, factory)
+        def equalArtifact = new DefaultResolvedArtifact(dependencySameModule, Stub(IvyArtifactName), artifactId, Stub(TaskDependency), Stub(Factory), ImmutableAttributes.EMPTY, factory)
+        def differentModule = new DefaultResolvedArtifact(dependency2, ivyArt, artifactId, buildDependencies, artifactSource, ImmutableAttributes.EMPTY, factory)
+        def differentId = new DefaultResolvedArtifact(dependency, ivyArt, otherArtifactId, buildDependencies, artifactSource, ImmutableAttributes.EMPTY, factory)
 
         expect:
         artifact Matchers.strictlyEqual(equalArtifact)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedArtifactTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedArtifactTest.groovy
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
-import org.gradle.api.internal.attributes.AttributeContainerInternal
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.internal.Factory
 import org.gradle.internal.component.model.IvyArtifactName
@@ -35,10 +35,10 @@ class DefaultResolvedArtifactTest extends Specification {
         def otherArtifactId = Stub(ComponentArtifactIdentifier)
         def buildDependencies = Stub(TaskDependency)
 
-        def artifact = new DefaultResolvedArtifact(dependency, ivyArt, artifactId, buildDependencies, artifactSource, AttributeContainerInternal.EMPTY)
-        def equalArtifact = new DefaultResolvedArtifact(dependencySameModule, Stub(IvyArtifactName), artifactId, Stub(TaskDependency), Stub(Factory), AttributeContainerInternal.EMPTY)
-        def differentModule = new DefaultResolvedArtifact(dependency2, ivyArt, artifactId, buildDependencies, artifactSource, AttributeContainerInternal.EMPTY)
-        def differentId = new DefaultResolvedArtifact(dependency, ivyArt, otherArtifactId, buildDependencies, artifactSource, AttributeContainerInternal.EMPTY)
+        def artifact = new DefaultResolvedArtifact(dependency, ivyArt, artifactId, buildDependencies, artifactSource, ImmutableAttributes.EMPTY)
+        def equalArtifact = new DefaultResolvedArtifact(dependencySameModule, Stub(IvyArtifactName), artifactId, Stub(TaskDependency), Stub(Factory), ImmutableAttributes.EMPTY)
+        def differentModule = new DefaultResolvedArtifact(dependency2, ivyArt, artifactId, buildDependencies, artifactSource, ImmutableAttributes.EMPTY)
+        def differentId = new DefaultResolvedArtifact(dependency, ivyArt, otherArtifactId, buildDependencies, artifactSource, ImmutableAttributes.EMPTY)
 
         expect:
         artifact Matchers.strictlyEqual(equalArtifact)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactBackedArtifactSet;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -126,7 +126,7 @@ public class DefaultResolvedDependencyTest {
             allowing(version).getId();
             will(returnValue(new DefaultModuleVersionIdentifier("group", name, "1.2")));
         }});
-        return new DefaultResolvedArtifact(resolvedDependency.getModule().getId(), artifactStub, context.mock(ComponentArtifactIdentifier.class), context.mock(TaskDependency.class), artifactSource, AttributeContainerInternal.EMPTY);
+        return new DefaultResolvedArtifact(resolvedDependency.getModule().getId(), artifactStub, context.mock(ComponentArtifactIdentifier.class), context.mock(TaskDependency.class), artifactSource, ImmutableAttributes.EMPTY);
     }
 
     private DefaultResolvedDependency createResolvedDependency() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactBackedArtifactSet;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -103,7 +104,9 @@ public class DefaultResolvedDependencyTest {
 
     public static DefaultResolvedArtifact createResolvedArtifact(final Mockery context, final String name, final String type, final String extension, final File file) {
         final IvyArtifactName artifactStub = context.mock(IvyArtifactName.class, "artifact" + name);
+        final ImmutableAttributesFactory factory = context.mock(ImmutableAttributesFactory.class);
         context.checking(new Expectations() {{
+            allowing(factory).builder(ImmutableAttributes.EMPTY);
             allowing(artifactStub).getName();
             will(returnValue(name));
             allowing(artifactStub).getType();
@@ -126,7 +129,7 @@ public class DefaultResolvedDependencyTest {
             allowing(version).getId();
             will(returnValue(new DefaultModuleVersionIdentifier("group", name, "1.2")));
         }});
-        return new DefaultResolvedArtifact(resolvedDependency.getModule().getId(), artifactStub, context.mock(ComponentArtifactIdentifier.class), context.mock(TaskDependency.class), artifactSource, ImmutableAttributes.EMPTY);
+        return new DefaultResolvedArtifact(resolvedDependency.getModule().getId(), artifactStub, context.mock(ComponentArtifactIdentifier.class), context.mock(TaskDependency.class), artifactSource, ImmutableAttributes.EMPTY, factory);
     }
 
     private DefaultResolvedDependency createResolvedDependency() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDepen
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.ConfigurationComponentMetaDataBuilder
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.event.ListenerManager
@@ -46,8 +47,9 @@ class DefaultConfigurationContainerSpec extends Specification {
     private ComponentIdentifierFactory componentIdentifierFactory = Mock()
     private DependencySubstitutionRules globalSubstitutionRules = Mock()
     private BuildOperationExecutor buildOperationExecutor = Mock()
+    private DefaultImmutableAttributesFactory immutableAttributesFactory = new DefaultImmutableAttributesFactory()
 
-    private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(resolver, instantiator, domainObjectContext, listenerManager, metaDataProvider, projectAccessListener, projectFinder, metaDataBuilder, fileCollectionFactory, globalSubstitutionRules, componentIdentifierFactory, buildOperationExecutor);
+    private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(resolver, instantiator, domainObjectContext, listenerManager, metaDataProvider, projectAccessListener, projectFinder, metaDataBuilder, fileCollectionFactory, globalSubstitutionRules, componentIdentifierFactory, buildOperationExecutor, immutableAttributesFactory);
 
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.ConfigurationComponentMetaDataBuilder
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.BasicDomainObjectContext
 import org.gradle.initialization.ProjectAccessListener
@@ -46,10 +47,11 @@ class DefaultConfigurationContainerTest extends Specification {
     private DependencySubstitutionRules globalSubstitutionRules = Mock(DependencySubstitutionRules)
     private BuildOperationExecutor buildOperationExecutor = Mock(BuildOperationExecutor)
     private Instantiator instantiator = new ClassGeneratorBackedInstantiator(new AsmBackedClassGenerator(), DirectInstantiator.INSTANCE)
+    private DefaultImmutableAttributesFactory immutableAttributesFactory = new DefaultImmutableAttributesFactory()
     private DefaultConfigurationContainer configurationContainer = instantiator.newInstance(DefaultConfigurationContainer.class,
             resolver, instantiator, new BasicDomainObjectContext(),
             listenerManager, metaDataProvider, projectAccessListener, projectFinder, metaDataBuilder, TestFiles.fileCollectionFactory(),
-            globalSubstitutionRules, componentIdentifierFactory, buildOperationExecutor)
+            globalSubstitutionRules, componentIdentifierFactory, buildOperationExecutor, immutableAttributesFactory)
 
     def addsNewConfigurationWhenConfiguringSelf() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.configurations
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.artifacts.PublishArtifactSet
 import org.gradle.api.internal.attributes.AttributeContainerInternal
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.typeconversion.NotationParser
@@ -29,7 +30,8 @@ class DefaultConfigurationPublicationsTest extends Specification {
     def artifacts = Stub(PublishArtifactSet)
     def notationParser = Stub(NotationParser)
     def fileCollectionFactory = Stub(FileCollectionFactory)
-    def publications = new DefaultConfigurationPublications(artifacts,parentAttributes, DirectInstantiator.INSTANCE, notationParser, fileCollectionFactory)
+    def attributesFactory = new DefaultImmutableAttributesFactory()
+    def publications = new DefaultConfigurationPublications(artifacts, parentAttributes, DirectInstantiator.INSTANCE, notationParser, fileCollectionFactory, attributesFactory)
 
     def "converts to OutgoingVariant when no variants defined"() {
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -49,6 +49,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Visit
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributeContainerInternal
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
@@ -77,6 +78,7 @@ class DefaultConfigurationSpec extends Specification {
     def projectFinder = Mock(ProjectFinder)
     def metaDataBuilder = Mock(ConfigurationComponentMetaDataBuilder)
     def componentIdentifierFactory = Mock(ComponentIdentifierFactory)
+    def immutableAttributesFactory = new DefaultImmutableAttributesFactory()
 
     def setup() {
         ListenerBroadcast<DependencyResolutionListener> broadcast = new ListenerBroadcast<DependencyResolutionListener>(DependencyResolutionListener)
@@ -1496,7 +1498,8 @@ All Artifacts:
 
     private DefaultConfiguration conf(String confName = "conf", String path = ":conf") {
         new DefaultConfiguration(Path.path(path), Path.path(path), confName, configurationsProvider, resolver, listenerManager, metaDataProvider,
-            resolutionStrategy, projectAccessListener, projectFinder, metaDataBuilder, TestFiles.fileCollectionFactory(), componentIdentifierFactory, new TestBuildOperationExecutor(), DirectInstantiator.INSTANCE, Stub(NotationParser))
+            resolutionStrategy, projectAccessListener, projectFinder, metaDataBuilder, TestFiles.fileCollectionFactory(), componentIdentifierFactory,
+            new TestBuildOperationExecutor(), DirectInstantiator.INSTANCE, Stub(NotationParser), immutableAttributesFactory)
     }
 
     private DefaultPublishArtifact artifact(String name) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ArtifactAttributeMatchingCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ArtifactAttributeMatchingCacheTest.groovy
@@ -21,8 +21,9 @@ import org.gradle.api.artifacts.transform.ArtifactTransform
 import org.gradle.api.artifacts.transform.ArtifactTransformTargets
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
-import org.gradle.api.internal.attributes.DefaultAttributeContainer
+import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.internal.component.model.ComponentAttributeMatcher
 import spock.lang.Specification
 
@@ -30,14 +31,15 @@ class ArtifactAttributeMatchingCacheTest extends Specification {
 
     def matcher = Mock(ComponentAttributeMatcher)
     def schema = new DefaultAttributesSchema(matcher)
-    def transformRegistrations = new DefaultArtifactTransformRegistrations()
+    def immutableAttributesFactory = new DefaultImmutableAttributesFactory()
+    def transformRegistrations = new DefaultArtifactTransformRegistrations(immutableAttributesFactory)
     def matchingCache = new ArtifactAttributeMatchingCache(transformRegistrations, schema)
 
     def a1 = Attribute.of("a1", String)
     def a2 = Attribute.of("a2", Integer)
-    def c1 = new DefaultAttributeContainer().attribute(a1, "1").attribute(a2, 1).asImmutable()
-    def c2 = new DefaultAttributeContainer().attribute(a1, "1").attribute(a2, 2).asImmutable()
-    def c3 = new DefaultAttributeContainer().attribute(a1, "1").attribute(a2, 3).asImmutable()
+    def c1 = new DefaultMutableAttributeContainer(immutableAttributesFactory).attribute(a1, "1").attribute(a2, 1).asImmutable()
+    def c2 = new DefaultMutableAttributeContainer(immutableAttributesFactory).attribute(a1, "1").attribute(a2, 2).asImmutable()
+    def c3 = new DefaultMutableAttributeContainer(immutableAttributesFactory).attribute(a1, "1").attribute(a2, 3).asImmutable()
 
     static class Transform extends ArtifactTransform {
         void configure(AttributeContainer from, ArtifactTransformTargets targetRegistry) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -264,7 +264,7 @@ class DefaultLocalComponentMetadataTest extends Specification {
     }
 
     private AttributeContainerInternal attributes() {
-        def attrs = Stub(ImmutableAttributes)
+        def attrs = ImmutableAttributes.EMPTY
         attrs.asImmutable() >> attrs
         return attrs
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.Modul
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.PatternMatchers
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributeContainerInternal
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.internal.component.external.descriptor.DefaultExclude
@@ -263,7 +264,7 @@ class DefaultLocalComponentMetadataTest extends Specification {
     }
 
     private AttributeContainerInternal attributes() {
-        def attrs = Stub(AttributeContainerInternal)
+        def attrs = Stub(ImmutableAttributes)
         attrs.asImmutable() >> attrs
         return attrs
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
@@ -18,22 +18,25 @@ package org.gradle.internal.component.model
 
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributesSchema
-import org.gradle.api.internal.attributes.DefaultAttributeContainer
+import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import spock.lang.Specification
 
 class ComponentAttributeMatcherTest extends Specification {
 
     AttributesSchema schema = new DefaultAttributesSchema(new ComponentAttributeMatcher())
+    ImmutableAttributesFactory factory = new DefaultImmutableAttributesFactory()
 
     def "Matching two exactly similar attributes gives a full match" () {
         def key = Attribute.of(String)
         schema.attribute(key)
 
         given:
-        def candidate = new DefaultAttributeContainer()
+        def candidate = new DefaultMutableAttributeContainer(factory)
         candidate.attribute(key, "value1")
-        def requested = new DefaultAttributeContainer()
+        def requested = new DefaultMutableAttributeContainer(factory)
         requested.attribute(key, "value1")
 
         when:
@@ -52,9 +55,9 @@ class ComponentAttributeMatcherTest extends Specification {
         }
 
         given:
-        def candidate = new DefaultAttributeContainer()
+        def candidate = new DefaultMutableAttributeContainer(factory)
         candidate.attribute(key1, "value1")
-        def requested = new DefaultAttributeContainer()
+        def requested = new DefaultMutableAttributeContainer(factory)
         requested.attribute(key1, "value1")
         requested.attribute(key2, "value2")
 
@@ -72,9 +75,9 @@ class ComponentAttributeMatcherTest extends Specification {
         schema.attribute(key2)
 
         given:
-        def candidate = new DefaultAttributeContainer()
+        def candidate = new DefaultMutableAttributeContainer(factory)
         candidate.attribute(key1, "value1")
-        def requested = new DefaultAttributeContainer()
+        def requested = new DefaultMutableAttributeContainer(factory)
         requested.attribute(key2, "value1")
 
         when:
@@ -89,9 +92,9 @@ class ComponentAttributeMatcherTest extends Specification {
         schema.attribute(key)
 
         given:
-        def candidate = new DefaultAttributeContainer()
+        def candidate = new DefaultMutableAttributeContainer(factory)
         candidate.attribute(key, "value1")
-        def requested = new DefaultAttributeContainer()
+        def requested = new DefaultMutableAttributeContainer(factory)
         requested.attribute(key, "value2")
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -28,8 +28,10 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
-import org.gradle.api.internal.attributes.DefaultAttributeContainer
+import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.internal.component.NoMatchingConfigurationSelectionException
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
@@ -39,9 +41,11 @@ import spock.lang.Unroll
 
 class LocalComponentDependencyMetadataTest extends Specification {
     AttributesSchemaInternal attributesSchema
+    ImmutableAttributesFactory factory
 
     def setup() {
         attributesSchema = new DefaultAttributesSchema(new ComponentAttributeMatcher())
+        factory = new DefaultImmutableAttributesFactory()
     }
 
     def "returns this when same version requested"() {
@@ -523,7 +527,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
     }
 
     private AttributeContainer attributes(Map<String, ?> src) {
-        def attributes = new DefaultAttributeContainer()
+        def attributes = new DefaultMutableAttributeContainer(factory)
         src.each { String name, Object value ->
             def key = Attribute.of(name, value.class)
             attributes.attribute(key, value)

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -24,8 +24,8 @@ import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.local.model.DefaultLibraryComponentSelector;
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
@@ -84,7 +84,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
                 Collections.singleton(usage),
                 true,
                 true,
-                AttributeContainerInternal.EMPTY,
+                ImmutableAttributes.EMPTY,
                 true,
                 false);
         }


### PR DESCRIPTION
This PR changes the implementation of immutable attributes, by forcing the creation of such attributes through a factory. This allows us to cache the attributes and dramatically reduce the memory pressure around it.