### PR TITLE
Add Action<T> overloads to methods that takes a Closure in :antlr

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrSourceVirtualDirectory.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrSourceVirtualDirectory.java
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins.antlr;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 
 /**
@@ -43,4 +44,12 @@ public interface AntlrSourceVirtualDirectory {
      */
     AntlrSourceVirtualDirectory antlr(Closure configureClosure);
 
+    /**
+     * Configures the Antlr source for this set. The given action is used to configure the {@link org.gradle.api.file.SourceDirectorySet} (see
+     * {@link #getAntlr}) which contains the Antlr source.
+     *
+     * @param configureAction The action to use to configure the Antlr source.
+     * @return this
+     */
+    AntlrSourceVirtualDirectory antlr(Action<? super SourceDirectorySet> configureAction);
 }

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSourceVirtualDirectoryImpl.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSourceVirtualDirectoryImpl.java
@@ -16,10 +16,11 @@
 package org.gradle.api.plugins.antlr.internal;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.plugins.antlr.AntlrSourceVirtualDirectory;
-import org.gradle.util.ConfigureUtil;
 
 /**
  * The implementation of the {@link org.gradle.api.plugins.antlr.AntlrSourceVirtualDirectory} contract.
@@ -34,12 +35,20 @@ public class AntlrSourceVirtualDirectoryImpl implements AntlrSourceVirtualDirect
         antlr.getFilter().include("**/*.g4");
     }
 
+    @Override
     public SourceDirectorySet getAntlr() {
         return antlr;
     }
 
+    @Override
     public AntlrSourceVirtualDirectory antlr(Closure configureClosure) {
-        ConfigureUtil.configure(configureClosure, getAntlr());
+        antlr(ClosureBackedAction.of(configureClosure));
+        return this;
+    }
+
+    @Override
+    public AntlrSourceVirtualDirectory antlr(Action<? super SourceDirectorySet> configureAction) {
+        configureAction.execute(getAntlr());
         return this;
     }
 }

--- a/subprojects/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
+++ b/subprojects/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.plugins.antlr
 
+import org.gradle.api.Action
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 class AntlrPluginTest extends AbstractProjectBuilderSpec {
@@ -37,6 +38,27 @@ class AntlrPluginTest extends AbstractProjectBuilderSpec {
         then:
         def custom = project.sourceSets.custom
         custom.antlr.srcDirs == [project.file('src/custom/antlr')] as Set
+    }
+
+    def "allows configuration of antlr directories on source sets"() {
+        when:
+        project.pluginManager.apply(AntlrPlugin)
+
+        and: 'using Closure'
+        def main = project.sourceSets.main
+        main.antlr { sourceSet ->
+            sourceSet.srcDirs = [project.file('src/main/antlr-custom')]
+        }
+
+        and: 'using Action'
+        def test = project.sourceSets.test
+        test.antlr({ sourceSet ->
+            sourceSet.srcDirs = [project.file('src/test/antlr-custom')]
+        } as Action)
+
+        then:
+        main.antlr.srcDirs == [project.file('src/main/antlr-custom')] as Set
+        test.antlr.srcDirs == [project.file('src/test/antlr-custom')] as Set
     }
 
     def addsTaskForEachSourceSet() {


### PR DESCRIPTION
For the sake of type-safety and better Kotlin support.