### PR TITLE
Deprecate CompileOptions.dependOptions

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -262,14 +262,18 @@ public class CompileOptions extends AbstractOptions {
      * Returns options for using the Ant {@code <depend>} task.
      */
     @Nested
+    @Deprecated
     public DependOptions getDependOptions() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("CompileOptions.getDependOptions()");
         return dependOptions;
     }
 
     /**
      * Sets options for using the Ant {@code <depend>} task.
      */
+    @Deprecated
     public void setDependOptions(DependOptions dependOptions) {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("CompileOptions.setDependOptions()");
         this.dependOptions = dependOptions;
     }
 


### PR DESCRIPTION
As in version 3.3 Ant depend related stuff in compile options were deprecated, I guess dependOptions should also be deprecated and just was overlooked.
So this PR adds the deprecation annotation and nag screen for dependOptions.