### PR TITLE
Make configuration variants cheaper

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -72,14 +73,15 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
 
             @Override
             public Set<? extends OutgoingVariant> getChildren() {
+                if (variants == null || variants.isEmpty()) {
+                    return Collections.singleton(new LeafOutgoingVariant(attributes, allArtifacts));
+                }
                 Set<OutgoingVariant> result = new LinkedHashSet<OutgoingVariant>();
-                if (allArtifacts.size() > 0 || variants == null) {
+                if (!allArtifacts.isEmpty()) {
                     result.add(new LeafOutgoingVariant(attributes, allArtifacts));
                 }
-                if (variants != null) {
-                    for (DefaultVariant variant : variants.withType(DefaultVariant.class)) {
-                        result.add(variant.convertToOutgoingVariant());
-                    }
+                for (DefaultVariant variant : variants.withType(DefaultVariant.class)) {
+                    result.add(variant.convertToOutgoingVariant());
                 }
                 return result;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -19,11 +19,10 @@ package org.gradle.internal.component.local.model;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.PublishArtifact;
@@ -43,6 +42,7 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantMetadata;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -53,7 +53,6 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     private final Map<String, DefaultLocalConfigurationMetadata> allConfigurations = Maps.newHashMap();
     private final Multimap<String, LocalComponentArtifactMetadata> allArtifacts = ArrayListMultimap.create();
     private final Multimap<String, LocalFileDependencyMetadata> allFiles = ArrayListMultimap.create();
-    private final SetMultimap<String, DefaultVariantMetadata> allVariants = LinkedHashMultimap.create();
     private final List<LocalOriginDependencyMetadata> allDependencies = Lists.newArrayList();
     private final List<Exclude> allExcludes = Lists.newArrayList();
     private final ModuleVersionIdentifier id;
@@ -92,14 +91,15 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
             copy.allArtifacts.put(entry.getKey(), newArtifact);
         }
 
-        // Variants
-        for (Map.Entry<String, DefaultVariantMetadata> entry : allVariants.entries()) {
-            DefaultVariantMetadata oldVariant = entry.getValue();
-            Set<LocalComponentArtifactMetadata> newArtifacts = new LinkedHashSet<LocalComponentArtifactMetadata>(oldVariant.getArtifacts().size());
-            for (ComponentArtifactMetadata oldArtifact : oldVariant.getArtifacts()) {
-                newArtifacts.add(copyArtifact((LocalComponentArtifactMetadata) oldArtifact, artifacts, transformedArtifacts));
+        //Variants
+        for (DefaultLocalConfigurationMetadata configuration : allConfigurations.values()) {
+            for (VariantMetadata oldVariant : configuration.getVariants()) {
+                Set<LocalComponentArtifactMetadata> newArtifacts = new LinkedHashSet<LocalComponentArtifactMetadata>(oldVariant.getArtifacts().size());
+                for (ComponentArtifactMetadata oldArtifact : oldVariant.getArtifacts()) {
+                    newArtifacts.add(copyArtifact((LocalComponentArtifactMetadata) oldArtifact, artifacts, transformedArtifacts));
+                }
+                copy.allConfigurations.get(configuration.getName()).addVariant(new DefaultVariantMetadata(oldVariant.getAttributes(), newArtifacts));
             }
-            copy.allVariants.put(entry.getKey(), new DefaultVariantMetadata(oldVariant.getAttributes(), newArtifacts));
         }
 
         // Don't include file dependencies
@@ -138,9 +138,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
 
     @Override
     public void addVariant(String configuration, OutgoingVariant variant) {
-        Set<LocalComponentArtifactMetadata> artifacts = toArtifactMetadata(variant);
-        DefaultVariantMetadata variantMetadata = new DefaultVariantMetadata(variant.getAttributes().asImmutable(), artifacts);
-        allVariants.put(configuration, variantMetadata);
+        allConfigurations.get(configuration).addVariant(variant);
     }
 
     private Set<LocalComponentArtifactMetadata> toArtifactMetadata(OutgoingVariant variant) {
@@ -273,6 +271,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         private final AttributeContainerInternal attributes;
         private final boolean canBeConsumed;
         private final boolean canBeResolved;
+        private Set<VariantMetadata> variants;
 
         private List<LocalOriginDependencyMetadata> configurationDependencies;
         private Set<LocalComponentArtifactMetadata> configurationArtifacts;
@@ -345,7 +344,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
 
         @Override
         public Set<? extends VariantMetadata> getVariants() {
-            return allVariants.get(name);
+            return variants == null ? Collections.<VariantMetadata>emptySet() : variants;
         }
 
         @Override
@@ -444,6 +443,23 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
             }
 
             return new MissingLocalArtifactMetadata(componentIdentifier, ivyArtifactName);
+        }
+
+        private void addVariant(OutgoingVariant variant) {
+            Set<LocalComponentArtifactMetadata> artifacts = toArtifactMetadata(variant);
+            VariantMetadata variantMetadata = new DefaultVariantMetadata(variant.getAttributes().asImmutable(), artifacts);
+            addVariant(variantMetadata);
+        }
+
+        private void addVariant(VariantMetadata variantMetadata) {
+            if (variants == null) {
+                variants = Collections.singleton(variantMetadata);
+            } else {
+                if (variants.size() == 1) {
+                    variants = Sets.newLinkedHashSet(variants);
+                }
+                variants.add(variantMetadata);
+            }
         }
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLibraryResolveContext.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLibraryResolveContext.java
@@ -81,24 +81,26 @@ public class JvmLibraryResolveContext implements ResolveContext {
     public ComponentResolveMetadata toRootComponentMetaData() {
         DefaultLibraryLocalComponentMetadata componentMetadata = newResolvingLocalComponentMetadata(libraryBinaryIdentifier, usage.getConfigurationName(), dependencies);
         for (UsageKind usageKind : UsageKind.values()) {
-            componentMetadata.addVariant(usageKind.getConfigurationName(), new OutgoingVariant() {
-                @Override
-                public AttributeContainerInternal getAttributes() {
-                    return ImmutableAttributes.EMPTY;
-                }
-
-                @Override
-                public Set<? extends PublishArtifact> getArtifacts() {
-                    return ImmutableSet.of();
-                }
-
-                @Override
-                public Set<? extends OutgoingVariant> getChildren() {
-                    return ImmutableSet.of();
-                }
-            });
+            componentMetadata.addVariant(usageKind.getConfigurationName(), EMPTY_VARIANT);
         }
         return componentMetadata;
     }
+
+    private static final OutgoingVariant EMPTY_VARIANT = new OutgoingVariant() {
+        @Override
+        public AttributeContainerInternal getAttributes() {
+            return ImmutableAttributes.EMPTY;
+        }
+
+        @Override
+        public Set<? extends PublishArtifact> getArtifacts() {
+            return ImmutableSet.of();
+        }
+
+        @Override
+        public Set<? extends OutgoingVariant> getChildren() {
+            return ImmutableSet.of();
+        }
+    };
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLocalLibraryMetaDataAdapter.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/JvmLocalLibraryMetaDataAdapter.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +83,7 @@ public class JvmLocalLibraryMetaDataAdapter implements LocalLibraryMetaDataAdapt
 
                 @Override
                 public Set<? extends PublishArtifact> getArtifacts() {
-                    return new LinkedHashSet<PublishArtifact>(publishArtifacts);
+                    return ImmutableSet.copyOf(publishArtifacts);
                 }
 
                 @Override


### PR DESCRIPTION
Variant aware dependency management made project dependencies more expensive (since more state about a `Configuration` needs to be held. This change minimizes the impact by optimizing two common cases

- a `Configuration` only has a single variant (the default variant)
- a variant only has a single artifact