### PR TITLE
Fix potential deadlock when setting test.maxParallelForks > maxWorkers

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 import org.gradle.util.Requires;
 
-public class TestTaskIntegrationTest extends AbstractIntegrationSpec {
+class TestTaskIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("GRADLE-2702")
     def "should not resolve configuration results when there are no tests"() {
@@ -92,19 +92,49 @@ public class TestTaskIntegrationTest extends AbstractIntegrationSpec {
 
     }
 
+    def "test task do not hang if maxParallelForks is greater than max-workers"() {
+        given:
+        def maxWorkers = Runtime.runtime.availableProcessors()
+        def maxParallelForks = maxWorkers + 1
+
+        and: 'enough tests to trigger a deadlock'
+        2000.times { num ->
+            file("src/test/java/SomeTest${num}.java") << testClass("SomeTest${num}")
+        }
+
+        and:
+        buildFile << """
+            apply plugin: 'java'
+            repositories { jcenter() }
+            dependencies { testCompile 'junit:junit:4.12' }
+            test {
+                maxParallelForks = $maxParallelForks
+            }
+        """.stripIndent()
+
+        when:
+        succeeds 'test', '--parallel'
+
+        then:
+        output.contains("test.maxParallelForks ($maxParallelForks) is larger than max-workers ($maxWorkers), forcing it to $maxWorkers")
+    }
+
     private static String standaloneTestClass() {
-        '''
+        return testClass('MyTest')
+    }
+
+    private static String testClass(String className) {
+        return """
             import org.junit.*;
 
-            public class MyTest {
+            public class $className {
                @Test
                public void test() {
                   System.out.println(System.getProperty("java.version"));
                   Assert.assertEquals(1,1);
                }
             }
-
-        '''
+        """.stripIndent()
     }
 
     private static String java9Build() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -27,6 +27,8 @@ import org.gradle.api.internal.tasks.testing.processors.MaxNParallelTestClassPro
 import org.gradle.api.internal.tasks.testing.processors.RestartEveryNTestClassProcessor;
 import org.gradle.api.internal.tasks.testing.processors.TestMainAction;
 import org.gradle.api.internal.tasks.testing.worker.ForkingTestClassProcessor;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.Factory;
 import org.gradle.internal.actor.ActorFactory;
@@ -42,18 +44,23 @@ import java.util.Set;
  * The default test class scanner factory.
  */
 public class DefaultTestExecuter implements TestExecuter {
+
+    private static final Logger LOGGER = Logging.getLogger(DefaultTestExecuter.class);
+
     private final WorkerProcessFactory workerFactory;
     private final ActorFactory actorFactory;
     private final ModuleRegistry moduleRegistry;
     private final BuildOperationWorkerRegistry buildOperationWorkerRegistry;
     private final BuildOperationExecutor buildOperationExecutor;
+    private final int maxWorkerCount;
 
-    public DefaultTestExecuter(WorkerProcessFactory workerFactory, ActorFactory actorFactory, ModuleRegistry moduleRegistry, BuildOperationWorkerRegistry buildOperationWorkerRegistry, BuildOperationExecutor buildOperationExecutor) {
+    public DefaultTestExecuter(WorkerProcessFactory workerFactory, ActorFactory actorFactory, ModuleRegistry moduleRegistry, BuildOperationWorkerRegistry buildOperationWorkerRegistry, BuildOperationExecutor buildOperationExecutor, int maxWorkerCount) {
         this.workerFactory = workerFactory;
         this.actorFactory = actorFactory;
         this.moduleRegistry = moduleRegistry;
         this.buildOperationWorkerRegistry = buildOperationWorkerRegistry;
         this.buildOperationExecutor = buildOperationExecutor;
+        this.maxWorkerCount = maxWorkerCount;
     }
 
     @Override
@@ -74,7 +81,7 @@ public class DefaultTestExecuter implements TestExecuter {
             }
         };
 
-        TestClassProcessor processor = new MaxNParallelTestClassProcessor(testTask.getMaxParallelForks(),
+        TestClassProcessor processor = new MaxNParallelTestClassProcessor(getMaxParallelForks(testTask),
             reforkingProcessorFactory, actorFactory);
 
         final FileTree testClassFiles = testTask.getCandidateClassFiles();
@@ -92,5 +99,14 @@ public class DefaultTestExecuter implements TestExecuter {
         final Object testTaskOperationId = buildOperationExecutor.getCurrentOperation().getParentId();
 
         new TestMainAction(detector, processor, testResultProcessor, new TrueTimeProvider(), testTaskOperationId, testTask.getPath(), "Gradle Test Run " + testTask.getIdentityPath()).run();
+    }
+
+    private int getMaxParallelForks(Test testTask) {
+        int maxParallelForks = testTask.getMaxParallelForks();
+        if (maxParallelForks > maxWorkerCount) {
+            LOGGER.warn("test.maxParallelForks ({}) is larger than max-workers ({}), forcing it to {}", maxParallelForks, maxWorkerCount, maxWorkerCount);
+            maxParallelForks = maxWorkerCount;
+        }
+        return maxParallelForks;
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -104,7 +104,7 @@ public class DefaultTestExecuter implements TestExecuter {
     private int getMaxParallelForks(Test testTask) {
         int maxParallelForks = testTask.getMaxParallelForks();
         if (maxParallelForks > maxWorkerCount) {
-            LOGGER.warn("test.maxParallelForks ({}) is larger than max-workers ({}), forcing it to {}", maxParallelForks, maxWorkerCount, maxWorkerCount);
+            LOGGER.warn("{}.maxParallelForks ({}) is larger than max-workers ({}), forcing it to {}", testTask.getName(), maxParallelForks, maxWorkerCount, maxWorkerCount);
             maxParallelForks = maxWorkerCount;
         }
         return maxParallelForks;

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1132,6 +1132,7 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
 
     /**
      * Returns the maximum number of forked test processes to execute in parallel. The default value is 1 (no parallel test execution).
+     * It cannot exceed the value of {@literal max-workers} for the current build.
      *
      * @return The maximum number of forked test processes.
      */

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.testing;
 
 import groovy.lang.Closure;
+import org.gradle.StartParameter;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
@@ -615,7 +616,10 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
         TestResultProcessor resultProcessor = new StateTrackingTestResultProcessor(testListenerInternalBroadcaster.getSource());
 
         if (testExecuter == null) {
-            testExecuter = new DefaultTestExecuter(getProcessBuilderFactory(), getActorFactory(), getModuleRegistry(), getServices().get(BuildOperationWorkerRegistry.class), getServices().get(BuildOperationExecutor.class));
+            testExecuter = new DefaultTestExecuter(getProcessBuilderFactory(), getActorFactory(), getModuleRegistry(),
+                getServices().get(BuildOperationWorkerRegistry.class),
+                getServices().get(BuildOperationExecutor.class),
+                getServices().get(StartParameter.class).getMaxWorkerCount());
         }
 
         JavaVersion javaVersion = getJavaVersion();


### PR DESCRIPTION
maxParallelForks is capped to maxWorkers
a warning is logged if forced to maxWorkers
