### PR TITLE
issue #899: Improve Deprecation Nagger

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core/src/main/java/org/gradle/StartParameter.java
@@ -124,6 +124,16 @@ public class StartParameter implements LoggingConfiguration, Serializable {
         loggingConfiguration.setShowStacktrace(showStacktrace);
     }
 
+    @Override
+    public boolean isDeprecation() {
+        return loggingConfiguration.isDeprecation();
+    }
+
+    @Override
+    public void setDeprecation(boolean deprecation) {
+        loggingConfiguration.setDeprecation(deprecation);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -220,6 +230,7 @@ public class StartParameter implements LoggingConfiguration, Serializable {
         p.setLogLevel(getLogLevel());
         p.setConsoleOutput(getConsoleOutput());
         p.setShowStacktrace(getShowStacktrace());
+        p.setDeprecation(isDeprecation());
         p.profile = profile;
         p.continueOnFailure = continueOnFailure;
         p.offline = offline;
@@ -724,6 +735,7 @@ public class StartParameter implements LoggingConfiguration, Serializable {
             + ", gradleHome=" + gradleHomeDir
             + ", logLevel=" + getLogLevel()
             + ", showStacktrace=" + getShowStacktrace()
+            + ", deprecation=" + isDeprecation()
             + ", buildFile=" + buildFile
             + ", initScripts=" + initScripts
             + ", dryRun=" + dryRun

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -175,6 +175,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             default:
                 LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(false);
         }
+        LoggingDeprecatedFeatureHandler.setDeprecation(startParameter.isDeprecation());
         DeprecationLogger.useLocationReporter(usageLocationReporter);
 
         SettingsLoaderFactory settingsLoaderFactory = serviceRegistry.get(SettingsLoaderFactory.class);

--- a/subprojects/docs/src/docs/userguide/commandLine.xml
+++ b/subprojects/docs/src/docs/userguide/commandLine.xml
@@ -103,6 +103,14 @@
             </listitem>
         </varlistentry>
         <varlistentry>
+            <term><option>--deprecation</option>
+            </term>
+            <listitem>
+                <para>Specifies whether all deprecation findings should be shown, otherwise only the first of each finding is displayed. See <xref linkend="logging"/>.
+                </para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
             <term><option>-g</option>, <option>--gradle-user-home</option>
             </term>
             <listitem>

--- a/subprojects/docs/src/docs/userguide/logging.xml
+++ b/subprojects/docs/src/docs/userguide/logging.xml
@@ -58,7 +58,8 @@
         <title>Choosing a log level</title>
         <para>You can use the command line switches shown in <xref linkend='logLevelCommandLineOptions'/> to choose
             different log levels. In <xref linkend='stacktraces'/> you find the command line switches which affect
-            stacktrace logging.
+            stacktrace logging. In <xref linkend='deprecation'/> you find the command line switches which affect
+            deprecation logging.
         </para>
         <table id='logLevelCommandLineOptions'>
             <title>Log level command-line options</title>
@@ -125,6 +126,25 @@
                 </td>
             </tr>
 
+        </table>
+        <table id='deprecation'>
+            <title>Deprecation command-line options</title>
+            <thead>
+                <tr>
+                    <td>Option</td>
+                    <td>Meaning</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>No deprecation option</td>
+                <td>Only the first occurrence of each concrete deprecation finding is displayed.</td>
+            </tr>
+            <tr>
+                <td>
+                    <literal>--deprecation</literal>
+                </td>
+                <td>All occurrences of each concrete deprecation finding are displayed.</td>
+            </tr>
         </table>
     </section>
     <section id="sec:sending_your_own_log_messages">

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -97,7 +97,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         output.count('The deprecated task has been deprecated') == 1
 
         and:
-        output.count('\tat') == 3
+        output.count('\tat') == 7
     }
 
     def 'DeprecatedPlugin and DeprecatedTask - with full stacktrace.'() {
@@ -181,7 +181,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 
         output.count(PLUGIN_DEPRECATION_MESSAGE) == 1
 
-        output.count('\tat') == 1
+        output.count('\tat') == 2
     }
 
     def 'DeprecatedPlugin from applied script - with full stacktrace.'() {

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
@@ -53,4 +53,14 @@ public interface LoggingConfiguration {
      * Sets the detail that should be included in stacktraces.
      */
     void setShowStacktrace(ShowStacktrace showStacktrace);
+
+    /**
+     * Returns whether all deprecation findings should be shown, otherwise only the first of each finding is displayed. Defaults to {@code false}.
+     */
+    boolean isDeprecation();
+
+    /**
+     * Sets whether all deprecation findings should be shown, otherwise only the first of each finding is displayed.
+     */
+    void setDeprecation(boolean deprecation);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -27,6 +27,8 @@ import java.util.Set;
 
 public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler {
     public static final String ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME = "org.gradle.deprecation.trace";
+    private static final String STACKTRACE_HINT = String.format("%sRun with --stacktrace option or system property '%s' set to 'true' to get the full stack trace.",
+        SystemProperties.getInstance().getLineSeparator(), ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingDeprecatedFeatureHandler.class);
     private static final String ELEMENT_PREFIX = "\tat ";
@@ -59,6 +61,10 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
             }
             message.append(usage.getMessage());
             logTraceIfNecessary(usage.getStack(), message);
+            if (!isTraceLoggingEnabled()) {
+                message.append(STACKTRACE_HINT);
+            }
+            message.append(SystemProperties.getInstance().getLineSeparator());
             LOGGER.warn(message.toString());
         }
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -29,10 +29,13 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
     public static final String ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME = "org.gradle.deprecation.trace";
     private static final String STACKTRACE_HINT = String.format("%sRun with --stacktrace option or system property '%s' set to 'true' to get the full stack trace.",
         SystemProperties.getInstance().getLineSeparator(), ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME);
+    private static final String DEPRECATION_HINT = String.format("%sRun with --deprecation option to get all deprecation findings instead of only the first of each.",
+        SystemProperties.getInstance().getLineSeparator());
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingDeprecatedFeatureHandler.class);
     private static final String ELEMENT_PREFIX = "\tat ";
     private static boolean traceLoggingEnabled;
+    private static boolean deprecation;
     private final Set<String> messages = new HashSet<String>();
     private UsageLocationReporter locationReporter;
 
@@ -52,7 +55,7 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
     }
 
     public void deprecatedFeatureUsed(DeprecatedFeatureUsage usage) {
-        if (messages.add(usage.getMessage())) {
+        if (isDeprecation() || messages.add(usage.getMessage())) {
             usage = usage.withStackTrace();
             StringBuilder message = new StringBuilder();
             locationReporter.reportLocation(usage, message);
@@ -63,6 +66,9 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
             logTraceIfNecessary(usage.getStack(), message);
             if (!isTraceLoggingEnabled()) {
                 message.append(STACKTRACE_HINT);
+            }
+            if (!isDeprecation()) {
+                message.append(DEPRECATION_HINT);
             }
             message.append(SystemProperties.getInstance().getLineSeparator());
             LOGGER.warn(message.toString());
@@ -147,4 +153,11 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
         return Boolean.parseBoolean(value);
     }
 
+    public static void setDeprecation(boolean deprecation) {
+        LoggingDeprecatedFeatureHandler.deprecation = deprecation;
+    }
+
+    static boolean isDeprecation() {
+        return deprecation;
+    }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -74,11 +74,18 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
             return;
         }
 
+        boolean nonSystemOrScriptElementFound = false;
         for (StackTraceElement element : stack) {
             if (isGradleScriptElement(element)) {
                 // only print first Gradle script stack trace element
                 appendStackTraceElement(element, message, lineSeparator);
                 return;
+            }
+
+            if (!nonSystemOrScriptElementFound && !isSystemElement(element)) {
+                // only print first Gradle script stack trace element
+                appendStackTraceElement(element, message, lineSeparator);
+                nonSystemOrScriptElementFound = true;
             }
         }
     }
@@ -101,6 +108,17 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
             return true;
         }
         return false;
+    }
+
+    private static boolean isSystemElement(StackTraceElement element) {
+        String className = element.getClassName();
+        return className.startsWith("org.codehaus.groovy.")
+            || className.startsWith("org.gradle.")
+            || className.startsWith("groovy.")
+            || className.startsWith("java.")
+            || className.startsWith("sun.")
+            || className.startsWith("com.sun.")
+            || className.startsWith("jdk.internal.");
     }
 
     /**

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
@@ -29,6 +29,7 @@ public class DefaultLoggingConfiguration implements Serializable, LoggingConfigu
     private LogLevel logLevel = LogLevel.LIFECYCLE;
     private ShowStacktrace showStacktrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private ConsoleOutput consoleOutput = ConsoleOutput.Auto;
+    private boolean deprecation;
 
     public boolean equals(Object obj) {
         return EqualsBuilder.reflectionEquals(this, obj);
@@ -68,5 +69,15 @@ public class DefaultLoggingConfiguration implements Serializable, LoggingConfigu
     @Override
     public void setShowStacktrace(ShowStacktrace showStacktrace) {
         this.showStacktrace = showStacktrace;
+    }
+
+    @Override
+    public boolean isDeprecation() {
+        return deprecation;
+    }
+
+    @Override
+    public void setDeprecation(boolean deprecation) {
+        this.deprecation = deprecation;
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
@@ -43,6 +43,7 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
     public static final String FULL_STACKTRACE_LONG = "full-stacktrace";
     public static final String STACKTRACE = "s";
     public static final String STACKTRACE_LONG = "stacktrace";
+    public static final String DEPRECATION = "deprecation";
     private final BiMap<String, LogLevel> logLevelMap = HashBiMap.create();
     private final BiMap<String, ShowStacktrace> showStacktraceMap = HashBiMap.create();
 
@@ -78,6 +79,10 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
             }
         }
 
+        if (commandLine.hasOption(DEPRECATION)) {
+            loggingConfiguration.setDeprecation(true);
+        }
+
         return loggingConfiguration;
     }
 
@@ -92,6 +97,8 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
         parser.option(STACKTRACE, STACKTRACE_LONG).hasDescription("Print out the stacktrace for all exceptions.");
         parser.option(FULL_STACKTRACE, FULL_STACKTRACE_LONG).hasDescription("Print out the full (very verbose) stacktrace for all exceptions.");
         parser.allowOneOf(STACKTRACE, FULL_STACKTRACE_LONG);
+
+        parser.option(DEPRECATION).hasDescription("Specifies whether all deprecation findings should be shown, otherwise only the first of each finding is displayed.");
     }
 
     /**

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -197,7 +197,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         and:
         def message = events[0].message
 
-        message == TextUtil.toPlatformLineSeparators("fake\n\tat some.ArbitraryClass.withSource(ArbitraryClass.java:42)$LoggingDeprecatedFeatureHandler.STACKTRACE_HINT\n")
+        message == TextUtil.toPlatformLineSeparators("fake\n\tat some.ArbitraryClass.withSource(ArbitraryClass.java:42)$LoggingDeprecatedFeatureHandler.STACKTRACE_HINT$LoggingDeprecatedFeatureHandler.DEPRECATION_HINT\n")
 
         where:
         fakeStackTrace = [
@@ -227,7 +227,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         and:
         def message = events[0].message
 
-        message == TextUtil.toPlatformLineSeparators("fake$LoggingDeprecatedFeatureHandler.STACKTRACE_HINT\n")
+        message == TextUtil.toPlatformLineSeparators("fake$LoggingDeprecatedFeatureHandler.STACKTRACE_HINT$LoggingDeprecatedFeatureHandler.DEPRECATION_HINT\n")
 
         where:
         fakeStackTrace = [
@@ -262,7 +262,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     }
 
     @Unroll
-    def 'fake call without stack trace elements and #deprecationTracePropertyName=#deprecationTraceProperty logs only message and stacktrace hint'() {
+    def 'fake call without stack trace elements and #deprecationTracePropertyName=#deprecationTraceProperty logs only message and hints'() {
         given:
         System.setProperty(deprecationTracePropertyName, '' + deprecationTraceProperty)
 
@@ -274,7 +274,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         events.size() == 1
 
         and:
-        events[0].message == TextUtil.toPlatformLineSeparators("fake${deprecationTraceProperty?'':LoggingDeprecatedFeatureHandler.STACKTRACE_HINT}\n")
+        events[0].message == TextUtil.toPlatformLineSeparators("fake${deprecationTraceProperty?'':LoggingDeprecatedFeatureHandler.STACKTRACE_HINT}$LoggingDeprecatedFeatureHandler.DEPRECATION_HINT\n")
 
         where:
         deprecationTraceProperty << [true, false]

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -47,8 +47,8 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         events.size() == 2
 
         and:
-        events[0].message == 'feature1'
-        events[1].message == 'feature2'
+        events[0].message.startsWith TextUtil.toPlatformLineSeparators('feature1\n')
+        events[1].message.startsWith TextUtil.toPlatformLineSeparators('feature2\n')
     }
 
     def 'deprecations are logged at WARN level'() {
@@ -60,7 +60,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
         and:
         def event = outputEventListener.events[0]
-        event.message == 'feature'
+        event.message.startsWith TextUtil.toPlatformLineSeparators('feature\n')
         event.logLevel == LogLevel.WARN
     }
 
@@ -103,7 +103,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     }
 
     @Unroll
-    def 'fake call with Gradle script element first and #deprecationTracePropertyName=false logs only Gradle script element'() {
+    def 'fake call with Gradle script element first and #deprecationTracePropertyName=false logs only Gradle script element and first non-system element before script element'() {
         given:
         System.setProperty(deprecationTracePropertyName, 'false')
 
@@ -119,6 +119,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
         message.startsWith(TextUtil.toPlatformLineSeparators('fake\n'))
         message.contains('some.GradleScript.foo')
+        message.contains('some.Class.withSource')
 
         !message.contains('SimulatedJavaCallLocation.create')
         !message.contains('java.lang.reflect.Method.invoke')
@@ -130,6 +131,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         fakeStackTrace = [
             new StackTraceElement('org.gradle.internal.featurelifecycle.SimulatedJavaCallLocation', 'create', 'SimulatedJavaCallLocation.java', 25),
             new StackTraceElement('java.lang.reflect.Method', 'invoke', 'Method.java', 498),
+            new StackTraceElement('some.Class', 'withSource', 'Class.groovy', 123),
             new StackTraceElement('some.Class', 'withoutSource', null, -1),
             new StackTraceElement('some.Class', 'withNativeMethod', null, -2),
             new StackTraceElement('some.GradleScript', 'foo', 'GradleScript.gradle', 1337),
@@ -141,7 +143,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     }
 
     @Unroll
-    def 'fake call with Gradle Kotlin script element first and #deprecationTracePropertyName=false logs only Gradle Kotlin script element'() {
+    def 'fake call with Gradle Kotlin script element first and #deprecationTracePropertyName=false logs only Gradle Kotlin script element and first non-system element before script element'() {
         given:
         System.setProperty(deprecationTracePropertyName, 'false')
 
@@ -157,6 +159,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
         message.startsWith(TextUtil.toPlatformLineSeparators('fake\n'))
         message.contains('some.KotlinGradleScript')
+        message.contains('some.Class.withSource')
 
         !message.contains('SimulatedJavaCallLocation.create')
         !message.contains('java.lang.reflect.Method.invoke')
@@ -168,6 +171,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         fakeStackTrace = [
             new StackTraceElement('org.gradle.internal.featurelifecycle.SimulatedJavaCallLocation', 'create', 'SimulatedJavaCallLocation.java', 25),
             new StackTraceElement('java.lang.reflect.Method', 'invoke', 'Method.java', 498),
+            new StackTraceElement('some.Class', 'withSource', 'Class.groovy', 123),
             new StackTraceElement('some.Class', 'withoutSource', null, -1),
             new StackTraceElement('some.Class', 'withNativeMethod', null, -2),
             new StackTraceElement('some.KotlinGradleScript', 'foo', 'GradleScript.gradle.kts', 31337),
@@ -179,7 +183,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     }
 
     @Unroll
-    def 'fake call without Gradle script elements and #deprecationTracePropertyName=false does not log a stack trace element.'() {
+    def 'fake call without Gradle script elements and #deprecationTracePropertyName=false logs only first non-system element'() {
         given:
         System.setProperty(deprecationTracePropertyName, 'false')
 
@@ -193,7 +197,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         and:
         def message = events[0].message
 
-        message == 'fake'
+        message == TextUtil.toPlatformLineSeparators('fake\n\tat some.ArbitraryClass.withSource(ArbitraryClass.java:42)')
 
         where:
         fakeStackTrace = [
@@ -209,7 +213,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     }
 
     @Unroll
-    def 'fake call with only a single stack trace element and #deprecationTracePropertyName=false does not log that element'() {
+    def 'fake call with only a single system stack trace element and #deprecationTracePropertyName=false does not log that element'() {
         given:
         System.setProperty(deprecationTracePropertyName, 'false')
 
@@ -227,7 +231,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
         where:
         fakeStackTrace = [
-            new StackTraceElement('some.ArbitraryClass', 'withSource', 'ArbitraryClass.java', 42),
+            new StackTraceElement('java.some.ArbitraryClass', 'withSource', 'ArbitraryClass.java', 42),
         ]
         deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
     }
@@ -289,7 +293,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         and:
         def events = outputEventListener.events
         events.size() == 1
-        events[0].message == TextUtil.toPlatformLineSeparators('location\nfeature')
+        events[0].message.startsWith TextUtil.toPlatformLineSeparators('location\nfeature\n')
     }
 
     @Unroll

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -197,7 +197,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         and:
         def message = events[0].message
 
-        message == TextUtil.toPlatformLineSeparators('fake\n\tat some.ArbitraryClass.withSource(ArbitraryClass.java:42)')
+        message == TextUtil.toPlatformLineSeparators("fake\n\tat some.ArbitraryClass.withSource(ArbitraryClass.java:42)$LoggingDeprecatedFeatureHandler.STACKTRACE_HINT\n")
 
         where:
         fakeStackTrace = [
@@ -227,7 +227,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         and:
         def message = events[0].message
 
-        message == 'fake'
+        message == TextUtil.toPlatformLineSeparators("fake$LoggingDeprecatedFeatureHandler.STACKTRACE_HINT\n")
 
         where:
         fakeStackTrace = [
@@ -262,7 +262,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     }
 
     @Unroll
-    def 'fake call without stack trace elements and #deprecationTracePropertyName=#deprecationTraceProperty logs only message'() {
+    def 'fake call without stack trace elements and #deprecationTracePropertyName=#deprecationTraceProperty logs only message and stacktrace hint'() {
         given:
         System.setProperty(deprecationTracePropertyName, '' + deprecationTraceProperty)
 
@@ -274,7 +274,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         events.size() == 1
 
         and:
-        events[0].message == 'fake'
+        events[0].message == TextUtil.toPlatformLineSeparators("fake${deprecationTraceProperty?'':LoggingDeprecatedFeatureHandler.STACKTRACE_HINT}\n")
 
         where:
         deprecationTraceProperty << [true, false]


### PR DESCRIPTION
To tackle the issues mentioned in issues #899 and #1269 I created this PR.

It

- outputs the first non-system stack frame before a script stack frame to see where the issue really comes from if from a 3rd party
- adds a hint to deprecation warnings to use --stacktrace to see the full stacktrace
- adds a --deprecation command line argument that makes Gradle output all occurrences of all deprecation findings instead of only the first occurrence of each finding

I've seen too late that there is PR #699 that might do some similar things according to @huxi, but as I already finished this work and it is a bit more lightweight change, I decided to submit the PR anyway and let you guys decide what you want to merge, if at all. :-)