### PR TITLE
ExtensionContainer allows to declare extensions public type

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
@@ -57,7 +57,7 @@ public class DefaultConvention implements Convention, ExtensionContainerInternal
 
     public DefaultConvention(Instantiator instantiator) {
         this.instantiator = instantiator;
-        add(ExtraPropertiesExtension.EXTENSION_NAME, extraProperties);
+        add(ExtraPropertiesExtension.EXTENSION_NAME, ExtraPropertiesExtension.class, extraProperties);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
@@ -57,7 +57,7 @@ public class DefaultConvention implements Convention, ExtensionContainerInternal
 
     public DefaultConvention(Instantiator instantiator) {
         this.instantiator = instantiator;
-        add(ExtraPropertiesExtension.EXTENSION_NAME, ExtraPropertiesExtension.class, extraProperties);
+        add(ExtraPropertiesExtension.class, ExtraPropertiesExtension.EXTENSION_NAME, extraProperties);
     }
 
     @Override
@@ -110,24 +110,24 @@ public class DefaultConvention implements Convention, ExtensionContainerInternal
         if (extension instanceof Class) {
             create(name, (Class<?>) extension);
         } else {
-            add(name, (Class) extension.getClass(), extension);
+            add((Class) extension.getClass(), name, extension);
         }
     }
 
     @Override
-    public <P, I extends P> void add(String name, Class<P> publicType, I extension) {
-        extensionsStorage.add(name, publicType, extension);
+    public <T> void add(Class<T> publicType, String name, T extension) {
+        extensionsStorage.add(publicType, name, extension);
     }
 
     @Override
     public <T> T create(String name, Class<T> type, Object... constructionArguments) {
-        return create(name, type, type, constructionArguments);
+        return create(type, name, type, constructionArguments);
     }
 
     @Override
-    public <P, I extends P> I create(String name, Class<P> publicType, Class<I> instanceType, Object... constructionArguments) {
-        I instance = getInstantiator().newInstance(instanceType, constructionArguments);
-        add(name, publicType, instance);
+    public <T> T create(Class<T> publicType, String name, Class<? extends T> instanceType, Object... constructionArguments) {
+        T instance = getInstantiator().newInstance(instanceType, constructionArguments);
+        add(publicType, name, instance);
         return instance;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ExtensionsStorage.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ExtensionsStorage.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class ExtensionsStorage {
     private final Map<String, ExtensionHolder> extensions = new LinkedHashMap<String, ExtensionHolder>();
 
-    public <T> void add(String name, Class<T> publicType, T extension) {
+    public <T> void add(Class<T> publicType, String name, T extension) {
         if (extensions.containsKey(name)) {
             throw new IllegalArgumentException(String.format("Cannot add extension with name '%s', as there is an extension already registered with that name.", name));
         }
@@ -46,16 +46,16 @@ public class ExtensionsStorage {
 
     public Map<String, Object> getAsMap() {
         Map<String, Object> rawExtensions = new LinkedHashMap<String, Object>(extensions.size());
-        for (String name : extensions.keySet()) {
-            rawExtensions.put(name, extensions.get(name).get());
+        for (Map.Entry<String, ExtensionHolder> entry : extensions.entrySet()) {
+            rawExtensions.put(entry.getKey(), entry.getValue().get());
         }
         return rawExtensions;
     }
 
     public Map<String, Class<?>> getSchema() {
         Map<String, Class<?>> schema = new LinkedHashMap<String, Class<?>>(extensions.size());
-        for (String name : extensions.keySet()) {
-            schema.put(name, extensions.get(name).getType());
+        for (Map.Entry<String, ExtensionHolder> entry : extensions.entrySet()) {
+            schema.put(entry.getKey(), entry.getValue().getType());
         }
         return schema;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
@@ -21,6 +21,8 @@ import org.gradle.api.Incubating;
 import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.internal.HasInternalProtocol;
 
+import java.util.Map;
+
 /**
  * Allows adding 'namespaced' DSL extensions to a target object.
  */
@@ -28,21 +30,67 @@ import org.gradle.internal.HasInternalProtocol;
 public interface ExtensionContainer {
 
     /**
+     * Adds a new extension to this container.
+     *
      * Adding an extension of name 'foo' will:
      * <li> add 'foo' dynamic property
      * <li> add 'foo' dynamic method that accepts a closure that is a configuration script block
      *
-     * @param name Will be used as a sort of namespace of properties/methods.
-     * @param extension Any object whose methods and properties will extend the target object
+     * The extension will be exposed as {@code publicType}.
+     *
+     * @param name The name for the extension
+     * @param publicType The extension public type
+     * @param extension Any object implementing {@code publicType}
+     * @param <P> the extension public type
+     * @param <I> the extension instance type
      * @throws IllegalArgumentException When an extension with the given name already exists.
+     * @since 4.0
+     */
+    @Incubating
+    <P, I extends P> void add(String name, Class<P> publicType, I extension);
+
+    /**
+     * Adds a new extension to this container.
+     *
+     * Adding an extension of name 'foo' will:
+     * <li> add 'foo' dynamic property
+     * <li> add 'foo' dynamic method that accepts a closure that is a configuration script block
+     *
+     * The extension will be exposed as {@code extension.getClass()}.
+     *
+     * @param name The name for the extension
+     * @param extension Any object
+     * @throws IllegalArgumentException When an extension with the given name already exists
      */
     void add(String name, Object extension);
 
     /**
-     * Adds a new extension to this container, that itself is dynamically made {@link ExtensionAware}.
+     * Creates and adds a new extension to this container.
      *
-     * A new instance of the given {@code type} will be created using the given {@code constructionArguments}. The new
-     * instance will have been dynamically which means that you can cast the object to {@link ExtensionAware}.
+     * A new instance of the given {@code instanceType} will be created using the given {@code constructionArguments}.
+     * The extension will be exposed as {@code publicType}.
+     * The new instance will have been dynamically made {@link ExtensionAware}, which means that you can cast it to {@link ExtensionAware}.
+     *
+     * @see #add(String, Class, Object)
+     * @param name The name for the extension
+     * @param publicType The extension public type
+     * @param instanceType The extension instance type
+     * @param constructionArguments The arguments to be used to construct the extension instance
+     * @param <P> the extension public type
+     * @param <I> the extension instance type
+     * @return The created instance
+     * @throws IllegalArgumentException When an extension with the given name already exists.
+     * @since 4.0
+     */
+    @Incubating
+    <P, I extends P> I create(String name, Class<P> publicType, Class<I> instanceType, Object... constructionArguments);
+
+    /**
+     * Creates and adds a new extension to this container.
+     *
+     * A new instance of the given {@code type} will be created using the given {@code constructionArguments}.
+     * The extension will be exposed as {@code type}.
+     * The new instance will have been dynamically made {@link ExtensionAware}, which means that you can cast it to {@link ExtensionAware}.
      *
      * @see #add(String, Object)
      * @param name The name for the extension
@@ -52,6 +100,15 @@ public interface ExtensionContainer {
      * @throws IllegalArgumentException When an extension with the given name already exists.
      */
     <T> T create(String name, Class<T> type, Object... constructionArguments);
+
+    /**
+     * Provide access to all known extensions types.
+     *
+     * @return A map of extensions public types, keyed by name
+     * @since 4.0
+     */
+    @Incubating
+    Map<String, Class<?>> getSchema();
 
     /**
      * Looks for the extension of a given type (useful to avoid casting). If none found it will throw an exception.

--- a/subprojects/core/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
@@ -38,16 +38,15 @@ public interface ExtensionContainer {
      *
      * The extension will be exposed as {@code publicType}.
      *
-     * @param name The name for the extension
+     * @param <T> the extension public type
      * @param publicType The extension public type
+     * @param name The name for the extension
      * @param extension Any object implementing {@code publicType}
-     * @param <P> the extension public type
-     * @param <I> the extension instance type
      * @throws IllegalArgumentException When an extension with the given name already exists.
      * @since 4.0
      */
     @Incubating
-    <P, I extends P> void add(String name, Class<P> publicType, I extension);
+    <T> void add(Class<T> publicType, String name, T extension);
 
     /**
      * Adds a new extension to this container.
@@ -71,19 +70,18 @@ public interface ExtensionContainer {
      * The extension will be exposed as {@code publicType}.
      * The new instance will have been dynamically made {@link ExtensionAware}, which means that you can cast it to {@link ExtensionAware}.
      *
-     * @see #add(String, Class, Object)
-     * @param name The name for the extension
+     * @param <T> the extension public type
      * @param publicType The extension public type
+     * @param name The name for the extension
      * @param instanceType The extension instance type
      * @param constructionArguments The arguments to be used to construct the extension instance
-     * @param <P> the extension public type
-     * @param <I> the extension instance type
      * @return The created instance
      * @throws IllegalArgumentException When an extension with the given name already exists.
+     * @see #add(Class, String, Object)
      * @since 4.0
      */
     @Incubating
-    <P, I extends P> I create(String name, Class<P> publicType, Class<I> instanceType, Object... constructionArguments);
+    <T> T create(Class<T> publicType, String name, Class<? extends T> instanceType, Object... constructionArguments);
 
     /**
      * Creates and adds a new extension to this container.
@@ -92,17 +90,17 @@ public interface ExtensionContainer {
      * The extension will be exposed as {@code type}.
      * The new instance will have been dynamically made {@link ExtensionAware}, which means that you can cast it to {@link ExtensionAware}.
      *
-     * @see #add(String, Object)
      * @param name The name for the extension
      * @param type The type of the extension
      * @param constructionArguments The arguments to be used to construct the extension instance
      * @return The created instance
      * @throws IllegalArgumentException When an extension with the given name already exists.
+     * @see #add(String, Object)
      */
     <T> T create(String name, Class<T> type, Object... constructionArguments);
 
     /**
-     * Provide access to all known extensions types.
+     * Provides access to all known extensions types.
      *
      * @return A map of extensions public types, keyed by name
      * @since 4.0

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
@@ -148,7 +148,7 @@ class ExtensionContainerTest extends Specification {
 
         then:
         def ex = thrown(UnknownDomainObjectException)
-        ex.message == "Extension of type 'SomeExtension' does not exist. Currently registered extension types: [${DefaultExtraPropertiesExtension.simpleName}, FooExtension]"
+        ex.message == "Extension of type 'SomeExtension' does not exist. Currently registered extension types: [${ExtraPropertiesExtension.simpleName}, FooExtension]"
     }
 
     def "types can be retrieved by interface and super types"() {
@@ -202,7 +202,7 @@ class ExtensionContainerTest extends Specification {
         container.add 'bar', Capability, Impl
 
         expect:
-        container.schema == [ext: DefaultExtraPropertiesExtension, foo: Parent, bar: Capability]
+        container.schema == [ext: ExtraPropertiesExtension, foo: Parent, bar: Capability]
     }
 }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import spock.lang.Specification
 
-public class ExtensionContainerTest extends Specification {
+class ExtensionContainerTest extends Specification {
 
     def container = new DefaultConvention(ThreadGlobalInstantiator.getOrCreate())
     def extension = new FooExtension()
@@ -182,6 +182,28 @@ public class ExtensionContainerTest extends Specification {
         extension.thing.name == "bar"
     }
 
+    def "can hide implementation type of extensions"() {
+        given:
+        container.create 'foo', Parent, Child
+        container.add 'bar', Capability, Impl
+
+        expect:
+        container.findByType(Parent) != null
+        container.findByType(Child) == null
+
+        and:
+        container.findByType(Capability) != null
+        container.findByType(Impl) == null
+    }
+
+    def "can get extensions schema"() {
+        given:
+        container.create 'foo', Parent, Child
+        container.add 'bar', Capability, Impl
+
+        expect:
+        container.schema == [ext: DefaultExtraPropertiesExtension, foo: Parent, bar: Capability]
+    }
 }
 
 interface Capability {}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
@@ -184,8 +184,8 @@ class ExtensionContainerTest extends Specification {
 
     def "can hide implementation type of extensions"() {
         given:
-        container.create 'foo', Parent, Child
-        container.add 'bar', Capability, Impl
+        container.create Parent, 'foo', Child
+        container.create Capability, 'bar', Impl
 
         expect:
         container.findByType(Parent) != null
@@ -198,8 +198,8 @@ class ExtensionContainerTest extends Specification {
 
     def "can get extensions schema"() {
         given:
-        container.create 'foo', Parent, Child
-        container.add 'bar', Capability, Impl
+        container.create Parent, 'foo', Child
+        container.create Capability, 'bar', Impl
 
         expect:
         container.schema == [ext: ExtraPropertiesExtension, foo: Parent, bar: Capability]

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionsStorageTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionsStorageTest.groovy
@@ -28,8 +28,8 @@ class ExtensionsStorageTest extends Specification {
     def setExtension = Mock(Set)
 
     def "setup"() {
-        storage.add("list", listExtension)
-        storage.add("set", setExtension)
+        storage.add("list", List, listExtension)
+        storage.add("set", Set, setExtension)
     }
 
     def "has extension"() {
@@ -82,7 +82,7 @@ class ExtensionsStorageTest extends Specification {
     def "configures regular extension"() {
         when:
         def extension = Mock(TestExtension)
-        storage.add("ext", extension)
+        storage.add("ext", TestExtension, extension)
 
         and:
         storage.configureExtension("ext", {
@@ -112,7 +112,7 @@ class ExtensionsStorageTest extends Specification {
         extension.delegate = delegate
 
         when:
-        storage.add("ext", extension)
+        storage.add("ext", TestDeferredExtension, extension)
         storage.configureExtension("ext", {
             it.call(1)
         })
@@ -140,7 +140,7 @@ class ExtensionsStorageTest extends Specification {
         extension.delegate = delegate
 
         given:
-        storage.add("ext", extension)
+        storage.add("ext", TestDeferredExtension, extension)
         storage.configureExtension("ext", {
             throw new RuntimeException("bad")
         })
@@ -167,7 +167,7 @@ class ExtensionsStorageTest extends Specification {
         extension.delegate = delegate
 
         when:
-        storage.add("ext", extension)
+        storage.add("ext", TestDeferredExtension, extension)
         storage.configureExtension("ext", {
             throw new UnknownDomainObjectException("ORIGINAL")
         })
@@ -190,7 +190,7 @@ class ExtensionsStorageTest extends Specification {
         extension.delegate = delegate
 
         given:
-        storage.add("ext", extension)
+        storage.add("ext", TestDeferredExtension, extension)
         storage.configureExtension("ext", {
             it.call(1)
         })
@@ -219,5 +219,21 @@ class ExtensionsStorageTest extends Specification {
         void call(def value) {
             delegate.call(value)
         }
+    }
+
+    def "get schema"() {
+        expect:
+        storage.getSchema() == [list: List, set: Set]
+    }
+
+    def "only considers public type when addressing extensions by type"() {
+        given:
+        Integer number = 23
+        storage.add 'number', Number, number
+
+        expect:
+        storage.findByType(Integer) == null
+        storage.findByType(Number) == number
+        storage.getByType(Number) == number
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionsStorageTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionsStorageTest.groovy
@@ -28,8 +28,8 @@ class ExtensionsStorageTest extends Specification {
     def setExtension = Mock(Set)
 
     def "setup"() {
-        storage.add("list", List, listExtension)
-        storage.add("set", Set, setExtension)
+        storage.add(List, "list", listExtension)
+        storage.add(Set, "set", setExtension)
     }
 
     def "has extension"() {
@@ -82,7 +82,7 @@ class ExtensionsStorageTest extends Specification {
     def "configures regular extension"() {
         when:
         def extension = Mock(TestExtension)
-        storage.add("ext", TestExtension, extension)
+        storage.add(TestExtension, "ext", extension)
 
         and:
         storage.configureExtension("ext", {
@@ -112,7 +112,7 @@ class ExtensionsStorageTest extends Specification {
         extension.delegate = delegate
 
         when:
-        storage.add("ext", TestDeferredExtension, extension)
+        storage.add(TestDeferredExtension, "ext", extension)
         storage.configureExtension("ext", {
             it.call(1)
         })
@@ -140,7 +140,7 @@ class ExtensionsStorageTest extends Specification {
         extension.delegate = delegate
 
         given:
-        storage.add("ext", TestDeferredExtension, extension)
+        storage.add(TestDeferredExtension, "ext", extension)
         storage.configureExtension("ext", {
             throw new RuntimeException("bad")
         })
@@ -167,7 +167,7 @@ class ExtensionsStorageTest extends Specification {
         extension.delegate = delegate
 
         when:
-        storage.add("ext", TestDeferredExtension, extension)
+        storage.add(TestDeferredExtension, "ext", extension)
         storage.configureExtension("ext", {
             throw new UnknownDomainObjectException("ORIGINAL")
         })
@@ -190,7 +190,7 @@ class ExtensionsStorageTest extends Specification {
         extension.delegate = delegate
 
         given:
-        storage.add("ext", TestDeferredExtension, extension)
+        storage.add(TestDeferredExtension, "ext", extension)
         storage.configureExtension("ext", {
             it.call(1)
         })
@@ -229,7 +229,7 @@ class ExtensionsStorageTest extends Specification {
     def "only considers public type when addressing extensions by type"() {
         given:
         Integer number = 23
-        storage.add 'number', Number, number
+        storage.add Number, 'number', number
 
         expect:
         storage.findByType(Integer) == null

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -6,6 +6,22 @@ Here are the new features introduced in this Gradle release.
 IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
 Add-->
 
+### Extensions now have a public type
+
+Extensions can now be registered in `ExtensionContainer`s with an explicit public type.
+ This allows plugin authors to hide their implementation type from build scripts and
+ allow `ExtensionContainer`s to expose a schema of all the registered extensions.
+
+For example, if you have a `FancyExtension` type, implemented by some `DefaultFancyExtension` type, here is how
+ you should register it:
+
+    // If you want to delegate the extension instance creation to Gradle:
+    project.extensions.create FancyExtension, 'fancy', DefaultFancyExtension
+
+    // Or if you need to create the extension instance yourself:
+    FancyExtension fancyInstance = new DefaultFancyExtension(...)
+    project.extensions.add FancyExtension, 'fancy', fancyInstance
+
 <!--
 ### Example new and noteworthy
 -->
@@ -35,6 +51,19 @@ The following are the newly deprecated items in this Gradle release. If you have
 -->
 
 ## Potential breaking changes
+
+### Core extensions should be addressed by their public type
+
+Now that extensions's implementation type is hidden from plugins and build scripts and can only be
+ addressed by their public type, some Gradle core extensions are not addressable by their implementation type anymore:
+
+- `DefaultExtraPropertiesExtension`, use `ExtraPropertiesExtension` instead
+- `DefaultDistributionContainer`, use `DistributionContainer` instead
+- `DefaultPublishingExtension`, use `PublishingExtension` instead
+- `DefaultPlatformContainer`, use `PlatformContainer` instead
+- `DefaultBuildTypeContainer`, use `BuildTypeContainer` instead
+- `DefaultFlavorContainer`, use `FlavorContainer` instead
+- `DefaultNativeToolChainRegistry`, use `NativeToolChainRegistry` instead
 
 <!--
 ### Example breaking change

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -54,7 +54,7 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 ### Core extensions should be addressed by their public type
 
-Now that extensions's implementation type is hidden from plugins and build scripts and can only be
+Now that extensions implementation type is hidden from plugins and build scripts that extensions can only be
  addressed by their public type, some Gradle core extensions are not addressable by their implementation type anymore:
 
 - `DefaultExtraPropertiesExtension`, use `ExtraPropertiesExtension` instead

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
@@ -156,7 +156,7 @@ public class ComponentModelBasePlugin implements Plugin<Project> {
 
         @Mutate
         void registerPlatformExtension(ExtensionContainer extensions, PlatformContainer platforms) {
-            extensions.add("platforms", platforms);
+            extensions.add("platforms", PlatformContainer.class, platforms);
         }
 
         @Mutate

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
@@ -156,7 +156,7 @@ public class ComponentModelBasePlugin implements Plugin<Project> {
 
         @Mutate
         void registerPlatformExtension(ExtensionContainer extensions, PlatformContainer platforms) {
-            extensions.add("platforms", PlatformContainer.class, platforms);
+            extensions.add(PlatformContainer.class, "platforms", platforms);
         }
 
         @Mutate

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
@@ -126,9 +126,9 @@ public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
     public void apply(final ProjectInternal project) {
         project.getPluginManager().apply(ComponentModelBasePlugin.class);
 
-        project.getExtensions().create("buildTypes", DefaultBuildTypeContainer.class, instantiator);
-        project.getExtensions().create("flavors", DefaultFlavorContainer.class, instantiator);
-        project.getExtensions().create("toolChains", DefaultNativeToolChainRegistry.class, instantiator);
+        project.getExtensions().create("buildTypes", BuildTypeContainer.class, DefaultBuildTypeContainer.class, instantiator);
+        project.getExtensions().create("flavors", FlavorContainer.class, DefaultFlavorContainer.class, instantiator);
+        project.getExtensions().create("toolChains", NativeToolChainRegistryInternal.class, DefaultNativeToolChainRegistry.class, instantiator);
     }
 
     static class Rules extends RuleSource {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
@@ -126,9 +126,9 @@ public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
     public void apply(final ProjectInternal project) {
         project.getPluginManager().apply(ComponentModelBasePlugin.class);
 
-        project.getExtensions().create("buildTypes", BuildTypeContainer.class, DefaultBuildTypeContainer.class, instantiator);
-        project.getExtensions().create("flavors", FlavorContainer.class, DefaultFlavorContainer.class, instantiator);
-        project.getExtensions().create("toolChains", NativeToolChainRegistryInternal.class, DefaultNativeToolChainRegistry.class, instantiator);
+        project.getExtensions().create(BuildTypeContainer.class, "buildTypes", DefaultBuildTypeContainer.class, instantiator);
+        project.getExtensions().create(FlavorContainer.class, "flavors", DefaultFlavorContainer.class, instantiator);
+        project.getExtensions().create(NativeToolChainRegistryInternal.class, "toolChains", DefaultNativeToolChainRegistry.class, instantiator);
     }
 
     static class Rules extends RuleSource {

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.distribution.Distribution;
+import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.distribution.internal.DefaultDistributionContainer;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.internal.IConventionAware;
@@ -70,7 +71,7 @@ public class DistributionPlugin implements Plugin<ProjectInternal> {
     @Override
     public void apply(final ProjectInternal project) {
         project.getPluginManager().apply(BasePlugin.class);
-        DefaultDistributionContainer distributions = project.getExtensions().create("distributions", DefaultDistributionContainer.class, Distribution.class, instantiator, fileOperations);
+        DefaultDistributionContainer distributions = project.getExtensions().create("distributions", DistributionContainer.class, DefaultDistributionContainer.class, Distribution.class, instantiator, fileOperations);
 
         // TODO - refactor this action out so it can be unit tested
         distributions.all(new Action<Distribution>() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
@@ -71,7 +71,7 @@ public class DistributionPlugin implements Plugin<ProjectInternal> {
     @Override
     public void apply(final ProjectInternal project) {
         project.getPluginManager().apply(BasePlugin.class);
-        DefaultDistributionContainer distributions = project.getExtensions().create("distributions", DistributionContainer.class, DefaultDistributionContainer.class, Distribution.class, instantiator, fileOperations);
+        DistributionContainer distributions = project.getExtensions().create(DistributionContainer.class, "distributions", DefaultDistributionContainer.class, Distribution.class, instantiator, fileOperations);
 
         // TODO - refactor this action out so it can be unit tested
         distributions.all(new Action<Distribution>() {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -66,7 +66,7 @@ public class PublishingPlugin implements Plugin<Project> {
         PublicationContainer publications = instantiator.newInstance(DefaultPublicationContainer.class, instantiator);
 
         // TODO Registering an extension should register it with the model registry as well
-        project.getExtensions().create(PublishingExtension.NAME, DefaultPublishingExtension.class, repositories, publications);
+        project.getExtensions().create(PublishingExtension.NAME, PublishingExtension.class, DefaultPublishingExtension.class, repositories, publications);
 
         Task publishLifecycleTask = project.getTasks().create(PUBLISH_LIFECYCLE_TASK_NAME);
         publishLifecycleTask.setDescription("Publishes all publications produced by this project.");

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -66,7 +66,7 @@ public class PublishingPlugin implements Plugin<Project> {
         PublicationContainer publications = instantiator.newInstance(DefaultPublicationContainer.class, instantiator);
 
         // TODO Registering an extension should register it with the model registry as well
-        project.getExtensions().create(PublishingExtension.NAME, PublishingExtension.class, DefaultPublishingExtension.class, repositories, publications);
+        project.getExtensions().create(PublishingExtension.class, PublishingExtension.NAME, DefaultPublishingExtension.class, repositories, publications);
 
         Task publishLifecycleTask = project.getTasks().create(PUBLISH_LIFECYCLE_TASK_NAME);
         publishLifecycleTask.setDescription("Publishes all publications produced by this project.");


### PR DESCRIPTION
Only extensions public types are considered with addressing them by type.
Each ExtensionContainer exposes its “schema”: all registered extensions types keyed by extension name.

This change is backward compatible API-wise, existing methods are unchanged and their contract is to use the instantiated or instance extension type as public type.

Existing extensions are registered with their intended public type. This means that build/plugin authors can't address them using their implementation type, this is mentioned in the release notes as a potential breaking change.

This change is motivated by https://github.com/gradle/gradle-script-kotlin/issues/159

This PR intent is to discuss the acceptability of such a change.