### PR TITLE
Allow running tasks before executing BuildAction

### DIFF
--- a/design-docs/tooling-api-improvements.md
+++ b/design-docs/tooling-api-improvements.md
@@ -224,6 +224,34 @@ This story adds support to build models that have a scope of a whole Gradle buil
 
 Similar to `gradleApi()`
 
+## Story: Run tasks before executing a BuildAction
+
+This story adds support to fetch complex models that are not known upfront, but depend on the result of some tasks.
+
+Some complex models generation might involve analyzing project's source tree, upstream dependencies, etc.
+Thus it's necessary to make the Tooling API allow users to pass a list of tasks to be executed before the BuildAction
+is executed (in the same connection to improve performance).
+
+1. Modify the `BuildActionExecuter` interface to allow passing a list of tasks to be run:
+
+```java
+public interface BuildActionExecuter<T> extends ConfigurableLauncher<BuildActionExecuter<T>> {
+    BuildActionExecuter<T> forTasks(String... tasks);
+    BuildActionExecuter<T> forTasks(Iterable<String> tasks);
+}
+```
+
+2. Implement the ability of running tasks in `ClientProvidedBuildActionRunner` based on `BuildModelActionRunner` implementation.
+
+### Test cases
+
+- `ProjectConnection.action(myAction).forTasks(myTasks)` is called.
+  - Project is configured, tasks graph is calculated and tasks are run before `BuildAction.execute` is called.
+- `forTasks` is called more than once.
+  - Tasks defined in the last call override the previous
+- Failure occurs while executing tasks.
+  - Exception is thrown and the `BuildAction` is not executed
+
 # Backlog
 
 * Replace `LongRunningOperation.standardOutput` and `standardError` with overloads that take a `Writer`, and (later) deprecate the `OutputStream` variants.

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ClientProvidedBuildAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ClientProvidedBuildAction.java
@@ -22,11 +22,13 @@ import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 public class ClientProvidedBuildAction extends SubscribableBuildAction {
     private final StartParameter startParameter;
     private final SerializedPayload action;
+    private final boolean runTasks;
 
-    public ClientProvidedBuildAction(StartParameter startParameter, SerializedPayload action, BuildClientSubscriptions clientSubscriptions) {
+    public ClientProvidedBuildAction(StartParameter startParameter, SerializedPayload action, boolean runTasks, BuildClientSubscriptions clientSubscriptions) {
         super(clientSubscriptions);
         this.startParameter = startParameter;
         this.action = action;
+        this.runTasks = runTasks;
     }
 
     @Override
@@ -36,5 +38,9 @@ public class ClientProvidedBuildAction extends SubscribableBuildAction {
 
     public SerializedPayload getAction() {
         return action;
+    }
+
+    public boolean isRunTasks() {
+        return runTasks;
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -119,11 +119,12 @@ public class ProviderConnection {
     }
 
     public Object run(InternalBuildAction<?> clientAction, BuildCancellationToken cancellationToken, ProviderOperationParameters providerParameters) {
+        List<String> tasks = providerParameters.getTasks();
         SerializedPayload serializedAction = payloadSerializer.serialize(clientAction);
         Parameters params = initParams(providerParameters);
         StartParameter startParameter = new ProviderStartParameterConverter().toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
-        BuildAction action = new ClientProvidedBuildAction(startParameter, serializedAction, listenerConfig.clientSubscriptions);
+        BuildAction action = new ClientProvidedBuildAction(startParameter, serializedAction, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
     }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunner.java
@@ -48,20 +48,28 @@ public class ClientProvidedBuildActionRunner implements BuildActionRunner {
         PayloadSerializer payloadSerializer = getPayloadSerializer(gradle);
         final InternalBuildAction<?> clientAction = (InternalBuildAction<?>) payloadSerializer.deserialize(clientProvidedBuildAction.getAction());
 
+        final boolean isRunTasks = clientProvidedBuildAction.isRunTasks();
+
         gradle.addBuildListener(new BuildAdapter() {
             @Override
             public void buildFinished(BuildResult result) {
                 if (result.getFailure() == null) {
-                    buildController.setResult(buildResult(clientAction, gradle));
+                    buildController.setResult(buildResult(clientAction, gradle, isRunTasks));
                 }
             }
         });
 
-        buildController.configure();
+        if (isRunTasks) {
+            buildController.run();
+        } else {
+            buildController.configure();
+        }
     }
 
-    private BuildActionResult buildResult(InternalBuildAction<?> clientAction, GradleInternal gradle) {
-        forceFullConfiguration(gradle);
+    private BuildActionResult buildResult(InternalBuildAction<?> clientAction, GradleInternal gradle, boolean isRunTasks) {
+        if (!isRunTasks) {
+            forceFullConfiguration(gradle);
+        }
 
         InternalBuildController internalBuildController = new DefaultBuildController(gradle);
         Object model = null;

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunnerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunnerTest.groovy
@@ -60,7 +60,7 @@ class ClientProvidedBuildActionRunnerTest extends Specification {
         }
         getGradle() >> gradle
     }
-    def clientProvidedBuildAction = new ClientProvidedBuildAction(startParameter, action, clientSubscriptions)
+    def clientProvidedBuildAction = new ClientProvidedBuildAction(startParameter, action, false /* isRunTasks */, clientSubscriptions)
     def runner = new ClientProvidedBuildActionRunner()
 
     def "can run action and returns result when completed"() {
@@ -80,6 +80,7 @@ class ClientProvidedBuildActionRunnerTest extends Specification {
             assert result.failure == null
             assert result.result == output
         }
+        0 * buildController.run()
     }
 
     def "can run action and reports failure"() {
@@ -103,6 +104,7 @@ class ClientProvidedBuildActionRunnerTest extends Specification {
             assert result.failure == output
             assert result.result == null
         }
+        0 * buildController.run()
     }
 
     def "can run action and propagate cancellation exception"() {
@@ -126,5 +128,17 @@ class ClientProvidedBuildActionRunnerTest extends Specification {
             assert result.failure == output
             assert result.result == null
         }
+        0 * buildController.run()
+    }
+
+    def "can run tasks before run action"() {
+        given:
+        def clientProvidedBuildActionRunTasks = new ClientProvidedBuildAction(startParameter, action, true /* isRunTasks */, clientSubscriptions)
+
+        when:
+        runner.run(clientProvidedBuildActionRunTasks, buildController)
+
+        then:
+        1 * buildController.run()
     }
 }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r35/RunTasksBeforeRunActionCrossVersion.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r35/RunTasksBeforeRunActionCrossVersion.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r35
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+
+import java.util.regex.Pattern
+
+
+@ToolingApiVersion('>=3.5')
+@TargetGradleVersion('>=3.5')
+class RunTasksBeforeRunActionCrossVersion extends ToolingApiSpecification {
+    def setup() {
+        buildFile << """
+            task hello {
+                doLast {
+                    println "hello"
+                }
+            }
+
+            task bye(dependsOn: hello) {
+                doLast {
+                    println "bye"
+                }
+            }
+        """
+    }
+
+    def "can run tasks"() {
+        when:
+        def stdOut = new ByteArrayOutputStream()
+        withConnection {
+            connection -> connection.action(new SimpleAction()).forTasks("hello", "bye").setStandardOutput(stdOut).run()
+        }
+
+        then:
+        assert stdOut.toString().contains("hello")
+        assert stdOut.toString().contains("bye")
+    }
+
+    def "tasks are run before action is executed"() {
+        when:
+        def stdOut = new ByteArrayOutputStream()
+        def result = withConnection {
+            connection -> connection.action(new SimpleAction()).forTasks("bye").setStandardOutput(stdOut).run()
+        }
+
+        then:
+        Pattern regex = Pattern.compile(".*hello.*bye.*starting action.*", Pattern.DOTALL)
+        assert stdOut.toString().matches(regex)
+        assert result == "Action result"
+    }
+}

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r35/RunTasksBeforeRunActionCrossVersion.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r35/RunTasksBeforeRunActionCrossVersion.groovy
@@ -71,7 +71,7 @@ class RunTasksBeforeRunActionCrossVersion extends ToolingApiSpecification {
     }
 
     @TargetGradleVersion(">=1.2 <3.5")
-    def "run tasks should fail when it is not supported by target"() {
+    def "BuildExecuter.forTasks() should fail when it is not supported by target"() {
         when:
         withConnection {
             connection -> connection.action(new SimpleAction()).forTasks("hello").run()
@@ -79,11 +79,11 @@ class RunTasksBeforeRunActionCrossVersion extends ToolingApiSpecification {
 
         then:
         UnsupportedVersionException e = thrown()
-        assert e.message == "The version of Gradle you are using (${targetDist.version.version}) does not support the run tasks before executing BuildAction feature. Support for this is available in Gradle 3.5 and all later versions."
+        assert e.message == "The version of Gradle you are using (${targetDist.version.version}) does not support the BuildActionExecuter.forTasks(). Support for this is available in Gradle 3.5 and all later versions."
     }
 
     @TargetGradleVersion(">=1.2 <3.5")
-    def "run tasks notify failure to handler when it is not supported by target"() {
+    def "BuildExecuter.forTasks() notifies failure to handler when it is not supported by target"() {
         def handler = Mock(ResultHandler)
         def version = targetDist.version.version
 
@@ -97,7 +97,7 @@ class RunTasksBeforeRunActionCrossVersion extends ToolingApiSpecification {
         1 * handler.onFailure(_) >> { args ->
             GradleConnectionException failure = args[0]
             assert failure instanceof UnsupportedVersionException
-            assert failure.message == "The version of Gradle you are using (${version}) does not support the run tasks before executing BuildAction feature. Support for this is available in Gradle 3.5 and all later versions."
+            assert failure.message == "The version of Gradle you are using (${version}) does not support the BuildActionExecuter.forTasks(). Support for this is available in Gradle 3.5 and all later versions."
         }
     }
 }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r35/SimpleAction.java
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r35/SimpleAction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r35;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+
+public class SimpleAction implements BuildAction<String> {
+    @Override
+    public String execute(BuildController controller) {
+        System.out.println("starting action");
+        return "Action result";
+    }
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildActionExecuter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildActionExecuter.java
@@ -28,6 +28,30 @@ import org.gradle.api.Incubating;
 public interface BuildActionExecuter<T> extends ConfigurableLauncher<BuildActionExecuter<T>> {
 
     /**
+     * Specifies the tasks to execute before executing the BuildAction.
+     *
+     * If not configured, null, or an empty array is passed, then no tasks will be executed.
+     *
+     * @param tasks The paths of the tasks to be executed. Relative paths are evaluated relative to the project for which this launcher was created.
+     * @return this
+     * @since 3.5
+     */
+    @Incubating
+    BuildActionExecuter<T> forTasks(String... tasks);
+
+    /**
+     * Specifies the tasks to execute before executing the BuildAction.
+     *
+     * If not configured, null, or an empty array is passed, then no tasks will be executed.
+     *
+     * @param tasks The paths of the tasks to be executed. Relative paths are evaluated relative to the project for which this launcher was created.
+     * @return this
+     * @since 3.5
+     */
+    @Incubating
+    BuildActionExecuter<T> forTasks(Iterable<String> tasks);
+
+    /**
      * Runs the action, blocking until its result is available.
      *
      * @throws UnsupportedVersionException When the target Gradle version does not support build action execution.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildActionExecuter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildActionExecuter.java
@@ -42,6 +42,18 @@ class DefaultBuildActionExecuter<T> extends AbstractLongRunningOperation<Default
         return this;
     }
 
+    @Override
+    public BuildActionExecuter<T> forTasks(String... tasks) {
+        operationParamsBuilder.setTasks(rationalizeInput(tasks));
+        return getThis();
+    }
+
+    @Override
+    public BuildActionExecuter<T> forTasks(Iterable<String> tasks) {
+        operationParamsBuilder.setTasks(rationalizeInput(tasks));
+        return getThis();
+    }
+
     public T run() throws GradleConnectionException {
         BlockingResultHandler<Object> handler = new BlockingResultHandler<Object>(Object.class);
         run(handler);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ParameterValidatingConsumerConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ParameterValidatingConsumerConnection.java
@@ -49,6 +49,7 @@ public class ParameterValidatingConsumerConnection implements ConsumerConnection
     @Override
     public <T> T run(BuildAction<T> action, ConsumerOperationParameters operationParameters) throws UnsupportedOperationException, IllegalStateException {
         validateParameters(operationParameters);
+        validateBuildActionParameters(operationParameters);
         return delegate.run(action, operationParameters);
     }
 
@@ -62,6 +63,14 @@ public class ParameterValidatingConsumerConnection implements ConsumerConnection
         if (!targetVersionDetails.supportsEnvironmentVariablesCustomization()) {
             if (operationParameters.getEnvironmentVariables() != null) {
                 throw Exceptions.unsupportedFeature("environment variables customization feature", targetVersionDetails.getVersion(), "3.5");
+            }
+        }
+    }
+
+    private void validateBuildActionParameters(ConsumerOperationParameters operationParameters) {
+        if (!targetVersionDetails.supportsRunTasksBeforeExecutingAction()) {
+            if (operationParameters.getTasks() != null) {
+                throw Exceptions.unsupportedFeature("run tasks before executing BuildAction feature", targetVersionDetails.getVersion(), "3.5");
             }
         }
     }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ParameterValidatingConsumerConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ParameterValidatingConsumerConnection.java
@@ -70,7 +70,7 @@ public class ParameterValidatingConsumerConnection implements ConsumerConnection
     private void validateBuildActionParameters(ConsumerOperationParameters operationParameters) {
         if (!targetVersionDetails.supportsRunTasksBeforeExecutingAction()) {
             if (operationParameters.getTasks() != null) {
-                throw Exceptions.unsupportedFeature("run tasks before executing BuildAction feature", targetVersionDetails.getVersion(), "3.5");
+                throw Exceptions.unsupportedFeature("BuildActionExecuter.forTasks()", targetVersionDetails.getVersion(), "3.5");
             }
         }
     }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/versioning/VersionDetails.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/versioning/VersionDetails.java
@@ -82,6 +82,10 @@ public abstract class VersionDetails implements Serializable {
         return false;
     }
 
+    public boolean supportsRunTasksBeforeExecutingAction() {
+        return false;
+    }
+
     private static class R12VersionDetails extends VersionDetails {
         public R12VersionDetails(String version) {
             super(version);
@@ -158,6 +162,11 @@ public abstract class VersionDetails implements Serializable {
 
         @Override
         public boolean supportsEnvironmentVariablesCustomization() {
+            return true;
+        }
+
+        @Override
+        public boolean supportsRunTasksBeforeExecutingAction() {
             return true;
         }
     }


### PR DESCRIPTION
Introduce methods forTasks in tooling API's BuildActionExecuter so the
user is able to run tasks before having his BuildAction executed, in the
same connection.

This feature is useful in Android development for determining a list of
APK slipts (running some tasks) and return a model with them afterwards
so the IDE can configure the project.

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [ ] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [x] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on your local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
