### PR TITLE
Introduce `BuildSrcProjectConfigurationAction`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/configuration/project/PluginsProjectConfigureActions.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/PluginsProjectConfigureActions.java
@@ -17,19 +17,32 @@
 package org.gradle.configuration.project;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Action;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.service.ServiceLocator;
 
 public class PluginsProjectConfigureActions implements ProjectConfigureAction {
-    private final Iterable<ProjectConfigureAction> actions;
 
-    public PluginsProjectConfigureActions(ServiceLocator pluginsServiceLocator) {
-        actions = ImmutableList.copyOf(pluginsServiceLocator.getAll(ProjectConfigureAction.class));
+    public static ProjectConfigureAction from(ServiceLocator serviceLocator) {
+        return of(ProjectConfigureAction.class, serviceLocator);
+    }
+
+    public static <T extends Action<ProjectInternal>> ProjectConfigureAction of(Class<T> serviceType,
+                                                                                ServiceLocator serviceLocator) {
+        return new PluginsProjectConfigureActions(
+            ImmutableList.<Action<ProjectInternal>>copyOf(
+                serviceLocator.getAll(serviceType)));
+    }
+
+    private final Iterable<Action<ProjectInternal>> actions;
+
+    private PluginsProjectConfigureActions(Iterable<Action<ProjectInternal>> actions) {
+        this.actions = actions;
     }
 
     public void execute(ProjectInternal project) {
-        for (ProjectConfigureAction configureAction : actions) {
-            configureAction.execute(project);
+        for (Action<ProjectInternal> action : actions) {
+            action.execute(project);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
@@ -17,13 +17,14 @@
 package org.gradle.initialization.buildsrc;
 
 import org.gradle.BuildAdapter;
-import org.gradle.api.Project;
-import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.Action;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.component.BuildableJavaComponent;
 import org.gradle.api.internal.component.ComponentRegistry;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.initialization.ModelConfigurationListener;
+import org.gradle.internal.Actions;
 
 import java.io.File;
 import java.util.Collection;
@@ -31,27 +32,34 @@ import java.util.Set;
 
 public class BuildSrcBuildListenerFactory {
 
+    private final Action<ProjectInternal> buildSrcRootProjectConfiguration;
+
+    public BuildSrcBuildListenerFactory() {
+        this(Actions.<ProjectInternal>doNothing());
+    }
+
+    public BuildSrcBuildListenerFactory(Action<ProjectInternal> buildSrcRootProjectConfiguration) {
+        this.buildSrcRootProjectConfiguration = buildSrcRootProjectConfiguration;
+    }
+
     Listener create(boolean rebuild) {
-        return new Listener(rebuild);
+        return new Listener(rebuild, buildSrcRootProjectConfiguration);
     }
 
     public static class Listener extends BuildAdapter implements ModelConfigurationListener {
         private Set<File> classpath;
         private final boolean rebuild;
+        private final Action<ProjectInternal> rootProjectConfiguration;
 
-        public Listener(boolean rebuild) {
+        private Listener(boolean rebuild, Action<ProjectInternal> rootProjectConfiguration) {
             this.rebuild = rebuild;
+            this.rootProjectConfiguration = rootProjectConfiguration;
         }
 
         @Override
         public void projectsLoaded(Gradle gradle) {
-            Project rootProject = gradle.getRootProject();
+            rootProjectConfiguration.execute((ProjectInternal)gradle.getRootProject());
 
-            rootProject.getPluginManager().apply("groovy");
-
-            DependencyHandler dependencies = rootProject.getDependencies();
-            dependencies.add("compile", dependencies.gradleApi());
-            dependencies.add("compile", dependencies.localGroovy());
         }
 
         public Collection<File> getRuntimeClasspath() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcProjectConfigurationAction.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcProjectConfigurationAction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization.buildsrc;
+
+import org.gradle.api.Action;
+import org.gradle.api.internal.project.ProjectInternal;
+
+/**
+ * Can be implemented by plugins to auto-configure the buildSrc root project.
+ *
+ * <p>Implementations are discovered using the JAR service locator mechanism (see {@link org.gradle.internal.service.ServiceLocator}).
+ * Each action is invoked for the buildSrc project that is to be configured, before the project has been configured. Actions are executed
+ * in an arbitrary order.
+ */
+public interface BuildSrcProjectConfigurationAction extends Action<ProjectInternal> {
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -118,6 +118,7 @@ import org.gradle.initialization.SettingsProcessor;
 import org.gradle.initialization.StackTraceSanitizingExceptionAnalyser;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.initialization.buildsrc.BuildSrcBuildListenerFactory;
+import org.gradle.initialization.buildsrc.BuildSrcProjectConfigurationAction;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.actor.internal.DefaultActorFactory;
@@ -218,7 +219,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
 
     protected ProjectEvaluator createProjectEvaluator(BuildOperationExecutor buildOperationExecutor, CachingServiceLocator cachingServiceLocator, ScriptPluginFactory scriptPluginFactory) {
         ConfigureActionsProjectEvaluator withActionsEvaluator = new ConfigureActionsProjectEvaluator(
-            new PluginsProjectConfigureActions(cachingServiceLocator),
+            PluginsProjectConfigureActions.from(cachingServiceLocator),
             new BuildScriptProcessor(scriptPluginFactory),
             new DelayedConfigurationActions()
         );
@@ -297,7 +298,8 @@ public class BuildScopeServices extends DefaultServiceRegistry {
     protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, NestedBuildFactory nestedBuildFactory,
                                                                 ClassLoaderScopeRegistry classLoaderScopeRegistry, CacheRepository cacheRepository,
                                                                 BuildLoader buildLoader, BuildOperationExecutor buildOperationExecutor,
-                                                                ServiceRegistry serviceRegistry, CachedClasspathTransformer cachedClasspathTransformer) {
+                                                                ServiceRegistry serviceRegistry, CachedClasspathTransformer cachedClasspathTransformer,
+                                                                CachingServiceLocator cachingServiceLocator) {
         return new DefaultSettingsLoaderFactory(
             new DefaultSettingsFinder(new BuildLayoutFactory()),
             settingsProcessor,
@@ -307,7 +309,10 @@ public class BuildScopeServices extends DefaultServiceRegistry {
                 cacheRepository,
                 buildOperationExecutor,
                 cachedClasspathTransformer,
-                new BuildSrcBuildListenerFactory()),
+                new BuildSrcBuildListenerFactory(
+                    PluginsProjectConfigureActions.of(
+                        BuildSrcProjectConfigurationAction.class,
+                        cachingServiceLocator))),
             buildLoader,
             serviceRegistry
         );

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/project/PluginsProjectConfigureActionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/project/PluginsProjectConfigureActionsTest.groovy
@@ -23,7 +23,7 @@ class PluginsProjectConfigureActionsTest extends Specification {
     final def pluginsClassLoader = Mock(ClassLoader)
 
     private PluginsProjectConfigureActions createActions() {
-        new PluginsProjectConfigureActions(new DefaultServiceLocator(pluginsClassLoader))
+        PluginsProjectConfigureActions.from(new DefaultServiceLocator(pluginsClassLoader))
     }
 
     def "executes all implicit configuration actions"() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactoryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.initialization.buildsrc
 
 import org.gradle.StartParameter
+import org.gradle.api.Action
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.component.BuildableJavaComponent
 import org.gradle.api.internal.component.ComponentRegistry
@@ -61,5 +62,16 @@ class BuildSrcBuildListenerFactoryTest extends Specification {
 
         then:
         1 * startParameter.setTaskNames(['barBuild'])
+    }
+
+    def "executes buildSrc configuration action after projects are loaded"() {
+        def action = Mock(Action)
+        def listener = new BuildSrcBuildListenerFactory(action).create(true)
+
+        when:
+        listener.projectsLoaded(gradle)
+
+        then:
+        1 * action.execute(project)
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/initialization/buildsrc/GroovyBuildSrcProjectConfigurationAction.java
+++ b/subprojects/plugins/src/main/java/org/gradle/initialization/buildsrc/GroovyBuildSrcProjectConfigurationAction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization.buildsrc;
+
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.plugins.GroovyPlugin;
+
+public class GroovyBuildSrcProjectConfigurationAction implements BuildSrcProjectConfigurationAction {
+
+    @Override
+    public void execute(ProjectInternal project) {
+        project.getPluginManager().apply(GroovyPlugin.class);
+
+        DependencyHandler dependencies = project.getDependencies();
+        dependencies.add("compile", dependencies.gradleApi());
+        dependencies.add("compile", dependencies.localGroovy());
+    }
+}

--- a/subprojects/plugins/src/main/resources/META-INF/services/org.gradle.initialization.buildsrc.BuildSrcProjectConfigurationAction
+++ b/subprojects/plugins/src/main/resources/META-INF/services/org.gradle.initialization.buildsrc.BuildSrcProjectConfigurationAction
@@ -1,0 +1,1 @@
+org.gradle.initialization.buildsrc.GroovyBuildSrcProjectConfigurationAction


### PR DESCRIPTION
This new extension point allows any module in the classpath to
contribute configuration actions targeting specifically at the `buildSrc`
root project.

The motivating use-case is allowing gradle-script-kotlin to contribute
tasks and source-sets to the `buildSrc` project without introducing
a hard-coded dependency (see gradle/gradle-script-kotlin#230).

As a bonus, the Groovy buildSrc configuration was extracted to its own
configuration action class and moved closer to `GroovyPlugin` so it
could be applied by type instead of id.