### PR TITLE
Lenient compile classpath snapshotting

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -555,5 +555,29 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         outputContains 'Malformed class file [foo.class] found on compile classpath'
     }
 
+    @Issue("gradle/gradle#1359")
+    def "compile classpath snapshotting should support unicode class names"() {
+        settingsFile << 'include "b"'
+        file("b/build.gradle") << '''
+            apply plugin: 'java'
+        '''
+        file("b/src/main/java/λ.java") << 'public class λ {}'
+
+        buildFile << '''
+            apply plugin: 'java'
+            
+            dependencies {
+               compile project(':b')
+            }
+        '''
+        file('src/main/java/Lambda.java') << 'public class Lambda extends λ {}'
+
+        when:
+        run 'compileJava'
+
+        then:
+        noExceptionThrown()
+        executedAndNotSkipped ':compileJava'
+    }
 
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -497,6 +497,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':compileJava'
+        outputContains 'Malformed jar [foo.jar] found on compile classpath'
 
     }
 
@@ -528,6 +529,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':fooJar', ':compileJava'
+        outputContains 'Malformed class file [foo.class] in jar'
     }
 
     @Issue("gradle/gradle#1358")
@@ -550,6 +552,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':compileJava'
+        outputContains 'Malformed class file [foo.class] found on compile classpath'
     }
 
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessorDetector.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessorDetector.java
@@ -20,7 +20,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import org.apache.tools.zip.ZipFile;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.cache.FileContentCache;
 import org.gradle.api.internal.cache.FileContentCacheFactory;
@@ -32,6 +31,8 @@ import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.nativeintegration.filesystem.FileType;
 import org.gradle.internal.serialize.BaseSerializerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Set;
 
 public class AnnotationProcessorDetector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationProcessorDetector.class);
     private final FileCollectionFactory fileCollectionFactory;
     private final FileContentCache<Boolean> cache;
 
@@ -113,7 +115,9 @@ public class AnnotationProcessorDetector {
                         zipFile.close();
                     }
                 } catch (IOException e) {
-                    throw new UncheckedIOException("Could not read service definition from JAR " + file, e);
+                    // Using a warning, not a deprecation message, because we already show a deprecation message during
+                    // compile classpath snapshotting, but we still want to warn
+                    LOGGER.warn("Could not read service definition from JAR " + file);
                 }
             }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessorDetector.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessorDetector.java
@@ -31,8 +31,7 @@ import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.nativeintegration.filesystem.FileType;
 import org.gradle.internal.serialize.BaseSerializerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,7 +41,6 @@ import java.util.List;
 import java.util.Set;
 
 public class AnnotationProcessorDetector {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationProcessorDetector.class);
     private final FileCollectionFactory fileCollectionFactory;
     private final FileContentCache<Boolean> cache;
 
@@ -115,9 +113,7 @@ public class AnnotationProcessorDetector {
                         zipFile.close();
                     }
                 } catch (IOException e) {
-                    // Using a warning, not a deprecation message, because we already show a deprecation message during
-                    // compile classpath snapshotting, but we still want to warn
-                    LOGGER.warn("Could not read service definition from JAR " + file);
+                    DeprecationLogger.nagUserWith("Malformed jar [" + file.getName() + "] found on compile classpath. Gradle 5.0 will no longer allow malformed jars on compile classpath.");
                 }
             }
 


### PR DESCRIPTION
Since the introduction of compile classpath snapshotting, and the improvements to annotation processor detection,
we're much stricter with regards to what we find on classpath. If a jar is broken (unreadable, or has wrong entries)
or that a class file is unreadable, we fail early and do not bother compiling. The justification for this is that
we want to make sure compile classpath snapshotting is valid: if for example a bug is introduced in ASM, that we use
for snapshotting, we want to make sure we realize this and not silently ignore errors and lead to wrong ABI signatures.

But the consequence for the user is too big: upgrading from Gradle 3.3 to Gradle 3.4 can make compile fail just because
of the presence of a broken Jar on classpath (even if it means, in practice, that the jar is probably a leaking dependency
not used in sources, otherwise javac would also fail), or a broken class on classpath (even if it means that Javac itself
would fail, so the class is unused). The reality is that there are many broken jars in the wild, apparently. So we
start with being more lenient, and tolerate them, but warn the user of the presence of a broken jar/class, and that we
will not support this in Gradle 5.0. This gives the opportunity to the user to either fix the jar, remove the leaking
dependency, or ask to the maintainers of the dependency to fix it.

