### PR TITLE
Fix SourceSet.compileClasspath default value documentation

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.SourceSet.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.SourceSet.xml
@@ -27,7 +27,7 @@
             </tr>
             <tr>
                 <td>compileClasspath</td>
-                <td><literal>project.configurations.compile</literal> (or <literal>project.configurations.testCompile</literal> for the <literal>test</literal> source set).</td>
+                <td><literal>project.configurations.compileClasspath</literal> (or <literal>project.configurations.testCompileClasspath</literal> for the <literal>test</literal> source set).</td>
             </tr>
             <tr>
                 <td>java</td>


### PR DESCRIPTION
All of 6b5be29da02b11eb7d40cca2d0e13a389a2f85c1, f1c664a7e22655072c3e8df453adace5739c5c45, and fb8dc31524b2dd6679738f9488bf8b4146165df2 forgot to update this file.

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`
