### PR TITLE
Improve fully qualified representation of nested model types

### DIFF
--- a/subprojects/dependency-management/dependency-management.gradle
+++ b/subprojects/dependency-management/dependency-management.gradle
@@ -43,6 +43,7 @@ dependencies {
 
 useTestFixtures()
 useTestFixtures(project: ":messaging")
+useTestFixtures(project: ":modelCore")
 
 verifyTestFilesCleanup.errorWhenNotEmpty = false
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/rules/RuleSourceBackedRuleActionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/rules/RuleSourceBackedRuleActionTest.groovy
@@ -22,6 +22,8 @@ import spock.lang.Specification
 
 import java.util.concurrent.atomic.AtomicReference
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class RuleSourceBackedRuleActionTest extends Specification {
     private ModelType<List<String>> listType = new ModelType<List<String>>() {}
     private action
@@ -92,7 +94,7 @@ class RuleSourceBackedRuleActionTest extends Specification {
 
         then:
         def e = thrown RuleActionValidationException
-        e.message.startsWith("Type ${ruleSource.class.name} is not a valid rule source:")
+        e.message.startsWith("Type ${fullyQualifiedNameOf(ruleSource.class)} is not a valid rule source:")
         def messageReasons = getReasons(e.message)
         messageReasons.size() == reasons.size()
         messageReasons.sort() == reasons.sort()

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleValidationIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleValidationIntegrationTest.groovy
@@ -40,7 +40,7 @@ class ModelRuleValidationIntegrationTest extends AbstractIntegrationSpec {
 
         and:
         failure.assertHasCause("Failed to apply plugin [class 'MyPlugin']")
-        failure.assertHasCause('''Type MyPlugin$Rules is not a valid rule source:
+        failure.assertHasCause('''Type MyPlugin.Rules is not a valid rule source:
 - Method strings() is not a valid rule method: The declared model element path ' ' is not a valid path: Model element name ' ' has illegal first character ' ' (names must start with an ASCII letter or underscore).''')
     }
 
@@ -64,7 +64,7 @@ class ModelRuleValidationIntegrationTest extends AbstractIntegrationSpec {
 
         and:
         failure.assertHasCause("Failed to apply plugin [class 'MyPlugin']")
-        failure.assertHasCause('''Type MyPlugin$Rules is not a valid rule source:
+        failure.assertHasCause('''Type MyPlugin.Rules is not a valid rule source:
 - Method strings() is not a valid rule method: The declared model element path 'foo. bar' is not a valid path: Model path 'foo. bar' is invalid due to invalid name component.''')
     }
 }

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedAsProjectPluginIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedAsProjectPluginIntegrationTest.groovy
@@ -139,7 +139,7 @@ model {
 
         and:
         failure.assertHasCause("Failed to apply plugin [class 'MyPlugin']")
-        failure.assertHasCause('''Type MyPlugin$Rules is not a valid rule source:
+        failure.assertHasCause('''Type MyPlugin.Rules is not a valid rule source:
 - Enclosed classes must be static and non private
 - Cannot declare a constructor that takes arguments''')
     }

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/schema/extract/ManagedProxyClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/schema/extract/ManagedProxyClassGenerator.java
@@ -158,7 +158,7 @@ public class ManagedProxyClassGenerator extends AbstractProxyClassGenerator {
 
         ModelType<M> viewType = viewSchema.getType();
 
-        StringBuilder generatedTypeNameBuilder = new StringBuilder(viewType.getName());
+        StringBuilder generatedTypeNameBuilder = new StringBuilder(viewType.getRawClass().getName());
         if (backingStateType == GeneratedViewState.class) {
             generatedTypeNameBuilder.append("$View");
         } else {

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/type/ClassTypeWrapper.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/type/ClassTypeWrapper.java
@@ -19,6 +19,7 @@ package org.gradle.model.internal.type;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 
 class ClassTypeWrapper implements TypeWrapper {
     private final WeakReference<Class<?>> reference;
@@ -67,25 +68,45 @@ class ClassTypeWrapper implements TypeWrapper {
 
     @Override
     public String getRepresentation(boolean full) {
-        if (full) {
-            return unwrap().getName();
-        } else {
+        try {
+            return tryToGetRepresentation(full);
+        } catch (NoClassDefFoundError ignore) {
+            // This happens for IBM JDK 6 for nested interfaces -- see https://issues.apache.org/jira/browse/GROOVY-7010
+            // Let's try to return something as close as possible to the intended value
             Class<?> clazz = unwrap();
-            try {
-                StringBuilder sb = new StringBuilder();
-                sb.append(clazz.getSimpleName());
-                for (Class<?> c = clazz.getEnclosingClass(); c != null; c = c.getEnclosingClass()) {
-                    sb.insert(0, '.');
-                    sb.insert(0, c.getSimpleName());
-                }
-                return sb.toString();
-            } catch (NoClassDefFoundError ignore) {
-                // This happens for IBM JDK 6 for nested interfaces -- see https://issues.apache.org/jira/browse/GROOVY-7010
-                // Let's try to return something as close as possible to the intended value
-                Package pkg = clazz.getPackage();
-                int pkgPrefixLength = pkg == null ? 0 : pkg.getName().length() + 1;
-                return clazz.getName().substring(pkgPrefixLength).replace('$', '.');
-            }
+            Package pkg = clazz.getPackage();
+            int pkgPrefixLength = pkg == null ? 0 : pkg.getName().length() + 1;
+            String simpleName = clazz.getName().substring(pkgPrefixLength).replace('$', '.');
+            return full && pkg != null
+                ? pkg.getName() + "." + simpleName
+                : simpleName;
         }
+    }
+
+    private String tryToGetRepresentation(boolean full) {
+        ArrayList<Class<?>> classChain = getEnclosingClassChain();
+
+        int topLevelIndex = classChain.size() - 1;
+        Class<?> topLevelClass = classChain.get(topLevelIndex);
+
+        StringBuilder representation = new StringBuilder();
+        representation.append(
+            full ? topLevelClass.getName() : topLevelClass.getSimpleName());
+
+        for (int i = topLevelIndex - 1; i >= 0; i--) {
+            representation.append('.');
+            representation.append(classChain.get(i).getSimpleName());
+        }
+        return representation.toString();
+    }
+
+    private ArrayList<Class<?>> getEnclosingClassChain() {
+        ArrayList<Class<?>> classChain = new ArrayList<Class<?>>();
+        Class<?> clazz = unwrap();
+        do {
+            classChain.add(clazz);
+            clazz = clazz.getEnclosingClass();
+        } while (clazz != null);
+        return classChain;
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/typeregistration/BaseInstanceFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/typeregistration/BaseInstanceFactory.java
@@ -222,7 +222,7 @@ public class BaseInstanceFactory<PUBLIC> implements InstanceFactory<PUBLIC> {
             Class<?> implementationClass = implementationType.getConcreteClass();
             ImplementationFactory<S, ?> factory = findFactory(implementationClass);
             if (factory == null) {
-                throw new IllegalArgumentException(String.format("No factory registered to create an instance of implementation class '%s'.", implementationClass.getName()));
+                throw new IllegalArgumentException(String.format("No factory registered to create an instance of implementation class '%s'.", implementationType));
             }
             this.implementationRegistration = new ImplementationRegistration<S>(source, implementationType, factory);
         }
@@ -266,7 +266,7 @@ public class BaseInstanceFactory<PUBLIC> implements InstanceFactory<PUBLIC> {
                         && !type.isAssignableFrom(delegateType.getConcreteClass())) {
                         throw new IllegalStateException(String.format("Factory registration for '%s' is invalid because the default implementation type '%s' does not implement unmanaged internal view '%s', "
                                 + "internal view was registered by %s",
-                            publicType, delegateType, type.getName(),
+                            publicType, delegateType, ModelType.of(type),
                             internalViewRegistration.getSource()));
                     }
                 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/ManagedNodeBackedModelMapTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/ManagedNodeBackedModelMapTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.model.internal.core.ModelRegistrations
 import org.gradle.model.internal.core.ModelRuleExecutionException
 import org.gradle.model.internal.manage.binding.InvalidManagedTypeException
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
 import static org.gradle.model.internal.core.NodeInitializerContext.forType
 
 class ManagedNodeBackedModelMapTest extends NodeBackedModelMapSpec<NamedThingInterface, SpecialNamedThingInterface> {
@@ -81,7 +82,8 @@ class ManagedNodeBackedModelMapTest extends NodeBackedModelMapSpec<NamedThingInt
         then:
         def e = thrown ModelRuleExecutionException
         e.cause instanceof InvalidManagedTypeException
-        e.cause.message == """Type $Invalid.name is not a valid managed type:
+        e.cause.message == """Type ${fullyQualifiedNameOf(Invalid)} is not a valid managed type:
 - Cannot be a parameterized type."""
     }
 }
+

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/NodeBackedModelMapSpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/NodeBackedModelMapSpec.groovy
@@ -29,6 +29,7 @@ import org.gradle.model.internal.registry.UnboundModelRulesException
 import org.gradle.model.internal.type.ModelType
 import org.gradle.model.internal.type.ModelTypes
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
 import static org.gradle.util.TextUtil.normaliseLineSeparators
 
 abstract class NodeBackedModelMapSpec<T extends Named, S extends T & Special> extends ProjectRegistrySpec {
@@ -324,10 +325,7 @@ abstract class NodeBackedModelMapSpec<T extends Named, S extends T & Special> ex
         then:
         def ex = thrown InvalidModelRuleException
         ex.cause instanceof ModelRuleBindingException
-        normaliseLineSeparators(ex.cause.message) == """Model reference to element 'map.item' with type $specialItemClass.name is invalid due to incompatible types.
-This element was created by testrule > create(item) and can be mutated as the following types:
-  - $itemClass.name (or assignment compatible type thereof)
-  - ${ModelElement.name} (or assignment compatible type thereof)"""
+        normaliseLineSeparators(ex.cause.message) == incompatibleTypesMessage()
     }
 
     def "named(String, Action) fails when named element requested in chain filtered collection with incompatible type"() {
@@ -338,9 +336,13 @@ This element was created by testrule > create(item) and can be mutated as the fo
         def ex = thrown ModelRuleExecutionException
         ex.cause instanceof InvalidModelRuleException
         ex.cause.cause instanceof ModelRuleBindingException
-        normaliseLineSeparators(ex.cause.cause.message) == """Model reference to element 'map.item' with type $specialItemClass.name is invalid due to incompatible types.
+        normaliseLineSeparators(ex.cause.cause.message) == incompatibleTypesMessage()
+    }
+
+    private String incompatibleTypesMessage() {
+        """Model reference to element 'map.item' with type ${fullyQualifiedNameOf(specialItemClass)} is invalid due to incompatible types.
 This element was created by testrule > create(item) and can be mutated as the following types:
-  - $itemClass.name (or assignment compatible type thereof)
+  - ${fullyQualifiedNameOf(itemClass)} (or assignment compatible type thereof)
   - ${ModelElement.name} (or assignment compatible type thereof)"""
     }
 
@@ -354,10 +356,7 @@ This element was created by testrule > create(item) and can be mutated as the fo
         def ex = thrown ModelRuleExecutionException
         ex.cause instanceof InvalidModelRuleException
         ex.cause.cause instanceof ModelRuleBindingException
-        normaliseLineSeparators(ex.cause.cause.message) == """Model reference to element 'map.item' with type $specialItemClass.name is invalid due to incompatible types.
-This element was created by testrule > create(item) and can be mutated as the following types:
-  - $itemClass.name (or assignment compatible type thereof)
-  - ${ModelElement.name} (or assignment compatible type thereof)"""
+        normaliseLineSeparators(ex.cause.cause.message) == incompatibleTypesMessage()
     }
 
     def "named(String, DeferredModelAction) fails when named element requested in filtered collection with incompatible type"() {
@@ -367,10 +366,7 @@ This element was created by testrule > create(item) and can be mutated as the fo
         then:
         def ex = thrown InvalidModelRuleException
         ex.cause instanceof ModelRuleBindingException
-        normaliseLineSeparators(ex.cause.message) == """Model reference to element 'map.item' with type $specialItemClass.name is invalid due to incompatible types.
-This element was created by testrule > create(item) and can be mutated as the following types:
-  - $itemClass.name (or assignment compatible type thereof)
-  - ${ModelElement.name} (or assignment compatible type thereof)"""
+        normaliseLineSeparators(ex.cause.message) == incompatibleTypesMessage()
     }
 
     def "named(String, DeferredModelAction) fails when named element requested in chain filtered collection with incompatible type"() {
@@ -381,10 +377,7 @@ This element was created by testrule > create(item) and can be mutated as the fo
         def ex = thrown ModelRuleExecutionException
         ex.cause instanceof InvalidModelRuleException
         ex.cause.cause instanceof ModelRuleBindingException
-        normaliseLineSeparators(ex.cause.cause.message) == """Model reference to element 'map.item' with type $specialItemClass.name is invalid due to incompatible types.
-This element was created by testrule > create(item) and can be mutated as the following types:
-  - $itemClass.name (or assignment compatible type thereof)
-  - ${ModelElement.name} (or assignment compatible type thereof)"""
+        normaliseLineSeparators(ex.cause.cause.message) == incompatibleTypesMessage()
     }
 
     def "withType(Class, Action) respects chained filtering"() {
@@ -499,7 +492,7 @@ This element was created by testrule > create(item) and can be mutated as the fo
 
     def assertCannotCreateException(ModelRuleExecutionException ex) {
         assert ex.cause instanceof IllegalArgumentException
-        assert ex.cause.message == "Cannot create 'map.item' with type '$String.name' as this is not a subtype of '$itemClass.name'."
+        assert ex.cause.message == "Cannot create 'map.item' with type '$String.name' as this is not a subtype of '${fullyQualifiedNameOf(itemClass)}'."
         return true
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/core/ModelTypeTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/core/ModelTypeTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.model.internal.type.ModelType
 import org.gradle.util.Matchers
 import spock.lang.Specification
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class ModelTypeTest extends Specification {
     class Nested {}
     interface NestedInterface {}
@@ -38,7 +40,7 @@ class ModelTypeTest extends Specification {
         type.displayName == String.simpleName
 
         def nested = ModelType.of(Nested)
-        nested.toString() == Nested.name
+        nested.toString() == fullyQualifiedNameOf(Nested)
         nested.displayName == "ModelTypeTest.Nested"
     }
 
@@ -92,7 +94,7 @@ class ModelTypeTest extends Specification {
         nestedInterface.rawClass == NestedInterface
         nestedInterface.concreteClass == NestedInterface
 
-        nestedInterface.toString() == NestedInterface.name
+        nestedInterface.toString() == fullyQualifiedNameOf(NestedInterface)
         nestedInterface.displayName == "ModelTypeTest.NestedInterface"
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/FormattingValidationProblemCollectorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/FormattingValidationProblemCollectorTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.model.internal.inspect
 import org.gradle.model.internal.type.ModelType
 import spock.lang.Specification
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class FormattingValidationProblemCollectorTest extends Specification {
     def "formats message with a single problem"() {
         given:
@@ -55,7 +57,7 @@ class FormattingValidationProblemCollectorTest extends Specification {
         collector.add(SuperClass.class.getMethod("thing"), "rule", "is not annotated with anything.")
 
         expect:
-        collector.format() == """Type ${WithConstructor.name} is not a valid <thing>:
+        collector.format() == """Type ${fullyQualifiedNameOf(WithConstructor)} is not a valid <thing>:
 - Method SuperClass.thing() is not a valid rule method: is not annotated with anything."""
     }
 
@@ -88,7 +90,7 @@ class FormattingValidationProblemCollectorTest extends Specification {
         collector.add(WithConstructor.getDeclaredConstructor(String), "should accept an int")
 
         expect:
-        collector.format() == """Type ${WithConstructor.name} is not a valid <thing>:
+        collector.format() == """Type ${fullyQualifiedNameOf(WithConstructor)} is not a valid <thing>:
 - Constructor WithConstructor(java.lang.String) is not valid: doesn't do anything
 - Constructor WithConstructor(java.lang.String) is not valid: should accept an int"""
     }
@@ -101,7 +103,7 @@ class FormattingValidationProblemCollectorTest extends Specification {
         collector.add(SuperClass.getDeclaredField("value"), "cannot have fields")
 
         expect:
-        collector.format() == """Type ${WithConstructor.name} is not a valid <thing>:
+        collector.format() == """Type ${fullyQualifiedNameOf(WithConstructor)} is not a valid <thing>:
 - Field value is not valid: should have an initializer
 - Field value is not valid: should accept an int
 - Field SuperClass.value is not valid: cannot have fields"""

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/ManagedModelInitializerTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/ManagedModelInitializerTest.groovy
@@ -32,6 +32,8 @@ import spock.lang.Unroll
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class ManagedModelInitializerTest extends ProjectRegistrySpec {
 
     def classLoader = new GroovyClassLoader(getClass().classLoader)
@@ -49,7 +51,7 @@ class ManagedModelInitializerTest extends ProjectRegistrySpec {
 
         then:
         def ex = thrown(ModelRuleExecutionException)
-        ex.cause.message == TextUtil.toPlatformLineSeparators("""A model element of type: '$ManagedWithInvalidModelMap.name' can not be constructed.
+        ex.cause.message == TextUtil.toPlatformLineSeparators("""A model element of type: '${fullyQualifiedNameOf(ManagedWithInvalidModelMap)}' can not be constructed.
 Its property 'org.gradle.model.ModelMap<java.io.FileInputStream> map' is not a valid managed collection
 A managed collection can not contain 'java.io.FileInputStream's
 A valid managed collection takes the form of ModelSet<T> or ModelMap<T> where 'T' is:
@@ -72,7 +74,7 @@ A valid managed collection takes the form of ModelSet<T> or ModelMap<T> where 'T
 
         then:
         def ex = thrown(ModelRuleExecutionException)
-        ex.cause.message == TextUtil.toPlatformLineSeparators("""A model element of type: '$ManagedWithInvalidScalarCollection.name' can not be constructed.
+        ex.cause.message == TextUtil.toPlatformLineSeparators("""A model element of type: '${fullyQualifiedNameOf(ManagedWithInvalidScalarCollection)}' can not be constructed.
 Its property 'java.util.List<java.io.FileInputStream> scalarThings' is not a valid scalar collection
 A scalar collection can not contain 'java.io.FileInputStream's
 A valid scalar collection takes the form of List<T> or Set<T> where 'T' is one of (String, Boolean, Character, Byte, Short, Integer, Float, Long, Double, BigInteger, BigDecimal, File)""")
@@ -89,7 +91,7 @@ A valid scalar collection takes the form of List<T> or Set<T> where 'T' is one o
 
         then:
         def ex = thrown(ModelRuleExecutionException)
-        ex.cause.message == TextUtil.toPlatformLineSeparators("""A model element of type: '$ManagedReadOnlyWithInvalidProperty.name' can not be constructed.
+        ex.cause.message == TextUtil.toPlatformLineSeparators("""A model element of type: '${fullyQualifiedNameOf(ManagedReadOnlyWithInvalidProperty)}' can not be constructed.
 Its property 'java.io.FileInputStream stream' can not be constructed
 It must be one of:
     - A managed type (annotated with @Managed)
@@ -110,7 +112,7 @@ It must be one of:
 
         then:
         def ex = thrown(ModelRuleExecutionException)
-        ex.cause.message == TextUtil.toPlatformLineSeparators("""A model element of type: '$ManagedReadWriteWithInvalidProperty.name' can not be constructed.
+        ex.cause.message == TextUtil.toPlatformLineSeparators("""A model element of type: '${fullyQualifiedNameOf(ManagedReadWriteWithInvalidProperty)}' can not be constructed.
 Its property 'java.io.FileInputStream stream' can not be constructed
 It must be one of:
     - A managed type (annotated with @Managed)
@@ -160,8 +162,8 @@ It must be one of:
     def "only selected unmanaged property types are allowed #type"() {
         expect:
         failWhenRealized(type,
-            canNotBeConstructed("${type.name}"),
-            "Its property '$failingProperty.name $propertyName' can not be constructed",
+            canNotBeConstructed(fullyQualifiedNameOf(type)),
+            "Its property '${fullyQualifiedNameOf(failingProperty)} $propertyName' can not be constructed",
             "It must be one of:",
             "    - A managed collection.",
             "    - A scalar collection.",
@@ -177,7 +179,7 @@ It must be one of:
     def "unmanaged types must be annotated with unmanaged"() {
         expect:
         failWhenRealized(MissingUnmanaged,
-            canNotBeConstructed(MissingUnmanaged.name),
+            canNotBeConstructed(fullyQualifiedNameOf(MissingUnmanaged)),
             "Its property 'java.io.InputStream thing' can not be constructed",
             "It must be one of:",
             "- An unmanaged property (i.e. annotated with @Unmanaged)"
@@ -224,7 +226,7 @@ interface Managed${typeName} {
     @Unroll
     def "must have a setter - #managedType.simpleName"() {
         expect:
-        failWhenRealized(managedType, "Invalid managed model type '$managedType.name': read only property 'thing' has non managed type boolean, only managed types can be used")
+        failWhenRealized(managedType, "Invalid managed model type '${fullyQualifiedNameOf(managedType)}': read only property 'thing' has non managed type boolean, only managed types can be used")
 
         where:
         managedType << [OnlyIsGetter, OnlyGetGetter]

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleExtractorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleExtractorTest.groovy
@@ -29,6 +29,8 @@ import spock.lang.Unroll
 
 import java.beans.Introspector
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class ModelRuleExtractorTest extends ProjectRegistrySpec {
     def extractor = new ModelRuleExtractor(MethodModelRuleExtractors.coreExtractors(SCHEMA_STORE), MANAGED_PROXY_FACTORY, SCHEMA_STORE, STRUCT_BINDINGS_STORE)
     ModelRegistry registry = new DefaultModelRegistry(extractor, null)
@@ -156,7 +158,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type $type.name is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(type)} is not a valid rule source:
 - Rule source classes must directly extend org.gradle.model.RuleSource"""
 
         where:
@@ -169,7 +171,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type $AbstractMethodsRules.name is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(AbstractMethodsRules)} is not a valid rule source:
 - Method thing(java.lang.String) is not a valid rule method: A rule method cannot be abstract"""
     }
 
@@ -179,7 +181,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type $WithGroovyMeta.name is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(WithGroovyMeta)} is not a valid rule source:
 - Method methodMissing(java.lang.String, java.lang.Object) is not a valid rule method: A method that is not annotated as a rule must be private
 - Method propertyMissing(java.lang.String) is not a valid rule method: A method that is not annotated as a rule must be private
 - Method propertyMissing(java.lang.String, java.lang.Object) is not a valid rule method: A method that is not annotated as a rule must be private"""
@@ -262,7 +264,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type $HasGenericModelRule.name is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(HasGenericModelRule)} is not a valid rule source:
 - Method thing() is not a valid rule method: Cannot have type variables (i.e. cannot be a generic method)"""
     }
 
@@ -280,7 +282,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type ${HasMultipleRuleAnnotations.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(HasMultipleRuleAnnotations)} is not a valid rule source:
 - Method thing() is not a valid rule method: Can only be one of [annotated with @Model and returning a model element, annotated with @Model and taking a managed model element, annotated with @Defaults, annotated with @Mutate, annotated with @Finalize, annotated with @Validate, annotated with @Rules]"""
     }
 
@@ -331,7 +333,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type ${GenericMutationRule.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(GenericMutationRule)} is not a valid rule source:
 - Method mutate(T) is not a valid rule method: Cannot have type variables (i.e. cannot be a generic method)"""
     }
 
@@ -346,7 +348,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type $NonVoidMutationRule.name is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(NonVoidMutationRule)} is not a valid rule source:
 - Method mutate(java.lang.String) is not a valid rule method: A method annotated with @Mutate must have void return type."""
     }
 
@@ -361,7 +363,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type $NoSubjectMutationRule.name is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(NoSubjectMutationRule)} is not a valid rule source:
 - Method mutate() is not a valid rule method: A method annotated with @Mutate must have at least one parameter"""
     }
 
@@ -376,7 +378,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type ${RuleWithEmptyInputPath.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(RuleWithEmptyInputPath)} is not a valid rule source:
 - Method create(java.lang.String) is not a valid rule method: The declared model element path '' used for parameter 1 is not a valid path: Cannot use an empty string as a model path."""
     }
 
@@ -391,7 +393,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type ${RuleWithInvalidInputPath.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(RuleWithInvalidInputPath)} is not a valid rule source:
 - Method create(java.lang.String) is not a valid rule method: The declared model element path '!!!!' used for parameter 1 is not a valid path: Model element name '!!!!' has illegal first character '!' (names must start with an ASCII letter or underscore)."""
     }
 
@@ -483,7 +485,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type ${InvalidModelNameViaAnnotation.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(InvalidModelNameViaAnnotation)} is not a valid rule source:
 - Method foo() is not a valid rule method: The declared model element path ' ' is not a valid path: Model element name ' ' has illegal first character ' ' (names must start with an ASCII letter or underscore)."""
     }
 
@@ -499,7 +501,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         InvalidModelRuleDeclarationException e = thrown()
-        e.message == """Type $RuleSourceCreatingARawModelMap.name is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(RuleSourceCreatingARawModelMap)} is not a valid rule source:
 - Method bar(org.gradle.model.ModelMap) is not a valid rule method: Raw type org.gradle.model.ModelMap used for parameter 1 (all type parameters must be specified of parameterized type)"""
     }
 
@@ -515,7 +517,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         InvalidModelRuleDeclarationException e = thrown()
-        e.message == """Type ${RuleSourceWithAVoidReturningNoArgumentMethod.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(RuleSourceWithAVoidReturningNoArgumentMethod)} is not a valid rule source:
 - Method bar() is not a valid rule method: A method annotated with @Model must either take at least one parameter or have a non-void return type"""
     }
 
@@ -544,8 +546,8 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
 - type parameter of org.gradle.model.ModelMap cannot be a wildcard.
 
 The type was analyzed due to the following dependencies:
-${managedType.name}
-  \\--- property 'managedWithNestedInvalidManagedType' (${nestedManagedType.name})
+${fullyQualifiedNameOf(managedType)}
+  \\--- property 'managedWithNestedInvalidManagedType' (${fullyQualifiedNameOf(nestedManagedType)})
     \\--- property 'invalidManaged' ($ModelMap.name<?>)"""
 
         where:
@@ -572,8 +574,8 @@ ${managedType.name}
 - type parameter of org.gradle.model.ModelMap cannot be a wildcard.
 
 The type was analyzed due to the following dependencies:
-${ManagedWithNonManageableParents.name}
-  \\--- property 'invalidManaged' declared by ${AnotherManagedWithPropertyOfInvalidManagedType.name}, ${ManagedWithPropertyOfInvalidManagedType.name} ($ModelMap.name<?>)"""
+${fullyQualifiedNameOf(ManagedWithNonManageableParents)}
+  \\--- property 'invalidManaged' declared by ${fullyQualifiedNameOf(AnotherManagedWithPropertyOfInvalidManagedType)}, ${fullyQualifiedNameOf(ManagedWithPropertyOfInvalidManagedType)} ($ModelMap.name<?>)"""
 
         where:
         invalidTypeName = "$ParametrizedManaged.name<$String.name>"
@@ -592,7 +594,7 @@ ${ManagedWithNonManageableParents.name}
 
         then:
         InvalidModelRuleDeclarationException e = thrown()
-        e.message == """Type $HasRuleWithUncheckedModelMap.name is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(HasRuleWithUncheckedModelMap)} is not a valid rule source:
 - Method modelPath(org.gradle.model.ModelMap) is not a valid rule method: Raw type org.gradle.model.ModelMap used for parameter 1 (all type parameters must be specified of parameterized type)"""
     }
 
@@ -608,7 +610,7 @@ ${ManagedWithNonManageableParents.name}
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type ${NotEverythingAnnotated.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(NotEverythingAnnotated)} is not a valid rule source:
 - Method mutate(java.lang.String) is not a valid rule method: A method that is not annotated as a rule must be private"""
     }
 
@@ -623,7 +625,7 @@ ${ManagedWithNonManageableParents.name}
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type ${PrivateAnnotated.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(PrivateAnnotated)} is not a valid rule source:
 - Method notOk(java.lang.String) is not a valid rule method: A rule method cannot be private"""
     }
 
@@ -653,7 +655,7 @@ ${ManagedWithNonManageableParents.name}
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == '''Type org.gradle.model.internal.inspect.ModelRuleExtractorTest$SeveralProblems is not a valid rule source:
+        e.message == '''Type org.gradle.model.internal.inspect.ModelRuleExtractorTest.SeveralProblems is not a valid rule source:
 - Rule source classes must directly extend org.gradle.model.RuleSource
 - Field field1 is not valid: Fields must be static final.
 - Field field2 is not valid: Fields must be static final.
@@ -785,7 +787,7 @@ ${ManagedWithNonManageableParents.name}
 
         then:
         def e = thrown InvalidModelRuleDeclarationException
-        e.message == """Type ${InvalidEachAnnotation.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(InvalidEachAnnotation)} is not a valid rule source:
 - Method mutate(java.lang.String, java.lang.Integer) is not a valid rule method: Rule parameter #2 should not be annotated with @Each."""
     }
 
@@ -803,7 +805,7 @@ ${ManagedWithNonManageableParents.name}
 
         then:
         def e = thrown InvalidModelRuleDeclarationException
-        e.message == """Type ${InvalidEachAndPathAnnotation.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(InvalidEachAndPathAnnotation)} is not a valid rule source:
 - Method invalid(java.lang.String, java.lang.Integer) is not a valid rule method: Rule subject must not be annotated with both @Path and @Each."""
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/RuleDefinitionRuleExtractorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/RuleDefinitionRuleExtractorTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.model.*
 import org.gradle.model.internal.fixture.ProjectRegistrySpec
 import org.gradle.model.internal.registry.DefaultModelRegistry
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class RuleDefinitionRuleExtractorTest extends ProjectRegistrySpec {
     def extractor = new ModelRuleExtractor([new RuleDefinitionRuleExtractor()], proxyFactory, schemaStore, structBindingsStore)
 
@@ -44,7 +46,7 @@ class RuleDefinitionRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown(InvalidModelRuleDeclarationException)
-        e.message == """Type ${InvalidSignature.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(InvalidSignature)} is not a valid rule source:
 - Method broken3(java.lang.String) is not a valid rule method: A method annotated with @Rules must have void return type.
 - Method broken3(java.lang.String) is not a valid rule method: A method annotated with @Rules must have at least two parameters
 - Method broken1(java.lang.String, ${RuleSource.name}) is not a valid rule method: The first parameter of a method annotated with @Rules must be a subtype of ${RuleSource.name}
@@ -64,7 +66,7 @@ class RuleDefinitionRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown InvalidModelRuleDeclarationException
-        e.message == """Type ${InvalidEachAnnotationOnParameter.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(InvalidEachAnnotationOnParameter)} is not a valid rule source:
 - Method input($SomeRuleSource.name, java.lang.String, java.lang.Integer) is not a valid rule method: Rule parameter #3 should not be annotated with @Each."""
     }
 
@@ -80,7 +82,7 @@ class RuleDefinitionRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown InvalidModelRuleDeclarationException
-        e.message == """Type ${InvalidEachAnnotationOnRuleSource.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(InvalidEachAnnotationOnRuleSource)} is not a valid rule source:
 - Method rules($SomeRuleSource.name, java.lang.String, java.lang.Integer) is not a valid rule method: Rule parameter #1 should not be annotated with @Each."""
     }
 
@@ -98,7 +100,7 @@ class RuleDefinitionRuleExtractorTest extends ProjectRegistrySpec {
 
         then:
         def e = thrown InvalidModelRuleDeclarationException
-        e.message == """Type ${InvalidEachAndPathAnnotation.name} is not a valid rule source:
+        e.message == """Type ${fullyQualifiedNameOf(InvalidEachAndPathAnnotation)} is not a valid rule source:
 - Method invalid($SomeRuleSource.name, java.lang.String, java.lang.Integer) is not a valid rule method: Rule subject must not be annotated with both @Path and @Each."""
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/binding/DefaultStructBindingsStoreTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/binding/DefaultStructBindingsStoreTest.groovy
@@ -24,6 +24,8 @@ import org.gradle.model.internal.type.ModelType
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class DefaultStructBindingsStoreTest extends Specification {
     def schemaStore = new DefaultModelSchemaStore(DefaultModelSchemaExtractor.withDefaultStrategies())
     def bindingStore = new DefaultStructBindingsStore(schemaStore)
@@ -93,7 +95,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "public type must be abstract"() {
         when: extract EmptyStaticClass
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $EmptyStaticClass.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(EmptyStaticClass)} is not a valid managed type:
 - Must be defined as an interface or an abstract class."""
     }
 
@@ -103,7 +105,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "public type cannot be parameterized"() {
         when: extract ParameterizedEmptyInterface
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $ParameterizedEmptyInterface.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(ParameterizedEmptyInterface)} is not a valid managed type:
 - Cannot be a parameterized type."""
     }
 
@@ -117,7 +119,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "instance scoped fields are not allowed"() {
         when:  extract WithInstanceScopedField
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $WithInstanceScopedField.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(WithInstanceScopedField)} is not a valid managed type:
 - Field name is not valid: Fields must be static final.
 - Field age is not valid: Fields must be static final."""
     }
@@ -129,7 +131,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "instance scoped fields are not allowed in super-class"() {
         when: extract WithInstanceScopedFieldInSuperclass
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $WithInstanceScopedFieldInSuperclass.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(WithInstanceScopedFieldInSuperclass)} is not a valid managed type:
 - Field WithInstanceScopedField.name is not valid: Fields must be static final.
 - Field WithInstanceScopedField.age is not valid: Fields must be static final."""
     }
@@ -151,7 +153,7 @@ class DefaultStructBindingsStoreTest extends Specification {
 
         then:
         def e = thrown InvalidManagedTypeException
-        e.message == """Type $ProtectedAbstractMethods.name is not a valid managed type:
+        e.message == """Type ${fullyQualifiedNameOf(ProtectedAbstractMethods)} is not a valid managed type:
 - Method getName() is not a valid method: Protected and private methods are not supported.
 - Method setName(java.lang.String) is not a valid method: Protected and private methods are not supported."""
 
@@ -160,7 +162,7 @@ class DefaultStructBindingsStoreTest extends Specification {
 
         then:
         e = thrown InvalidManagedTypeException
-        e.message == """Type $ProtectedAbstractMethodsInSuper.name is not a valid managed type:
+        e.message == """Type ${fullyQualifiedNameOf(ProtectedAbstractMethodsInSuper)} is not a valid managed type:
 - Method ProtectedAbstractMethods.getName() is not a valid method: Protected and private methods are not supported.
 - Method ProtectedAbstractMethods.setName(java.lang.String) is not a valid method: Protected and private methods are not supported."""
     }
@@ -179,7 +181,7 @@ class DefaultStructBindingsStoreTest extends Specification {
         extract ProtectedAndPrivateNonAbstractMethods
         then:
         def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $ProtectedAndPrivateNonAbstractMethods.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(ProtectedAndPrivateNonAbstractMethods)} is not a valid managed type:
 - Method setName(java.lang.String) is not a valid method: Protected and private methods are not supported.
 - Method getName() is not a valid method: Protected and private methods are not supported."""
     }
@@ -191,7 +193,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "protected and private non-abstract methods are not allowed in super-type"() {
         when: extract ProtectedAndPrivateNonAbstractMethodsInSuper
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $ProtectedAndPrivateNonAbstractMethodsInSuper.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(ProtectedAndPrivateNonAbstractMethodsInSuper)} is not a valid managed type:
 - Method ProtectedAndPrivateNonAbstractMethods.setName(java.lang.String) is not a valid method: Protected and private methods are not supported.
 - Method ProtectedAndPrivateNonAbstractMethods.getName() is not a valid method: Protected and private methods are not supported."""
     }
@@ -201,7 +203,7 @@ class DefaultStructBindingsStoreTest extends Specification {
         extract TypeWithImplementedProperty, DelegateTypeWithImplementedProperty
         then:
         def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $TypeWithImplementedProperty.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(TypeWithImplementedProperty)} is not a valid managed type:
 - Method getZ() is not a valid method: it is both implemented by the view '${getName(TypeWithImplementedProperty)}' and the delegate type '${getName(DelegateTypeWithImplementedProperty)}'
 - Method setZ(int) is not a valid method: it is both implemented by the view '${getName(TypeWithImplementedProperty)}' and the delegate type '${getName(DelegateTypeWithImplementedProperty)}'"""
     }
@@ -215,7 +217,7 @@ class DefaultStructBindingsStoreTest extends Specification {
         extract(TypeWithAbstractWriteOnlyProperty)
         then:
         def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $TypeWithAbstractWriteOnlyProperty.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(TypeWithAbstractWriteOnlyProperty)} is not a valid managed type:
 - Property 'z' is not valid: it must both have an abstract getter and a setter"""
     }
 
@@ -229,7 +231,7 @@ class DefaultStructBindingsStoreTest extends Specification {
         extract(TypeWithInconsistentPropertyType)
         then:
         def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $TypeWithInconsistentPropertyType.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(TypeWithInconsistentPropertyType)} is not a valid managed type:
 - Method setZ(int) is not a valid method: it should take parameter with type 'String'"""
     }
 
@@ -279,7 +281,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "cannot annotate managed type property with unmanaged"() {
         when: extract HasUnmanagedOnManaged
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $HasUnmanagedOnManaged.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(HasUnmanagedOnManaged)} is not a valid managed type:
 - Property 'myEnum' is not valid: it is marked as @Unmanaged, but is of @Managed type '${getName(MyEnum)}'; please remove the @Managed annotation"""
     }
 
@@ -292,7 +294,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "must have setter for unmanaged"() {
         when: extract NoSetterForUnmanaged
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $NoSetterForUnmanaged.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(NoSetterForUnmanaged)} is not a valid managed type:
 - Property 'thing' is not valid: it must not be read only, because it is marked as @Unmanaged"""
     }
 
@@ -322,14 +324,14 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "map cannot be writable"() {
         when: extract WritableMapProperty
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $WritableMapProperty.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(WritableMapProperty)} is not a valid managed type:
 - Property 'map' is not valid: it cannot have a setter (ModelMap properties must be read only)"""
     }
 
     def "set cannot be writable"() {
         when: extract WritableSetProperty
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $WritableSetProperty.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(WritableSetProperty)} is not a valid managed type:
 - Property 'set' is not valid: it cannot have a setter (ModelSet properties must be read only)"""
     }
 
@@ -342,7 +344,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "malformed getter"() {
         when: extract GetterWithParams
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $GetterWithParams.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(GetterWithParams)} is not a valid managed type:
 - Method getName(java.lang.String) is not a valid property accessor method: getter method must not take parameters
 - Property 'name' is not valid: it must both have an abstract getter and a setter"""
     }
@@ -356,7 +358,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "non void setter"() {
         when: extract NonVoidSetter
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $NonVoidSetter.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(NonVoidSetter)} is not a valid managed type:
 - Method setName(java.lang.String) is not a valid property accessor method: setter method must have void return type"""
     }
 
@@ -369,7 +371,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "setter with extra params"() {
         when: extract SetterWithExtraParams
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $SetterWithExtraParams.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(SetterWithExtraParams)} is not a valid managed type:
 - Method setName(java.lang.String, java.lang.String) is not a valid property accessor method: setter method must take exactly one parameter"""
     }
 
@@ -389,14 +391,14 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "can only have abstract getters and setters"() {
         when: extract HasExtraNonPropertyMethods
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $HasExtraNonPropertyMethods.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(HasExtraNonPropertyMethods)} is not a valid managed type:
 - Method foo(java.lang.String) is not a valid managed type method: it must have an implementation"""
     }
 
     def "can only have abstract getters and setters in inherited type"() {
         when: extract ChildWithExtraNonPropertyMethods
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $ChildWithExtraNonPropertyMethods.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(ChildWithExtraNonPropertyMethods)} is not a valid managed type:
 - Method ${HasExtraNonPropertyMethods.simpleName}.foo(java.lang.String) is not a valid managed type method: it must have an implementation"""
     }
 
@@ -408,7 +410,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "reject two firsts char lowercase getters"() {
         when: extract HasTwoFirstsCharLowercaseGetter
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $HasTwoFirstsCharLowercaseGetter.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(HasTwoFirstsCharLowercaseGetter)} is not a valid managed type:
 - Method getccCompiler() is not a valid managed type method: it must have an implementation"""
     }
 
@@ -420,7 +422,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "get-getters-like methods not considered as getters"() {
         when: extract HasGetGetterLikeMethod
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $HasGetGetterLikeMethod.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(HasGetGetterLikeMethod)} is not a valid managed type:
 - Method gettingStarted() is not a valid managed type method: it must have an implementation"""
     }
 
@@ -432,7 +434,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "is-getters-like methods not considered as getters"() {
         when: extract HasIsGetterLikeMethod
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $HasIsGetterLikeMethod.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(HasIsGetterLikeMethod)} is not a valid managed type:
 - Method isidore() is not a valid managed type method: it must have an implementation"""
     }
 
@@ -444,7 +446,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "setters-like methods not considered as setters"() {
         when: extract HasSetterLikeMethod
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $HasSetterLikeMethod.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(HasSetterLikeMethod)} is not a valid managed type:
 - Method settings(java.lang.String) is not a valid managed type method: it must have an implementation"""
     }
 
@@ -457,7 +459,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "misaligned setter type"() {
         when: def bindings = extract MisalignedSetterType
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $MisalignedSetterType.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(MisalignedSetterType)} is not a valid managed type:
 - Method setThing(java.lang.Object) is not a valid method: it should take parameter with type 'String'"""
     }
 
@@ -476,14 +478,14 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "non-abstract getter with abstract setter is not allowed"() {
         when: extract NonAbstractGetterWithSetter
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $NonAbstractGetterWithSetter.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(NonAbstractGetterWithSetter)} is not a valid managed type:
 - Property 'name' is not valid: it must have either only abstract accessor methods or only implemented accessor methods"""
     }
 
     def "non-abstract setter without getter is not allowed"() {
         when: extract NonAbstractSetter
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $NonAbstractSetter.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(NonAbstractSetter)} is not a valid managed type:
 - Property 'name' is not valid: it must have either only abstract accessor methods or only implemented accessor methods"""
     }
 
@@ -496,7 +498,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "displays a reasonable error message when getter and setter of a property of collection of scalar types do not use the same generic type"() {
         given: when: extract CollectionType
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $CollectionType.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(CollectionType)} is not a valid managed type:
 - Method setItems(java.util.List<java.lang.Integer>) is not a valid method: it should take parameter with type 'List<String>'"""
     }
 
@@ -548,7 +550,7 @@ class DefaultStructBindingsStoreTest extends Specification {
 
         then:
         def e = thrown Exception
-        e.message == """Type $MutableName.name is not a valid managed type:
+        e.message == """Type ${fullyQualifiedNameOf(MutableName)} is not a valid managed type:
 - Property 'name' is not valid: it must not have a setter, because the type implements '$Named.name'"""
     }
 
@@ -561,7 +563,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "handles is/get property with non-matching type"() {
         when: extract HasIsAndGetPropertyWithDifferentTypes
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $HasIsAndGetPropertyWithDifferentTypes.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(HasIsAndGetPropertyWithDifferentTypes)} is not a valid managed type:
 - Property 'value' is not valid: it must have a consistent type, but it's defined as String, boolean"""
     }
 
@@ -581,7 +583,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "should not allow 'is' as a prefix for getter on non primitive boolean in #managedType"() {
         when: extract type
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $type.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(type)} is not a valid managed type:
 - Method isThing() is not a valid method: it should either return 'boolean', or its name should be 'getThing()'"""
 
         where:
@@ -617,17 +619,17 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "custom constructors are not allowed"() {
         when: extract ConstructorWithArguments
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $ConstructorWithArguments.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(ConstructorWithArguments)} is not a valid managed type:
 - Constructor ConstructorWithArguments(java.lang.String) is not valid: Custom constructors are not supported."""
 
         when: extract AdditionalConstructorWithArguments
         then: ex = thrown InvalidManagedTypeException
-        ex.message == """Type $AdditionalConstructorWithArguments.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(AdditionalConstructorWithArguments)} is not a valid managed type:
 - Constructor AdditionalConstructorWithArguments(java.lang.String) is not valid: Custom constructors are not supported."""
 
         when: extract CustomConstructorInSuperClass
         then: ex = thrown InvalidManagedTypeException
-        ex.message == """Type $CustomConstructorInSuperClass.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(CustomConstructorInSuperClass)} is not a valid managed type:
 - Constructor SuperConstructorWithArguments(java.lang.String) is not valid: Custom constructors are not supported."""
     }
 
@@ -646,7 +648,7 @@ class DefaultStructBindingsStoreTest extends Specification {
     def "collects all problems for a type"() {
         when: extract MultipleProblems
         then: def ex = thrown InvalidManagedTypeException
-        ex.message == """Type $MultipleProblems.name is not a valid managed type:
+        ex.message == """Type ${fullyQualifiedNameOf(MultipleProblems)} is not a valid managed type:
 - Must be defined as an interface or an abstract class.
 - Cannot be a parameterized type.
 - Constructor MultipleProblems(java.lang.String) is not valid: Custom constructors are not supported.

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/ScalarTypesInManagedModelTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/ScalarTypesInManagedModelTest.groovy
@@ -22,6 +22,8 @@ import spock.lang.Unroll
 
 import java.util.regex.Pattern
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class ScalarTypesInManagedModelTest extends ProjectRegistrySpec {
 
     def classLoader = new GroovyClassLoader(this.class.classLoader)
@@ -42,7 +44,7 @@ class ScalarTypesInManagedModelTest extends ProjectRegistrySpec {
         """
 
         then:
-        failWhenRealized(clazz, Pattern.quote("Invalid managed model type 'ManagedType': read only property 'managedProperty' has non managed type ${someType.name}, only managed types can be used"))
+        failWhenRealized(clazz, Pattern.quote("Invalid managed model type 'ManagedType': read only property 'managedProperty' has non managed type ${fullyQualifiedNameOf(someType)}, only managed types can be used"))
 
         where:
         someType << [

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/registry/DefaultModelRegistryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/registry/DefaultModelRegistryTest.groovy
@@ -31,6 +31,7 @@ import org.gradle.util.TextUtil
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
 import static org.gradle.model.internal.core.NodePredicate.allDescendants
 import static org.gradle.model.internal.core.NodePredicate.allLinks
 import static org.gradle.util.TextUtil.normaliseLineSeparators
@@ -703,7 +704,7 @@ class DefaultModelRegistryTest extends Specification {
 
         then:
         def ex = thrown IllegalStateException
-        ex.message == "Cannot bind subject 'ModelReference{path=thing, scope=null, type=${Bean.name}, state=GraphClosed}' to role '${targetRole}' because it is targeting a type and subject types are not yet available in that role"
+        ex.message == "Cannot bind subject 'ModelReference{path=thing, scope=null, type=${fullyQualifiedNameOf(Bean)}, state=GraphClosed}' to role '${targetRole}' because it is targeting a type and subject types are not yet available in that role"
 
         where:
         targetRole << ModelActionRole.values().findAll { !it.subjectViewAvailable }
@@ -1434,7 +1435,7 @@ foo
         then:
         def ex = thrown InvalidModelRuleException
         ex.cause instanceof ModelRuleBindingException
-        ex.cause.message == TextUtil.toPlatformLineSeparators("""Type-only model reference of type $Bean.name ($Bean.name) is ambiguous as multiple model elements are available for this type:
+        ex.cause.message == TextUtil.toPlatformLineSeparators("""Type-only model reference of type ${fullyQualifiedNameOf(Bean)} (${fullyQualifiedNameOf(Bean)}) is ambiguous as multiple model elements are available for this type:
   - dep (created by: dep creator)
   - dep2 (created by: dep2 creator)""")
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/typeregistration/BaseInstanceFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/typeregistration/BaseInstanceFactoryTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.model.internal.type.ModelType
 import spock.lang.Ignore
 import spock.lang.Specification
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
 import static org.gradle.model.internal.typeregistration.BaseInstanceFactory.ImplementationFactory
 
 class BaseInstanceFactoryTest extends Specification {
@@ -154,7 +155,7 @@ class BaseInstanceFactoryTest extends Specification {
 
         then:
         IllegalArgumentException e = thrown()
-        e.message == "No factory registered to create an instance of implementation class '${DefaultThingSpec.name}'."
+        e.message == "No factory registered to create an instance of implementation class '${fullyQualifiedNameOf(DefaultThingSpec)}'."
     }
 
     def "factory for closest superclass to create implementation for a public type"() {
@@ -227,7 +228,7 @@ class BaseInstanceFactoryTest extends Specification {
             .withImplementation(ModelType.of(NoDefaultConstructorThingSpec))
         then:
         def ex = thrown IllegalArgumentException
-        ex.message == "Implementation type '$NoDefaultConstructorThingSpec.name' registered for '$ThingSpec.name' must have a public default constructor"
+        ex.message == "Implementation type '${fullyQualifiedNameOf(NoDefaultConstructorThingSpec)}' registered for '${fullyQualifiedNameOf(ThingSpec)}' must have a public default constructor"
     }
 
     def "fails when registered implementation type is an abstract type"() {
@@ -236,7 +237,7 @@ class BaseInstanceFactoryTest extends Specification {
             .withImplementation(ModelType.of(AbstractThingSpec))
         then:
         def ex = thrown IllegalArgumentException
-        ex.message == "Implementation type '$AbstractThingSpec.name' registered for '$ThingSpec.name' must not be abstract"
+        ex.message == "Implementation type '${fullyQualifiedNameOf(AbstractThingSpec)}' registered for '${fullyQualifiedNameOf(ThingSpec)}' must not be abstract"
     }
 
     def "fails when implementation type is registered twice"() {
@@ -249,7 +250,7 @@ class BaseInstanceFactoryTest extends Specification {
             .withImplementation(ModelType.of(DefaultThingSpec))
         then:
         def ex = thrown IllegalStateException
-        ex.message == "Cannot register implementation for type '$ThingSpec.name' because an implementation for this type was already registered by test rule"
+        ex.message == "Cannot register implementation for type '${fullyQualifiedNameOf(ThingSpec)}' because an implementation for this type was already registered by test rule"
     }
 
     def "fails when asking for implementation info for a non-managed type"() {
@@ -257,7 +258,7 @@ class BaseInstanceFactoryTest extends Specification {
         instanceFactory.getManagedSubtypeImplementationInfo(ModelType.of(ThingSpec))
         then:
         def ex = thrown IllegalArgumentException
-        ex.message == "Type '$ThingSpec.name' is not managed"
+        ex.message == "Type '${fullyQualifiedNameOf(ThingSpec)}' is not managed"
     }
 
     def "fails validation if default implementation does not implement internal view"() {
@@ -271,7 +272,7 @@ class BaseInstanceFactoryTest extends Specification {
         instanceFactory.validateRegistrations()
         then:
         def ex = thrown IllegalStateException
-        ex.message == "Factory registration for '$ThingSpec.name' is invalid because the implementation type '$DefaultThingSpec.name' does not implement internal view '$NotImplementedInternalViewSpec.name'" +
+        ex.message == "Factory registration for '${fullyQualifiedNameOf(ThingSpec)}' is invalid because the implementation type '${fullyQualifiedNameOf(DefaultThingSpec)}' does not implement internal view '${fullyQualifiedNameOf(NotImplementedInternalViewSpec)}'" +
             ", implementation type was registered by impl rule, internal view was registered by view rule"
     }
 
@@ -282,7 +283,7 @@ class BaseInstanceFactoryTest extends Specification {
         instanceFactory.validateRegistrations()
         then:
         def ex = thrown IllegalStateException
-        ex.message == "Factory registration for '$ManagedThingSpec.name' is invalid because it doesn't extend an interface with a default implementation"
+        ex.message == "Factory registration for '${fullyQualifiedNameOf(ManagedThingSpec)}' is invalid because it doesn't extend an interface with a default implementation"
     }
 
     @Ignore("This would be hard to check, and we only use this internally, so we'll just be careful")
@@ -297,7 +298,7 @@ class BaseInstanceFactoryTest extends Specification {
         instanceFactory.validateRegistrations()
         then:
         def ex = thrown IllegalStateException
-        ex.message == "Factory registration for '$BothThingSpec.name' is invalid because it has multiple default implementations registered, super-types that registered an implementation are: $ThingSpec.name, $OtherThingSpec.name"
+        ex.message == "Factory registration for '${fullyQualifiedNameOf(BothThingSpec)}' is invalid because it has multiple default implementations registered, super-types that registered an implementation are: ${fullyQualifiedNameOf(ThingSpec)}, ${fullyQualifiedNameOf(OtherThingSpec)}"
     }
 
     def "fails when registering non-interface internal view"() {
@@ -306,7 +307,7 @@ class BaseInstanceFactoryTest extends Specification {
             .withInternalView(ModelType.of(Object))
         then:
         def ex = thrown IllegalArgumentException
-        ex.message == "Internal view '$Object.name' registered for '$ThingSpec.name' must be an interface"
+        ex.message == "Internal view '$Object.name' registered for '${fullyQualifiedNameOf(ThingSpec)}' must be an interface"
     }
 
     def "fails when registering unmanaged internal view for managed type"() {
@@ -315,7 +316,7 @@ class BaseInstanceFactoryTest extends Specification {
             .withInternalView(ModelType.of(ThingSpecInternal))
         then:
         def ex = thrown IllegalArgumentException
-        ex.message == "Internal view '$ThingSpecInternal.name' registered for managed type '$ManagedThingSpec.name' must be managed"
+        ex.message == "Internal view '${fullyQualifiedNameOf(ThingSpecInternal)}' registered for managed type '${fullyQualifiedNameOf(ManagedThingSpec)}' must be managed"
     }
 
     def "can register managed internal view for managed type that extends interface that is implemented by delegate type"() {
@@ -342,7 +343,6 @@ class BaseInstanceFactoryTest extends Specification {
         instanceFactory.validateRegistrations()
         then:
         def ex = thrown IllegalStateException
-        ex.message == "Factory registration for '$ManagedThingSpec.name' is invalid because the default implementation type '$DefaultThingSpec.name' does not implement unmanaged internal view '$OtherThingSpec.name', internal view was registered by managed thing"
+        ex.message == "Factory registration for '${fullyQualifiedNameOf(ManagedThingSpec)}' is invalid because the default implementation type '${fullyQualifiedNameOf(DefaultThingSpec)}' does not implement unmanaged internal view '${fullyQualifiedNameOf(OtherThingSpec)}', internal view was registered by managed thing"
     }
-
 }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/model/ModelTypeTesting.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/model/ModelTypeTesting.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.model
+
+class ModelTypeTesting {
+
+    static String fullyQualifiedNameOf(Class<?> type) {
+        (type.enclosingClass != null
+            ? type.enclosingClass.name + "." + type.simpleName
+            : type.name)
+    }
+}

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
@@ -272,7 +272,7 @@ model {
         then:
         failure.assertHasDescription "A problem occurred evaluating root project 'custom-binary'."
         failure.assertHasCause "Failed to apply plugin [class 'MySamplePlugin']"
-        failure.assertHasCause '''Type MySamplePlugin$Rules is not a valid rule source:
+        failure.assertHasCause '''Type MySamplePlugin.Rules is not a valid rule source:
 - Method register(org.gradle.platform.base.TypeBuilder<SampleBinary>, java.lang.String) is not a valid rule method: A method annotated with @ComponentType must have a single parameter of type org.gradle.platform.base.TypeBuilder.'''
     }
 

--- a/subprojects/platform-base/src/test/groovy/org/gradle/language/base/internal/ComponentTypeModelRuleExtractorTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/language/base/internal/ComponentTypeModelRuleExtractorTest.groovy
@@ -33,6 +33,8 @@ import spock.lang.Unroll
 
 import java.lang.annotation.Annotation
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class ComponentTypeModelRuleExtractorTest extends AbstractAnnotationModelRuleExtractorTest {
     final static ModelType<ComponentSpecFactory> FACTORY_REGISTRY_TYPE = ModelType.of(ComponentSpecFactory)
     ComponentTypeModelRuleExtractor ruleHandler = new ComponentTypeModelRuleExtractor(schemaStore)
@@ -79,7 +81,7 @@ class ComponentTypeModelRuleExtractorTest extends AbstractAnnotationModelRuleExt
 
         then:
         def ex = thrown(InvalidModelRuleDeclarationException)
-        ex.message == """Type ${ruleClass.name} is not a valid rule source:
+        ex.message == """Type ${fullyQualifiedNameOf(ruleClass)} is not a valid rule source:
 - Method ${ruleDescription} is not a valid rule method: ${expectedMessage}"""
 
         where:

--- a/subprojects/platform-base/src/test/groovy/org/gradle/language/base/internal/registry/LanguageTypeModelRuleExtractorTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/language/base/internal/registry/LanguageTypeModelRuleExtractorTest.groovy
@@ -36,6 +36,8 @@ import spock.lang.Unroll
 
 import java.lang.annotation.Annotation
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class LanguageTypeModelRuleExtractorTest extends AbstractAnnotationModelRuleExtractorTest {
 
     Class<?> ruleClass = Rules
@@ -57,7 +59,7 @@ class LanguageTypeModelRuleExtractorTest extends AbstractAnnotationModelRuleExtr
 
         then:
         def ex = thrown(InvalidModelRuleDeclarationException)
-        ex.message == """Type ${ruleClass.name} is not a valid rule source:
+        ex.message == """Type ${fullyQualifiedNameOf(ruleClass)} is not a valid rule source:
 - Method ${ruleDescription} is not a valid rule method: ${expectedMessage}"""
 
         where:

--- a/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/registry/BinaryTasksModelRuleExtractorTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/registry/BinaryTasksModelRuleExtractorTest.groovy
@@ -31,6 +31,8 @@ import spock.lang.Unroll
 
 import java.lang.annotation.Annotation
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class BinaryTasksModelRuleExtractorTest extends AbstractAnnotationModelRuleExtractorTest {
 
     BinaryTasksModelRuleExtractor ruleHandler = new BinaryTasksModelRuleExtractor()
@@ -52,7 +54,7 @@ class BinaryTasksModelRuleExtractorTest extends AbstractAnnotationModelRuleExtra
 
         then:
         def ex = thrown(InvalidModelRuleDeclarationException)
-        ex.message == """Type ${ruleClass.name} is not a valid rule source:
+        ex.message == """Type ${fullyQualifiedNameOf(ruleClass)} is not a valid rule source:
 - Method ${ruleDescription} is not a valid rule method: ${expectedMessage}"""
 
         where:
@@ -74,7 +76,7 @@ class BinaryTasksModelRuleExtractorTest extends AbstractAnnotationModelRuleExtra
 
         then:
         def ex = thrown(InvalidModelRuleDeclarationException)
-        ex.message == """Type ${ruleClass.name} is not a valid rule source:
+        ex.message == """Type ${fullyQualifiedNameOf(ruleClass)} is not a valid rule source:
 - Method ${ruleDescription} is not a valid rule method: A method annotated with @BinaryTasks must have void return type.
 - Method ${ruleDescription} is not a valid rule method: The first parameter of a method annotated with @BinaryTasks must be of type org.gradle.model.ModelMap.
 - Method ${ruleDescription} is not a valid rule method: A method annotated with @BinaryTasks must have one parameter extending BinarySpec. Found no parameter extending BinarySpec."""

--- a/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/registry/BinaryTypeModelRuleExtractorTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/registry/BinaryTypeModelRuleExtractorTest.groovy
@@ -32,6 +32,8 @@ import spock.lang.Unroll
 
 import java.lang.annotation.Annotation
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class BinaryTypeModelRuleExtractorTest extends AbstractAnnotationModelRuleExtractorTest {
     ComponentTypeModelRuleExtractor ruleHandler = new ComponentTypeModelRuleExtractor(new DefaultModelSchemaStore(DefaultModelSchemaExtractor.withDefaultStrategies()))
 
@@ -72,7 +74,7 @@ class BinaryTypeModelRuleExtractorTest extends AbstractAnnotationModelRuleExtrac
 
         then:
         def ex = thrown(InvalidModelRuleDeclarationException)
-        ex.message == """Type ${ruleClass.name} is not a valid rule source:
+        ex.message == """Type ${fullyQualifiedNameOf(ruleClass)} is not a valid rule source:
 - Method ${ruleDescription} is not a valid rule method: ${expectedMessage}"""
 
         where:
@@ -80,7 +82,7 @@ class BinaryTypeModelRuleExtractorTest extends AbstractAnnotationModelRuleExtrac
         "extraParameter" | "A method annotated with @ComponentType must have a single parameter of type ${TypeBuilder.name}."              | "additional rule parameter"
         "returnValue"    | "A method annotated with @ComponentType must have void return type."                                            | "method with return type"
         "noTypeParam"    | "Parameter of type ${TypeBuilder.name} must declare a type parameter."                                          | "missing type parameter"
-        "notBinarySpec"  | "Type '${NotBinarySpec.name}' is not a subtype of '${ComponentSpec.name}'."                                     | "type not extending BinarySpec"
+        "notBinarySpec"  | "Type '${fullyQualifiedNameOf(NotBinarySpec)}' is not a subtype of '${ComponentSpec.name}'."                    | "type not extending BinarySpec"
         "wildcardType"   | "Type '?' cannot be a wildcard type (i.e. cannot use ? super, ? extends etc.)."                                 | "wildcard type parameter"
         "extendsType"    | "Type '? extends ${BinarySpec.getName()}' cannot be a wildcard type (i.e. cannot use ? super, ? extends etc.)." | "extends type parameter"
         "superType"      | "Type '? super ${BinarySpec.getName()}' cannot be a wildcard type (i.e. cannot use ? super, ? extends etc.)."   | "super type parameter"
@@ -101,11 +103,11 @@ class BinaryTypeModelRuleExtractorTest extends AbstractAnnotationModelRuleExtrac
         ex.cause.message == expectedMessage
 
         where:
-        methodName                         | expectedMessage                                                                                                               | descr
-        "implementationSetMultipleTimes"   | "Method annotated with @ComponentType cannot set default implementation multiple times."                                         | "implementation set multiple times"
-        "implementationSetForManagedType"  | "Method annotated with @ComponentType cannot set default implementation for managed type ${ManagedBinarySpec.name}."             | "implementation set for managed type"
-        "internalViewNotInterface"         | "Internal view ${NonInterfaceInternalView.name} must be an interface."                                                        | "non-interface internal view"
-        "repeatedInternalView"             | "Internal view '${BinarySpecInternalView.name}' must not be specified multiple times."                                        | "internal view specified multiple times"
+        methodName                        | expectedMessage                                                                                                                       | descr
+        "implementationSetMultipleTimes"  | "Method annotated with @ComponentType cannot set default implementation multiple times."                                              | "implementation set multiple times"
+        "implementationSetForManagedType" | "Method annotated with @ComponentType cannot set default implementation for managed type ${fullyQualifiedNameOf(ManagedBinarySpec)}." | "implementation set for managed type"
+        "internalViewNotInterface"        | "Internal view ${NonInterfaceInternalView.name} must be an interface."                                                                | "non-interface internal view"
+        "repeatedInternalView"            | "Internal view '${BinarySpecInternalView.name}' must not be specified multiple times."                                                | "internal view specified multiple times"
     }
 
     static interface SomeBinarySpec extends BinarySpec {}

--- a/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/registry/ComponentBinariesModelRuleExtractorTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/registry/ComponentBinariesModelRuleExtractorTest.groovy
@@ -29,6 +29,8 @@ import spock.lang.Unroll
 
 import java.lang.annotation.Annotation
 
+import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
+
 class ComponentBinariesModelRuleExtractorTest extends AbstractAnnotationModelRuleExtractorTest {
 
     ComponentBinariesModelRuleExtractor ruleHandler = new ComponentBinariesModelRuleExtractor()
@@ -74,7 +76,7 @@ class ComponentBinariesModelRuleExtractorTest extends AbstractAnnotationModelRul
 
         then:
         def ex = thrown(InvalidModelRuleDeclarationException)
-        ex.message == """Type ${ruleClass.name} is not a valid rule source:
+        ex.message == """Type ${fullyQualifiedNameOf(ruleClass)} is not a valid rule source:
 - Method ${ruleDescription} is not a valid rule method: ${expectedMessage}"""
 
         where:


### PR DESCRIPTION
Use `.` instead of `$` to separate the enclosing type name from the nested type name.

