### PR TITLE
Fix Visual Studio IDE Integration Regression

### DIFF
--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSingleProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSingleProjectIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.app.*
+import spock.lang.Issue
 
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.VISUALCPP
 
@@ -57,6 +58,38 @@ model {
     }
 }
 """
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/790")
+    def "creating visual studio multiple time gives the same result"() {
+        given:
+        app.writeSources(file("src/main"))
+        buildFile << """
+model {
+    components {
+        main(NativeExecutableSpec)
+    }
+}
+"""
+        when:
+        run "mainVisualStudio"
+        def filtersFileContent = filtersFile("mainExe.vcxproj.filters").file.text
+        def projectFileContent = projectFile("mainExe.vcxproj").projectFile.text
+        def solutionFileContent = solutionFile("mainExe.sln").file.text
+
+        then:
+        executedAndNotSkipped ":mainExeVisualStudio"
+
+        when:
+        run "mainVisualStudio"
+
+        then:
+        executedAndNotSkipped ":mainExeVisualStudio"
+
+        and:
+        filtersFile("mainExe.vcxproj.filters").file.text == filtersFileContent
+        projectFile("mainExe.vcxproj").projectFile.text == projectFileContent
+        solutionFile("mainExe.sln").file.text == solutionFileContent
     }
 
     def "create visual studio solution for single executable"() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/GeneratorTask.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/GeneratorTask.java
@@ -23,8 +23,8 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.MutableActionSet;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.plugins.ide.internal.generator.generator.Generator;
 
 import javax.inject.Inject;
@@ -104,14 +104,7 @@ public class GeneratorTask<T> extends ConventionTask {
     @Optional @InputFile
     protected File getInputFileIfExists() {
         File inputFile = getInputFile();
-        if (inputFile == null) {
-            File outputFile = getOutputFile();
-            if (outputFile != null && outputFile.exists()) {
-                return outputFile;
-            } else {
-                return null;
-            }
-        } else if (inputFile.exists()) {
+        if (inputFile != null && inputFile.exists()) {
             return inputFile;
         } else {
             return null;


### PR DESCRIPTION
The original changes (e6ac5922027a6b6ea01690b0763a0cf0a9a0153e and
9d64621f04456a57003199d0b8b1cc17a955d14d) assumed
`GeneratorTask#getInputFile` implementation would be the one provided
inside `GeneratorTask`. However, this is not always the case. Some task,
for example `GenerateProjectFileTask`, override `getInputFile` to return
a plain `null` value. The fix simply check for the validity of
`getInputFile`, whatever is the implementation.

#### Contributor Checklist
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

#### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
