### PR TITLE
Trigger factory action execution asynchronously

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/DefaultExecutorFactoryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/DefaultExecutorFactoryTest.groovy
@@ -122,15 +122,20 @@ class DefaultExecutorFactoryTest extends ConcurrentSpec {
     }
 
     def stopThrowsExceptionOnTimeout() {
+        def timeoutMs = 100
         def action = {
             thread.block()
         }
 
         when:
         def executor = factory.create('<display-name>')
-        executor.execute(action)
+
+        async {
+            executor.execute(action)
+        }
+
         operation.stop {
-            executor.stop(200, TimeUnit.MILLISECONDS)
+            executor.stop(timeoutMs, TimeUnit.MILLISECONDS)
         }
 
         then:
@@ -138,7 +143,7 @@ class DefaultExecutorFactoryTest extends ConcurrentSpec {
         e.message == 'Timeout waiting for concurrent jobs to complete.'
 
         and:
-        operation.stop.duration in approx(200)
+        operation.stop.duration in approx(timeoutMs)
     }
 
     def stopRethrowsFirstExecutionException() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/DefaultExecutorFactoryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/DefaultExecutorFactoryTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.concurrent
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class DefaultExecutorFactoryTest extends ConcurrentSpec {
@@ -123,16 +124,15 @@ class DefaultExecutorFactoryTest extends ConcurrentSpec {
 
     def stopThrowsExceptionOnTimeout() {
         def timeoutMs = 100
+        def latch = new CountDownLatch(1)
+
         def action = {
-            thread.block()
+            latch.await()
         }
 
         when:
         def executor = factory.create('<display-name>')
-
-        async {
-            executor.execute(action)
-        }
+        executor.execute(action)
 
         operation.stop {
             executor.stop(timeoutMs, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
Fix for flaky test `DefaultExecutorFactoryTest.stopThrowsExceptionOnTimeout`: 

https://builds.gradle.org/viewLog.html?buildId=2190377&buildTypeId=Gradle_Master_CommitPhase_WindowsCommit_WindowsCommitJava17_4WindowsCommitJava17