### PR TITLE
Increase the default version of Checkstyle

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginClasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginClasspathIntegrationTest.groovy
@@ -15,13 +15,14 @@
  */
 package org.gradle.api.plugins.quality
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.quality.integtest.fixtures.CheckstyleCoverage
 import spock.lang.Issue
 
 @Issue("gradle/gradle#855")
-@TargetCoverage({ CheckstyleCoverage.ALL })
+@TargetCoverage({ JavaVersion.current().java7 ? CheckstyleCoverage.JDK7_SUPPORTED : CheckstyleCoverage.ALL })
 class CheckstylePluginClasspathIntegrationTest extends MultiVersionIntegrationSpec {
     def setup() {
         writeBuildFiles()

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginClasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginClasspathIntegrationTest.groovy
@@ -15,14 +15,13 @@
  */
 package org.gradle.api.plugins.quality
 
-import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.quality.integtest.fixtures.CheckstyleCoverage
 import spock.lang.Issue
 
 @Issue("gradle/gradle#855")
-@TargetCoverage({ JavaVersion.current().java7 ? CheckstyleCoverage.JDK7_SUPPORTED : CheckstyleCoverage.ALL })
+@TargetCoverage({ CheckstyleCoverage.getSupportedVersionsByJdk() })
 class CheckstylePluginClasspathIntegrationTest extends MultiVersionIntegrationSpec {
     def setup() {
         writeBuildFiles()

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.util.TextUtil.normaliseFileSeparators
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.startsWith
 
-@TargetCoverage({ JavaVersion.current().isJava6() ? CheckstyleCoverage.JDK6_SUPPORTED : CheckstyleCoverage.ALL})
+@TargetCoverage({ JavaVersion.current().java7 ? CheckstyleCoverage.JDK7_SUPPORTED : CheckstyleCoverage.ALL })
 class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec {
 
     @Rule

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.plugins.quality
 
 import groovy.transform.NotYetImplemented
-import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
@@ -33,7 +32,7 @@ import static org.gradle.util.TextUtil.normaliseFileSeparators
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.startsWith
 
-@TargetCoverage({ JavaVersion.current().java7 ? CheckstyleCoverage.JDK7_SUPPORTED : CheckstyleCoverage.ALL })
+@TargetCoverage({ CheckstyleCoverage.getSupportedVersionsByJdk() })
 class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec {
 
     @Rule

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Callable;
  */
 public class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
 
-    public static final String DEFAULT_CHECKSTYLE_VERSION = "5.9";
+    public static final String DEFAULT_CHECKSTYLE_VERSION = "6.19";
     private CheckstyleExtension extension;
 
     @Override

--- a/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
+++ b/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
@@ -21,9 +21,10 @@ import org.gradle.util.VersionNumber
 
 class CheckstyleCoverage {
     // Note, this only work for major.minor versions
-    final static List<String> ALL = ['6.12', '6.9', '6.5', '6.0', '5.5', CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION].asImmutable()
+    final static List<String> ALL = ['7.4', '7.0', '6.12', '6.9', '6.2', CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION].asImmutable()
 
     final static List<VersionNumber> ALL_VERSIONS = ALL.collect { VersionNumber.parse(it) }
-    // JDK6 support was dropped in 6.2
-    final static List<String> JDK6_SUPPORTED = ALL_VERSIONS.findAll({ it < VersionNumber.parse("6.2") }).collect({ "${it.major}.${it.minor}" }).asImmutable()
+
+    // JDK7 support was dropped in 7.0
+    final static List<String> JDK7_SUPPORTED = ALL_VERSIONS.findAll({ it < VersionNumber.parse("7.0") }).collect({ "${it.major}.${it.minor}" }).asImmutable()
 }

--- a/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
+++ b/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
@@ -16,15 +16,20 @@
 
 package org.gradle.quality.integtest.fixtures
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.plugins.quality.CheckstylePlugin
 import org.gradle.util.VersionNumber
 
 class CheckstyleCoverage {
     // Note, this only work for major.minor versions
-    final static List<String> ALL = ['7.4', '7.0', '6.12', '6.9', '6.2', CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION].asImmutable()
+    private final static List<String> ALL = ['5.9', '6.2', '6.9', '6.12', '7.0', '7.4', CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION].asImmutable()
 
-    final static List<VersionNumber> ALL_VERSIONS = ALL.collect { VersionNumber.parse(it) }
+    private final static List<VersionNumber> ALL_VERSIONS = ALL.collect { VersionNumber.parse(it) }
 
     // JDK7 support was dropped in 7.0
-    final static List<String> JDK7_SUPPORTED = ALL_VERSIONS.findAll({ it < VersionNumber.parse("7.0") }).collect({ "${it.major}.${it.minor}" }).asImmutable()
+    private final static List<String> JDK7_SUPPORTED = ALL_VERSIONS.findAll({ it < VersionNumber.parse("7.0") }).collect({ "${it.major}.${it.minor}" }).asImmutable()
+
+    static getSupportedVersionsByJdk() {
+        JavaVersion.current().java7 ? JDK7_SUPPORTED : ALL
+    }
 }

--- a/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
+++ b/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
@@ -22,7 +22,7 @@ import org.gradle.util.VersionNumber
 
 class CheckstyleCoverage {
     // Note, this only work for major.minor versions
-    private final static List<String> ALL = ['5.9', '6.2', '6.9', '6.12', '7.0', '7.4', CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION].asImmutable()
+    private final static List<String> ALL = ['5.9', '6.2', '6.9', '6.12', '7.0', '7.6', CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION].asImmutable()
 
     private final static List<VersionNumber> ALL_VERSIONS = ALL.collect { VersionNumber.parse(it) }
 

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.CheckstyleExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.CheckstyleExtension.xml
@@ -10,7 +10,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>5.9</literal></td>
+                <td><literal>6.19</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -215,8 +215,11 @@ See [gradle/gradle#1378](https://github.com/gradle/gradle/issues/1378) for more 
 ### Version of Checkstyle has been upgraded
 
 By default, Gradle now uses [Checkstyle 6.19](http://checkstyle.sourceforge.net/releasenotes.html#Release_6.19). Previously, Gradle used Checkstyle 5.9.
+We cannot upgrade to the latest release because Checkstyle 7.0+ require Java 8. Gradle has been tested against Checkstyle 7.0 and 7.6. 
 
-You can downgrade the version of Checkstyle with:
+Newer versions of Checkstyle usually bring new rules, better inspections and bug fixes.  Your build may fail due to these changes.
+
+You can upgrade or downgrade the version of Checkstyle with:
 
     checkstyle {
         toolVersion = '5.9'

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -212,6 +212,16 @@ projects like those using Spring to have correct version comparison.
 
 See [gradle/gradle#1378](https://github.com/gradle/gradle/issues/1378) for more details.
 
+### Version of Checkstyle has been upgraded
+
+By default, Gradle now uses [Checkstyle 6.19](http://checkstyle.sourceforge.net/releasenotes.html#Release_6.19). Previously, Gradle used Checkstyle 5.9.
+
+You can downgrade the version of Checkstyle with:
+
+    checkstyle {
+        toolVersion = '5.9'
+    }
+
 ## External contributions
 
 We would like to thank the following community members for making contributions to this release of Gradle.


### PR DESCRIPTION
We should have bumped this in Gradle 3.0 since we were stuck with Checkstyle 5.9
due to JDK6.

Checkstyle 7.0 only supports JDK8, so this introduces something similar to how we handled
JDK6 and older Checkstyle versions.  This PR increases the version to 6.19 which is the last version to support JDK7.

This is related to #1067.

----

I was tired of running into these sort of false negatives with Sanity Check when a Javadoc comment causes an import to be added:
https://builds.gradle.org/viewLog.html?buildId=2075232&tab=buildResultsDiv&buildTypeId=Gradle_Master_CommitPhase_SanityCheck&logTab=

This is either a bug fix in a later version of Checkstyle or a different default.