### PR TITLE
Fixed bug in generating distributionUrl

### DIFF
--- a/subprojects/build-init/src/main/groovy/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/groovy/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -45,6 +45,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -311,7 +312,7 @@ public class Wrapper extends DefaultTask {
         if (distributionUrl != null) {
             return distributionUrl;
         } else if (gradleVersion != null) {
-            return locator.getDistributionFor(gradleVersion, distributionType.name().toLowerCase()).toString();
+            return locator.getDistributionFor(gradleVersion, distributionType.name().toLowerCase(Locale.ENGLISH)).toString();
         } else {
             return null;
         }

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -164,4 +164,21 @@ public class WrapperTest extends AbstractTaskTest {
         properties.getProperty(WrapperExecutor.ZIP_STORE_BASE_PROPERTY) == wrapper.getArchiveBase().toString()
         properties.getProperty(WrapperExecutor.ZIP_STORE_PATH_PROPERTY) == wrapper.getArchivePath()
     }
+
+    def "distributionUrl should not contain small dotless I letter when locale has small dotless I letter"() {
+        given:
+        Locale originalLocale = Locale.getDefault()
+        Locale.setDefault(new Locale("tr","TR"))
+
+        when:
+        wrapper.execute()
+        String distributionUrl = wrapper.getDistributionUrl()
+        Locale.setDefault(originalLocale)
+
+        then:
+        distributionUrl.contains("ı") == false
+        distributionUrl.contains("\\u0131") == false
+        Locale.getDefault() == originalLocale
+
+    }
 }


### PR DESCRIPTION
Bug was only in those locales which contain small dotless I letter (ı).
More detail: https://groups.google.com/forum/#!topic/gradle-dev/JHZqo_EJ2zs

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [x] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
