### PR TITLE
Make api/implementation work for testing too

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -72,6 +72,8 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import static org.gradle.api.attributes.Usage.*;
+
 /**
  * <p>A {@link org.gradle.api.Plugin} which compiles and tests Java source, and assembles it into a JAR file.</p>
  */
@@ -252,6 +254,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         compileClasspathConfiguration.extendsFrom(compileOnlyConfiguration);
         compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSet + ".");
         compileClasspathConfiguration.setCanBeConsumed(false);
+        compileClasspathConfiguration.attribute(USAGE_ATTRIBUTE, FOR_COMPILE);
 
         Configuration runtimeOnlyConfiguration = configurations.maybeCreate(sourceSet.getRuntimeOnlyConfigurationName());
         runtimeOnlyConfiguration.setVisible(false);
@@ -265,6 +268,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         runtimeClasspathConfiguration.setCanBeResolved(true);
         runtimeClasspathConfiguration.setDescription("Runtime classpath of " + sourceSet + ".");
         runtimeClasspathConfiguration.extendsFrom(runtimeOnlyConfiguration, runtimeConfiguration);
+        runtimeClasspathConfiguration.attribute(USAGE_ATTRIBUTE, FOR_RUNTIME);
 
         sourceSet.setCompileClasspath(compileClasspathConfiguration);
         sourceSet.setRuntimeClasspath(sourceSet.getOutput().plus(runtimeClasspathConfiguration));

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -39,7 +39,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.attributes.Usage.*;
+import static org.gradle.api.attributes.Usage.FOR_RUNTIME;
+import static org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE;
 
 /**
  * <p>A {@link Plugin} which compiles and tests Java source, and assembles it into a JAR file.</p>
@@ -178,9 +179,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         configurations.getByName(TEST_RUNTIME_CONFIGURATION_NAME).extendsFrom(runtimeConfiguration, compileTestsConfiguration, testImplementationConfiguration);
 
         configurations.getByName(Dependency.DEFAULT_CONFIGURATION).extendsFrom(runtimeConfiguration);
-        configurations.getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).attribute(USAGE_ATTRIBUTE, FOR_COMPILE);
         runtimeElementsConfiguration.attribute(USAGE_ATTRIBUTE, FOR_RUNTIME);
-        runtimeClasspathConfiguration.attribute(USAGE_ATTRIBUTE, FOR_RUNTIME);
 
         runtimeClasspathConfiguration.extendsFrom(runtimeElementsConfiguration);
 


### PR DESCRIPTION
The api/implementation configurations were ignored for test compilation and runtime
until now, meaning that all api dependencies were missing during compilation
and all implementation dependencies were missing at test runtime. Instead the default
configuration was used for both cases.

The fix was simply to add the usage attribute to the compile/runtime classpath configuration
of all sourceSets instead of just the main one.