### PR TITLE
Add Action<T> overloads to methods that takes a Closure in :war

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.file.copy.DefaultCopySpec;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.CacheableTask;
@@ -29,7 +30,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
-import org.gradle.util.ConfigureUtil;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -118,7 +118,21 @@ public class War extends Jar {
      * @return The newly created {@code CopySpec}.
      */
     public CopySpec webInf(Closure configureClosure) {
-        return ConfigureUtil.configure(configureClosure, getWebInf());
+        return webInf(ClosureBackedAction.of(configureClosure));
+    }
+
+    /**
+     * Adds some content to the {@code WEB-INF} directory for this WAR archive.
+     *
+     * <p>The given action is executed to configure a {@link CopySpec}.
+     *
+     * @param configureAction The action to execute
+     * @return The newly created {@code CopySpec}.
+     */
+    public CopySpec webInf(Action<? super CopySpec> configureAction) {
+        CopySpec webInf = getWebInf();
+        configureAction.execute(webInf);
+        return webInf;
     }
 
     /**

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/bundling/WarTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/bundling/WarTest.groovy
@@ -16,6 +16,10 @@
 
 package org.gradle.api.tasks.bundling
 
+import org.gradle.api.Action
+import org.gradle.api.file.CopySpec
+import org.gradle.test.fixtures.archive.JarTestFixture
+
 class WarTest extends AbstractArchiveTaskTest {
     War war
 
@@ -32,5 +36,18 @@ class WarTest extends AbstractArchiveTaskTest {
     def "test War"() {
         expect:
         war.extension == War.WAR_EXTENSION
+    }
+
+    def "can configure WEB-INF CopySpec using an Action"() {
+        given:
+        war.webInf({ CopySpec spec ->
+            spec.from temporaryFolder.createFile('file.txt')
+        } as Action<CopySpec>)
+
+        when:
+        war.execute()
+
+        then:
+        new JarTestFixture(war.archivePath).assertContainsFile('WEB-INF/file.txt')
     }
 }


### PR DESCRIPTION
For the sake of type-safety and better Kotlin support.