### PR TITLE
Add a gradle-wrapper.properties for buildSrc

### DIFF
--- a/buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Tue Mar 21 09:23:31 CET 2017
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-3.5-20170321074026+0000-bin.zip

--- a/gradle/wrapper.gradle
+++ b/gradle/wrapper.gradle
@@ -45,6 +45,14 @@ tasks.withType(Wrapper) {
         scriptFile.write scriptFile.text.replace("$optsEnvVar=\"\"", "$optsEnvVar=\"$jvmOpts\"")
         batchScript.write batchScript.text.replace("set $optsEnvVar=", "set $optsEnvVar=$jvmOpts")
     }
+    doLast {
+        def buildSrcWrapperDir = new File(rootDir, 'buildSrc/gradle/wrapper')
+        GFileUtils.mkdirs(buildSrcWrapperDir)
+        copy {
+            from propertiesFile
+            into buildSrcWrapperDir
+        }
+    }
 }
 wrapperUpdateTask "nightly", "nightly"
 wrapperUpdateTask "rc", "release-candidate"


### PR DESCRIPTION
## Context
It should be possible to import the Gradle project into IDEA without any errors. It seems like IDEA imports the buildSrc property separately - so it uses the Gradle version the tooling API detects. If there is no `gradle-wrapper.properties` in `buildSrc` then this import fails with
```
rror:Could not find method buildCache() for arguments [settings_6gkv94bllekbr8pd73dgqzir6$_run_closure1@31d5526] on settings 'buildSrc' of type org.gradle.initialization.DefaultSettings.
```

This PR adds a `gradle-wrapper.properties` to `buildSrc` which is automatically updated when running the `Wrapper` task.