### PR TITLE
Add Action<T> overloads to methods that takes a Closure on Upload task

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/Upload.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/Upload.java
@@ -17,10 +17,12 @@
 package org.gradle.api.tasks;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.PublishException;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.artifacts.ArtifactPublicationServices;
 import org.gradle.api.internal.artifacts.ArtifactPublisher;
@@ -28,7 +30,6 @@ import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository;
 import org.gradle.internal.Transformers;
-import org.gradle.util.ConfigureUtil;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -119,7 +120,16 @@ public class Upload extends ConventionTask {
      * Configures the set of repositories to upload to.
      */
     public RepositoryHandler repositories(Closure configureClosure) {
-        return ConfigureUtil.configure(configureClosure, getRepositories());
+        return repositories(ClosureBackedAction.of(configureClosure));
+    }
+
+    /**
+     * Configures the set of repositories to upload to.
+     */
+    public RepositoryHandler repositories(Action<? super RepositoryHandler> configureAction) {
+        RepositoryHandler repositories = getRepositories();
+        configureAction.execute(repositories);
+        return repositories;
     }
 
     /**

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/UploadTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/UploadTest.groovy
@@ -24,6 +24,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class UploadTest extends Specification {
+    
     @Rule
     public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 
@@ -43,7 +44,7 @@ class UploadTest extends Specification {
         upload.repositories.size() == 0
 
         when:
-        upload.repositories({RepositoryHandler repositories ->
+        upload.repositories({ RepositoryHandler repositories ->
             repositories.jcenter()
         } as Action<RepositoryHandler>)
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/UploadTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/UploadTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.api.tasks
 
+import org.gradle.api.Action
+import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.Rule
@@ -31,6 +33,22 @@ class UploadTest extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    def "can configure repositories with an Action"() {
+        given:
+        def upload = TestUtil.create(temporaryFolder).task(Upload)
+
+        expect:
+        upload.repositories.size() == 0
+
+        when:
+        upload.repositories({RepositoryHandler repositories ->
+            repositories.jcenter()
+        } as Action<RepositoryHandler>)
+
+        then:
+        upload.repositories.size() == 1
     }
 
 }


### PR DESCRIPTION
For the sake of type-safety and better Kotlin support.