### PR TITLE
Include variant attributes in resolved artifact result

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.api.artifacts.result;
 
 import org.gradle.api.Incubating;
-
-import java.io.File;
+import org.gradle.api.attributes.AttributeContainer;
 
 /**
- * The result of successfully resolving an artifact.
+ * The result of successfully resolving a component variant.
  *
- * @since 2.0
+ * @since 3.5
  */
 @Incubating
-public interface ResolvedArtifactResult extends ArtifactResult {
-    /**
-     * The file for the artifact.
-     */
-    File getFile();
-
-    /**
-     * The variant that included this artifact.
-     */
-    ResolvedVariantResult getVariant();
+public interface ResolvedVariantResult {
+    AttributeContainer getAttributes();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -35,14 +35,12 @@ def artifactType = Attribute.of('artifactType', String)
 def usage = Attribute.of('usage', String)
 
 allprojects {
-    allprojects {
-        repositories {
-            ivy { url '${ivyHttpRepo.uri}' }
-        }
-        dependencies {
-            attributesSchema {
-               attribute(usage)
-            }
+    repositories {
+        ivy { url '${ivyHttpRepo.uri}' }
+    }
+    dependencies {
+        attributesSchema {
+           attribute(usage)
         }
     }
     configurations {
@@ -117,11 +115,6 @@ allprojects {
             project(':app') {
                 def otherAttributeRequired = Attribute.of('otherAttributeRequired', String)
                 def otherAttributeOptional = Attribute.of('otherAttributeOptional', String)
-                
-                configurations {
-                    compile {
-                    }
-                }
 
                 dependencies {
                     compile project(':lib'), project(':ui')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactsApiIntegrationTest.groovy
@@ -22,6 +22,8 @@ import org.junit.runner.RunWith
 
 @RunWith(FluidDependenciesResolveRunner)
 class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    static defaultJarAttributes = "{artifactClassifier=, artifactExtension=jar, artifactType=jar}"
+
     def setup() {
         settingsFile << """
 rootProject.name = 'test'
@@ -108,7 +110,7 @@ task show {
         outputContains("display-names: [test-lib.jar, a-lib.jar, b-lib.jar, a.jar (project :a), test.jar (org:test:1.0), b.jar (project :b), test2.jar (org:test2:1.0)]")
         outputContains("components: [test-lib.jar, a-lib.jar, b-lib.jar, project :a, org:test:1.0, project :b, org:test2:1.0]")
         outputContains("unique components: [test-lib.jar, a-lib.jar, b-lib.jar, project :a, org:test:1.0, project :b, org:test2:1.0]")
-        outputContains("variants: [{}, {}, {}, {artifactType=jar}, {artifactType=jar}, {artifactType=jar}, {artifactType=jar}]")
+        outputContains("variants: [$defaultJarAttributes, $defaultJarAttributes, $defaultJarAttributes, {artifactType=jar}, {artifactType=jar}, {artifactType=jar}, {artifactType=jar}]")
     }
 
     def "result includes declared variant for local dependencies"() {
@@ -232,7 +234,7 @@ task show {
         then:
         outputContains("files: [transformed-test-lib.jar, transformed-a1.jar, transformed-test-1.0.jar]")
         outputContains("components: [transformed-test-lib.jar, project :a, org:test:1.0]")
-        outputContains("variants: [{}, {usage=transformed}, {usage=transformed}]")
+        outputContains("variants: [{usage=transformed}, {usage=transformed}, {usage=transformed}]")
     }
 
     def "more than one local file can have a given base name"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Nullable;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.internal.UncheckedException;
 
@@ -30,7 +31,7 @@ class ArtifactCollectingVisitor implements ArtifactVisitor {
     final Set<ResolvedArtifact> artifacts = Sets.newLinkedHashSet();
 
     @Override
-    public void visitArtifact(ResolvedArtifact artifact) {
+    public void visitArtifact(AttributeContainer variant, ResolvedArtifact artifact) {
         this.artifacts.add(artifact);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -46,7 +46,7 @@ class ArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, Iterable<File> files) {
+    public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, AttributeContainer variant, Iterable<File> files) {
         throw new UnsupportedOperationException();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -31,6 +31,7 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.component.Artifact;
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
@@ -323,7 +324,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         }
 
         @Override
-        public void visitArtifact(ResolvedArtifact artifact) {
+        public void visitArtifact(AttributeContainer variant, ResolvedArtifact artifact) {
             // Defer adding the artifacts until after all the file dependencies have been visited
             this.artifacts.add(artifact);
         }
@@ -376,12 +377,12 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         }
 
         @Override
-        public void visitArtifact(ResolvedArtifact artifact) {
+        public void visitArtifact(AttributeContainer variant, ResolvedArtifact artifact) {
             try {
                 if (seenArtifacts.add(artifact.getId())) {
                     // Trigger download of file, if required
                     File file = artifact.getFile();
-                    this.artifacts.add(new DefaultResolvedArtifactResult(artifact.getId(), Artifact.class, file));
+                    this.artifacts.add(new DefaultResolvedArtifactResult(artifact.getId(), variant, Artifact.class, file));
                 }
             } catch (Throwable t) {
                 failures.add(t);
@@ -404,7 +405,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
                         } else {
                             artifactIdentifier = new ComponentFileArtifactIdentifier(componentIdentifier, file.getName());
                         }
-                        artifacts.add(new DefaultResolvedArtifactResult(artifactIdentifier, Artifact.class, file));
+                        artifacts.add(new DefaultResolvedArtifactResult(artifactIdentifier, ImmutableAttributes.EMPTY, Artifact.class, file));
                     }
                 }
             } catch (Throwable t) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -340,7 +340,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         }
 
         @Override
-        public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, Iterable<File> files) {
+        public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, AttributeContainer variant, Iterable<File> files) {
             try {
                 for (File file : files) {
                     this.files.add(file);
@@ -395,7 +395,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         }
 
         @Override
-        public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, Iterable<File> files) {
+        public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, AttributeContainer variant, Iterable<File> files) {
             try {
                 for (File file : files) {
                     if (seenFiles.add(file)) {
@@ -405,7 +405,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
                         } else {
                             artifactIdentifier = new ComponentFileArtifactIdentifier(componentIdentifier, file.getName());
                         }
-                        artifacts.add(new DefaultResolvedArtifactResult(artifactIdentifier, ImmutableAttributes.EMPTY, Artifact.class, file));
+                        artifacts.add(new DefaultResolvedArtifactResult(artifactIdentifier, variant, Artifact.class, file));
                     }
                 }
             } catch (Throwable t) {
@@ -427,7 +427,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         }
 
         @Override
-        public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, Iterable<File> files) {
+        public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, AttributeContainer variant, Iterable<File> files) {
             CollectionUtils.addAll(this.files, files);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedArtifactSet.java
@@ -19,26 +19,29 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Buildable;
 import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.tasks.TaskDependency;
 
 import java.util.Collection;
 import java.util.Set;
 
 public class ArtifactBackedArtifactSet implements ResolvedArtifactSet {
+    private final AttributeContainer variant;
     private final ImmutableSet<ResolvedArtifact> artifacts;
 
-    private ArtifactBackedArtifactSet(Collection<? extends ResolvedArtifact> artifacts) {
+    private ArtifactBackedArtifactSet(AttributeContainer variant, Collection<? extends ResolvedArtifact> artifacts) {
+        this.variant = variant;
         this.artifacts = ImmutableSet.copyOf(artifacts);
     }
 
-    public static ResolvedArtifactSet of(Collection<? extends ResolvedArtifact> artifacts) {
+    public static ResolvedArtifactSet forVariant(AttributeContainer variantAttributes, Collection<? extends ResolvedArtifact> artifacts) {
         if (artifacts.isEmpty()) {
             return EMPTY;
         }
         if (artifacts.size() == 1) {
-            return new SingletonSet(artifacts.iterator().next());
+            return new SingletonSet(variantAttributes, artifacts.iterator().next());
         }
-        return new ArtifactBackedArtifactSet(artifacts);
+        return new ArtifactBackedArtifactSet(variantAttributes, artifacts);
     }
 
     @Override
@@ -56,14 +59,16 @@ public class ArtifactBackedArtifactSet implements ResolvedArtifactSet {
     @Override
     public void visit(ArtifactVisitor visitor) {
         for (ResolvedArtifact artifact : artifacts) {
-            visitor.visitArtifact(artifact);
+            visitor.visitArtifact(variant, artifact);
         }
     }
 
     private static class SingletonSet implements ResolvedArtifactSet {
+        private final AttributeContainer variantAttributes;
         private final ResolvedArtifact artifact;
 
-        SingletonSet(ResolvedArtifact artifact) {
+        SingletonSet(AttributeContainer variantAttributes, ResolvedArtifact artifact) {
+            this.variantAttributes = variantAttributes;
             this.artifact = artifact;
         }
 
@@ -74,7 +79,7 @@ public class ArtifactBackedArtifactSet implements ResolvedArtifactSet {
 
         @Override
         public void visit(ArtifactVisitor visitor) {
-            visitor.visitArtifact(artifact);
+            visitor.visitArtifact(variantAttributes, artifact);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import org.gradle.api.Nullable;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.attributes.AttributeContainer;
 
 import java.io.File;
 
@@ -29,7 +30,7 @@ public interface ArtifactVisitor {
     /**
      * Visits an artifact. Artifacts are resolved but not necessarily downloaded.
      */
-    void visitArtifact(ResolvedArtifact artifact);
+    void visitArtifact(AttributeContainer variant, ResolvedArtifact artifact);
 
     /**
      * Should {@link #visitFiles(ComponentIdentifier, Iterable)} be called?

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -33,14 +33,14 @@ public interface ArtifactVisitor {
     void visitArtifact(AttributeContainer variant, ResolvedArtifact artifact);
 
     /**
-     * Should {@link #visitFiles(ComponentIdentifier, Iterable)} be called?
+     * Should {@link #visitFiles(ComponentIdentifier, AttributeContainer, Iterable)} be called?
      */
     boolean includeFiles();
 
     /**
      * Visits a file collection. Should be considered a set of artifacts but is separate as a migration step.
      */
-    void visitFiles(@Nullable ComponentIdentifier componentIdentifier, Iterable<File> files);
+    void visitFiles(@Nullable ComponentIdentifier componentIdentifier, AttributeContainer variant, Iterable<File> files);
 
     /**
      * Called when some problem occurs visiting some element of the set. Visiting may continue.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -124,7 +124,7 @@ public class DefaultArtifactSet implements ArtifactSet {
                 }
                 resolvedArtifacts.add(resolvedArtifact);
             }
-            result.add(new DefaultResolvedVariant(attributes, ArtifactBackedArtifactSet.of(resolvedArtifacts)));
+            result.add(new DefaultResolvedVariant(attributes, ArtifactBackedArtifactSet.forVariant(attributes, resolvedArtifacts)));
         }
         return new ArtifactSetSnapshot(id, componentIdentifier, result.build());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -76,10 +76,13 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
     private static class SingletonFileResolvedArtifactSet implements ResolvedArtifactSet {
         private final ComponentIdentifier componentIdentifier;
         private final File file;
+        private final AttributeContainer variantAttributes;
 
-        SingletonFileResolvedArtifactSet(File file, @Nullable ComponentIdentifier componentIdentifier) {
+
+        SingletonFileResolvedArtifactSet(File file, @Nullable ComponentIdentifier componentIdentifier, AttributeContainer variantAttributes) {
             this.file = file;
             this.componentIdentifier = componentIdentifier;
+            this.variantAttributes = variantAttributes;
         }
 
         @Override
@@ -95,7 +98,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         @Override
         public void visit(ArtifactVisitor visitor) {
             if (visitor.includeFiles()) {
-                visitor.visitFiles(componentIdentifier, Collections.singletonList(file));
+                visitor.visitFiles(componentIdentifier, variantAttributes, Collections.singletonList(file));
             }
         }
     }
@@ -113,7 +116,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
 
         @Override
         public ResolvedArtifactSet getArtifacts() {
-            return new SingletonFileResolvedArtifactSet(file, componentIdentifier);
+            return new SingletonFileResolvedArtifactSet(file, componentIdentifier, variantAttributes);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -39,6 +39,7 @@ import org.gradle.api.internal.artifacts.result.DefaultComponentArtifactsResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult;
 import org.gradle.api.internal.artifacts.result.DefaultUnresolvedArtifactResult;
 import org.gradle.api.internal.artifacts.result.DefaultUnresolvedComponentResult;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.internal.Factory;
@@ -162,7 +163,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
             if (resolveResult.getFailure() != null) {
                 artifacts.addArtifact(new DefaultUnresolvedArtifactResult(artifactMetaData.getId(), type, resolveResult.getFailure()));
             } else {
-                artifacts.addArtifact(new DefaultResolvedArtifactResult(artifactMetaData.getId(), type, resolveResult.getResult()));
+                artifacts.addArtifact(new DefaultResolvedArtifactResult(artifactMetaData.getId(), ImmutableAttributes.EMPTY, type, resolveResult.getResult()));
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
@@ -17,17 +17,21 @@ package org.gradle.api.internal.artifacts.result;
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.component.Artifact;
 
 import java.io.File;
 
 public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
     private final ComponentArtifactIdentifier identifier;
+    private final ResolvedVariantResult variant;
     private final Class<? extends Artifact> type;
     private final File file;
 
-    public DefaultResolvedArtifactResult(ComponentArtifactIdentifier identifier,  Class<? extends Artifact> type, File file) {
+    public DefaultResolvedArtifactResult(ComponentArtifactIdentifier identifier, AttributeContainer variantAttributes, Class<? extends Artifact> type, File file) {
         this.identifier = identifier;
+        this.variant = new DefaultResolvedVariantResult(variantAttributes);
         this.type = type;
         this.file = file;
     }
@@ -48,5 +52,10 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
 
     public File getFile() {
         return file;
+    }
+
+    @Override
+    public ResolvedVariantResult getVariant() {
+        return variant;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedVariantResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedVariantResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.artifacts.result;
 
-import org.gradle.api.Incubating;
+package org.gradle.api.internal.artifacts.result;
 
-import java.io.File;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.attributes.AttributeContainer;
 
-/**
- * The result of successfully resolving an artifact.
- *
- * @since 2.0
- */
-@Incubating
-public interface ResolvedArtifactResult extends ArtifactResult {
-    /**
-     * The file for the artifact.
-     */
-    File getFile();
+public class DefaultResolvedVariantResult implements ResolvedVariantResult {
+    private final AttributeContainer attributes;
 
-    /**
-     * The variant that included this artifact.
-     */
-    ResolvedVariantResult getVariant();
+    public DefaultResolvedVariantResult(AttributeContainer attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return attributes;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
@@ -24,6 +24,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DefaultResolvedArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
@@ -149,11 +150,11 @@ public class DefaultArtifactTransforms implements ArtifactTransforms {
         }
 
         @Override
-        public void visitArtifact(ResolvedArtifact artifact) {
+        public void visitArtifact(AttributeContainer variant, ResolvedArtifact artifact) {
             List<ResolvedArtifact> transformResults = matchingCache.getTransformedArtifacts(artifact, target);
             if (transformResults != null) {
                 for (ResolvedArtifact resolvedArtifact : transformResults) {
-                    visitor.visitArtifact(resolvedArtifact);
+                    visitor.visitArtifact(target, resolvedArtifact);
                 }
                 return;
             }
@@ -173,7 +174,7 @@ public class DefaultArtifactTransforms implements ArtifactTransforms {
                 IvyArtifactName artifactName = DefaultIvyArtifactName.forAttributeContainer(output.getName(), this.target);
                 ResolvedArtifact resolvedArtifact = new DefaultResolvedArtifact(artifact.getModuleVersion().getId(), artifactName, newId, buildDependencies, output, this.target, attributesFactory);
                 transformResults.add(resolvedArtifact);
-                visitor.visitArtifact(resolvedArtifact);
+                visitor.visitArtifact(target, resolvedArtifact);
             }
 
             matchingCache.putTransformedArtifact(artifact, this.target, transformResults);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
@@ -191,7 +191,7 @@ public class DefaultArtifactTransforms implements ArtifactTransforms {
         }
 
         @Override
-        public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, Iterable<File> files) {
+        public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, AttributeContainer variant, Iterable<File> files) {
             List<File> result = new ArrayList<File>();
             try {
                 for (File file : files) {
@@ -214,7 +214,7 @@ public class DefaultArtifactTransforms implements ArtifactTransforms {
                 return;
             }
             if (!result.isEmpty()) {
-                visitor.visitFiles(componentIdentifier, result);
+                visitor.visitFiles(componentIdentifier, target, result);
             }
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencySpec.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts
 
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactBackedArtifactSet
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import spock.lang.Specification
 
 class DefaultResolvedDependencySpec extends Specification {
@@ -75,7 +76,7 @@ class DefaultResolvedDependencySpec extends Specification {
 
         given:
         dependency.parents.add(parent)
-        dependency.addParentSpecificArtifacts(parent, ArtifactBackedArtifactSet.of([artifact6, artifact1, artifact7, artifact5, artifact2, artifact3, artifact4]))
+        dependency.addParentSpecificArtifacts(parent, ArtifactBackedArtifactSet.forVariant(ImmutableAttributes.EMPTY, [artifact6, artifact1, artifact7, artifact5, artifact2, artifact3, artifact4]))
 
         expect:
         dependency.getParentArtifacts(parent) as List == [artifact1, artifact2, artifact3, artifact4, artifact5, artifact6, artifact7]
@@ -92,6 +93,6 @@ class DefaultResolvedDependencySpec extends Specification {
     }
 
     def add(DefaultResolvedDependency dependency, ResolvedArtifact artifact) {
-        dependency.addParentSpecificArtifacts(Stub(DefaultResolvedDependency), ArtifactBackedArtifactSet.of([artifact]))
+        dependency.addParentSpecificArtifacts(Stub(DefaultResolvedDependency), ArtifactBackedArtifactSet.forVariant(ImmutableAttributes.EMPTY, [artifact]))
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.java
@@ -79,8 +79,8 @@ public class DefaultResolvedDependencyTest {
         DefaultResolvedDependency parent2 = new DefaultResolvedDependency(16L, newId("someGroup", "someChild", "someVersion", "p2"));
         parent2.addChild(resolvedDependency);
 
-        resolvedDependency.addParentSpecificArtifacts(parent1, ArtifactBackedArtifactSet.of(Collections.singleton(artifact2)));
-        resolvedDependency.addParentSpecificArtifacts(parent2, ArtifactBackedArtifactSet.of(Arrays.asList(artifact1, artifact2)));
+        resolvedDependency.addParentSpecificArtifacts(parent1, ArtifactBackedArtifactSet.forVariant(ImmutableAttributes.EMPTY, Collections.singleton(artifact2)));
+        resolvedDependency.addParentSpecificArtifacts(parent2, ArtifactBackedArtifactSet.forVariant(ImmutableAttributes.EMPTY, Arrays.asList(artifact1, artifact2)));
 
         assertThat(resolvedDependency.getAllModuleArtifacts(), equalTo(toSet(artifact1, artifact2)));
     }
@@ -225,7 +225,7 @@ public class DefaultResolvedDependencyTest {
     private DefaultResolvedDependency createAndAddParent(String parentName, DefaultResolvedDependency resolvedDependency, Set<ResolvedArtifact> parentSpecificArtifacts) {
         DefaultResolvedDependency parent = new DefaultResolvedDependency(10L, newId("someGroup", parentName, "someVersion", "someConfiguration"));
         resolvedDependency.getParents().add(parent);
-        resolvedDependency.addParentSpecificArtifacts(parent, ArtifactBackedArtifactSet.of(parentSpecificArtifacts));
+        resolvedDependency.addParentSpecificArtifacts(parent, ArtifactBackedArtifactSet.forVariant(ImmutableAttributes.EMPTY, parentSpecificArtifacts));
         return parent;
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/CompositeArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/CompositeArtifactSetTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
 import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import spock.lang.Specification
 
 class CompositeArtifactSetTest extends Specification {
@@ -38,8 +39,8 @@ class CompositeArtifactSetTest extends Specification {
         def a1 = Mock(ResolvedArtifact)
         def a2 = Mock(ResolvedArtifact)
         def a3 = Mock(ResolvedArtifact)
-        def set1 = ArtifactBackedArtifactSet.of([a1, a2])
-        def set2 = ArtifactBackedArtifactSet.of([a2, a3])
+        def set1 = ArtifactBackedArtifactSet.forVariant(ImmutableAttributes.EMPTY, [a1, a2])
+        def set2 = ArtifactBackedArtifactSet.forVariant(ImmutableAttributes.EMPTY, [a2, a3])
 
         expect:
         CompositeArtifactSet.of([set1, set2]).artifacts as List == [a1, a2, a3]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -19,12 +19,14 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 import org.gradle.api.Transformer
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.artifacts.attributes.DefaultArtifactAttributes
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata
 import spock.lang.Specification
 
 class LocalFileDependencyBackedArtifactSetTest extends Specification {
+    def attributesFactory = new DefaultImmutableAttributesFactory()
     def dep = Mock(LocalFileDependencyMetadata)
     def selector = Mock(Transformer)
     def set = new LocalFileDependencyBackedArtifactSet(dep, selector, new DefaultImmutableAttributesFactory())
@@ -75,8 +77,8 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         _ * visitor.includeFiles() >> true
         1 * files.files >> ([f1, f2] as Set)
         2 * selector.transform(_) >> { Set<ResolvedVariant> variants -> variants.first().artifacts }
-        1 * visitor.visitFiles(id, [f1])
-        1 * visitor.visitFiles(id, [f2])
+        1 * visitor.visitFiles(id, DefaultArtifactAttributes.forFile(f1, attributesFactory), [f1])
+        1 * visitor.visitFiles(id, DefaultArtifactAttributes.forFile(f2, attributesFactory), [f2])
         0 * visitor._
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -83,13 +83,13 @@ class DefaultArtifactTransformsTest extends Specification {
         then:
         _ * artifacts1.visit(_) >> { ArtifactVisitor v ->
             v.visitArtifact(targetAttributes, sourceArtifact)
-            v.visitFiles(id, [sourceFile])
+            v.visitFiles(id, targetAttributes, [sourceFile])
         }
         1 * transformer.transform(sourceArtifactFile) >> [outFile1, outFile2]
         1 * transformer.transform(sourceFile) >> [outFile3, outFile4]
         1 * visitor.visitArtifact(targetAttributes, {it.file == outFile1})
         1 * visitor.visitArtifact(targetAttributes, {it.file == outFile2})
-        1 * visitor.visitFiles(id, [outFile3, outFile4])
+        1 * visitor.visitFiles(id, targetAttributes, [outFile3, outFile4])
         0 * visitor._
         0 * transformer._
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -66,28 +66,29 @@ class DefaultArtifactTransformsTest extends Specification {
         def outFile4 = new File("out4.classes")
         def transformer = Mock(Transformer)
         def visitor = Mock(ArtifactVisitor)
+        def targetAttributes = typeAttributes("classes")
 
         given:
         variant1.attributes >> typeAttributes("jar")
         variant2.attributes >> typeAttributes("dll")
         variant1.artifacts >> artifacts1
 
-        matchingCache.getTransform(typeAttributes("jar"), typeAttributes("classes")) >> transformer
-        matchingCache.getTransform(typeAttributes("dll"), typeAttributes("classes")) >> null
+        matchingCache.getTransform(typeAttributes("jar"), targetAttributes) >> transformer
+        matchingCache.getTransform(typeAttributes("dll"), targetAttributes) >> null
 
         when:
-        def result = transforms.variantSelector(typeAttributes("classes")).transform([variant1, variant2])
+        def result = transforms.variantSelector(targetAttributes).transform([variant1, variant2])
         result.visit(visitor)
 
         then:
         _ * artifacts1.visit(_) >> { ArtifactVisitor v ->
-            v.visitArtifact(sourceArtifact)
+            v.visitArtifact(targetAttributes, sourceArtifact)
             v.visitFiles(id, [sourceFile])
         }
         1 * transformer.transform(sourceArtifactFile) >> [outFile1, outFile2]
         1 * transformer.transform(sourceFile) >> [outFile3, outFile4]
-        1 * visitor.visitArtifact({it.file == outFile1})
-        1 * visitor.visitArtifact({it.file == outFile2})
+        1 * visitor.visitArtifact(targetAttributes, {it.file == outFile1})
+        1 * visitor.visitArtifact(targetAttributes, {it.file == outFile2})
         1 * visitor.visitFiles(id, [outFile3, outFile4])
         0 * visitor._
         0 * transformer._

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -113,7 +113,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             }
 
             @Override
-            public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, Iterable<File> files) {
+            public void visitFiles(@Nullable ComponentIdentifier componentIdentifier, AttributeContainer variant, Iterable<File> files) {
                 for (File file : files) {
                     result.add(file);
                 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -20,6 +20,7 @@ import org.gradle.api.Nullable;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
@@ -97,7 +98,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
         final Set<File> result = new LinkedHashSet<File>();
         resolveResult.artifactsResults.getArtifacts().visit(new ArtifactVisitor() {
             @Override
-            public void visitArtifact(ResolvedArtifact artifact) {
+            public void visitArtifact(AttributeContainer variant, ResolvedArtifact artifact) {
                 result.add(artifact.getFile());
             }
 


### PR DESCRIPTION
Adds `ResolvedArtifactResult.getVariant()` that returns a `ResolvedVariantResult` which contains the attributes of the variant that was resolved to include that artifact.