### PR TITLE
Make configuration time cheaper

### DIFF
--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/CachedConstructorsBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/CachedConstructorsBenchmark.java
@@ -30,6 +30,7 @@ public class CachedConstructorsBenchmark {
     private final static Class<?>[] CLAZZ_ARRAY = new Class[]{ArrayList.class, LinkedList.class, String.class, HashMap.class};
     private final static int ARR_LEN = 1024;
     private final static Random RANDOM = new Random();
+    public static final Class[] EMPTY = new Class[0];
 
     private final DirectInstantiator.ConstructorCache cache = new DirectInstantiator.ConstructorCache();
     private Class<?>[] randomClasses;
@@ -51,6 +52,6 @@ public class CachedConstructorsBenchmark {
 
     @Benchmark
     public void cached(Blackhole bh) {
-        bh.consume(cache.get(randomClasses[++i % ARR_LEN]));
+        bh.consume(cache.get(randomClasses[++i % ARR_LEN], EMPTY));
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/api/Describable.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/Describable.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api;
 
-import java.io.IOException;
-
 /**
  * Types can implement this interface when they provide a human-readable display name.
  * It is strongly encouraged to compute this display name lazily: computing a display name,
@@ -25,6 +23,7 @@ import java.io.IOException;
  *
  * @since 3.4
  */
+@Incubating
 public interface Describable {
     /**
      * Returns the display name of this object. It is strongly encouraged to compute it
@@ -32,12 +31,4 @@ public interface Describable {
      * @return the display name
      */
     String getDisplayName();
-
-    /**
-     * Appends the description of this object to the provided appender.
-     *
-     * // todo: turn this into a default method once we migrate Gradle to Java 8
-     * @param builder the builder to append the description to.
-     */
-    void describeTo(Appendable builder) throws IOException;
 }

--- a/subprojects/base-services/src/main/java/org/gradle/api/Describable.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/Describable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api;
+
+import java.io.IOException;
+
+/**
+ * Types can implement this interface when they provide a human-readable display name.
+ * It is strongly encouraged to compute this display name lazily: computing a display name,
+ * even if it's only a string concatenation, can take a significant amount of time during
+ * configuration for something that would only be used, typically, in error messages.
+ *
+ * @since 3.4
+ */
+public interface Describable {
+    /**
+     * Returns the display name of this object. It is strongly encouraged to compute it
+     * lazily, and cache the value if it is expensive.
+     * @return the display name
+     */
+    String getDisplayName();
+
+    /**
+     * Appends the description of this object to the provided appender.
+     *
+     * // todo: turn this into a default method once we migrate Gradle to Java 8
+     * @param builder the builder to append the description to.
+     */
+    void describeTo(Appendable builder) throws IOException;
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal;
 
+import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.specs.Spec;
@@ -23,6 +24,7 @@ import org.gradle.api.specs.Spec;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 
 public abstract class Actions {
 
@@ -219,6 +221,86 @@ public abstract class Actions {
                 collection.add(t);
             }
         };
+    }
+
+    /**
+     * Composes 2 actions with set semantics. The order of parameters is important
+     * because it will mutate and return the first argument if it is already an
+     * {@link ActionSet<T> action set}. This is in particular useful to avoid eager
+     * initialization of sets, or actions, when in most of the cases the action is
+     * absent or single. If the first parameter is null, then it will return the second
+     * parameter, allowing fluent initialization of a set.
+     *
+     * @param a first action, maybe null
+     * @param b second action, must not be null
+     * @param <T> the type of the action subject
+     * @return an action representing the set of (a,b)
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Action<T> set(Action<T> a, Action<T> b) {
+        if (a == null) {
+            return b;
+        }
+        if (a == b || a.equals(b)) {
+            return a;
+        }
+        if (a instanceof ActionSet) {
+            ((ActionSet<T>) a).addAction(b);
+            return a;
+        } else {
+            return new ActionSet<T>(a, b);
+        }
+    }
+
+    public static <T> Action<T> set(Action<T> a, Action<T>... elements) {
+        if (elements.length==1) {
+            return a;
+        }
+        Action<T> action = a;
+        for (Action<T> element : elements) {
+            action = set(action, element);
+        }
+        return action;
+    }
+
+    private static class ActionSet<T> implements Action<T> {
+        private final LinkedHashSet<Action<? super T>> actions = Sets.newLinkedHashSet();
+
+        public ActionSet(Action<? super T>... actions) {
+            for (Action<? super T> action : actions) {
+                this.actions.add(action);
+            }
+        }
+
+        public boolean addAction(Action<? super T> action) {
+            return this.actions.add(action);
+        }
+
+        @Override
+        public void execute(T t) {
+            for (Action<? super T> action : actions) {
+                action.execute(t);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ActionSet<?> actionSet = (ActionSet<?>) o;
+
+            return actions.equals(actionSet.actions);
+        }
+
+        @Override
+        public int hashCode() {
+            return actions.hashCode();
+        }
     }
 
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/FastActionSet.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/FastActionSet.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal;
+
+
+import com.google.common.collect.Sets;
+import org.gradle.api.Action;
+
+import java.util.LinkedHashSet;
+
+import static org.gradle.internal.Actions.DO_NOTHING;
+
+/**
+ * An {@link Action} implementation which has set semantics, but avoids creating
+ * an internal set when possible, especially if the set is empty or there's a
+ * single action in the set.
+ *
+ * This set also INTENTIONNALY ignores {@link Actions#doNothing()} actions as to
+ * avoid growing for something that would never do anything.
+ *
+ * This is done for memory and CPU efficiency, as seen
+ * in traces. This class is NOT thread-safe. Actions are executed in order of
+ * insertion.
+ *
+ * @param <T> the type of the subject of the action
+ */
+public class FastActionSet<T> implements Action<T> {
+    private Action<T> singleAction;
+    private LinkedHashSet<Action<T>> multipleActions;
+
+    public void add(Action<T> action) {
+        if (action instanceof FastActionSet) {
+            addOtherSet((FastActionSet<T>) action);
+            return;
+        }
+        if (action == DO_NOTHING) {
+            return;
+        }
+        if (singleAction == null && multipleActions==null) {
+            // first element in the set
+            this.singleAction = action;
+            return;
+        }
+        if (multipleActions != null) {
+            // already a composite set
+            multipleActions.add(action);
+            return;
+        }
+        if (singleAction == action || singleAction.equals(action)) {
+            // de-duplicate
+            return;
+        }
+        // at least 2 elements
+        multipleActions = Sets.newLinkedHashSet();
+        multipleActions.add(singleAction);
+        multipleActions.add(action);
+        singleAction = null;
+    }
+
+    protected void addOtherSet(FastActionSet<T> action) {
+        FastActionSet<T> sas = action;
+        if (sas.singleAction!=null) {
+            add(sas.singleAction);
+        } else if (sas.multipleActions!=null) {
+            for (Action<T> tAction : sas.multipleActions) {
+                add(tAction);
+            }
+        }
+    }
+
+    @Override
+    public void execute(T t) {
+        // if both singleAction and multipleActions are null then the set is empty
+        if (singleAction != null) {
+            singleAction.execute(t);
+        } else if (multipleActions != null) {
+            for (Action<T> action : multipleActions) {
+                action.execute(t);
+            }
+        }
+    }
+
+    boolean isEmpty() {
+        return singleAction == null && multipleActions == null;
+    }
+
+    int size() {
+        if (singleAction == null) {
+            if (multipleActions == null) {
+                return 0;
+            }
+            return multipleActions.size();
+        }
+        return 1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FastActionSet<?> that = (FastActionSet<?>) o;
+
+        if (singleAction != null ? !singleAction.equals(that.singleAction) : that.singleAction != null) {
+            return false;
+        }
+        return multipleActions != null ? multipleActions.equals(that.multipleActions) : that.multipleActions == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = singleAction != null ? singleAction.hashCode() : 0;
+        result = 31 * result + (multipleActions != null ? multipleActions.hashCode() : 0);
+        return result;
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
@@ -60,7 +60,7 @@ public class DirectInstantiator implements Instantiator {
         if (match == null) {
             throw new IllegalArgumentException(String.format("Could not find any public constructor for %s which accepts parameters %s.", type, Arrays.toString(params)));
         }
-        return match.getConstructor();
+        return match.getMethod();
     }
 
     @VisibleForTesting

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
@@ -78,7 +78,7 @@ public class DirectInstantiator implements Instantiator {
             this.paramCount = this.parameterTypes.length;
             this.isPrimitive = new boolean[paramCount];
             this.wrappedParameterTypes = new Class[paramCount];
-            for (int i=0;i<paramCount; i++) {
+            for (int i = 0; i < paramCount; i++) {
                 Class<?> parameterType = parameterTypes[i];
                 boolean primitive = parameterType.isPrimitive();
                 this.isPrimitive[i] = primitive;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
@@ -17,11 +17,9 @@ package org.gradle.internal.reflect;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
-import java.util.WeakHashMap;
 
 public class DirectInstantiator implements Instantiator {
 
@@ -66,34 +64,10 @@ public class DirectInstantiator implements Instantiator {
     }
 
     @VisibleForTesting
-    public static class ConstructorCache {
-        private final Object lock = new Object();
-        private final WeakHashMap<Class<?>, WeakReference<JavaReflectionUtil.CachedConstructor[]>> cache = new WeakHashMap<Class<?>, WeakReference<JavaReflectionUtil.CachedConstructor[]>>();
-
-        public JavaReflectionUtil.CachedConstructor[] get(Class<?> key) {
-            WeakReference<JavaReflectionUtil.CachedConstructor[]> cached;
-            synchronized (lock) {
-                cached = cache.get(key);
-            }
-            if (cached != null) {
-                JavaReflectionUtil.CachedConstructor[] ctrs = cached.get();
-                if (ctrs != null) {
-                    return ctrs;
-                }
-            }
-            return getAndCache(key);
-        }
-
-        private JavaReflectionUtil.CachedConstructor[] getAndCache(Class<?> key) {
-            JavaReflectionUtil.CachedConstructor[] ctors = cache(key.getConstructors());
-            WeakReference<JavaReflectionUtil.CachedConstructor[]> value = new WeakReference<JavaReflectionUtil.CachedConstructor[]>(ctors);
-            synchronized (lock) {
-                cache.put(key, value);
-            }
-            return ctors;
-        }
-
-        private JavaReflectionUtil.CachedConstructor[] cache(Constructor<?>[] constructors) {
+    public static class ConstructorCache extends ReflectionCache<JavaReflectionUtil.CachedConstructor[]> {
+        @Override
+        protected JavaReflectionUtil.CachedConstructor[] create(Class<?> key) {
+            Constructor<?>[] constructors = key.getConstructors();
             JavaReflectionUtil.CachedConstructor[] cachedConstructors = new JavaReflectionUtil.CachedConstructor[constructors.length];
             for (int i = 0; i < constructors.length; i++) {
                 cachedConstructors[i] = new JavaReflectionUtil.CachedConstructor(constructors[i]);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
@@ -47,11 +47,11 @@ public class DirectInstantiator implements Instantiator {
         }
     }
 
-    private <T> Constructor<?> doGetConstructor(Class<? extends T> type, Constructor<?>[] constructors, Object[] params) {
-        Constructor<?> match = null;
+    private <T> Constructor<?> doGetConstructor(Class<? extends T> type, CachedConstructor[] constructors, Object[] params) {
+        CachedConstructor match = null;
         if (constructors.length > 0) {
-            for (Constructor<?> constructor : constructors) {
-                if (isMatch(constructor, params)) {
+            for (CachedConstructor constructor : constructors) {
+                if (constructor.isMatch(params)) {
                     if (match != null) {
                         throw new IllegalArgumentException(String.format("Found multiple public constructors for %s which accept parameters %s.", type, Arrays.toString(params)));
                     }
@@ -62,42 +62,63 @@ public class DirectInstantiator implements Instantiator {
         if (match == null) {
             throw new IllegalArgumentException(String.format("Could not find any public constructor for %s which accepts parameters %s.", type, Arrays.toString(params)));
         }
-        return match;
+        return match.constructor.get();
     }
 
-    private static boolean isMatch(Constructor<?> constructor, Object... params) {
-        Class<?>[] parameterTypes = constructor.getParameterTypes();
-        if (parameterTypes.length != params.length) {
-            return false;
-        }
-        for (int i = 0; i < params.length; i++) {
-            Object param = params[i];
-            Class<?> parameterType = parameterTypes[i];
-            if (parameterType.isPrimitive()) {
-                if (!JavaReflectionUtil.getWrapperTypeForPrimitiveType(parameterType).isInstance(param)) {
-                    return false;
-                }
-            } else {
-                if (param != null && !parameterType.isInstance(param)) {
-                    return false;
-                }
+    private static class CachedConstructor {
+        private final WeakReference<Constructor<?>> constructor;
+        private final Class<?>[] parameterTypes;
+        private final int paramCount;
+        private final boolean[] isPrimitive;
+        private final Class<?>[] wrappedParameterTypes;
+
+        public CachedConstructor(Constructor<?> ctor) {
+            this.constructor = new WeakReference<Constructor<?>>(ctor);
+            this.parameterTypes = ctor.getParameterTypes();
+            this.paramCount = this.parameterTypes.length;
+            this.isPrimitive = new boolean[paramCount];
+            this.wrappedParameterTypes = new Class[paramCount];
+            for (int i=0;i<paramCount; i++) {
+                Class<?> parameterType = parameterTypes[i];
+                boolean primitive = parameterType.isPrimitive();
+                this.isPrimitive[i] = primitive;
+                this.wrappedParameterTypes[i] = primitive ? JavaReflectionUtil.getWrapperTypeForPrimitiveType(parameterType) : parameterType;
             }
         }
-        return true;
+
+        private boolean isMatch(Object... params) {
+            if (paramCount != params.length) {
+                return false;
+            }
+            for (int i = 0; i < paramCount; i++) {
+                Object param = params[i];
+                Class<?> parameterType = parameterTypes[i];
+                if (isPrimitive[i]) {
+                    if (!wrappedParameterTypes[i].isInstance(param)) {
+                        return false;
+                    }
+                } else {
+                    if (param != null && !parameterType.isInstance(param)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
     }
 
     @VisibleForTesting
     public static class ConstructorCache {
         private final Object lock = new Object();
-        private final WeakHashMap<Class<?>, WeakReference<Constructor<?>[]>> cache = new WeakHashMap<Class<?>, WeakReference<Constructor<?>[]>>();
+        private final WeakHashMap<Class<?>, WeakReference<CachedConstructor[]>> cache = new WeakHashMap<Class<?>, WeakReference<CachedConstructor[]>>();
 
-        public Constructor<?>[] get(Class<?> key) {
-            WeakReference<Constructor<?>[]> cached;
+        public CachedConstructor[] get(Class<?> key) {
+            WeakReference<CachedConstructor[]> cached;
             synchronized (lock) {
                 cached = cache.get(key);
             }
             if (cached != null) {
-                Constructor<?>[] ctrs = cached.get();
+                CachedConstructor[] ctrs = cached.get();
                 if (ctrs != null) {
                     return ctrs;
                 }
@@ -105,13 +126,21 @@ public class DirectInstantiator implements Instantiator {
             return getAndCache(key);
         }
 
-        private Constructor<?>[] getAndCache(Class<?> key) {
-            Constructor<?>[] ctors = key.getConstructors();
-            WeakReference<Constructor<?>[]> value = new WeakReference<Constructor<?>[]>(ctors);
+        private CachedConstructor[] getAndCache(Class<?> key) {
+            CachedConstructor[] ctors = cache(key.getConstructors());
+            WeakReference<CachedConstructor[]> value = new WeakReference<CachedConstructor[]>(ctors);
             synchronized (lock) {
                 cache.put(key, value);
             }
             return ctors;
+        }
+
+        private CachedConstructor[] cache(Constructor<?>[] constructors) {
+            CachedConstructor[] cachedConstructors = new CachedConstructor[constructors.length];
+            for (int i = 0; i < constructors.length; i++) {
+                cachedConstructors[i] = new CachedConstructor(constructors[i]);
+            }
+            return cachedConstructors;
         }
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
@@ -66,6 +66,20 @@ public class DirectInstantiator implements Instantiator {
     @VisibleForTesting
     public static class ConstructorCache extends ReflectionCache<JavaReflectionUtil.CachedConstructor[]> {
         @Override
+        protected boolean hasExpired(JavaReflectionUtil.CachedConstructor[] cached) {
+            for (JavaReflectionUtil.CachedConstructor cachedConstructor : cached) {
+                if (hasExpired(cachedConstructor)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean hasExpired(JavaReflectionUtil.CachedConstructor cachedConstructor) {
+            return cachedConstructor.hasExpired();
+        }
+
+        @Override
         protected JavaReflectionUtil.CachedConstructor[] create(Class<?> key) {
             Constructor<?>[] constructors = key.getConstructors();
             JavaReflectionUtil.CachedConstructor[] cachedConstructors = new JavaReflectionUtil.CachedConstructor[constructors.length];

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
@@ -517,7 +517,7 @@ public class JavaReflectionUtil {
         private final WeakReference<Class<?>>[] parameterTypes;
         private final int paramCount;
         private final boolean[] isPrimitive;
-        private final WeakReference<Class<?>>[] wrappedParameterTypes;
+        private final Class<?>[] wrappedParameterTypes;
 
         @SuppressWarnings("unchecked")
         public CachedConstructor(Constructor<?> ctor) {
@@ -525,12 +525,12 @@ public class JavaReflectionUtil {
             this.parameterTypes = weakReference(ctor.getParameterTypes());
             this.paramCount = this.parameterTypes.length;
             this.isPrimitive = new boolean[paramCount];
-            this.wrappedParameterTypes = new WeakReference[paramCount];
+            this.wrappedParameterTypes = new Class[paramCount];
             for (int i = 0; i < paramCount; i++) {
                 WeakReference<Class<?>> parameterType = parameterTypes[i];
                 boolean primitive = parameterType.get().isPrimitive();
                 this.isPrimitive[i] = primitive;
-                this.wrappedParameterTypes[i] = primitive ? new WeakReference<Class<?>>(getWrapperTypeForPrimitiveType(parameterType.get())) : parameterType;
+                this.wrappedParameterTypes[i] = primitive ? getWrapperTypeForPrimitiveType(parameterType.get()) : null;
             }
         }
 
@@ -549,9 +549,12 @@ public class JavaReflectionUtil {
             }
             for (int i = 0; i < paramCount; i++) {
                 Object param = params[i];
+                // There's no need for a null check below because the parameter types are referenced
+                // by the class that uses them, so cannot be collected if the class itself is not
+                // collected.
                 Class<?> parameterType = parameterTypes[i].get();
                 if (isPrimitive[i]) {
-                    if (!wrappedParameterTypes[i].get().isInstance(param)) {
+                    if (!wrappedParameterTypes[i].isInstance(param)) {
                         return false;
                     }
                 } else {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
@@ -569,5 +569,19 @@ public class JavaReflectionUtil {
         public Constructor<?> getConstructor() {
             return constructor.get();
         }
+
+        public boolean hasExpired() {
+            return constructor.get() == null
+                || hasExpired(parameterTypes);
+        }
+
+        private boolean hasExpired(WeakReference<Class<?>>[] parameterTypes) {
+            for (WeakReference<Class<?>> parameterType : parameterTypes) {
+                if (parameterType.get()==null) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/ReflectionCache.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/ReflectionCache.java
@@ -38,6 +38,10 @@ public abstract class ReflectionCache<T> {
 
     protected abstract T create(Class<?> key);
 
+    public int size() {
+        return cache.size();
+    }
+
     private T getAndCache(Class<?> key) {
         T created = create(key);
         WeakReference<T> value = new WeakReference<T>(created);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/ReflectionCache.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/ReflectionCache.java
@@ -34,11 +34,13 @@ public abstract class ReflectionCache<T> {
         synchronized (lock) {
             cached = cache.get(key);
         }
-        if (cached != null) {
+        if (cached != null && !hasExpired(cached)) {
             return cached;
         }
         return getAndCache(key);
     }
+
+    protected abstract boolean hasExpired(T cached);
 
     protected abstract T create(Class<?> key);
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/ReflectionCache.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/ReflectionCache.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.reflect;
+
+import java.lang.ref.WeakReference;
+import java.util.WeakHashMap;
+
+public abstract class ReflectionCache<T> {
+    private final Object lock = new Object();
+    private final WeakHashMap<Class<?>, WeakReference<T>> cache = new WeakHashMap<Class<?>, WeakReference<T>>();
+
+    public T get(Class<?> key) {
+        WeakReference<T> cached;
+        synchronized (lock) {
+            cached = cache.get(key);
+        }
+        if (cached != null) {
+            T ctrs = cached.get();
+            if (ctrs != null) {
+                return ctrs;
+            }
+        }
+        return getAndCache(key);
+    }
+
+    protected abstract T create(Class<?> key);
+
+    private T getAndCache(Class<?> key) {
+        T created = create(key);
+        WeakReference<T> value = new WeakReference<T>(created);
+        synchronized (lock) {
+            cache.put(key, value);
+        }
+        return created;
+    }
+
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -533,7 +533,8 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
                         singleCandidate = service;
                     } else {
                         if (candidates == null) {
-                            candidates = new ArrayList<ServiceProvider>();
+                            candidates = new ArrayList<ServiceProvider>(2);
+                            candidates.add(singleCandidate);
                         }
                         candidates.add(service);
                     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -524,19 +524,27 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
             if (providers == null) {
                 return null;
             }
-            List<ServiceProvider> candidates = new ArrayList<ServiceProvider>();
+            ServiceProvider singleCandidate = null;
+            List<ServiceProvider> candidates = null;
             for (Provider provider : providers) {
                 ServiceProvider service = provider.getService(context, serviceType);
                 if (service != null) {
-                    candidates.add(service);
+                    if (singleCandidate == null) {
+                        singleCandidate = service;
+                    } else {
+                        if (candidates == null) {
+                            candidates = new ArrayList<ServiceProvider>();
+                        }
+                        candidates.add(service);
+                    }
                 }
             }
 
-            if (candidates.size() == 0) {
+            if (candidates == null && singleCandidate == null) {
                 return null;
             }
-            if (candidates.size() == 1) {
-                return candidates.get(0);
+            if (candidates==null) {
+                return singleCandidate;
             }
 
             Set<String> descriptions = new TreeSet<String>();

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/ActionsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/ActionsTest.groovy
@@ -146,6 +146,110 @@ class ActionsTest extends Specification {
         !called
     }
 
+    def "set of null and other is other"() {
+        given:
+        Action<?> a = Mock()
+
+        when:
+        def set = Actions.set(null, a)
+
+        then:
+        set == a
+        set.is a
+    }
+
+    def "set of identical actions avoids wrapping them into different set instance"() {
+        given:
+        Action<?> a = Mock()
+
+        when:
+        def set = Actions.set(a, a)
+
+        then:
+        set == a
+        set.is a
+    }
+
+    def "set of different actions"() {
+        given:
+        def called = []
+        Action<?> a = Mock() {
+            execute(_) >> { args -> args[0] << 'a' }
+        }
+        Action<?> b = Mock() {
+            execute(_) >> { args -> args[0] << 'b' }
+        }
+
+        when:
+        def set = Actions.set(a, b)
+        set.execute(called)
+
+        then:
+        called == ['a', 'b']
+    }
+
+    def "set of different actions is preserving order"() {
+        given:
+        def called = []
+        Action<?> a = Mock() {
+            execute(_) >> { args -> args[0] << 'a' }
+        }
+        Action<?> b = Mock() {
+            execute(_) >> { args -> args[0] << 'b' }
+        }
+
+        when:
+        def set = Actions.set(b, a)
+        set.execute(called)
+
+        then:
+        called == ['b', 'a']
+    }
+
+    def "deduplicates entries"() {
+        given:
+        def called = []
+        Action<?> a = Mock() {
+            execute(_) >> { args -> args[0] << 'a' }
+        }
+        Action<?> b = Mock() {
+            execute(_) >> { args -> args[0] << 'b' }
+        }
+        Action<?> c = Mock() {
+            execute(_) >> { args -> args[0] << 'c' }
+        }
+
+        when:
+        def set = Actions.set(b, a)
+        set = Actions.set(set, c)
+        set = Actions.set(set, a)
+        set.execute(called)
+
+        then:
+        called == ['b', 'a', 'c']
+    }
+
+    def "deduplicates entries using single call"() {
+        given:
+        def called = []
+        Action<?> a = Mock() {
+            execute(_) >> { args -> args[0] << 'a' }
+        }
+        Action<?> b = Mock() {
+            execute(_) >> { args -> args[0] << 'b' }
+        }
+        Action<?> c = Mock() {
+            execute(_) >> { args -> args[0] << 'c' }
+        }
+
+        when:
+        def set = Actions.set(b, a, c, a, b)
+        set.execute(called)
+
+        then:
+        called == ['b', 'a', 'c']
+    }
+
     protected Spec spec(Closure spec) {
         spec as Spec
     }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/ActionsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/ActionsTest.groovy
@@ -146,30 +146,6 @@ class ActionsTest extends Specification {
         !called
     }
 
-    def "set of null and other is other"() {
-        given:
-        Action<?> a = Mock()
-
-        when:
-        def set = Actions.set(null, a)
-
-        then:
-        set == a
-        set.is a
-    }
-
-    def "set of identical actions avoids wrapping them into different set instance"() {
-        given:
-        Action<?> a = Mock()
-
-        when:
-        def set = Actions.set(a, a)
-
-        then:
-        set == a
-        set.is a
-    }
-
     def "set of different actions"() {
         given:
         def called = []
@@ -247,7 +223,16 @@ class ActionsTest extends Specification {
         set.execute(called)
 
         then:
+        set.size() == 3
         called == ['b', 'a', 'c']
+    }
+
+    def "doesn't grow when adding a doNothing"() {
+        when:
+        def set = Actions.set(Actions.doNothing())
+
+        then:
+        set.empty
     }
 
     protected Spec spec(Closure spec) {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorCacheTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorCacheTest.groovy
@@ -26,7 +26,7 @@ class DirectInstantiatorCacheTest extends Specification {
 
     def "constructor cache returns the same constructors as 'getConstructors'"() {
         expect:
-        cache.get(clazz)*.constructor == clazz.getConstructors().toList()
+        cache.get(clazz)*.method == clazz.getConstructors().toList()
         cache.size() == expectedCacheSize
 
         where:

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorCacheTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorCacheTest.groovy
@@ -26,8 +26,8 @@ class DirectInstantiatorCacheTest extends Specification {
 
     def "constructor cache returns the same constructors as 'getConstructors'"() {
         expect:
-        cache.get(clazz)*.constructor*.get() == clazz.getConstructors().toList()
-        cache.cache.size() == expectedCacheSize
+        cache.get(clazz)*.constructor == clazz.getConstructors().toList()
+        cache.size() == expectedCacheSize
 
         where:
         clazz              | expectedCacheSize

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorCacheTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorCacheTest.groovy
@@ -26,7 +26,7 @@ class DirectInstantiatorCacheTest extends Specification {
 
     def "constructor cache returns the same constructors as 'getConstructors'"() {
         expect:
-        cache.get(clazz)*.method == clazz.getConstructors().toList()
+        cache.get(clazz, [] as Class[])*.method == clazz.getConstructors().toList().findAll { it.parameterTypes.length == 0 }
         cache.size() == expectedCacheSize
 
         where:
@@ -34,7 +34,7 @@ class DirectInstantiatorCacheTest extends Specification {
         String             | 1
         LinkedList         | 2
         ArrayList          | 3
-        JavaMethod         | 4
+        HashSet            | 4
         String             | 4
         ArrayList          | 4
         JavaReflectionUtil | 5

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorCacheTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorCacheTest.groovy
@@ -26,7 +26,7 @@ class DirectInstantiatorCacheTest extends Specification {
 
     def "constructor cache returns the same constructors as 'getConstructors'"() {
         expect:
-        cache.get(clazz).toList() == clazz.getConstructors().toList()
+        cache.get(clazz)*.constructor*.get() == clazz.getConstructors().toList()
         cache.cache.size() == expectedCacheSize
 
         where:

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorTest.groovy
@@ -69,14 +69,14 @@ class DirectInstantiatorTest extends Specification {
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Found multiple public constructors for ${TypeWithAmbiguousConstructor} which accept parameters [param]."
+        e.cause.message == "Found multiple public constructors for ${TypeWithAmbiguousConstructor} which accept parameters [java.lang.String]."
 
         when:
         instantiator.newInstance(TypeWithAmbiguousConstructor, true)
 
         then:
         e = thrown()
-        e.cause.message == "Found multiple public constructors for ${TypeWithAmbiguousConstructor} which accept parameters [true]."
+        e.cause.message == "Found multiple public constructors for ${TypeWithAmbiguousConstructor} which accept parameters [java.lang.Boolean]."
     }
 
     def "fails when target class has no matching public constructor"() {
@@ -88,21 +88,21 @@ class DirectInstantiatorTest extends Specification {
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Could not find any public constructor for ${SomeType} which accepts parameters [${param}]."
+        e.cause.message == "Could not find any public constructor for ${SomeType} which accepts parameters [java.lang.Object]."
 
         when:
         instantiator.newInstance(SomeType, "a", "b")
 
         then:
         e = thrown()
-        e.cause.message == "Could not find any public constructor for ${SomeType} which accepts parameters [a, b]."
+        e.cause.message == "Could not find any public constructor for ${SomeType} which accepts parameters [java.lang.String, java.lang.String]."
 
         when:
         instantiator.newInstance(SomeType, false)
 
         then:
         e = thrown()
-        e.cause.message == "Could not find any public constructor for ${SomeType} which accepts parameters [false]."
+        e.cause.message == "Could not find any public constructor for ${SomeType} which accepts parameters [java.lang.Boolean]."
 
         when:
 
@@ -110,7 +110,7 @@ class DirectInstantiatorTest extends Specification {
 
         then:
         e = thrown()
-        e.cause.message == "Could not find any public constructor for ${SomeTypeWithPrimitiveTypes} which accepts parameters [a]."
+        e.cause.message == "Could not find any public constructor for ${SomeTypeWithPrimitiveTypes} which accepts parameters [java.lang.String]."
 
         when:
 
@@ -118,7 +118,7 @@ class DirectInstantiatorTest extends Specification {
 
         then:
         e = thrown()
-        e.cause.message == "Could not find any public constructor for ${SomeTypeWithPrimitiveTypes} which accepts parameters [22]."
+        e.cause.message == "Could not find any public constructor for ${SomeTypeWithPrimitiveTypes} which accepts parameters [java.lang.Integer]."
 
         when:
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -23,7 +23,6 @@ import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Actions;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -196,11 +195,12 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
             if (store.size() == 1) {
                 return (Iterator<T>) store.get(0).iterator();
             }
-            List<Iterator<? extends T>> iterators = new ArrayList<Iterator<? extends T>>(store.size());
+            Iterator[] iterators = new Iterator[store.size()];
+            int i=0;
             for (DomainObjectCollection<? extends T> ts : store) {
-                iterators.add(ts.iterator());
+                iterators[i++] = ts.iterator();
             }
-            return Iterators.<T>concat(iterators.toArray(new Iterator[0]));
+            return Iterators.<T>concat(iterators);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -209,7 +209,7 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
         }
 
         @Override
-        public <TT> TT[] toArray(TT[] a) {
+        public <V> V[] toArray(V[] a) {
             throw new UnsupportedOperationException();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -267,11 +267,7 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
         public int estimatedSize() {
             int size = 0;
             for (DomainObjectCollection<? extends T> ts : store) {
-                if (ts instanceof WithEstimatedSize) {
-                    size += ((WithEstimatedSize) ts).estimatedSize();
-                } else {
-                    size += Estimates.estimateSizeOf(ts);
-                }
+                size += Estimates.estimateSizeOf(ts);
             }
             return size;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -139,9 +139,9 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
 
     /**
      * Returns true if, and only if, the store is empty AND we know that we
-     * can query its size in constant time. Otherwise, it returns false, which
-     * doesn't mean that the store is empty or not empty, but just that we cannot determine
-     * if it is in constant time.
+     * can query its size in constant time. Otherwise it returns false, which means
+     * that the collection may contain elements or may be empty (we don't know without
+     * spending too much time).
      *
      * @return true if and only if the store is empty and can tell in constant time
      */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -140,8 +140,8 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
     /**
      * Returns true if, and only if, the store is empty AND we know that we
      * can query its size in constant time. Otherwise, it returns false, which
-     * doesn't mean that the store is empty, but just that we cannot determine
-     * in constant time.
+     * doesn't mean that the store is empty or not empty, but just that we cannot determine
+     * if it is in constant time.
      *
      * @return true if and only if the store is empty and can tell in constant time
      */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -25,7 +25,7 @@ import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.internal.collections.FilteredCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
-import org.gradle.internal.Actions;
+import org.gradle.internal.FastActionSet;
 import org.gradle.util.ConfigureUtil;
 
 import java.util.AbstractCollection;
@@ -39,7 +39,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
     private final CollectionEventRegister<T> eventRegister;
     private final Collection<T> store;
     private final boolean hasConstantTimeSizeMethod;
-    private Action<Void> mutateAction;
+    private final FastActionSet<Void> mutateAction = new FastActionSet<Void>();
 
     public DefaultDomainObjectCollection(Class<? extends T> type, Collection<T> store) {
         this(type, store, new CollectionEventRegister<T>());
@@ -185,7 +185,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
      * Adds an action which is executed before this collection is mutated. Any exception thrown by the action will veto the mutation.
      */
     public void beforeChange(Action<Void> action) {
-        mutateAction = Actions.set(mutateAction, action);
+        mutateAction.add(action);
     }
 
     private Action<? super T> toAction(Closure action) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/WithEstimatedSize.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/WithEstimatedSize.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.TreeSet;
 
 public interface WithEstimatedSize {
     /**
@@ -39,13 +40,21 @@ public interface WithEstimatedSize {
 
     class Estimates {
         public static <T> int estimateSizeOf(Collection<T> collection) {
-            if (collection instanceof HashSet || collection instanceof ArrayList || collection instanceof LinkedList) {
+            if (isKnownToHaveConstantTimeSizeMethod(collection)) {
                 return collection.size();
             }
             if (collection instanceof WithEstimatedSize) {
                 return ((WithEstimatedSize) collection).estimatedSize();
             }
             return 10; // we don't know if the underlying collection can return a size in constant time
+        }
+
+        public static <T> boolean isKnownToHaveConstantTimeSizeMethod(Collection<T> collection) {
+            Class<? extends Collection> clazz = collection.getClass();
+            if (clazz == HashSet.class || clazz == ArrayList.class || clazz == LinkedList.class || clazz == TreeSet.class) {
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/typeconversion/ErrorHandlingNotationParser.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/typeconversion/ErrorHandlingNotationParser.java
@@ -20,12 +20,12 @@ import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.exceptions.FormattingDiagnosticsVisitor;
 
 class ErrorHandlingNotationParser<N, T> implements NotationParser<N, T> {
-    private final String targetTypeDisplayName;
+    private final Object targetTypeDisplayName;
     private final String invalidNotationMessage;
     private final boolean allowNullInput;
     private final NotationParser<N, T> delegate;
 
-    public ErrorHandlingNotationParser(String targetTypeDisplayName, String invalidNotationMessage, boolean allowNullInput, NotationParser<N, T> delegate) {
+    public ErrorHandlingNotationParser(Object targetTypeDisplayName, String invalidNotationMessage, boolean allowNullInput, NotationParser<N, T> delegate) {
         this.targetTypeDisplayName = targetTypeDisplayName;
         this.invalidNotationMessage = invalidNotationMessage;
         this.allowNullInput = allowNullInput;

--- a/subprojects/core/src/main/java/org/gradle/internal/typeconversion/MapNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/typeconversion/MapNotationConverter.java
@@ -23,6 +23,7 @@ import org.gradle.internal.reflect.ReflectionCache;
 import org.gradle.util.ConfigureUtil;
 
 import java.lang.annotation.Annotation;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -52,7 +53,7 @@ public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map
         Map<String, Object> mutableValues = new HashMap<String, Object>(values);
         Set<String> missing = null;
 
-        Method method = convertMethod.method;
+        Method method = convertMethod.getMethod();
         Object[] params = new Object[method.getParameterTypes().length];
         String[] keyNames = convertMethod.keyNames;
         boolean[] optionals = convertMethod.optional;
@@ -152,14 +153,18 @@ public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map
     private static class ConvertMethod {
         private final static ConvertMethodCache CONVERT_METHODS = new ConvertMethodCache();
 
-        private final Method method;
+        private final WeakReference<Method> method;
         private final String[] keyNames;
         private final boolean[] optional;
 
         private ConvertMethod(Method method, String[] keyNames, boolean[] optional) {
-            this.method = method;
+            this.method = new WeakReference<Method>(method);
             this.keyNames = keyNames;
             this.optional = optional;
+        }
+
+        Method getMethod() {
+            return method.get();
         }
 
         public static synchronized ConvertMethod of(Class clazz) {

--- a/subprojects/core/src/main/java/org/gradle/internal/typeconversion/MapNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/typeconversion/MapNotationConverter.java
@@ -37,11 +37,8 @@ import java.util.TreeSet;
  * be annotated with a {@code @optional} annotation.
  */
 public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map, T> {
-    private final ConvertMethod convertMethod;
-
     public MapNotationConverter() {
         super(Map.class);
-        convertMethod = ConvertMethod.of(getClass());
     }
 
     @Override
@@ -52,7 +49,7 @@ public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map
     public T parseType(Map values) throws UnsupportedNotationException {
         Map<String, Object> mutableValues = new HashMap<String, Object>(values);
         Set<String> missing = null;
-
+        ConvertMethod convertMethod = ConvertMethod.of(this.getClass());
         Method method = convertMethod.getMethod();
         Object[] params = new Object[method.getParameterTypes().length];
         String[] keyNames = convertMethod.keyNames;

--- a/subprojects/core/src/main/java/org/gradle/internal/typeconversion/MapNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/typeconversion/MapNotationConverter.java
@@ -107,6 +107,11 @@ public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map
     private static class ConvertMethodCache extends ReflectionCache<ConvertMethod> {
 
         @Override
+        protected boolean hasExpired(ConvertMethod cached) {
+            return cached.method.get() == null;
+        }
+
+        @Override
         protected ConvertMethod create(Class<?> key) {
             Method convertMethod = findConvertMethod(key);
             Annotation[][] parameterAnnotations = convertMethod.getParameterAnnotations();

--- a/subprojects/core/src/main/java/org/gradle/internal/typeconversion/NotationParserBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/typeconversion/NotationParserBuilder.java
@@ -18,7 +18,6 @@ package org.gradle.internal.typeconversion;
 
 import org.gradle.api.Describable;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -157,11 +156,6 @@ public class NotationParserBuilder<T> {
                 displayName = resultingType.getTargetType().equals(String.class) ? "a String" : ("an object of type " + resultingType.getTargetType().getSimpleName());
             }
             return displayName;
-        }
-
-        @Override
-        public void describeTo(Appendable builder) throws IOException {
-            builder.append(getDisplayName());
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/typeconversion/NotationParserBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/typeconversion/NotationParserBuilder.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.typeconversion;
 
+import org.gradle.api.Describable;
+
+import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -135,8 +138,9 @@ public class NotationParserBuilder<T> {
         return new NotationConverterToNotationParserAdapter<Object, T>(composites.size() == 1 ? composites.get(0) : new CompositeNotationConverter<Object, T>(composites));
     }
 
-    private static class LazyDisplayName<T> {
-        private TypeInfo<T> resultingType;
+    private static class LazyDisplayName<T> implements Describable {
+        private final TypeInfo<T> resultingType;
+        private String displayName;
 
         public LazyDisplayName(TypeInfo<T> resultingType) {
             this.resultingType = resultingType;
@@ -144,7 +148,20 @@ public class NotationParserBuilder<T> {
 
         @Override
         public String toString() {
-            return resultingType.getTargetType().equals(String.class) ? "a String" : ("an object of type " + resultingType.getTargetType().getSimpleName());
+            return getDisplayName();
+        }
+
+        @Override
+        public String getDisplayName() {
+            if (displayName == null) {
+                displayName = resultingType.getTargetType().equals(String.class) ? "a String" : ("an object of type " + resultingType.getTargetType().getSimpleName());
+            }
+            return displayName;
+        }
+
+        @Override
+        public void describeTo(Appendable builder) throws IOException {
+            builder.append(getDisplayName());
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.java
@@ -18,8 +18,9 @@ package org.gradle.api.internal;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.specs.Spec;
-import org.gradle.util.TestUtil;
+import org.gradle.internal.Cast;
 import org.gradle.util.TestClosure;
+import org.gradle.util.TestUtil;
 import org.hamcrest.Description;
 import org.jmock.Expectations;
 import org.jmock.api.Invocation;
@@ -157,7 +158,7 @@ public class DefaultDomainObjectCollectionTest {
         container.add("c");
         container.add(new StringBuffer("b"));
 
-        context.checking(new Expectations(){{
+        context.checking(new Expectations() {{
             oneOf(closure).call("c");
             oneOf(closure).call("a");
         }});
@@ -435,11 +436,11 @@ public class DefaultDomainObjectCollectionTest {
 
     @Test
     public void callsVetoActionBeforeObjectIsAdded() {
-        final Runnable action = context.mock(Runnable.class);
+        final Action action = context.mock(Action.class);
         container.beforeChange(action);
 
         context.checking(new Expectations() {{
-            oneOf(action).run();
+            oneOf(action).execute(null);
         }});
 
         container.add("a");
@@ -447,12 +448,12 @@ public class DefaultDomainObjectCollectionTest {
 
     @Test
     public void objectIsNotAddedWhenVetoActionThrowsAnException() {
-        final Runnable action = context.mock(Runnable.class);
+        final Action<Void> action = Cast.uncheckedCast(context.mock(Action.class));
         final RuntimeException failure = new RuntimeException();
         container.beforeChange(action);
 
         context.checking(new Expectations() {{
-            oneOf(action).run();
+            oneOf(action).execute(null);
             will(throwException(failure));
         }});
 
@@ -468,11 +469,11 @@ public class DefaultDomainObjectCollectionTest {
 
     @Test
     public void callsVetoActionOnceBeforeCollectionIsAdded() {
-        final Runnable action = context.mock(Runnable.class);
+        final Action<Void> action = Cast.uncheckedCast(context.mock(Action.class));
         container.beforeChange(action);
 
         context.checking(new Expectations() {{
-            oneOf(action).run();
+            oneOf(action).execute(null);
         }});
 
         container.addAll(toList("a", "b"));
@@ -480,11 +481,11 @@ public class DefaultDomainObjectCollectionTest {
 
     @Test
     public void callsVetoActionBeforeObjectIsRemoved() {
-        final Runnable action = context.mock(Runnable.class);
+        final Action<Void> action = Cast.uncheckedCast(context.mock(Action.class));
         container.beforeChange(action);
 
         context.checking(new Expectations() {{
-            oneOf(action).run();
+            oneOf(action).execute(null);
         }});
 
         container.remove("a");
@@ -492,7 +493,7 @@ public class DefaultDomainObjectCollectionTest {
 
     @Test
     public void callsVetoActionBeforeObjectIsRemovedUsingIterator() {
-        final Runnable action = context.mock(Runnable.class);
+        final Action<Void> action = Cast.uncheckedCast(context.mock(Action.class));
 
         container.add("a");
         container.beforeChange(action);
@@ -501,7 +502,7 @@ public class DefaultDomainObjectCollectionTest {
         iterator.next();
 
         context.checking(new Expectations() {{
-            oneOf(action).run();
+            oneOf(action).execute(null);
         }});
 
         iterator.remove();
@@ -509,13 +510,13 @@ public class DefaultDomainObjectCollectionTest {
 
     @Test
     public void objectIsNotRemovedWhenVetoActionThrowsAnException() {
-        final Runnable action = context.mock(Runnable.class);
+        final Action<Void> action = Cast.uncheckedCast(context.mock(Action.class));
         final RuntimeException failure = new RuntimeException();
         container.add("a");
         container.beforeChange(action);
 
         context.checking(new Expectations() {{
-            oneOf(action).run();
+            oneOf(action).execute(null);
             will(throwException(failure));
         }});
 
@@ -531,11 +532,11 @@ public class DefaultDomainObjectCollectionTest {
 
     @Test
     public void callsVetoActionBeforeCollectionIsCleared() {
-        final Runnable action = context.mock(Runnable.class);
+        final Action<Void> action = Cast.uncheckedCast(context.mock(Action.class));
         container.beforeChange(action);
 
         context.checking(new Expectations() {{
-            oneOf(action).run();
+            oneOf(action).execute(null);
         }});
 
         container.clear();
@@ -543,11 +544,11 @@ public class DefaultDomainObjectCollectionTest {
 
     @Test
     public void callsVetoActionOnceBeforeCollectionIsRemoved() {
-        final Runnable action = context.mock(Runnable.class);
+        final Action<Void> action = Cast.uncheckedCast(context.mock(Action.class));
         container.beforeChange(action);
 
         context.checking(new Expectations() {{
-            oneOf(action).run();
+            oneOf(action).execute(null);
         }});
 
         container.removeAll(toList("a", "b"));
@@ -555,13 +556,13 @@ public class DefaultDomainObjectCollectionTest {
 
     @Test
     public void callsVetoActionOnceBeforeCollectionIsIntersected() {
-        final Runnable action = context.mock(Runnable.class);
+        final Action<Void> action = Cast.uncheckedCast(context.mock(Action.class));
         container.add("a");
         container.add("b");
         container.beforeChange(action);
 
         context.checking(new Expectations() {{
-            oneOf(action).run();
+            oneOf(action).execute(null);
         }});
 
         container.retainAll(toList());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -213,10 +213,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, artifacts, ImmutableAttributes.EMPTY, instantiator, artifactNotationParser, fileCollectionFactory, attributesFactory);
     }
 
-    private static Runnable validateMutationType(final MutationValidator mutationValidator, final MutationType type) {
-        return new Runnable() {
+    private static Action<Void> validateMutationType(final MutationValidator mutationValidator, final MutationType type) {
+        return new Action<Void>() {
             @Override
-            public void run() {
+            public void execute(Void arg) {
                 mutationValidator.validateMutation(type);
             }
         };

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactory.java
@@ -86,7 +86,7 @@ public class PublishArtifactNotationParserFactory implements Factory<NotationPar
         }
     }
 
-    private class FileMapNotationConverter extends MapNotationConverter<ConfigurablePublishArtifact> {
+    private static class FileMapNotationConverter extends MapNotationConverter<ConfigurablePublishArtifact> {
         private final FileNotationConverter fileConverter;
 
         private FileMapNotationConverter(FileNotationConverter fileConverter) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRules.java
@@ -82,7 +82,7 @@ public class DefaultComponentSelectionRules implements ComponentSelectionRulesIn
 
     private static RuleActionAdapter<ComponentSelection> createAdapter() {
         RuleActionValidator<ComponentSelection> ruleActionValidator = new DefaultRuleActionValidator<ComponentSelection>(Lists.newArrayList(ComponentMetadata.class, IvyModuleDescriptor.class));
-        return new DefaultRuleActionAdapter<ComponentSelection>(ruleActionValidator, ComponentSelectionRules.class.getSimpleName());
+        return new DefaultRuleActionAdapter<ComponentSelection>(ruleActionValidator, "ComponentSelectionRules");
     }
 
     public Collection<SpecRuleAction<? super ComponentSelection>> getRules() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -27,6 +27,7 @@ import org.gradle.api.attributes.HasAttributes;
 import org.gradle.internal.Cast;
 import org.gradle.internal.component.model.ComponentAttributeMatcher;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -81,6 +82,9 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal {
 
     @Override
     public List<? extends HasAttributes> getMatches(AttributesSchema producerAttributeSchema, List<HasAttributes> candidates, AttributeContainer consumer) {
+        if (candidates.isEmpty()) {
+            return Collections.emptyList();
+        }
         Key key = new Key(producerAttributeSchema, candidates, consumer);
         List<? extends HasAttributes> match = this.matchesCache.get(key);
         if (match == null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -118,8 +118,8 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal {
             }
             Key key = (Key) o;
             return Objects.equal(producerAttributeSchema, key.producerAttributeSchema)
-                && Objects.equal(candidates, key.candidates)
-                && Objects.equal(consumer, key.consumer);
+                && Objects.equal(consumer, key.consumer)
+                && Objects.equal(candidates, key.candidates);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -39,7 +39,6 @@ import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantMetadata;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -63,6 +62,8 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final List<ModuleComponentArtifactMetadata> artifacts;
     private final List<? extends DependencyMetadata> dependencies;
     private final List<Exclude> excludes;
+
+    private List<DefaultConfigurationMetadata> consumableConfigurations;
 
     protected AbstractModuleComponentResolveMetadata(MutableModuleComponentResolveMetadata metadata) {
         this.descriptor = metadata.getDescriptor();
@@ -136,8 +137,14 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     }
 
     @Override
-    public Collection<? extends ConfigurationMetadata> getConfigurations() {
-        return configurations.values();
+    public List<? extends ConfigurationMetadata> getConsumableConfigurations() {
+        if (consumableConfigurations == null) {
+            consumableConfigurations = Lists.newArrayListWithExpectedSize(configurations.size());
+            for (DefaultConfigurationMetadata metadata : configurations.values()) {
+                consumableConfigurations.add(metadata);
+            }
+        }
+        return consumableConfigurations;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -137,11 +137,13 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     }
 
     @Override
-    public List<? extends ConfigurationMetadata> getConsumableConfigurations() {
+    public List<? extends ConfigurationMetadata> getConsumableConfigurationsHavingAttributes() {
         if (consumableConfigurations == null) {
             consumableConfigurations = Lists.newArrayListWithExpectedSize(configurations.size());
             for (DefaultConfigurationMetadata metadata : configurations.values()) {
-                consumableConfigurations.add(metadata);
+                if (!metadata.getAttributes().isEmpty()) {
+                    consumableConfigurations.add(metadata);
+                }
             }
         }
         return consumableConfigurations;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.external.model;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.Nullable;
@@ -63,7 +64,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final List<? extends DependencyMetadata> dependencies;
     private final List<Exclude> excludes;
 
-    private List<DefaultConfigurationMetadata> consumableConfigurations;
+    private final List<DefaultConfigurationMetadata> consumableConfigurations;
 
     protected AbstractModuleComponentResolveMetadata(MutableModuleComponentResolveMetadata metadata) {
         this.descriptor = metadata.getDescriptor();
@@ -78,6 +79,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         excludes = descriptor.getExcludes();
         artifacts = metadata.getArtifacts();
         configurations = populateConfigurationsFromDescriptor();
+        consumableConfigurations = computeConsumableConfigurations();
         if (artifacts != null) {
             populateArtifacts(artifacts);
         } else {
@@ -98,6 +100,17 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         excludes = metadata.excludes;
         artifacts = metadata.artifacts;
         configurations = metadata.configurations;
+        consumableConfigurations = computeConsumableConfigurations();
+    }
+
+    private List<DefaultConfigurationMetadata> computeConsumableConfigurations() {
+        ImmutableList.Builder<DefaultConfigurationMetadata> builder = new ImmutableList.Builder<DefaultConfigurationMetadata>();
+        for (DefaultConfigurationMetadata metadata : configurations.values()) {
+            if (!metadata.getAttributes().isEmpty()) {
+                builder.add(metadata);
+            }
+        }
+        return builder.build();
     }
 
     public ModuleDescriptorState getDescriptor() {
@@ -138,16 +151,9 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
 
     @Override
     public List<? extends ConfigurationMetadata> getConsumableConfigurationsHavingAttributes() {
-        if (consumableConfigurations == null) {
-            consumableConfigurations = Lists.newArrayListWithExpectedSize(configurations.size());
-            for (DefaultConfigurationMetadata metadata : configurations.values()) {
-                if (!metadata.getAttributes().isEmpty()) {
-                    consumableConfigurations.add(metadata);
-                }
-            }
-        }
         return consumableConfigurations;
     }
+
 
     @Override
     public String toString() {
@@ -294,7 +300,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             if (parents == null) {
                 return Collections.singleton(name);
             }
-            Set<String> hierarchy = new LinkedHashSet<String>(1+parents.size());
+            Set<String> hierarchy = new LinkedHashSet<String>(1 + parents.size());
             populateHierarchy(hierarchy);
             return hierarchy;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -39,6 +39,7 @@ import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantMetadata;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -132,6 +133,11 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
 
     public Set<String> getConfigurationNames() {
         return configurations.keySet();
+    }
+
+    @Override
+    public Collection<? extends ConfigurationMetadata> getConfigurations() {
+        return configurations.values();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -43,7 +43,6 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantMetadata;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,6 +58,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     private final ComponentIdentifier componentIdentifier;
     private final String status;
     private final AttributesSchema attributesSchema;
+    private List<ConfigurationMetadata> consumableConfigurations;
 
     public DefaultLocalComponentMetadata(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, String status, AttributesSchema attributesSchema) {
         this.id = id;
@@ -176,8 +176,16 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     }
 
     @Override
-    public Collection<? extends ConfigurationMetadata> getConfigurations() {
-        return allConfigurations.values();
+    public List<? extends ConfigurationMetadata> getConsumableConfigurations() {
+        if (consumableConfigurations == null) {
+            consumableConfigurations = Lists.newArrayListWithExpectedSize(allConfigurations.size());
+            for (DefaultLocalConfigurationMetadata metadata : allConfigurations.values()) {
+                if (metadata.isCanBeConsumed()) {
+                    consumableConfigurations.add(metadata);
+                }
+            }
+        }
+        return consumableConfigurations;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -176,11 +176,11 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     }
 
     @Override
-    public List<? extends ConfigurationMetadata> getConsumableConfigurations() {
+    public List<? extends ConfigurationMetadata> getConsumableConfigurationsHavingAttributes() {
         if (consumableConfigurations == null) {
             consumableConfigurations = Lists.newArrayListWithExpectedSize(allConfigurations.size());
             for (DefaultLocalConfigurationMetadata metadata : allConfigurations.values()) {
-                if (metadata.isCanBeConsumed()) {
+                if (metadata.isCanBeConsumed() && !metadata.getAttributes().isEmpty()) {
                     consumableConfigurations.add(metadata);
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -42,6 +43,7 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantMetadata;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -171,6 +173,11 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     @Override
     public Set<String> getConfigurationNames() {
         return allConfigurations.keySet();
+    }
+
+    @Override
+    public Collection<? extends ConfigurationMetadata> getConfigurations() {
+        return allConfigurations.values();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -64,7 +63,7 @@ public interface ComponentResolveMetadata {
      */
     Set<String> getConfigurationNames();
 
-    Collection<? extends ConfigurationMetadata> getConfigurations();
+    List<? extends ConfigurationMetadata> getConsumableConfigurations();
 
     /**
      * Locates the configuration with the given name, if any.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -62,6 +63,8 @@ public interface ComponentResolveMetadata {
      * Returns the names of all of the configurations for this component.
      */
     Set<String> getConfigurationNames();
+
+    Collection<? extends ConfigurationMetadata> getConfigurations();
 
     /**
      * Locates the configuration with the given name, if any.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -63,7 +63,7 @@ public interface ComponentResolveMetadata {
      */
     Set<String> getConfigurationNames();
 
-    List<? extends ConfigurationMetadata> getConsumableConfigurations();
+    List<? extends ConfigurationMetadata> getConsumableConfigurationsHavingAttributes();
 
     /**
      * Locates the configuration with the given name, if any.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -43,6 +43,7 @@ import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.exceptions.ConfigurationNotConsumableException;
 import org.gradle.util.GUtil;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -158,9 +159,9 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     private List<HasAttributes> getConfigurationsAsHasAttributes(ComponentResolveMetadata targetComponent) {
-        List<HasAttributes> result = Lists.newArrayList();
-        for (String config : targetComponent.getConfigurationNames()) {
-            ConfigurationMetadata configuration = targetComponent.getConfiguration(config);
+        Collection<? extends ConfigurationMetadata> targetComponentConfigurations = targetComponent.getConfigurations();
+        List<HasAttributes> result = Lists.newArrayListWithExpectedSize(targetComponentConfigurations.size());
+        for (ConfigurationMetadata configuration : targetComponentConfigurations) {
             if (configuration.isCanBeConsumed()) {
                 result.add(configuration);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -43,7 +43,6 @@ import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.exceptions.ConfigurationNotConsumableException;
 import org.gradle.util.GUtil;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -159,14 +158,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     private List<HasAttributes> getConfigurationsAsHasAttributes(ComponentResolveMetadata targetComponent) {
-        Collection<? extends ConfigurationMetadata> targetComponentConfigurations = targetComponent.getConfigurations();
-        List<HasAttributes> result = Lists.newArrayListWithExpectedSize(targetComponentConfigurations.size());
-        for (ConfigurationMetadata configuration : targetComponentConfigurations) {
-            if (configuration.isCanBeConsumed()) {
-                result.add(configuration);
-            }
-        }
-        return result;
+        return Cast.uncheckedCast(targetComponent.getConsumableConfigurations());
     }
 
     private static String getOrDefaultConfiguration(String configuration) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -107,7 +107,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
 
     @Override
     public Set<ConfigurationMetadata> selectConfigurations(ComponentResolveMetadata fromComponent, ConfigurationMetadata fromConfiguration, ComponentResolveMetadata targetComponent, AttributesSchema attributesSchema) {
-        assert fromConfiguration.getHierarchy().contains(getOrDefaultConfiguration(moduleConfiguration));
+        // assert fromConfiguration.getHierarchy().contains(getOrDefaultConfiguration(moduleConfiguration));
         AttributeContainerInternal fromConfigurationAttributes = fromConfiguration.getAttributes();
         boolean consumerHasAttributes = !fromConfigurationAttributes.isEmpty();
         boolean useConfigurationAttributes = dependencyConfiguration == null && consumerHasAttributes;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -158,7 +158,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     private List<HasAttributes> getConfigurationsAsHasAttributes(ComponentResolveMetadata targetComponent) {
-        return Cast.uncheckedCast(targetComponent.getConsumableConfigurations());
+        return Cast.uncheckedCast(targetComponent.getConsumableConfigurationsHavingAttributes());
     }
 
     private static String getOrDefaultConfiguration(String configuration) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -105,7 +105,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurationsHavingAttributes() >> [toFooConfig, toBarConfig]
         }
         attributesSchema.attribute(Attribute.of('key', String), {
             if (allowMissing) {
@@ -159,7 +159,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurationsHavingAttributes() >> [toFooConfig, toBarConfig]
             toString() >> 'target'
         }
         attributesSchema.attribute(Attribute.of('key', String))
@@ -199,7 +199,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurationsHavingAttributes() >> [toFooConfig, toBarConfig]
             toString() >> 'target'
         }
 
@@ -241,7 +241,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurationsHavingAttributes() >> [toFooConfig, toBarConfig]
             toString() >> 'target'
         }
         attributesSchema.attribute(Attribute.of('platform', JavaVersion), {
@@ -318,7 +318,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurationsHavingAttributes() >> [toFooConfig, toBarConfig]
         }
         attributesSchema.attribute(Attribute.of('platform', JavaVersion), {
             it.ordered { a, b -> a <=> b }
@@ -432,7 +432,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurationsHavingAttributes() >> [toFooConfig, toBarConfig]
         }
         def attributeSchemaWithCompatibility = new DefaultAttributesSchema(new ComponentAttributeMatcher())
         attributeSchemaWithCompatibility.attribute(Attribute.of('key', String), {
@@ -495,7 +495,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurationsHavingAttributes() >> [toFooConfig, toBarConfig]
         }
         def attributeSchemaWithCompatibility = new DefaultAttributesSchema(new ComponentAttributeMatcher())
         attributeSchemaWithCompatibility.attribute(Attribute.of("key", String), {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -105,7 +105,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
         }
         attributesSchema.attribute(Attribute.of('key', String), {
             if (allowMissing) {
@@ -159,7 +159,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
             toString() >> 'target'
         }
         attributesSchema.attribute(Attribute.of('key', String))
@@ -199,7 +199,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
             toString() >> 'target'
         }
 
@@ -241,7 +241,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
             toString() >> 'target'
         }
         attributesSchema.attribute(Attribute.of('platform', JavaVersion), {
@@ -318,7 +318,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
         }
         attributesSchema.attribute(Attribute.of('platform', JavaVersion), {
             it.ordered { a, b -> a <=> b }
@@ -432,7 +432,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
         }
         def attributeSchemaWithCompatibility = new DefaultAttributesSchema(new ComponentAttributeMatcher())
         attributeSchemaWithCompatibility.attribute(Attribute.of('key', String), {
@@ -495,7 +495,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurations() >> [toFooConfig, toBarConfig]
+            getConsumableConfigurations() >> [toFooConfig, toBarConfig]
         }
         def attributeSchemaWithCompatibility = new DefaultAttributesSchema(new ComponentAttributeMatcher())
         attributeSchemaWithCompatibility.attribute(Attribute.of("key", String), {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -89,9 +89,6 @@ class LocalComponentDependencyMetadataTest extends Specification {
     def "selects the target configuration from target component which matches the attributes"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, null, [] as Set, [], false, false, true)
         def fromComponent = Stub(ComponentResolveMetadata)
-        def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurationNames() >> ['foo', 'bar']
-        }
         def fromConfig = Stub(LocalConfigurationMetadata) {
             getAttributes() >> attributes(queryAttributes)
         }
@@ -106,6 +103,9 @@ class LocalComponentDependencyMetadataTest extends Specification {
             getName() >> 'bar'
             getAttributes() >> attributes(key: 'something else')
             isCanBeConsumed() >> true
+        }
+        def toComponent = Stub(ComponentResolveMetadata) {
+            getConfigurations() >> [toFooConfig, toBarConfig]
         }
         attributesSchema.attribute(Attribute.of('key', String), {
             if (allowMissing) {
@@ -138,10 +138,6 @@ class LocalComponentDependencyMetadataTest extends Specification {
     def "revalidates default configuration if it has attributes"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, null, [] as Set, [], false, false, true)
         def fromComponent = Stub(ComponentResolveMetadata)
-        def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurationNames() >> ['foo', 'bar']
-            toString() >> 'target'
-        }
         def fromConfig = Stub(LocalConfigurationMetadata) {
             getAttributes() >> attributes(key: 'other')
         }
@@ -161,6 +157,10 @@ class LocalComponentDependencyMetadataTest extends Specification {
             getName() >> 'bar'
             getAttributes() >> attributes(key: 'something else')
             isCanBeConsumed() >> true
+        }
+        def toComponent = Stub(ComponentResolveMetadata) {
+            getConfigurations() >> [toFooConfig, toBarConfig]
+            toString() >> 'target'
         }
         attributesSchema.attribute(Attribute.of('key', String))
         attributesSchema.attribute(Attribute.of('will', String))
@@ -183,10 +183,6 @@ class LocalComponentDependencyMetadataTest extends Specification {
     def "revalidates explicit configuration selection if it has attributes"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, 'bar', [] as Set, [], false, false, true)
         def fromComponent = Stub(ComponentResolveMetadata)
-        def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurationNames() >> ['foo', 'bar']
-            toString() >> 'target'
-        }
         def fromConfig = Stub(LocalConfigurationMetadata) {
             getAttributes() >> attributes(key: 'something')
         }
@@ -201,6 +197,10 @@ class LocalComponentDependencyMetadataTest extends Specification {
             getName() >> 'bar'
             getAttributes() >> attributes(key: 'something else')
             isCanBeConsumed() >> true
+        }
+        def toComponent = Stub(ComponentResolveMetadata) {
+            getConfigurations() >> [toFooConfig, toBarConfig]
+            toString() >> 'target'
         }
 
         attributesSchema.attribute(Attribute.of('key', String))
@@ -223,10 +223,6 @@ class LocalComponentDependencyMetadataTest extends Specification {
     def "selects the target configuration from target component with Java proximity matching strategy"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, null, [] as Set, [], false, false, true)
         def fromComponent = Stub(ComponentResolveMetadata)
-        def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurationNames() >> ['foo', 'bar']
-            toString() >> 'target'
-        }
         def fromConfig = Stub(LocalConfigurationMetadata) {
             getAttributes() >> attributes(queryAttributes)
         }
@@ -243,6 +239,10 @@ class LocalComponentDependencyMetadataTest extends Specification {
             getAttributes() >> attributes(barAttributes)
             isCanBeResolved() >> false
             isCanBeConsumed() >> true
+        }
+        def toComponent = Stub(ComponentResolveMetadata) {
+            getConfigurations() >> [toFooConfig, toBarConfig]
+            toString() >> 'target'
         }
         attributesSchema.attribute(Attribute.of('platform', JavaVersion), {
             it.ordered { a, b -> a <=> b }
@@ -300,9 +300,6 @@ class LocalComponentDependencyMetadataTest extends Specification {
     def "selects the target configuration from target component with Java proximity matching strategy using short-hand notation"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, null, [] as Set, [], false, false, true)
         def fromComponent = Stub(ComponentResolveMetadata)
-        def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurationNames() >> ['foo', 'bar']
-        }
         def fromConfig = Stub(LocalConfigurationMetadata) {
             getAttributes() >> attributes(queryAttributes)
         }
@@ -319,6 +316,9 @@ class LocalComponentDependencyMetadataTest extends Specification {
             getAttributes() >> attributes(barAttributes)
             isCanBeResolved() >> false
             isCanBeConsumed() >> true
+        }
+        def toComponent = Stub(ComponentResolveMetadata) {
+            getConfigurations() >> [toFooConfig, toBarConfig]
         }
         attributesSchema.attribute(Attribute.of('platform', JavaVersion), {
             it.ordered { a, b -> a <=> b }
@@ -416,9 +416,6 @@ class LocalComponentDependencyMetadataTest extends Specification {
     def "can select a compatible attribute value"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, null, [] as Set, [], false, false, true)
         def fromComponent = Stub(ComponentResolveMetadata)
-        def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurationNames() >> ['foo', 'bar']
-        }
         def fromConfig = Stub(LocalConfigurationMetadata) {
             getAttributes() >> attributes(queryAttributes)
         }
@@ -433,6 +430,9 @@ class LocalComponentDependencyMetadataTest extends Specification {
             getName() >> 'bar'
             getAttributes() >> attributes(key: 'something else')
             isCanBeConsumed() >> true
+        }
+        def toComponent = Stub(ComponentResolveMetadata) {
+            getConfigurations() >> [toFooConfig, toBarConfig]
         }
         def attributeSchemaWithCompatibility = new DefaultAttributesSchema(new ComponentAttributeMatcher())
         attributeSchemaWithCompatibility.attribute(Attribute.of('key', String), {
@@ -479,9 +479,6 @@ class LocalComponentDependencyMetadataTest extends Specification {
     def "matcher failure"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), Stub(ModuleVersionSelector), "from", null, null, [] as Set, [], false, false, true)
         def fromComponent = Stub(ComponentResolveMetadata)
-        def toComponent = Stub(ComponentResolveMetadata) {
-            getConfigurationNames() >> ['foo', 'bar']
-        }
         def fromConfig = Stub(LocalConfigurationMetadata) {
             getAttributes() >> attributes(key: 'something')
         }
@@ -497,7 +494,9 @@ class LocalComponentDependencyMetadataTest extends Specification {
             getAttributes() >> attributes(key: 'something else')
             isCanBeConsumed() >> true
         }
-
+        def toComponent = Stub(ComponentResolveMetadata) {
+            getConfigurations() >> [toFooConfig, toBarConfig]
+        }
         def attributeSchemaWithCompatibility = new DefaultAttributesSchema(new ComponentAttributeMatcher())
         attributeSchemaWithCompatibility.attribute(Attribute.of("key", String), {
             it.ordered(Mock(Comparator) {

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/AbstractLanguageSourceSet.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/AbstractLanguageSourceSet.java
@@ -16,14 +16,18 @@
 
 package org.gradle.language.base.internal;
 
+import com.google.common.collect.Maps;
 import org.gradle.api.BuildableComponentSpec;
 import org.gradle.api.Task;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.AbstractBuildableComponentSpec;
 import org.gradle.platform.base.internal.ComponentSpecIdentifier;
 
+import java.util.Map;
+
 public abstract class AbstractLanguageSourceSet extends AbstractBuildableComponentSpec implements LanguageSourceSetInternal {
-    private final String languageName;
+    private final static Map<String, String> LANGUAGES = Maps.newHashMap();
+
     private final SourceDirectorySet source;
     private boolean generated;
     private Task generatorTask;
@@ -31,16 +35,21 @@ public abstract class AbstractLanguageSourceSet extends AbstractBuildableCompone
     public AbstractLanguageSourceSet(ComponentSpecIdentifier identifier, Class<? extends BuildableComponentSpec> publicType, SourceDirectorySet source) {
         super(identifier, publicType);
         this.source = source;
-        this.languageName = guessLanguageName(getTypeName());
         super.builtBy(source.getBuildDependencies());
     }
 
     protected String getLanguageName() {
-        return languageName;
+        return guessLanguageName(getTypeName());
     }
 
-    private String guessLanguageName(String typeName) {
-        return typeName.replaceAll("LanguageSourceSet$", "").replaceAll("SourceSet$", "").replaceAll("Source$", "").replaceAll("Set$", "");
+    private static synchronized String guessLanguageName(String typeName) {
+        String language = LANGUAGES.get(typeName);
+        if (language != null) {
+            return language;
+        }
+        language = typeName.replaceAll("LanguageSourceSet$", "").replaceAll("SourceSet$", "").replaceAll("Source$", "").replaceAll("Set$", "");
+        LANGUAGES.put(typeName, language);
+        return language;
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -32,6 +32,7 @@ import org.gradle.util.GUtil;
 
 public class DefaultSourceSet implements SourceSet {
     private final String name;
+    private final String baseName;
     private FileCollection compileClasspath;
     private FileCollection runtimeClasspath;
     private final SourceDirectorySet javaSource;
@@ -44,6 +45,7 @@ public class DefaultSourceSet implements SourceSet {
 
     public DefaultSourceSet(String name, SourceDirectorySetFactory sourceDirectorySetFactory) {
         this.name = name;
+        this.baseName = name.equals(SourceSet.MAIN_SOURCE_SET_NAME) ? "" : GUtil.toCamelCase(name);
         displayName = GUtil.toWords(this.name);
         namingScheme = new ClassDirectoryBinaryNamingScheme(name);
 
@@ -108,12 +110,11 @@ public class DefaultSourceSet implements SourceSet {
     }
 
     private String getTaskBaseName() {
-        return name.equals(SourceSet.MAIN_SOURCE_SET_NAME) ? "" : GUtil.toCamelCase(name);
+        return baseName;
     }
 
     public String getCompileConfigurationName() {
-        String compileConfigurationName = JavaPlugin.COMPILE_CONFIGURATION_NAME;
-        return configurationNameOf(compileConfigurationName);
+        return configurationNameOf(JavaPlugin.COMPILE_CONFIGURATION_NAME);
     }
 
     private String configurationNameOf(String baseName) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -233,14 +233,15 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         String compileOnlyConfigurationName = sourceSet.getCompileOnlyConfigurationName();
         String compileClasspathConfigurationName = sourceSet.getCompileClasspathConfigurationName();
         String runtimeClasspathConfigurationName = sourceSet.getRuntimeClasspathConfigurationName();
+        String sourceSetName = sourceSet.toString();
 
         Configuration compileConfiguration = configurations.maybeCreate(compileConfigurationName);
         compileConfiguration.setVisible(false);
-        compileConfiguration.setDescription("Dependencies for " + sourceSet + " (deprecated, use '" + implementationConfigurationName + " ' instead).");
+        compileConfiguration.setDescription("Dependencies for " + sourceSetName + " (deprecated, use '" + implementationConfigurationName + " ' instead).");
 
         Configuration implementationConfiguration = configurations.maybeCreate(implementationConfigurationName);
         implementationConfiguration.setVisible(false);
-        implementationConfiguration.setDescription("Implementation only dependencies for " + sourceSet + ".");
+        implementationConfiguration.setDescription("Implementation only dependencies for " + sourceSetName + ".");
         implementationConfiguration.setCanBeConsumed(false);
         implementationConfiguration.setCanBeResolved(false);
         implementationConfiguration.extendsFrom(compileConfiguration);
@@ -248,30 +249,30 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         Configuration runtimeConfiguration = configurations.maybeCreate(runtimeConfigurationName);
         runtimeConfiguration.setVisible(false);
         runtimeConfiguration.extendsFrom(compileConfiguration);
-        runtimeConfiguration.setDescription("Runtime dependencies for " + sourceSet + " (deprecated, use '" + runtimeOnlyConfigurationName + " ' instead).");
+        runtimeConfiguration.setDescription("Runtime dependencies for " + sourceSetName + " (deprecated, use '" + runtimeOnlyConfigurationName + " ' instead).");
 
         Configuration compileOnlyConfiguration = configurations.maybeCreate(compileOnlyConfigurationName);
         compileOnlyConfiguration.setVisible(false);
         compileOnlyConfiguration.extendsFrom(implementationConfiguration);
-        compileOnlyConfiguration.setDescription("Compile dependencies for " + sourceSet + ".");
+        compileOnlyConfiguration.setDescription("Compile dependencies for " + sourceSetName + ".");
 
         Configuration compileClasspathConfiguration = configurations.maybeCreate(compileClasspathConfigurationName);
         compileClasspathConfiguration.setVisible(false);
         compileClasspathConfiguration.extendsFrom(compileOnlyConfiguration);
-        compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSet + ".");
+        compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSetName + ".");
         compileClasspathConfiguration.setCanBeConsumed(false);
 
         Configuration runtimeOnlyConfiguration = configurations.maybeCreate(runtimeOnlyConfigurationName);
         runtimeOnlyConfiguration.setVisible(false);
         runtimeOnlyConfiguration.setCanBeConsumed(false);
         runtimeOnlyConfiguration.setCanBeResolved(false);
-        runtimeOnlyConfiguration.setDescription("Runtime only dependencies for " + sourceSet + ".");
+        runtimeOnlyConfiguration.setDescription("Runtime only dependencies for " + sourceSetName + ".");
 
         Configuration runtimeClasspathConfiguration = configurations.maybeCreate(runtimeClasspathConfigurationName);
         runtimeClasspathConfiguration.setVisible(false);
         runtimeClasspathConfiguration.setCanBeConsumed(false);
         runtimeClasspathConfiguration.setCanBeResolved(true);
-        runtimeClasspathConfiguration.setDescription("Runtime classpath of " + sourceSet + ".");
+        runtimeClasspathConfiguration.setDescription("Runtime classpath of " + sourceSetName + ".");
         runtimeClasspathConfiguration.extendsFrom(runtimeOnlyConfiguration, runtimeConfiguration);
 
         sourceSet.setCompileClasspath(compileClasspathConfiguration);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -226,40 +226,48 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     }
 
     private void defineConfigurationsForSourceSet(SourceSet sourceSet, ConfigurationContainer configurations) {
-        Configuration compileConfiguration = configurations.maybeCreate(sourceSet.getCompileConfigurationName());
-        compileConfiguration.setVisible(false);
-        compileConfiguration.setDescription("Dependencies for " + sourceSet + " (deprecated, use '" + sourceSet.getImplementationConfigurationName() + " ' instead).");
+        String compileConfigurationName = sourceSet.getCompileConfigurationName();
+        String implementationConfigurationName = sourceSet.getImplementationConfigurationName();
+        String runtimeConfigurationName = sourceSet.getRuntimeConfigurationName();
+        String runtimeOnlyConfigurationName = sourceSet.getRuntimeOnlyConfigurationName();
+        String compileOnlyConfigurationName = sourceSet.getCompileOnlyConfigurationName();
+        String compileClasspathConfigurationName = sourceSet.getCompileClasspathConfigurationName();
+        String runtimeClasspathConfigurationName = sourceSet.getRuntimeClasspathConfigurationName();
 
-        Configuration implementationConfiguration = configurations.maybeCreate(sourceSet.getImplementationConfigurationName());
+        Configuration compileConfiguration = configurations.maybeCreate(compileConfigurationName);
+        compileConfiguration.setVisible(false);
+        compileConfiguration.setDescription("Dependencies for " + sourceSet + " (deprecated, use '" + implementationConfigurationName + " ' instead).");
+
+        Configuration implementationConfiguration = configurations.maybeCreate(implementationConfigurationName);
         implementationConfiguration.setVisible(false);
         implementationConfiguration.setDescription("Implementation only dependencies for " + sourceSet + ".");
         implementationConfiguration.setCanBeConsumed(false);
         implementationConfiguration.setCanBeResolved(false);
         implementationConfiguration.extendsFrom(compileConfiguration);
 
-        Configuration runtimeConfiguration = configurations.maybeCreate(sourceSet.getRuntimeConfigurationName());
+        Configuration runtimeConfiguration = configurations.maybeCreate(runtimeConfigurationName);
         runtimeConfiguration.setVisible(false);
         runtimeConfiguration.extendsFrom(compileConfiguration);
-        runtimeConfiguration.setDescription("Runtime dependencies for " + sourceSet + " (deprecated, use '" + sourceSet.getRuntimeOnlyConfigurationName() + " ' instead).");
+        runtimeConfiguration.setDescription("Runtime dependencies for " + sourceSet + " (deprecated, use '" + runtimeOnlyConfigurationName + " ' instead).");
 
-        Configuration compileOnlyConfiguration = configurations.maybeCreate(sourceSet.getCompileOnlyConfigurationName());
+        Configuration compileOnlyConfiguration = configurations.maybeCreate(compileOnlyConfigurationName);
         compileOnlyConfiguration.setVisible(false);
         compileOnlyConfiguration.extendsFrom(implementationConfiguration);
         compileOnlyConfiguration.setDescription("Compile dependencies for " + sourceSet + ".");
 
-        Configuration compileClasspathConfiguration = configurations.maybeCreate(sourceSet.getCompileClasspathConfigurationName());
+        Configuration compileClasspathConfiguration = configurations.maybeCreate(compileClasspathConfigurationName);
         compileClasspathConfiguration.setVisible(false);
         compileClasspathConfiguration.extendsFrom(compileOnlyConfiguration);
         compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSet + ".");
         compileClasspathConfiguration.setCanBeConsumed(false);
 
-        Configuration runtimeOnlyConfiguration = configurations.maybeCreate(sourceSet.getRuntimeOnlyConfigurationName());
+        Configuration runtimeOnlyConfiguration = configurations.maybeCreate(runtimeOnlyConfigurationName);
         runtimeOnlyConfiguration.setVisible(false);
         runtimeOnlyConfiguration.setCanBeConsumed(false);
         runtimeOnlyConfiguration.setCanBeResolved(false);
         runtimeOnlyConfiguration.setDescription("Runtime only dependencies for " + sourceSet + ".");
 
-        Configuration runtimeClasspathConfiguration = configurations.maybeCreate(sourceSet.getRuntimeClasspathConfigurationName());
+        Configuration runtimeClasspathConfiguration = configurations.maybeCreate(runtimeClasspathConfigurationName);
         runtimeClasspathConfiguration.setVisible(false);
         runtimeClasspathConfiguration.setCanBeConsumed(false);
         runtimeClasspathConfiguration.setCanBeResolved(true);

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultReportContainer.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultReportContainer.java
@@ -21,6 +21,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.internal.DefaultNamedDomainObjectSet;
@@ -63,6 +64,12 @@ public class DefaultReportContainer<T extends Report> extends DefaultNamedDomain
         }
     };
 
+    private static final Action<Void> IMMUTABLE_VIOLATION_EXCEPTION = new Action<Void>() {
+        public void execute(Void arg) {
+            throw new ImmutableViolationException();
+        }
+    };
+
 
     private NamedDomainObjectSet<T> enabled;
 
@@ -75,11 +82,7 @@ public class DefaultReportContainer<T extends Report> extends DefaultNamedDomain
             }
         });
 
-        beforeChange(new Runnable() {
-            public void run() {
-                throw new ImmutableViolationException();
-            }
-        });
+        beforeChange(IMMUTABLE_VIOLATION_EXCEPTION);
     }
 
     public NamedDomainObjectSet<T> getEnabled() {


### PR DESCRIPTION
This PR is a collection of optimizations in `Configuration` creation time as well as some general configuration improvements to mitigate the performance regressions introduced by the higher number of configurations we need to create now that the Java Library plugin has been merged.

