### PR TITLE
Default to compileClasspath for dependencyInsight task

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -71,7 +71,7 @@ class DependencyInsightReportTaskIntegrationTest extends AbstractIntegrationSpec
 
         then:
         output.contains """
-No dependencies matching given input were found in configuration ':compile'
+No dependencies matching given input were found in configuration ':compileClasspath'
 """
     }
 
@@ -1041,7 +1041,42 @@ project :impl
         output.contains """
 org:leaf4:1.0
 \\--- project :impl
-     \\--- compile
+     \\--- compileClasspath
+"""
+    }
+
+    def "selects both api and implementation dependencies with dependency command line option"() {
+        given:
+        mavenRepo.module("org", "leaf1").publish()
+        mavenRepo.module("org", "leaf2").publish()
+
+        file("build.gradle") << """
+                apply plugin: 'java-library'
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                dependencies {
+                    api 'org:leaf1:1.0'
+                    implementation 'org:leaf2:1.0'
+                }
+        """
+
+        when:
+        run "dependencyInsight", "--dependency", "leaf1"
+
+        then:
+        output.contains """
+org:leaf1:1.0
+\\--- compileClasspath
+"""
+
+        when:
+        run "dependencyInsight", "--dependency", "leaf2"
+
+        then:
+        output.contains """
+org:leaf2:1.0
+\\--- compileClasspath
 """
     }
 
@@ -1086,7 +1121,7 @@ org:leaf4:1.0
         output.contains """
 project :api
 \\--- project :impl
-     \\--- compile
+     \\--- compileClasspath
 """
     }
 
@@ -1132,7 +1167,7 @@ org:leaf3:1.0
 \\--- org:leaf2:1.0
      +--- project :api
      |    \\--- project :impl
-     |         \\--- compile
+     |         \\--- compileClasspath
      \\--- org:leaf1:1.0
           \\--- project :impl (*)
 """

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.xml
@@ -26,7 +26,7 @@
             </thead>
             <tr>
                 <td>configuration</td>
-                <td><literal>compile</literal> configuration</td>
+                <td><literal>compileClasspath</literal> configuration</td>
             </tr>
             <tr>
                 <td>dependencySpec</td>

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -450,7 +450,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         }
 
         public Configuration getCompileDependencies() {
-            return convention.getProject().getConfigurations().getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME);
+            return convention.getProject().getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
         }
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -52,7 +52,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         component.rebuildTasks == [BasePlugin.CLEAN_TASK_NAME, JavaBasePlugin.BUILD_TASK_NAME]
         component.buildTasks == [JavaBasePlugin.BUILD_TASK_NAME]
         component.runtimeClasspath != null
-        component.compileDependencies == project.configurations.compile
+        component.compileDependencies == project.configurations.compileClasspath
     }
 
     def addsConfigurationsToTheProject() {


### PR DESCRIPTION
Issue: #1376

This should be probably also merged to 3.4 release branch.

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`
