### PR TITLE
Eclipse resource filters (code review changes)

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectIntegrationTest.groovy
@@ -572,6 +572,29 @@ eclipse {
         project.assertHasResourceFilterXml(resourceFilterXml)
     }
 
+    void "resource filter matcher id is required"() {
+        given:
+        buildScript """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+eclipse {
+  project {
+    resourceFilter {
+      matcher {
+        arguments = 'foobar'
+      }
+    }
+  }
+}
+        """
+        when:
+        fails "eclipse"
+
+        then:
+        failure.assertHasCause("id must not be null")
+    }
+
     void enablesBeforeAndWhenHooksForProject() {
         given:
         def projectFile = file('.project')

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseProject.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseProject.java
@@ -19,10 +19,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import groovy.lang.Closure;
-import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 
 import java.util.Arrays;
@@ -315,17 +313,6 @@ public class EclipseProject {
             throw new InvalidUserDataException("resourceFilters must not be null");
         }
         this.resourceFilters = resourceFilters;
-    }
-
-    /**
-     * Adds a resource filter to the eclipse project.
-     * <p>
-     * For examples, see docs for {@link ResourceFilter}
-     *
-     * @param configureClosure The closure to use to configure the resource filter.
-     */
-    public ResourceFilter resourceFilter(@DelegatesTo(value=ResourceFilter.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
-        return resourceFilter(new ClosureBackedAction<ResourceFilter>(configureClosure));
     }
 
     /**

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilter.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilter.java
@@ -16,11 +16,8 @@
 package org.gradle.plugins.ide.eclipse.model;
 
 import com.google.common.base.Objects;
-import groovy.lang.Closure;
-import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.internal.ClosureBackedAction;
 
 /**
  * The gradle DSL model of an Eclipse resource filter.
@@ -132,15 +129,6 @@ public final class ResourceFilter {
      */
     public void setMatcher(ResourceFilterMatcher matcher) {
         this.matcher = matcher;
-    }
-
-    /**
-     * Configures the matcher of this resource filter.  Will create the matcher if it does not yet exist, or configure the existing matcher if it already exists.
-     *
-     * @param configureClosure The closure to use to configure the matcher.
-     */
-    public ResourceFilterMatcher matcher(@DelegatesTo(value=ResourceFilterMatcher.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
-        return matcher(new ClosureBackedAction<ResourceFilterMatcher>(configureClosure));
     }
 
     /**

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcher.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcher.java
@@ -17,12 +17,9 @@ package org.gradle.plugins.ide.eclipse.model;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
-import groovy.lang.Closure;
-import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Nullable;
-import org.gradle.api.internal.ClosureBackedAction;
 
 import java.util.Set;
 
@@ -62,6 +59,9 @@ public final class ResourceFilterMatcher {
     }
 
     public void setId(String id) {
+        if (id == null) {
+            throw new InvalidUserDataException("id must not be null");
+        }
         this.id = id;
     }
 
@@ -84,15 +84,6 @@ public final class ResourceFilterMatcher {
         }
         this.children = children;
     }    
-
-    /**
-     * Adds a child/nested matcher to this matcher.
-     *
-     * @param configureClosure The closure to use to configure the matcher.
-     */
-    public ResourceFilterMatcher matcher(@DelegatesTo(value=ResourceFilterMatcher.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
-        return matcher(new ClosureBackedAction<ResourceFilterMatcher>(configureClosure));
-    }
 
     /**
      * Adds a child/nested matcher to this matcher.


### PR DESCRIPTION
This is a continuation of #846 to address review comments that were added after that PR merged.

* Newly-added closure-backed methods have been removed at the request of @big-guy
* Null check added to ResourceFilterMatcher.setId(...)

- [ ] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on my local linux machine via the command
`./gradlew quickCheck :ide:check`.