### PR TITLE
Plugins can listen to build operations

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildOperationServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildOperationServiceIntegrationTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.progress
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class BuildOperationServiceIntegrationTest extends AbstractIntegrationSpec {
+
+    def "build can listen to build operations events"() {
+        given:
+        buildFile << '''
+            import org.gradle.internal.progress.* 
+            gradle.services.get(BuildOperationService).addListener(new InternalBuildListener() {
+                @Override
+                void started(BuildOperationInternal operation, OperationStartEvent startEvent) {
+                    logger.lifecycle "START $operation.displayName"
+                }
+    
+                @Override
+                void finished(BuildOperationInternal operation, OperationResult finishEvent) {
+                    logger.lifecycle "FINISH $operation.displayName"
+                }
+            })
+        '''.stripIndent()
+
+        when:
+        succeeds 'help'
+
+        then:
+        result.output.contains 'START Task :help'
+        result.output.contains 'FINISH Task :help'
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildOperationServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildOperationServiceIntegrationTest.groovy
@@ -24,7 +24,7 @@ class BuildOperationServiceIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << '''
             import org.gradle.internal.progress.* 
-            gradle.services.get(BuildOperationService).addListener(new InternalBuildListener() {
+            gradle.services.get(BuildOperationService).addListener(new InternalBuildOperationListener() {
                 @Override
                 void started(BuildOperationInternal operation, OperationStartEvent startEvent) {
                     logger.lifecycle "START $operation.displayName"

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildOperationServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildOperationServiceIntegrationTest.groovy
@@ -24,7 +24,7 @@ class BuildOperationServiceIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << '''
             import org.gradle.internal.progress.* 
-            gradle.services.get(BuildOperationService).addListener(new InternalBuildOperationListener() {
+            gradle.services.get(BuildOperationService).addListener(new BuildOperationListener() {
                 @Override
                 void started(BuildOperationInternal operation, OperationStartEvent startEvent) {
                     logger.lifecycle "START $operation.displayName"

--- a/subprojects/core/src/main/java/org/gradle/api/execution/internal/InternalTaskExecutionListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/execution/internal/InternalTaskExecutionListener.java
@@ -16,12 +16,11 @@
 
 package org.gradle.api.execution.internal;
 
-import org.gradle.internal.progress.InternalBuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 
 /**
- * Used by build scans to collect some task details, and will be retired. Use {@link InternalBuildOperationListener} instead.
+ * Used by build scans to collect some task details, and will be retired. Use {@link org.gradle.internal.progress.BuildOperationListener} instead.
  */
 public interface InternalTaskExecutionListener {
     void beforeExecute(TaskOperationInternal taskOperation, OperationStartEvent startEvent);

--- a/subprojects/core/src/main/java/org/gradle/api/execution/internal/InternalTaskExecutionListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/execution/internal/InternalTaskExecutionListener.java
@@ -16,11 +16,12 @@
 
 package org.gradle.api.execution.internal;
 
+import org.gradle.internal.progress.InternalBuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 
 /**
- * Used by build scans to collect some task details, and will be retired. Use {@link org.gradle.internal.progress.InternalBuildListener} instead.
+ * Used by build scans to collect some task details, and will be retired. Use {@link InternalBuildOperationListener} instead.
  */
 public interface InternalTaskExecutionListener {
     void beforeExecute(TaskOperationInternal taskOperation, OperationStartEvent startEvent);

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -27,14 +27,11 @@ import org.gradle.configuration.BuildConfigurer;
 import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.execution.BuildExecuter;
 import org.gradle.internal.concurrent.CompositeStoppable;
-import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.progress.BuildOperationExecutor;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class DefaultGradleLauncher implements GradleLauncher {
@@ -55,9 +52,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
     private final BuildConfigurationActionExecuter buildConfigurationActionExecuter;
     private final BuildExecuter buildExecuter;
     private final BuildScopeServices buildServices;
-    private final ListenerManager globalListenerManager;
     private final List<?> servicesToStop;
-    private final List<Stoppable> listeners = new ArrayList<Stoppable>();
     private GradleInternal gradle;
     private SettingsInternal settings;
     private Stage stage;
@@ -68,7 +63,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
                                  ModelConfigurationListener modelConfigurationListener,
                                  BuildCompletionListener buildCompletionListener, BuildOperationExecutor operationExecutor,
                                  BuildConfigurationActionExecuter buildConfigurationActionExecuter, BuildExecuter buildExecuter,
-                                 BuildScopeServices buildServices, ListenerManager globalListenerManager, List<?> servicesToStop) {
+                                 BuildScopeServices buildServices, List<?> servicesToStop) {
         this.gradle = gradle;
         this.initScriptHandler = initScriptHandler;
         this.settingsLoader = settingsLoader;
@@ -82,7 +77,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
         this.buildExecuter = buildExecuter;
         this.buildCompletionListener = buildCompletionListener;
         this.buildServices = buildServices;
-        this.globalListenerManager = globalListenerManager;
         this.servicesToStop = servicesToStop;
         loggingManager.start();
     }
@@ -186,18 +180,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
         gradle.addListener(listener);
     }
 
-    @Override
-    public void addNestedListener(final Object listener) {
-        // Add the listener and remove when stopped
-        globalListenerManager.addListener(listener);
-        listeners.add(new Stoppable() {
-            @Override
-            public void stop() {
-                globalListenerManager.removeListener(listener);
-            }
-        });
-    }
-
     /**
      * <p>Adds a {@link StandardOutputListener} to this build instance. The listener is notified of any text written to standard output by Gradle's logging system
      *
@@ -221,7 +203,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
     public void stop() {
         try {
             loggingManager.stop();
-            CompositeStoppable.stoppable(listeners).add(buildServices).add(servicesToStop).stop();
+            CompositeStoppable.stoppable(buildServices).add(servicesToStop).stop();
         } finally {
             buildCompletionListener.completed();
         }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -61,14 +61,12 @@ import org.gradle.util.DeprecationLogger;
 import java.util.List;
 
 public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
-    private final ListenerManager globalListenerManager;
     private final GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry;
     private final BuildProgressLogger buildProgressLogger;
     private DefaultGradleLauncher rootBuild;
 
     public DefaultGradleLauncherFactory(
         ListenerManager listenerManager, ProgressLoggerFactory progressLoggerFactory, GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry) {
-        this.globalListenerManager = listenerManager;
         this.userHomeDirServiceRegistry = userHomeDirServiceRegistry;
 
         // Register default loggers
@@ -196,7 +194,6 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             gradle.getServices().get(BuildConfigurationActionExecuter.class),
             gradle.getServices().get(BuildExecuter.class),
             serviceRegistry,
-            globalListenerManager,
             servicesToStop
         );
         nestedBuildFactory.setParent(gradleLauncher);

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
@@ -59,11 +59,6 @@ public interface GradleLauncher extends Stoppable {
     void addListener(Object listener);
 
     /**
-     * <p>Adds a nested listener to this build instance. Receives events for this build and all nested builds.
-     */
-    void addNestedListener(Object listener);
-
-    /**
      * <p>Adds a {@link StandardOutputListener} to this build instance. The listener is notified of any text written to standard output by Gradle's logging system
      *
      * @param listener The listener to add. Has no effect if the listener has already been added.

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/BuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/BuildController.java
@@ -23,10 +23,6 @@ import org.gradle.api.internal.GradleInternal;
  * This is intended to eventually replace {@link org.gradle.initialization.GradleLauncher} internally. It's pretty rough at the moment.
  */
 public interface BuildController {
-    /**
-     * Adds a listener that receives all events for this build invocation, including those from the current build and all nested builds.
-     */
-    void addNestedListener(Object listener);
 
     /**
      * @return The {@link org.gradle.api.internal.GradleInternal} object that represents the build invocation.

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationExecutor.java
@@ -28,7 +28,7 @@ import org.gradle.internal.operations.BuildOperationContext;
  * The executor provides several capabilities:
  *
  * <ul>
- *     <p>Fires events via {@link InternalBuildListener}. For example, this means that notification of build operation
+ *     <p>Fires events via {@link InternalBuildOperationListener}. For example, this means that notification of build operation
  *     execution can be received by tooling API clients.</p>
  *     <p>Generates progress logging events.</p>
  * </ul>

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationExecutor.java
@@ -28,7 +28,7 @@ import org.gradle.internal.operations.BuildOperationContext;
  * The executor provides several capabilities:
  *
  * <ul>
- *     <p>Fires events via {@link InternalBuildOperationListener}. For example, this means that notification of build operation
+ *     <p>Fires events via {@link BuildOperationListener}. For example, this means that notification of build operation
  *     execution can be received by tooling API clients.</p>
  *     <p>Generates progress logging events.</p>
  * </ul>

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationListener.java
@@ -18,7 +18,7 @@ package org.gradle.internal.progress;
 /**
  * A listener that is notified as build operations are executed via a {@link BuildOperationExecutor}.
  */
-public interface InternalBuildOperationListener {
+public interface BuildOperationListener {
 
     void started(BuildOperationInternal buildOperation, OperationStartEvent startEvent);
 

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationService.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.progress;
+
+public interface BuildOperationService {
+
+    void addListener(InternalBuildListener listener);
+
+    void removeListener(InternalBuildListener listener);
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationService.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationService.java
@@ -18,8 +18,8 @@ package org.gradle.internal.progress;
 
 public interface BuildOperationService {
 
-    void addListener(InternalBuildOperationListener listener);
+    void addListener(BuildOperationListener listener);
 
-    void removeListener(InternalBuildOperationListener listener);
+    void removeListener(BuildOperationListener listener);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationService.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildOperationService.java
@@ -18,8 +18,8 @@ package org.gradle.internal.progress;
 
 public interface BuildOperationService {
 
-    void addListener(InternalBuildListener listener);
+    void addListener(InternalBuildOperationListener listener);
 
-    void removeListener(InternalBuildListener listener);
+    void removeListener(InternalBuildOperationListener listener);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
@@ -30,13 +30,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class DefaultBuildOperationExecutor implements BuildOperationExecutor {
-    private final InternalBuildOperationListener listener;
+    private final BuildOperationListener listener;
     private final TimeProvider timeProvider;
     private final ProgressLoggerFactory progressLoggerFactory;
     private final AtomicLong nextId = new AtomicLong();
     private final ThreadLocal<OperationDetails> currentOperation = new ThreadLocal<OperationDetails>();
 
-    public DefaultBuildOperationExecutor(InternalBuildOperationListener listener, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory) {
+    public DefaultBuildOperationExecutor(BuildOperationListener listener, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory) {
         this.listener = listener;
         this.timeProvider = timeProvider;
         this.progressLoggerFactory = progressLoggerFactory;

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
@@ -30,13 +30,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class DefaultBuildOperationExecutor implements BuildOperationExecutor {
-    private final InternalBuildListener listener;
+    private final InternalBuildOperationListener listener;
     private final TimeProvider timeProvider;
     private final ProgressLoggerFactory progressLoggerFactory;
     private final AtomicLong nextId = new AtomicLong();
     private final ThreadLocal<OperationDetails> currentOperation = new ThreadLocal<OperationDetails>();
 
-    public DefaultBuildOperationExecutor(InternalBuildListener listener, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory) {
+    public DefaultBuildOperationExecutor(InternalBuildOperationListener listener, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory) {
         this.listener = listener;
         this.timeProvider = timeProvider;
         this.progressLoggerFactory = progressLoggerFactory;

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationService.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.progress;
+
+import org.gradle.internal.event.ListenerManager;
+
+public class DefaultBuildOperationService implements BuildOperationService {
+    private final ListenerManager globalListenerManager;
+
+    public DefaultBuildOperationService(ListenerManager globalListenerManager) {
+        this.globalListenerManager = globalListenerManager;
+    }
+
+    @Override
+    public void addListener(InternalBuildListener listener) {
+        globalListenerManager.addListener(listener);
+    }
+
+    @Override
+    public void removeListener(InternalBuildListener listener) {
+        globalListenerManager.removeListener(listener);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationService.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationService.java
@@ -26,12 +26,12 @@ public class DefaultBuildOperationService implements BuildOperationService {
     }
 
     @Override
-    public void addListener(InternalBuildListener listener) {
+    public void addListener(InternalBuildOperationListener listener) {
         globalListenerManager.addListener(listener);
     }
 
     @Override
-    public void removeListener(InternalBuildListener listener) {
+    public void removeListener(InternalBuildOperationListener listener) {
         globalListenerManager.removeListener(listener);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationService.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationService.java
@@ -26,12 +26,12 @@ public class DefaultBuildOperationService implements BuildOperationService {
     }
 
     @Override
-    public void addListener(InternalBuildOperationListener listener) {
+    public void addListener(BuildOperationListener listener) {
         globalListenerManager.addListener(listener);
     }
 
     @Override
-    public void removeListener(InternalBuildOperationListener listener) {
+    public void removeListener(BuildOperationListener listener) {
         globalListenerManager.removeListener(listener);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/InternalBuildOperationListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/InternalBuildOperationListener.java
@@ -18,7 +18,7 @@ package org.gradle.internal.progress;
 /**
  * A listener that is notified as build operations are executed via a {@link BuildOperationExecutor}.
  */
-public interface InternalBuildListener {
+public interface InternalBuildOperationListener {
 
     void started(BuildOperationInternal buildOperation, OperationStartEvent startEvent);
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -87,7 +87,9 @@ import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.progress.BuildOperationExecutor;
+import org.gradle.internal.progress.BuildOperationService;
 import org.gradle.internal.progress.DefaultBuildOperationExecutor;
+import org.gradle.internal.progress.DefaultBuildOperationService;
 import org.gradle.internal.progress.InternalBuildListener;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;
@@ -160,6 +162,10 @@ public class GlobalScopeServices {
 
     BuildOperationExecutor createBuildOperationExecutor(ListenerManager listenerManager, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory) {
         return new DefaultBuildOperationExecutor(listenerManager.getBroadcaster(InternalBuildListener.class), timeProvider, progressLoggerFactory);
+    }
+
+    BuildOperationService createBuildOperationService(ListenerManager listenerManager) {
+        return new DefaultBuildOperationService(listenerManager);
     }
 
     TemporaryFileProvider createTemporaryFileProvider() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -90,7 +90,7 @@ import org.gradle.internal.progress.BuildOperationExecutor;
 import org.gradle.internal.progress.BuildOperationService;
 import org.gradle.internal.progress.DefaultBuildOperationExecutor;
 import org.gradle.internal.progress.DefaultBuildOperationService;
-import org.gradle.internal.progress.InternalBuildListener;
+import org.gradle.internal.progress.InternalBuildOperationListener;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.remote.MessagingServer;
@@ -161,7 +161,7 @@ public class GlobalScopeServices {
     }
 
     BuildOperationExecutor createBuildOperationExecutor(ListenerManager listenerManager, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory) {
-        return new DefaultBuildOperationExecutor(listenerManager.getBroadcaster(InternalBuildListener.class), timeProvider, progressLoggerFactory);
+        return new DefaultBuildOperationExecutor(listenerManager.getBroadcaster(InternalBuildOperationListener.class), timeProvider, progressLoggerFactory);
     }
 
     BuildOperationService createBuildOperationService(ListenerManager listenerManager) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -87,10 +87,10 @@ import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.progress.BuildOperationExecutor;
+import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.BuildOperationService;
 import org.gradle.internal.progress.DefaultBuildOperationExecutor;
 import org.gradle.internal.progress.DefaultBuildOperationService;
-import org.gradle.internal.progress.InternalBuildOperationListener;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.remote.MessagingServer;
@@ -161,7 +161,7 @@ public class GlobalScopeServices {
     }
 
     BuildOperationExecutor createBuildOperationExecutor(ListenerManager listenerManager, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory) {
-        return new DefaultBuildOperationExecutor(listenerManager.getBroadcaster(InternalBuildOperationListener.class), timeProvider, progressLoggerFactory);
+        return new DefaultBuildOperationExecutor(listenerManager.getBroadcaster(BuildOperationListener.class), timeProvider, progressLoggerFactory);
     }
 
     BuildOperationService createBuildOperationService(ListenerManager listenerManager) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -32,7 +32,6 @@ import org.gradle.execution.BuildConfigurationActionExecuter
 import org.gradle.execution.BuildExecuter
 import org.gradle.execution.TaskGraphExecuter
 import org.gradle.internal.concurrent.Stoppable
-import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.progress.BuildOperationExecutor
 import org.gradle.internal.progress.TestBuildOperationExecutor
@@ -68,7 +67,7 @@ public class DefaultGradleLauncherSpec extends Specification {
     private BuildCompletionListener buildCompletionListener = Mock(BuildCompletionListener.class);
     private BuildOperationExecutor buildOperationExecutor = new TestBuildOperationExecutor();
     private BuildScopeServices buildServices = Mock(BuildScopeServices.class);
-    private ListenerManager globalListenerManager = Mock(ListenerManager)
+//    private ListenerManager globalListenerManager = Mock(ListenerManager)
     private Stoppable otherService = Mock(Stoppable)
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
 
@@ -113,7 +112,7 @@ public class DefaultGradleLauncherSpec extends Specification {
         return new DefaultGradleLauncher(gradleMock, initScriptHandlerMock, settingsLoaderMock,
             buildConfigurerMock, exceptionAnalyserMock, loggingManagerMock, buildBroadcaster,
             modelListenerMock, buildCompletionListener, buildOperationExecutor, buildConfigurationActionExecuter, buildExecuter,
-            buildServices, globalListenerManager, [otherService]);
+            buildServices, [otherService]);
     }
 
     public void testRun() {
@@ -250,30 +249,6 @@ public class DefaultGradleLauncherSpec extends Specification {
         1 * buildServices.close()
         1 * otherService.stop()
         1 * buildCompletionListener.completed()
-    }
-
-    public void testRemovesListenersOnStop() throws IOException {
-        def listener1 = new Object()
-        def listener2 = new Object()
-
-        given:
-        expectLoggingStarted();
-
-        when:
-        DefaultGradleLauncher gradleLauncher = launcher();
-        gradleLauncher.addNestedListener(listener1)
-        gradleLauncher.addNestedListener(listener2)
-
-        then:
-        1 * globalListenerManager.addListener(listener1)
-        1 * globalListenerManager.addListener(listener2)
-
-        when:
-        gradleLauncher.stop();
-
-        then:
-        1 * globalListenerManager.removeListener(listener1)
-        1 * globalListenerManager.removeListener(listener2)
     }
 
     private void expectLoggingStarted() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.time.TimeProvider
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
-    def listener = Mock(InternalBuildListener)
+    def listener = Mock(InternalBuildOperationListener)
     def timeProvider = Mock(TimeProvider)
     def progressLoggerFactory = Mock(ProgressLoggerFactory)
     def operationExecutor = new DefaultBuildOperationExecutor(listener, timeProvider, progressLoggerFactory)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.time.TimeProvider
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
-    def listener = Mock(InternalBuildOperationListener)
+    def listener = Mock(BuildOperationListener)
     def timeProvider = Mock(TimeProvider)
     def progressLoggerFactory = Mock(ProgressLoggerFactory)
     def operationExecutor = new DefaultBuildOperationExecutor(listener, timeProvider, progressLoggerFactory)

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/GradleBuildController.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/GradleBuildController.java
@@ -39,11 +39,6 @@ public class GradleBuildController implements BuildController {
     }
 
     @Override
-    public void addNestedListener(Object listener) {
-        gradleLauncher.addNestedListener(listener);
-    }
-
-    @Override
     public boolean hasResult() {
         return hasResult;
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingBuildOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingBuildOperationListener.java
@@ -18,7 +18,7 @@ package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildOperationListener;
+import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.provider.events.*;
@@ -30,7 +30,7 @@ import java.util.Collections;
  *
  * @since 2.5
  */
-class ClientForwardingBuildOperationListener implements InternalBuildOperationListener {
+class ClientForwardingBuildOperationListener implements BuildOperationListener {
 
     private final BuildEventConsumer eventConsumer;
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingBuildOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingBuildOperationListener.java
@@ -18,7 +18,7 @@ package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildListener;
+import org.gradle.internal.progress.InternalBuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.provider.events.*;
@@ -30,11 +30,11 @@ import java.util.Collections;
  *
  * @since 2.5
  */
-class ClientForwardingBuildListener implements InternalBuildListener {
+class ClientForwardingBuildOperationListener implements InternalBuildOperationListener {
 
     private final BuildEventConsumer eventConsumer;
 
-    ClientForwardingBuildListener(BuildEventConsumer eventConsumer) {
+    ClientForwardingBuildOperationListener(BuildEventConsumer eventConsumer) {
         this.eventConsumer = eventConsumer;
     }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildListener;
+import org.gradle.internal.progress.InternalBuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
@@ -43,13 +43,13 @@ import java.util.Set;
  *
  * @since 2.5
  */
-class ClientForwardingTaskListener implements InternalBuildListener {
+class ClientForwardingTaskOperationListener implements InternalBuildOperationListener {
     private final BuildEventConsumer eventConsumer;
     private final BuildClientSubscriptions clientSubscriptions;
-    private final InternalBuildListener delegate;
+    private final InternalBuildOperationListener delegate;
     private final Set<Object> skipEvents = new HashSet<Object>();
 
-    ClientForwardingTaskListener(BuildEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, InternalBuildListener delegate) {
+    ClientForwardingTaskOperationListener(BuildEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, InternalBuildOperationListener delegate) {
         this.eventConsumer = eventConsumer;
         this.clientSubscriptions = clientSubscriptions;
         this.delegate = delegate;

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildOperationListener;
+import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
@@ -43,13 +43,13 @@ import java.util.Set;
  *
  * @since 2.5
  */
-class ClientForwardingTaskOperationListener implements InternalBuildOperationListener {
+class ClientForwardingTaskOperationListener implements BuildOperationListener {
     private final BuildEventConsumer eventConsumer;
     private final BuildClientSubscriptions clientSubscriptions;
-    private final InternalBuildOperationListener delegate;
+    private final BuildOperationListener delegate;
     private final Set<Object> skipEvents = new HashSet<Object>();
 
-    ClientForwardingTaskOperationListener(BuildEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, InternalBuildOperationListener delegate) {
+    ClientForwardingTaskOperationListener(BuildEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, BuildOperationListener delegate) {
         this.eventConsumer = eventConsumer;
         this.clientSubscriptions = clientSubscriptions;
         this.delegate = delegate;

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
@@ -27,7 +27,7 @@ import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestResult;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildListener;
+import org.gradle.internal.progress.InternalBuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.protocol.events.InternalJvmTestDescriptor;
@@ -48,13 +48,13 @@ import java.util.Map;
 /**
  * Test listener that forwards all receiving events to the client via the provided {@code BuildEventConsumer} instance.
  */
-class ClientForwardingTestListener implements TestListenerInternal, InternalBuildListener {
+class ClientForwardingTestOperationListener implements TestListenerInternal, InternalBuildOperationListener {
 
     private final BuildEventConsumer eventConsumer;
     private final BuildClientSubscriptions clientSubscriptions;
     private Map<Object, String> runningTasks = Maps.newHashMap();
 
-    ClientForwardingTestListener(BuildEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions) {
+    ClientForwardingTestOperationListener(BuildEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions) {
         this.eventConsumer = eventConsumer;
         this.clientSubscriptions = clientSubscriptions;
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTestOperationListener.java
@@ -27,7 +27,7 @@ import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestResult;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildOperationListener;
+import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.protocol.events.InternalJvmTestDescriptor;
@@ -48,7 +48,7 @@ import java.util.Map;
 /**
  * Test listener that forwards all receiving events to the client via the provided {@code BuildEventConsumer} instance.
  */
-class ClientForwardingTestOperationListener implements TestListenerInternal, InternalBuildOperationListener {
+class ClientForwardingTestOperationListener implements TestListenerInternal, BuildOperationListener {
 
     private final BuildEventConsumer eventConsumer;
     private final BuildClientSubscriptions clientSubscriptions;

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/SubscribableBuildActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/SubscribableBuildActionRunner.java
@@ -22,14 +22,14 @@ import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildListener;
+import org.gradle.internal.progress.InternalBuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
 import org.gradle.tooling.internal.provider.SubscribableBuildAction;
 
 public class SubscribableBuildActionRunner implements BuildActionRunner {
-    private static final InternalBuildListener NO_OP = new InternalBuildListener() {
+    private static final InternalBuildOperationListener NO_OP = new InternalBuildOperationListener() {
         @Override
         public void started(BuildOperationInternal buildOperation, OperationStartEvent startEvent) {
         }
@@ -47,17 +47,17 @@ public class SubscribableBuildActionRunner implements BuildActionRunner {
     private void registerListenersForClientSubscriptions(BuildClientSubscriptions clientSubscriptions, GradleInternal gradle, BuildController buildController) {
         BuildEventConsumer eventConsumer = gradle.getServices().get(BuildEventConsumer.class);
         if (clientSubscriptions.isSendTestProgressEvents()) {
-            buildController.addNestedListener(new ClientForwardingTestListener(eventConsumer, clientSubscriptions));
+            buildController.addNestedListener(new ClientForwardingTestOperationListener(eventConsumer, clientSubscriptions));
         }
         if (!clientSubscriptions.isSendBuildProgressEvents() && !clientSubscriptions.isSendTaskProgressEvents()) {
             return;
         }
 
-        InternalBuildListener buildListener = NO_OP;
+        InternalBuildOperationListener buildListener = NO_OP;
         if (clientSubscriptions.isSendBuildProgressEvents()) {
-            buildListener = new ClientForwardingBuildListener(eventConsumer);
+            buildListener = new ClientForwardingBuildOperationListener(eventConsumer);
         }
-        buildListener = new ClientForwardingTaskListener(eventConsumer, clientSubscriptions, buildListener);
+        buildListener = new ClientForwardingTaskOperationListener(eventConsumer, clientSubscriptions, buildListener);
         buildController.addNestedListener(buildListener);
     }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/SubscribableBuildActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/SubscribableBuildActionRunner.java
@@ -22,14 +22,14 @@ import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildOperationListener;
+import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
 import org.gradle.tooling.internal.provider.SubscribableBuildAction;
 
 public class SubscribableBuildActionRunner implements BuildActionRunner {
-    private static final InternalBuildOperationListener NO_OP = new InternalBuildOperationListener() {
+    private static final BuildOperationListener NO_OP = new BuildOperationListener() {
         @Override
         public void started(BuildOperationInternal buildOperation, OperationStartEvent startEvent) {
         }
@@ -53,7 +53,7 @@ public class SubscribableBuildActionRunner implements BuildActionRunner {
             return;
         }
 
-        InternalBuildOperationListener buildListener = NO_OP;
+        BuildOperationListener buildListener = NO_OP;
         if (clientSubscriptions.isSendBuildProgressEvents()) {
             buildListener = new ClientForwardingBuildOperationListener(eventConsumer);
         }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.testing.TestExecutionException;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestResult;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildOperationListener;
+import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.protocol.events.InternalTestDescriptor;
@@ -41,7 +41,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-class TestExecutionResultEvaluator implements TestListenerInternal, InternalBuildOperationListener {
+class TestExecutionResultEvaluator implements TestListenerInternal, BuildOperationListener {
     private static final String INDENT = "    ";
 
     private long resultCount;

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.testing.TestExecutionException;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestResult;
 import org.gradle.internal.progress.BuildOperationInternal;
-import org.gradle.internal.progress.InternalBuildListener;
+import org.gradle.internal.progress.InternalBuildOperationListener;
 import org.gradle.internal.progress.OperationResult;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.tooling.internal.protocol.events.InternalTestDescriptor;
@@ -41,7 +41,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-class TestExecutionResultEvaluator implements TestListenerInternal, InternalBuildListener {
+class TestExecutionResultEvaluator implements TestListenerInternal, InternalBuildOperationListener {
     private static final String INDENT = "    ";
 
     private long resultCount;

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
@@ -18,6 +18,7 @@ package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.progress.BuildOperationExecutor;
+import org.gradle.internal.progress.BuildOperationService;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.PluginServiceRegistry;
 import org.gradle.launcher.exec.ChainingBuildActionRunner;
@@ -29,15 +30,15 @@ public class ToolingBuilderServices implements PluginServiceRegistry {
     public void registerGlobalServices(ServiceRegistration registration) {
 
         registration.addProvider(new Object() {
-            BuildActionRunner createBuildActionRunner(BuildOperationExecutor buildOperationExecutor) {
+            BuildActionRunner createBuildActionRunner(BuildOperationExecutor buildOperationExecutor, BuildOperationService buildOperationService) {
                 return new SubscribableBuildActionRunner(
                     new RunAsBuildOperationBuildActionRunner(
                         new ChainingBuildActionRunner(
                             Arrays.asList(
                                 new BuildModelActionRunner(),
-                                new TestExecutionRequestActionRunner(),
+                                new TestExecutionRequestActionRunner(buildOperationService),
                                 new ClientProvidedBuildActionRunner())),
-                        buildOperationExecutor));
+                        buildOperationExecutor), buildOperationService);
             }
         });
     }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/SubscribableBuildActionRunnerSpec.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/SubscribableBuildActionRunnerSpec.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.runner
+
+import org.gradle.api.internal.GradleInternal
+import org.gradle.initialization.BuildEventConsumer
+import org.gradle.internal.invocation.BuildActionRunner
+import org.gradle.internal.invocation.BuildController
+import org.gradle.internal.progress.BuildOperationService
+import org.gradle.internal.service.ServiceRegistry
+import org.gradle.tooling.internal.provider.BuildClientSubscriptions
+import org.gradle.tooling.internal.provider.SubscribableBuildAction
+import spock.lang.Specification
+
+class SubscribableBuildActionRunnerSpec extends Specification {
+
+
+    def testRemovesListenersOnStop() throws IOException {
+        given:
+        BuildActionRunner buildActionRunner = Mock(BuildActionRunner)
+        BuildOperationService buildOperationService = Mock(BuildOperationService)
+        SubscribableBuildAction buildAction = subscribableBuildAction() //Mock(SubscribableBuildAction)
+        BuildController buildController = buildController() //Mock(BuildController)
+
+        def runner = new SubscribableBuildActionRunner(buildActionRunner, buildOperationService);
+
+        when:
+        runner.run(buildAction, buildController)
+
+        then:
+        2 * buildOperationService.addListener(_)
+        2 * buildOperationService.removeListener(_)
+    }
+
+    SubscribableBuildAction subscribableBuildAction() {
+        SubscribableBuildAction buildAction = Mock()
+        BuildClientSubscriptions clientSubscriptions = Mock()
+        _ * clientSubscriptions.isSendBuildProgressEvents() >> true
+        _ * clientSubscriptions.isSendTaskProgressEvents() >> true
+        _ * clientSubscriptions.isSendTestProgressEvents() >> true
+        _ * buildAction.getClientSubscriptions() >> clientSubscriptions
+        buildAction
+    }
+
+    BuildController buildController() {
+        BuildController buildController = Mock()
+        GradleInternal gradleInternal = Mock()
+        ServiceRegistry gradleServices = Mock()
+        _ * gradleServices.get(BuildEventConsumer) >> Mock(BuildEventConsumer)
+        _ * gradleInternal.getServices() >> gradleServices
+        _ * buildController.getGradle() >> gradleInternal
+        buildController
+    }
+}

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunnerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunnerTest.groovy
@@ -17,13 +17,15 @@
 package org.gradle.tooling.internal.provider.runner
 import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.invocation.BuildController
+import org.gradle.internal.progress.BuildOperationService
 import spock.lang.Specification
 
 class TestExecutionRequestActionRunnerTest extends Specification {
 
     def "does not handle non TestExecutionRequestAction"(){
         given:
-        def runner = new TestExecutionRequestActionRunner()
+        BuildOperationService buildOperationService = Mock(BuildOperationService)
+        def runner = new TestExecutionRequestActionRunner(buildOperationService)
         BuildAction buildAction = Mock(BuildAction)
         BuildController buildController= Mock(BuildController)
         when:


### PR DESCRIPTION
- rename `InternalBuildListener` to `BuildOperationListener`
- introduce new service to register Build
- integ test coverage for listening to build operation events
- rework TAPI `DefaultGradleLauncher` and `BuildController` to use new Service  