### PR TITLE
Display task outcome stats after build progress on rich console

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressFilter.java
@@ -94,8 +94,7 @@ public class BuildProgressFilter implements BuildListener, TaskExecutionGraphLis
     @Override
     public void afterExecute(Task task, TaskState state) {
         if (task.getProject().getGradle() == gradle) {
-            // TODO(ew): task outcome stats reusing logic from TaskExecutionStatisticsEventAdapter
-            logger.afterExecute();
+            logger.afterExecute(state);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/TaskOutcomeStatisticsFormatter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/TaskOutcomeStatisticsFormatter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.progress;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.Maps;
+import org.gradle.api.internal.tasks.TaskExecutionOutcome;
+import org.gradle.api.internal.tasks.TaskStateInternal;
+import org.gradle.api.tasks.TaskState;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class TaskOutcomeStatisticsFormatter {
+    private final Map<TaskExecutionOutcome, Integer> taskCounts = Maps.newEnumMap(
+        Maps.toMap(Arrays.asList(TaskExecutionOutcome.values()), Functions.constant(0))
+    );
+    private int allTasksCount;
+
+    public String incrementAndGetProgress(TaskState state) {
+        recordTaskOutcome(state);
+
+        int tasksAvoided = 0;
+        int tasksExecuted = 0;
+        for (TaskExecutionOutcome outcome : TaskExecutionOutcome.values()) {
+            switch (outcome) {
+                case EXECUTED: tasksExecuted += taskCounts.get(outcome); break;
+                default: tasksAvoided += taskCounts.get(outcome);
+            }
+        }
+        return " [" + formatPercentage(tasksAvoided, allTasksCount) + " AVOIDED, " + formatPercentage(tasksExecuted, allTasksCount) + " EXECUTED]";
+    }
+
+    private String formatPercentage(int num, int total) {
+        return String.valueOf(Math.round(num * 100.0 / total)) + '%';
+    }
+
+    private void recordTaskOutcome(final TaskState state) {
+        TaskStateInternal stateInternal = (TaskStateInternal) state;
+        TaskExecutionOutcome outcome = stateInternal.getOutcome();
+        taskCounts.put(outcome, taskCounts.get(outcome) + 1);
+        allTasksCount++;
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressFilterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressFilterTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.Task
 import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
+import org.gradle.api.tasks.TaskState
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -42,6 +43,7 @@ class BuildProgressFilterTest extends Specification {
     }
     def result = Stub(BuildResult) { getGradle() >> gradle }
     def task = Stub(Task) { getProject() >> project }
+    def taskState = Stub(TaskState) {}
 
     def "delegates to logger when building root project"() {
         gradle.getParent() >> null
@@ -53,7 +55,7 @@ class BuildProgressFilterTest extends Specification {
         f.beforeEvaluate(project)
         f.afterEvaluate(project, null)
         f.graphPopulated(graph)
-        f.afterExecute(task, null)
+        f.afterExecute(task, taskState)
         f.buildFinished(result)
 
         then: 1 * logger.buildStarted()
@@ -62,7 +64,7 @@ class BuildProgressFilterTest extends Specification {
         then: 1 * logger.beforeEvaluate(":foo:bar")
         then: 1 * logger.afterEvaluate(":foo:bar")
         then: 1 * logger.graphPopulated(3)
-        then: 1 * logger.afterExecute()
+        then: 1 * logger.afterExecute(taskState)
         then: 1 * logger.buildFinished()
         then: 0 * logger._
     }
@@ -77,7 +79,7 @@ class BuildProgressFilterTest extends Specification {
         f.beforeEvaluate(project)
         f.afterEvaluate(project, null)
         f.graphPopulated(graph)
-        f.afterExecute(task, null)
+        f.afterExecute(task, taskState)
         f.buildFinished(result)
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressLoggerTest.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.progress
 
+import org.gradle.api.internal.tasks.TaskExecutionOutcome
+import org.gradle.api.internal.tasks.TaskStateInternal
+import org.gradle.api.tasks.TaskState
 import org.gradle.internal.logging.progress.ProgressLogger
 import spock.lang.Specification
 import spock.lang.Subject
@@ -78,6 +81,10 @@ class BuildProgressLoggerTest extends Specification {
     }
 
     def "logs execution phase"() {
+        given:
+        TaskState taskState = new TaskStateInternal(":task")
+        taskState.setOutcome(TaskExecutionOutcome.EXECUTED)
+
         when:
         buildProgressLogger.buildStarted()
         buildProgressLogger.graphPopulated(10)
@@ -87,7 +94,7 @@ class BuildProgressLoggerTest extends Specification {
         1 * provider.start(BuildProgressLogger.EXECUTION_PHASE_DESCRIPTION, _) >> buildProgress
 
         when:
-        buildProgressLogger.afterExecute()
+        buildProgressLogger.afterExecute(taskState)
 
         then:
         1 * buildProgress.progress(_)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/TaskOutcomeStatisticsFormatterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/TaskOutcomeStatisticsFormatterTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.progress
+
+import org.gradle.api.internal.tasks.TaskExecutionOutcome
+import org.gradle.api.internal.tasks.TaskStateInternal
+import org.gradle.api.tasks.TaskState
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static org.gradle.api.internal.tasks.TaskExecutionOutcome.EXECUTED
+import static org.gradle.api.internal.tasks.TaskExecutionOutcome.FROM_CACHE
+import static org.gradle.api.internal.tasks.TaskExecutionOutcome.NO_SOURCE
+import static org.gradle.api.internal.tasks.TaskExecutionOutcome.SKIPPED
+import static org.gradle.api.internal.tasks.TaskExecutionOutcome.UP_TO_DATE
+
+@Subject(TaskOutcomeStatisticsFormatter)
+class TaskOutcomeStatisticsFormatterTest extends Specification {
+    TaskOutcomeStatisticsFormatter formatter
+
+    def setup() {
+        formatter = new TaskOutcomeStatisticsFormatter()
+    }
+
+    def "groups non-executed work as AVOIDED"() {
+        expect:
+        formatter.incrementAndGetProgress(taskState(UP_TO_DATE)) == " [100% AVOIDED, 0% EXECUTED]"
+        formatter.incrementAndGetProgress(taskState(FROM_CACHE)) == " [100% AVOIDED, 0% EXECUTED]"
+        formatter.incrementAndGetProgress(taskState(NO_SOURCE)) == " [100% AVOIDED, 0% EXECUTED]"
+        formatter.incrementAndGetProgress(taskState(SKIPPED)) == " [100% AVOIDED, 0% EXECUTED]"
+    }
+
+    def "formats executed task as EXECUTED"() {
+        expect:
+        formatter.incrementAndGetProgress(taskState(EXECUTED)) == " [0% AVOIDED, 100% EXECUTED]"
+    }
+
+    def "formats multiple outcome types"() {
+        expect:
+        formatter.incrementAndGetProgress(taskState(SKIPPED)) == " [100% AVOIDED, 0% EXECUTED]"
+        formatter.incrementAndGetProgress(taskState(UP_TO_DATE)) == " [100% AVOIDED, 0% EXECUTED]"
+        formatter.incrementAndGetProgress(taskState(FROM_CACHE)) == " [100% AVOIDED, 0% EXECUTED]"
+        formatter.incrementAndGetProgress(taskState(NO_SOURCE)) == " [100% AVOIDED, 0% EXECUTED]"
+        formatter.incrementAndGetProgress(taskState(EXECUTED)) == " [80% AVOIDED, 20% EXECUTED]"
+        formatter.incrementAndGetProgress(taskState(UP_TO_DATE)) == " [83% AVOIDED, 17% EXECUTED]"
+    }
+
+    private TaskState taskState(TaskExecutionOutcome taskExecutionOutcome) {
+        def state = new TaskStateInternal('')
+        state.outcome = taskExecutionOutcome
+        state
+    }
+}


### PR DESCRIPTION
This change extracts the concept of a TaskExecutionStatisticsAggregator out of TaskExecutionStatisticsEventAdapter so that it can be reused by build progress logging.

The BuildProgressLogger uses a new TaskOutcomeStatisticsFormatter to
aggregate and return a summary of how tasks have been completed.