### PR TITLE
Add Action<T> overloads to methods that takes a Closure on Javadoc task

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -15,6 +15,8 @@
  */
 package org.gradle.javadoc
 
+import org.gradle.api.Action
+import org.gradle.external.javadoc.MinimalJavadocOptions
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.util.Requires
@@ -59,6 +61,23 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
         when: run("javadoc", "-i")
         then:
         file("build/docs/javadoc/Foo.html").text.contains("""Hey Joe!""")
+    }
+
+    def "can configure options with an Action"() {
+        given:
+        buildFile << '''
+            apply plugin: "java"
+            javadoc.options({ MinimalJavadocOptions options ->
+                options.header = 'myHeader'
+            } as Action<MinimalJavadocOptions>)
+        '''.stripIndent()
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when:
+        run 'javadoc'
+
+        then:
+        file('build/docs/javadoc/Foo.html').text.contains('myHeader')
     }
 
     @Requires(TestPrecondition.NOT_WINDOWS)

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -17,9 +17,11 @@
 package org.gradle.api.tasks.javadoc;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -322,7 +324,16 @@ public class Javadoc extends SourceTask {
      * @param block The configuration block for Javadoc generation options.
      */
     public void options(Closure<?> block) {
-        getProject().configure(getOptions(), block);
+        options(ClosureBackedAction.of(block));
+    }
+
+    /**
+     * Convenience method for configuring Javadoc generation options.
+     *
+     * @param action The action for Javadoc generation options.
+     */
+    public void options(Action<? super MinimalJavadocOptions> action) {
+        action.execute(getOptions());
     }
 
     /**


### PR DESCRIPTION
For the sake of type-safety and better Kotlin support.