### PR TITLE
Extract interfaces for ResourceFilters

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseProject.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseProject.java
@@ -24,6 +24,7 @@ import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultResourceFilter;
 
 import java.util.Arrays;
 import java.util.List;
@@ -301,20 +302,11 @@ public class EclipseProject {
         linkedResources.add(new Link(args.get("name"), args.get("type"), args.get("location"), args.get("locationUri")));
     }
 
+    /**
+     * The resource filters of the eclipse project.
+     */
     public Set<ResourceFilter> getResourceFilters() {
         return resourceFilters;
-    }
-
-    /**
-     * The resource filters to apply to this Eclipse project.
-     * <p>
-     * For examples, see docs for {@link ResourceFilter}
-     */
-    public void setResourceFilters(Set<ResourceFilter> resourceFilters) {
-        if (resourceFilters == null) {
-            throw new InvalidUserDataException("resourceFilters must not be null");
-        }
-        this.resourceFilters = resourceFilters;
     }
 
     /**
@@ -336,7 +328,7 @@ public class EclipseProject {
      * @param configureAction The action to use to configure the resource filter.
      */
     public ResourceFilter resourceFilter(Action<? super ResourceFilter> configureAction) {
-        ResourceFilter f = new ResourceFilter();
+        ResourceFilter f = new DefaultResourceFilter();
         configureAction.execute(f);
         resourceFilters.add(f);
         return f;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Project.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Project.java
@@ -22,6 +22,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import groovy.util.Node;
 import org.gradle.internal.xml.XmlTransformer;
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultResourceFilter;
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultResourceFilterMatcher;
 import org.gradle.plugins.ide.internal.generator.XmlPersistableConfigurationObject;
 
 import java.util.Arrays;
@@ -32,7 +34,8 @@ import java.util.Set;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
 import static org.gradle.plugins.ide.eclipse.model.ResourceFilterAppliesTo.*;
-import static org.gradle.plugins.ide.eclipse.model.ResourceFilterType.*;
+import static org.gradle.plugins.ide.eclipse.model.ResourceFilterType.EXCLUDE_ALL;
+import static org.gradle.plugins.ide.eclipse.model.ResourceFilterType.INCLUDE_ONLY;
 
 /**
  * Represents the customizable elements of an eclipse project file. (via XML hooks everything is customizable).
@@ -47,7 +50,7 @@ public class Project extends XmlPersistableConfigurationObject {
     private List<String> natures = Lists.newArrayList();
     private List<BuildCommand> buildCommands = Lists.newArrayList();
     private Set<Link> linkedResources = Sets.newLinkedHashSet();
-    private Set<ResourceFilter> resourceFilters = Sets.newLinkedHashSet();    
+    private Set<ResourceFilter> resourceFilters = Sets.newLinkedHashSet();
 
     public Project(XmlTransformer xmlTransformer) {
         super(xmlTransformer);
@@ -207,7 +210,7 @@ public class Project extends XmlPersistableConfigurationObject {
             ResourceFilterType type = resourceFilterTypeBitmaskToType(typeBitmask);
             boolean recursive = isResourceFilterTypeBitmaskRecursive(typeBitmask);
             ResourceFilterMatcher matcher = readResourceFilterMatcher(matcherNode);
-            resourceFilters.add(new ResourceFilter(
+            resourceFilters.add(new DefaultResourceFilter(
                 appliesTo,
                 type,
                 recursive,
@@ -324,7 +327,7 @@ public class Project extends XmlPersistableConfigurationObject {
                 type |= 12;
                 break;
         }
-        if (resourceFilter.getRecursive()) {
+        if (resourceFilter.isRecursive()) {
             type |= 16;
         }
         return type;
@@ -379,7 +382,7 @@ public class Project extends XmlPersistableConfigurationObject {
         } else {
             arguments = argumentsNode != null ? argumentsNode.text() : null;
         }
-        return new ResourceFilterMatcher(
+        return new DefaultResourceFilterMatcher(
             idNode != null ? idNode.text() : null,
             arguments,
             children
@@ -426,7 +429,7 @@ public class Project extends XmlPersistableConfigurationObject {
             + ", natures=" + natures
             + ", buildCommands=" + buildCommands
             + ", linkedResources=" + linkedResources
-            + ", resourceFilters=" + resourceFilters            
+            + ", resourceFilters=" + resourceFilters
             + "}";
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilter.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.plugins.ide.eclipse.model;
 
-import com.google.common.base.Objects;
-import groovy.lang.Closure;
-import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.internal.ClosureBackedAction;
 
 /**
  * The gradle DSL model of an Eclipse resource filter.
@@ -51,146 +47,50 @@ import org.gradle.api.internal.ClosureBackedAction;
  *
  * @since 3.5
  */
-public final class ResourceFilter {
-    private ResourceFilterAppliesTo appliesTo = ResourceFilterAppliesTo.FILES_AND_FOLDERS;
-    private ResourceFilterType type = ResourceFilterType.EXCLUDE_ALL;
-    private boolean recursive = true;
-    private ResourceFilterMatcher matcher;
-
-    public ResourceFilter() {
-    }
-
-    public ResourceFilter(ResourceFilterAppliesTo appliesTo, ResourceFilterType type, boolean recursive, ResourceFilterMatcher matcher) {
-        this();
-        setAppliesTo(appliesTo);
-        setType(type);
-        setRecursive(recursive);
-        setMatcher(matcher);
-    }
-
+public interface ResourceFilter {
     /**
      * Indicates whether this ResourceFilter applies to files, folders, or both.  Default is FILES_AND_FOLDERS
      */
-    public ResourceFilterAppliesTo getAppliesTo() {
-        return appliesTo;
-    }
-    
+    ResourceFilterAppliesTo getAppliesTo();
+
     /**
      * Indicates whether this ResourceFilter applies to files, folders, or both.  Default is FILES_AND_FOLDERS
-     * 
-     * @throws InvalidUserDataException if appliesTo is null.
+     *
+     * @throws org.gradle.api.InvalidUserDataException if appliesTo is null.
      */
-    public void setAppliesTo(ResourceFilterAppliesTo appliesTo) {
-        if (appliesTo == null) {
-            throw new InvalidUserDataException("appliesTo must not be null");
-        }
-        this.appliesTo = appliesTo;
-    }
-    
+    void setAppliesTo(ResourceFilterAppliesTo appliesTo);
+
     /**
      * Specifies whether this ResourceFilter is including or excluding resources.  Default is EXCLUDE_ALL
      */
-    public ResourceFilterType getType() {
-        return type;
-    }
+    ResourceFilterType getType();
 
     /**
      * Sets the ResourceFilterType
-     * 
-     * @throws InvalidUserDataException if type is null.
+     *
+     * @throws org.gradle.api.InvalidUserDataException if type is null.
      */
-    public void setType(ResourceFilterType type) {
-        if (type == null) {
-            throw new InvalidUserDataException("type must not be null");
-        }
-        this.type = type;
-    }
+    void setType(ResourceFilterType type);
 
     /**
      * Indicates whether this ResourceFilter applies recursively to all children of the project it is created on.  Default is true.
      */
-    public boolean getRecursive() {
-        return recursive;
-    }
+    boolean isRecursive();
 
     /**
      * Sets whether this ResourceFilter applies recursively or not.
      */
-    public void setRecursive(boolean recursive) {
-        this.recursive = recursive;
-    }
+    void setRecursive(boolean recursive);
 
     /**
      * Gets the matcher of this ResourceFilter.
      */
-    public ResourceFilterMatcher getMatcher() {
-        return matcher;
-    }
-
-    /**
-     * Sets the matcher of this ResourceFilter.
-     */
-    public void setMatcher(ResourceFilterMatcher matcher) {
-        this.matcher = matcher;
-    }
-
-    /**
-     * Configures the matcher of this resource filter.  Will create the matcher if it does not yet exist, or configure the existing matcher if it already exists.
-     *
-     * @param configureClosure The closure to use to configure the matcher.
-     */
-    public ResourceFilterMatcher matcher(@DelegatesTo(value=ResourceFilterMatcher.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
-        return matcher(new ClosureBackedAction<ResourceFilterMatcher>(configureClosure));
-    }
+    ResourceFilterMatcher getMatcher();
 
     /**
      * Configures the matcher of this resource filter.  Will create the matcher if it does not yet exist, or configure the existing matcher if it already exists.
      *
      * @param configureAction The action to use to configure the matcher.
      */
-    public ResourceFilterMatcher matcher(Action<? super ResourceFilterMatcher> configureAction) {
-        if (this.matcher == null) {
-            this.matcher = new ResourceFilterMatcher();
-        }
-        configureAction.execute(this.matcher);
-        return this.matcher;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null) {
-            return false;
-        }
-        if (!getClass().equals(o.getClass())) {
-            return false;
-        }
-        ResourceFilter resourceFilter = (ResourceFilter) o;
-        return Objects.equal(appliesTo, resourceFilter.appliesTo)
-            && Objects.equal(type, resourceFilter.type)
-            && Objects.equal(recursive, resourceFilter.recursive)
-            && Objects.equal(matcher, resourceFilter.matcher);
-    }
-
-    @Override
-    public int hashCode() {
-        int result;
-        result = appliesTo != null ? appliesTo.hashCode() : 0;
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + Boolean.valueOf(recursive).hashCode();
-        result = 31 * result + (matcher != null ? matcher.hashCode() : 0);
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "ResourceFilter{"
-            + "appliesTo='" + appliesTo + '\''
-            + ", type='" + type + '\''
-            + ", recursive='" + recursive + '\''
-            + ", matcher='" + matcher + '\''            
-            + '}';
-    }
+    ResourceFilterMatcher matcher(Action<? super ResourceFilterMatcher> configureAction);
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcher.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.plugins.ide.eclipse.model;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.Sets;
-import groovy.lang.Closure;
-import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Nullable;
-import org.gradle.api.internal.ClosureBackedAction;
 
 import java.util.Set;
-
 /**
  * The model of an Eclipse resource filter matcher.
  * <p>
@@ -42,102 +36,44 @@ import java.util.Set;
  *
  * @since 3.5
  */
-public final class ResourceFilterMatcher {
-    private String id;
-    private String arguments;
-    private Set<ResourceFilterMatcher> children = Sets.newLinkedHashSet();
-
-    public ResourceFilterMatcher() {
-    }
-
-    public ResourceFilterMatcher(String id, String arguments, Set<ResourceFilterMatcher> children) {
-        this();
-        this.id = id;
-        this.arguments = arguments;
-        this.children = children;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
+public interface ResourceFilterMatcher {
+    /**
+     * The id of the matcher type, as defined by its Eclipse extension.
+     *
+     * Can be null on a newly created matcher, but must be set in order to be considered valid.
+     */
     @Nullable
-    public String getArguments() {
-        return arguments;
-    }
-
-    public void setArguments(String arguments) {
-        this.arguments = arguments;
-    }
-
-    public Set<ResourceFilterMatcher> getChildren() {
-        return children;
-    }
-
-    public void setChildren(Set<ResourceFilterMatcher> children) {
-        if (children == null) {
-            throw new InvalidUserDataException("children must not be null");
-        }
-        this.children = children;
-    }    
+    String getId();
 
     /**
-     * Adds a child/nested matcher to this matcher.
+     * Sets the id of the matcher type.
      *
-     * @param configureClosure The closure to use to configure the matcher.
+     * @param id the id, cannot be null
      */
-    public ResourceFilterMatcher matcher(@DelegatesTo(value=ResourceFilterMatcher.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
-        return matcher(new ClosureBackedAction<ResourceFilterMatcher>(configureClosure));
-    }
+    void setId(String id);
+
+    /**
+     * The arguments of the matcher or null if it has children.
+     */
+    @Nullable
+    String getArguments();
+
+    /**
+     * Sets the arguments of the matcher.
+     *
+     * @param arguments the arguments or null if the matcher should have child matchers instead
+     */
+    void setArguments(String arguments);
+
+    /**
+     * The child matchers of this matcher, e.g. when this is an OR-matcher.
+     */
+    Set<ResourceFilterMatcher> getChildren();
 
     /**
      * Adds a child/nested matcher to this matcher.
      *
      * @param configureAction The action to use to configure the matcher.
      */
-    public ResourceFilterMatcher matcher(Action<? super ResourceFilterMatcher> configureAction) {
-        ResourceFilterMatcher m = new ResourceFilterMatcher();
-        configureAction.execute(m);
-        children.add(m);
-        return m;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null) {
-            return false;
-        }
-        if (!getClass().equals(o.getClass())) {
-            return false;
-        }
-        ResourceFilterMatcher resourceFilterMatcher = (ResourceFilterMatcher) o;
-        return Objects.equal(id, resourceFilterMatcher.id)
-            && Objects.equal(arguments, resourceFilterMatcher.arguments)
-            && Objects.equal(children, resourceFilterMatcher.children);
-    }
-
-    @Override
-    public int hashCode() {
-        int result;
-        result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (arguments != null ? arguments.hashCode() : 0);
-        result = 31 * result + (children != null ? children.hashCode() : 0);
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "ResourceFilterMatcher{"
-            + "id='" + id + '\''
-            + ", arguments='" + arguments + '\''
-            + ", children='" + children + '\''
-            + '}';
-    }    
+    ResourceFilterMatcher matcher(Action<? super ResourceFilterMatcher> configureAction);
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/DefaultResourceFilter.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/DefaultResourceFilter.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model.internal;
+
+import com.google.common.base.Objects;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.internal.ClosureBackedAction;
+import org.gradle.plugins.ide.eclipse.model.ResourceFilter;
+import org.gradle.plugins.ide.eclipse.model.ResourceFilterAppliesTo;
+import org.gradle.plugins.ide.eclipse.model.ResourceFilterMatcher;
+import org.gradle.plugins.ide.eclipse.model.ResourceFilterType;
+
+public final class DefaultResourceFilter implements ResourceFilter {
+    private ResourceFilterAppliesTo appliesTo = ResourceFilterAppliesTo.FILES_AND_FOLDERS;
+    private ResourceFilterType type = ResourceFilterType.EXCLUDE_ALL;
+    private boolean recursive = true;
+    private ResourceFilterMatcher matcher;
+
+    public DefaultResourceFilter() {
+    }
+
+    public DefaultResourceFilter(ResourceFilterAppliesTo appliesTo, ResourceFilterType type, boolean recursive, ResourceFilterMatcher matcher) {
+        this();
+        setAppliesTo(appliesTo);
+        setType(type);
+        setRecursive(recursive);
+        setMatcher(matcher);
+    }
+
+    @Override
+    public ResourceFilterAppliesTo getAppliesTo() {
+        return appliesTo;
+    }
+
+    @Override
+    public void setAppliesTo(ResourceFilterAppliesTo appliesTo) {
+        if (appliesTo == null) {
+            throw new InvalidUserDataException("appliesTo must not be null");
+        }
+        this.appliesTo = appliesTo;
+    }
+
+    @Override
+    public ResourceFilterType getType() {
+        return type;
+    }
+
+    @Override
+    public void setType(ResourceFilterType type) {
+        if (type == null) {
+            throw new InvalidUserDataException("type must not be null");
+        }
+        this.type = type;
+    }
+
+    @Override
+    public boolean isRecursive() {
+        return recursive;
+    }
+
+    @Override
+    public void setRecursive(boolean recursive) {
+        this.recursive = recursive;
+    }
+
+    @Override
+    public ResourceFilterMatcher getMatcher() {
+        return matcher;
+    }
+
+    public void setMatcher(ResourceFilterMatcher matcher) {
+        this.matcher = matcher;
+    }
+
+    public ResourceFilterMatcher matcher(@DelegatesTo(value = ResourceFilterMatcher.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
+        return matcher(new ClosureBackedAction<ResourceFilterMatcher>(configureClosure));
+    }
+
+    @Override
+    public ResourceFilterMatcher matcher(Action<? super ResourceFilterMatcher> configureAction) {
+        if (this.matcher == null) {
+            this.matcher = new DefaultResourceFilterMatcher();
+        }
+        configureAction.execute(this.matcher);
+        return this.matcher;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (!getClass().equals(o.getClass())) {
+            return false;
+        }
+        DefaultResourceFilter resourceFilter = (DefaultResourceFilter) o;
+        return Objects.equal(appliesTo, resourceFilter.appliesTo)
+            && Objects.equal(type, resourceFilter.type)
+            && Objects.equal(recursive, resourceFilter.recursive)
+            && Objects.equal(matcher, resourceFilter.matcher);
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        result = appliesTo != null ? appliesTo.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + Boolean.valueOf(recursive).hashCode();
+        result = 31 * result + (matcher != null ? matcher.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceFilter{"
+            + "appliesTo='" + appliesTo + '\''
+            + ", type='" + type + '\''
+            + ", recursive='" + recursive + '\''
+            + ", matcher='" + matcher + '\''
+            + '}';
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/DefaultResourceFilterMatcher.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/DefaultResourceFilterMatcher.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model.internal;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Sets;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Nullable;
+import org.gradle.api.internal.ClosureBackedAction;
+import org.gradle.plugins.ide.eclipse.model.ResourceFilterMatcher;
+
+import java.util.Set;
+
+public final class DefaultResourceFilterMatcher implements ResourceFilterMatcher {
+    private String id;
+    private String arguments;
+    private Set<ResourceFilterMatcher> children = Sets.newLinkedHashSet();
+
+    public DefaultResourceFilterMatcher() {
+    }
+
+    public DefaultResourceFilterMatcher(String id, String arguments, Set<ResourceFilterMatcher> children) {
+        this();
+        this.id = id;
+        this.arguments = arguments;
+        this.children = children;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    @Nullable
+    public String getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public void setArguments(String arguments) {
+        this.arguments = arguments;
+    }
+
+    @Override
+    public Set<ResourceFilterMatcher> getChildren() {
+        return children;
+    }
+
+    public void setChildren(Set<ResourceFilterMatcher> children) {
+        if (children == null) {
+            throw new InvalidUserDataException("children must not be null");
+        }
+        this.children = children;
+    }
+
+    public ResourceFilterMatcher matcher(@DelegatesTo(value = ResourceFilterMatcher.class, strategy = Closure.DELEGATE_FIRST) Closure configureClosure) {
+        return matcher(new ClosureBackedAction<ResourceFilterMatcher>(configureClosure));
+    }
+
+    @Override
+    public ResourceFilterMatcher matcher(Action<? super ResourceFilterMatcher> configureAction) {
+        ResourceFilterMatcher m = new DefaultResourceFilterMatcher();
+        configureAction.execute(m);
+        children.add(m);
+        return m;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (!getClass().equals(o.getClass())) {
+            return false;
+        }
+        DefaultResourceFilterMatcher resourceFilterMatcher = (DefaultResourceFilterMatcher) o;
+        return Objects.equal(id, resourceFilterMatcher.id)
+            && Objects.equal(arguments, resourceFilterMatcher.arguments)
+            && Objects.equal(children, resourceFilterMatcher.children);
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (arguments != null ? arguments.hashCode() : 0);
+        result = 31 * result + (children != null ? children.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceFilterMatcher{"
+            + "id='" + id + '\''
+            + ", arguments='" + arguments + '\''
+            + ", children='" + children + '\''
+            + '}';
+    }
+}

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ProjectTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ProjectTest.groovy
@@ -17,6 +17,8 @@ package org.gradle.plugins.ide.eclipse.model;
 
 
 import org.gradle.internal.xml.XmlTransformer
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultResourceFilter
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultResourceFilterMatcher
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -24,11 +26,11 @@ import spock.lang.Specification
 public class ProjectTest extends Specification {
     def static final CUSTOM_REFERENCED_PROJECTS = ['refProject'] as LinkedHashSet
     def static final CUSTOM_BUILD_COMMANDS = [new BuildCommand('org.eclipse.jdt.core.scalabuilder', [climate: 'cold'])]
-    def static final CUSTOM_NATURES = ['org.eclipse.jdt.core.scalanature'] 
+    def static final CUSTOM_NATURES = ['org.eclipse.jdt.core.scalanature']
     def static final CUSTOM_LINKED_RESOURCES = [new Link('somename', 'sometype', 'somelocation', '')] as Set
     def static final CUSTOM_RESOURCE_FILTERS = [
-        new ResourceFilter(ResourceFilterAppliesTo.FILES_AND_FOLDERS, ResourceFilterType.EXCLUDE_ALL, true, new ResourceFilterMatcher('org.eclipse.some.custom.matcher', 'foobar', [] as LinkedHashSet)),
-        new ResourceFilter(ResourceFilterAppliesTo.FOLDERS, ResourceFilterType.INCLUDE_ONLY, false, new ResourceFilterMatcher('org.eclipse.ui.ide.orFilterMatcher', null, [new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet))] as LinkedHashSet
+        new DefaultResourceFilter(ResourceFilterAppliesTo.FILES_AND_FOLDERS, ResourceFilterType.EXCLUDE_ALL, true, new DefaultResourceFilterMatcher('org.eclipse.some.custom.matcher', 'foobar', [] as LinkedHashSet)),
+        new DefaultResourceFilter(ResourceFilterAppliesTo.FOLDERS, ResourceFilterType.INCLUDE_ONLY, false, new DefaultResourceFilterMatcher('org.eclipse.ui.ide.orFilterMatcher', null, [new DefaultResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new DefaultResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet))] as LinkedHashSet
 
     @Rule
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
@@ -57,8 +59,8 @@ public class ProjectTest extends Specification {
         eclipseProject.natures = ['constructorNature']
         eclipseProject.linkedResources = [new Link('constructorName', 'constructorType', 'constructorLocation', '')] as Set
         eclipseProject.resourceFilters = [
-            new ResourceFilter(ResourceFilterAppliesTo.FILES, ResourceFilterType.INCLUDE_ONLY, false, new ResourceFilterMatcher('matcherId', 'matcherArgs', [] as LinkedHashSet)),
-            new ResourceFilter(ResourceFilterAppliesTo.FILES_AND_FOLDERS, ResourceFilterType.EXCLUDE_ALL, true, new ResourceFilterMatcher('org.eclipse.ui.ide.orFilterMatcher', null, [new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet)] as LinkedHashSet))] as LinkedHashSet
+            new DefaultResourceFilter(ResourceFilterAppliesTo.FILES, ResourceFilterType.INCLUDE_ONLY, false, new DefaultResourceFilterMatcher('matcherId', 'matcherArgs', [] as LinkedHashSet)),
+            new DefaultResourceFilter(ResourceFilterAppliesTo.FILES_AND_FOLDERS, ResourceFilterType.EXCLUDE_ALL, true, new DefaultResourceFilterMatcher('org.eclipse.ui.ide.orFilterMatcher', null, [new DefaultResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet)] as LinkedHashSet))] as LinkedHashSet
 
         when:
         project.load(customProjectReader)
@@ -93,7 +95,7 @@ public class ProjectTest extends Specification {
         eclipseProject.name = 'constructorName'
         eclipseProject.comment = 'constructorComment'
         eclipseProject.referencedProjects = ['constructorRefProject'] as LinkedHashSet
-        eclipseProject.resourceFilters = [new ResourceFilter(ResourceFilterAppliesTo.FOLDERS, ResourceFilterType.INCLUDE_ONLY, true, new ResourceFilterMatcher('matcherId2', 'matcherArgs2', [] as LinkedHashSet))] as LinkedHashSet
+        eclipseProject.resourceFilters = [new DefaultResourceFilter(ResourceFilterAppliesTo.FOLDERS, ResourceFilterType.INCLUDE_ONLY, true, new DefaultResourceFilterMatcher('matcherId2', 'matcherArgs2', [] as LinkedHashSet))] as LinkedHashSet
 
         when:
         project.load(customProjectReader)

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcherTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ResourceFilterMatcherTest.groovy
@@ -18,14 +18,15 @@ package org.gradle.plugins.ide.eclipse.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultResourceFilterMatcher
 import spock.lang.Specification
 
 public class ResourceFilterMatcherTest extends Specification {
     def "ResourceFilterMatcher equals and hashCode satisfies contract"() {
         when:
-        EqualsVerifier.forClass(ResourceFilterMatcher.class)
+        EqualsVerifier.forClass(DefaultResourceFilterMatcher.class)
                 .suppress(Warning.NONFINAL_FIELDS)
-                .withPrefabValues(Set.class, [new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet, [] as LinkedHashSet)
+                .withPrefabValues(Set.class, [new DefaultResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new DefaultResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet, [] as LinkedHashSet)
                 .verify()
 
         then:

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ResourceFilterTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ResourceFilterTest.groovy
@@ -18,14 +18,16 @@ package org.gradle.plugins.ide.eclipse.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier
 import nl.jqno.equalsverifier.Warning
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultResourceFilter
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultResourceFilterMatcher
 import spock.lang.Specification
 
 public class ResourceFilterTest extends Specification {
     def "ResourceFilter equals and hashCode satisfies contract"() {
         when:
-        EqualsVerifier.forClass(ResourceFilter.class)
+        EqualsVerifier.forClass(DefaultResourceFilter.class)
                 .suppress(Warning.NONFINAL_FIELDS)
-                .withPrefabValues(Set.class, [new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new ResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet, [] as LinkedHashSet)
+                .withPrefabValues(Set.class, [new DefaultResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new DefaultResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet, [] as LinkedHashSet)
                 .verify()
 
         then:


### PR DESCRIPTION
We want to get rid of the Closure-taking methods, but that would require
a bigger refactoring of the `EclipseProject` code to use the `Instantiator`
everywhere. Instead of doing this shortly before a release, I decided to
extract interfaces for the ResourceFilters (which will come in handy anyway
when we introduce convenience subclasses). This way we hide the
Closure-taking methods from the public API, making the easier to remove
later on.