### PR TITLE
Add Action<T> overloads to methods that takes a Closure in :osgi

### DIFF
--- a/subprojects/osgi/src/main/java/org/gradle/api/plugins/osgi/OsgiPluginConvention.java
+++ b/subprojects/osgi/src/main/java/org/gradle/api/plugins/osgi/OsgiPluginConvention.java
@@ -16,14 +16,16 @@
 package org.gradle.api.plugins.osgi;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.plugins.osgi.DefaultOsgiManifest;
 import org.gradle.api.internal.plugins.osgi.OsgiHelper;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.BasePluginConvention;
+import org.gradle.internal.Actions;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.util.ConfigureUtil;
 
 import java.util.concurrent.Callable;
 
@@ -57,7 +59,7 @@ public class OsgiPluginConvention {
      * </ul>
      */
     public OsgiManifest osgiManifest() {
-        return osgiManifest(null);
+        return osgiManifest(Actions.<OsgiManifest>doNothing());
     }
 
     /**
@@ -65,7 +67,17 @@ public class OsgiPluginConvention {
      * the new manifest instance before it is returned.
      */
     public OsgiManifest osgiManifest(Closure closure) {
-        return ConfigureUtil.configure(closure, createDefaultOsgiManifest(project));
+        return osgiManifest(ClosureBackedAction.of(closure));
+    }
+
+    /**
+     * Creates and configures a new instance of an  {@link org.gradle.api.plugins.osgi.OsgiManifest}. The action configures
+     * the new manifest instance before it is returned.
+     */
+    public OsgiManifest osgiManifest(Action<? super OsgiManifest> action) {
+        OsgiManifest manifest = createDefaultOsgiManifest(project);
+        action.execute(manifest);
+        return manifest;
     }
 
     private OsgiManifest createDefaultOsgiManifest(final ProjectInternal project) {

--- a/subprojects/osgi/src/test/groovy/org/gradle/api/plugins/osgi/OsgiPluginConventionTest.groovy
+++ b/subprojects/osgi/src/test/groovy/org/gradle/api/plugins/osgi/OsgiPluginConventionTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.plugins.osgi
 
+import org.gradle.api.Action
 import org.gradle.api.internal.plugins.osgi.DefaultOsgiManifest
 import org.gradle.api.internal.plugins.osgi.OsgiHelper
 import org.gradle.api.plugins.JavaBasePlugin
@@ -41,6 +42,16 @@ class OsgiPluginConventionTest extends AbstractProjectBuilderSpec {
         OsgiManifest osgiManifest = osgiPluginConvention.osgiManifest {
             description = 'myDescription'
         }
+
+        expect:
+        matchesExpectedConfig(osgiManifest)
+        osgiManifest.description == 'myDescription'
+    }
+
+    def osgiManifestWithAction() {
+        OsgiManifest osgiManifest = osgiPluginConvention.osgiManifest({ OsgiManifest manifest ->
+            manifest.description = 'myDescription'
+        } as Action<OsgiManifest>)
 
         expect:
         matchesExpectedConfig(osgiManifest)


### PR DESCRIPTION
For the sake of type-safety and better Kotlin support.