### PR TITLE
Allow log level for WARN and above to be specified via CLI

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
@@ -241,6 +241,12 @@ public class DefaultCommandLineConverterTest extends CommandLineConverterTestSup
     }
 
     @Test
+    public void withWarnLoggingOptions() {
+        expectedLogLevel = LogLevel.WARN;
+        checkConversion("-w");
+    }
+
+    @Test
     public void withNoColor() {
         expectedConsoleOutput = ConsoleOutput.Plain;
         checkConversion("--console", "plain");

--- a/subprojects/docs/src/docs/userguide/commandLine.xml
+++ b/subprojects/docs/src/docs/userguide/commandLine.xml
@@ -321,6 +321,14 @@
             </listitem>
         </varlistentry>
         <varlistentry>
+            <term>
+                <option>-w</option>, <option>--warn</option>
+            </term>
+            <listitem>
+                <para>Set log level to warn. See <xref linkend="logging"/></para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
             <term><option>-x</option>, <option>--exclude-task</option>
             </term>
             <listitem>

--- a/subprojects/docs/src/docs/userguide/logging.xml
+++ b/subprojects/docs/src/docs/userguide/logging.xml
@@ -80,6 +80,12 @@
             </tr>
             <tr>
                 <td>
+                    <literal>-w</literal> or <literal>--warn</literal>
+                </td>
+                <td>WARN and higher</td>
+            </tr>
+            <tr>
+                <td>
                     <literal>-i</literal> or <literal>--info</literal>
                 </td>
                 <td>INFO and higher</td>

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -50,7 +50,7 @@ public class DaemonGradleExecuter extends ForkingGradleExecuter {
     protected List<String> getAllArgs() {
         List<String> args = new ArrayList<String>(super.getAllArgs());
         if(!isQuiet() && isAllowExtraLogging()) {
-            if (!containsAny(args, asList("-i", "--info", "-d", "--debug", "-q", "--quiet"))) {
+            if (!containsAny(args, asList("-i", "--info", "-d", "--debug", "-w", "--warn", "-q", "--quiet"))) {
                 args.add(0, "-i");
             }
         }

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
@@ -36,6 +36,7 @@ class BuildLogLevelMixInTest extends Specification {
         args                     | logLevel
         ['-i']                   | LogLevel.INFO
         ['-q']                   | LogLevel.QUIET
+        ['-w']                   | LogLevel.WARN
         ['foo', '--info', 'bar'] | LogLevel.INFO
         ['-i', 'foo', 'bar']     | LogLevel.INFO
         ['foo', 'bar', '-i']     | LogLevel.INFO

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/JavaUtilLoggingSystemIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/JavaUtilLoggingSystemIntegrationTest.groovy
@@ -62,6 +62,32 @@ class JavaUtilLoggingSystemIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @NotYetImplemented
+    def 'JUL logger.isLoggable corresponds to gradle log level for --warn'() {
+        given:
+        buildFile << """
+            task isLoggable() {
+                doLast {
+                    def logger = Logger.getLogger('some-logger')
+
+                    assert logger.isLoggable(Level.SEVERE)
+                    assert logger.isLoggable(Level.WARNING)
+                    assert !logger.isLoggable(Level.INFO)
+                    assert !logger.isLoggable(Level.CONFIG)
+                    assert !logger.isLoggable(Level.FINE)
+                    assert !logger.isLoggable(Level.FINER)
+                    assert !logger.isLoggable(Level.FINEST)
+                }
+            }
+        """
+
+        when:
+        executer.withArgument("--warn")
+
+        then:
+        succeeds('isLoggable')
+    }
+
+    @NotYetImplemented
     def 'JUL logger.isLoggable corresponds to gradle log level for --info'() {
         given:
         buildFile << """

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
@@ -18,22 +18,27 @@ package org.gradle.internal.logging;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.configuration.ConsoleOutput;
+import org.gradle.api.logging.configuration.LoggingConfiguration;
+import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.cli.AbstractCommandLineConverter;
 import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
-import org.gradle.api.logging.configuration.ConsoleOutput;
-import org.gradle.api.logging.configuration.LoggingConfiguration;
-import org.gradle.api.logging.configuration.ShowStacktrace;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 public class LoggingCommandLineConverter extends AbstractCommandLineConverter<LoggingConfiguration> {
     public static final String DEBUG = "d";
     public static final String DEBUG_LONG = "debug";
+    public static final String WARN = "w";
+    public static final String WARN_LONG = "warn";
     public static final String INFO = "i";
     public static final String INFO_LONG = "info";
     public static final String QUIET = "q";
@@ -48,6 +53,7 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
 
     public LoggingCommandLineConverter() {
         logLevelMap.put(QUIET, LogLevel.QUIET);
+        logLevelMap.put(WARN, LogLevel.WARN);
         logLevelMap.put(INFO, LogLevel.INFO);
         logLevelMap.put(DEBUG, LogLevel.DEBUG);
         showStacktraceMap.put(FULL_STACKTRACE, ShowStacktrace.ALWAYS_FULL);
@@ -85,7 +91,8 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
         parser.option(DEBUG, DEBUG_LONG).hasDescription("Log in debug mode (includes normal stacktrace).");
         parser.option(QUIET, QUIET_LONG).hasDescription("Log errors only.");
         parser.option(INFO, INFO_LONG).hasDescription("Set log level to info.");
-        parser.allowOneOf(DEBUG, QUIET, INFO);
+        parser.option(WARN, WARN_LONG).hasDescription("Set log level to warn.");
+        parser.allowOneOf(DEBUG, QUIET, INFO, WARN);
 
         parser.option(CONSOLE).hasArgument().hasDescription("Specifies which type of console output to generate. Values are 'plain', 'auto' (default) or 'rich'.");
 
@@ -130,7 +137,7 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
      * @return a collection of available log levels
      */
     public Set<LogLevel> getLogLevels() {
-        return new HashSet<LogLevel>(Arrays.asList(LogLevel.DEBUG, LogLevel.INFO, LogLevel.LIFECYCLE, LogLevel.QUIET));
+        return new HashSet<LogLevel>(Arrays.asList(LogLevel.DEBUG, LogLevel.INFO, LogLevel.LIFECYCLE, LogLevel.QUIET, LogLevel.WARN));
     }
 
     /**

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
@@ -55,6 +55,14 @@ class LoggingCommandLineConverterTest extends Specification {
         checkConversion(['--quiet'])
     }
 
+    def convertsWarnLevel() {
+         expectedConfig.logLevel = LogLevel.WARN
+
+         expect:
+         checkConversion(['-w'])
+         checkConversion(['--warn'])
+     }
+
     def convertsConsole() {
         expectedConfig.consoleOutput = consoleOutput
 
@@ -104,8 +112,8 @@ class LoggingCommandLineConverterTest extends Specification {
 
     def providesLogLevelOptions() {
         expect:
-        converter.logLevelOptions == ["d", "q", "i"] as Set
-        converter.logLevels == [LogLevel.DEBUG, LogLevel.INFO, LogLevel.LIFECYCLE, LogLevel.QUIET] as Set
+        converter.logLevelOptions == ['d', 'q', 'i', 'w'] as Set
+        converter.logLevels == [LogLevel.DEBUG, LogLevel.INFO, LogLevel.LIFECYCLE, LogLevel.QUIET, LogLevel.WARN] as Set
     }
 
     void checkConversion(List<String> args) {


### PR DESCRIPTION
This introduces the --warn and -w command line parameters
that set log level to WARN.

Issue: #935

