### PR TITLE
Change `gradle init --type java-library` to use the `java-library` plugin

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -36,7 +36,7 @@ class JavaLibraryInitIntegrationTest extends AbstractIntegrationSpec {
         then:
         file(SAMPLE_LIBRARY_CLASS).exists()
         file(SAMPLE_LIBRARY_TEST_CLASS).exists()
-        buildFile.exists()
+        buildFileSeparatesImplementationAndApi()
         settingsFile.exists()
         wrapper.generated()
 
@@ -54,7 +54,7 @@ class JavaLibraryInitIntegrationTest extends AbstractIntegrationSpec {
         then:
         file(SAMPLE_LIBRARY_CLASS).exists()
         file(SAMPLE_SPOCK_LIBRARY_TEST_CLASS).exists()
-        buildFile.exists()
+        buildFileSeparatesImplementationAndApi('org.spockframework')
         settingsFile.exists()
         wrapper.generated()
 
@@ -72,7 +72,7 @@ class JavaLibraryInitIntegrationTest extends AbstractIntegrationSpec {
         then:
         file(SAMPLE_LIBRARY_CLASS).exists()
         file(SAMPLE_LIBRARY_TEST_CLASS).exists()
-        buildFile.exists()
+        buildFileSeparatesImplementationAndApi('org.testng')
         settingsFile.exists()
         wrapper.generated()
 
@@ -103,7 +103,7 @@ class JavaLibraryInitIntegrationTest extends AbstractIntegrationSpec {
         then:
         !file(SAMPLE_LIBRARY_CLASS).exists()
         !file(SAMPLE_LIBRARY_TEST_CLASS).exists()
-        buildFile.exists()
+        buildFileSeparatesImplementationAndApi()
         settingsFile.exists()
         wrapper.generated()
     }
@@ -112,5 +112,13 @@ class JavaLibraryInitIntegrationTest extends AbstractIntegrationSpec {
         TestExecutionResult testResult = new DefaultTestExecutionResult(testDirectory)
         testResult.assertTestClassesExecuted("LibraryTest")
         testResult.testClass("LibraryTest").assertTestPassed(name)
+    }
+
+    private void buildFileSeparatesImplementationAndApi(String testFramework = 'junit:junit:') {
+        assert buildFile.exists()
+        def text = buildFile.text
+        assert text.contains("api 'org.apache.commons:commons-math3")
+        assert text.contains("implementation 'com.google.guava:guava:")
+        assert text.contains("testImplementation '$testFramework")
     }
 }

--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/GroovyLibraryProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/GroovyLibraryProjectInitDescriptor.java
@@ -39,7 +39,7 @@ public class GroovyLibraryProjectInitDescriptor extends LanguageLibraryProjectIn
             .fileComment("For more details take a look at the Groovy Quickstart chapter in the Gradle")
             .fileComment("user guide available at " + documentationRegistry.getDocumentationFor("tutorial_groovy_projects"))
             .plugin("Apply the groovy plugin to add support for Groovy", "groovy")
-            .dependency("Use the latest Groovy version for building this library",
+            .compileDependency("Use the latest Groovy version for building this library",
                 "org.codehaus.groovy:groovy-all:" + libraryVersionProvider.getVersion("groovy"))
             .testCompileDependency("Use the awesome Spock testing and specification framework",
                 "org.spockframework:spock-core:" + libraryVersionProvider.getVersion("spock"),

--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/JavaApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/JavaApplicationProjectInitDescriptor.java
@@ -26,6 +26,7 @@ public class JavaApplicationProjectInitDescriptor extends JavaProjectInitDescrip
 
     @Override
     protected void configureBuildScript(BuildScriptBuilder buildScriptBuilder) {
+        super.configureBuildScript(buildScriptBuilder);
         buildScriptBuilder
             .plugin("Apply the application plugin to add support for building an application", "application")
             .configuration("Define the main class for the application", "mainClassName = 'App'");

--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/JavaLibraryProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/JavaLibraryProjectInitDescriptor.java
@@ -20,6 +20,13 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.FileResolver;
 
 public class JavaLibraryProjectInitDescriptor extends JavaProjectInitDescriptor {
+    private final static Description DESCRIPTION = new Description(
+        "Java Library",
+        "Java Libraries",
+        "java_library_plugin",
+        "java-library"
+    );
+
     public JavaLibraryProjectInitDescriptor(TemplateOperationFactory templateOperationFactory,
                                             FileResolver fileResolver,
                                             TemplateLibraryVersionProvider libraryVersionProvider,
@@ -43,5 +50,24 @@ public class JavaLibraryProjectInitDescriptor extends JavaProjectInitDescriptor 
             default:
                 return fromClazzTemplate("javalibrary/LibraryTest.java.template", "test");
         }
+    }
+
+    @Override
+    protected Description getDescription() {
+        return DESCRIPTION;
+    }
+
+    @Override
+    protected String getImplementationConfigurationName() {
+        return "implementation";
+    }
+
+    @Override
+    protected void configureBuildScript(BuildScriptBuilder buildScriptBuilder) {
+        buildScriptBuilder.dependency(
+            "api",
+            "This dependency is exposed to consumers",
+            "org.apache.commons:commons-math3:" + libraryVersionProvider.getVersion("commons-math"));
+        super.configureBuildScript(buildScriptBuilder);
     }
 }

--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/JavaProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/JavaProjectInitDescriptor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.buildinit.plugins.internal;
 
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.FileResolver;
 
@@ -23,6 +24,12 @@ import static org.gradle.buildinit.plugins.internal.BuildInitTestFramework.SPOCK
 import static org.gradle.buildinit.plugins.internal.BuildInitTestFramework.TESTNG;
 
 public abstract class JavaProjectInitDescriptor extends LanguageLibraryProjectInitDescriptor {
+    private final static Description DESCRIPTION = new Description(
+        "Java",
+        "Java Quickstart",
+        "tutorial_java_projects",
+        "java"
+    );
     private final DocumentationRegistry documentationRegistry;
 
     public JavaProjectInitDescriptor(TemplateOperationFactory templateOperationFactory,
@@ -37,14 +44,12 @@ public abstract class JavaProjectInitDescriptor extends LanguageLibraryProjectIn
     @Override
     public void generate(BuildInitTestFramework testFramework) {
         globalSettingsDescriptor.generate(testFramework);
-
+        Description desc = getDescription();
         BuildScriptBuilder buildScriptBuilder = new BuildScriptBuilder(fileResolver.resolve("build.gradle"))
-            .fileComment("This generated file contains a sample Java project to get you started.")
-            .fileComment("For more details take a look at the Java Quickstart chapter in the Gradle")
-            .fileComment("user guide available at " + documentationRegistry.getDocumentationFor("tutorial_java_projects"))
-            .plugin("Apply the java plugin to add support for Java", "java")
-            .dependency("The production code uses Guava",
-                "com.google.guava:guava:" + libraryVersionProvider.getVersion("guava"));
+            .fileComment("This generated file contains a sample " + desc.projectType + " project to get you started.")
+            .fileComment("For more details take a look at the " + desc.chapterName + " chapter in the Gradle")
+            .fileComment("user guide available at " + documentationRegistry.getDocumentationFor(desc.userguideId))
+            .plugin("Apply the " + desc.pluginName +" plugin to add support for " + desc.projectType, desc.pluginName);
         configureBuildScript(buildScriptBuilder);
         addTestFramework(testFramework, buildScriptBuilder);
         buildScriptBuilder.create().generate();
@@ -53,31 +58,45 @@ public abstract class JavaProjectInitDescriptor extends LanguageLibraryProjectIn
         whenNoSourcesAvailable(javaSourceTemplate, testTemplateOperation(testFramework)).generate();
     }
 
+    protected Description getDescription() {
+        return DESCRIPTION;
+    }
+
+    protected String getImplementationConfigurationName() {
+        return "compile";
+    }
+
+    protected String getTestImplementationConfigurationName() {
+        return "test" + StringUtils.capitalize(getImplementationConfigurationName());
+    }
+
     private void addTestFramework(BuildInitTestFramework testFramework, BuildScriptBuilder buildScriptBuilder) {
         switch (testFramework) {
             case SPOCK:
                 buildScriptBuilder
                     .plugin("Apply the groovy plugin to also add support for Groovy (needed for Spock)", "groovy")
-                    .testCompileDependency("Use the latest Groovy version for Spock testing",
+                    .dependency(getTestImplementationConfigurationName(), "Use the latest Groovy version for Spock testing",
                         "org.codehaus.groovy:groovy-all:" + libraryVersionProvider.getVersion("groovy"))
-                    .testCompileDependency("Use the awesome Spock testing and specification framework even with Java",
+                    .dependency(getTestImplementationConfigurationName(), "Use the awesome Spock testing and specification framework even with Java",
                         "org.spockframework:spock-core:" + libraryVersionProvider.getVersion("spock"),
                         "junit:junit:" + libraryVersionProvider.getVersion("junit"));
                 break;
             case TESTNG:
                 buildScriptBuilder
-                    .testCompileDependency("Use TestNG framework, also requires calling test.useTestNG() below",
+                    .dependency(getTestImplementationConfigurationName(), "Use TestNG framework, also requires calling test.useTestNG() below",
                         "org.testng:testng:" + libraryVersionProvider.getVersion("testng"))
                     .configuration("Use TestNG for unit tests", "test.useTestNG()");
                 break;
             default:
                 buildScriptBuilder
-                    .testCompileDependency("Use JUnit test framework", "junit:junit:" + libraryVersionProvider.getVersion("junit"));
+                    .dependency(getTestImplementationConfigurationName(), "Use JUnit test framework", "junit:junit:" + libraryVersionProvider.getVersion("junit"));
                 break;
         }
     }
 
     protected void configureBuildScript(BuildScriptBuilder buildScriptBuilder) {
+        buildScriptBuilder.dependency(getImplementationConfigurationName(), "The production code uses Guava",
+            "com.google.guava:guava:" + libraryVersionProvider.getVersion("guava"));
     }
 
     protected abstract TemplateOperation sourceTemplateOperation();
@@ -87,5 +106,19 @@ public abstract class JavaProjectInitDescriptor extends LanguageLibraryProjectIn
     @Override
     public boolean supports(BuildInitTestFramework testFramework) {
         return testFramework == SPOCK || testFramework == TESTNG;
+    }
+
+    protected static class Description {
+        private final String projectType;
+        private final String chapterName;
+        private final String userguideId;
+        private final String pluginName;
+
+        public Description(String projectType, String chapterName, String userguideId, String pluginName) {
+            this.projectType = projectType;
+            this.chapterName = chapterName;
+            this.userguideId = userguideId;
+            this.pluginName = pluginName;
+        }
     }
 }

--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/ScalaLibraryProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/ScalaLibraryProjectInitDescriptor.java
@@ -44,7 +44,7 @@ public class ScalaLibraryProjectInitDescriptor extends LanguageLibraryProjectIni
             .fileComment("For more details take a look at the Scala plugin chapter in the Gradle")
             .fileComment("user guide available at " + documentationRegistry.getDocumentationFor("scala_plugin"))
             .plugin("Apply the scala plugin to add support for Scala", "scala")
-            .dependency("Use Scala " + scalaVersion + " in our library project",
+            .compileDependency("Use Scala " + scalaVersion + " in our library project",
                 "org.scala-lang:scala-library:" + scalaLibraryVersion)
             .testCompileDependency("Use Scalatest for testing our library",
                 "junit:junit:" + junitVersion,

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
@@ -9,3 +9,4 @@ groovy=2.4.7
 junit=4.12
 spock=1.0-groovy-2.4
 guava=20.0
+commons-math:3.6.1

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderTest.groovy
@@ -82,8 +82,8 @@ apply plugin: 'application'
 
     def "can add compile dependencies"() {
         when:
-        builder.dependency("Use slf4j", "org.slf4j:slf4j-api:2.7", "org.slf4j:slf4j-simple:2.7")
-        builder.dependency("Use Scala to compile", "org.scala-lang:scala-library:2.10")
+        builder.compileDependency("Use slf4j", "org.slf4j:slf4j-api:2.7", "org.slf4j:slf4j-simple:2.7")
+        builder.compileDependency("Use Scala to compile", "org.scala-lang:scala-library:2.10")
         builder.create().generate()
 
         then:


### PR DESCRIPTION
This commit changes the build init plugin so that for a Java Library template, it uses the new `java-library` plugin.