### PR TITLE
Remove unnecessary modifier of variables inside of Project.java

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/java/org/gradle/api/Project.java
@@ -211,25 +211,25 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     /**
      * The default project build file name.
      */
-    public static final String DEFAULT_BUILD_FILE = "build.gradle";
+    String DEFAULT_BUILD_FILE = "build.gradle";
 
     /**
      * The hierarchy separator for project and task path names.
      */
-    public static final String PATH_SEPARATOR = ":";
+    String PATH_SEPARATOR = ":";
 
     /**
      * The default build directory name.
      */
-    public static final String DEFAULT_BUILD_DIR_NAME = "build";
+    String DEFAULT_BUILD_DIR_NAME = "build";
 
-    public static final String GRADLE_PROPERTIES = "gradle.properties";
+    String GRADLE_PROPERTIES = "gradle.properties";
 
-    public static final String SYSTEM_PROP_PREFIX = "systemProp";
+    String SYSTEM_PROP_PREFIX = "systemProp";
 
-    public static final String DEFAULT_VERSION = "unspecified";
+    String DEFAULT_VERSION = "unspecified";
 
-    public static final String DEFAULT_STATUS = "release";
+    String DEFAULT_STATUS = "release";
 
     /**
      * <p>Returns the root project for the hierarchy that this project belongs to.  In the case of a single-project


### PR DESCRIPTION
- Just removed `public static final` since `Project.java` is interface.

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`