### PR TITLE
Avoid build summary counting skipped, no-source, and no-action tasks

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -24,11 +24,11 @@ import org.gradle.api.tasks.TaskState;
 public class TaskStateInternal implements TaskState {
     private boolean executing;
     private boolean didWork;
+    private boolean hasActions;
     private Throwable failure;
     private String description;
     private TaskOutputCachingState taskOutputCaching;
     private TaskExecutionOutcome outcome;
-
     public TaskStateInternal(String description) {
         this.description = description;
     }
@@ -127,5 +127,13 @@ public class TaskStateInternal implements TaskState {
 
     public boolean isFromCache() {
         return outcome == TaskExecutionOutcome.FROM_CACHE;
+    }
+
+    public boolean isHasActions() {
+        return hasActions;
+    }
+
+    public void setHasActions(boolean hasActions) {
+        this.hasActions = hasActions;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -60,7 +60,9 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
 
     public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
         listener.beforeActions(task);
-        if (!task.getTaskActions().isEmpty()) {
+        boolean hasActions = !task.getTaskActions().isEmpty();
+        state.setHasActions(hasActions);
+        if (hasActions) {
             outputsGenerationListener.beforeTaskOutputsGenerated();
         }
         state.setExecuting(true);

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/TaskOutcomeStatisticsFormatter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/TaskOutcomeStatisticsFormatter.java
@@ -19,15 +19,17 @@ import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.tasks.TaskState;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class TaskOutcomeStatisticsFormatter {
-    private int avoidedTasksCount;
-    private int allTasksCount;
+    private AtomicInteger avoidedTasksCount = new AtomicInteger(0);
+    private AtomicInteger allTasksCount = new AtomicInteger(0);
 
     public String incrementAndGetProgress(final TaskState state) {
         recordTaskOutcome(state);
 
-        if (allTasksCount > 0) {
-            final long avoidedPercentage = Math.round(avoidedTasksCount * 100.0 / allTasksCount);
+        if (allTasksCount.get() > 0) {
+            final long avoidedPercentage = Math.round(avoidedTasksCount.get() * 100.0 / allTasksCount.get());
             return " [" + avoidedPercentage + "% AVOIDED, " + (100 - avoidedPercentage) + "% DONE]";
         } else {
             return "";
@@ -37,12 +39,18 @@ public class TaskOutcomeStatisticsFormatter {
     private void recordTaskOutcome(final TaskState state) {
         TaskStateInternal stateInternal = (TaskStateInternal) state;
 
-        TaskExecutionOutcome outcome = stateInternal.getOutcome();
-        if (outcome == TaskExecutionOutcome.UP_TO_DATE || outcome == TaskExecutionOutcome.FROM_CACHE) {
-            avoidedTasksCount++;
+        if (shouldCountTask(stateInternal)) {
+            allTasksCount.getAndIncrement();
+            if (stateInternal.getUpToDate() || stateInternal.isFromCache()) {
+                avoidedTasksCount.getAndIncrement();
+            }
         }
-        if (outcome != TaskExecutionOutcome.NO_SOURCE && outcome != TaskExecutionOutcome.SKIPPED && stateInternal.isHasActions()) {
-            allTasksCount++;
-        }
+    }
+
+    private boolean shouldCountTask(final TaskStateInternal state) {
+        return state.isHasActions() &&
+            !state.getNoSource() &&
+            // NOTE: cannot use state.getSkipped() because UP-TO-DATE tasks are considered "skipped" in TaskExecutionOutcome
+            state.getOutcome() != TaskExecutionOutcome.SKIPPED;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/TaskOutcomeStatisticsFormatter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/TaskOutcomeStatisticsFormatter.java
@@ -20,22 +20,29 @@ import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.tasks.TaskState;
 
 public class TaskOutcomeStatisticsFormatter {
-    private int executedTasksCount;
+    private int avoidedTasksCount;
     private int allTasksCount;
 
-    public String incrementAndGetProgress(TaskState state) {
+    public String incrementAndGetProgress(final TaskState state) {
         recordTaskOutcome(state);
 
-        final long executedPercentage = Math.round(executedTasksCount * 100.0 / allTasksCount);
-        return " [" + (100 - executedPercentage) + "% AVOIDED, " + executedPercentage + "% DONE]";
+        if (allTasksCount > 0) {
+            final long avoidedPercentage = Math.round(avoidedTasksCount * 100.0 / allTasksCount);
+            return " [" + avoidedPercentage + "% AVOIDED, " + (100 - avoidedPercentage) + "% DONE]";
+        } else {
+            return "";
+        }
     }
 
     private void recordTaskOutcome(final TaskState state) {
         TaskStateInternal stateInternal = (TaskStateInternal) state;
+
         TaskExecutionOutcome outcome = stateInternal.getOutcome();
-        if (outcome == TaskExecutionOutcome.EXECUTED) {
-            executedTasksCount++;
+        if (outcome == TaskExecutionOutcome.UP_TO_DATE || outcome == TaskExecutionOutcome.FROM_CACHE) {
+            avoidedTasksCount++;
         }
-        allTasksCount++;
+        if (outcome != TaskExecutionOutcome.NO_SOURCE && outcome != TaskExecutionOutcome.SKIPPED && stateInternal.isHasActions()) {
+            allTasksCount++;
+        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskStateInternalTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskStateInternalTest.groovy
@@ -39,6 +39,7 @@ class TaskStateInternalTest {
         assertThat(state.getSkipMessage(), nullValue())
         assertFalse(state.upToDate)
         assertFalse(state.taskOutputCaching.enabled)
+        assertFalse(state.hasActions)
     }
 
     @Test

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -87,6 +87,7 @@ public class ExecuteActionsTaskExecuterTest extends Specification {
         state.outcome == TaskExecutionOutcome.UP_TO_DATE
         !state.didWork
         !state.executing
+        !state.hasActions
     }
 
     def executesEachActionInOrder() {
@@ -138,6 +139,7 @@ public class ExecuteActionsTaskExecuterTest extends Specification {
         state.didWork
         state.outcome == TaskExecutionOutcome.EXECUTED
         !state.failure
+        state.hasActions
     }
 
     def executeDoesOperateOnNewActionListInstance() {
@@ -209,6 +211,7 @@ public class ExecuteActionsTaskExecuterTest extends Specification {
         !state.executing
         state.didWork
         state.outcome == TaskExecutionOutcome.EXECUTED
+        state.hasActions
 
         TaskExecutionException wrappedFailure = (TaskExecutionException) state.failure
         wrappedFailure instanceof TaskExecutionException
@@ -301,6 +304,7 @@ public class ExecuteActionsTaskExecuterTest extends Specification {
         state.outcome == TaskExecutionOutcome.EXECUTED
         !state.executing
         !state.failure
+        state.hasActions
 
         noMoreInteractions()
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/TaskOutcomeStatisticsFormatterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/TaskOutcomeStatisticsFormatterTest.groovy
@@ -57,9 +57,12 @@ class TaskOutcomeStatisticsFormatterTest extends Specification {
     def "tasks with no actions are not counted"() {
         given:
         formatter.incrementAndGetProgress(taskState(UP_TO_DATE))
+        formatter.incrementAndGetProgress(taskState(EXECUTED))
 
         expect:
-        formatter.incrementAndGetProgress(taskState(EXECUTED, false)) == " [100% AVOIDED, 0% DONE]"
+        formatter.incrementAndGetProgress(taskState(EXECUTED, false)) == " [50% AVOIDED, 50% DONE]"
+        formatter.incrementAndGetProgress(taskState(UP_TO_DATE, false)) == " [50% AVOIDED, 50% DONE]"
+        formatter.incrementAndGetProgress(taskState(FROM_CACHE, false)) == " [50% AVOIDED, 50% DONE]"
     }
 
     def "returns nothing given only non-counted tasks"() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/TaskOutcomeStatisticsFormatterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/TaskOutcomeStatisticsFormatterTest.groovy
@@ -36,28 +36,58 @@ class TaskOutcomeStatisticsFormatterTest extends Specification {
         expect:
         formatter.incrementAndGetProgress(taskState(UP_TO_DATE)) == " [100% AVOIDED, 0% DONE]"
         formatter.incrementAndGetProgress(taskState(FROM_CACHE)) == " [100% AVOIDED, 0% DONE]"
-        formatter.incrementAndGetProgress(taskState(NO_SOURCE)) == " [100% AVOIDED, 0% DONE]"
-        formatter.incrementAndGetProgress(taskState(SKIPPED)) == " [100% AVOIDED, 0% DONE]"
+    }
+
+    def "tasks with NO-SOURCE are not counted"() {
+        given:
+        formatter.incrementAndGetProgress(taskState(EXECUTED))
+
+        expect:
+        formatter.incrementAndGetProgress(taskState(NO_SOURCE)) == " [0% AVOIDED, 100% DONE]"
+    }
+
+    def "SKIPPED tasks are not counted"() {
+        given:
+        formatter.incrementAndGetProgress(taskState(EXECUTED))
+
+        expect:
+        formatter.incrementAndGetProgress(taskState(SKIPPED)) == " [0% AVOIDED, 100% DONE]"
+    }
+
+    def "tasks with no actions are not counted"() {
+        given:
+        formatter.incrementAndGetProgress(taskState(UP_TO_DATE))
+
+        expect:
+        formatter.incrementAndGetProgress(taskState(EXECUTED, false)) == " [100% AVOIDED, 0% DONE]"
+    }
+
+    def "returns nothing given only non-counted tasks"() {
+        expect:
+        formatter.incrementAndGetProgress(taskState(NO_SOURCE)) == ""
+        formatter.incrementAndGetProgress(taskState(SKIPPED)) == ""
+        formatter.incrementAndGetProgress(taskState(EXECUTED, false)) == ""
     }
 
     def "formats executed tasks as DONE"() {
         expect:
-        formatter.incrementAndGetProgress(taskState(EXECUTED)) == " [0% AVOIDED, 100% DONE]"
+        formatter.incrementAndGetProgress(taskState(EXECUTED, true)) == " [0% AVOIDED, 100% DONE]"
     }
 
     def "formats multiple outcome types"() {
         expect:
-        formatter.incrementAndGetProgress(taskState(SKIPPED)) == " [100% AVOIDED, 0% DONE]"
+        formatter.incrementAndGetProgress(taskState(NO_SOURCE)) == ""
         formatter.incrementAndGetProgress(taskState(UP_TO_DATE)) == " [100% AVOIDED, 0% DONE]"
-        formatter.incrementAndGetProgress(taskState(FROM_CACHE)) == " [100% AVOIDED, 0% DONE]"
-        formatter.incrementAndGetProgress(taskState(NO_SOURCE)) == " [100% AVOIDED, 0% DONE]"
-        formatter.incrementAndGetProgress(taskState(EXECUTED)) == " [80% AVOIDED, 20% DONE]"
-        formatter.incrementAndGetProgress(taskState(UP_TO_DATE)) == " [83% AVOIDED, 17% DONE]"
+        formatter.incrementAndGetProgress(taskState(EXECUTED)) == " [50% AVOIDED, 50% DONE]"
+        formatter.incrementAndGetProgress(taskState(SKIPPED)) == " [50% AVOIDED, 50% DONE]"
+        formatter.incrementAndGetProgress(taskState(FROM_CACHE)) == " [67% AVOIDED, 33% DONE]"
+        formatter.incrementAndGetProgress(taskState(UP_TO_DATE)) == " [75% AVOIDED, 25% DONE]"
     }
 
-    private TaskState taskState(TaskExecutionOutcome taskExecutionOutcome) {
+    private TaskState taskState(TaskExecutionOutcome taskExecutionOutcome, boolean hasActions = true) {
         def state = new TaskStateInternal('')
         state.outcome = taskExecutionOutcome
+        state.hasActions = hasActions
         state
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/TaskOutcomeStatisticsFormatterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/TaskOutcomeStatisticsFormatterTest.groovy
@@ -57,12 +57,9 @@ class TaskOutcomeStatisticsFormatterTest extends Specification {
     def "tasks with no actions are not counted"() {
         given:
         formatter.incrementAndGetProgress(taskState(UP_TO_DATE))
-        formatter.incrementAndGetProgress(taskState(EXECUTED))
 
         expect:
-        formatter.incrementAndGetProgress(taskState(EXECUTED, false)) == " [50% AVOIDED, 50% DONE]"
-        formatter.incrementAndGetProgress(taskState(UP_TO_DATE, false)) == " [50% AVOIDED, 50% DONE]"
-        formatter.incrementAndGetProgress(taskState(FROM_CACHE, false)) == " [50% AVOIDED, 50% DONE]"
+        formatter.incrementAndGetProgress(taskState(EXECUTED, false)) == " [100% AVOIDED, 0% DONE]"
     }
 
     def "returns nothing given only non-counted tasks"() {


### PR DESCRIPTION
This unifies the execution outcome grouping with what we do in
build scans.

- UP-TO-DATE and FROM-CACHE tasks are AVOIDED
- EXECUTED tasks with actions are DONE
- all other tasks are not counted

## Context
Hans, Mark, Sterling and others have suggested this change. It is very visual, and it's important that this is _right_.

#### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
