### PR TITLE
Add Action<T> overloads to methods that takes a Closure in :ear

### DIFF
--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.FileCopyDetails;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.file.collections.FileTreeAdapter;
 import org.gradle.api.internal.file.collections.MapFileTree;
 import org.gradle.api.internal.file.copy.CopySpecInternal;
@@ -35,7 +36,6 @@ import org.gradle.plugins.ear.descriptor.EarModule;
 import org.gradle.plugins.ear.descriptor.internal.DefaultDeploymentDescriptor;
 import org.gradle.plugins.ear.descriptor.internal.DefaultEarModule;
 import org.gradle.plugins.ear.descriptor.internal.DefaultEarWebModule;
-import org.gradle.util.ConfigureUtil;
 import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
@@ -141,11 +141,23 @@ public class Ear extends Jar {
      * @return This.
      */
     public Ear deploymentDescriptor(@DelegatesTo(value = DeploymentDescriptor.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
+        return deploymentDescriptor(ClosureBackedAction.of(configureClosure));
+    }
+
+    /**
+     * Configures the deployment descriptor for this EAR archive.
+     *
+     * <p>The given action is executed to configure the deployment descriptor.</p>
+     *
+     * @param configureAction The action.
+     * @return This.
+     */
+    public Ear deploymentDescriptor(Action<? super DeploymentDescriptor> configureAction) {
         if (deploymentDescriptor == null) {
             deploymentDescriptor = getInstantiator().newInstance(DefaultDeploymentDescriptor.class, getFileResolver(), getInstantiator());
         }
 
-        ConfigureUtil.configure(configureClosure, deploymentDescriptor);
+        configureAction.execute(deploymentDescriptor);
         return this;
     }
 
@@ -166,7 +178,21 @@ public class Ear extends Jar {
      * @return The created {@code CopySpec}
      */
     public CopySpec lib(@DelegatesTo(value = CopySpec.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
-        return ConfigureUtil.configure(configureClosure, getLib());
+        return lib(ClosureBackedAction.of(configureClosure));
+    }
+
+    /**
+     * Adds dependency libraries to include in the 'lib' directory of the EAR archive.
+     *
+     * <p>The given action is executed to configure a {@code CopySpec}.</p>
+     *
+     * @param configureAction The action.
+     * @return The created {@code CopySpec}
+     */
+    public CopySpec lib(Action<? super CopySpec> configureAction) {
+        CopySpec copySpec = getLib();
+        configureAction.execute(copySpec);
+        return copySpec;
     }
 
     /**

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
@@ -16,11 +16,12 @@
 package org.gradle.plugins.ear;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 import org.gradle.plugins.ear.descriptor.internal.DefaultDeploymentDescriptor;
-import org.gradle.util.ConfigureUtil;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -116,11 +117,23 @@ public class EarPluginConvention {
      * @return This.
      */
     public EarPluginConvention deploymentDescriptor(Closure configureClosure) {
+        return deploymentDescriptor(ClosureBackedAction.of(configureClosure));
+    }
+
+    /**
+     * Configures the deployment descriptor for this EAR archive.
+     *
+     * <p>The given action is executed to configure the deployment descriptor.</p>
+     *
+     * @param configureAction The action.
+     * @return This.
+     */
+    public EarPluginConvention deploymentDescriptor(Action<? super DeploymentDescriptor> configureAction) {
         if (deploymentDescriptor == null) {
             deploymentDescriptor = instantiator.newInstance(DefaultDeploymentDescriptor.class, fileResolver, instantiator);
             assert deploymentDescriptor != null;
         }
-        ConfigureUtil.configure(configureClosure, deploymentDescriptor);
+        configureAction.execute(deploymentDescriptor);
         return this;
     }
 }

--- a/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
+++ b/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.WarPlugin
+import org.gradle.plugins.ear.descriptor.DeploymentDescriptor
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
@@ -309,6 +310,18 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         inEar("META-INF/myapp.xml").text == TEST_APP_XML
+    }
+
+    def "can configure deployment descriptor using an Action"() {
+        when:
+        project.pluginManager.apply(EarPlugin)
+        project.convention.plugins.ear.deploymentDescriptor( { DeploymentDescriptor descriptor ->
+            descriptor.fileName = "myapp.xml"
+        } as Action<DeploymentDescriptor> )
+        execute project.tasks[EarPlugin.EAR_TASK_NAME]
+
+        then:
+        inEar "META-INF/myapp.xml"
     }
 
     private static void execute(Task task) {


### PR DESCRIPTION
For the sake of type-safety and better Kotlin support.