### PR TITLE
Coordinate network requests

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultProducerGuard.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultProducerGuard.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.cache.internal;
+
+import com.google.common.collect.Sets;
+import org.gradle.internal.Factory;
+import org.gradle.internal.UncheckedException;
+
+import java.util.Set;
+
+public class DefaultProducerGuard<T> implements ProducerGuard<T> {
+    private final Set<T> producing = Sets.newHashSet();
+
+    /**
+     * Synchronizes access to some resource, by making sure that 2 threads do not try to produce it at the same time.
+     * The resource to be accessed is represented by the key, and the factory is whatever needs to be done to produce it.
+     * This is <b>not</b> a cache: it only guards access to the resource, making sure that for the same key, there cannot
+     * be 2 producers running concurrently. But once the first one finished producing something, the second factory will
+     * be called. In other words, the factory should take care of caching whenever it makes sense.
+     *
+     * @param key the key used to synchronize access to a resource
+     * @param factory the code that will produce a value for the given key
+     * @param <V> the type of the value returned by the producer
+     * @return the value produced by the factory
+     */
+    @Override
+    public <V> V guardByKey(T key, Factory<V> factory) {
+        synchronized (producing) {
+            while (!producing.add(key)) {
+                try {
+                    producing.wait();
+                } catch (InterruptedException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            }
+        }
+        try {
+            return factory.create();
+        } finally {
+            synchronized (producing) {
+                producing.remove(key);
+                producing.notifyAll();
+            }
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/ProducerGuard.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/ProducerGuard.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.cache.internal;
+
+import org.gradle.internal.Factory;
+
+public interface ProducerGuard<T> {
+    <V> V guardByKey(T key, Factory<V> factory);
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedChangingModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedChangingModulesIntegrationTest.groovy
@@ -62,7 +62,7 @@ public class CachedChangingModulesIntegrationTest extends AbstractHttpDependency
 
         when:
         server.resetExpectations()
-        module.metaData.expectGetRevalidate()
+        module.metaData.expectHeadRevalidate()
         sourceArtifact.expectHeadRevalidate()
         module.pom.expectHeadRevalidate()
         then:
@@ -72,6 +72,7 @@ public class CachedChangingModulesIntegrationTest extends AbstractHttpDependency
         module.publishWithChangedContent()
         server.resetExpectations()
 
+        module.metaData.expectHeadRevalidate()
         module.metaData.expectGetRevalidate()
         module.pom.sha1.expectGetRevalidate()
         module.pom.expectHeadRevalidate()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
@@ -343,10 +343,10 @@ Required by:
 
         when:
         server.resetExpectations()
-        repo1Module.rootMetaData.expectGet()
+        repo1Module.rootMetaData.expectHead()
         repo1Module.pom.expectGetMissing()
         repo1Module.artifact.expectHeadMissing()
-        repo2Module.rootMetaData.expectGet()
+        repo2Module.rootMetaData.expectHead()
         repo2Module.pom.expectGetMissing()
         repo2Module.artifact.expectHeadMissing()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ParallelDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ParallelDependencyResolutionIntegrationTest.groovy
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.caching
+
+import com.google.common.hash.Hashing
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.test.fixtures.server.http.RepositoryHttpServer
+import org.junit.Rule
+import spock.lang.IgnoreIf
+
+import java.text.SimpleDateFormat
+
+@IgnoreIf({ GradleContextualExecuter.parallel })
+// no point, always runs in parallel
+class ParallelDependencyResolutionIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    final RepositoryHttpServer server = new RepositoryHttpServer(temporaryFolder)
+
+    File mavenMetadata
+    String lastVersion
+    File pomFile, pomFileSha1
+    File jarFile, jarFileSha1
+    int buildNumber
+
+    def setup() {
+        executer.withArgument('--parallel')
+        executer.withArgument('--max-workers=3') // needs to be set to the maximum number of expectConcurrentExecution() calls
+        executer.withArgument('--info')
+
+        metadataFile()
+        createPomFile()
+        createJarFile()
+
+        executer.requireOwnGradleUserHomeDir()
+
+    }
+
+    private void createJarFile() {
+        jarFile = temporaryFolder.createFile('dummy-1.0-SNAPSHOT.jar')
+        jarFileSha1 = temporaryFolder.createFile('dummy-1.0-SNAPSHOT.jar.sha1')
+        jarFileSha1.text = Hashing.sha1().hashBytes(jarFile.bytes).toString()
+    }
+
+    private void createPomFile() {
+        pomFile = temporaryFolder.createFile('dummy-1.0-SNAPSHOT.pom')
+        pomFile.setText("""<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.acme</groupId>
+  <artifactId>dummy</artifactId>
+  <version>1.0-SNAPSHOT</version>
+</project>""", "utf-8")
+        pomFileSha1 = temporaryFolder.createFile('dummy-1.0-SNAPSHOT.pom.sha1')
+        pomFileSha1.text = Hashing.sha1().hashBytes(pomFile.bytes).toString()
+    }
+
+    private void metadataFile() {
+        mavenMetadata = temporaryFolder.createFile('maven-metadata.xml')
+        def now = new Date()
+        lastVersion = new SimpleDateFormat("yyyyMMdd.HHmmss").format(now)
+        mavenMetadata.setText("""<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.acme</groupId>
+  <artifactId>dummy</artifactId>
+  <versioning>
+    <snapshot>
+      <timestamp>${lastVersion}</timestamp>
+      <buildNumber>${buildNumber++}</buildNumber>
+    </snapshot>
+    <lastUpdated>${new SimpleDateFormat("yyyyMMddHHmmss").format(now)}</lastUpdated>
+  </versioning>
+</metadata>
+""", "UTF-8")
+    }
+
+    def "dependency is only downloaded at most once per build"() {
+        given:
+        server.expectGet('/com/acme/dummy/1.0-SNAPSHOT/maven-metadata.xml', mavenMetadata)
+        ('a'..'z').each {
+            settingsFile << "include '$it'\n"
+            file("${it}/build.gradle") << """
+                apply plugin: 'java-library'
+                
+                repositories {
+                    maven {
+                        url '${server.address}'
+                    }
+                }
+
+                dependencies {
+                    implementation 'com.acme:dummy:1.0-SNAPSHOT'
+                }
+
+                task resolveDependencies {
+                    doLast {
+                        configurations.compileClasspath.resolve()
+                    }
+                }
+            """
+            server.allowGetOrHead('/com/acme/dummy/1.0-SNAPSHOT/maven-metadata.xml', mavenMetadata)
+        }
+        println "Last version : $lastVersion"
+
+        expectGetPomFile()
+        server.expectGet("/com/acme/dummy/1.0-SNAPSHOT/dummy-1.0-${lastVersion}-0.jar", jarFile)
+
+        when:
+        run 'resolveDependencies'
+
+        then:
+        noExceptionThrown()
+    }
+
+    private void expectGetPomFile() {
+//        server.expectHead("/com/acme/dummy/1.0-SNAPSHOT/dummy-1.0-${lastVersion}-0.pom", pomFile)
+        server.expectGet("/com/acme/dummy/1.0-SNAPSHOT/dummy-1.0-${lastVersion}-0.pom", pomFile)
+//        server.expectGet("/com/acme/dummy/1.0-SNAPSHOT/dummy-1.0-${lastVersion}-0.pom.sha1", pomFileSha1)
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ParallelDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ParallelDependencyResolutionIntegrationTest.groovy
@@ -146,7 +146,6 @@ class ParallelDependencyResolutionIntegrationTest extends AbstractIntegrationSpe
                     }
                 }
             """
-            server.allowGetOrHead('/com/acme/dummy/1.0-SNAPSHOT/maven-metadata.xml', mavenMetadata)
         }
         println "Last version : $lastVersion"
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
@@ -338,7 +338,7 @@ Searched in the following locations:
 
         when:
         server.resetExpectations()
-        repo.getModuleMetaData("group", "projectA").expectGet()
+        repo.getModuleMetaData("group", "projectA").expectHead()
         projectA.pom.expectHead()
         projectA.artifact.expectGet()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenJvmLibraryArtifactResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenJvmLibraryArtifactResolutionIntegrationTest.groovy
@@ -122,6 +122,7 @@ if (project.hasProperty('nocache')) {
 
         and:
         server.resetExpectations()
+        snapshotModule.metaData.expectHead()
         snapshotModule.metaData.expectGet()
         snapshotModule.pom.expectHead()
         snapshotModule.pom.sha1.expectGet()
@@ -173,6 +174,7 @@ if (project.hasProperty('nocache')) {
 
         and:
         server.resetExpectations()
+        snapshotModule.metaData.expectHead()
         snapshotModule.metaData.expectGet()
         snapshotModule.pom.expectHead()
         snapshotModule.pom.sha1.expectGet()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
@@ -141,7 +141,7 @@ if (project.hasProperty('skipCache')) {
         // New artifact is detected
         when:
         server.resetExpectations()
-        snapshotA.metaData.expectGet()
+        snapshotA.metaData.expectHead()
         snapshotA.pom.expectHead()
         snapshotA.artifact.expectHead()
         snapshotA.artifact.expectGet()
@@ -157,7 +157,7 @@ if (project.hasProperty('skipCache')) {
         // Jar artifact removal is detected
         when:
         server.resetExpectations()
-        snapshotA.metaData.expectGet()
+        snapshotA.metaData.expectHead()
         snapshotA.pom.expectHead()
         snapshotA.artifact.expectHeadMissing()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -472,7 +472,8 @@ tasks.getByPath(":a:retrieve").dependsOn ":b:retrieve"
         file('b/build').assertHasDescendants('testproject-1.0-SNAPSHOT.jar')
     }
 
-    @Ignore //TODO SF need to rework this test. First step might be turning off in-memory metadata caching for this test.
+    @Ignore
+    //TODO SF need to rework this test. First step might be turning off in-memory metadata caching for this test.
     def "can update snapshot artifact during build even if it is locked earlier in build"() {
         given:
         def module = mavenHttpRepo("/repo", maven("repo1")).module("org.gradle.integtests.resolve", "testproject", "1.0-SNAPSHOT").withNonUniqueSnapshots().publish()
@@ -671,7 +672,7 @@ task retrieve(type: Sync) {
         file('libs').assertHasDescendants('projectA-1.0-SNAPSHOT.jar', 'projectB-1.0.jar')
 
         when: "Resolve without cache"
-        projectA.metaData.expectGet()
+        projectA.metaData.expectHead()
         projectA.pom.expectHead()
         projectA.pom.sha1.expectGet()
         projectA.pom.expectGet()
@@ -1034,6 +1035,9 @@ Required by:
     }
 
     private expectChangedModuleServed(MavenHttpModule module) {
+        if (module.uniqueSnapshots) {
+            module.metaData.expectHead()
+        }
         module.metaData.expectGet()
         module.pom.expectHead()
         module.pom.sha1.expectGet()
@@ -1044,7 +1048,11 @@ Required by:
     }
 
     private expectChangedArtifactServed(MavenHttpModule module) {
-        module.metaData.expectGet()
+        if (module.uniqueSnapshots) {
+            module.metaData.expectHead()
+        } else {
+            module.metaData.expectGet()
+        }
         module.pom.expectHead()
         def artifact = module.artifact
         artifact.expectHead()
@@ -1053,7 +1061,11 @@ Required by:
     }
 
     private expectChangedProbe(MavenHttpModule module) {
-        module.metaData.expectGet()
+        if (module.uniqueSnapshots) {
+            module.metaData.expectHead()
+        } else {
+            module.metaData.expectGet()
+        }
         module.pom.expectHead()
         module.artifact.expectHead()
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1114,7 +1114,7 @@ allprojects {
         server.resetExpectations()
         m1.pom.expectHead()
         m1.artifact.expectHead()
-        m2.metaData.expectGet()
+        m2.metaData.expectHead()
         // TODO - these should not be required for unique versions
         m2.pom.expectHead()
         m2.artifact.expectHead()
@@ -1136,7 +1136,7 @@ allprojects {
         m1.artifact.expectHead()
         m1.artifact.sha1.expectGet()
         m1.artifact.expectGet()
-        m2.metaData.expectGet()
+        m2.metaData.expectHead()
         // TODO - these should not be required for unique versions
         m2.pom.expectHead()
         m2.artifact.expectHead()
@@ -1155,7 +1155,7 @@ allprojects {
         server.resetExpectations()
         m1.pom.expectHead()
         m1.artifact.expectHead()
-        m2.metaData.expectGet()
+        m2.metaData.expectHead()
         // TODO - these should not be required for unique versions
         m2.pom.expectHead()
         m2.artifact.expectHead()
@@ -1173,6 +1173,7 @@ allprojects {
         m1.pom.expectHead()
         m1.artifact.expectHead()
         m2.publishWithChangedContent()
+        m2.metaData.expectHead()
         m2.metaData.expectGet()
         m2.pom.expectHead()
         m2.pom.sha1.expectGet()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -77,6 +77,7 @@ import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory;
 import org.gradle.cache.internal.CacheScopeMapping;
 import org.gradle.cache.internal.VersionStrategy;
+import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.initialization.BuildIdentity;
 import org.gradle.initialization.DefaultBuildIdentity;
 import org.gradle.initialization.ProjectAccessListener;
@@ -95,6 +96,7 @@ import org.gradle.internal.resource.local.ivy.LocallyAvailableResourceFinderFact
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.util.BuildCommencedTimeProvider;
 
+import java.net.URI;
 import java.util.List;
 
 /**
@@ -233,7 +235,8 @@ class DependencyManagementBuildScopeServices {
                                                                 BuildCommencedTimeProvider buildCommencedTimeProvider,
                                                                 CacheLockingManager cacheLockingManager,
                                                                 ServiceRegistry serviceRegistry,
-                                                                BuildOperationExecutor buildOperationExecutor) {
+                                                                BuildOperationExecutor buildOperationExecutor,
+                                                                ProducerGuard<URI> producerGuard) {
         StartParameterResolutionOverride startParameterResolutionOverride = new StartParameterResolutionOverride(startParameter);
         return new RepositoryTransportFactory(
             serviceRegistry.getAll(ResourceConnectorFactory.class),
@@ -243,7 +246,8 @@ class DependencyManagementBuildScopeServices {
             buildCommencedTimeProvider,
             cacheLockingManager,
             buildOperationExecutor,
-            startParameterResolutionOverride);
+            startParameterResolutionOverride,
+            producerGuard);
     }
 
     ResolveIvyFactory createResolveIvyFactory(StartParameter startParameter, ModuleVersionsCache moduleVersionsCache, ModuleMetaDataCache moduleMetaDataCache, ModuleArtifactsCache moduleArtifactsCache,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -28,8 +28,12 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExternalModuleIvyDependencyDescriptorFactory;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ProjectIvyDependencyDescriptorFactory;
+import org.gradle.cache.internal.DefaultProducerGuard;
+import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.resource.connector.ResourceConnectorFactory;
 import org.gradle.internal.resource.transport.file.FileConnectorFactory;
+
+import java.net.URI;
 
 class DependencyManagementGlobalScopeServices {
 
@@ -66,5 +70,9 @@ class DependencyManagementGlobalScopeServices {
 
     ResourceConnectorFactory createFileConnectorFactory() {
         return new FileConnectorFactory();
+    }
+
+    ProducerGuard<URI> createProducerAccess() {
+        return new DefaultProducerGuard<URI>();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -113,7 +113,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
 
     public MavenArtifactRepository createMavenRepository() {
         return instantiator.newInstance(DefaultMavenArtifactRepository.class, fileResolver, transportFactory,
-                locallyAvailableResourceFinder, instantiator, artifactFileStore, pomParser, createAuthenticationContainer(), moduleIdentifierFactory);
+                locallyAvailableResourceFinder, instantiator, artifactFileStore, pomParser, createAuthenticationContainer(), moduleIdentifierFactory, externalResourcesFileStore);
     }
 
     protected AuthenticationContainer createAuthenticationContainer() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -49,6 +49,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     private final FileStore<ModuleComponentArtifactIdentifier> artifactFileStore;
     private final MetaDataParser<MutableMavenModuleResolveMetadata> pomParser;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+    private final FileStore<String> resourcesFileStore;
 
     public DefaultMavenArtifactRepository(FileResolver fileResolver, RepositoryTransportFactory transportFactory,
                                           LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
@@ -56,7 +57,8 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
                                           FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
                                           MetaDataParser<MutableMavenModuleResolveMetadata> pomParser,
                                           AuthenticationContainer authenticationContainer,
-                                          ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+                                          ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                                          FileStore<String> resourcesFileStore) {
         super(instantiator, authenticationContainer);
         this.fileResolver = fileResolver;
         this.transportFactory = transportFactory;
@@ -64,6 +66,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         this.artifactFileStore = artifactFileStore;
         this.pomParser = pomParser;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
+        this.resourcesFileStore = resourcesFileStore;
     }
 
     public URI getUrl() {
@@ -114,7 +117,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     private MavenResolver createResolver(URI rootUri) {
         RepositoryTransport transport = getTransport(rootUri.getScheme());
-        return new MavenResolver(getName(), rootUri, transport, locallyAvailableResourceFinder, artifactFileStore, pomParser, moduleIdentifierFactory);
+        return new MavenResolver(getName(), rootUri, transport, locallyAvailableResourceFinder, artifactFileStore, pomParser, moduleIdentifierFactory, transport.getResourceAccessor(), resourcesFileStore);
     }
 
     public MetaDataParser<MutableMavenModuleResolveMetadata> getPomParser() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenLocalResolver;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver;
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
@@ -42,7 +43,7 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
                                                MetaDataParser<MutableMavenModuleResolveMetadata> pomParser,
                                                AuthenticationContainer authenticationContainer,
                                                ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-        super(fileResolver, transportFactory, locallyAvailableResourceFinder, instantiator, artifactFileStore, pomParser, authenticationContainer, moduleIdentifierFactory);
+        super(fileResolver, transportFactory, locallyAvailableResourceFinder, instantiator, artifactFileStore, pomParser, authenticationContainer, moduleIdentifierFactory, null);
         this.moduleIdentifierFactory = moduleIdentifierFactory;
     }
 
@@ -52,7 +53,8 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
             throw new InvalidUserDataException("You must specify a URL for a Maven repository.");
         }
 
-        MavenResolver resolver = new MavenLocalResolver(getName(), rootUri, getTransport(rootUri.getScheme()), getLocallyAvailableResourceFinder(), getArtifactFileStore(), getPomParser(), moduleIdentifierFactory);
+        RepositoryTransport transport = getTransport(rootUri.getScheme());
+        MavenResolver resolver = new MavenLocalResolver(getName(), rootUri, transport, getLocallyAvailableResourceFinder(), getArtifactFileStore(), getPomParser(), moduleIdentifierFactory, transport.getResourceAccessor());
         for (URI repoUrl : getArtifactUrls()) {
             resolver.addArtifactLocation(repoUrl);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenLocalResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenLocalResolver.java
@@ -27,6 +27,7 @@ import org.gradle.internal.resolve.result.DefaultResourceAwareResolveResult;
 import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.gradle.internal.resource.local.FileStore;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
+import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,8 +40,9 @@ public class MavenLocalResolver extends MavenResolver {
                               LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
                               FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
                               MetaDataParser<MutableMavenModuleResolveMetadata> pomParser,
-                              ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-        super(name, rootUri, transport, locallyAvailableResourceFinder, artifactFileStore, pomParser, moduleIdentifierFactory);
+                              ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                              CacheAwareExternalResourceAccessor cacheAwareExternalResourceAccessor) {
+        super(name, rootUri, transport, locallyAvailableResourceFinder, artifactFileStore, pomParser, moduleIdentifierFactory, cacheAwareExternalResourceAccessor, null);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -47,6 +47,7 @@ import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.local.FileStore;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
+import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -69,15 +70,17 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
                          LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
                          FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
                          MetaDataParser<MutableMavenModuleResolveMetadata> pomParser,
-                         ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+                         ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                         CacheAwareExternalResourceAccessor cacheAwareExternalResourceAccessor,
+                         FileStore<String> resourcesFileStore) {
         super(name, transport.isLocal(),
                 transport.getRepository(),
                 transport.getResourceAccessor(),
-                new ChainedVersionLister(new MavenVersionLister(transport.getRepository()), new ResourceVersionLister(transport.getRepository())),
+                new ChainedVersionLister(new MavenVersionLister(cacheAwareExternalResourceAccessor, resourcesFileStore), new ResourceVersionLister(transport.getRepository())),
                 locallyAvailableResourceFinder,
                 artifactFileStore, moduleIdentifierFactory);
         this.metaDataParser = pomParser;
-        this.mavenMetaDataLoader = new MavenMetadataLoader(transport.getRepository());
+        this.mavenMetaDataLoader = new MavenMetadataLoader(cacheAwareExternalResourceAccessor, resourcesFileStore);
         this.root = rootUri;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         updatePatterns();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionLister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionLister.java
@@ -18,10 +18,11 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.resources.ResourceException;
-import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.gradle.internal.resource.ExternalResourceName;
-import org.gradle.internal.resource.transport.ExternalResourceRepository;
+import org.gradle.internal.resource.local.FileStore;
+import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -30,8 +31,8 @@ import java.util.Set;
 public class MavenVersionLister implements VersionLister {
     private final MavenMetadataLoader mavenMetadataLoader;
 
-    public MavenVersionLister(ExternalResourceRepository repository) {
-        this.mavenMetadataLoader = new MavenMetadataLoader(repository);
+    public MavenVersionLister(CacheAwareExternalResourceAccessor cacheAwareExternalResourceAccessor, FileStore<String> resourcesFileStore) {
+        this.mavenMetadataLoader = new MavenMetadataLoader(cacheAwareExternalResourceAccessor, resourcesFileStore);
     }
 
     public VersionPatternVisitor newVisitor(final ModuleIdentifier module, final Collection<String> dest, final ResourceAwareResolveResult result) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultEx
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.authentication.Authentication;
+import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.authentication.AuthenticationInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.progress.BuildOperationExecutor;
@@ -36,6 +37,7 @@ import org.gradle.internal.resource.transport.ResourceConnectorRepositoryTranspo
 import org.gradle.internal.resource.transport.file.FileTransport;
 import org.gradle.util.BuildCommencedTimeProvider;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -51,6 +53,7 @@ public class RepositoryTransportFactory {
     private final CacheLockingManager cacheLockingManager;
     private final BuildOperationExecutor buildOperationExecutor;
     private final StartParameterResolutionOverride startParameterResolutionOverride;
+    private final ProducerGuard<URI> producerGuard;
 
     public RepositoryTransportFactory(Collection<ResourceConnectorFactory> resourceConnectorFactory,
                                       ProgressLoggerFactory progressLoggerFactory,
@@ -59,7 +62,8 @@ public class RepositoryTransportFactory {
                                       BuildCommencedTimeProvider timeProvider,
                                       CacheLockingManager cacheLockingManager,
                                       BuildOperationExecutor buildOperationExecutor,
-                                      StartParameterResolutionOverride startParameterResolutionOverride) {
+                                      StartParameterResolutionOverride startParameterResolutionOverride,
+                                      ProducerGuard<URI> producerGuard) {
         this.progressLoggerFactory = progressLoggerFactory;
         this.temporaryFileProvider = temporaryFileProvider;
         this.cachedExternalResourceIndex = cachedExternalResourceIndex;
@@ -67,6 +71,7 @@ public class RepositoryTransportFactory {
         this.cacheLockingManager = cacheLockingManager;
         this.buildOperationExecutor = buildOperationExecutor;
         this.startParameterResolutionOverride = startParameterResolutionOverride;
+        this.producerGuard = producerGuard;
 
         for (ResourceConnectorFactory connectorFactory : resourceConnectorFactory) {
             register(connectorFactory);
@@ -108,7 +113,7 @@ public class RepositoryTransportFactory {
         ExternalResourceConnector resourceConnector = connectorFactory.createResourceConnector(connectionDetails);
         ExternalResourceCachePolicy cachePolicy = startParameterResolutionOverride.overrideExternalResourceCachePolicy(new DefaultExternalResourceCachePolicy());
 
-        return new ResourceConnectorRepositoryTransport(name, progressLoggerFactory, temporaryFileProvider, cachedExternalResourceIndex, timeProvider, cacheLockingManager, resourceConnector, buildOperationExecutor, cachePolicy);
+        return new ResourceConnectorRepositoryTransport(name, progressLoggerFactory, temporaryFileProvider, cachedExternalResourceIndex, timeProvider, cacheLockingManager, resourceConnector, buildOperationExecutor, cachePolicy, producerGuard);
     }
 
     private void validateSchemes(Set<String> schemes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.resources.ResourceException;
+import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.Factory;
 import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.hash.HashValue;
@@ -61,82 +62,94 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
     private final TemporaryFileProvider temporaryFileProvider;
     private final CacheLockingManager cacheLockingManager;
     private final ExternalResourceCachePolicy externalResourceCachePolicy;
+    private final ProducerGuard<URI> producerGuard;
 
-    public DefaultCacheAwareExternalResourceAccessor(ExternalResourceRepository delegate, CachedExternalResourceIndex<String> cachedExternalResourceIndex, BuildCommencedTimeProvider timeProvider, TemporaryFileProvider temporaryFileProvider, CacheLockingManager cacheLockingManager, ExternalResourceCachePolicy externalResourceCachePolicy) {
+    public DefaultCacheAwareExternalResourceAccessor(ExternalResourceRepository delegate, CachedExternalResourceIndex<String> cachedExternalResourceIndex, BuildCommencedTimeProvider timeProvider, TemporaryFileProvider temporaryFileProvider, CacheLockingManager cacheLockingManager, ExternalResourceCachePolicy externalResourceCachePolicy, ProducerGuard<URI> producerGuard) {
         this.delegate = delegate;
         this.cachedExternalResourceIndex = cachedExternalResourceIndex;
         this.timeProvider = timeProvider;
         this.temporaryFileProvider = temporaryFileProvider;
         this.cacheLockingManager = cacheLockingManager;
         this.externalResourceCachePolicy = externalResourceCachePolicy;
+        this.producerGuard = producerGuard;
     }
 
-    public LocallyAvailableExternalResource getResource(final URI location, final ResourceFileStore fileStore, @Nullable LocallyAvailableResourceCandidates additionalCandidates) throws IOException {
-        LOGGER.debug("Constructing external resource: {}", location);
-        CachedExternalResource cached = cachedExternalResourceIndex.lookup(location.toString());
+    public LocallyAvailableExternalResource getResource(final URI location, final ResourceFileStore fileStore, @Nullable final LocallyAvailableResourceCandidates additionalCandidates) throws IOException {
+        return producerGuard.guardByKey(location, new Factory<LocallyAvailableExternalResource>() {
+            @Override
+            public LocallyAvailableExternalResource create() {
+                LOGGER.debug("Constructing external resource: {}", location);
+                CachedExternalResource cached = cachedExternalResourceIndex.lookup(location.toString());
 
-        // If we have no caching options, just get the thing directly
-        if (cached == null && (additionalCandidates == null || additionalCandidates.isNone())) {
-            return copyToCache(location, fileStore, delegate.withProgressLogging().getResource(location, false));
-        }
+                // If we have no caching options, just get the thing directly
+                if (cached == null && (additionalCandidates == null || additionalCandidates.isNone())) {
+                    return copyToCache(location, fileStore, delegate.withProgressLogging().getResource(location, false));
+                }
 
-        // We might be able to use a cached/locally available version
-        if (cached != null && !externalResourceCachePolicy.mustRefreshExternalResource(getAgeMillis(timeProvider, cached))) {
-            return new DefaultLocallyAvailableExternalResource(location, new DefaultLocallyAvailableResource(cached.getCachedFile()), cached.getExternalResourceMetaData());
-        }
+                // We might be able to use a cached/locally available version
+                if (cached != null && !externalResourceCachePolicy.mustRefreshExternalResource(getAgeMillis(timeProvider, cached))) {
+                    return new DefaultLocallyAvailableExternalResource(location, new DefaultLocallyAvailableResource(cached.getCachedFile()), cached.getExternalResourceMetaData());
+                }
 
-        // We have a cached version, but it might be out of date, so we tell the upstreams to revalidate too
-        final boolean revalidate = true;
+                // We have a cached version, but it might be out of date, so we tell the upstreams to revalidate too
+                final boolean revalidate = true;
 
-        // Get the metadata first to see if it's there
-        final ExternalResourceMetaData remoteMetaData = delegate.getResourceMetaData(location, revalidate);
-        if (remoteMetaData == null) {
-            return null;
-        }
+                // Get the metadata first to see if it's there
+                final ExternalResourceMetaData remoteMetaData = delegate.getResourceMetaData(location, revalidate);
+                if (remoteMetaData == null) {
+                    return null;
+                }
 
-        // Is the cached version still current?
-        if (cached != null) {
-            boolean isUnchanged = ExternalResourceMetaDataCompare.isDefinitelyUnchanged(
-                cached.getExternalResourceMetaData(),
-                new Factory<ExternalResourceMetaData>() {
-                    public ExternalResourceMetaData create() {
-                        return remoteMetaData;
+                // Is the cached version still current?
+                if (cached != null) {
+                    boolean isUnchanged = ExternalResourceMetaDataCompare.isDefinitelyUnchanged(
+                        cached.getExternalResourceMetaData(),
+                        new Factory<ExternalResourceMetaData>() {
+                            public ExternalResourceMetaData create() {
+                                return remoteMetaData;
+                            }
+                        }
+                    );
+
+                    if (isUnchanged) {
+                        LOGGER.info("Cached resource {} is up-to-date (lastModified: {}).", location, cached.getExternalLastModified());
+                        // TODO - update the index with the new remote meta-data
+                        return new DefaultLocallyAvailableExternalResource(location, new DefaultLocallyAvailableResource(cached.getCachedFile()), cached.getExternalResourceMetaData());
                     }
                 }
-            );
 
-            if (isUnchanged) {
-                LOGGER.info("Cached resource {} is up-to-date (lastModified: {}).", location, cached.getExternalLastModified());
-                // TODO - update the index with the new remote meta-data
-                return new DefaultLocallyAvailableExternalResource(location, new DefaultLocallyAvailableResource(cached.getCachedFile()), cached.getExternalResourceMetaData());
-            }
-        }
+                // Either no cached, or it's changed. See if we can find something local with the same checksum
+                boolean hasLocalCandidates = additionalCandidates != null && !additionalCandidates.isNone();
+                if (hasLocalCandidates) {
+                    // The “remote” may have already given us the checksum
+                    HashValue remoteChecksum = remoteMetaData.getSha1();
 
-        // Either no cached, or it's changed. See if we can find something local with the same checksum
-        boolean hasLocalCandidates = additionalCandidates != null && !additionalCandidates.isNone();
-        if (hasLocalCandidates) {
-            // The “remote” may have already given us the checksum
-            HashValue remoteChecksum = remoteMetaData.getSha1();
+                    if (remoteChecksum == null) {
+                        remoteChecksum = getResourceSha1(location, revalidate);
+                    }
 
-            if (remoteChecksum == null) {
-                remoteChecksum = getResourceSha1(location, revalidate);
-            }
-
-            if (remoteChecksum != null) {
-                LocallyAvailableResource local = additionalCandidates.findByHashValue(remoteChecksum);
-                if (local != null) {
-                    LOGGER.info("Found locally available resource with matching checksum: [{}, {}]", location, local.getFile());
-                    // TODO - should iterate over each candidate until we successfully copy into the cache
-                    LocallyAvailableExternalResource resource = copyCandidateToCache(location, fileStore, remoteMetaData, remoteChecksum, local);
-                    if (resource != null) {
-                        return resource;
+                    if (remoteChecksum != null) {
+                        LocallyAvailableResource local = additionalCandidates.findByHashValue(remoteChecksum);
+                        if (local != null) {
+                            LOGGER.info("Found locally available resource with matching checksum: [{}, {}]", location, local.getFile());
+                            // TODO - should iterate over each candidate until we successfully copy into the cache
+                            LocallyAvailableExternalResource resource = null;
+                            try {
+                                resource = copyCandidateToCache(location, fileStore, remoteMetaData, remoteChecksum, local);
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                            if (resource != null) {
+                                return resource;
+                            }
+                        }
                     }
                 }
-            }
-        }
 
-        // All local/cached options failed, get directly
-        return copyToCache(location, fileStore, delegate.withProgressLogging().getResource(location, revalidate));
+                // All local/cached options failed, get directly
+                return copyToCache(location, fileStore, delegate.withProgressLogging().getResource(location, revalidate));
+            }
+        });
     }
 
     private HashValue getResourceSha1(URI location, boolean revalidate) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/ResourceConnectorRepositoryTransport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/ResourceConnectorRepositoryTransport.java
@@ -19,6 +19,7 @@ package org.gradle.internal.resource.transport;
 import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.file.TemporaryFileProvider;
+import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.progress.BuildOperationExecutor;
 import org.gradle.internal.resource.cached.CachedExternalResourceIndex;
@@ -28,6 +29,8 @@ import org.gradle.internal.resource.transfer.ExternalResourceConnector;
 import org.gradle.internal.resource.transfer.ProgressLoggingExternalResourceAccessor;
 import org.gradle.internal.resource.transfer.ProgressLoggingExternalResourceUploader;
 import org.gradle.util.BuildCommencedTimeProvider;
+
+import java.net.URI;
 
 public class ResourceConnectorRepositoryTransport extends AbstractRepositoryTransport {
     private final ExternalResourceRepository repository;
@@ -41,12 +44,13 @@ public class ResourceConnectorRepositoryTransport extends AbstractRepositoryTran
                                                 CacheLockingManager cacheLockingManager,
                                                 ExternalResourceConnector connector,
                                                 BuildOperationExecutor buildOperationExecutor,
-                                                ExternalResourceCachePolicy cachePolicy) {
+                                                ExternalResourceCachePolicy cachePolicy,
+                                                ProducerGuard<URI> producerGuard) {
         super(name);
         ProgressLoggingExternalResourceUploader loggingUploader = new ProgressLoggingExternalResourceUploader(connector, progressLoggerFactory);
         ProgressLoggingExternalResourceAccessor loggingAccessor = new ProgressLoggingExternalResourceAccessor(connector, progressLoggerFactory);
         repository = new DefaultExternalResourceRepository(name, connector, connector, connector, loggingAccessor, loggingUploader, buildOperationExecutor);
-        resourceAccessor = new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, cacheLockingManager, cachePolicy);
+        resourceAccessor = new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, cacheLockingManager, cachePolicy, producerGuard);
     }
 
     public ExternalResourceRepository getRepository() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -42,7 +42,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Stub()
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenArtifactRepository(
-        resolver, transportFactory, locallyAvailableResourceFinder, DirectInstantiator.INSTANCE, artifactIdentifierFileStore, pomParser, authenticationContainer, moduleIdentifierFactory)
+        resolver, transportFactory, locallyAvailableResourceFinder, DirectInstantiator.INSTANCE, artifactIdentifierFileStore, pomParser, authenticationContainer, moduleIdentifierFactory, externalResourceFileStore)
 
     def "creates local repository"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
@@ -20,10 +20,11 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataPa
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.internal.resource.local.FileStore
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
+import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor
 import spock.lang.Specification
 
 class MavenResolverTest extends Specification {
-    def resolver = new MavenResolver("repo", new URI("http://localhost"), Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), Stub(FileStore), Stub(MetaDataParser), Stub(ImmutableModuleIdentifierFactory))
+    def resolver = new MavenResolver("repo", new URI("http://localhost"), Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), Stub(FileStore), Stub(MetaDataParser), Stub(ImmutableModuleIdentifierFactory), Stub(CacheAwareExternalResourceAccessor), Stub(FileStore))
 
     def "has useful string representation"() {
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionListerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionListerTest.groovy
@@ -25,7 +25,9 @@ import org.gradle.api.resources.ResourceException
 import org.gradle.internal.UncheckedException
 import org.gradle.internal.component.model.DefaultIvyArtifactName
 import org.gradle.internal.resolve.result.DefaultResourceAwareResolveResult
-import org.gradle.internal.resource.ExternalResource
+import org.gradle.internal.resource.local.FileStore
+import org.gradle.internal.resource.local.LocallyAvailableExternalResource
+import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor
 import org.gradle.internal.resource.transport.ExternalResourceRepository
 import org.xml.sax.SAXParseException
 import spock.lang.Specification
@@ -38,14 +40,15 @@ class MavenVersionListerTest extends Specification {
     def moduleVersion = new DefaultModuleVersionIdentifier(module, "1.0")
     def artifact = new DefaultIvyArtifactName("testproject", "jar", "jar")
 
-    def repository = Mock(ExternalResourceRepository)
+    def resourceAccessor = Mock(CacheAwareExternalResourceAccessor)
+    def fileStore = Mock(FileStore)
     def pattern = pattern("testRepo/" + MavenPattern.M2_PATTERN)
     def metaDataResource = new URI('testRepo/org/acme/testproject/maven-metadata.xml')
 
-    final MavenVersionLister lister = new MavenVersionLister(repository)
+    final MavenVersionLister lister = new MavenVersionLister(resourceAccessor, fileStore)
 
     def "visit parses maven-metadata.xml"() {
-        ExternalResource resource = Mock()
+        LocallyAvailableExternalResource resource = Mock()
 
         when:
         def versions = []
@@ -57,7 +60,7 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [metaDataResource.toString()]
 
         and:
-        1 * repository.getResource(metaDataResource, true) >> resource
+        1 * resourceAccessor.getResource(metaDataResource, _, null) >> resource
         1 * resource.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("""
 <metadata>
     <versioning>
@@ -69,13 +72,13 @@ class MavenVersionListerTest extends Specification {
 </metadata>""".bytes))
         }
         1 * resource.close()
-        0 * repository._
+        0 * resourceAccessor._
         0 * resource._
     }
 
     def "visit builds union of versions"() {
-        ExternalResource resource1 = Mock()
-        ExternalResource resource2 = Mock()
+        LocallyAvailableExternalResource resource1 = Mock()
+        LocallyAvailableExternalResource resource2 = Mock()
         def pattern1 = pattern("prefix1/" + MavenPattern.M2_PATTERN)
         def pattern2 = pattern("prefix2/" + MavenPattern.M2_PATTERN)
         def location1 = new URI('prefix1/org/acme/testproject/maven-metadata.xml')
@@ -92,7 +95,7 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [location1.toString(), location2.toString()]
 
         and:
-        1 * repository.getResource(location1, true) >> resource1
+        1 * resourceAccessor.getResource(location1, _, null) >> resource1
         1 * resource1.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("""
 <metadata>
     <versioning>
@@ -103,7 +106,7 @@ class MavenVersionListerTest extends Specification {
     </versioning>
 </metadata>""".bytes))
         }
-        1 * repository.getResource(location2, true) >> resource2
+        1 * resourceAccessor.getResource(location2, _, null) >> resource2
         1 * resource2.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("""
 <metadata>
     <versioning>
@@ -117,7 +120,7 @@ class MavenVersionListerTest extends Specification {
     }
 
     def "visit ignores duplicate patterns"() {
-        ExternalResource resource = Mock()
+        LocallyAvailableExternalResource resource = Mock()
 
         when:
         def versions = []
@@ -130,7 +133,7 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [metaDataResource.toString()]
 
         and:
-        1 * repository.getResource(metaDataResource, true) >> resource
+        1 * resourceAccessor.getResource(metaDataResource, _, null) >> resource
         1 * resource.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("""
 <metadata>
     <versioning>
@@ -142,7 +145,7 @@ class MavenVersionListerTest extends Specification {
 </metadata>""".bytes))
         }
         1 * resource.close()
-        0 * repository._
+        0 * resourceAccessor._
         0 * resource._
     }
 
@@ -159,12 +162,12 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [metaDataResource.toString()]
 
         and:
-        1 * repository.getResource(metaDataResource, true) >> null
-        0 * repository._
+        1 * resourceAccessor.getResource(metaDataResource, _, null) >> null
+        0 * resourceAccessor._
     }
 
     def "visit throws ResourceException when maven-metadata cannot be parsed"() {
-        ExternalResource resource = Mock()
+        LocallyAvailableExternalResource resource = Mock()
 
         when:
         def versionList = lister.newVisitor(module, [], result)
@@ -181,9 +184,9 @@ class MavenVersionListerTest extends Specification {
 
         and:
         1 * resource.close()
-        1 * repository.getResource(metaDataResource, true) >> resource;
+        1 * resourceAccessor.getResource(metaDataResource, _, null) >> resource;
         1 * resource.withContent(_) >> { Action action -> action.execute(new ByteArrayInputStream("yo".bytes)) }
-        0 * repository._
+        0 * resourceAccessor._
     }
 
     def "visit throws ResourceException when maven-metadata cannot be loaded"() {
@@ -202,8 +205,8 @@ class MavenVersionListerTest extends Specification {
         result.attempted == [metaDataResource.toString()]
 
         and:
-        1 * repository.getResource(metaDataResource, true) >> { throw failure }
-        0 * repository._
+        1 * resourceAccessor.getResource(metaDataResource, _, null) >> { throw failure }
+        0 * resourceAccessor._
     }
 
     def pattern(String pattern) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.credentials.Credentials
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StartParameterResolutionOverride
 import org.gradle.authentication.Authentication
+import org.gradle.cache.internal.ProducerGuard
 import org.gradle.internal.authentication.AbstractAuthentication
 import org.gradle.internal.resource.connector.ResourceConnectorFactory
 import org.gradle.internal.resource.transport.ResourceConnectorRepositoryTransport
@@ -32,6 +33,7 @@ class RepositoryTransportFactoryTest extends Specification {
 
     def connectorFactory1 = Mock(ResourceConnectorFactory)
     def connectorFactory2 = Mock(ResourceConnectorFactory)
+    def producerGuard = Mock(ProducerGuard)
     def repositoryTransportFactory
 
     def setup() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
@@ -41,7 +41,7 @@ class RepositoryTransportFactoryTest extends Specification {
         connectorFactory2.getSupportedAuthentication() >> ([] as Set)
         List<ResourceConnectorFactory> resourceConnectorFactories = Lists.newArrayList(connectorFactory1, connectorFactory2)
         StartParameterResolutionOverride override = new StartParameterResolutionOverride(new StartParameter())
-        repositoryTransportFactory = new RepositoryTransportFactory(resourceConnectorFactories, null, null, null, null, null, null, override)
+        repositoryTransportFactory = new RepositoryTransportFactory(resourceConnectorFactories, null, null, null, null, null, null, override, producerGuard)
     }
 
     def "cannot create a transport for url with unsupported scheme"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Transformer
 import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultExternalResourceCachePolicy
 import org.gradle.api.internal.file.TemporaryFileProvider
+import org.gradle.cache.internal.ProducerGuard
 import org.gradle.internal.hash.HashUtil
 import org.gradle.internal.resource.ExternalResource
 import org.gradle.internal.resource.cached.CachedExternalResource
@@ -47,6 +48,12 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
     }
     final cacheLockingManager = Mock(CacheLockingManager)
     final cachePolicy = new DefaultExternalResourceCachePolicy()
+    final ProducerGuard<URI> producerGuard = Stub() {
+        guardByKey(_, _) >> { args ->
+            def (key, factory) = args
+            factory.create()
+        }
+    }
     final cache = new DefaultCacheAwareExternalResourceAccessor(repository, index, timeProvider, temporaryFileProvider, cacheLockingManager, cachePolicy, producerGuard)
 
     def "returns null when the request resource is not cached and does not exist in the remote repository"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
@@ -47,7 +47,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
     }
     final cacheLockingManager = Mock(CacheLockingManager)
     final cachePolicy = new DefaultExternalResourceCachePolicy()
-    final cache = new DefaultCacheAwareExternalResourceAccessor(repository, index, timeProvider, temporaryFileProvider, cacheLockingManager, cachePolicy)
+    final cache = new DefaultCacheAwareExternalResourceAccessor(repository, index, timeProvider, temporaryFileProvider, cacheLockingManager, cachePolicy, producerGuard)
 
     def "returns null when the request resource is not cached and does not exist in the remote repository"() {
         def uri = new URI("scheme:thing")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -163,4 +163,9 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
         backingModule.withNonUniqueSnapshots();
         return t();
     }
+
+    @Override
+    public boolean getUniqueSnapshots() {
+        return backingModule.getUniqueSnapshots();
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -79,4 +79,6 @@ interface MavenModule extends Module {
     MavenPom getParsedPom()
 
     MavenMetaData getRootMetaData()
+
+    boolean getUniqueSnapshots()
 }


### PR DESCRIPTION
This pull request implements coordinated network access: it will prevent the same artifacts, or metadata, to be downloaded multiple times in a single build, in particular when running with `--parallel`. The goal is to guarantee that in a single build, an artifact will not be downloaded multiple times.

This happens today because when `--parallel` is used, multiple configurations can have the same dependencies. If a dependency is missing, Gradle will trigger download of metadata, and finally artifacts, of this dependency, but the result is only cached once everything is downloaded (metadata, or artifacts, separately). This means that 2 projects will start downloading the same artifact concurrently, then cache the result, both on their ends. We multiply the number of network requests, as well as download the same artifact multiple times, for nothing.

To prevent this, this commit introduces a _guard_ that is using a remote URI as the key. If one artifacts needs to be downloaded, it acquires the lock for this URI, and only releases it once done. So other projects will be blocked until the artifact is downloaded, but we will only perform a single request. It's worth noting that blocking is not an issue, as in the end, we would have waited as long (and probably longer) without this PR. And eventually, a subsequent story will allow downloading metadata in parallel, meaning that _other_ dependencies will be downloaded while waiting for the lock to release.

Last but not least, this is a step towards aligning the behavior of Gradle when run serially and in parallel. It's still not strictly equivalent (because we wouldn't get cached metadata from the in-memory cache like in the serial case), but it should be consistent, and limit the number of requests to the same amount as when using serial execution.