### PR TITLE
Avoid launching an external process to locate mavenLocal repo

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -19,8 +19,6 @@ import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.test.fixtures.maven.MavenModule
 import spock.lang.Issue
 
-import static org.hamcrest.Matchers.containsString
-
 class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionTest {
 
     def setup() {
@@ -129,7 +127,7 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         runAndFail 'retrieve'
 
         then:
-        failure.assertThatCause(containsString(String.format("Non-parseable settings %s:", m2.userSettingsFile.absolutePath)));
+        failure.assertHasCause("Unable to parse local Maven settings: " + m2.userSettingsFile.absolutePath)
     }
 
     def "mavenLocal is ignored if no local maven repository exists"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.mvnsettings;
 
-import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.SettingsBuildingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,8 +64,7 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
     // (see http://forums.gradle.org/gradle/topics/override_location_of_the_local_maven_repo).
     private synchronized String parseLocalRepoPathFromMavenSettings() throws SettingsBuildingException {
         if (localRepoPathFromMavenSettings == null) {
-            Settings settings = settingsProvider.buildSettings();
-            localRepoPathFromMavenSettings = settings.getLocalRepository();
+            localRepoPathFromMavenSettings = settingsProvider.getLocalRepository();
         }
         return localRepoPathFromMavenSettings;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/MavenSettingsProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/MavenSettingsProvider.java
@@ -20,4 +20,5 @@ import org.apache.maven.settings.building.SettingsBuildingException;
 
 public interface MavenSettingsProvider {
     Settings buildSettings() throws SettingsBuildingException;
+    String getLocalRepository();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.gradle.api.internal.artifacts.mvnsettings
+
+import org.apache.maven.settings.io.SettingsParseException
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -72,8 +74,8 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
         locator.localMavenRepository
         then:
         def ex = thrown(CannotLocateLocalMavenRepositoryException);
-        ex.message == "Unable to parse local Maven settings."
-        ex.cause.message.contains(settingsFile.absolutePath)
+        ex.message == "Unable to parse local Maven settings: " + settingsFile.absolutePath
+        ex.cause instanceof SettingsParseException
     }
 
     def "throws exception on broken user settings file with decent error message"() {
@@ -84,8 +86,8 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
         locator.localMavenRepository
         then:
         def ex = thrown(CannotLocateLocalMavenRepositoryException)
-        ex.message == "Unable to parse local Maven settings."
-        ex.cause.message.contains(settingsFile.absolutePath)
+        ex.message == "Unable to parse local Maven settings: " + settingsFile.absolutePath
+        ex.cause instanceof SettingsParseException
     }
 
     def "honors location specified in user settings file"() {


### PR DESCRIPTION
To determine the location of the local maven repo, Gradle parses these values
from the Maven settings files. Using Maven's `DefaultSettingsBuilder`
to parse the Settings files involves quite a lot of additional processing
including spawning a new process to determine environment variables.

This change hooks directly into the Maven `SettingsReader` read settings files
bypassing much of the work performed by `DefaultSettingsBuilder`.
