### PR TITLE
Wait for `strip` to finish before proceeding

### DIFF
--- a/subprojects/docs/src/samples/native-binaries/cpp-exe/build.gradle
+++ b/subprojects/docs/src/samples/native-binaries/cpp-exe/build.gradle
@@ -20,7 +20,7 @@ model {
                 dependsOn binary.tasks.link
                 doFirst {
                     if (binary.toolChain in Gcc) {
-                        ["strip", binary.tasks.link.outputFile].execute().waitForOrKill(1000);
+                        ["strip", binary.tasks.link.outputFile].execute().waitForOrKill(1000)
                     }
                 }
             }

--- a/subprojects/docs/src/samples/native-binaries/cpp-exe/build.gradle
+++ b/subprojects/docs/src/samples/native-binaries/cpp-exe/build.gradle
@@ -20,7 +20,7 @@ model {
                 dependsOn binary.tasks.link
                 doFirst {
                     if (binary.toolChain in Gcc) {
-                        ["strip", binary.tasks.link.outputFile].execute().waitFor()
+                        ["strip", binary.tasks.link.outputFile].execute().waitForOrKill(1000);
                     }
                 }
             }

--- a/subprojects/docs/src/samples/native-binaries/cpp-exe/build.gradle
+++ b/subprojects/docs/src/samples/native-binaries/cpp-exe/build.gradle
@@ -20,7 +20,7 @@ model {
                 dependsOn binary.tasks.link
                 doFirst {
                     if (binary.toolChain in Gcc) {
-                        ["strip", binary.tasks.link.outputFile].execute()
+                        ["strip", binary.tasks.link.outputFile].execute().waitFor()
                     }
                 }
             }


### PR DESCRIPTION
It seems there is a small chance where the `strip` process is launch
and, while we are proceeding to the `installMainExecutable` task, the
`strip` process replace the current executable by removing it first then
writing the new one. If we try to open the executable file on the after
`strip` removed the file we would get a `FileNotFoundException` or
similar. Waiting for the `strip` process to finish is the best way to
avoid this kind of errors.