### PR TITLE
Teach git that gradlew ought to have crlf lineendings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+gradlew.bat	eol=crlf
+


### PR DESCRIPTION
This makes it easier to work with this file on systems where the native
line ending isn't CRLF.