### PR TITLE
Set memory for compiler jvm to work with javac

### DIFF
--- a/subprojects/performance/src/templates/project-with-source/build.gradle
+++ b/subprojects/performance/src/templates/project-with-source/build.gradle
@@ -65,7 +65,8 @@ int testForkEvery = getProperty('testForkEvery') as Integer
 tasks.withType(JavaCompile) {
     options.fork = true
     options.incremental = true
-    options.forkOptions.jvmArgs = ["-Xms\$compilerMemory".toString(), "-Xmx\$compilerMemory".toString()]
+    options.forkOptions.memoryInitialSize=compilerMemory
+    options.forkOptions.memoryMaximumSize=compilerMemory
 }
 tasks.withType(Test) {
     minHeapSize = testRunnerMemory


### PR DESCRIPTION
When setting the JavaCompile.options.forkOptions.executable to a
javac executable the performance projects would fail since they try
to pass memory settings directly to javac via `-Xms`/`-Xmx`. When
using `memoryInitialSize`/`memoryMaximumSize` to set the memory
settings the parameters are passed correctly via `-J-Xms`/`-J-Xmx`.

Any of the checked boxes below indicate that I took action:
