### PR TITLE
IDE mapping for java-library plugin

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdeaProjectIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdeaProjectIntegrationTest.groovy
@@ -361,13 +361,13 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractCompositeBuildInt
 
     private void imlHasDependencies(TestFile projectDir = buildA, List<String> expectedModules, List<String> expectedLibraries) {
         def dependencies = iml(projectDir).dependencies
-        assert dependencies.modules.size() == expectedModules.size()
+        assert dependencies.modules.size() == expectedModules.size() * 3
         expectedModules.each {
-            dependencies.assertHasModule(it)
+            dependencies.assertHasModule(["PROVIDED", "RUNTIME", "TEST"], it)
         }
-        assert dependencies.libraries.size() == expectedLibraries.size()
+        assert dependencies.libraries.size() == expectedLibraries.size() * 3
         expectedLibraries.each {
-            dependencies.assertHasLibrary(it)
+            dependencies.assertHasLibrary(["PROVIDED", "RUNTIME", "TEST"], it)
         }
     }
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -166,6 +166,23 @@ When the now deprecated `Javadoc.setOptions(MinimalJavadocOptions)` method is ca
 
 The fact that `compileOnly` extends the `compile` configuration was on oversight. It made it very hard for users to query for the dependencies that were actually "only used for compilation".
 
+### IDEA mapping has been simplified
+
+The mapping from Gradle's configurations to IntelliJ IDEA's scopes has been drastically simplified. There used to be a lot of hardcoded mappings and pseudo-scopes in order to reduce the number of dependency declarations in the .iml files.
+These hardcoded mappings were intransparent to the user and added a lot of complexity to the codebase. Thus we decided to reimplement IDEA mapping with a very simple scheme:
+
+- The core Gradle plugins now use `idea.module.scopes.SCOPENAME.plus/minus` just like a user would
+- Only `COMPILE`, `PROVIDED`, `RUNTIME` and `TEST` are valid scope names. The (undocumented) pseudo-scopes like `RUNTIME_TEST` no longer have any effect
+- the following default mappings apply when using the `java` plugin
+    - the `COMPILE` scope is empty
+    - the `PROVIDED` scope contains the `compileClasspath` configuration
+    - the `RUNTIME` scope contains the `runtimeClasspath` configuration
+    - the `TEST` scope contains the `testCompileClasspath` and `testRuntimeClasspath` configurations
+
+This means that some `runtime` dependencies might be visible when using auto-completion in test classes. This felt like a small price to pay, since the same was already true for `testRuntime` dependencies.
+
+We have thoroughly tested these new mappings and found them to work well. Nevertheless, if you encounter any problems importing projects into IDEA, please let us know.
+
 ## External contributions
 
 We would like to thank the following community members for making contributions to this release of Gradle.

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
@@ -203,6 +203,53 @@ configure(project(":c")){
     }
 
     @Test
+    void includesTransitiveImplementationDependencies() {
+        //given
+        def someArtifactJar = mavenRepo.module('someGroup', 'someArtifact', '1.0').publish().artifactFile
+        def someOtherArtifactJar = mavenRepo.module('someGroup', 'someOtherArtifact', '1.0').publish().artifactFile
+
+        //when
+        runEclipseTask """include 'a', 'b', 'c'""", """
+subprojects {
+    apply plugin: 'java'
+    apply plugin: 'eclipse'
+
+    repositories {
+        maven { url "${mavenRepo.uri}" }
+    }
+}
+
+configure(project(":a")){
+    dependencies {
+        compile 'someGroup:someOtherArtifact:1.0'
+
+        compile project(':b')
+    }
+}
+
+configure(project(":b")){
+    apply plugin: 'java-library'
+    dependencies {
+        api project(':c')
+    }
+}
+
+configure(project(":c")){
+    apply plugin: 'java-library'
+    dependencies {
+        implementation 'someGroup:someArtifact:1.0'
+    }
+}
+"""
+
+        def libs = classpath("a").libs
+        assert classpath("a").projects == ["/b", "/c"]
+        assert libs.size() == 2
+        libs[0].assertHasJar(someOtherArtifactJar)
+        libs[1].assertHasJar(someArtifactJar)
+    }
+
+    @Test
     void transitiveProjectDependenciesMappedAsDirectDependencies() {
         given:
         runEclipseTask """include 'a', 'b', 'c'""", """
@@ -1129,6 +1176,11 @@ project(':b') {
         classpathB.assertHasLibs('compile-1.0.jar')
     }
 
+    /*
+     * This is a test describing the current, not necessarily desired behavior. We really shouldn't
+     * put duplicate dependencies on the classpath. The order will always be arbitrary and break one
+     * use case or another.
+     */
     @Test
     void "conflicting versions of the same library for compile and compile-only mapped to classpath"() {
         // given
@@ -1164,12 +1216,17 @@ project(':b') {
         def classpathA = classpath('a')
         def classpathB = classpath('b')
         assert classpathA.libs.size() == 2
-        classpathA.assertHasLibs('conflictingDependency-1.0.jar', 'conflictingDependency-2.0.jar')
+        classpathA.assertHasLibs('conflictingDependency-2.0.jar', 'conflictingDependency-1.0.jar')
         assert classpathB.libs.size() == 1
         assert classpathB.projects == ['/a']
         classpathB.assertHasLibs('conflictingDependency-1.0.jar')
     }
 
+    /*
+     * This is a test describing the current, not necessarily desired behavior. We really shouldn't
+     * put duplicate dependencies on the classpath. The order will always be arbitrary and break one
+     * use case or another.
+     */
     @Test
     void "conflicting versions of the same library for runtime and compile-only mapped to classpath"() {
         // given
@@ -1205,12 +1262,17 @@ project(':b') {
         def classpathA = classpath('a')
         def classpathB = classpath('b')
         assert classpathA.libs.size() == 2
-        classpathA.assertHasLibs('conflictingDependency-1.0.jar', 'conflictingDependency-2.0.jar')
+        classpathA.assertHasLibs('conflictingDependency-2.0.jar', 'conflictingDependency-1.0.jar')
         assert classpathB.libs.size() == 1
         assert classpathB.projects == ['/a']
         classpathB.assertHasLibs('conflictingDependency-1.0.jar')
     }
 
+    /*
+     * This is a test describing the current, not necessarily desired behavior. We really shouldn't
+     * put duplicate dependencies on the classpath. The order will always be arbitrary and break one
+     * use case or another.
+     */
     @Test
     void "conflicting versions of the same library for test-compile and testcompile-only mapped to classpath"() {
         // given
@@ -1246,7 +1308,7 @@ project(':b') {
         def classpathA = classpath('a')
         def classpathB = classpath('b')
         assert classpathA.libs.size() == 2
-        classpathA.assertHasLibs('conflictingDependency-1.0.jar', 'conflictingDependency-2.0.jar')
+        classpathA.assertHasLibs('conflictingDependency-2.0.jar', 'conflictingDependency-1.0.jar')
         assert classpathB.libs.size() == 0
         assert classpathB.projects == ['/a']
     }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
@@ -79,7 +79,7 @@ class EclipseWtpWebAndJavaProjectIntegrationTest extends AbstractEclipseIntegrat
         javaClasspath.lib('hamcrest-core-1.3.jar').assertIsExcludedFromDeployment()
 
         def webClasspath = classpath('web')
-        webClasspath.assertHasLibs('commons-lang3-3.0.jar', 'javax.servlet-api-3.1.0.jar', 'junit-4.12.jar', "guava-18.0.jar", 'hamcrest-core-1.3.jar')
+        webClasspath.assertHasLibs('commons-lang3-3.0.jar', 'javax.servlet-api-3.1.0.jar', "guava-18.0.jar", 'junit-4.12.jar', 'hamcrest-core-1.3.jar')
         webClasspath.lib('commons-lang3-3.0.jar').assertIsDeployedTo("/WEB-INF/lib")
         webClasspath.lib('javax.servlet-api-3.1.0.jar').assertIsExcludedFromDeployment()
         webClasspath.lib('junit-4.12.jar').assertIsExcludedFromDeployment()

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebProjectIntegrationTest.groovy
@@ -54,7 +54,7 @@ class EclipseWtpWebProjectIntegrationTest extends AbstractEclipseIntegrationSpec
 
         // Classpath
         def classpath = classpath
-        classpath.assertHasLibs('guava-18.0.jar', 'javax.servlet-api-3.1.0.jar', 'junit-4.12.jar', 'hamcrest-core-1.3.jar', 'jstl-1.2.jar')
+        classpath.assertHasLibs('guava-18.0.jar', 'jstl-1.2.jar', 'javax.servlet-api-3.1.0.jar', 'junit-4.12.jar', 'hamcrest-core-1.3.jar')
         classpath.lib('guava-18.0.jar').assertIsDeployedTo("/WEB-INF/lib")
         classpath.lib('javax.servlet-api-3.1.0.jar').assertIsExcludedFromDeployment()
         classpath.lib('jstl-1.2.jar').assertIsExcludedFromDeployment()

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
@@ -47,8 +47,8 @@ project(":project2") {
 
         def dependencies = parseIml("project2/project2.iml").dependencies
         assert dependencies.libraries.size() == 0
-        assert dependencies.modules.size() == 1
-        dependencies.assertHasModule('COMPILE', 'project1')
+        assert dependencies.modules.size() == 3
+        dependencies.assertHasModule(['PROVIDED', 'RUNTIME','TEST'], 'project1')
     }
 
     @Test
@@ -80,10 +80,10 @@ project(":project2") {
 """)
 
         def dependencies = parseIml("project2/project2.iml").dependencies
-        assert dependencies.libraries.size() == 1
-        dependencies.assertHasLibrary("COMPILE", "module1-1.0.jar")
-        assert dependencies.modules.size() == 1
-        dependencies.assertHasModule('COMPILE', 'project1')
+        assert dependencies.libraries.size() == 3
+        dependencies.assertHasLibrary(['PROVIDED', 'RUNTIME','TEST'], "module1-1.0.jar")
+        assert dependencies.modules.size() == 3
+        dependencies.assertHasModule(['PROVIDED', 'RUNTIME','TEST'], 'project1')
     }
 
     @Test
@@ -112,8 +112,8 @@ project(":project2") {
 """)
 
         def dependencies = parseIml("project2/project2.iml").dependencies
-        assert dependencies.libraries.size() == 1
-        dependencies.assertHasLibrary('COMPILE', 'junit-4.7.jar')
+        assert dependencies.libraries.size() == 3
+        dependencies.assertHasLibrary(['PROVIDED', 'RUNTIME','TEST'], 'junit-4.7.jar')
         assert dependencies.modules.size() == 0
     }
 }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -151,7 +151,7 @@ dependencies {
 
         def module = parseImlFile("root")
         def libs = module.component.orderEntry.library
-        assert libs.size() == 2
+        assert libs.size() == 6
         assert libs.CLASSES.root*.@url*.text().collect { new File(it).name } as Set == [artifact1.name + "!", artifact2.name + "!"] as Set
     }
 
@@ -179,9 +179,9 @@ dependencies {
 
         def module = parseImlFile("root")
         def libs = module.component.orderEntry.library
-        assert libs.size() == 1
+        assert libs.size() == 3
         assert libs.CLASSES.root*.@url*.text().collect { new File(it).name } as Set == [artifact1.name + "!"] as Set
-        assert libs.CLASSES.root*.@url*.text().findAll() { it.contains("\$GRADLE_REPO\$") }.size() == 1
+        assert libs.CLASSES.root*.@url*.text().findAll() { it.contains("\$GRADLE_REPO\$") }.size() == 3
         assert libs.CLASSES.root*.@url*.text().collect { it.replace("\$GRADLE_REPO\$", relPath(repoDir)) } as Set == ["jar://${relPath(artifact1)}!/"] as Set
     }
 
@@ -255,7 +255,7 @@ dependencies {
 
         def module = parseImlFile("root")
         def libs = module.component.orderEntry.library
-        assert libs.size() == 1
+        assert libs.size() == 3
     }
 
     @Test
@@ -281,7 +281,7 @@ dependencies {
 
         def module = parseImlFile("root")
         def libs = module.component.orderEntry.library
-        assert libs.size() == 1
+        assert libs.size() == 3
     }
 
     @Test

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
@@ -739,4 +739,54 @@ dependencies {
         dependencies.assertHasLibrary('TEST', 'bothCompileAndCompileOnly-1.0.jar')
         dependencies.assertHasLibrary('TEST', 'bothCompileAndCompileOnly-2.0.jar')
     }
+
+    @Test
+    void "providedCompile dependencies are added to PROVIDED only"() {
+        // given
+        mavenRepo.module('org.gradle.test', 'foo', '1.0').publish()
+
+        // when
+        runIdeaTask """
+            apply plugin: 'war'
+            apply plugin: 'idea'
+
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+
+            dependencies {
+                providedCompile 'org.gradle.test:foo:1.0'
+            }
+        """.stripIndent()
+
+        // then
+        def dependencies = parseIml("root.iml").dependencies
+        assert dependencies.libraries.size() == 1
+        dependencies.assertHasLibrary('PROVIDED', 'foo-1.0.jar')
+    }
+
+    @Test
+    void "providedRuntime dependencies are added to PROVIDED only"() {
+        // given
+        mavenRepo.module('org.gradle.test', 'foo', '1.0').publish()
+
+        // when
+        runIdeaTask """
+            apply plugin: 'war'
+            apply plugin: 'idea'
+
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+
+            dependencies {
+                providedRuntime 'org.gradle.test:foo:1.0'
+            }
+        """.stripIndent()
+
+        // then
+        def dependencies = parseIml("root.iml").dependencies
+        assert dependencies.libraries.size() == 1
+        dependencies.assertHasLibrary('PROVIDED', 'foo-1.0.jar')
+    }
 }

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/api/api.iml.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/api/api.iml.xml
@@ -33,6 +33,19 @@
         </SOURCES>
       </library>
     </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar!/"/>
+        </CLASSES>
+        <JAVADOC>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
+        </JAVADOC>
+        <SOURCES>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar!/"/>
+        </SOURCES>
+      </library>
+    </orderEntry>
   </component>
   <component name="ModuleRootManager"/>
 </module>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webservice/webservice.iml.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webservice/webservice.iml.xml
@@ -9,6 +9,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.gradle"/>
     </content>
     <orderEntry type="sourceFolder" forTests="false"/>
+    <orderEntry module-name="api" type="module" scope="PROVIDED"/>
     <orderEntry type="module-library" scope="PROVIDED">
       <library>
         <CLASSES>
@@ -20,8 +21,7 @@
         </SOURCES>
       </library>
     </orderEntry>
-    <orderEntry type="module" module-name="api"/>
-    <orderEntry type="module-library">
+    <orderEntry type="module-library" scope="PROVIDED">
       <library>
         <CLASSES>
           <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar!/"/>
@@ -34,13 +34,25 @@
         </SOURCES>
       </library>
     </orderEntry>
-    <orderEntry type="module-library">
+    <orderEntry type="module-library" scope="PROVIDED">
       <library>
         <CLASSES>
           <root url="jar://$MODULE_DIR$/lib/compile-1.0.jar!/"/>
         </CLASSES>
         <JAVADOC/>
         <SOURCES/>
+      </library>
+    </orderEntry>
+    <orderEntry module-name="api" type="module" scope="RUNTIME"/>
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library>
+        <CLASSES>
+          <root url="jar://@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8.jar!/"/>
+        </CLASSES>
+        <JAVADOC/>
+        <SOURCES>
+          <root url="jar://@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8-sources.jar!/"/>
+        </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
@@ -69,6 +81,27 @@
         </SOURCES>
       </library>
     </orderEntry>
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/compile-1.0.jar!/"/>
+        </CLASSES>
+        <JAVADOC/>
+        <SOURCES/>
+      </library>
+    </orderEntry>
+    <orderEntry module-name="api" type="module" scope="TEST"/>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8.jar!/"/>
+        </CLASSES>
+        <JAVADOC/>
+        <SOURCES>
+          <root url="jar://@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8-sources.jar!/"/>
+        </SOURCES>
+      </library>
+    </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
@@ -78,6 +111,54 @@
         <SOURCES>
           <root url="jar://@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar!/"/>
         </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar!/"/>
+        </CLASSES>
+        <JAVADOC>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
+        </JAVADOC>
+        <SOURCES>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar!/"/>
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://@CACHE_DIR@/commons-lang/commons-lang/2.4/@SHA1@/commons-lang-2.4.jar!/"/>
+        </CLASSES>
+        <JAVADOC>
+          <root url="jar://@CACHE_DIR@/commons-lang/commons-lang/2.4/@SHA1@/commons-lang-2.4-javadoc.jar!/"/>
+        </JAVADOC>
+        <SOURCES>
+          <root url="jar://@CACHE_DIR@/commons-lang/commons-lang/2.4/@SHA1@/commons-lang-2.4-sources.jar!/"/>
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2.jar!/"/>
+        </CLASSES>
+        <JAVADOC>
+          <root url="jar://@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-javadoc.jar!/"/>
+        </JAVADOC>
+        <SOURCES>
+          <root url="jar://@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-sources.jar!/"/>
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/compile-1.0.jar!/"/>
+        </CLASSES>
+        <JAVADOC/>
+        <SOURCES/>
       </library>
     </orderEntry>
   </component>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webservice/webservice.iml.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webservice/webservice.iml.xml
@@ -47,17 +47,6 @@
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8.jar!/"/>
-        </CLASSES>
-        <JAVADOC/>
-        <SOURCES>
-          <root url="jar://@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8-sources.jar!/"/>
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" scope="RUNTIME">
-      <library>
-        <CLASSES>
           <root url="jar://@CACHE_DIR@/commons-lang/commons-lang/2.4/@SHA1@/commons-lang-2.4.jar!/"/>
         </CLASSES>
         <JAVADOC>
@@ -91,17 +80,6 @@
       </library>
     </orderEntry>
     <orderEntry module-name="api" type="module" scope="TEST"/>
-    <orderEntry type="module-library" scope="TEST">
-      <library>
-        <CLASSES>
-          <root url="jar://@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8.jar!/"/>
-        </CLASSES>
-        <JAVADOC/>
-        <SOURCES>
-          <root url="jar://@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8-sources.jar!/"/>
-        </SOURCES>
-      </library>
-    </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/overwritesExistingDependencies/expectedFiles/root.iml.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/overwritesExistingDependencies/expectedFiles/root.iml.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <module relativePaths="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output/>
@@ -19,6 +20,28 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
+      <library>
+        <CLASSES>
+          <root url="jar://@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar!/"/>
+        </CLASSES>
+        <JAVADOC/>
+        <SOURCES>
+          <root url="jar://@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar!/"/>
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar!/"/>
+        </CLASSES>
+        <JAVADOC/>
+        <SOURCES>
+          <root url="jar://@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar!/"/>
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
           <root url="jar://@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar!/"/>

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -271,7 +271,7 @@ public class EclipsePlugin extends IdePlugin {
     }
 
     private static void configureJavaClasspath(final Project project, GenerateEclipseClasspath task) {
-        task.getClasspath().setPlusConfigurations(Lists.newArrayList(project.getConfigurations().getByName("testRuntime"), project.getConfigurations().getByName("compileClasspath"), project.getConfigurations().getByName("testCompileClasspath")));
+        task.getClasspath().setPlusConfigurations(Lists.newArrayList(project.getConfigurations().getByName("compileClasspath"), project.getConfigurations().getByName("runtimeClasspath"), project.getConfigurations().getByName("testCompileClasspath"), project.getConfigurations().getByName("testRuntimeClasspath")));
         ((IConventionAware) task.getClasspath()).getConventionMapping().map("classFolders", new Callable<List<File>>() {
             @Override
             public List<File> call() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -46,14 +46,14 @@ import java.util.Set;
  * apply plugin: 'java'
  * apply plugin: 'idea'
  *
- * //for the sake of this example, let's introduce a 'provided' configuration
+ * //for the sake of this example, let's introduce a 'performanceTestCompile' configuration
  * configurations {
- *   provided
- *   provided.extendsFrom(compile)
+ *   performanceTestCompile
+ *   performanceTestCompile.extendsFrom(testCompile)
  * }
  *
  * dependencies {
- *   //provided "some.interesting:dependency:1.0"
+ *   //performanceTestCompile "some.interesting:dependency:1.0"
  * }
  *
  * idea {
@@ -85,8 +85,8 @@ import java.util.Set;
  *     //if you prefer different SDK than the one inherited from IDEA project
  *     jdkName = '1.6'
  *
- *     //if you need to put 'provided' dependencies on the classpath
- *     scopes.PROVIDED.plus += [ configurations.provided ]
+ *     //put our custom test dependencies onto IDEA's TEST scope
+ *     scopes.TEST.plus += [ configurations.performanceTestCompile ]
  *
  *     //if 'content root' (as IDEA calls it) of the module is different
  *     contentRoot = file('my-module-content-root')
@@ -239,23 +239,23 @@ public class IdeaModule {
      * The values of those keys are collections of {@link org.gradle.api.artifacts.Configuration} objects. The files of the
      * plus configurations are added minus the files from the minus configurations. See example below...
      * <p>
-     * Example how to use scopes property to enable 'provided' dependencies in the output *.iml file:
+     * Example how to use scopes property to enable 'performanceTestCompile' dependencies in the output *.iml file:
      * <pre autoTested=''>
      * apply plugin: 'java'
      * apply plugin: 'idea'
      *
      * configurations {
-     *   provided
-     *   provided.extendsFrom(compile)
+     *   performanceTestCompile
+     *   performanceTestCompile.extendsFrom(testCompile)
      * }
      *
      * dependencies {
-     *   //provided "some.interesting:dependency:1.0"
+     *   //performanceTestCompile "some.interesting:dependency:1.0"
      * }
      *
      * idea {
      *   module {
-     *     scopes.PROVIDED.plus += [ configurations.provided ]
+     *     scopes.TEST.plus += [ configurations.performanceTestCompile ]
      *   }
      * }
      * </pre>

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/GeneratedIdeaScope.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/GeneratedIdeaScope.java
@@ -16,28 +16,12 @@
 
 package org.gradle.plugins.ide.idea.model.internal;
 
-import com.google.common.collect.Sets;
-
-import java.util.Collections;
-import java.util.Set;
-
 /**
- * An enumeration of possible mappings used to assign Idea classpath scope to Gradle dependency.
+ * The classpath scopes available in IntelliJ IDEA
  */
 public enum GeneratedIdeaScope {
-    PROVIDED_TEST("PROVIDED", "TEST"),
-    PROVIDED("PROVIDED"),
-    COMPILE("COMPILE"),
-    RUNTIME_COMPILE_CLASSPATH("PROVIDED", "RUNTIME"),
-    RUNTIME_TEST_COMPILE_CLASSPATH("PROVIDED", "TEST"),
-    RUNTIME_TEST("RUNTIME", "TEST"),
-    RUNTIME("RUNTIME"),
-    TEST("TEST"),
-    COMPILE_CLASSPATH("PROVIDED");
-
-    public final Set<String> scopes;
-
-    GeneratedIdeaScope(String ... scopes) {
-        this.scopes = Collections.unmodifiableSet(Sets.newHashSet(scopes));
-    }
+    PROVIDED,
+    COMPILE,
+    RUNTIME,
+    TEST;
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
@@ -39,6 +39,8 @@ import java.util.Set;
 
 public class IdeaDependenciesProvider {
 
+    public static final String SCOPE_PLUS = "plus";
+    public static final String SCOPE_MINUS = "minus";
     private final IdeDependenciesExtractor dependenciesExtractor;
     private final ModuleDependencyBuilder moduleDependencyBuilder;
 
@@ -161,11 +163,11 @@ public class IdeaDependenciesProvider {
     }
 
     private Collection<Configuration> getPlusConfigurations(IdeaModule ideaModule, GeneratedIdeaScope scope) {
-        return getConfigurations(ideaModule, scope, "plus");
+        return getConfigurations(ideaModule, scope, SCOPE_PLUS);
     }
 
     private Collection<Configuration> getMinusConfigurations(IdeaModule ideaModule, GeneratedIdeaScope scope) {
-        return getConfigurations(ideaModule, scope, "minus");
+        return getConfigurations(ideaModule, scope, SCOPE_MINUS);
     }
 
     private Collection<Configuration> getConfigurations(IdeaModule ideaModule, GeneratedIdeaScope scope, String plusMinus) {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
@@ -58,7 +58,7 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
         project.apply(plugin: 'java')
 
         then:
-        checkEclipseClasspath([project.configurations.testRuntime, project.configurations.compileClasspath, project.configurations.testCompileClasspath])
+        checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath])
     }
 
     def applyToScalaProject_shouldHaveProjectAndClasspathTaskForScala() {
@@ -80,7 +80,7 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
         project.apply(plugin: 'scala')
 
         then:
-        checkEclipseClasspath([project.configurations.testRuntime, project.configurations.compileClasspath, project.configurations.testCompileClasspath], scalaIdeContainer)
+        checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath], scalaIdeContainer)
     }
 
     def applyToGroovyProject_shouldHaveProjectAndClasspathTaskForGroovy() {
@@ -100,7 +100,7 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
         project.apply(plugin: 'groovy')
 
         then:
-        checkEclipseClasspath([project.configurations.testRuntime, project.configurations.compileClasspath, project.configurations.testCompileClasspath])
+        checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath])
     }
 
     def "creates empty classpath model for non java projects"() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -67,7 +67,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         [project.tasks.cleanEclipseWtpComponent, project.tasks.cleanEclipseWtpFacet].each {
             assert project.tasks.cleanEclipseWtp.dependsOn.contains(it)
         }
-        checkEclipseClasspath([project.configurations.testRuntime, project.configurations.compileClasspath, project.configurations.testCompileClasspath])
+        checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath])
         checkEclipseWtpComponentForJava()
         checkEclipseWtpFacet([
                 new Facet(FacetType.fixed, 'jst.java', null),
@@ -85,7 +85,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         [project.tasks.cleanEclipseWtpComponent, project.tasks.cleanEclipseWtpFacet].each {
             assert project.tasks.cleanEclipseWtp.dependsOn.contains(it)
         }
-        checkEclipseClasspath([project.configurations.testRuntime, project.configurations.compileClasspath, project.configurations.testCompileClasspath])
+        checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath])
         checkEclipseWtpComponentForJava()
         checkEclipseWtpFacet([
                 new Facet(FacetType.fixed, 'jst.java', null),
@@ -124,7 +124,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
             assert project.tasks.cleanEclipseWtp.dependsOn.contains(it)
         }
 
-        checkEclipseClasspath([project.configurations.testRuntime, project.configurations.compileClasspath, project.configurations.testCompileClasspath])
+        checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath])
         checkEclipseWtpComponentForWar()
         checkEclipseWtpFacet([
                 new Facet(FacetType.fixed, "jst.java", null),
@@ -144,7 +144,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
             assert project.tasks.cleanEclipseWtp.dependsOn.contains(it)
         }
 
-        checkEclipseClasspath([project.configurations.testRuntime, project.configurations.compileClasspath, project.configurations.testCompileClasspath])
+        checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath])
         checkEclipseWtpComponentForWar()
         checkEclipseWtpFacet([
                 new Facet(FacetType.fixed, "jst.java", null),
@@ -218,7 +218,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         }
 
         if (plugs.contains('java')) {
-            checkEclipseClasspath([project.configurations.testRuntime, project.configurations.compileClasspath, project.configurations.testCompileClasspath])
+            checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath])
             checkEclipseWtpComponentForEar(project.sourceSets.main.allSource.srcDirs)
         } else {
             checkEclipseClasspath([])

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
@@ -92,12 +92,11 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         then:
         project.idea.project.languageLevel.level == new IdeaLanguageLevel(project.sourceCompatibility).level
 
-        // def configurations = project.configurations
         project.idea.module.scopes == [
-                PROVIDED: [plus: [], minus: []],
+                PROVIDED: [plus: [project.configurations.compileClasspath], minus: []],
                 COMPILE: [plus: [], minus: []],
-                RUNTIME: [plus: [], minus: []],
-                TEST: [plus: [], minus: []],
+                RUNTIME: [plus: [project.configurations.runtimeClasspath], minus: []],
+                TEST: [plus: [project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath], minus: []],
         ]
     }
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
@@ -53,7 +53,7 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         result.isEmpty()
     }
 
-    def "common dependencies"() {
+    def "dependencies are added to each required scope"() {
         applyPluginToProjects()
         project.apply(plugin: 'java')
 
@@ -66,8 +66,10 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 2
-        assertSingleLibrary(result, 'COMPILE', 'guava.jar')
+        result.size() == 4
+        assertSingleLibrary(result, 'PROVIDED', 'guava.jar')
+        assertSingleLibrary(result, 'RUNTIME', 'guava.jar')
+        assertSingleLibrary(result, 'TEST', 'guava.jar')
         assertSingleLibrary(result, 'TEST', 'mockito.jar')
     }
 
@@ -80,9 +82,9 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('compile', project.files('lib/guava.jar'))
+        project.dependencies.add('testRuntime', project.files('lib/guava.jar'))
         project.dependencies.add('excluded', project.files('lib/guava.jar'))
-        module.scopes.COMPILE.minus << project.configurations.getByName('excluded')
+        module.scopes.TEST.minus << project.configurations.getByName('excluded')
         def result = dependenciesProvider.provide(module)
 
         then:
@@ -99,12 +101,12 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('compile', project.files('lib/guava.jar'))
-        project.dependencies.add('compile', project.files('lib/slf4j-api.jar'))
+        project.dependencies.add('testRuntime', project.files('lib/guava.jar'))
+        project.dependencies.add('testRuntime', project.files('lib/slf4j-api.jar'))
         project.dependencies.add('excluded1', project.files('lib/guava.jar'))
         project.dependencies.add('excluded2', project.files('lib/slf4j-api.jar'))
-        module.scopes.COMPILE.minus << project.configurations.getByName('excluded1')
-        module.scopes.COMPILE.minus << project.configurations.getByName('excluded2')
+        module.scopes.TEST.minus << project.configurations.getByName('excluded1')
+        module.scopes.TEST.minus << project.configurations.getByName('excluded2')
         def result = dependenciesProvider.provide(module)
 
         then:
@@ -142,8 +144,10 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 1
-        result.findAll { it.scope == 'COMPILE' }.size() == 1
+        result.size() == 3
+        result.findAll { it.scope == 'PROVIDED' }.size() == 1
+        result.findAll { it.scope == 'RUNTIME' }.size() == 1
+        result.findAll { it.scope == 'TEST' }.size() == 1
     }
 
     def "test and runtime scope for the same dependency"() {
@@ -154,14 +158,12 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('compile', project.files('lib/foo-api.jar'))
         project.dependencies.add('testCompile', project.files('lib/foo-impl.jar'))
         project.dependencies.add('runtime', project.files('lib/foo-impl.jar'))
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 3
-        assertSingleLibrary(result, 'COMPILE', 'foo-api.jar')
+        result.size() == 2
         assertSingleLibrary(result, 'TEST', 'foo-impl.jar')
         assertSingleLibrary(result, 'RUNTIME', 'foo-impl.jar')
     }
@@ -174,14 +176,12 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('compile', project.files('lib/guava.jar'))
         project.dependencies.add('compileOnly', project.files('lib/foo-api.jar'))
         project.dependencies.add('testRuntime', project.files('lib/foo-impl.jar'))
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 3
-        assertSingleLibrary(result, 'COMPILE', 'guava.jar')
+        result.size() == 2
         assertSingleLibrary(result, 'PROVIDED', 'foo-api.jar')
         assertSingleLibrary(result, 'TEST', 'foo-impl.jar')
     }
@@ -201,10 +201,11 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 4
+        result.size() == 5
         assertSingleLibrary(result, 'PROVIDED', 'foo-runtime.jar')
         assertSingleLibrary(result, 'PROVIDED', 'foo-testRuntime.jar')
         assertSingleLibrary(result, 'RUNTIME', 'foo-runtime.jar')
+        assertSingleLibrary(result, 'TEST', 'foo-runtime.jar')
         assertSingleLibrary(result, 'TEST', 'foo-testRuntime.jar')
     }
 
@@ -223,9 +224,9 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def result = dependenciesProvider.provide(module)
 
         then:
-        // only for compile, runtime, testCompile, testRuntime, compileOnly, testCompileOnly
-        6 * dependenciesExtractor.extractProjectDependencies(_, { !it.contains(extraConfiguration) }, _)
-        6 * dependenciesExtractor.extractLocalFileDependencies({ !it.contains(extraConfiguration) }, _)
+        // only for compileClasspath, runtimeClasspath, testCompileClasspath, testRuntimeClasspath
+        4 * dependenciesExtractor.extractProjectDependencies(_, { !it.contains(extraConfiguration) }, _)
+        4 * dependenciesExtractor.extractLocalFileDependencies({ !it.contains(extraConfiguration) }, _)
         // offline: 4 * dependenciesExtractor.extractRepoFileDependencies(_, { !it.contains(extraConfiguration) }, _, _, _)
         0 * dependenciesExtractor._
         result.size() == 1

--- a/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaModuleFixture.groovy
+++ b/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaModuleFixture.groovy
@@ -145,6 +145,14 @@ class IdeaModuleFixture {
             assert dependencies.findAll { it.type == 'sourceFolder' }.any { ImlSource it -> it.forTests == forTests }
         }
 
+        void assertHasModule(List<String> scopes, String name) {
+            scopes.each {assertHasModule(it, name)}
+        }
+
+        void assertHasLibrary(List<String> scopes, String name) {
+            scopes.each {assertHasLibrary(it, name)}
+        }
+
         void assertHasModule(String scope = 'COMPILE', String name) {
             assert modules.any { ImlModule it ->
                 it.scope == scope && it.moduleName == name

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.tooling.model.idea.IdeaModule
 import org.gradle.tooling.model.idea.IdeaModuleDependency
 import org.gradle.tooling.model.idea.IdeaProject
 import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
+import org.gradle.util.GradleVersion
 
 class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
 
@@ -215,7 +216,11 @@ project(':impl') {
 
         IdeaModuleDependency mod = libs.find {it instanceof IdeaModuleDependency}
         mod.dependencyModule == project.modules.find { it.name == 'api'}
-        mod.scope.scope == 'COMPILE'
+        if (targetVersion >= GradleVersion.version("3.4")) {
+            mod.scope.scope == 'PROVIDED'
+        } else {
+            mod.scope.scope == 'COMPILE'
+        }
     }
 
     @TargetGradleVersion('>=1.2 <=2.7')
@@ -307,8 +312,13 @@ project(':impl') {
 
         then:
         def libs = impl.dependencies
-        libs.size() == 1
-        IdeaModuleDependency d = libs[0]
-        d.dependencyModule == project.modules.find { it.name == 'api' }
+        if (targetVersion >= GradleVersion.version("3.4")) {
+            libs.size() == 3
+        } else {
+            libs.size() == 1
+        }
+        libs.each {
+            it.dependencyModule == project.modules.find { it.name == 'api' }
+        }
     }
 }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r11rc1/DependencyMetaDataCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r11rc1/DependencyMetaDataCrossVersionSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.tooling.model.ExternalDependency
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.idea.IdeaProject
+import org.gradle.util.GradleVersion
 
 class DependencyMetaDataCrossVersionSpec extends ToolingApiSpecification {
 
@@ -70,8 +71,6 @@ dependencies {
     }
 
     private void containModuleInfo(libs) {
-        assert libs.size() == 3
-
         ExternalDependency coolLib = libs.find { it.file.name == 'coolLib-2.0.jar' }
         assert coolLib.gradleModuleVersion
         assert coolLib.gradleModuleVersion.group == 'foo.bar'

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r11rc1/DependencyMetaDataCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r11rc1/DependencyMetaDataCrossVersionSpec.groovy
@@ -20,7 +20,6 @@ import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.tooling.model.ExternalDependency
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.idea.IdeaProject
-import org.gradle.util.GradleVersion
 
 class DependencyMetaDataCrossVersionSpec extends ToolingApiSpecification {
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/AdHocCompositeDependencySubstitutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/AdHocCompositeDependencySubstitutionCrossVersionSpec.groovy
@@ -38,7 +38,7 @@ class AdHocCompositeDependencySubstitutionCrossVersionSpec extends ToolingApiSpe
             buildFile << """
                 apply plugin: 'java'
                 dependencies {
-                    compile "org.test:b1:1.0"
+                    testCompile "org.test:b1:1.0"
                 }
             """
         }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
@@ -37,7 +37,7 @@ class PersistentCompositeDependencySubstitutionCrossVersionSpec extends ToolingA
             buildFile << """
                 apply plugin: 'java'
                 dependencies {
-                    compile "org.test:b1:1.0"
+                    testCompile "org.test:b1:1.0"
                 }
             """
             settingsFile << """

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.tooling.model.idea.IdeaModuleDependency
 import org.gradle.tooling.model.idea.IdeaProject
 import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
+import org.gradle.util.GradleVersion
 
 class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
     @ToolingApiVersion(">=3.1")
@@ -109,6 +110,10 @@ project(':impl') {
 
         IdeaModuleDependency mod = libs.find {it instanceof IdeaModuleDependency}
         mod.dependencyModule == project.modules.find { it.name == 'api'}
-        mod.scope.scope == 'COMPILE'
+        if (targetVersion >= GradleVersion.version("3.4")) {
+            mod.scope.scope == 'PROVIDED'
+        } else {
+            mod.scope.scope == 'COMPILE'
+        }
     }
 }


### PR DESCRIPTION
This adds IDE support for the new `java-libary` plugin, adding api/implementation dependencies to the right buckets in the IDEs.

The majority of the changes are a refactoring of the IDEA mapping, which has been greatly simplified. This will need some exploratory testing to make sure all use cases are still properly supported. @melix @jjohannes I've added you both as reviewers because of this higher testing overhead. 

More details from the commit message:

The old scope mapping code was hardcoded, hard to understand and exploded in complexity
each time we added a new configuration to the Java plugin. It was doing this hardcoded
mapping in an attempt to minimize the number of dependency declarations in IDEA, e.g.
remove `testRuntime` dependencies from the `TEST` scope if they were already in the `RUNTIME`
scope and not present in `testCompile`. While this slightly reduces the number of false positives
in auto completion, it is hard to follow, as IDEA itself simply does not differentiate between
"test compilation" and "test runtime".

The new implementation accepts IDEA's dependency model and does the simples possible mapping to it:

- no hardcoded mapping rules for the Java plugin
- users can put dependencies into the 4 IDEA scopes (`COMPILE`,`PROVIDED`,`RUNTIME`, `TEST`)
- the IdeaPlugin uses the same API for adding dependencies that the user would use
- those scopes are not postprocessed in any way

The default mapping for the Java plugin is simplified to:
 - `COMPILE` is empty
 - `PROVIDED` = `compileClasspath`
 - `RUNTIME` = `runtimeClasspath`
 - `TEST`= `testCompileClasspath + testRuntimeClasspath`

The benefit of this mapping is that we no longer use `minus` configurations, which we might want
to deprecate/remove as well.