### PR TITLE
Fix worker action deserialization race condition

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
@@ -191,7 +191,7 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
 
     def handlesWorkerActionThatCannotBeDeserialized() {
         when:
-        execute(worker(new NotDeserializable()).expectStopFailure())
+        execute(worker(new NotDeserializable()).expectStartFailure())
 
         then:
         noExceptionThrown()

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcess.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcess.java
@@ -86,11 +86,19 @@ public class DefaultWorkerProcess implements WorkerProcess {
     }
 
     public void onConnect(ObjectConnection connection) {
-        AsyncStoppable stoppable;
+        onConnect(connection, null);
+    }
 
+    public void onConnect(ObjectConnection connection, Runnable connectionHandler) {
+        AsyncStoppable stoppable;
         lock.lock();
         try {
             LOGGER.debug("Received connection {} from {}", connection, execHandle);
+            
+            if (connectionHandler != null && running) {
+                connectionHandler.run();
+            }
+
             this.connection = connection;
             condition.signalAll();
             stoppable = acceptor;

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcess.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcess.java
@@ -173,11 +173,12 @@ public class DefaultWorkerProcess implements WorkerProcess {
                     throw UncheckedException.throwAsUncheckedException(e);
                 }
             }
-            if (processFailure != null) {
-                throw UncheckedException.throwAsUncheckedException(processFailure);
-            }
             if (connection == null) {
-                throw new ExecException(format("Never received a connection from %s.", execHandle));
+                if (processFailure != null) {
+                    throw UncheckedException.throwAsUncheckedException(processFailure);
+                } else {
+                    throw new ExecException(format("Never received a connection from %s.", execHandle));
+                }
             }
         } finally {
             lock.unlock();


### PR DESCRIPTION
This fixes a race condition where errors when deserializing the worker action could show up during either `WorkerProcess.start()` or `WorkerProcess.waitForStop()`.  They will now always show up during `start()`.