### PR TITLE
Allow special handling of "release" in version comparator

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 class StaticVersionComparator implements Comparator<Version> {
     private static final Map<String, Integer> SPECIAL_MEANINGS =
-            ImmutableMap.of("dev", new Integer(-1), "rc", new Integer(1), "final", new Integer(2));
+            ImmutableMap.of("dev", -1, "rc", 1, "release", 2, "final", 3);
 
     /**
      * Compares 2 versions. Algorithm is inspired by PHP version_compare one.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
@@ -90,7 +90,7 @@ class DefaultVersionComparatorTest extends Specification {
         "a-b-c"     | "a.b"
     }
 
-    def "gives some special treatment to 'dev', 'rc', and 'final' qualifiers"() {
+    def "gives some special treatment to 'dev', 'rc', 'release', and 'final' qualifiers"() {
         expect:
         compare(smaller, larger) < 0
         compare(larger, smaller) > 0
@@ -98,17 +98,22 @@ class DefaultVersionComparatorTest extends Specification {
         compare(larger, larger) == 0
 
         where:
-        smaller     | larger
-        "1.0-dev-1" | "1.0"
-        "1.0-dev-1" | "1.0-dev-2"
-        "1.0-rc-1"  | "1.0"
-        "1.0-rc-1"  | "1.0-rc-2"
-        "1.0-dev-1" | "1.0-xx-1"
-        "1.0-xx-1"  | "1.0-rc-1"
-        "1.0-final" | "1.0"
-        "1.0-dev-1" | "1.0-rc-1"
-        "1.0-rc-1"  | "1.0-final"
-        "1.0-dev-1" | "1.0-final"
+        smaller       | larger
+        "1.0-dev-1"   | "1.0"
+        "1.0-dev-1"   | "1.0-dev-2"
+        "1.0-rc-1"    | "1.0"
+        "1.0-rc-1"    | "1.0-rc-2"
+        "1.0-rc-1"    | "1.0-release"
+        "1.0-dev-1"   | "1.0-xx-1"
+        "1.0-xx-1"    | "1.0-rc-1"
+        "1.0-release" | "1.0"
+        "1.0-final"   | "1.0"
+        "1.0-dev-1"   | "1.0-rc-1"
+        "1.0-rc-1"    | "1.0-final"
+        "1.0-dev-1"   | "1.0-final"
+        "1.0-release" | "1.0-final"
+        "1.0.0.RC1"   | "1.0.0.RC2"
+        "1.0.0.RC2"   | "1.0.0.RELEASE"
     }
 
     def "compares identical versions equal"() {


### PR DESCRIPTION
This adds "release" as a special term in the StaticVersionComparator
Release versions are considered higher than "dev" and "RC" and
"anythingelse", but smaller than "final".

Fixes #1378
