### PR TITLE
Fix maven publishing of Java libraries

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.test.fixtures.maven
 
+import com.google.common.collect.ArrayListMultimap
+
 class MavenPom {
     String groupId
     String artifactId
@@ -33,6 +35,7 @@ class MavenPom {
             version = pom.version[0]?.text()
             packaging = pom.packaging[0]?.text()
             description = pom.description[0]?.text()
+            def scopesByDependency = ArrayListMultimap.create()
 
             pom.dependencies.dependency.each { dep ->
                 def scopeElement = dep.scope
@@ -64,6 +67,11 @@ class MavenPom {
                 def key = "${mavenDependency.groupId}:${mavenDependency.artifactId}:${mavenDependency.version}"
                 key += mavenDependency.classifier ? ":${mavenDependency.classifier}" : ""
                 scope.dependencies[key] = mavenDependency
+                scopesByDependency.put(key, scopeName)
+            }
+
+            scopesByDependency.asMap().entrySet().findAll { it.value.size() > 1 }.each {
+                throw new AssertionError("$it.key appeared in more than one scope: $it.value")
             }
         }
     }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
@@ -162,7 +162,7 @@ class MavenPublishDependenciesIntegTest extends AbstractIntegrationSpec {
         'java'         | 'implementation'     | 'runtime'
 
         'java-library' | 'api'                | 'compile'
-        'java-library' | 'compile'            | 'runtime'
+        'java-library' | 'compile'            | 'compile'
         'java-library' | 'implementation'     | 'runtime'
 
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
@@ -83,15 +83,7 @@ public class JavaLibrary implements SoftwareComponentInternal {
 
         public Set<ModuleDependency> getDependencies() {
             if (dependencies == null) {
-                // this configuration is purely virtual, intended to build the correct set of dependencies when we publish
-                // We cannot use the new runtimeClasspath configuration because it would include local, runtime only dependencies
-                // and we still need, for backwards compatibility, things from the `runtime` configuration, so we end
-                // up building a configuration which is the union of both `runtime` and `runtimeElements`
-                Configuration runtimeConfiguration = configurations.getByName(RUNTIME_CONFIGURATION_NAME);
-                Configuration runtimeElementsConfiguration = configurations.getByName(RUNTIME_ELEMENTS_CONFIGURATION_NAME);
-                Configuration runtimePublishConfiguration = configurations.detachedConfiguration();
-                runtimePublishConfiguration.extendsFrom(runtimeConfiguration, runtimeElementsConfiguration);
-                dependencies = runtimePublishConfiguration.getAllDependencies();
+                dependencies = configurations.getByName(RUNTIME_ELEMENTS_CONFIGURATION_NAME).getAllDependencies();
             }
             return dependencies.withType(ModuleDependency.class);
         }


### PR DESCRIPTION
The maven-publish plugin was adding dependencies to two scopes, which
leads to Maven just picking the last one. This will usually be wrong.

This changes the pom generation to only add dependencies once and sorts
the scopes such that compile dependencies are preferred over runtime
dependencies.