### PR TITLE
Issue: #952 Make project.sync() a public API

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/java/org/gradle/api/Project.java
@@ -1405,6 +1405,15 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     WorkResult copy(Closure closure);
 
     /**
+     * Copies the specified files.  The given action is used to configure a {@link CopySpec}, which is then used to
+     * copy the files.
+     * @see #copy(Closure)
+     * @param action Action to configure the CopySpec
+     * @return {@link WorkResult} that can be used to check if the copy did any work.
+     */
+    WorkResult copy(Action<? super CopySpec> action);
+
+    /**
      * Creates a {@link CopySpec} which can later be used to copy files or create an archive. The given closure is used
      * to configure the {@link CopySpec} before it is returned by this method.
      *
@@ -1426,15 +1435,6 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     CopySpec copySpec(Closure closure);
 
     /**
-     * Copies the specified files.  The given action is used to configure a {@link CopySpec}, which is then used to
-     * copy the files.
-     * @see #copy(Closure)
-     * @param action Action to configure the CopySpec
-     * @return {@link WorkResult} that can be used to check if the copy did any work.
-     */
-    WorkResult copy(Action<? super CopySpec> action);
-
-    /**
      * Creates a {@link CopySpec} which can later be used to copy files or create an archive. The given action is used
      * to configure the {@link CopySpec} before it is returned by this method.
      *
@@ -1450,6 +1450,41 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @return a newly created copy spec
      */
     CopySpec copySpec();
+
+    /**
+     * Synchronizes the contents of a destination directory with some source directories and files.
+     * The given action is used to configure a {@link CopySpec}, which is then used to synchronize the files.
+     *
+     * <p>
+     * This method is like the {@link #copy(Action)} task, except the destination directory will only contain the files copied.
+     * All files that exist in the destination directory will be deleted before copying files, unless a preserve option is specified.
+     *
+     * <p>
+     * Example:
+     *
+     * <pre>
+     * project.sync {
+     *    from 'my/shared/dependencyDir'
+     *    into 'build/deps/compile'
+     * }
+     * </pre>
+     * Note that you can preserve output that already exists in the destination directory:
+     * <pre>
+     * project.sync {
+     *     from 'source'
+     *     into 'dest'
+     *     preserve {
+     *         include 'extraDir/**'
+     *         include 'dir1/**'
+     *         exclude 'dir1/extra.txt'
+     *     }
+     * }
+     * </pre>
+     *
+     * @param action Action to configure the CopySpec.
+     * @return {@link WorkResult} that can be used to check if the sync did any work.
+     */
+    WorkResult sync(Action<? super CopySpec> action);
 
     /**
      * Returns the evaluation state of this project. You can use this to access information about the evaluation of this

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.Project.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.Project.xml
@@ -174,6 +174,9 @@
                 <td>copySpec</td>
             </tr>
             <tr>
+                <td>sync</td>
+            </tr>
+            <tr>
                 <td>javaexec</td>
             </tr>
             <tr>

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -299,6 +299,191 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         !file('dest/nonPreservedDir').isDirectory()
     }
 
+    def "sync action"() {
+        given:
+        defaultSourceFileTree()
+        file('dest').create {
+            file 'extra1.txt'
+            extraDir { file 'extra2.txt' }
+        }
+        buildScript '''
+            task syncIt() {
+                doLast {
+                    project.sync {
+                        from 'source'
+                        into 'dest'
+                    }
+                }
+            }
+        '''.stripIndent()
+
+        when:
+        run 'syncIt'
+
+        then:
+        file('dest').assertHasDescendants(
+            'dir1/file1.txt',
+            'dir2/subdir/file2.txt',
+            'dir2/file3.txt'
+        )
+        file('dest/emptyDir').exists()
+        !file('dest/extra1.txt').exists()
+        !file('dest/extraDir/extra2.txt').exists()
+    }
+
+    def "sync single files"() {
+        given:
+        file('source').create {
+            file 'file1.txt'
+            file 'file2.txt'
+        }
+        file('dest').create {
+            file 'extra.txt'
+        }
+        buildScript '''
+            task syncIt {
+                doLast {
+                    project.sync {
+                        from 'source'
+                        into 'dest'
+                    }
+                }
+            }
+        '''.stripIndent()
+
+        when:
+        run 'syncIt'
+
+        then:
+        file('dest').assertHasDescendants(
+            'file1.txt',
+            'file2.txt',
+        )
+        !file('dest/extra.txt').exists()
+    }
+
+    def "sync from file tree"() {
+        given:
+        file('source').create {
+            file 'file1.txt'
+            dir1 { file 'file2.txt' }
+            ignore { file 'file3.txt' } // to be ignored
+        }
+        file('dest').create {
+            file 'extra1.txt'
+            dir1 { file 'extra2.txt' }
+            dir2 { file 'extra3.txt' }
+        }
+        buildScript '''
+        task syncIt {
+            doLast {
+                project.sync {
+                    from fileTree(dir: 'source', excludes: ['**/ignore/**'], includes: ['*', '*/*'])
+                    into 'dest'
+                }
+            }
+        }
+        '''.stripIndent()
+
+        when:
+        run 'syncIt'
+
+        then:
+        file('dest').assertHasDescendants(
+            'file1.txt',
+            'dir1/file2.txt',
+        )
+        !file('ignore/file3.txt').exists()
+        !file('dest/extra1.txt').exists()
+        !file('dest/dir1/extra2.txt').exists()
+        !file('dest/dir2/extra3.txt').exists()
+    }
+
+    def "sync from file collection"() {
+        given:
+        file('source').create {
+            file 'file1.txt'
+            dir1 { file 'file2.txt' }
+            ignore { file 'file3.txt' } // to be ignored
+        }
+        file('dest').create {
+            file 'extra1.txt'
+            dir1 { file 'extra2.txt' }
+            dir2 { file 'extra3.txt' }
+        }
+        buildScript '''
+            task syncIt {
+                doLast {
+                    project.sync {
+                        from files('source')
+                        into 'dest'
+                        exclude '**/ignore/**'
+                        exclude '*/*/*/**'
+                    }
+                }
+            }
+        '''.stripIndent()
+
+        when:
+        run 'syncIt'
+
+        then:
+        file('dest').assertHasDescendants(
+            'file1.txt',
+            'dir1/file2.txt',
+        )
+        !file('ignore/file3.txt').exists()
+        !file('dest/extra1.txt').exists()
+        !file('dest/dir1/extra2.txt').exists()
+        !file('dest/dir2/extra3.txt').exists()
+    }
+
+    def "sync from composite file collection"() {
+        given:
+        file('source').create {
+            file 'file1.txt'
+            dir1 { file 'file2.txt' }
+        }
+        file('source2').create {
+            file 'file3.txt'
+            dir1 { file 'file4.txt' }
+            ignore { file 'file5.txt' } // to be ignored
+        }
+        file('dest').create {
+            file 'extra1.txt'
+            dir1 { file 'extra2.txt' }
+        }
+        file('f.jar').touch()
+        buildScript '''
+            configurations { compile }
+            dependencies { compile files('f.jar') }
+            task syncIt {
+                doLast {
+                    project.sync {
+                        from files('source') + fileTree('source2') { exclude '**/ignore/**' } + configurations.compile
+                        into 'dest'
+                        include { fte -> fte.relativePath.segments.length < 3 && (fte.file.directory || fte.file.name.contains('f')) }
+                    }
+                }
+            }
+        '''.stripIndent()
+
+        when:
+        run 'syncIt'
+
+        then:
+        file('dest').assertHasDescendants(
+            'file1.txt',
+            'f.jar',
+            'file3.txt',
+            'dir1/file2.txt',
+            'dir1/file4.txt',
+        )
+        !file('ignore/file5.txt').exists()
+        !file('dest/extra1.txt').exists()
+        !file('dest/dir1/extra2.txt').exists()
+    }
+
     def defaultSourceFileTree() {
         file('source').create {
             dir1 { file 'file1.txt' }


### PR DESCRIPTION
### Overview

- This change closes https://github.com/gradle/gradle/issues/752.
- Add `WorkResult sync(Action<? super CopySpec> action);` and doc to `Project.java`. 

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [x] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [x] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.