### PR TITLE
Closes #1086: corrected documentation error

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
@@ -38,7 +38,7 @@
             </tr>
             <tr>
                 <td>destinationDir</td>
-                <td><literal>project.distsDir</literal></td>
+                <td><literal>project.libsDir</literal></td>
             </tr>
             <tr>
                 <td>preserveFileTimestamps</td>


### PR DESCRIPTION
https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:destinationDir  had contained wrong information on default for the "File destinationDir". This patch is replacing the wrong default 'project.distsDir' by the correct default 'project.libsDir'.

Any of the checked boxes below indicate that I took action:

- [ ] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [ ] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [ ] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [ ] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
