### PR TITLE
Support of compileOnly scope in buildInit plugin

### DIFF
--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/maven/Maven2Gradle.groovy
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/maven/Maven2Gradle.groovy
@@ -309,7 +309,12 @@ version = '$project.version'""";
                 if (!war && scope == 'providedCompile') {
                     scope = 'compileOnly'
                 }
-                createBasicDependency(mavenDependency, sb, scope)
+                def exclusions = mavenDependency.exclusions.exclusion
+                if (exclusions.size() > 0) {
+                    createComplexDependency(mavenDependency, sb, scope, "")
+                } else {
+                    createBasicDependency(mavenDependency, sb, scope)
+                }
             }
         }
 

--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/maven/Maven2Gradle.groovy
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/maven/Maven2Gradle.groovy
@@ -311,7 +311,7 @@ version = '$project.version'""";
                 }
                 def exclusions = mavenDependency.exclusions.exclusion
                 if (exclusions.size() > 0) {
-                    createComplexDependency(mavenDependency, sb, scope, "")
+                    createComplexDependency(mavenDependency, sb, scope)
                 } else {
                     createBasicDependency(mavenDependency, sb, scope)
                 }
@@ -486,13 +486,10 @@ project('$entry.key').projectDir = """ + '"$rootDir/' + "${entry.value}" + '" as
  * iterate over each <exclusion> node and print out the artifact id.
  * It also provides review comments for the user.
  */
-    private def createComplexDependency(it, build, scope, providedMessage) {
+    private def createComplexDependency(it, build, scope) {
         build.append("    ${scope}(${contructSignature(it)}) {\n")
         it.exclusions.exclusion.each() {
             build.append("exclude(module: '${it.artifactId}')\n")
-        }
-        if (providedMessage) {
-            build.append(providedMessage)
         }
         build.append("    }\n")
     }

--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/maven/Maven2Gradle.groovy
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/maven/Maven2Gradle.groovy
@@ -269,9 +269,8 @@ version = '$project.version'""";
         def systemScope = []
 
         //cleanup duplicates from parent
-
-// using Groovy Looping and mapping a Groovy Closure to each element, we collect together all
-// the dependency nodes into corresponding collections depending on their scope value.
+        // using Groovy Looping and mapping a Groovy Closure to each element, we collect together all
+        // the dependency nodes into corresponding collections depending on their scope value.
         dependencies.each() {
             if (!duplicateDependency(it, project, allProjects)) {
                 def scope = (elementHasText(it.scope)) ? it.scope : "compile"
@@ -307,21 +306,10 @@ version = '$project.version'""";
             if (projectDep) {
                 createProjectDependency(projectDep, sb, scope, allProjects)
             } else {
-                def providedMessage = "";
                 if (!war && scope == 'providedCompile') {
-                    scope = 'compile'
-                    providedMessage = '''\
-                       /* This dependency was originally in the Maven provided scope, but the project was not of type war.
-                       This behavior is not yet supported by Gradle, so this dependency has been converted to a compile dependency.
-                       Please review and delete this closure when resolved. */
-                       '''.stripIndent(16)
+                    scope = 'compileOnly'
                 }
-                def exclusions = mavenDependency.exclusions.exclusion
-                if (exclusions.size() > 0 || providedMessage != "") {
-                    createComplexDependency(mavenDependency, sb, scope, providedMessage)
-                } else {
-                    createBasicDependency(mavenDependency, sb, scope)
-                }
+                createBasicDependency(mavenDependency, sb, scope)
             }
         }
 

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/maven/MavenProjectsCreatorSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/maven/MavenProjectsCreatorSpec.groovy
@@ -114,7 +114,7 @@ class MavenProjectsCreatorSpec extends Specification {
         ex.message == "Unable to create Maven project model. The POM file $pom does not exist."
     }
 
-    def "creates projects with compileOnly library"() {
+    def "can translate dependency assigned to Maven provided scope into compileOnly"() {
         given:
             def pom = temp.file("pom.xml")
             pom.text = """<project>
@@ -136,8 +136,9 @@ class MavenProjectsCreatorSpec extends Specification {
         def converter = new Maven2Gradle(mavenProjects, temp.root.getCanonicalFile())
 
         when:
-            def gradleProject = converter.convert()
+        def gradleProject = converter.convert()
+
         then:
-            gradleProject.contains("compileOnly group: 'org.gradle', name: 'build-init', version:'1.0.0'")
+        gradleProject.contains("compileOnly group: 'org.gradle', name: 'build-init', version:'1.0.0'")
     }
 }

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/maven/MavenProjectsCreatorSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/maven/MavenProjectsCreatorSpec.groovy
@@ -18,9 +18,7 @@ package org.gradle.buildinit.plugins.internal.maven
 
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenSettingsProvider
 import org.gradle.api.internal.artifacts.mvnsettings.MavenFileLocations
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 


### PR DESCRIPTION
Issue: #1533

Any of the checked boxes below indicate that I took action:

- [x] Reviewed the [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
- [x] Signed the [Gradle CLA](http://gradle.org/contributor-license-agreement/).
- [x] Ensured that basic checks pass: `./gradlew quickCheck`

For all non-trivial changes that modify the behavior or public API:

- [ ] Before submitting a pull request, I started a discussion on the [Gradle developer list](https://groups.google.com/forum/#!forum/gradle-dev),
      the [forum](https://discuss.gradle.org/) or can reference a [JIRA issue](https://issues.gradle.org/secure/Dashboard.jspa).
- [ ] I considered writing a design document. A design document can be
brief but explains the use case or problem you are trying to solve,
touches on the planned implementation approach as well as the test cases
that verify the behavior. Optimally, design documents should be submitted
as a separate pull request. [Samples](https://github.com/gradle/gradle/tree/master/design-docs)
can be found in the Gradle GitHub repository. Please let us know if you need help with
creating the design document. We are happy to help!
- [x] The pull request contains an appropriate level of unit and integration
test coverage to verify the behavior. Before submitting the pull request
I ran a build on my local machine via the command
`./gradlew quickCheck <impacted-subproject>:check`.
- [ ] The pull request updates the Gradle documentation like user guide,
DSL reference and Javadocs where applicable.
