### PR TITLE
Improve Build Summary in Console

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
@@ -47,7 +47,6 @@ public class BuildProgressLogger implements LoggerProvider {
 
     BuildProgressLogger(ProgressLoggerProvider loggerProvider) {
         this.loggerProvider = loggerProvider;
-        this.taskOutcomeStatisticsFormatter = new TaskOutcomeStatisticsFormatter();
     }
 
     public void buildStarted() {
@@ -75,6 +74,7 @@ public class BuildProgressLogger implements LoggerProvider {
     public void graphPopulated(int totalTasks) {
         taskGraphPopulated = true;
         buildProgress.completed();
+        taskOutcomeStatisticsFormatter = new TaskOutcomeStatisticsFormatter(totalTasks);
         progressBar = newProgressBar(EXECUTION_PHASE_SHORT_DESCRIPTION, totalTasks);
         buildProgress = loggerProvider.start(EXECUTION_PHASE_DESCRIPTION, progressBar.getProgress());
     }


### PR DESCRIPTION
This changes the display of the running build summary by:
- Adding a count of completed/total tasks
- removing grouping of task outcomes and displaying failed tasks.

Specifically, only FAILED, FROM_CACHE, and UP-TO-DATE tasks are
called out.

