### PR TITLE
Fix cyclic dependency in dependency-management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,6 +287,7 @@ patchedExternalModules.builtBy 'patchExternalModules'
 dependencies {
     externalModules 'org.gradle:gradle-script-kotlin:0.8.0'
     coreRuntime project(':launcher')
+    coreRuntime project(':runtimeApiInfo')
     runtime project(':wrapper')
     runtime project(":installationBeacon")
     runtime patchedExternalModules

--- a/gradle/buildSplits.gradle
+++ b/gradle/buildSplits.gradle
@@ -16,7 +16,8 @@
 
 def buckets = [
     "1": [
-        ":platformPlay"
+        ":platformPlay",
+        ":runtimeApiInfo",
     ],
 
     "2": [

--- a/settings.gradle
+++ b/settings.gradle
@@ -90,6 +90,7 @@ include 'soak'
 include 'smokeTest'
 include 'compositeBuilds'
 include 'workers'
+include 'runtimeApiInfo'
 
 rootProject.name = 'gradle'
 rootProject.children.each {project ->

--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -66,6 +66,7 @@ dependencies {
     testFixturesRuntime project(':dependencyManagement')
     testFixturesRuntime project(':pluginUse')
     testFixturesRuntime project(path: ":versionInfo", configuration: "testVersionInfo")
+    testFixturesRuntime project(':runtimeApiInfo')
 
     integTestImplementation project(":internalIntegTesting")
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
@@ -103,7 +103,7 @@ public class DefaultModuleRegistry implements ModuleRegistry {
         }
 
         if (gradleInstallation == null) {
-            throw new UnknownModuleException(String.format("Cannot locate manifest for module '%s' in classpath.", moduleName));
+            throw new UnknownModuleException(String.format("Cannot locate manifest for module '%s' in classpath: %s.", moduleName, classpath));
         }
         throw new UnknownModuleException(String.format("Cannot locate JAR for module '%s' in distribution directory '%s'.", moduleName, gradleInstallation.getGradleHome()));
     }

--- a/subprojects/dependency-management/dependency-management.gradle
+++ b/subprojects/dependency-management/dependency-management.gradle
@@ -47,37 +47,6 @@ useTestFixtures(project: ":modelCore")
 
 verifyTestFilesCleanup.errorWhenNotEmpty = false
 
-ext.runtimeShadedPath = "$buildDir/generated-resources/main/org/gradle/api/internal/runtimeshaded"
-
-task configureGenerateGradleApiPackageList {
-    doLast {
-        generateGradleApiPackageList.configure {
-            classpath = files(
-                rootProject.configurations.externalModules,
-                [':core', ':dependencyManagement', ':pluginUse', ":toolingApi"].collect() {
-                    project(it).configurations.runtime
-                }, project(':').configurations.gradlePlugins)
-        }
-    }
+classpathManifest {
+    additionalProjects = [project(':runtimeApiInfo')]
 }
-
-task generateGradleApiPackageList(type: org.gradle.api.internal.runtimeshaded.PackageListGenerator) {
-    dependsOn configureGenerateGradleApiPackageList
-    outputFile = file("$runtimeShadedPath/api-relocated.txt")
-}
-
-task configureGenerateTestKitPackageList {
-    doLast {
-        generateTestKitPackageList.configure {
-            classpath = project(':testKit').configurations.compile
-        }
-    }
-}
-
-task generateTestKitPackageList(type: org.gradle.api.internal.runtimeshaded.PackageListGenerator) {
-    dependsOn configureGenerateTestKitPackageList
-    outputFile = file("$runtimeShadedPath/test-kit-relocated.txt")
-}
-
-jar.dependsOn(generateGradleApiPackageList, generateTestKitPackageList)
-

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
     abstract String getDistributionLabel()
 
     int getLibJarsCount() {
-        174
+        175
     }
 
     def "no duplicate entries"() {

--- a/subprojects/runtime-api-info/runtime-api-info.gradle
+++ b/subprojects/runtime-api-info/runtime-api-info.gradle
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def runtimeShadedPath = "$buildDir/runtime-api-info"
+
+task generateGradleApiPackageList(type: org.gradle.api.internal.runtimeshaded.PackageListGenerator) {
+    classpath = files(
+        rootProject.configurations.externalModules,
+        [':core', ':dependencyManagement', ':pluginUse', ":toolingApi"].collect() {
+            project(it).configurations.runtime
+        }, project(':').configurations.gradlePlugins)
+    outputFile = file("$runtimeShadedPath/api-relocated.txt")
+}
+
+task generateTestKitPackageList(type: org.gradle.api.internal.runtimeshaded.PackageListGenerator) {
+    classpath = project(':testKit').configurations.compile
+    outputFile = file("$runtimeShadedPath/test-kit-relocated.txt")
+}
+
+jar {
+    into ("org/gradle/api/internal/runtimeshaded") {
+        from generateGradleApiPackageList
+        from generateTestKitPackageList
+    }
+}


### PR DESCRIPTION
Extracted shaded runtime API relocation info into separate project/JAR and rearranged dependencies around it.