### PR TITLE
Fix serialization issues in worker daemons

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/SocketConnection.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/SocketConnection.java
@@ -86,6 +86,8 @@ public class SocketConnection<T> implements RemoteConnection<T> {
             throw new RecoverableMessageIOException(String.format("Could not read message from '%s'.", remoteAddress), e);
         } catch (ClassNotFoundException e) {
             throw new RecoverableMessageIOException(String.format("Could not read message from '%s'.", remoteAddress), e);
+        } catch (IOException e) {
+            throw new RecoverableMessageIOException(String.format("Could not read message from '%s'.", remoteAddress), e);
         } catch (Exception e) {
             throw new MessageIOException(String.format("Could not read message from '%s'.", remoteAddress), e);
         }
@@ -115,7 +117,9 @@ public class SocketConnection<T> implements RemoteConnection<T> {
         } catch (ObjectStreamException e) {
             throw new RecoverableMessageIOException(String.format("Could not write message %s to '%s'.", message, remoteAddress), e);
         } catch (ClassNotFoundException e) {
-            throw new RecoverableMessageIOException(String.format("Could not read message from '%s'.", remoteAddress), e);
+            throw new RecoverableMessageIOException(String.format("Could not write message %s to '%s'.", message, remoteAddress), e);
+        } catch (IOException e) {
+            throw new RecoverableMessageIOException(String.format("Could not write message %s to '%s'.", message, remoteAddress), e);
         } catch (Exception e) {
             throw new MessageIOException(String.format("Could not write message %s to '%s'.", message, remoteAddress), e);
         }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -90,7 +90,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
         then:
         failureHasCause("A failure occurred while executing org.gradle.test.TestRunnable")
-        failureCauseContains("Could not write message")
+        failureHasCause("Could not serialize parameters")
         failureHasCause("Broken")
 
         and:
@@ -120,7 +120,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
         then:
         failureHasCause("A failure occurred while executing org.gradle.test.TestRunnable")
-        failureCauseContains("Could not read message")
+        failureHasCause("Could not deserialize parameters")
         failureHasCause("Broken")
 
         and:

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -70,7 +70,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     def "produces a sensible error when a parameter can't be serialized"() {
         withRunnableClassInBuildSrc()
-        withUnserializableParameterInBuildSrc()
+        withParameterMemberThatFailsSerialization()
 
         buildFile << """
             $alternateRunnable
@@ -91,7 +91,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         then:
         failureHasCause("A failure occurred while executing org.gradle.test.TestRunnable")
         failureCauseContains("Could not write message")
-        errorOutput.contains("Caused by: java.io.NotSerializableException: org.gradle.error.Bar")
+        failureHasCause("Broken")
 
         and:
         executedAndNotSkipped(":runAgainInDaemon")
@@ -99,9 +99,8 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
     }
 
     def "produces a sensible error when a parameter can't be de-serialized in the worker"() {
-        def parameterJar = file("parameter.jar")
         withRunnableClassInBuildSrc()
-        withUnserializableParameterMemberInExternalJar(parameterJar)
+        withParameterMemberThatFailsDeserialization()
 
         buildFile << """  
             $alternateRunnable
@@ -111,7 +110,6 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
             }
 
             task runInDaemon(type: DaemonTask) {
-                additionalClasspath = files('${parameterJar.name}')
                 foo = new FooWithUnserializableBar()
                 finalizedBy runAgainInDaemon
             }
@@ -123,7 +121,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         then:
         failureHasCause("A failure occurred while executing org.gradle.test.TestRunnable")
         failureCauseContains("Could not read message")
-        errorOutput.contains("Caused by: java.lang.ClassNotFoundException: org.gradle.error.Bar")
+        failureHasCause("Broken")
 
         and:
         executedAndNotSkipped(":runAgainInDaemon")
@@ -241,11 +239,32 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         """
     }
 
-    String getUnserializableClass() {
+    String getClassThatFailsDeserialization() {
         return """
-            package org.gradle.error;
+            package org.gradle.other;
             
-            public class Bar {
+            import java.io.Serializable;
+            import java.io.IOException;
+            
+            public class Bar implements Serializable {
+                private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+                    throw new IOException("Broken");
+                }
+            }
+        """
+    }
+
+    String getClassThatFailsSerialization() {
+        return """
+            package org.gradle.other;
+            
+            import java.io.Serializable;
+            import java.io.IOException;
+            
+            public class Bar implements Serializable {
+                private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+                    throw new IOException("Broken");
+                }
             }
         """
     }
@@ -254,7 +273,6 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         return """
             package org.gradle.other;
             
-            import org.gradle.error.Bar;
             import java.io.Serializable;
             
             public class FooWithUnserializableBar extends Foo implements Serializable {
@@ -276,10 +294,10 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         """
     }
 
-    void withUnserializableParameterInBuildSrc() {
+    void withParameterMemberThatFailsSerialization() {
         // Create an un-serializable class
-        file('buildSrc/src/main/java/org/gradle/error/Bar.java').text = """
-            $unserializableClass
+        file('buildSrc/src/main/java/org/gradle/other/Bar.java').text = """
+            $classThatFailsSerialization
         """
 
         // Create a Foo class with an un-serializable member
@@ -290,29 +308,17 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         addImportToBuildScript("org.gradle.other.FooWithUnserializableBar")
     }
 
-    void withUnserializableParameterMemberInExternalJar(File parameterJar) {
-        def builder = artifactBuilder()
-
-        builder.sourceFile("org/gradle/error/Bar.java") << """
-            $unserializableClass
-        """
-
+    void withParameterMemberThatFailsDeserialization() {
         // Overwrite the Foo class with a class with an un-serializable member
         file('buildSrc/src/main/java/org/gradle/other/FooWithUnserializableBar.java').text = """
             $parameterClassWithUnserializableMember
         """
 
-        // A serializable form of the class so we can get past sending the message
+        // An unserializable member class
         file('buildSrc/src/main/java/org/gradle/error/Bar.java').text = """
-            package org.gradle.error;
-            
-            import java.io.Serializable;
-            
-            public class Bar implements Serializable {
-            }
+            $classThatFailsDeserialization
         """
 
-        builder.buildJar(parameterJar)
         addImportToBuildScript("org.gradle.other.FooWithUnserializableBar")
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonRunnableAction.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonRunnableAction.java
@@ -31,7 +31,7 @@ public class WorkerDaemonRunnableAction implements WorkerDaemonAction<ParamSpec>
     @Override
     public DefaultWorkResult execute(ParamSpec spec) {
         try {
-            Runnable runnable = DirectInstantiator.instantiate(runnableClass, (Object[])spec.getParams());
+            Runnable runnable = DirectInstantiator.instantiate(runnableClass, (Object[])spec.getParams(runnableClass.getClassLoader()));
             runnable.run();
             return new DefaultWorkResult(true, null);
         } catch (ObjectInstantiationException e) {


### PR DESCRIPTION
This fixes a couple of serialization issues in worker daemons:

- Deserialization issues are better handled in the worker
- Integration tests do a better job of testing serialization problems
- Move serialization/deserialization of runnable params inside ParamSpec so that we don't have to add shared package declarations for everything a param might touch.