### PR TITLE
Use max worker count for build progress labels

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -128,6 +128,11 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         ListenerManager listenerManager = serviceRegistry.get(ListenerManager.class);
         LoggingManagerInternal loggingManager = serviceRegistry.newInstance(LoggingManagerInternal.class);
         loggingManager.setLevelInternal(startParameter.getLogLevel());
+        if (startParameter.isParallelProjectExecutionEnabled()) {
+            loggingManager.setMaxWorkerCount(startParameter.getMaxWorkerCount());
+        } else {
+            loggingManager.setMaxWorkerCount(1);
+        }
 
         //this hooks up the ListenerManager and LoggingConfigurer so you can call Gradle.addListener() with a StandardOutputListener.
         loggingManager.addStandardOutputListener(listenerManager.getBroadcaster(StandardOutputListener.class));

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfiguration.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.gradle.api.Incubating;
+
+import java.io.Serializable;
+
+public class DefaultParallelismConfiguration implements Serializable, ParallelismConfiguration {
+    private boolean parallelProjectExecution;
+    private int maxWorkerCount;
+
+    public DefaultParallelismConfiguration() {
+        maxWorkerCount = Runtime.getRuntime().availableProcessors();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Incubating
+    @Override
+    public boolean isParallelProjectExecutionEnabled() {
+        return parallelProjectExecution;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Incubating
+    @Override
+    public void setParallelProjectExecutionEnabled(boolean parallelProjectExecution) {
+        this.parallelProjectExecution = parallelProjectExecution;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Incubating
+    @Override
+    public int getMaxWorkerCount() {
+        return maxWorkerCount;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Incubating
+    @Override
+    public void setMaxWorkerCount(int maxWorkerCount) {
+        if (maxWorkerCount < 1) {
+            throw new IllegalArgumentException("Max worker count must be > 0");
+        } else {
+            this.maxWorkerCount = maxWorkerCount;
+        }
+    }
+
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A {@code ParallelismConfiguration} defines the parallel settings for a Gradle build.
+ */
+public interface ParallelismConfiguration {
+    /**
+     * Returns true if parallel project execution is enabled.
+     *
+     * @see #getMaxWorkerCount()
+     */
+    @Incubating
+    boolean isParallelProjectExecutionEnabled();
+
+    /**
+     * Enables/disables parallel project execution.
+     *
+     * @see #isParallelProjectExecutionEnabled()
+     */
+    @Incubating
+    void setParallelProjectExecutionEnabled(boolean parallelProjectExecution);
+
+    /**
+     * Returns the maximum number of concurrent workers used for underlying build operations.
+     *
+     * Workers can be threads, processes or whatever Gradle considers a "worker". Some examples:
+     *
+     * <ul>
+     *     <li>A thread running a task</li>
+     *     <li>A test process</li>
+     *     <li>A language compiler in a forked process</li>
+     * </ul>
+     *
+     * Defaults to the number of processors available to the Java virtual machine.
+     *
+     * @return maximum number of concurrent workers, always >= 1.
+     * @see java.lang.Runtime#availableProcessors()
+     */
+    @Incubating
+    int getMaxWorkerCount();
+
+    /**
+     * Specifies the maximum number of concurrent workers used for underlying build operations.
+     *
+     * @throws IllegalArgumentException if {@code maxWorkerCount} is &lt; 1
+     * @see #getMaxWorkerCount()
+     */
+    @Incubating
+    void setMaxWorkerCount(int maxWorkerCount);
+
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.cli.AbstractCommandLineConverter;
+import org.gradle.cli.CommandLineArgumentException;
+import org.gradle.cli.CommandLineParser;
+import org.gradle.cli.ParsedCommandLine;
+
+public class ParallelismConfigurationCommandLineConverter extends AbstractCommandLineConverter<ParallelismConfiguration> {
+    private static final String PARALLEL = "parallel";
+    private static final String MAX_WORKERS = "max-workers";
+
+    public ParallelismConfiguration convert(ParsedCommandLine options, ParallelismConfiguration target) throws CommandLineArgumentException {
+        if (options.hasOption(PARALLEL)) {
+            target.setParallelProjectExecutionEnabled(true);
+        }
+
+        if (options.hasOption(MAX_WORKERS)) {
+            String value = options.option(MAX_WORKERS).getValue();
+            try {
+                int workerCount = Integer.parseInt(value);
+                if (workerCount < 1) {
+                    invalidMaxWorkersSwitchValue(value);
+                }
+                target.setMaxWorkerCount(workerCount);
+            } catch (NumberFormatException e) {
+                invalidMaxWorkersSwitchValue(value);
+            }
+        }
+
+        return target;
+    }
+
+    private ParallelismConfiguration invalidMaxWorkersSwitchValue(String value) {
+        throw new CommandLineArgumentException(String.format("Argument value '%s' given for --%s option is invalid (must be a positive, non-zero, integer)", value, MAX_WORKERS));
+    }
+
+    public void configure(CommandLineParser parser) {
+        parser.option(PARALLEL).hasDescription("Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.").incubating();
+        parser.option(MAX_WORKERS).hasArgument().hasDescription("Configure the number of concurrent workers Gradle is allowed to use.").incubating();
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.initialization
+
+import org.gradle.cli.CommandLineArgumentException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ParallelismConfigurationCommandLineConverterTest extends Specification {
+    final def converter = new ParallelismConfigurationCommandLineConverter()
+
+    def "converts parallel executor"() {
+        when:
+        def result = convert("--parallel")
+
+        then:
+        result.parallelProjectExecutionEnabled == true
+    }
+
+    def "converts max workers"() {
+        given:
+        def maxWorkerCount = 5
+
+        when:
+        def result = convert("--max-workers", "$maxWorkerCount")
+
+        then:
+        result.maxWorkerCount == maxWorkerCount
+    }
+
+    def "converts empty arguments set max workers to number of processors"() {
+        when:
+        def result = convert()
+
+        then:
+        result.maxWorkerCount == Runtime.getRuntime().availableProcessors()
+    }
+
+    @Unroll
+    def "converts invalid max workers (#value)"() {
+        when:
+        convert("--max-workers", value);
+
+        then:
+        thrown(CommandLineArgumentException)
+
+        where:
+        value << ["foo", "-1", "0"]
+    }
+
+    ParallelismConfiguration convert(String... args) {
+        return converter.convert(Arrays.asList(args), new DefaultParallelismConfiguration())
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -46,7 +46,7 @@ import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.bootstrap.ExecutionListener;
-import org.gradle.launcher.cli.converter.PropertiesToParallelConfigurationConverter;
+import org.gradle.launcher.cli.converter.PropertiesToParallelismConfigurationConverter;
 import org.gradle.process.internal.DefaultExecActionFactory;
 import org.gradle.util.GradleVersion;
 
@@ -221,8 +221,8 @@ public class CommandLineActionFactory {
                 Map<String, String> properties = new HashMap<String, String>();
                 systemPropertiesCommandLineConverter.convert(parsedCommandLine, properties);
                 projectPropertiesCommandLineConverter.convert(parsedCommandLine, properties);
-                PropertiesToParallelConfigurationConverter propertiesToParallelConfigurationConverter = new PropertiesToParallelConfigurationConverter();
-                propertiesToParallelConfigurationConverter.convert(properties, parallelismConfiguration);
+                PropertiesToParallelismConfigurationConverter propertiesToParallelismConfigurationConverter = new PropertiesToParallelismConfigurationConverter();
+                propertiesToParallelismConfigurationConverter.convert(properties, parallelismConfiguration);
             } catch (CommandLineArgumentException e) {
                 // Ignore, deal with this problem later
             }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -24,9 +24,14 @@ import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineConverter;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
+import org.gradle.cli.ProjectPropertiesCommandLineConverter;
+import org.gradle.cli.SystemPropertiesCommandLineConverter;
 import org.gradle.configuration.GradleLauncherMetaData;
 import org.gradle.initialization.BuildLayoutParameters;
+import org.gradle.initialization.DefaultParallelismConfiguration;
 import org.gradle.initialization.LayoutCommandLineConverter;
+import org.gradle.initialization.ParallelismConfiguration;
+import org.gradle.initialization.ParallelismConfigurationCommandLineConverter;
 import org.gradle.internal.Actions;
 import org.gradle.internal.buildevents.BuildExceptionReporter;
 import org.gradle.internal.jvm.Jvm;
@@ -41,13 +46,16 @@ import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.bootstrap.ExecutionListener;
+import org.gradle.launcher.cli.converter.PropertiesToParallelConfigurationConverter;
 import org.gradle.process.internal.DefaultExecActionFactory;
 import org.gradle.util.GradleVersion;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>Responsible for converting a set of command-line arguments into a {@link Runnable} action.</p>
@@ -187,22 +195,47 @@ public class CommandLineActionFactory {
         public void execute(ExecutionListener executionListener) {
             CommandLineConverter<LoggingConfiguration> loggingConfigurationConverter = new LoggingCommandLineConverter();
             CommandLineConverter<BuildLayoutParameters> buildLayoutConverter = new LayoutCommandLineConverter();
+            CommandLineConverter<ParallelismConfiguration> parallelConverter = new ParallelismConfigurationCommandLineConverter();
+            CommandLineConverter<Map<String, String>> systemPropertiesCommandLineConverter = new SystemPropertiesCommandLineConverter();
+            CommandLineConverter<Map<String, String>> projectPropertiesCommandLineConverter = new ProjectPropertiesCommandLineConverter();
+
             BuildLayoutParameters buildLayout = new BuildLayoutParameters();
+            ParallelismConfiguration parallelismConfiguration = new DefaultParallelismConfiguration();
+
             CommandLineParser parser = new CommandLineParser();
             loggingConfigurationConverter.configure(parser);
             buildLayoutConverter.configure(parser);
+            parallelConverter.configure(parser);
+            systemPropertiesCommandLineConverter.configure(parser);
+            projectPropertiesCommandLineConverter.configure(parser);
+
             parser.allowUnknownOptions();
             parser.allowMixedSubcommandsAndOptions();
+
             try {
                 ParsedCommandLine parsedCommandLine = parser.parse(args);
                 loggingConfigurationConverter.convert(parsedCommandLine, loggingConfiguration);
                 buildLayoutConverter.convert(parsedCommandLine, buildLayout);
+                parallelConverter.convert(parsedCommandLine, parallelismConfiguration);
+
+                Map<String, String> properties = new HashMap<String, String>();
+                systemPropertiesCommandLineConverter.convert(parsedCommandLine, properties);
+                projectPropertiesCommandLineConverter.convert(parsedCommandLine, properties);
+                PropertiesToParallelConfigurationConverter propertiesToParallelConfigurationConverter = new PropertiesToParallelConfigurationConverter();
+                propertiesToParallelConfigurationConverter.convert(properties, parallelismConfiguration);
             } catch (CommandLineArgumentException e) {
                 // Ignore, deal with this problem later
             }
 
             LoggingManagerInternal loggingManager = loggingServices.getFactory(LoggingManagerInternal.class).create();
             loggingManager.setLevelInternal(loggingConfiguration.getLogLevel());
+
+            if (parallelismConfiguration.isParallelProjectExecutionEnabled()) {
+                loggingManager.setMaxWorkerCount(parallelismConfiguration.getMaxWorkerCount());
+            } else {
+                loggingManager.setMaxWorkerCount(1);
+            }
+
             loggingManager.start();
             try {
                 NativeServices.initialize(buildLayout.getGradleUserHomeDir());

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelConfigurationConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelConfigurationConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.cli.converter;
+
+import org.gradle.StartParameter;
+import org.gradle.initialization.ParallelismConfiguration;
+import org.gradle.launcher.daemon.configuration.GradleProperties;
+
+import java.util.Map;
+
+import static org.gradle.util.GUtil.isTrue;
+
+public class PropertiesToParallelConfigurationConverter {
+    public ParallelismConfiguration convert(Map<String, String> properties, ParallelismConfiguration parallelismConfiguration) {
+        String parallel = properties.get(GradleProperties.PARALLEL_PROPERTY);
+        if (isTrue(parallel)) {
+            parallelismConfiguration.setParallelProjectExecutionEnabled(true);
+        }
+
+        String workers = properties.get(GradleProperties.WORKERS_PROPERTY);
+        if (workers != null) {
+            try {
+                int workerCount = Integer.parseInt(workers);
+                if (workerCount < 1) {
+                    invalidMaxWorkersPropValue(workers);
+                }
+                parallelismConfiguration.setMaxWorkerCount(workerCount);
+            } catch (NumberFormatException e) {
+                invalidMaxWorkersPropValue(workers);
+            }
+        }
+
+        return parallelismConfiguration;
+    }
+
+    private StartParameter invalidMaxWorkersPropValue(String value) {
+        throw new IllegalArgumentException(String.format("Value '%s' given for %s system property is invalid (must be a positive, non-zero, integer)", value, GradleProperties.WORKERS_PROPERTY));
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 import static org.gradle.util.GUtil.isTrue;
 
-public class PropertiesToParallelConfigurationConverter {
+public class PropertiesToParallelismConfigurationConverter {
     public ParallelismConfiguration convert(Map<String, String> properties, ParallelismConfiguration parallelismConfiguration) {
         String parallel = properties.get(GradleProperties.PARALLEL_PROPERTY);
         if (isTrue(parallel)) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
@@ -25,12 +25,12 @@ import java.util.Map;
 import static org.gradle.launcher.daemon.configuration.GradleProperties.isTrue;
 
 public class PropertiesToStartParameterConverter {
-    private final PropertiesToParallelConfigurationConverter propertiesToParallelConfigurationConverter = new PropertiesToParallelConfigurationConverter();
+    private final PropertiesToParallelismConfigurationConverter propertiesToParallelismConfigurationConverter = new PropertiesToParallelismConfigurationConverter();
 
     public StartParameter convert(Map<String, String> properties, StartParameter startParameter) {
         startParameter.setConfigureOnDemand(isTrue(properties.get(GradleProperties.CONFIGURE_ON_DEMAND_PROPERTY)));
 
-        propertiesToParallelConfigurationConverter.convert(properties, startParameter);
+        propertiesToParallelismConfigurationConverter.convert(properties, startParameter);
 
         // Warn anyone using the old property to stop
         String taskOutputCache = properties.get(GradleProperties.TASK_OUTPUT_CACHE_PROPERTY);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
@@ -25,26 +25,12 @@ import java.util.Map;
 import static org.gradle.launcher.daemon.configuration.GradleProperties.isTrue;
 
 public class PropertiesToStartParameterConverter {
+    private final PropertiesToParallelConfigurationConverter propertiesToParallelConfigurationConverter = new PropertiesToParallelConfigurationConverter();
+
     public StartParameter convert(Map<String, String> properties, StartParameter startParameter) {
         startParameter.setConfigureOnDemand(isTrue(properties.get(GradleProperties.CONFIGURE_ON_DEMAND_PROPERTY)));
 
-        String parallel = properties.get(GradleProperties.PARALLEL_PROPERTY);
-        if (isTrue(parallel)) {
-            startParameter.setParallelProjectExecutionEnabled(true);
-        }
-
-        String workers = properties.get(GradleProperties.WORKERS_PROPERTY);
-        if (workers != null) {
-            try {
-                int workerCount = Integer.parseInt(workers);
-                if (workerCount < 1) {
-                    invalidMaxWorkersPropValue(workers);
-                }
-                startParameter.setMaxWorkerCount(workerCount);
-            } catch (NumberFormatException e) {
-                invalidMaxWorkersPropValue(workers);
-            }
-        }
+        propertiesToParallelConfigurationConverter.convert(properties, startParameter);
 
         // Warn anyone using the old property to stop
         String taskOutputCache = properties.get(GradleProperties.TASK_OUTPUT_CACHE_PROPERTY);
@@ -60,9 +46,5 @@ public class PropertiesToStartParameterConverter {
         }
 
         return startParameter;
-    }
-
-    private StartParameter invalidMaxWorkersPropValue(String value) {
-        throw new IllegalArgumentException(String.format("Value '%s' given for %s system property is invalid (must be a positive, non-zero, integer)", value, GradleProperties.WORKERS_PROPERTY));
     }
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/CommandLineActionFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/CommandLineActionFactoryTest.groovy
@@ -37,6 +37,7 @@ import org.gradle.util.RedirectStdOutAndErr
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class CommandLineActionFactoryTest extends Specification {
     @Rule
@@ -114,6 +115,29 @@ class CommandLineActionFactoryTest extends Specification {
         1 * actionFactory1.configureCommandLineParser(!null)
         1 * actionFactory2.configureCommandLineParser(!null)
         1 * actionFactory1.createAction(!null, !null) >> rawAction
+    }
+
+    @Unroll
+    def "set logging max worker count to #expectedMaxWorkerCount according to command line flags #flags"() {
+        when:
+        def action = factory.convert(flags)
+
+        then:
+        action
+
+        when:
+        action.execute(executionListener)
+
+        then:
+        1 * loggingManager.setMaxWorkerCount(expectedMaxWorkerCount);
+
+        where:
+        expectedMaxWorkerCount | flags
+        1                      | []
+        1                      | ['--max-workers=4']
+        4                      | ['--parallel', '--max-workers=4']
+        4                      | ['--parallel', '-Dorg.gradle.workers.max=4']
+        6                      | ['--parallel', '--max-workers=6', '-Dorg.gradle.workers.max=4']
     }
 
     def "reports command-line parse failure"() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/CommandLineActionFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/CommandLineActionFactoryTest.groovy
@@ -138,6 +138,7 @@ class CommandLineActionFactoryTest extends Specification {
         4                      | ['--parallel', '--max-workers=4']
         4                      | ['--parallel', '-Dorg.gradle.workers.max=4']
         6                      | ['--parallel', '--max-workers=6', '-Dorg.gradle.workers.max=4']
+        4                      | ['-Dorg.gradle.parallel=true', '--max-workers=4']
     }
 
     def "reports command-line parse failure"() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingManagerInternal.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingManagerInternal.java
@@ -50,4 +50,9 @@ public interface LoggingManagerInternal extends LoggingManager, StandardOutputCa
     LoggingManagerInternal captureStandardError(LogLevel level);
 
     LoggingManagerInternal setLevelInternal(LogLevel logLevel);
+
+    /**
+     * Sets the worker count to display in the UI.
+     */
+    LoggingManagerInternal setMaxWorkerCount(int maxWorkerCount);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/config/LoggingRouter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/config/LoggingRouter.java
@@ -21,4 +21,5 @@ import org.gradle.internal.logging.LoggingOutputInternal;
 
 public interface LoggingRouter extends LoggingSystem, LoggingOutputInternal {
     void configure(LogLevel logLevel);
+    void configureMaxWorkerCount(int maxWorkerCount);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/AnsiConsole.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/AnsiConsole.java
@@ -31,20 +31,19 @@ public class AnsiConsole implements Console {
         }
     };
     private final Flushable flushable;
-    private final MultiLineBuildProgressArea buildStatusArea;
+    private final MultiLineBuildProgressArea buildStatusArea = new MultiLineBuildProgressArea();
     private final DefaultTextArea buildOutputArea;
     private final AnsiExecutor ansiExecutor;
 
-    public AnsiConsole(Appendable target, Flushable flushable, ColorMap colorMap, ConsoleMetaData consoleMetaData, int numWorkersToDisplay, boolean forceAnsi) {
-        this(target, flushable, colorMap, consoleMetaData, numWorkersToDisplay, new DefaultAnsiFactory(forceAnsi));
+    public AnsiConsole(Appendable target, Flushable flushable, ColorMap colorMap, ConsoleMetaData consoleMetaData, boolean forceAnsi) {
+        this(target, flushable, colorMap, consoleMetaData, new DefaultAnsiFactory(forceAnsi));
     }
 
-    private AnsiConsole(Appendable target, Flushable flushable, ColorMap colorMap, ConsoleMetaData consoleMetaData, int numWorkersToDisplay, AnsiFactory factory) {
+    private AnsiConsole(Appendable target, Flushable flushable, ColorMap colorMap, ConsoleMetaData consoleMetaData, AnsiFactory factory) {
         this.flushable = flushable;
         this.ansiExecutor = new DefaultAnsiExecutor(target, colorMap, factory, consoleMetaData, Cursor.newBottomLeft(), new Listener());
 
         buildOutputArea = new DefaultTextArea(ansiExecutor);
-        buildStatusArea = new MultiLineBuildProgressArea(numWorkersToDisplay);
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildProgressArea.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildProgressArea.java
@@ -22,5 +22,6 @@ public interface BuildProgressArea {
     // TODO(ew): Consider whether this belongs in Console or here
     StyledLabel getProgressBar();
     List<StyledLabel> getBuildProgressLabels();
+    void resizeBuildProgressTo(int numberOfLabels);
     void setVisible(boolean isVisible);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ConsoleLayoutCalculator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ConsoleLayoutCalculator.java
@@ -18,17 +18,21 @@ package org.gradle.internal.logging.console;
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
 
 public class ConsoleLayoutCalculator {
+    private final ConsoleMetaData consoleMetaData;
+
+    /**
+     * @param consoleMetaData used to get console dimensions
+     */
+    public ConsoleLayoutCalculator(ConsoleMetaData consoleMetaData) {
+        this.consoleMetaData = consoleMetaData;
+    }
     /**
      * Calculate number of Console lines to use for work-in-progress display.
      *
-     * @param consoleMetaData used to get console dimensions
+     * @param ideal number of Console lines
      * @return height of progress area.
      */
-    public static int calculateNumWorkersForConsoleDisplay(ConsoleMetaData consoleMetaData) {
-        // FIXME(ew): this not only doesn't honor gradle property, but it wouldn't honor CLI --max-workers option if it did
-        // Order of preference: "org.gradle.workers.max", # Processors, 1/2 height of Console
-        int ideal = Integer.getInteger("org.gradle.workers.max", Runtime.getRuntime().availableProcessors());
-
+    public int calculateNumWorkersForConsoleDisplay(int ideal) {
         // Disallow work-in-progress to take up more than half of the console display
         int maximumAvailableLines = consoleMetaData.getRows() / 2;
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/MultiLineBuildProgressArea.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/MultiLineBuildProgressArea.java
@@ -21,32 +21,25 @@ import java.util.Collections;
 import java.util.List;
 
 public class MultiLineBuildProgressArea implements BuildProgressArea {
-    private final List<DefaultRedrawableLabel> entries;
+    // 2 lines: 1 for BuildStatus and 1 for Cursor parking space
+    private final List<DefaultRedrawableLabel> entries = new ArrayList<DefaultRedrawableLabel>(2);
     private final DefaultRedrawableLabel progressBarLabel;
 
-    private final List<StyledLabel> buildProgressLabels;
+    private final List<StyledLabel> buildProgressLabels = new ArrayList<StyledLabel>();
+    private final DefaultRedrawableLabel parkingLabel;
     private final Cursor statusAreaPos = new Cursor();
     private boolean isVisible;
     private boolean isPreviouslyVisible;
 
-    public MultiLineBuildProgressArea(int numLabels) {
-        this.buildProgressLabels = new ArrayList<StyledLabel>(numLabels);
-        // 2 extra lines: 1 for BuildStatus and 1 for Cursor parking space
-        this.entries = new ArrayList<DefaultRedrawableLabel>(numLabels + 2);
-
+    public MultiLineBuildProgressArea() {
         int row = 0;
 
         progressBarLabel = newLabel(row--);
         entries.add(progressBarLabel);
 
-        for (int i = 0; i < numLabels; ++i) {
-            DefaultRedrawableLabel label = newLabel(row--);
-            entries.add(label);
-            buildProgressLabels.add(label);
-        }
-
         // Parking space for the write cursor
-        entries.add(newLabel(row--));
+        parkingLabel = newLabel(row--);
+        entries.add(parkingLabel);
     }
 
     private DefaultRedrawableLabel newLabel(int row) {
@@ -69,6 +62,23 @@ public class MultiLineBuildProgressArea implements BuildProgressArea {
 
     public int getHeight() {
         return entries.size();
+    }
+
+    @Override
+    public void resizeBuildProgressTo(int buildProgressLabelCount) {
+        int delta = buildProgressLabelCount - buildProgressLabels.size();
+        if (delta <= 0) {
+            // We don't support shrinking at the moment
+            return;
+        }
+
+        int row = parkingLabel.getWritePosition().row;
+        parkingLabel.scrollDownBy(delta);
+        while (delta-- > 0) {
+            DefaultRedrawableLabel label = newLabel(row--);
+            entries.add(entries.size() - 1, label);
+            buildProgressLabels.add(label);
+        }
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/MaxWorkerCountChangeEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/MaxWorkerCountChangeEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.events;
+
+import org.gradle.api.logging.LogLevel;
+
+/**
+ * Notifies output consumers that the max worker count has changed.
+ */
+public class MaxWorkerCountChangeEvent extends OutputEvent {
+    private final int newMaxWorkerCount;
+
+    public MaxWorkerCountChangeEvent(int newMaxWorkerCount) {
+        this.newMaxWorkerCount = newMaxWorkerCount;
+    }
+
+    public int getNewMaxWorkerCount() {
+        return newMaxWorkerCount;
+    }
+
+    @Override
+    public String toString() {
+        return MaxWorkerCountChangeEvent.class.getSimpleName() + " " + newMaxWorkerCount;
+    }
+
+    @Override
+    public LogLevel getLogLevel() {
+        return null;
+    }
+}
+

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
@@ -115,6 +115,12 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
     }
 
     @Override
+    public DefaultLoggingManager setMaxWorkerCount(int maxWorkerCount) {
+        loggingRouter.setMaxWorkerCount(maxWorkerCount);
+        return this;
+    }
+
+    @Override
     public DefaultLoggingManager captureSystemSources() {
         stdOutLoggingSystem.enableCapture();
         stdErrLoggingSystem.enableCapture();
@@ -199,6 +205,7 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
     private static class StartableLoggingRouter implements Stoppable {
         private final LoggingRouter loggingRouter;
         private LogLevel level;
+        private Integer maxWorkerCount;
         private LoggingSystem.Snapshot originalState;
         private ConsoleOutput consoleOutput;
         private OutputStream consoleOutputStream;
@@ -211,6 +218,9 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
             originalState = loggingRouter.snapshot();
             if (level != null) {
                 loggingRouter.configure(level);
+            }
+            if (maxWorkerCount != null) {
+                loggingRouter.configureMaxWorkerCount(maxWorkerCount.intValue());
             }
             if (consoleOutput != null) {
                 loggingRouter.attachProcessConsole(consoleOutput);
@@ -260,6 +270,18 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
                 loggingRouter.configure(logLevel);
             }
             level = logLevel;
+        }
+
+        public void setMaxWorkerCount(int maxWorkerCount) {
+            if (this.maxWorkerCount != null && this.maxWorkerCount == maxWorkerCount) {
+                return;
+            }
+
+            if (originalState != null) {
+                // Already started
+                loggingRouter.configureMaxWorkerCount(maxWorkerCount);
+            }
+            this.maxWorkerCount = Integer.valueOf(maxWorkerCount);
         }
 
         @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
@@ -19,7 +19,6 @@ package org.gradle.internal.logging.sink;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.internal.logging.console.AnsiConsole;
 import org.gradle.internal.logging.console.Console;
-import org.gradle.internal.logging.console.ConsoleLayoutCalculator;
 import org.gradle.internal.nativeintegration.console.ConsoleDetector;
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
 import org.gradle.internal.nativeintegration.console.FallbackConsoleMetaData;
@@ -48,17 +47,16 @@ public class ConsoleConfigureAction {
 
         boolean stdOutIsTerminal = consoleMetaData.isStdOut();
         boolean stdErrIsTerminal = consoleMetaData.isStdErr();
-        int numWorkersToDisplay = ConsoleLayoutCalculator.calculateNumWorkersForConsoleDisplay(consoleMetaData);
         if (stdOutIsTerminal) {
             OutputStream originalStdOut = renderer.getOriginalStdOut();
             OutputStreamWriter outStr = new OutputStreamWriter(force ? originalStdOut : AnsiConsoleUtil.wrapOutputStream(originalStdOut));
-            Console console = new AnsiConsole(outStr, outStr, renderer.getColourMap(), consoleMetaData, numWorkersToDisplay, force);
+            Console console = new AnsiConsole(outStr, outStr, renderer.getColourMap(), consoleMetaData, force);
             renderer.addConsole(console, true, stdErrIsTerminal, consoleMetaData);
         } else if (stdErrIsTerminal) {
             // Only stderr is connected to a terminal
             OutputStream originalStdErr = renderer.getOriginalStdErr();
             OutputStreamWriter errStr = new OutputStreamWriter(force ? originalStdErr : AnsiConsoleUtil.wrapOutputStream(originalStdErr));
-            Console console = new AnsiConsole(errStr, errStr, renderer.getColourMap(), consoleMetaData, numWorkersToDisplay, force);
+            Console console = new AnsiConsole(errStr, errStr, renderer.getColourMap(), consoleMetaData, force);
             renderer.addConsole(console, false, true, consoleMetaData);
         }
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -35,6 +35,7 @@ import org.gradle.internal.logging.console.WorkInProgressRenderer;
 import org.gradle.internal.logging.events.BatchOutputEventListener;
 import org.gradle.internal.logging.events.EndOutputEvent;
 import org.gradle.internal.logging.events.LogLevelChangeEvent;
+import org.gradle.internal.logging.events.MaxWorkerCountChangeEvent;
 import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.text.StreamBackedStandardOutputListener;
@@ -58,6 +59,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
     private final Object lock = new Object();
     private final DefaultColorMap colourMap = new DefaultColorMap();
     private LogLevel logLevel = LogLevel.LIFECYCLE;
+    private int maxWorkerCount;
     private final ConsoleConfigureAction consoleConfigureAction;
     private OutputStream originalStdOut;
     private OutputStream originalStdErr;
@@ -77,7 +79,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
     public Snapshot snapshot() {
         synchronized (lock) {
             // Currently only snapshot the console output listener. Should snapshot all output listeners, and cleanup in restore()
-            return new SnapshotImpl(logLevel, console);
+            return new SnapshotImpl(logLevel, console, maxWorkerCount);
         }
     }
 
@@ -87,6 +89,10 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
             SnapshotImpl snapshot = (SnapshotImpl) state;
             if (snapshot.logLevel != logLevel) {
                 configure(snapshot.logLevel);
+            }
+
+            if (snapshot.maxWorkerCount != maxWorkerCount) {
+                configureMaxWorkerCount(snapshot.maxWorkerCount);
             }
             // TODO - also close console when it is replaced
             // TODO - remove console from formatters
@@ -124,8 +130,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
         synchronized (lock) {
             ConsoleMetaData consoleMetaData = new FallbackConsoleMetaData();
             OutputStreamWriter writer = new OutputStreamWriter(outputStream);
-            int numWorkersToDisplay = ConsoleLayoutCalculator.calculateNumWorkersForConsoleDisplay(consoleMetaData);
-            Console console = new AnsiConsole(writer, writer, colourMap, consoleMetaData, numWorkersToDisplay, true);
+            Console console = new AnsiConsole(writer, writer, colourMap, consoleMetaData, true);
             addConsole(console, true, true, consoleMetaData);
         }
     }
@@ -193,7 +198,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
                 new WorkInProgressRenderer(
                     new ProgressLogEventGenerator(
                         new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), true),
-                    console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData)),
+                    console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
                 console.getStatusBar(), console, consoleMetaData),
             new TrueTimeProvider());
         synchronized (lock) {
@@ -209,6 +214,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
                 removeStandardErrorListener();
             }
             consoleChain.onOutput(new LogLevelChangeEvent(logLevel));
+            consoleChain.onOutput(new MaxWorkerCountChangeEvent(maxWorkerCount));
             formatters.add(this.console);
         }
         return this;
@@ -272,6 +278,11 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
     }
 
     @Override
+    public void configureMaxWorkerCount(int maxWorkerCount) {
+        onOutput(new MaxWorkerCountChangeEvent(maxWorkerCount));
+    }
+
+    @Override
     public void onOutput(OutputEvent event) {
         synchronized (lock) {
             if (event.getLogLevel() != null && event.getLogLevel().compareTo(logLevel) < 0) {
@@ -284,6 +295,13 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
                     return;
                 }
                 this.logLevel = newLogLevel;
+            } else if (event instanceof MaxWorkerCountChangeEvent) {
+                MaxWorkerCountChangeEvent changeEvent = (MaxWorkerCountChangeEvent) event;
+                int newMaxWorkerCount = changeEvent.getNewMaxWorkerCount();
+                if (newMaxWorkerCount == this.maxWorkerCount) {
+                    return;
+                }
+                this.maxWorkerCount = newMaxWorkerCount;
             }
             formatters.getSource().onOutput(event);
         }
@@ -292,10 +310,12 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
     private class SnapshotImpl implements Snapshot {
         private final LogLevel logLevel;
         private final OutputEventListener console;
+        private final int maxWorkerCount;
 
-        SnapshotImpl(LogLevel logLevel, OutputEventListener console) {
+        SnapshotImpl(LogLevel logLevel, OutputEventListener console, int maxWorkerCount) {
             this.logLevel = logLevel;
             this.console = console;
+            this.maxWorkerCount = maxWorkerCount;
         }
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/source/PrintStreamLoggingSystem.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/source/PrintStreamLoggingSystem.java
@@ -19,13 +19,13 @@ package org.gradle.internal.logging.source;
 import org.gradle.api.Nullable;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.StandardOutputListener;
-import org.gradle.internal.time.TimeProvider;
 import org.gradle.internal.io.LinePerThreadBufferingOutputStream;
 import org.gradle.internal.io.TextStream;
 import org.gradle.internal.logging.config.LoggingSourceSystem;
 import org.gradle.internal.logging.events.LogLevelChangeEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.events.StyledTextOutputEvent;
+import org.gradle.internal.time.TimeProvider;
 
 import java.io.PrintStream;
 import java.util.concurrent.atomic.AtomicReference;

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleLayoutCalculatorTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleLayoutCalculatorTest.groovy
@@ -21,25 +21,14 @@ import spock.lang.Specification
 
 class ConsoleLayoutCalculatorTest extends Specification {
     def consoleMetaData = Mock(ConsoleMetaData)
+    def consoleLayoutCalculator = new ConsoleLayoutCalculator(consoleMetaData);
 
-    def "lines should be org.gradle.workers.max value if console is large enough"() {
-        given:
-        System.setProperty("org.gradle.workers.max", "5")
-        1 * consoleMetaData.getRows() >> 100
-
-        expect:
-        ConsoleLayoutCalculator.calculateNumWorkersForConsoleDisplay(consoleMetaData) == 5
-
-        cleanup:
-        System.clearProperty("org.gradle.workers.max")
-    }
-
-    def "lines should be available processors if no property set and console is large enough"() {
+    def "lines should be ideal value if console is large enough"() {
         given:
         1 * consoleMetaData.getRows() >> 100
 
         expect:
-        ConsoleLayoutCalculator.calculateNumWorkersForConsoleDisplay(consoleMetaData) == Runtime.runtime.availableProcessors()
+        consoleLayoutCalculator.calculateNumWorkersForConsoleDisplay(5) == 5
     }
 
     def "lines should be half the console size for small consoles"() {
@@ -47,6 +36,6 @@ class ConsoleLayoutCalculatorTest extends Specification {
         1 * consoleMetaData.getRows() >> 4
 
         expect:
-        ConsoleLayoutCalculator.calculateNumWorkersForConsoleDisplay(consoleMetaData) == 2
+        consoleLayoutCalculator.calculateNumWorkersForConsoleDisplay(5) == 2
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleStub.java
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleStub.java
@@ -91,6 +91,7 @@ public class ConsoleStub implements Console {
 
     protected class TestableBuildProgressTextArea extends TestStyledTextOutput implements BuildProgressArea {
         boolean visible;
+        int buildProgressLabelCount;
         private final List<TestableRedrawableLabel> testableLabels;
         private final List<StyledLabel> buildProgressLabels;
 
@@ -122,6 +123,11 @@ public class ConsoleStub implements Console {
 
         public boolean getVisible() {
             return visible;
+        }
+
+        @Override
+        public void resizeBuildProgressTo(int buildProgressLabelCount) {
+            this.buildProgressLabelCount = buildProgressLabelCount;
         }
 
         public List<String> getDisplay() {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/MultiLineBuildProgressAreaTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/MultiLineBuildProgressAreaTest.groovy
@@ -38,7 +38,7 @@ class MultiLineBuildProgressAreaTest extends Specification {
 
     def setup() {
         progressArea.resizeBuildProgressTo(4);
-        newLineListener.beforeNewLineWritten(_) >> {
+        newLineListener.beforeNewLineWritten(_, _) >> {
             progressArea.newLineAdjustment();
         }
 


### PR DESCRIPTION
Break handling of --parallel and --max-workers CLI handling
out of StartParameter and use it in the CommandLineConverter.

Set the max number of WIP lines through the GradleLauncher and
thread through to the Console configuration.
