### PR TITLE
Allow single quote characters in javadoc task options.

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Issue
+import spock.lang.Unroll
 
 class JavadocIntegrationTest extends AbstractIntegrationSpec {
     @Rule TestResources testResources = new TestResources(temporaryFolder)
@@ -62,10 +63,12 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("gradle/gradle#1090")
-    def "escape single quotes in doubled quoted string"() {
+    @Unroll
+    def "escape single quote in options enclosed with #quote"() {
+        given:
         buildFile << """
             apply plugin: "java"
-            javadoc.options.header = "'double quoted' \' \\\'"
+            javadoc.options.header = $optionIn
         """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
@@ -74,55 +77,14 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
         succeeds 'javadoc'
 
         then:
-        file("build/docs/javadoc/Foo.html").text.contains("""'double quoted' ' '""")
-    }
+        file("build/docs/javadoc/Foo.html").text.contains(optionOut)
 
-    @Issue("gradle/gradle#1090")
-    def "escape single quotes triple quoted string"() {
-        buildFile << """
-            apply plugin: "java"
-            javadoc.options.header = \"\"\""'triple quoted' \' \\\'\"\"\"
-        """
-
-        file("src/main/java/Foo.java") << "public class Foo {}"
-
-        when:
-        succeeds 'javadoc'
-
-        then:
-        file("build/docs/javadoc/Foo.html").text.contains("""'triple quoted' ' '""")
-    }
-
-    @Issue("gradle/gradle#1090")
-    def "escape single quotes in single quoted string"() {
-        buildFile << """
-            apply plugin: "java"
-            javadoc.options.header = '\\\'single quoted\\\''
-        """
-
-        file("src/main/java/Foo.java") << "public class Foo {}"
-
-        when:
-        succeeds 'javadoc'
-
-        then:
-        file("build/docs/javadoc/Foo.html").text.contains("""'single quoted'""")
-    }
-
-    @Issue("gradle/gradle#1090")
-    def "escape single quotes in slashed string"() {
-        buildFile << """
-            apply plugin: "java"
-            javadoc.options.header = /'slash quoted' \'/
-        """
-
-        file("src/main/java/Foo.java") << "public class Foo {}"
-
-        when:
-        succeeds 'javadoc'
-
-        then:
-        file("build/docs/javadoc/Foo.html").text.contains("""'slash quoted' '""")
+        where:
+        quote    | optionIn                                   | optionOut
+        "\'"     | """'\\\'single quoted\\\''"""              | """'single quoted'"""
+        "\""     | """\"'double quoted' \' \\\'\""""          | """'double quoted' ' '"""
+        "\"\"\"" | """\"\"\""'triple quoted' \' \\\'\"\"\"""" | """'triple quoted' ' '"""
+        "/"      |"""/'slash quoted' \'/"""                   | """'slash quoted' '"""
     }
 
     def "can configure options with an Action"() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -64,11 +64,11 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("gradle/gradle#1090")
     @Unroll
-    def "escape single quote in options enclosed with #quote"() {
+    def "allow single quote characters in options when string delimited with #delimiter"() {
         given:
         buildFile << """
             apply plugin: "java"
-            javadoc.options.header = $optionIn
+            javadoc.options.header = ${delimiter}${header}${delimiter}
         """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
@@ -77,14 +77,13 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
         succeeds 'javadoc'
 
         then:
-        file("build/docs/javadoc/Foo.html").text.contains(optionOut)
+        file("build/docs/javadoc/Foo.html").text.contains('"\'header\'"')
 
         where:
-        quote    | optionIn                                   | optionOut
-        "\'"     | """'\\\'single quoted\\\''"""              | """'single quoted'"""
-        "\""     | """\"'double quoted' \' \\\'\""""          | """'double quoted' ' '"""
-        "\"\"\"" | """\"\"\""'triple quoted' \' \\\'\"\"\"""" | """'triple quoted' ' '"""
-        "/"      |"""/'slash quoted' \'/"""                   | """'slash quoted' '"""
+        delimiter | header
+        "'"       | /"\'header\'"/
+        '"'       | /\"'header'\"/
+        "/"       | /"'header'"/
     }
 
     def "can configure options with an Action"() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -61,6 +61,20 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
         file("build/docs/javadoc/Foo.html").text.contains("""Hey Joe!""")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/1090")
+    def "escape single quotes in javadoc options"() {
+        buildFile << """
+            apply plugin: "java"
+            javadoc.options.header = "where you goin' with that gun in your hand"
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when: run("javadoc", "-i")
+        then:
+        file("build/docs/javadoc/Foo.html").text.contains("""where you goin' with that gun in your hand""")
+    }
+
     def "can configure options with an Action"() {
         given:
         buildFile << '''

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -63,12 +63,10 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("gradle/gradle#1090")
-    @Unroll
-    def "allow single quote characters in options when string delimited with #delimiter"() {
-        given:
+    def "allow single quote characters in options"() {
         buildFile << """
             apply plugin: "java"
-            javadoc.options.header = ${delimiter}${header}${delimiter}
+            javadoc.options.header = "\\"'header text'\\""
         """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
@@ -77,13 +75,7 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
         succeeds 'javadoc'
 
         then:
-        file("build/docs/javadoc/Foo.html").text.contains('"\'header\'"')
-
-        where:
-        delimiter | header
-        "'"       | /"\'header\'"/
-        '"'       | /\"'header'\"/
-        "/"       | /"'header'"/
+        file("build/docs/javadoc/Foo.html").text.contains("\"'header text'\"")
     }
 
     def "can configure options with an Action"() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -61,18 +61,68 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
         file("build/docs/javadoc/Foo.html").text.contains("""Hey Joe!""")
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/1090")
-    def "escape single quotes in javadoc options"() {
+    @Issue("gradle/gradle#1090")
+    def "escape single quotes in doubled quoted string"() {
         buildFile << """
             apply plugin: "java"
-            javadoc.options.header = "where you goin' with that gun in your hand"
+            javadoc.options.header = "'double quoted' \' \\\'"
         """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
 
-        when: run("javadoc", "-i")
+        when:
+        succeeds 'javadoc'
+
         then:
-        file("build/docs/javadoc/Foo.html").text.contains("""where you goin' with that gun in your hand""")
+        file("build/docs/javadoc/Foo.html").text.contains("""'double quoted' ' '""")
+    }
+
+    @Issue("gradle/gradle#1090")
+    def "escape single quotes triple quoted string"() {
+        buildFile << """
+            apply plugin: "java"
+            javadoc.options.header = \"\"\""'triple quoted' \' \\\'\"\"\"
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when:
+        succeeds 'javadoc'
+
+        then:
+        file("build/docs/javadoc/Foo.html").text.contains("""'triple quoted' ' '""")
+    }
+
+    @Issue("gradle/gradle#1090")
+    def "escape single quotes in single quoted string"() {
+        buildFile << """
+            apply plugin: "java"
+            javadoc.options.header = '\\\'single quoted\\\''
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when:
+        succeeds 'javadoc'
+
+        then:
+        file("build/docs/javadoc/Foo.html").text.contains("""'single quoted'""")
+    }
+
+    @Issue("gradle/gradle#1090")
+    def "escape single quotes in slashed string"() {
+        buildFile << """
+            apply plugin: "java"
+            javadoc.options.header = /'slash quoted' \'/
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when:
+        succeeds 'javadoc'
+
+        then:
+        file("build/docs/javadoc/Foo.html").text.contains("""'slash quoted' '""")
     }
 
     def "can configure options with an Action"() {

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFileWriterContext.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFileWriterContext.java
@@ -69,7 +69,8 @@ public class JavadocOptionFileWriterContext {
                 //below does not help on windows environments. I was unable to get plain javadoc utility to work successfully with multiline options _in_ the options file.
                 //at least, it will work out of the box on linux or mac environments.
                 //on windows, the options file will have correct contents according to the javadoc spec but it may not work (the failure will be exactly the same as if we didn't replace line breaks)
-                .replaceAll(SystemProperties.getInstance().getLineSeparator(), "\\\\" + SystemProperties.getInstance().getLineSeparator()));
+                .replaceAll(SystemProperties.getInstance().getLineSeparator(), "\\\\" + SystemProperties.getInstance().getLineSeparator())
+                .replace("\'", "\\'"));
         write("\'");
         return this;
     }


### PR DESCRIPTION
Fix and test for the following issue.

gradle/gradle#1090

Any of the checked boxes below indicate that I took action:

- [x ] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

The report from languageJava:integtest shows the new test passing successfully. 

I tried to make sure the fix doesn't break an existing workaround by trying many combinations of backslashes and delimiters (single, double, triple quoted & slashy strings), all variations failed to build. 