### PR TITLE
Change memory leak soak test to leak a little slower

### DIFF
--- a/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringSoakTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.launcher.daemon.server.health.GcThrashingDaemonExpirationStrat
 import org.gradle.soak.categories.SoakTest
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.junit.experimental.categories.Category
+import spock.lang.Unroll
 
 import static org.junit.Assume.assumeTrue
 
@@ -53,7 +54,8 @@ class DaemonPerformanceMonitoringSoakTest extends DaemonMultiJdkIntegrationTest 
         )
     }
 
-    def "when build leaks slowly daemon is eventually expired"() {
+    @Unroll
+    def "when build leaks slowly daemon is eventually expired (heap: #heap)"() {
         when:
         setupBuildScript = tenuredHeapLeak
         maxBuilds = builds
@@ -65,7 +67,7 @@ class DaemonPerformanceMonitoringSoakTest extends DaemonMultiJdkIntegrationTest 
 
         where:
         builds | heap    | rate
-        40     | "200m"  | 800
+        45     | "200m"  | 600
         40     | "1024m" | 4000
     }
 


### PR DESCRIPTION
For the small heap scenario in `DaemonPerformanceMonitoringSoakTest`, we would occasionally come in just under the threshold for the low jvm daemon expiration check and then the next build would push the jvm over the edge and we would get a GC overhead limit exceeded error.  The daemon expiration would still trigger and the daemon would be stopped, but the error during the build was causing the test to fail.   This change causes us to leak a little more slowly when we are using the small heap scenario to avoid the error.  