### PR TITLE
Fix lazy evaluation of parent/grand-parent pom's properties (#1080)

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -95,7 +95,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
                     pomReader.getParentGroupId(),
                     pomReader.getParentArtifactId(),
                     pomReader.getParentVersion());
-            PomReader parentPomReader = parseOtherPom(parserSettings, parentId);
+            PomReader parentPomReader = parseOtherPom(parserSettings, parentId, pomReader.getAllPomProperties());
             pomReader.setPomParent(parentPomReader);
         }
         pomReader.resolveGAV();
@@ -210,6 +210,16 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
     private PomReader parseOtherPom(DescriptorParseContext parseContext, ModuleComponentIdentifier parentId) throws IOException, SAXException {
         LocallyAvailableExternalResource localResource = parseContext.getMetaDataArtifact(parentId, ArtifactType.MAVEN_POM);
         PomReader pomReader = new PomReader(localResource, moduleIdentifierFactory);
+        return finalizePomReader(parseContext, pomReader);
+    }
+
+    private PomReader parseOtherPom(DescriptorParseContext parseContext, ModuleComponentIdentifier parentId, Map<String, String> properties) throws IOException, SAXException {
+        LocallyAvailableExternalResource localResource = parseContext.getMetaDataArtifact(parentId, ArtifactType.MAVEN_POM);
+        PomReader pomReader = new PomReader(localResource, moduleIdentifierFactory, properties);
+        return finalizePomReader(parseContext, pomReader);
+    }
+
+    private PomReader finalizePomReader(DescriptorParseContext parseContext, PomReader pomReader) throws IOException, SAXException {
         GradlePomModuleDescriptorBuilder mdBuilder = new GradlePomModuleDescriptorBuilder(pomReader, gradleVersionSelectorScheme, mavenVersionSelectorScheme, moduleIdentifierFactory, moduleExclusions);
         doParsePom(parseContext, mdBuilder, pomReader);
         return pomReader;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -95,7 +95,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
                     pomReader.getParentGroupId(),
                     pomReader.getParentArtifactId(),
                     pomReader.getParentVersion());
-            PomReader parentPomReader = parseOtherPom(parserSettings, parentId, pomReader.getAllPomProperties());
+            PomReader parentPomReader = parseParentPom(parserSettings, parentId, pomReader.getAllPomProperties());
             pomReader.setPomParent(parentPomReader);
         }
         pomReader.resolveGAV();
@@ -213,7 +213,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
         return finalizePomReader(parseContext, pomReader);
     }
 
-    private PomReader parseOtherPom(DescriptorParseContext parseContext, ModuleComponentIdentifier parentId, Map<String, String> properties) throws IOException, SAXException {
+    private PomReader parseParentPom(DescriptorParseContext parseContext, ModuleComponentIdentifier parentId, Map<String, String> properties) throws IOException, SAXException {
         LocallyAvailableExternalResource localResource = parseContext.getMetaDataArtifact(parentId, ArtifactType.MAVEN_POM);
         PomReader pomReader = new PomReader(localResource, moduleIdentifierFactory, properties);
         return finalizePomReader(parseContext, pomReader);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
@@ -204,7 +204,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
 <project>
     <modelVersion>4.0.0</modelVersion>
     <groupId>group-one</groupId>
-    <artifactId>artifact-one</artifactId>
+    <artifactId>parent</artifactId>
     <version>version-one</version>
 
     <dependencyManagement>


### PR DESCRIPTION
Fixes
https://github.com/gradle/gradle/issues/1080

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [x] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [x] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
