### PR TITLE
Faster serialization

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/InputPropertiesSerializer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/InputPropertiesSerializer.java
@@ -17,8 +17,15 @@
 package org.gradle.api.internal.changedetection.state;
 
 import org.gradle.api.GradleException;
-import org.gradle.internal.serialize.*;
+import org.gradle.internal.serialize.AbstractCollectionSerializer;
+import org.gradle.internal.serialize.BaseSerializerFactory;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.serialize.MapSerializer;
+import org.gradle.internal.serialize.Serializer;
+import org.gradle.internal.serialize.WellKnownTypesSerializer;
 
+import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -28,7 +35,7 @@ class InputPropertiesSerializer implements Serializer<Map<String, Object>> {
     private final MapSerializer<String, Object> serializer;
 
     InputPropertiesSerializer(ClassLoader classloader) {
-        this.serializer = new MapSerializer<String, Object>(BaseSerializerFactory.STRING_SERIALIZER, new DefaultSerializer<Object>(classloader));
+        this.serializer = new MapSerializer<String, Object>(BaseSerializerFactory.STRING_SERIALIZER, new WellKnownTypesSerializer<Object>(classloader));
     }
 
     public Map<String, Object> read(Decoder decoder) throws Exception {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/InputPropertiesSerializer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/InputPropertiesSerializer.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.changedetection.state;
 
 import org.gradle.api.GradleException;
-import org.gradle.internal.serialize.AbstractCollectionSerializer;
 import org.gradle.internal.serialize.BaseSerializerFactory;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -25,7 +24,6 @@ import org.gradle.internal.serialize.MapSerializer;
 import org.gradle.internal.serialize.Serializer;
 import org.gradle.internal.serialize.WellKnownTypesSerializer;
 
-import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndex.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndex.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.internal.resource.cached.ivy.AbstractCachedIndex;
 import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
 import org.gradle.internal.serialize.DefaultSerializer;
+import org.gradle.internal.serialize.WellKnownTypesSerializer;
 import org.gradle.util.BuildCommencedTimeProvider;
 
 import java.io.File;
@@ -30,7 +31,7 @@ public class DefaultCachedExternalResourceIndex<K extends Serializable> extends 
     private final BuildCommencedTimeProvider timeProvider;
 
     public DefaultCachedExternalResourceIndex(String persistentCacheFile, Class<K> keyType, BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager) {
-        super(persistentCacheFile, new DefaultSerializer<K>(keyType.getClassLoader()), new DefaultSerializer<CachedExternalResource>(CachedExternalResource.class.getClassLoader()), cacheLockingManager);
+        super(persistentCacheFile, new WellKnownTypesSerializer<K>(keyType.getClassLoader()), new DefaultSerializer<CachedExternalResource>(CachedExternalResource.class.getClassLoader()), cacheLockingManager);
         this.timeProvider = timeProvider;
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
@@ -19,11 +19,13 @@ package org.gradle.internal.serialize;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
+import java.io.EOFException;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
 public class BaseSerializerFactory {
+    public static final Serializer<Object> NULL_SERIALIZER = new NullSerializer();
     public static final Serializer<String> STRING_SERIALIZER = new StringSerializer();
     public static final Serializer<Boolean> BOOLEAN_SERIALIZER = new BooleanSerializer();
     public static final Serializer<Byte> BYTE_SERIALIZER = new ByteSerializer();
@@ -237,6 +239,18 @@ public class BaseSerializerFactory {
 
         public void write(Encoder encoder, Throwable value) throws Exception {
             Message.send(value, encoder.getOutputStream());
+        }
+    }
+
+    private static class NullSerializer extends AbstractSerializer<Object> {
+        @Override
+        public Object read(Decoder decoder) throws EOFException, Exception {
+            return null;
+        }
+
+        @Override
+        public void write(Encoder encoder, Object value) throws Exception {
+
         }
     }
 }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
@@ -18,6 +18,7 @@ package org.gradle.internal.serialize;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.HashCode;
 
 import java.io.EOFException;
 import java.io.File;
@@ -38,6 +39,7 @@ public class BaseSerializerFactory {
     public static final Serializer<byte[]> BYTE_ARRAY_SERIALIZER = new ByteArraySerializer();
     public static final Serializer<Map<String, String>> NO_NULL_STRING_MAP_SERIALIZER = new StringMapSerializer();
     public static final Serializer<Throwable> THROWABLE_SERIALIZER = new ThrowableSerializer();
+    public static final Serializer<HashCode> HASHCODE_SERIALIZER = new HashCodeSerializer();
 
     public <T> Serializer<T> getSerializerFor(Class<T> type) {
         if (type.equals(String.class)) {
@@ -60,6 +62,9 @@ public class BaseSerializerFactory {
         }
         if (Throwable.class.isAssignableFrom(type)) {
             return (Serializer<T>) THROWABLE_SERIALIZER;
+        }
+        if (type.equals(HashCode.class)) {
+            return (Serializer<T>) HASHCODE_SERIALIZER;
         }
         return new DefaultSerializer<T>(type.getClassLoader());
     }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/WellKnownTypesSerializer.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/WellKnownTypesSerializer.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.serialize;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
+import org.gradle.internal.Cast;
+import org.gradle.internal.io.ClassLoaderObjectInputStream;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.StreamCorruptedException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.gradle.internal.serialize.BaseSerializerFactory.*;
+
+public class WellKnownTypesSerializer<T> extends AbstractSerializer<T> {
+    private static final Serializer<?>[] SERIALIZERS = new Serializer[]{
+        NULL_SERIALIZER,
+        STRING_SERIALIZER,
+        BOOLEAN_SERIALIZER,
+        BYTE_SERIALIZER,
+        SHORT_SERIALIZER,
+        INTEGER_SERIALIZER,
+        LONG_SERIALIZER,
+        FLOAT_SERIALIZER,
+        DOUBLE_SERIALIZER,
+        FILE_SERIALIZER,
+        BYTE_ARRAY_SERIALIZER
+    };
+    private static final Class<?>[] SERIALIZER_INDEX = new Class[]{
+        null,
+        String.class,
+        Boolean.class,
+        Byte.class,
+        Short.class,
+        Integer.class,
+        Long.class,
+        Float.class,
+        Double.class,
+        File.class,
+        byte[].class
+    };
+
+    private int serializerFor(Object obj) {
+        Class<?> clazz = obj == null ? null : obj.getClass();
+        for (int i = 0; i < SERIALIZER_INDEX.length; i++) {
+            if (clazz == SERIALIZER_INDEX[i]) {
+                return i;
+            }
+        }
+        if (obj instanceof List) {
+            return -2;
+        }
+        if (obj instanceof Map) {
+            return -3;
+        }
+        if (obj instanceof Enum) {
+            return -4;
+        }
+        if (obj instanceof Set) {
+            return -5;
+        }
+        System.err.println("Cannot optimize for class " + clazz);
+        return -1;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Serializer<Object> serializerFor(int idx) {
+        if (idx < 0) {
+            switch (idx) {
+                case -1:
+                    return null;
+                case -2:
+                    return (Serializer<Object>) listSerializer;
+                case -3:
+                    return (Serializer<Object>) mapSerializer;
+                case -4:
+                    return (Serializer<Object>) enumSerializer;
+                case -5:
+                    return (Serializer<Object>) setSerializer;
+            }
+        }
+        return Cast.uncheckedCast(SERIALIZERS[idx]);
+    }
+
+    private final ClassLoader classLoader;
+    private final Serializer<?> listSerializer;
+    private final Serializer<?> mapSerializer;
+    private final Serializer<?> setSerializer;
+    private final Serializer<?> enumSerializer;
+
+    public WellKnownTypesSerializer(ClassLoader classLoader) {
+        this.classLoader = classLoader != null ? classLoader : getClass().getClassLoader();
+        Serializer<Object> objectSerializer = Cast.uncheckedCast(this);
+        this.listSerializer = new ListSerializer<Object>(objectSerializer);
+        this.setSerializer = new SetSerializer<Object>(objectSerializer);
+        this.mapSerializer = new MapSerializer<Object, Object>(objectSerializer, objectSerializer);
+        this.enumSerializer = new EnumSerializer<Enum>(classLoader);
+    }
+
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    public T read(Decoder decoder) throws Exception {
+        try {
+            int idx = decoder.readByte();
+            if (idx == -1) {
+                return (T) new ClassLoaderObjectInputStream(decoder.getInputStream(), classLoader).readObject();
+            }
+            return Cast.uncheckedCast(serializerFor(idx).read(decoder));
+        } catch (StreamCorruptedException e) {
+            return null;
+        }
+    }
+
+    public void write(Encoder encoder, T value) throws IOException {
+        int idx = serializerFor(value);
+        encoder.writeByte((byte) idx);
+        if (idx == -1) {
+            ObjectOutputStream objectStr = new ObjectOutputStream(encoder.getOutputStream());
+            objectStr.writeObject(value);
+            objectStr.flush();
+        } else {
+            try {
+                serializerFor(idx).write(encoder, value);
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        WellKnownTypesSerializer rhs = (WellKnownTypesSerializer) obj;
+        return Objects.equal(classLoader, rhs.classLoader);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(super.hashCode(), classLoader);
+    }
+
+    private static class EnumSerializer<T extends Enum> extends AbstractSerializer<T> {
+        private final ClassLoader cl;
+        private final Map<String, Class<? extends Enum>> cachedClasses = Maps.newHashMap();
+
+        private EnumSerializer(ClassLoader cl) {
+            this.cl = cl;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T read(Decoder decoder) throws Exception {
+            String cn = decoder.readString();
+            Class<? extends Enum> en = getEnumClass(cn);
+            return (T) en.getEnumConstants()[decoder.readSmallInt()];
+        }
+
+        @SuppressWarnings("unchecked")
+        private Class<? extends Enum> getEnumClass(String cn) throws ClassNotFoundException {
+            Class<? extends Enum> clazz = cachedClasses.get(cn);
+            if (clazz == null) {
+                clazz = (Class<? extends Enum>) cl.loadClass(cn);
+                cachedClasses.put(cn, clazz);
+            }
+            return clazz;
+        }
+
+        public void write(Encoder encoder, T value) throws Exception {
+            encoder.writeString(value.getClass().getName());
+            encoder.writeSmallInt((byte) value.ordinal());
+        }
+    }
+}

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/WellKnownTypesSerializer.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/WellKnownTypesSerializer.java
@@ -30,6 +30,14 @@ import java.util.Set;
 
 import static org.gradle.internal.serialize.BaseSerializerFactory.*;
 
+/**
+ * An optimized serializer for a value which type is not known in advance. It will try
+ * to use an optimized serializer for a set of known types, and resort on Java serialization
+ * if it cannot find one. It also has support for `Set`, `List` and `Map` serialization, in
+ * which case it will recursively use itself for serializing values (or map keys). However,
+ * for those interfaces, it is *not* guaranteed that the deserialized type will be the same,
+ * so one should not rely on this serializer if the type of the deserialized collection matters.
+ */
 public class WellKnownTypesSerializer<T> extends AbstractSerializer<T> {
     private static final Serializer<?>[] SERIALIZERS = new Serializer[]{
         NULL_SERIALIZER,
@@ -77,7 +85,6 @@ public class WellKnownTypesSerializer<T> extends AbstractSerializer<T> {
         if (obj instanceof Set) {
             return -5;
         }
-        System.err.println("Cannot optimize for class " + clazz);
         return -1;
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/WellKnownTypesSerializer.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/WellKnownTypesSerializer.java
@@ -17,6 +17,7 @@ package org.gradle.internal.serialize;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
+import com.google.common.hash.HashCode;
 import org.gradle.internal.Cast;
 import org.gradle.internal.io.ClassLoaderObjectInputStream;
 
@@ -50,7 +51,8 @@ public class WellKnownTypesSerializer<T> extends AbstractSerializer<T> {
         FLOAT_SERIALIZER,
         DOUBLE_SERIALIZER,
         FILE_SERIALIZER,
-        BYTE_ARRAY_SERIALIZER
+        BYTE_ARRAY_SERIALIZER,
+        HASHCODE_SERIALIZER
     };
     private static final Class<?>[] SERIALIZER_INDEX = new Class[]{
         null,
@@ -63,7 +65,8 @@ public class WellKnownTypesSerializer<T> extends AbstractSerializer<T> {
         Float.class,
         Double.class,
         File.class,
-        byte[].class
+        byte[].class,
+        HashCode.class
     };
 
     private int serializerFor(Object obj) {

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/WellKnownTypesSerializerTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/WellKnownTypesSerializerTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.serialize
+
+import groovy.transform.Canonical
+import spock.lang.Unroll
+
+class WellKnownTypesSerializerTest extends SerializerSpec {
+    def serializer = new WellKnownTypesSerializer(this.class.classLoader)
+
+    def canSerializeAndDeserializeObject() {
+        GroovyClassLoader classLoader = new GroovyClassLoader(getClass().classLoader)
+        WellKnownTypesSerializer serializer = new WellKnownTypesSerializer(classLoader)
+
+        Class cl = classLoader.parseClass('package org.gradle.cache; class TestObj implements Serializable { }')
+        Object o = cl.newInstance()
+
+        when:
+        def r = serialize(o, serializer)
+
+        then:
+        cl.isInstance(r)
+    }
+
+    @Unroll
+    def "efficient serialization of #type"() {
+        expect:
+        usesEfficientSerialization(value, serializer, null) == value
+
+        where:
+        value << [
+            null, 1, 2L, "foo", (short) 4, 2d, 3f, Foo.bar, Foo.baz,
+            [1, 2],
+            [a: 'foo', b: 23L],
+            [Foo.bar, 2] as Set,
+            [123, 45] as byte[],
+            new File('foo'),
+            true,
+            false,
+            [(true): [122: ['x', new File('foo')]]] as TreeMap,
+            [new A(name: 'foo')]
+        ]
+        type = value!=null?value.getClass():'null'
+
+    }
+
+    enum Foo {
+        bar,
+        baz
+    }
+
+    @Canonical
+    static class A implements Serializable {
+        String name
+    }
+}

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/WellKnownTypesSerializerTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/WellKnownTypesSerializerTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.serialize
 
+import com.google.common.hash.HashCode
 import groovy.transform.Canonical
 import spock.lang.Unroll
 
@@ -42,24 +43,25 @@ class WellKnownTypesSerializerTest extends SerializerSpec {
 
         where:
         value << [
-            null, 1, 2L, "foo", (short) 4, 2d, 3f, Foo.bar, Foo.baz,
+            null, 1, 2L, "foo", (short) 4, 2d, 3f, Foo.BAR, Foo.BAZ,
             [1, 2],
             [a: 'foo', b: 23L],
-            [Foo.bar, 2] as Set,
+            [Foo.BAR, 2] as Set,
             [123, 45] as byte[],
             new File('foo'),
             true,
             false,
             [(true): [122: ['x', new File('foo')]]] as TreeMap,
-            [new A(name: 'foo')]
+            [new A(name: 'foo')],
+            [a:HashCode.fromString("abcdef0002")]
         ]
         type = value!=null?value.getClass():'null'
 
     }
 
     enum Foo {
-        bar,
-        baz
+        BAR,
+        BAZ
     }
 
     @Canonical


### PR DESCRIPTION
This pull request is the result of the investigation of several performance regressions on non-daemon use cases. Let's take the example of "Up-to-date full build - lotDependencies". When we compare the snapshots of 3.3 and 3.4, we can see a larger block in serialization:

This is in 3.3:

![selection_007](https://cloud.githubusercontent.com/assets/316357/22150692/c8d98212-df1a-11e6-8f42-4d0f16aa6ca5.png)

And the same block with 3.4:

![selection_008](https://cloud.githubusercontent.com/assets/316357/22150917/ff1c3544-df1b-11e6-91dd-a8ef7904a675.png)

And when we zoom in, we can see that there's a significant amount of good old Java serialization in action.

It's inefficient because we use `DefaultSerializer` for serializing values even for types that we already know and have more efficient implementations for. This pull request introduces a new serializer for that purpose, which makes sure we always use a well known serializer for types we know about, and only fallback to java serialization when we don't know how to efficiently serialize a type.

After this pull request, the flame graph looks like this:

![selection_009](https://cloud.githubusercontent.com/assets/316357/22150980/47a9f24c-df1c-11e6-934d-0ad79b5fe603.png)

All slow Java serialization has gone.

It's worth noting that this does NOT fix the performance regression alone, I still have to understand why we see MD5 hashing now, that we didn't see before.