### PR TITLE
Reattach stdout/stderr in worker process before stopping messaging se…

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/OutputOnShutdownHookProcess.java
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/OutputOnShutdownHookProcess.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal;
+
+import org.gradle.api.Action;
+import org.gradle.process.internal.worker.WorkerProcessContext;
+
+import java.io.Serializable;
+
+public class OutputOnShutdownHookProcess implements Action<WorkerProcessContext>, Serializable {
+    @Override
+    public void execute(WorkerProcessContext workerProcessContext) {
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("Goodbye, world!");
+            }
+        }));
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
@@ -205,6 +205,16 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
         noExceptionThrown()
     }
 
+    def "handles output after worker messaging services are stopped"() {
+        when:
+        execute(worker(new OutputOnShutdownHookProcess()))
+
+        then:
+        noExceptionThrown()
+        stdout.stdOut.contains("Goodbye, world!")
+        ! stdout.stdErr.contains("java.lang.IllegalStateException")
+    }
+
     private class ChildProcess {
         private boolean stopFails;
         private boolean startFails;

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -86,6 +86,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
         MessagingServices messagingServices = new MessagingServices();
         WorkerServices workerServices = new WorkerServices(messagingServices);
 
+        WorkerLogEventListener workerLogEventListener = null;
         try {
             // Read serialized worker
             byte[] serializedWorker = decoder.readBinary();
@@ -100,7 +101,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
             }
 
             final ObjectConnection connection = messagingServices.get(MessagingClient.class).getConnection(serverAddress);
-            configureLogging(loggingManager, connection);
+            workerLogEventListener = configureLogging(loggingManager, connection);
             if (shouldPublishJvmMemoryInfo) {
                 configureWorkerJvmMemoryInfoEvents(workerServices, connection);
             }
@@ -120,16 +121,22 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
                 connection.stop();
             }
         } finally {
+            if (workerLogEventListener != null) {
+                loggingManager.removeOutputEventListener(workerLogEventListener);
+            }
             messagingServices.close();
+            loggingManager.stop();
         }
 
         return null;
     }
 
-    private void configureLogging(LoggingManagerInternal loggingManager, ObjectConnection connection) {
+    private WorkerLogEventListener configureLogging(LoggingManagerInternal loggingManager, ObjectConnection connection) {
         connection.useParameterSerializers(WorkerLoggingSerializer.create());
         WorkerLoggingProtocol workerLoggingProtocol = connection.addOutgoing(WorkerLoggingProtocol.class);
-        loggingManager.addOutputEventListener(new WorkerLogEventListener(workerLoggingProtocol));
+        WorkerLogEventListener workerLogEventListener = new WorkerLogEventListener(workerLoggingProtocol);
+        loggingManager.addOutputEventListener(workerLogEventListener);
+        return workerLogEventListener;
     }
 
     private void configureWorkerJvmMemoryInfoEvents(WorkerServices services, ObjectConnection connection) {


### PR DESCRIPTION
This is a fix for #1387.  The problem is that we are intercepting stdout/stderr and pushing it through the messaging infrastructure to the build process, but by the time shutdown hooks fire, we have already stopped the messaging services.  This changes the worker shutdown to reattach the original stdout/stderr just before stopping messaging services so that anything printed to stdout/stderr afterwards will not produce an exception.