### PR TITLE
Add "unresolvable configurations" to the breaking changes section of the release notes of 3.4

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -266,6 +266,12 @@ When resolving the runtime classpath for Java applications, Gradle will now use 
 
 Tooling providers should try not to depend on configurations directly, but use `sourceSet.runtimeClasspath` where applicable. This always contains the correct classpath for the current Gradle version and has been changed to return the `runtimeClasspath` configuration in this release. If you are directly resolving the `runtime` configuration, your tool will not work with the `java-library` plugin.
 
+### Configurations can be unresolvable
+
+The concept of unresolvable configurations has been introduced. When trying to resolve an unresolvable configuration an `IllegalStateException` will be thrown. You can check whether a configuration is resolvable by calling `Configuration.isCanBeResolved()`.
+
+Though the concept has already been introduced with Gradle 3.3, the first release that comes with unresolvable configurations by default is Gradle 3.4. The Java plugin adds the following unresolvable configurations: ```"apiElements", "implementation", "runtimeElements", "runtimeOnly", "testImplementation", "testRuntimeOnly"```. The concept has been introduced in order to support variant aware dependency resolution.
+
 ## External contributions
 
 We would like to thank the following community members for making contributions to this release of Gradle.


### PR DESCRIPTION
… changes section of the Release Notes

See discussion in https://discuss.gradle.org/t/3-4-rc-1-3-3-resolving-configurations-may-be-disallowed-and-throw-illegalstateexception/21470

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [ ] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
