### PR TITLE
Fixing test issues with #883

### DIFF
--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
@@ -24,7 +24,6 @@ import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -201,7 +200,6 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
         repoType << [IVY, MAVEN]
     }
 
-    @Ignore
     def "Prefers Plugin Repositories over buildscript ones."() {
         given:
         publishPlugins(MAVEN)

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/resolve/service/PluginResolutionCachingCrossVersionIntegrationTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/resolve/service/PluginResolutionCachingCrossVersionIntegrationTest.groovy
@@ -18,11 +18,10 @@ package org.gradle.plugin.use.resolve.service
 
 import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.test.fixtures.server.http.MavenHttpModule
-import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.junit.Rule
-import spock.lang.Ignore
 
 @TargetVersions(["2.1+"])
 @LeaksFileHandles
@@ -41,7 +40,6 @@ class PluginResolutionCachingCrossVersionIntegrationTest extends CrossVersionInt
         requireOwnGradleUserHomeDir()
     }
 
-    @Ignore
     def "cached resolution by previous version is not used by this version"() {
         when:
         def gradleUserHome = file("gradle-home")

--- a/subprojects/plugin-use/src/testFixtures/groovy/org/gradle/plugin/use/resolve/service/PluginResolutionServiceTestServer.groovy
+++ b/subprojects/plugin-use/src/testFixtures/groovy/org/gradle/plugin/use/resolve/service/PluginResolutionServiceTestServer.groovy
@@ -67,6 +67,7 @@ class PluginResolutionServiceTestServer extends ExternalResource {
 
     void injectUrlOverride(GradleExecuter e) {
         e.withArgument("-D$PluginPortalResolver.OVERRIDE_URL_PROPERTY=$apiAddress")
+        e.withArgument("-Dorg.gradle.plugin.use.resolve.service.internal.PluginResolutionServiceResolver.repo.override=$apiAddress") //Class was renamed, for old versions to override url
     }
 
     public <T> T forVersion(GradleVersion gradleVersion, @DelegatesTo(PluginResolutionServiceTestServer) Closure<T> closure) {


### PR DESCRIPTION
1) PluginResolutionServiceResolver was renamed to PluginPortalResolver,
which broke tests that set the url for the portal.
2) We need to make sure to move the buildscript repositories after the
plugin repositories