### PR TITLE
Fix issue gradle/gradle#1566

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.logging.text;
 
+import org.gradle.api.Action;
 import org.gradle.internal.SystemProperties;
 
 /**
@@ -25,6 +26,7 @@ public abstract class AbstractLineChoppingStyledTextOutput extends AbstractStyle
     private final char[] eolChars;
     private final String eol;
     private int seenCharsFromEol;
+    private State currentState = INITIAL_STATE;
 
     protected AbstractLineChoppingStyledTextOutput() {
         eol = SystemProperties.getInstance().getLineSeparator();
@@ -33,36 +35,13 @@ public abstract class AbstractLineChoppingStyledTextOutput extends AbstractStyle
 
     @Override
     protected final void doAppend(String text) {
-        int max = text.length();
-        int pos = 0;
-        int start = 0;
-        while (pos < max) {
-            if (seenCharsFromEol == eolChars.length) {
-                doStartLine();
-                seenCharsFromEol = 0;
-            }
-            if (seenCharsFromEol < eolChars.length && text.charAt(pos) == eolChars[seenCharsFromEol]) {
-                seenCharsFromEol++;
-                pos++;
-                if (seenCharsFromEol == eolChars.length) {
-                    if (start < pos - seenCharsFromEol) {
-                        doLineText(text.substring(start,  pos - seenCharsFromEol));
-                    }
-                    doEndLine(eol);
-                    start = pos;
-                }
-            } else {
-                if (seenCharsFromEol > 0 && start == 0) {
-                    doLineText(eol.substring(0, seenCharsFromEol));
-                    start = pos;
-                }
-                seenCharsFromEol = 0;
-                pos++;
-            }
+        StateContext context = new StateContext(text);
+
+        while (context.hasChar()) {
+            currentState.execute(context);
         }
-        if (start < pos - seenCharsFromEol) {
-            doLineText(text.substring(start,  pos - seenCharsFromEol));
-        }
+        seenCharsFromEol = context.seenCharsFromEol;
+        context.flushLineText();
     }
 
     /**
@@ -80,4 +59,157 @@ public abstract class AbstractLineChoppingStyledTextOutput extends AbstractStyle
      * Called when end of line is to be appended.
      */
     protected abstract void doEndLine(CharSequence endOfLine);
+
+    private interface State extends Action<StateContext> {}
+
+    private class StateContext {
+        private final String text;
+        private int pos;
+        private int max;
+        private int start;
+        private int seenCharsFromEol = AbstractLineChoppingStyledTextOutput.this.seenCharsFromEol;
+        private final char[] eolChars = AbstractLineChoppingStyledTextOutput.this.eolChars;
+        private final String eol = AbstractLineChoppingStyledTextOutput.this.eol;
+
+        StateContext(String text) {
+            this.text = text;
+            this.max = text.length();
+            this.pos = -seenCharsFromEol;
+            this.start = pos;
+        }
+
+        void next() {
+            pos++;
+        }
+
+        void next(int count) {
+            pos += count;
+        }
+
+        boolean isCurrentCharEquals(char value) {
+            char ch;
+            if ((seenCharsFromEol + pos) < 0) {
+                ch = eolChars[pos+AbstractLineChoppingStyledTextOutput.this.seenCharsFromEol];
+            } else {
+                ch = text.charAt(pos + seenCharsFromEol);
+            }
+            return ch == value;
+        }
+
+        boolean hasChar() {
+            return (pos + seenCharsFromEol) < max;
+        }
+
+        void setState(State state) {
+            currentState = state;
+        }
+
+        void reset() {
+            start = pos;
+            seenCharsFromEol = 0;
+        }
+
+        void flushLineText() {
+            if (start < pos) {
+                if (start < 0) {
+                    doLineText(eol.substring(0, AbstractLineChoppingStyledTextOutput.this.seenCharsFromEol) + text.substring(0, seenCharsFromEol - AbstractLineChoppingStyledTextOutput.this.seenCharsFromEol));
+                } else {
+                    doLineText(text.substring(start, pos));
+                }
+            }
+        }
+
+        void flushEndLine(String eol) {
+            doEndLine(eol);
+        }
+
+        void flushStartLine() {
+            doStartLine();
+        }
+    }
+
+    private static final State SYSTEM_EOL_PARSING_STATE = new State() {
+        @Override
+        public void execute(StateContext context) {
+            if (context.seenCharsFromEol < context.eolChars.length) {
+                if (context.isCurrentCharEquals(context.eolChars[context.seenCharsFromEol])) {
+                    context.seenCharsFromEol++;
+                    if (context.seenCharsFromEol == context.eolChars.length) {
+                        context.flushLineText();
+                        context.flushEndLine(context.eol);
+                        context.next(context.seenCharsFromEol);
+                        context.reset();
+                        context.setState(START_LINE_STATE);
+                    }
+                    return;
+                } else if (context.seenCharsFromEol == 0) {
+                    WELL_KNOWN_EOL_PARSING_STATE.execute(context);
+                    return;
+                }
+            }
+
+            context.next(context.seenCharsFromEol);
+            context.flushLineText();
+            context.reset();
+            context.setState(INITIAL_STATE);
+        }
+    };
+
+    private static final State INITIAL_STATE = SYSTEM_EOL_PARSING_STATE;
+
+    private static final State WELL_KNOWN_EOL_PARSING_STATE = new State() {
+        @Override
+        public void execute(StateContext context) {
+            if (context.isCurrentCharEquals('\r')) {
+                context.flushLineText();
+                context.next();
+                context.reset();
+
+                // We try our best to detect the right eol
+                if (context.hasChar()) {
+                    if (context.isCurrentCharEquals('\n')) {
+                        context.flushEndLine("\r\n");
+                        context.next();
+                        context.reset();
+                    } else {
+                        context.flushEndLine("\r");
+                    }
+                    context.setState(START_LINE_STATE);
+                } else {
+                    // We print the eol now even if incorrect eol type
+                    context.flushEndLine("\r");
+                    context.setState(WINDOWS_EOL_PARSING_ODDITY_STATE);
+                }
+
+            } else if (context.isCurrentCharEquals('\n')) {
+                context.flushLineText();
+                context.flushEndLine("\n");
+                context.next();
+                context.reset();
+                context.setState(START_LINE_STATE);
+            } else {
+                context.next();
+                context.setState(INITIAL_STATE);
+            }
+        }
+    };
+
+    private static final State WINDOWS_EOL_PARSING_ODDITY_STATE = new State() {
+        @Override
+        public void execute(StateContext context) {
+            if (context.isCurrentCharEquals('\n')) {
+                context.next();
+                context.reset();
+            }
+            context.setState(START_LINE_STATE);
+        }
+    };
+
+    private static final State START_LINE_STATE = new State() {
+        @Override
+        public void execute(StateContext context) {
+            context.flushStartLine();
+            context.setState(INITIAL_STATE);
+        }
+    };
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/StyledTextOutputBackedRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/StyledTextOutputBackedRendererTest.groovy
@@ -16,12 +16,15 @@
 package org.gradle.internal.logging.console
 
 import org.gradle.api.logging.LogLevel
+import org.gradle.internal.SystemProperties
 import org.gradle.internal.logging.events.LogLevelChangeEvent
 import org.gradle.internal.logging.events.RenderableOutputEvent
 import org.gradle.internal.logging.events.StyledTextOutputEvent
 import org.gradle.internal.logging.OutputSpecification
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.TestStyledTextOutput
+import spock.lang.Issue
+import spock.lang.Unroll
 
 class StyledTextOutputBackedRendererTest extends OutputSpecification {
     def rendersOutputEvent() {
@@ -77,7 +80,7 @@ class StyledTextOutputBackedRendererTest extends OutputSpecification {
         then:
         output.value == '10:00:00.000 [INFO] [category] message\n'
     }
-    
+
     def continuesLineWhenPreviousOutputEventDidNotEndWithEOL() {
         TestStyledTextOutput output = new TestStyledTextOutput()
         StyledTextOutputBackedRenderer renderer = new StyledTextOutputBackedRenderer(output)
@@ -106,5 +109,30 @@ class StyledTextOutputBackedRendererTest extends OutputSpecification {
 
         then:
         output.value == '10:00:00.000 [INFO] [category] message\n10:00:00.000 [INFO] [category2] message2'
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/1566")
+    @Unroll
+    def renderMultiNonNativeNewLineTextCorrectly() {
+        StyledTextOutput output = new TestStyledTextOutput()
+        StyledTextOutputBackedRenderer renderer = new StyledTextOutputBackedRenderer(output)
+        RenderableOutputEvent event = Mock()
+        String headerLine = "###"
+        String firstLine = "# This is the first long line!"
+        String secondLine = "# This is the second long line!"
+        String thirdLine = "# This is the third long line!"
+        String fourthLine = "# This is the fourth long line!"
+        String fifthLine = "# This is the fifth long line!"
+        String footerLine = "###"
+
+        when:
+        renderer.onOutput(event)
+
+        then:
+        1 * event.render(!null) >> { args -> args[0].text("$headerLine$eol$firstLine$eol$secondLine$eol$thirdLine$eol$fourthLine$eol$fifthLine$eol$footerLine") }
+        output.value == "$headerLine\n$firstLine\n$secondLine\n$thirdLine\n$fourthLine\n$fifthLine\n$footerLine"
+
+        where:
+        eol << [SystemProperties.instance.lineSeparator, "\n", "\r\n", "\r"]
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/StyledTextOutputBackedRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/StyledTextOutputBackedRendererTest.groovy
@@ -17,11 +17,12 @@ package org.gradle.internal.logging.console
 
 import org.gradle.api.logging.LogLevel
 import org.gradle.internal.SystemProperties
+import org.gradle.internal.logging.OutputSpecification
 import org.gradle.internal.logging.events.LogLevelChangeEvent
 import org.gradle.internal.logging.events.RenderableOutputEvent
 import org.gradle.internal.logging.events.StyledTextOutputEvent
-import org.gradle.internal.logging.OutputSpecification
 import org.gradle.internal.logging.text.StyledTextOutput
+import org.gradle.internal.logging.text.TestLineChoppingStyledTextOuput
 import org.gradle.internal.logging.text.TestStyledTextOutput
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -114,7 +115,7 @@ class StyledTextOutputBackedRendererTest extends OutputSpecification {
     @Issue("https://github.com/gradle/gradle/issues/1566")
     @Unroll
     def renderMultiNonNativeNewLineTextCorrectly() {
-        StyledTextOutput output = new TestStyledTextOutput()
+        StyledTextOutput output = new TestLineChoppingStyledTextOuput()
         StyledTextOutputBackedRenderer renderer = new StyledTextOutputBackedRenderer(output)
         RenderableOutputEvent event = Mock()
         String headerLine = "###"

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
@@ -34,7 +34,6 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
     ]
     @Rule final SetSystemProperties systemProperties = new SetSystemProperties()
     final StringBuilder result = new StringBuilder()
-    //final String eol = SystemProperties.instance.getLineSeparator()
 
     def "appends text to current line"() {
         def output = output()

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
@@ -19,11 +19,22 @@ import org.gradle.internal.SystemProperties
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class AbstractLineChoppingStyledTextOutputTest extends Specification {
+    private static final String NIX_EOL = "\n"
+    private static final String WINDOWS_EOL = "\r\n"
+    private static final String MACOS9_EOL = "\r"
+    private static final String SYSTEM_EOL = SystemProperties.instance.getLineSeparator();
+    private static final def EOLS = [
+        ["System", SYSTEM_EOL],
+        ["*nix", NIX_EOL],
+        ["Windows", WINDOWS_EOL],
+        ["Mac OS 9", MACOS9_EOL]
+    ]
     @Rule final SetSystemProperties systemProperties = new SetSystemProperties()
     final StringBuilder result = new StringBuilder()
-    final String eol = SystemProperties.instance.getLineSeparator()
+    //final String eol = SystemProperties.instance.getLineSeparator()
 
     def "appends text to current line"() {
         def output = output()
@@ -35,7 +46,8 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
         result.toString() == "[some text]"
     }
 
-    def "append empty lines"() {
+    @Unroll
+    def "append empty lines [#type]"() {
         def output = output()
 
         when:
@@ -45,9 +57,13 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         then:
         result.toString() == "{eol}{start}{eol}{start}{eol}{start}{eol}"
+
+        where:
+        [type, eol] << EOLS
     }
 
-    def "appends eol to current line"() {
+    @Unroll
+    def "appends eol to current line [#type]"() {
         def output = output()
 
         when:
@@ -56,9 +72,13 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         then:
         result.toString() == "[some text]{eol}"
+
+        where:
+        [type, eol] << EOLS
     }
 
-    def "append text that contains multiple lines"() {
+    @Unroll
+    def "append text that contains multiple lines [#type]"() {
         def output = output()
 
         when:
@@ -66,9 +86,13 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         then:
         result.toString() == "[a]{eol}{start}[b]"
+
+        where:
+        [type, eol] << EOLS
     }
 
-    def "append text that ends with eol"() {
+    @Unroll
+    def "append text that ends with eol [#type]"() {
         def output = output()
 
         when:
@@ -84,6 +108,9 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         then:
         result.toString() == "[a]{eol}{start}[b]{eol}{start}{eol}{start}[c]"
+
+        where:
+        [type, eol] << EOLS
     }
 
     def "can append eol in chunks"() {
@@ -92,13 +119,13 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         when:
         output.text("a--")
-        
+
         then:
         result.toString() == "[a]"
-        
+
         when:
         output.text("--b")
-        
+
         then:
         result.toString() == "[a]{eol}{start}[b]"
     }
@@ -109,7 +136,7 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         when:
         output.text("a--")
-        
+
         then:
         result.toString() == "[a]"
 
@@ -135,6 +162,30 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
         result.toString() == "{style}{eol}"
     }
 
+    def "can split mixed eol"() {
+        def output = output()
+
+        when:
+        output.text(SYSTEM_EOL)
+        output.text(MACOS9_EOL)
+        output.text("$WINDOWS_EOL$NIX_EOL")
+
+        then:
+        result.toString() == "{eol}{start}{eol}{start}{eol}{start}{eol}"
+    }
+
+    def "can split Windows eol across multiple call on non-Windows eol default"() {
+        System.setProperty("line.separator", "\n")
+        def output = output()
+
+        when:
+        output.text("\r")
+        output.text("\n")
+
+        then:
+        result.toString() == "{eol}"
+    }
+
     def output() {
         final AbstractLineChoppingStyledTextOutput output = new AbstractLineChoppingStyledTextOutput() {
             @Override
@@ -156,7 +207,7 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
             @Override
             protected void doEndLine(CharSequence endOfLine) {
-                assert endOfLine == System.getProperty("line.separator")
+                assert endOfLine in [System.getProperty("line.separator"), NIX_EOL, WINDOWS_EOL, MACOS9_EOL]
                 result.append("{eol}")
             }
         }

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestLineChoppingStyledTextOuput.groovy
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestLineChoppingStyledTextOuput.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.text
+
+class TestLineChoppingStyledTextOuput extends AbstractLineChoppingStyledTextOutput {
+    TestStyledTextOutput delegate = new TestStyledTextOutput()
+
+    @Override
+    String toString() {
+        delegate.toString()
+    }
+
+    /**
+     * @see TestStyledTextOutput#getValue()
+     */
+    String getValue() {
+        return delegate.getValue()
+    }
+
+    @Override
+    protected void doLineText(CharSequence text) {
+        delegate.text(text)
+    }
+
+    @Override
+    protected void doEndLine(CharSequence endOfLine) {
+        delegate.text("\n")
+    }
+}

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutput.groovy
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutput.groovy
@@ -16,9 +16,10 @@
 
 package org.gradle.internal.logging.text
 
+import org.gradle.internal.SystemProperties
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 
-class TestStyledTextOutput extends AbstractLineChoppingStyledTextOutput {
+class TestStyledTextOutput extends AbstractStyledTextOutput {
     StringBuilder result = new StringBuilder()
 
     @Override
@@ -46,8 +47,9 @@ class TestStyledTextOutput extends AbstractLineChoppingStyledTextOutput {
     String getValue() {
         StringBuilder normalised = new StringBuilder()
 
+        String eol = SystemProperties.instance.lineSeparator
         boolean inStackTrace = false
-        new StringTokenizer(result.toString(), '\n', true).each { String line ->
+        new StringTokenizer(result.toString().replaceAll(eol, '\n'), '\n', true).each { String line ->
             if (line == '\n') {
                 if (!inStackTrace) {
                     normalised.append('\n')
@@ -71,12 +73,7 @@ class TestStyledTextOutput extends AbstractLineChoppingStyledTextOutput {
     }
 
     @Override
-    protected void doLineText(CharSequence text) {
+    protected void doAppend(String text) {
         result.append(text)
-    }
-
-    @Override
-    protected void doEndLine(CharSequence endOfLine) {
-        result.append("\n");
     }
 }

--- a/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutput.groovy
+++ b/subprojects/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutput.groovy
@@ -16,10 +16,9 @@
 
 package org.gradle.internal.logging.text
 
-import org.gradle.internal.SystemProperties
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 
-class TestStyledTextOutput extends AbstractStyledTextOutput {
+class TestStyledTextOutput extends AbstractLineChoppingStyledTextOutput {
     StringBuilder result = new StringBuilder()
 
     @Override
@@ -47,9 +46,8 @@ class TestStyledTextOutput extends AbstractStyledTextOutput {
     String getValue() {
         StringBuilder normalised = new StringBuilder()
 
-        String eol = SystemProperties.instance.lineSeparator
         boolean inStackTrace = false
-        new StringTokenizer(result.toString().replaceAll(eol, '\n'), '\n', true).each { String line ->
+        new StringTokenizer(result.toString(), '\n', true).each { String line ->
             if (line == '\n') {
                 if (!inStackTrace) {
                     normalised.append('\n')
@@ -73,7 +71,12 @@ class TestStyledTextOutput extends AbstractStyledTextOutput {
     }
 
     @Override
-    protected void doAppend(String text) {
+    protected void doLineText(CharSequence text) {
         result.append(text)
+    }
+
+    @Override
+    protected void doEndLine(CharSequence endOfLine) {
+        result.append("\n");
     }
 }


### PR DESCRIPTION
The fix refactored the state machine inside `AbstractLineChoppingStyledTextOutput` to consider non-system end-of-lines (Windows, *nix and Mac OS 9). Regardless of the eol used, a new line will be detected.