### PR TITLE
Separate instantiating the build cache from combining

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServiceInstantiator.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServiceInstantiator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.internal;
+
+import org.gradle.caching.BuildCacheService;
+import org.gradle.caching.configuration.BuildCache;
+
+public interface BuildCacheServiceInstantiator {
+    BuildCacheService createBuildCacheService(BuildCache configuration, boolean pullDisabled, boolean pushDisabled);
+}

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/DefaultBuildCacheServiceInstantiator.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/DefaultBuildCacheServiceInstantiator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.internal;
+
+import org.gradle.caching.BuildCacheService;
+import org.gradle.caching.BuildCacheServiceFactory;
+import org.gradle.caching.configuration.BuildCache;
+import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
+import org.gradle.internal.Cast;
+import org.gradle.internal.progress.BuildOperationExecutor;
+import org.gradle.internal.reflect.Instantiator;
+
+public class DefaultBuildCacheServiceInstantiator implements BuildCacheServiceInstantiator {
+    private final BuildOperationExecutor buildOperationExecutor;
+    private final BuildCacheConfigurationInternal buildCacheConfiguration;
+    private final Instantiator instantiator;
+
+    public DefaultBuildCacheServiceInstantiator(BuildCacheConfigurationInternal buildCacheConfiguration, BuildOperationExecutor buildOperationExecutor, Instantiator instantiator) {
+        this.buildOperationExecutor = buildOperationExecutor;
+        this.buildCacheConfiguration = buildCacheConfiguration;
+        this.instantiator = instantiator;
+    }
+
+    @Override
+    public BuildCacheService createBuildCacheService(BuildCache configuration, boolean pullDisabled, boolean pushDisabled) {
+        return decorateBuildCacheService(pullDisabled, pushDisabled, instantiateService(configuration));
+    }
+
+    private BuildCacheService decorateBuildCacheService(boolean pullDisabled, boolean pushDisabled, BuildCacheService buildCacheService) {
+        return new LenientBuildCacheServiceDecorator(
+            new ShortCircuitingErrorHandlerBuildCacheServiceDecorator(
+                3,
+                new LoggingBuildCacheServiceDecorator(
+                    new PushOrPullPreventingBuildCacheServiceDecorator(
+                        pushDisabled,
+                        pullDisabled,
+                        new BuildOperationFiringBuildCacheServiceDecorator(
+                            buildOperationExecutor,
+                            buildCacheService
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private <T extends BuildCache> BuildCacheService instantiateService(final T configuration) {
+        Class<? extends BuildCacheServiceFactory<T>> buildCacheServiceFactoryType = Cast.uncheckedCast(buildCacheConfiguration.getBuildCacheServiceFactoryType(configuration.getClass()));
+        return instantiator.newInstance(buildCacheServiceFactoryType).build(configuration);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -71,7 +71,9 @@ import org.gradle.cache.CacheValidator;
 import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
 import org.gradle.caching.configuration.internal.BuildCacheServiceRegistration;
 import org.gradle.caching.configuration.internal.DefaultBuildCacheConfiguration;
+import org.gradle.caching.internal.BuildCacheServiceInstantiator;
 import org.gradle.caching.internal.BuildCacheServiceProvider;
+import org.gradle.caching.internal.DefaultBuildCacheServiceInstantiator;
 import org.gradle.caching.internal.DefaultBuildCacheServiceProvider;
 import org.gradle.caching.internal.LocalBuildCacheServiceRegistration;
 import org.gradle.caching.internal.tasks.TaskExecutionStatisticsEventAdapter;
@@ -446,8 +448,13 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return instantiator.newInstance(DefaultBuildCacheConfiguration.class, instantiator, allBuildCacheServiceFactories);
     }
 
-    BuildCacheServiceProvider createBuildCacheServiceProvider(StartParameter startParameter, BuildCacheConfigurationInternal buildCacheConfiguration, BuildOperationExecutor buildOperationExecutor) {
-        return new DefaultBuildCacheServiceProvider(buildCacheConfiguration, startParameter, new DependencyInjectingInstantiator(this, new DependencyInjectingInstantiator.ConstructorCache()), buildOperationExecutor);
+    BuildCacheServiceInstantiator createBuildCacheServiceInstantiator(BuildCacheConfigurationInternal buildCacheConfiguration, BuildOperationExecutor buildOperationExecutor) {
+        return new DefaultBuildCacheServiceInstantiator(buildCacheConfiguration, buildOperationExecutor,
+            new DependencyInjectingInstantiator(this, new DependencyInjectingInstantiator.ConstructorCache()));
+    }
+
+    BuildCacheServiceProvider createBuildCacheServiceProvider(StartParameter startParameter, BuildCacheConfigurationInternal buildCacheConfiguration, BuildCacheServiceInstantiator instantiator) {
+        return new DefaultBuildCacheServiceProvider(buildCacheConfiguration, startParameter, instantiator);
     }
 
     BuildCacheServiceRegistration createLocalBuildCacheServiceRegistration() {


### PR DESCRIPTION
We have now an instantiator which takes a `BuildCache` and creates a decorated `BuildCacheService` from it.
It would be great to be able to remove all that passing around of `push`/`pullDisabled`. We would need a `DecoratedBuildCacheService` having `isPull()` and `isPush()` methods.