### PR TITLE
Faster file stat

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
@@ -22,8 +22,6 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.util.CollectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
@@ -43,7 +41,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class JavaReflectionUtil {
-    private static final Logger LOGGER = LoggerFactory.getLogger(JavaReflectionUtil.class);
 
     private static final WeakHashMap<Class<?>, ConcurrentMap<String, Boolean>> PROPERTY_CACHE = new WeakHashMap<Class<?>, ConcurrentMap<String, Boolean>>();
 
@@ -92,8 +89,6 @@ public class JavaReflectionUtil {
 
     /**
      * Locates the field with the given name as a readable property.  Searches only public fields.
-     *
-     * @throws NoSuchPropertyException
      */
     public static <T, F> PropertyAccessor<T, F> readableField(Class<T> target, Class<F> fieldType, String fieldName) throws NoSuchPropertyException {
         Field field = findField(target, fieldName);
@@ -106,8 +101,6 @@ public class JavaReflectionUtil {
 
     /**
      * Locates the field with the given name as a readable property.  Searches only public fields.
-     *
-     * @throws NoSuchPropertyException
      */
     public static <T, F> PropertyAccessor<T, F> readableField(T target, Class<F> fieldType, String fieldName) throws NoSuchPropertyException {
         @SuppressWarnings("unchecked")
@@ -294,13 +287,11 @@ public class JavaReflectionUtil {
         if (JavaVersion.current().isJava7Compatible()) {
             try {
                 handlerClass = loader.loadClass(jdk7Type);
-                LOGGER.debug("Using service {}", jdk7Type);
             } catch (ClassNotFoundException e) {
                 // Ignore
             }
         }
         if (handlerClass == null) {
-            LOGGER.debug("Unable to load {}. Continuing with fallback {}.", jdk7Type, fallbackType.getName());
             handlerClass = fallbackType;
         }
         try {
@@ -328,7 +319,7 @@ public class JavaReflectionUtil {
             Method override = CollectionUtils.findFirst(seenWithName, new Spec<Method>() {
                 public boolean isSatisfiedBy(Method potentionOverride) {
                     return potentionOverride.getName().equals(method.getName())
-                            && Arrays.equals(potentionOverride.getParameterTypes(), method.getParameterTypes());
+                        && Arrays.equals(potentionOverride.getParameterTypes(), method.getParameterTypes());
                 }
             });
 

--- a/subprojects/native/native.gradle
+++ b/subprojects/native/native.gradle
@@ -18,3 +18,60 @@ dependencies {
 useTestFixtures()
 useTestFixtures(project: ":logging")
 useClassycle()
+
+jmh {
+    fork = 1
+    resultFormat = 'CSV'
+}
+
+task copyJmhReport(type: Copy) {
+    destinationDir = file("$buildDir/reports/jmh-html")
+
+    from 'src/jmh/html'
+}
+
+task convertCSV {
+    ext.inputFile = file("$buildDir/reports/jmh/results.csv")
+    ext.outputFile = file("$buildDir/reports/jmh-html/data.csv")
+    inputs.file(inputFile)
+    outputs.file(outputFile)
+    doLast {
+        def benchToScenarioName = [
+            'org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessorBenchmark.stat_existing': 'Existing',
+            'org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessorBenchmark.stat_directory': 'Directory',
+            'org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessorBenchmark.stat_missing_file': 'Missing',
+        ]
+        boolean first = true
+        def benchmarks = [:].withDefault { [] }
+        inputFile.eachLine { line ->
+            if (first) {
+                first = false
+            } else {
+                def (benchmark, mode, threads, samples, score, error, unit, accessor) = line.replace('"', '').split(",")
+                benchmarks[benchToScenarioName[benchmark]] << [accessor - 'FileMetadataAccessor', Double.valueOf(score) as int]
+            }
+        }
+        outputFile.parentFile.mkdirs()
+        Set tested = []
+        benchmarks.each { benchmark, values ->
+            values.each {
+                tested << it[0]
+            }
+        }
+        outputFile.withWriter { writer ->
+            writer << "Scenario,${tested.join(',')}\n"
+            benchmarks.each { benchmark, values ->
+                writer << "$benchmark"
+                tested.each { test ->
+                    writer << ",${values.find { it[0] == test }[1]}"
+                }
+                writer << '\n'
+            }
+        }
+        println outputFile.absolutePath
+    }
+}
+
+task jmhReport {
+    dependsOn 'jmh', copyJmhReport, convertCSV
+}

--- a/subprojects/native/src/jmh/html/index.html
+++ b/subprojects/native/src/jmh/html/index.html
@@ -1,99 +1,50 @@
+
 <!--
-    Inspired from https://bl.ocks.org/mbostock/3887051
--->
+  ~ Copyright 2017 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <!DOCTYPE html>
 <style>
-
-.axis .domain {
-  display: none;
+#chart {
+    width: 50%
 }
 </style>
-<svg width="960" height="500"></svg>
-<script src="https://d3js.org/d3.v4.min.js"></script>
+<div id="chart"></div>
+<!-- Load c3.css -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.css" rel="stylesheet" type="text/css">
+
+<!-- Load d3.js and c3.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.4/d3.min.js" charset="utf-8"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js"></script>
 <script>
-
-var svg = d3.select("svg"),
-    margin = {top: 20, right: 20, bottom: 30, left: 40},
-    width = +svg.attr("width") - margin.left - margin.right,
-    height = +svg.attr("height") - margin.top - margin.bottom,
-    g = svg.append("g").attr("transform", "translate(" + margin.left + "," + margin.top + ")");
-
-var x0 = d3.scaleBand()
-    .rangeRound([0, width])
-    .paddingInner(0.1);
-
-var x1 = d3.scaleBand()
-    .padding(0.05);
-
-var y = d3.scaleLinear()
-    .rangeRound([height, 0]);
-
-var z = d3.scaleOrdinal()
-    .range([" #4D4D4D", " #5DA5DA", " #FAA43A", " #60BD68", " #F17CB0", "#B2912F", "#B276B2", "#DECF3F", "#F15854"]);
-
-d3.csv("data.csv", function(d, i, columns) {
-  for (var i = 1, n = columns.length; i < n; ++i) d[columns[i]] = +d[columns[i]];
-  return d;
-}, function(error, data) {
-  if (error) throw error;
-
-  var keys = data.columns.slice(1);
-
-  x0.domain(data.map(function(d) { return d.Scenario; }));
-  x1.domain(keys).rangeRound([0, x0.bandwidth()]);
-  y.domain([0, d3.max(data, function(d) { return d3.max(keys, function(key) { return d[key]; }); })]).nice();
-
-  g.append("g")
-    .selectAll("g")
-    .data(data)
-    .enter().append("g")
-      .attr("transform", function(d) { return "translate(" + x0(d.Scenario) + ",0)"; })
-    .selectAll("rect")
-    .data(function(d) { return keys.map(function(key) { return {key: key, value: d[key]}; }); })
-    .enter().append("rect")
-      .attr("x", function(d) { return x1(d.key); })
-      .attr("y", function(d) { return y(d.value); })
-      .attr("width", x1.bandwidth())
-      .attr("height", function(d) { return height - y(d.value); })
-      .attr("fill", function(d) { return z(d.key); });
-
-  g.append("g")
-      .attr("class", "axis")
-      .attr("transform", "translate(0," + height + ")")
-      .call(d3.axisBottom(x0));
-
-  g.append("g")
-      .attr("class", "axis")
-      .call(d3.axisLeft(y).ticks(null, "s"))
-    .append("text")
-      .attr("x", 2)
-      .attr("y", y(y.ticks().pop()) + 0.5)
-      .attr("dy", "0.32em")
-      .attr("fill", "#000")
-      .attr("font-weight", "bold")
-      .attr("text-anchor", "start")
-      .text("ops/s");
-
-  var legend = g.append("g")
-      .attr("font-family", "sans-serif")
-      .attr("font-size", 10)
-      .attr("text-anchor", "end")
-    .selectAll("g")
-    .data(keys.slice().reverse())
-    .enter().append("g")
-      .attr("transform", function(d, i) { return "translate(0," + i * 20 + ")"; });
-
-  legend.append("rect")
-      .attr("x", width - 19)
-      .attr("width", 19)
-      .attr("height", 19)
-      .attr("fill", z);
-
-  legend.append("text")
-      .attr("x", width - 24)
-      .attr("y", 9.5)
-      .attr("dy", "0.32em")
-      .text(function(d) { return d; });
+var chart = c3.generate({
+    data: {
+        url: 'data.csv',
+        type: 'bar',
+        x: 'Scenario'
+    },
+    axis: {
+        x: {
+            type: 'category'
+        },
+        y: {
+            label: 'ops/s',
+            tick: {
+                format: function (x) { return (x / 1000000) + "M" }
+            }
+        }
+    }
 });
-
 </script>

--- a/subprojects/native/src/jmh/html/index.html
+++ b/subprojects/native/src/jmh/html/index.html
@@ -1,0 +1,99 @@
+<!--
+    Inspired from https://bl.ocks.org/mbostock/3887051
+-->
+<!DOCTYPE html>
+<style>
+
+.axis .domain {
+  display: none;
+}
+</style>
+<svg width="960" height="500"></svg>
+<script src="https://d3js.org/d3.v4.min.js"></script>
+<script>
+
+var svg = d3.select("svg"),
+    margin = {top: 20, right: 20, bottom: 30, left: 40},
+    width = +svg.attr("width") - margin.left - margin.right,
+    height = +svg.attr("height") - margin.top - margin.bottom,
+    g = svg.append("g").attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+var x0 = d3.scaleBand()
+    .rangeRound([0, width])
+    .paddingInner(0.1);
+
+var x1 = d3.scaleBand()
+    .padding(0.05);
+
+var y = d3.scaleLinear()
+    .rangeRound([height, 0]);
+
+var z = d3.scaleOrdinal()
+    .range([" #4D4D4D", " #5DA5DA", " #FAA43A", " #60BD68", " #F17CB0", "#B2912F", "#B276B2", "#DECF3F", "#F15854"]);
+
+d3.csv("data.csv", function(d, i, columns) {
+  for (var i = 1, n = columns.length; i < n; ++i) d[columns[i]] = +d[columns[i]];
+  return d;
+}, function(error, data) {
+  if (error) throw error;
+
+  var keys = data.columns.slice(1);
+
+  x0.domain(data.map(function(d) { return d.Scenario; }));
+  x1.domain(keys).rangeRound([0, x0.bandwidth()]);
+  y.domain([0, d3.max(data, function(d) { return d3.max(keys, function(key) { return d[key]; }); })]).nice();
+
+  g.append("g")
+    .selectAll("g")
+    .data(data)
+    .enter().append("g")
+      .attr("transform", function(d) { return "translate(" + x0(d.Scenario) + ",0)"; })
+    .selectAll("rect")
+    .data(function(d) { return keys.map(function(key) { return {key: key, value: d[key]}; }); })
+    .enter().append("rect")
+      .attr("x", function(d) { return x1(d.key); })
+      .attr("y", function(d) { return y(d.value); })
+      .attr("width", x1.bandwidth())
+      .attr("height", function(d) { return height - y(d.value); })
+      .attr("fill", function(d) { return z(d.key); });
+
+  g.append("g")
+      .attr("class", "axis")
+      .attr("transform", "translate(0," + height + ")")
+      .call(d3.axisBottom(x0));
+
+  g.append("g")
+      .attr("class", "axis")
+      .call(d3.axisLeft(y).ticks(null, "s"))
+    .append("text")
+      .attr("x", 2)
+      .attr("y", y(y.ticks().pop()) + 0.5)
+      .attr("dy", "0.32em")
+      .attr("fill", "#000")
+      .attr("font-weight", "bold")
+      .attr("text-anchor", "start")
+      .text("ops/s");
+
+  var legend = g.append("g")
+      .attr("font-family", "sans-serif")
+      .attr("font-size", 10)
+      .attr("text-anchor", "end")
+    .selectAll("g")
+    .data(keys.slice().reverse())
+    .enter().append("g")
+      .attr("transform", function(d, i) { return "translate(0," + i * 20 + ")"; });
+
+  legend.append("rect")
+      .attr("x", width - 19)
+      .attr("width", 19)
+      .attr("height", 19)
+      .attr("fill", z);
+
+  legend.append("text")
+      .attr("x", width - 24)
+      .attr("y", 9.5)
+      .attr("dy", "0.32em")
+      .text(function(d) { return d; });
+});
+
+</script>

--- a/subprojects/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
+++ b/subprojects/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.nativeintegration.filesystem;
+
+import com.google.common.collect.ImmutableMap;
+import net.rubygrapefruit.platform.Files;
+import org.gradle.internal.nativeintegration.filesystem.jdk7.Jdk7FileMetadataAccessor;
+import org.gradle.internal.nativeintegration.filesystem.services.FallbackFileMetadataAccessor;
+import org.gradle.internal.nativeintegration.filesystem.services.NativePlatformBackedFileMetadataAccessor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Map;
+import java.util.UUID;
+
+@State(Scope.Benchmark)
+public class FileMetadataAccessorBenchmark {
+    private static final Map<String, FileMetadataAccessor> ACCESSORS = ImmutableMap.<String, FileMetadataAccessor>builder()
+        .put(FallbackFileMetadataAccessor.class.getSimpleName(), new FallbackFileMetadataAccessor())
+        .put(NativePlatformBackedFileMetadataAccessor.class.getSimpleName(), new NativePlatformBackedFileMetadataAccessor(net.rubygrapefruit.platform.Native.get(Files.class)))
+        .put(Jdk7FileMetadataAccessor.class.getSimpleName(), new Jdk7FileMetadataAccessor())
+        .put(NioFileMetadataAccessor.class.getSimpleName(), new NioFileMetadataAccessor())
+        .build();
+
+
+    @Param({
+        "FallbackFileMetadataAccessor",
+        "NativePlatformBackedFileMetadataAccessor",
+        "Jdk7FileMetadataAccessor",
+        "NioFileMetadataAccessor"
+    })
+    String accessorClassName;
+
+    FileMetadataAccessor accessor;
+    File missing;
+    File directory;
+    File realFile;
+
+    @Setup
+    public void prepare() throws IOException {
+        accessor = getAccessor(accessorClassName);
+        missing = new File(UUID.randomUUID().toString());
+        directory = File.createTempFile("jmh", "dir");
+        directory.mkdirs();
+        realFile = File.createTempFile("jmh", "tmp");
+
+        FileOutputStream fos = new FileOutputStream(realFile);
+        fos.write(new byte[1024]);
+        fos.close();
+    }
+
+    @TearDown
+    public void tearDown() {
+        directory.delete();
+        realFile.delete();
+    }
+
+    @SuppressWarnings("unchecked")
+    private FileMetadataAccessor getAccessor(String name) {
+        return ACCESSORS.get(name);
+    }
+
+    @Benchmark
+    public void stat_missing_file(Blackhole bh) {
+        bh.consume(getAccessor(accessorClassName).stat(missing));
+    }
+
+    @Benchmark
+    public void stat_directory(Blackhole bh) {
+        bh.consume(getAccessor(accessorClassName).stat(directory));
+    }
+
+    @Benchmark
+    public void stat_existing(Blackhole bh) {
+        bh.consume(getAccessor(accessorClassName).stat(realFile));
+    }
+
+    private static class NioFileMetadataAccessor implements FileMetadataAccessor {
+
+        @Override
+        public FileMetadataSnapshot stat(File f) {
+            try {
+                BasicFileAttributes bfa = java.nio.file.Files.readAttributes(f.toPath(), BasicFileAttributes.class);
+                if (bfa.isDirectory()) {
+                    return FileMetadataSnapshot.directory();
+                }
+                return new FileMetadataSnapshot(FileType.RegularFile, bfa.lastModifiedTime().toMillis(), bfa.size());
+            } catch (IOException e) {
+                return FileMetadataSnapshot.missing();
+            }
+        }
+    }
+}

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7FileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7FileMetadataAccessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.nativeintegration.filesystem.jdk7;
+
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessor;
+import org.gradle.internal.nativeintegration.filesystem.FileMetadataSnapshot;
+import org.gradle.internal.nativeintegration.filesystem.FileType;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class Jdk7FileMetadataAccessor implements FileMetadataAccessor {
+    @Override
+    public FileMetadataSnapshot stat(File f) {
+        if (!f.exists()) {
+            // This is really not cool, but we cannot rely on `readAttributes` because it will
+            // THROW AN EXCEPTION if the file is missing, which is really incredibly slow just
+            // to determine if a file exists or not.
+            return FileMetadataSnapshot.missing();
+        }
+        try {
+            BasicFileAttributes bfa = Files.readAttributes(f.toPath(), BasicFileAttributes.class);
+            if (bfa.isDirectory()) {
+                return FileMetadataSnapshot.directory();
+            }
+            return new FileMetadataSnapshot(FileType.RegularFile, bfa.lastModifiedTime().toMillis(), bfa.size());
+        } catch (IOException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+}

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FileSystemServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FileSystemServices.java
@@ -17,8 +17,6 @@
 package org.gradle.internal.nativeintegration.filesystem.services;
 
 import net.rubygrapefruit.platform.PosixFiles;
-import org.gradle.api.JavaVersion;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.nativeintegration.filesystem.FileCanonicalizer;
 import org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessor;
 import org.gradle.internal.nativeintegration.filesystem.FileModeAccessor;
@@ -26,6 +24,7 @@ import org.gradle.internal.nativeintegration.filesystem.FileModeMutator;
 import org.gradle.internal.nativeintegration.filesystem.Symlink;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,14 +33,14 @@ public class FileSystemServices {
 
     @SuppressWarnings("UnusedDeclaration")
     public FileCanonicalizer createFileCanonicalizer() {
-        return (FileCanonicalizer) newInstance("org.gradle.internal.nativeintegration.filesystem.jdk7.Jdk7FileCanonicalizer", FallbackFileCanonicalizer.class);
+        return JavaReflectionUtil.newInstanceOrFallback("org.gradle.internal.nativeintegration.filesystem.jdk7.Jdk7FileCanonicalizer", FileSystemServices.class.getClassLoader(), FallbackFileCanonicalizer.class);
     }
 
     @SuppressWarnings("UnusedDeclaration")
     public FileSystem createFileSystem(OperatingSystem operatingSystem, PosixFiles posixFiles, FileMetadataAccessor metadataAccessor) throws Exception {
 
         if (operatingSystem.isWindows()) {
-            Symlink symlink = (Symlink) newInstance("org.gradle.internal.nativeintegration.filesystem.jdk7.WindowsJdk7Symlink", WindowsSymlink.class);
+            Symlink symlink = JavaReflectionUtil.newInstanceOrFallback("org.gradle.internal.nativeintegration.filesystem.jdk7.WindowsJdk7Symlink", FileSystemServices.class.getClassLoader(), WindowsSymlink.class);
             return new GenericFileSystem(new EmptyChmod(), new FallbackStat(), symlink, metadataAccessor);
         }
 
@@ -54,33 +53,12 @@ public class FileSystemServices {
             return new GenericFileSystem(chmod, stat, symlink, metadataAccessor);
         }
 
-        Symlink symlink = (Symlink) newInstance("org.gradle.internal.nativeintegration.filesystem.jdk7.Jdk7Symlink", UnsupportedSymlink.class);
+        Symlink symlink = JavaReflectionUtil.newInstanceOrFallback("org.gradle.internal.nativeintegration.filesystem.jdk7.Jdk7Symlink", FileSystemServices.class.getClassLoader(), UnsupportedSymlink.class);
         LOGGER.debug("Using {} implementation as symlink.", symlink.getClass().getSimpleName());
 
         // Use java 7 APIs, if available, otherwise fallback to no-op
-        Object handler = newInstance("org.gradle.internal.nativeintegration.filesystem.jdk7.PosixJdk7FilePermissionHandler", UnsupportedFilePermissions.class);
+        Object handler = JavaReflectionUtil.newInstanceOrFallback("org.gradle.internal.nativeintegration.filesystem.jdk7.PosixJdk7FilePermissionHandler", FileSystemServices.class.getClassLoader(), UnsupportedFilePermissions.class);
         return new GenericFileSystem((FileModeMutator) handler, (FileModeAccessor) handler, symlink, metadataAccessor);
     }
 
-    private Object newInstance(String jdk7Type, Class<?> fallbackType) {
-        // Use java 7 APIs, if available
-        Class<?> handlerClass = null;
-        if (JavaVersion.current().isJava7Compatible()) {
-            try {
-                handlerClass = FileSystemServices.class.getClassLoader().loadClass(jdk7Type);
-                LOGGER.debug("Using JDK 7 file service {}", jdk7Type);
-            } catch (ClassNotFoundException e) {
-                // Ignore
-            }
-        }
-        if (handlerClass == null) {
-            LOGGER.debug("Unable to load {}. Continuing with fallback {}.", jdk7Type, fallbackType.getName());
-            handlerClass = fallbackType;
-        }
-        try {
-            return handlerClass.newInstance();
-        } catch (Exception e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        }
-    }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -25,6 +25,7 @@ import net.rubygrapefruit.platform.SystemInfo;
 import net.rubygrapefruit.platform.Terminals;
 import net.rubygrapefruit.platform.WindowsRegistry;
 import net.rubygrapefruit.platform.internal.DefaultProcessLauncher;
+import org.gradle.api.JavaVersion;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
@@ -41,6 +42,7 @@ import org.gradle.internal.nativeintegration.jansi.JansiBootPathConfigurer;
 import org.gradle.internal.nativeintegration.jna.UnsupportedEnvironment;
 import org.gradle.internal.nativeintegration.processenvironment.NativePlatformBackedProcessEnvironment;
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
 import org.slf4j.Logger;
@@ -223,6 +225,11 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
                 LOGGER.debug("Native-platform files integration is not available. Continuing with fallback.");
             }
         }
+
+        if (JavaVersion.current().isJava7Compatible()) {
+            return JavaReflectionUtil.newInstanceOrFallback("org.gradle.internal.nativeintegration.filesystem.jdk7.Jdk7FileMetadataAccessor", NativeServices.class.getClassLoader(), FallbackFileMetadataAccessor.class);
+        }
+
         return new FallbackFileMetadataAccessor();
     }
 

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -218,7 +218,13 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
     }
 
     protected FileMetadataAccessor createFileMetadataAccessor(OperatingSystem operatingSystem) {
-        if (operatingSystem.isMacOsX() && useNativeIntegrations) {
+        // Based on the benchmark found in org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessorBenchmark
+        // and the results in the PR https://github.com/gradle/gradle/pull/1183
+        // we're using "native platform" for Mac OS and Windows and a  mix of File and NIO API for Linux
+        // Once JDK 9 is out, we need to revisit the choice, because testing for file.exists() should become much
+        // cheaper using the pure NIO implementation.
+
+        if ((operatingSystem.isMacOsX() || operatingSystem.isWindows()) && useNativeIntegrations) {
             try {
                 return new NativePlatformBackedFileMetadataAccessor(net.rubygrapefruit.platform.Native.get(Files.class));
             } catch (NativeIntegrationUnavailableException e) {

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/AbstractFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/AbstractFileMetadataAccessorTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.nativeintegration.filesystem.services
+
+import org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessor
+import org.gradle.internal.nativeintegration.filesystem.FileType
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import org.gradle.util.UsesNativeServices
+import org.junit.Rule
+import spock.lang.Specification
+
+@UsesNativeServices
+abstract class AbstractFileMetadataAccessorTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    abstract FileMetadataAccessor getAccessor()
+
+    def "stats missing file"() {
+        def file = tmpDir.file("missing")
+
+        expect:
+        def stat = accessor.stat(file)
+        stat.type == FileType.Missing
+        stat.lastModified == 0
+        stat.length == 0
+    }
+
+    def "stats regular file"() {
+        def file = tmpDir.file("file")
+        file.text = "123"
+
+        expect:
+        def stat = accessor.stat(file)
+        stat.type == FileType.RegularFile
+        stat.lastModified == file.lastModified()
+        stat.length == 3
+    }
+
+    def "stats directory"() {
+        def dir = tmpDir.file("dir").createDir()
+
+        expect:
+        def stat = accessor.stat(dir)
+        stat.type == FileType.Directory
+        stat.lastModified == 0
+        stat.length == 0
+    }
+
+    @Requires(TestPrecondition.SYMLINKS)
+    def "stats symlink"() {
+        def file = tmpDir.file("file")
+        file.text = "123"
+        def link = tmpDir.file("link")
+        link.createLink(file)
+
+        expect:
+        def stat = accessor.stat(link)
+        stat.type == FileType.RegularFile
+        stat.lastModified == file.lastModified()
+        stat.length == 3
+    }
+}

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/Jdk7FileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/Jdk7FileMetadataAccessorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 package org.gradle.internal.nativeintegration.filesystem.services
 
 import org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessor
+import org.gradle.internal.nativeintegration.filesystem.jdk7.Jdk7FileMetadataAccessor
 import org.gradle.util.UsesNativeServices
 
 @UsesNativeServices
-class FallbackFileMetadataAccessorTest extends AbstractFileMetadataAccessorTest {
+class Jdk7FileMetadataAccessorTest extends AbstractFileMetadataAccessorTest {
     FileMetadataAccessor getAccessor() {
-        new FallbackFileMetadataAccessor()
-
+        new Jdk7FileMetadataAccessor()
     }
 }


### PR DESCRIPTION
While investigating performance regressions on `master`, I discovered that file stat (in particular because of annotation processor detection) was responsible for a large proportion of the performance regression. It is clearly visible in the following flame graph:

![selection_001](https://cloud.githubusercontent.com/assets/316357/21988332/2f5392ce-dc07-11e6-8a1f-f1aeaa24b67b.png)

This commit adds a new `Jdk7FileMetadataAccessor` which uses the JDK 7 NIO API to get file stats. We can therefore do the same in just 2 calls:

- one to check `exists`
- one to get all file stats (directory, length, last modified)

The difference is great:

![selection_002](https://cloud.githubusercontent.com/assets/316357/21988493/b02c7366-dc07-11e6-95ab-ecf193f5318e.png)

The regression goes from 10% slower to 4% slower (without the fixes I made in the other PR). We still need to make 2 calls, because `Files.exists` in JDK 7/8 is crazily expensive (because it internally throws an exception!). But this makes me wonder why `native-platform` would be slower than this, it makes no sense.