### PR TITLE
Annotate `Action<T>` as a target for lambdas with implicit receiver

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/Action.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/Action.java
@@ -18,8 +18,9 @@ package org.gradle.api;
 /**
  * Performs some action against objects of type T.
  *
- * @param <T> The type of object which this action accepts. 
+ * @param <T> The type of object which this action accepts.
  */
+@HasImplicitReceiver
 public interface Action<T> {
     /**
      * Performs this action against the given object.

--- a/subprojects/base-services/src/main/java/org/gradle/api/HasImplicitReceiver.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/HasImplicitReceiver.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a SAM interface as a target for lambda expressions / closures
+ * where the single parameter is passed as the implicit receiver of the
+ * invocation ({@code this} in Kotlin, {@code delegate} in Groovy) as if
+ * the lambda expression was an extension method of the parameter type.
+ *
+ * <pre>
+ *     // copySpec(Action&lt;CopySpec&gt;)
+ *     copySpec {
+ *         from("./sources") // the given CopySpec is the implicit receiver
+ *     }
+ * </pre>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface HasImplicitReceiver {
+}


### PR DESCRIPTION
So `it` becomes unnecessary (illegal, in fact) in Kotlin build scripts
within lambda expressions passed as `Action<T>` arguments.