### PR TITLE
Inhibit worker daemon expiration for select tests

### DIFF
--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
@@ -17,9 +17,15 @@
 package org.gradle.api.tasks.compile
 
 import org.gradle.launcher.continuous.Java7RequiringContinuousIntegrationTest
+import org.gradle.workers.internal.WorkerDaemonExpiration
 
 
 abstract class AbstractCompilerContinuousIntegrationTest extends Java7RequiringContinuousIntegrationTest {
+
+    def setup() {
+        executer.withArgument "-D${WorkerDaemonExpiration.DISABLE_EXPIRATION_PROPERTY_KEY}=true"
+    }
+
     def cleanup() {
         gradle.cancel()
     }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -87,6 +87,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "re-uses an existing idle daemon" () {
+        executer.withArgument "-D${WorkerDaemonExpiration.DISABLE_EXPIRATION_PROPERTY_KEY}=true"
         withRunnableClassInBuildSrc()
 
         buildFile << """
@@ -157,6 +158,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "re-uses an existing compatible daemon when a different runnable is executed" () {
+        executer.withArgument "-D${WorkerDaemonExpiration.DISABLE_EXPIRATION_PROPERTY_KEY}=true"
         withRunnableClassInBuildSrc()
         withAlternateRunnableClassInBuildSrc()
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonExpiration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonExpiration.java
@@ -29,6 +29,7 @@ import java.util.List;
 public class WorkerDaemonExpiration implements MemoryHolder {
 
     private static final Logger LOGGER = Logging.getLogger(WorkerDaemonExpiration.class);
+    public static final String DISABLE_EXPIRATION_PROPERTY_KEY = "org.gradle.workers.disable-daemons-expiration";
 
     private final WorkerDaemonClientsManager clientsManager;
     private final long osTotalMemory;
@@ -42,6 +43,10 @@ public class WorkerDaemonExpiration implements MemoryHolder {
     public long attemptToRelease(long memoryAmountBytes) throws IllegalArgumentException {
         if (memoryAmountBytes < 0) {
             throw new IllegalArgumentException("Negative memory amount");
+        }
+        if (Boolean.valueOf(System.getProperty(DISABLE_EXPIRATION_PROPERTY_KEY, "false"))) {
+            LOGGER.debug("Worker Daemons expiration is disabled, skipping");
+            return 0L;
         }
         LOGGER.debug("Will attempt to release {} of memory", memoryAmountBytes / 1024 / 1024);
         SimpleMemoryExpirationSelector selector = new SimpleMemoryExpirationSelector(memoryAmountBytes);


### PR DESCRIPTION
We have certain tests that specifically test for reuse of worker daemons. If system memory is low, these tests can return false negatives because the daemon is expired in between invocations to free up memory.

The introduced `org.gradle.workers.disable-daemons-expiration` system property set to  `true` allows this. Tests that relies on the same daemons being available across invocations have been updated.