### PR TITLE
Review/refactor task ordering constraints in tests

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -294,7 +294,7 @@ project(':api') {
 
         then:
         fixture.assertProjectsConfigured(":", ":impl", ":api")
-        result.assertTasksExecuted(":api:foo", ":impl:bar")
+        result.assertTasksExecutedInOrder(":api:foo", ":impl:bar")
     }
 
     def "supports buildSrc"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -318,7 +318,7 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        succeeds "b" assertTasksExecuted ":a", ":b"
+        succeeds "b" assertTasksExecutedInOrder ":a", ":b"
     }
 
     def "task is out of date when property added"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskBridgingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskBridgingIntegrationTest.groovy
@@ -20,6 +20,8 @@ import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.TextUtil
 
+import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.any
+
 class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements WithRuleBasedTasks {
 
     def "can view task container as various view types"() {
@@ -376,7 +378,7 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         succeeds('customTask')
 
         then:
-        result.assertTasksExecuted(':climbTask', ':customTask')
+        result.assertTasksExecutedInOrder(':climbTask', ':customTask')
     }
 
     def "a non-rule-source task can depend on one or more task of types created via both rule sources and old world container"() {
@@ -402,7 +404,7 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         succeeds('customTask')
 
         then:
-        result.assertTasksExecuted(':climbTask', ':oldClimber', ':customTask')
+        result.assertTasksExecutedInOrder(any(':climbTask', ':oldClimber'),  ':customTask')
     }
 
     def "can depend on a rule-source task in a project which has already evaluated"() {
@@ -435,7 +437,7 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         succeeds('sub2:customTask')
 
         then:
-        result.assertTasksExecuted(':sub1:climbTask', ':sub2:customTask')
+        result.assertTasksExecutedInOrder(':sub1:climbTask', ':sub2:customTask')
     }
 
     def "can depend on a rule-source task after a project has been evaluated"() {
@@ -462,7 +464,7 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         succeeds('customTask')
 
         then:
-        result.assertTasksExecuted(':climbTask', ':customTask')
+        result.assertTasksExecutedInOrder(':climbTask', ':customTask')
     }
 
     def "a build failure occurs when depending on a rule task with failing configuration"() {
@@ -531,7 +533,7 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         succeeds('customTask')
 
         then:
-        result.assertTasksExecuted(':climbTask', ':customTask')
+        result.assertTasksExecutedInOrder(':climbTask', ':customTask')
     }
 
     def "a non-rule-source task can depend on a rule-source task with matching criteria"() {
@@ -555,7 +557,7 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         succeeds('customTask')
 
         then:
-        result.assertTasksExecuted(':climbTask', ':customTask')
+        result.assertTasksExecutedInOrder(':climbTask', ':customTask')
     }
 
     def "a non-rule-source task can not depend on both realizable and default task collections"() {
@@ -580,7 +582,7 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         succeeds('customTask')
 
         then:
-        result.assertTasksExecuted(':foo', ':customTask')
+        result.assertTasksExecutedInOrder(':foo', ':customTask')
     }
 
     @NotYetImplemented
@@ -606,7 +608,7 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         succeeds('customTask')
 
         then:
-        result.assertTasksExecuted(':customTask', ':climbTask', ':jumpTask')
+        result.assertTasksExecutedInOrder(':customTask', ':climbTask', ':jumpTask')
     }
 
     @NotYetImplemented
@@ -694,6 +696,6 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         run "customTask"
 
         then:
-        result.assertTasksExecuted(':climbTask', ':customTask')
+        result.assertTasksExecutedInOrder(':climbTask', ':customTask')
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
@@ -346,7 +346,7 @@ task checkArtifacts {
 
         expect:
         succeeds("checkArtifacts")
-        result.assertTasksExecuted(":a:checkArtifacts", ":a:jar", ":b:checkArtifacts")
+        result.assertTasksExecutedInOrder(":a:checkArtifacts", ":a:jar", ":b:checkArtifacts")
     }
 
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -178,7 +178,7 @@ allprojects {
         expect:
         succeeds "resolve"
         // Currently builds all file dependencies
-        result.assertTasksExecuted(":lib:jar", ":lib:utilClasses", ":lib:utilDir", ":lib:utilJar", ":ui:jar", ":app:resolve")
+        executed ":lib:jar", ":lib:utilClasses", ":lib:utilDir", ":lib:utilJar", ":ui:jar", ":app:resolve"
     }
 
     def "can create a view that selects different artifacts from the same dependency graph"() {
@@ -254,7 +254,7 @@ allprojects {
         expect:
         succeeds "resolve"
         // Currently builds all file dependencies
-        result.assertTasksExecuted(":lib:classes", ":lib:utilClasses", ":lib:utilDir", ":lib:utilJar", ":ui:classes", ":app:resolve")
+        executed ":lib:classes", ":lib:utilClasses", ":lib:utilDir", ":lib:utilJar", ":ui:classes", ":app:resolve"
     }
 
     def "applies compatibility and disambiguation rules when selecting variant"() {
@@ -552,7 +552,7 @@ task show {
         expect:
         succeeds "resolve"
         // Currently builds all file dependencies
-        result.assertTasksExecuted(":lib:classes", ":lib:utilClasses", ":lib:utilDir", ":lib:utilJar", ":ui:classes", ":app:resolve")
+        executed ":lib:classes", ":lib:utilClasses", ":lib:utilDir", ":lib:utilJar", ":ui:classes", ":app:resolve"
     }
 
     def "can create a view for configuration that has no attributes"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
@@ -70,7 +70,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
         run taskName
 
         then:
-        result.assertTasksExecuted(":lib", ":child:jar", ":child:lib", ":$taskName");
+        executed ":lib", ":child:jar", ":child:lib", ":$taskName"
 
         where:
         taskName               | _
@@ -115,7 +115,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
         run("useCompileConfiguration")
 
         then:
-        result.assertTasksExecuted(":jar", ":lib", ":child:jar", ":child:lib", ":useCompileConfiguration")
+        executed ":jar", ":lib", ":child:jar", ":child:lib", ":useCompileConfiguration"
 
         where:
         fluid << [true, false]
@@ -152,7 +152,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
         run("useCompileConfiguration")
 
         then:
-        result.assertTasksExecuted(":jar", ":lib", ":child:jar", ":child:lib", ":useCompileConfiguration")
+        executed ":jar", ":lib", ":child:jar", ":child:lib", ":useCompileConfiguration"
 
         where:
         fluid << [true, false]
@@ -272,7 +272,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
         run 'useCompileConfiguration'
 
         then:
-        result.assertTasksExecuted(":child:jar", ":useCompileConfiguration")
+        executed ":child:jar", ":useCompileConfiguration"
     }
 
     def "does not download artifacts when task dependencies are calculated for configuration that is used as a task input when using fluid dependencies"() {
@@ -315,7 +315,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
         run 'useCompileConfiguration'
 
         then:
-        result.assertTasksExecuted(":child:jar", ":useCompileConfiguration")
+        executed ":child:jar", ":useCompileConfiguration"
     }
 
     void makeFluid(boolean fluid) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
@@ -56,7 +56,7 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
         run ":checkDeps"
 
         then:
-        result.assertTasksExecuted(":jar", ":sub:jar", ":checkDeps");
+        executed ":jar", ":sub:jar", ":checkDeps"
         resolve.expectGraph {
             root(":", ":main:") {
                 files << "main.jar"
@@ -101,7 +101,7 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
         run ":checkDeps"
 
         then:
-        result.assertTasksExecuted(":jar", ":sub:jar", ":checkDeps");
+        executed ":jar", ":sub:jar", ":checkDeps"
         resolve.expectGraph {
             root(":", ":main:") {
                 files << "main-1.jar"
@@ -176,7 +176,7 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
         run ":checkDeps"
 
         then:
-        result.assertTasksExecuted(":jar", ":sub:jar", ":checkDeps");
+        executed ":jar", ":sub:jar", ":checkDeps"
         resolve.expectGraph {
             root(":", ":main:") {
                 files << "main.jar"
@@ -222,7 +222,7 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
         run ":checkDeps"
 
         then:
-        result.assertTasksExecuted(":jar", ":checkDeps");
+        executed ":jar", ":checkDeps"
         resolve.expectGraph {
             root(":", ":main:") {
                 files << "main.jar"

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/AntProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/AntProjectIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Test
 
+import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.*
 import static org.hamcrest.Matchers.startsWith
 
 public class AntProjectIntegrationTest extends AbstractIntegrationTest {
@@ -45,7 +46,7 @@ task ant(dependsOn: target1)
         target1File.assertDoesNotExist()
         target2File.assertDoesNotExist()
 
-        inTestDirectory().withTasks('ant').run().assertTasksExecuted(':init', ':target2', ':target1', ':ant')
+        inTestDirectory().withTasks('ant').run().assertTasksExecutedInOrder(':init', ':target2', ':target1', ':ant')
 
         target1File.assertExists()
         target2File.assertExists()
@@ -175,7 +176,12 @@ ant.importBuild('build.xml')
         testFile('build.gradle') << """
 ant.importBuild('build.xml')
 """
-        inTestDirectory().withTasks('a', 'e', 'h').run().assertTasksExecuted(':d', ':c', ':b', ':a', ':g', ':f', ':e', ':i', ':h')
+        inTestDirectory().withTasks('a', 'e', 'h').run()
+            .assertTasksExecutedInOrder any(
+                exact(any(':d', ':c', ':b'), ':a'),
+                exact(any(':g', ':f'), ':e'),
+                exact(':i', ':h')
+            )
     }
 
     @Test
@@ -190,7 +196,7 @@ ant.importBuild('build.xml')
         testFile('build.gradle') << """
 ant.importBuild('build.xml')
 """
-        inTestDirectory().withTasks('a').run().assertTasksExecuted(':b', ':c', ':a')
+        inTestDirectory().withTasks('a').run().assertTasksExecutedInOrder(':b', ':c', ':a')
     }
 
     @Test
@@ -239,7 +245,7 @@ ant.importBuild(file('build.xml')) { antTaskName ->
 
 task ant(dependsOn: 'ant-target1')
 """
-        inTestDirectory().withTasks('clean', 'ant').run().assertTasksExecuted(':clean', ':ant-clean', ':ant-target2', ':ant-target1', ':ant')
+        inTestDirectory().withTasks('clean', 'ant').run().assertTasksExecutedInOrder(':clean', ':ant-clean', ':ant-target2', ':ant-target1', ':ant')
 
     }
 
@@ -260,7 +266,7 @@ ant.importBuild(file('build.xml')) { antTaskName ->
 
 task runAnt(dependsOn: 'a')
 """
-        inTestDirectory().withTasks('runAnt').run().assertTasksExecuted(':c', ':ant-b', ':a', ':runAnt')
+        inTestDirectory().withTasks('runAnt').run().assertTasksExecutedInOrder(':c', ':ant-b', ':a', ':runAnt')
 
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
@@ -245,9 +245,9 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
         TestFile childBuildFile = testFile("child/build.gradle");
         childBuildFile.writelns("task('do-stuff')", "task('task')");
 
-        usingProjectDir(getTestDirectory()).usingSettingsFile(settingsFile).withTasks("do-stuff").run().assertTasksExecuted(":child:task", ":do-stuff", ":child:do-stuff");
-        usingBuildFile(rootBuildFile).withTasks("do-stuff").run().assertTasksExecuted(":child:task", ":do-stuff", ":child:do-stuff");
-        usingBuildFile(childBuildFile).usingSettingsFile(settingsFile).withTasks("do-stuff").run().assertTasksExecuted(":child:do-stuff");
+        usingProjectDir(getTestDirectory()).usingSettingsFile(settingsFile).withTasks("do-stuff").run().assertTasksExecuted(":child:task", ":do-stuff", ":child:do-stuff").assertTaskOrder(":child:task", ":do-stuff");
+        usingBuildFile(rootBuildFile).withTasks("do-stuff").run().assertTasksExecuted(":child:task", ":do-stuff", ":child:do-stuff").assertTaskOrder(":child:task", ":do-stuff");
+        usingBuildFile(childBuildFile).usingSettingsFile(settingsFile).withTasks("do-stuff").run().assertTasksExecutedInOrder(":child:do-stuff");
     }
 
     @Test

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskAutoDependencyIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskAutoDependencyIntegrationTest.groovy
@@ -19,6 +19,8 @@ import org.junit.Ignore
 import org.junit.Test
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
 
+import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.any
+
 class TaskAutoDependencyIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void autoAddsInputFileCollectionAsADependency() {
@@ -54,7 +56,8 @@ configurations { archives }
 dependencies { archives files('b.jar') { builtBy jar } }
 artifacts { archives otherJar }
 '''
-        inTestDirectory().withTasks('doStuff').run().assertTasksExecuted(':b:jar', ':b:otherJar', ':a:doStuff')
+        inTestDirectory().withTasks('doStuff').run()
+            .assertTasksExecutedInOrder(any(':b:jar', ':b:otherJar'), ':a:doStuff')
     }
 
     @Test @Ignore
@@ -66,7 +69,7 @@ artifacts { archives otherJar }
     public void addsDependenciesForFileCollectionInSameProject() {
         fail()
     }
-    
+
     @Test @Ignore
     public void addsDependenciesForFileCollectionInProjectWithNoArtifacts() {
         fail()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Ignore
 import spock.lang.Issue
 
+import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.*
 import static org.hamcrest.Matchers.startsWith
 
 public class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
@@ -323,7 +324,7 @@ task someTask(dependsOn: [someDep, someOtherDep])
         succeeds 'c', 'd'
 
         then:
-        result.assertTasksExecuted(':d', ':b', ':a', ':c')
+        result.assertTasksExecutedInOrder(any(':d', ':b', ':a'), ':c')
     }
 
     def "finalizer task is executed if a finalized task is executed"() {
@@ -419,21 +420,19 @@ task someTask(dependsOn: [someDep, someOtherDep])
 
     def "honours shouldRunAfter task ordering"() {
         buildFile << """
-
-    class NotParallel extends DefaultTask {}
-
-    task a(type: NotParallel) {
+    task a() {
         dependsOn 'b'
     }
-    task b(type: NotParallel) {
+    task b() {
         shouldRunAfter 'c'
     }
-    task c(type: NotParallel)
-    task d(type: NotParallel) {
+    task c()
+    task d() {
         dependsOn 'c'
     }
 """
         when:
+        args("--max-workers=1")
         succeeds 'a', 'd'
 
         then:
@@ -442,35 +441,34 @@ task someTask(dependsOn: [someDep, someOtherDep])
 
     def "multiple should run after ordering can be ignored for one execution plan"() {
         buildFile << """
-    class NotParallel extends DefaultTask {}
-
-    task a(type: NotParallel) {
+    task a() {
         dependsOn 'b', 'h'
     }
-    task b(type: NotParallel) {
+    task b() {
         dependsOn 'c'
     }
-    task c(type: NotParallel) {
+    task c() {
         dependsOn 'g'
         shouldRunAfter 'd'
     }
-    task d(type: NotParallel) {
+    task d() {
         finalizedBy 'e'
         dependsOn 'f'
     }
-    task e(type: NotParallel)
-    task f(type: NotParallel) {
+    task e()
+    task f() {
         dependsOn 'c'
     }
-    task g(type: NotParallel) {
+    task g() {
         shouldRunAfter 'h'
     }
-    task h(type: NotParallel) {
+    task h() {
         dependsOn 'b'
     }
 """
 
         when:
+        args("--max-workers=1")
         succeeds 'a', 'd'
 
         then:
@@ -480,86 +478,100 @@ task someTask(dependsOn: [someDep, someOtherDep])
     @Issue("GRADLE-3575")
     def "honours task ordering with finalizers on finalizers"() {
         buildFile << """
-            class NotParallel extends DefaultTask {}
-
-            task a(type: NotParallel) {
+            task a() {
                 dependsOn 'c', 'g'
             }
 
-            task b(type: NotParallel) {
+            task b() {
                 dependsOn 'd'
                 finalizedBy 'e'
             }
 
-            task c(type: NotParallel) {
+            task c() {
                 dependsOn 'd'
             }
 
-            task d(type: NotParallel) {
+            task d() {
                 dependsOn 'f'
             }
 
-            task e(type: NotParallel) {
+            task e() {
                 finalizedBy 'h'
             }
 
-            task f(type: NotParallel) {
+            task f() {
                 finalizedBy 'h'
             }
 
-            task g(type: NotParallel) {
+            task g() {
                 dependsOn 'd'
             }
 
-            task h(type: NotParallel)
+            task h()
         """
 
         when:
         succeeds 'a'
 
         then:
-        executedTasks == [':f', ':h', ':d', ':c', ':g', ':a']
+        result.assertTasksExecutedInOrder(
+            any(
+                exact(':f', ':h'),
+                exact(any(':c', ':g'), ':a'),
+                exact(':f', ':d', ':c')
+            )
+        )
 
         when:
         succeeds 'b'
 
         then:
-        executedTasks == [':f', ':d', ':b', ':e', ':h']
+        result.assertTasksExecutedInOrder ':f', ':d', ':b', ':e', ':h'
 
         when:
         succeeds 'a', 'b'
 
         then:
-        executedTasks == [':f', ':d', ':c', ':g', ':a', ':b', ':e', ':h']
+        result.assertTasksExecutedInOrder(
+            any(
+                exact(':f', ':d', ':b', ':e', ':h'),
+                exact(any(':c', ':g'), ':a'),
+                exact(':f', ':d', ':c')
+            )
+        )
 
         when:
         succeeds 'b', 'a'
 
         then:
-        executedTasks == [':f', ':d', ':b', ':e', ':h', ':c', ':g', ':a']
+        result.assertTasksExecutedInOrder(
+            any(
+                exact(':f', ':d', ':b', ':e', ':h'),
+                exact(any(':c', ':g'), ':a'),
+                exact(':f', ':d', ':c')
+            )
+        )
     }
 
     @Issue("gradle/gradle#783")
     def "executes finalizer task as soon as possible after finalized task"() {
         buildFile << """
-            class NotParallel extends DefaultTask {}
-
             project(":a") {
-                task jar(type: NotParallel) {
+                task jar() {
                   dependsOn "compileJava"
                 }
-                task compileJava(type: NotParallel) {
+                task compileJava() {
                   dependsOn ":b:jar"
                   finalizedBy "compileFinalizer"
                 }
-                task compileFinalizer(type: NotParallel)
+                task compileFinalizer()
             }
 
             project(":b") {
-                task jar(type: NotParallel)
+                task jar()
             }
 
-            task build(type: NotParallel) {
+            task build() {
               dependsOn ":a:jar"
               dependsOn ":b:jar"
             }
@@ -577,24 +589,22 @@ task someTask(dependsOn: [someDep, someOtherDep])
     def "execution succeed in presence of long dependency chain"() {
         def count = 9000
         buildFile << """
-            class NotParallel extends DefaultTask {}
-
-            task a(type: NotParallel) {
+            task a() {
                 finalizedBy 'f'
             }
 
-            task f(type: NotParallel) {
+            task f() {
                 dependsOn "d_0"
             }
 
             def nextIndex
             ${count}.times {
                 nextIndex = it + 1
-                task "d_\$it"(type: NotParallel) { task ->
+                task "d_\$it"() { task ->
                     dependsOn "d_\$nextIndex"
                 }
             }
-            task "d_\$nextIndex"(type: NotParallel)
+            task "d_\$nextIndex"()
         """
 
         when:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -205,6 +205,11 @@ class AbstractIntegrationSpec extends Specification {
         }
     }
 
+    protected void assertTaskOrder(Object... tasks) {
+        assertHasResult()
+        result.assertTaskOrder(tasks)
+    }
+
     protected void failureHasCause(String cause) {
         failure.assertHasCause(cause)
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
@@ -52,8 +52,22 @@ public interface ExecutionResult {
 
     /**
      * Asserts that exactly the given set of tasks have been executed in the given order. Note: ignores buildSrc tasks.
+     * Each task path can be either a String or a {@link TaskOrderSpec}.  See {@link TaskOrderSpecs} for common assertions
+     * and an explanation of their usage.  Defaults to a {@link TaskOrderSpecs#exact(Object[])} assertion.
+     */
+    ExecutionResult assertTasksExecutedInOrder(Object... taskPaths);
+
+    /**
+     * Asserts that exactly the given set of tasks have been executed in any order. Note: ignores buildSrc tasks.
      */
     ExecutionResult assertTasksExecuted(String... taskPaths);
+
+    /**
+     * Asserts that the provided tasks were executed in the given order.  Each task path can be either a String
+     * or a {@link TaskOrderSpec}.  See {@link TaskOrderSpecs} for common assertions and an explanation of their usage.
+     * Defaults to a {@link TaskOrderSpecs#exact(Object[])} assertion.
+     */
+    ExecutionResult assertTaskOrder(Object... taskPaths);
 
     /**
      * Returns the tasks that were skipped, in an undefined order. Note: ignores buildSrc tasks.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -426,10 +426,24 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
             return new ArrayList<String>(plannedTasks);
         }
 
+        public ExecutionResult assertTasksExecutedInOrder(Object... taskPaths) {
+            Set<String> expected = TaskOrderSpecs.exact(taskPaths).getTasks();
+            assertThat(plannedTasks, containsInAnyOrder(expected.toArray()));
+            outputResult.assertTasksExecutedInOrder(taskPaths);
+            return this;
+        }
+
         public ExecutionResult assertTasksExecuted(String... taskPaths) {
-            List<String> expected = Arrays.asList(taskPaths);
-            assertThat(plannedTasks, equalTo(expected));
+            assertThat(plannedTasks, containsInAnyOrder(taskPaths));
             outputResult.assertTasksExecuted(taskPaths);
+            return this;
+        }
+
+        @Override
+        public ExecutionResult assertTaskOrder(Object... taskPaths) {
+            Set<String> expected = TaskOrderSpecs.exact(taskPaths).getTasks();
+            assertThat(plannedTasks, hasItems(expected.toArray(new String[]{})));
+            outputResult.assertTaskOrder(taskPaths);
             return this;
         }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -36,8 +36,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static org.gradle.util.TextUtil.normaliseLineSeparators;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class OutputScrapingExecutionResult implements ExecutionResult {
@@ -118,9 +117,23 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
         return grepTasks(taskPattern);
     }
 
+    public ExecutionResult assertTasksExecutedInOrder(Object... taskPaths) {
+        Set<String> allTasks = TaskOrderSpecs.exact(taskPaths).getTasks();
+        assertTasksExecuted(allTasks.toArray(new String[]{}));
+        assertTaskOrder(taskPaths);
+        return this;
+    }
+
+    @Override
     public ExecutionResult assertTasksExecuted(String... taskPaths) {
         List<String> expectedTasks = Arrays.asList(taskPaths);
-        assertThat(String.format("Expected tasks %s not found in process output:%n%s", expectedTasks, getOutput()), getExecutedTasks(), equalTo(expectedTasks));
+        assertThat(String.format("Expected tasks %s not found in process output:%n%s", expectedTasks, getOutput()), getExecutedTasks(), containsInAnyOrder(taskPaths));
+        return this;
+    }
+
+    @Override
+    public ExecutionResult assertTaskOrder(Object... taskPaths) {
+        TaskOrderSpecs.exact(taskPaths).assertMatches(-1, getExecutedTasks());
         return this;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/TaskOrderSpec.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/TaskOrderSpec.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer;
+
+import java.util.List;
+import java.util.Set;
+
+public interface TaskOrderSpec {
+    int assertMatches(int lastIndex, List<String> executedTaskPaths);
+
+    Set<String> getTasks();
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/TaskOrderSpecs.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/TaskOrderSpecs.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer;
+
+import com.google.common.collect.Sets;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Provides common assertions for querying task order.
+ *
+ * An 'any' rule asserts that all of the specified tasks occur in any order.
+ *
+ * any(':a', ':b', ':c') would match on any permutation of ':a', ':b', ':c'.
+ *
+ * An 'exact' rule asserts that all of the specified tasks occur in the order
+ * provided.  Note that other tasks may appear - it only verifies that the
+ * given tasks occur in order.
+ *
+ * exact(':b', ':d') would match on [ ':b', ':d' ] or say [ ':a', ':b', ':c', ':d' ]
+ *
+ * Assertions can also be nested:
+ *
+ * exact(':a', any(':b', ':c'), ':d') would match any of the following:
+ *   - [ ':a', ':b', ':c', ':d' ]
+ *   - [ ':a', ':c', ':b', ':d' ]
+ *   but not
+ *   - [ ':b', ':a', ':c', ':d' ]
+ *
+ * Similarly, an exact rule can be nested inside of an any rule:
+ *
+ * any(':a', exact(':b', ':c)) would match any of the following:
+ *   - [ ':a', ':b', ':c' ]
+ *   - [ ':b', ':c', ':a' ]
+ *   - [ ':b', ':a', ':c' ]
+ *   but not
+ *   - [ ':c', ':a', ':b' ]
+ *   - [ ':a', ':c', ':b' ]
+ *   or any other combination where :c occurs before :b
+ */
+public class TaskOrderSpecs {
+
+    public static TaskOrderSpec any(Object[] contraints) {
+        return new AnyOrderSpec(Arrays.asList(contraints));
+    }
+
+    public static TaskOrderSpec exact(Object[] constraints) {
+        return new ExactOrderSpec(Arrays.asList(constraints));
+    }
+
+    private static abstract class RecursiveOrderSpec implements TaskOrderSpec {
+        protected final List<Object> constraints;
+
+        public RecursiveOrderSpec(List<Object> constraints) {
+            this.constraints = constraints;
+        }
+
+        protected int checkConstraint(Object constraint, int lastIndex, List<String> executedTaskPaths) {
+            int index;
+            if (constraint instanceof String) {
+                index = executedTaskPaths.indexOf(constraint);
+            } else if (constraint instanceof TaskOrderSpec) {
+                index = ((TaskOrderSpec)constraint).assertMatches(lastIndex, executedTaskPaths);
+            } else {
+                throw new IllegalArgumentException();
+            }
+            assert index > lastIndex : String.format("%s does not occur in expected order (expected: %s, actual %s)", constraint, this.toString(), executedTaskPaths);
+            return index;
+        }
+
+        @Override
+        public Set<String> getTasks() {
+            Set<String> tasks = Sets.newHashSet();
+            for (Object constraint : constraints) {
+                if (constraint instanceof String) {
+                    tasks.add((String) constraint);
+                } else if (constraint instanceof TaskOrderSpec) {
+                    tasks.addAll(((TaskOrderSpec) constraint).getTasks());
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            }
+            return tasks;
+        }
+
+        abstract String getDisplayName();
+
+        @Override
+        public String toString() {
+            return String.format("%s(%s)", getDisplayName(), constraints);
+        }
+    }
+
+    private static class AnyOrderSpec extends RecursiveOrderSpec {
+        public AnyOrderSpec(List<Object> constraints) {
+            super(constraints);
+        }
+
+        @Override
+        public int assertMatches(int lastIndex, List<String> executedTaskPaths) {
+            int highestIndex = lastIndex;
+            for (Object constraint : constraints) {
+                int index = checkConstraint(constraint, lastIndex, executedTaskPaths);
+                highestIndex = index > highestIndex ? index : highestIndex;
+            }
+            return highestIndex;
+        }
+
+        @Override
+        String getDisplayName() {
+            return "any";
+        }
+    }
+
+    private static class ExactOrderSpec extends RecursiveOrderSpec {
+        public ExactOrderSpec(List<Object> constraints) {
+            super(constraints);
+        }
+
+        @Override
+        public int assertMatches(int lastIndex, List<String> executedTaskPaths) {
+            for (Object constraint : constraints) {
+                lastIndex = checkConstraint(constraint, lastIndex, executedTaskPaths);
+            }
+            return lastIndex;
+        }
+
+        @Override
+        String getDisplayName() {
+            return "exact";
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/TaskOrderSpecsTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/TaskOrderSpecsTest.groovy
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.*
+
+class TaskOrderSpecsTest extends Specification {
+    @Unroll
+    def "can match order exactly (#executedTasks)"() {
+        def spec = exact(':a', ':b', ':c')
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        executedTasks << [
+            [':a', ':b', ':c'],
+            [':a', ':b', ':c', ':d'],
+            [':z', ':a', ':b', ':c'],
+            [':a', ':z', ':b', ':c'],
+            [':z', ':a', ':x', ':y', ':b', ':c', ':d']
+        ]
+    }
+
+    @Unroll
+    def "can mismatch order exactly (#executedTasks)"() {
+        def spec = exact(':a', ':b', ':c')
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        thrown(AssertionError)
+
+        where:
+        executedTasks << [':a', ':b', ':c'].permutations().findAll { it != [':a', ':b', ':c'] } + [
+            [':a', ':c'],
+            [':a', ':b'],
+            [':b', ':c'],
+            [':a', ':c', ':b', ':d'],
+            [':z', ':b', ':a', ':c'],
+            [':z', ':c', ':x', ':y', ':b', ':a', ':d'],
+            []
+        ]
+    }
+
+    @Unroll
+    def "can match any order (#executedTasks)"() {
+        def spec = any(':a', ':b', ':c')
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        executedTasks << [':a', ':b', ':c'].permutations() + [
+            [':c', ':b', ':a', ':d'],
+            [':z', ':a', ':b', ':c'],
+            [':a', ':z', ':c', ':b'],
+            [':z', ':a', ':x', ':y', ':b', ':c', ':d']
+        ]
+    }
+
+    @Unroll
+    def "can mismatch any order (#executedTasks)"() {
+        def spec = any(':a', ':b', ':c')
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        thrown(AssertionError)
+
+        where:
+        executedTasks << [
+            [':c', ':b', ':d'],
+            [':z', ':a', ':b'],
+            [':b', ':z', ':s'],
+            [':z', ':a', ':x', ':y', ':b', ':d'],
+            [ ':a' ],
+            [ ':c' ],
+            []
+        ]
+    }
+
+    @Unroll
+    def "can match on 'any' rule nested inside 'exact' rule (#executedTasks)"() {
+        def spec = exact(any(':a', ':b'), ':c')
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        executedTasks << [
+            [':a', ':b', ':c'],
+            [':b', ':a', ':c'],
+            [':a', ':z', ':b', ':c'],
+            [':z', ':b', ':a', ':c'],
+            [':b', ':z', ':a', ':x', ':c', ':d']
+        ]
+    }
+
+    @Unroll
+    def "can mismatch on 'any' rule nested inside 'exact' rule (#executedTasks)"() {
+        def spec = exact(any(':a', ':b'), ':c')
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        thrown(AssertionError)
+
+        where:
+        executedTasks << [
+            [':a', ':b'],
+            [':b', ':c'],
+            [':a', ':c'],
+            [':b', ':a', ':z'],
+            [':c', ':a', ':b'],
+            [':z', ':c', ':a', ':x'],
+            [':c', ':z', ':a', ':x', ':b', ':d'],
+            []
+        ]
+    }
+
+    @Unroll
+    def "can match on 'exact' rule nested inside 'any' rule (#executedTasks)"() {
+        def spec = any(exact(':a', ':b'), ':c')
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        executedTasks << [
+            [':a', ':b', ':c'],
+            [':c', ':a', ':b'],
+            [':a', ':z', ':b', ':c'],
+            [':z', ':c', ':a', ':b'],
+            [':a', ':z', ':b', ':x', ':c', ':d']
+        ]
+    }
+
+    @Unroll
+    def "can mismatch on 'exact' rule nested inside 'any' rule (#executedTasks)"() {
+        def spec = any(exact(':a', ':b'), ':c')
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        thrown(AssertionError)
+
+        where:
+        executedTasks << [
+            [':a', ':b'],
+            [':b', ':c'],
+            [':a', ':c'],
+            [':b', ':a', ':z'],
+            [':c', ':b', ':a'],
+            [':b', ':c', ':a'],
+            [':b', ':a', ':c'],
+            [':z', ':a', ':c', ':x'],
+            [':c', ':z', ':b', ':x', ':a', ':d'],
+            []
+        ]
+    }
+
+    @Unroll
+    def "can match on complex rule (#executedTasks)"() {
+        def spec = exact(any(':a', ':b'), any(':c', exact(':d', ':e', ':f')))
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        executedTasks << [
+            [':a', ':b', ':c', ':d', ':e', ':f'],
+            [':b', ':a', ':c', ':d', ':e', ':f'],
+            [':b', ':a', ':d', ':e', ':f', ':c'],
+            [':a', ':b', ':d', ':e', ':f', ':c']
+        ]
+    }
+
+    @Unroll
+    def "can mismatch on complex rule (#executedTasks)"() {
+        def spec = exact(any(':a', ':b'), any(':c', exact(':d', ':e', ':f')))
+
+        when:
+        spec.assertMatches(-1, executedTasks)
+
+        then:
+        thrown(AssertionError)
+
+        where:
+        executedTasks << [
+            [':a', ':b', ':c', ':e', ':d', ':f'],
+            [':c', ':d', ':e', ':f', ':a', ':b'],
+            [':z', ':a', ':d', ':e', ':f', ':c'],
+            [':a', ':b', ':d', ':f', ':e', ':c'],
+            []
+        ]
+    }
+
+    def "can specify a task more than once in a complex rule"() {
+        def spec = any(exact(':a', ':c'), exact(':b', ':d'), exact(':a', ':d'))
+
+        given:
+        assert spec.getTasks() == [':a', ':b', ':c', ':d'] as Set
+
+        when:
+        spec.assertMatches(-1, [':a', ':b', ':c', ':d'])
+
+        then:
+        noExceptionThrown()
+
+        when:
+        spec.assertMatches(-1, [':b', ':a', ':c', ':d'])
+
+        then:
+        noExceptionThrown()
+
+        when:
+        spec.assertMatches(-1, [':b', ':d', ':a', ':c'])
+
+        then:
+        thrown(AssertionError)
+    }
+}

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/BinariesLifecycleTaskIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/BinariesLifecycleTaskIntegrationTest.groovy
@@ -102,7 +102,7 @@ class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec {
         run "assemble"
 
         then:
-        result.assertTasksExecuted(":someOtherTask", ":assemble")
+        result.assertTasksExecutedInOrder(":someOtherTask", ":assemble")
     }
 
     def "does not do anything when the project is empty" () {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/IncrementalGroovyCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/IncrementalGroovyCompileIntegrationTest.groovy
@@ -52,7 +52,7 @@ class IncrementalGroovyCompileIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void failsCompilationWhenConfigScriptIsUpdated() {
         // compilation passes with a config script that does nothing
-        executer.withTasks('compileGroovy').run().assertTasksExecuted(":compileJava",":compileGroovy")
+        executer.withTasks('compileGroovy').run().assertTasksExecutedInOrder(":compileJava",":compileGroovy")
 
         // make sure it fails if the config script applies type checking
         file('groovycompilerconfig.groovy').assertIsFile().copyFrom(file('newgroovycompilerconfig.groovy'))
@@ -63,7 +63,7 @@ class IncrementalGroovyCompileIntegrationTest extends AbstractIntegrationTest {
         // and eventually make sure it passes again if no config script is applied whatsoever
         file('build.gradle').assertIsFile().copyFrom(file('newbuild.gradle'))
 
-        executer.withTasks('compileGroovy').run().assertTasksExecuted(':compileJava',':compileGroovy').assertTaskSkipped(':compileJava')
+        executer.withTasks('compileGroovy').run().assertTasksExecutedInOrder(':compileJava',':compileGroovy').assertTaskSkipped(':compileJava')
 
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/jvm/test/JUnitStandaloneTestExecutionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/jvm/test/JUnitStandaloneTestExecutionIntegrationTest.groovy
@@ -268,7 +268,7 @@ class JUnitStandaloneTestExecutionIntegrationTest extends AbstractJUnitTestExecu
         fails 'check'
 
         then:
-        result.assertTasksExecuted ':compileMyTestBinaryMyTestJava', ':myTestBinaryTest' // only
+        result.assertTasksExecutedInOrder ':compileMyTestBinaryMyTestJava', ':myTestBinaryTest' // only
 
         and:
         def result = new DefaultTestExecutionResult(testDirectory, 'build', 'myTest')
@@ -293,7 +293,7 @@ class JUnitStandaloneTestExecutionIntegrationTest extends AbstractJUnitTestExecu
         succeeds 'myTestBinary'
 
         then:
-        result.assertTasksExecuted ':compileMyTestBinaryMyTestJava', ':myTestBinary' // only
+        result.assertTasksExecutedInOrder ':compileMyTestBinaryMyTestJava', ':myTestBinary' // only
     }
 
     @NotYetImplemented

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r112/BuildInvocationsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r112/BuildInvocationsCrossVersionSpec.groovy
@@ -125,14 +125,14 @@ project(':b:c') {
             it.forLaunchables(selectorT1, selectorT2)
         }
         then:
-        result.result.assertTasksExecuted(':t1', ':b:c:t1', ':b:t2', ':b:c:t2')
+        result.result.assertTasksExecutedInOrder(':t1', ':b:c:t1', ':b:t2', ':b:c:t2')
 
         when:
         result = withBuild { BuildLauncher it ->
             it.forLaunchables(selectorT2, selectorT1)
         }
         then:
-        result.result.assertTasksExecuted(':b:t2', ':b:c:t2', ':t1', ':b:c:t1')
+        result.result.assertTasksExecutedInOrder(':b:t2', ':b:c:t2', ':t1', ':b:c:t1')
     }
 
     def "can fetch task selectors for root project from connection"() {
@@ -225,14 +225,14 @@ project(':b:c') {
         }
 
         then:
-        result.result.assertTasksExecuted(':t1', ':b:t2', ':b:c:t1')
+        result.result.assertTasksExecutedInOrder(':t1', ':b:t2', ':b:c:t1')
 
         when:
         result = withBuild { BuildLauncher it ->
             it.forLaunchables(taskBCT1, taskBT2, taskT1)
         }
         then:
-        result.result.assertTasksExecuted(':b:c:t1', ':b:t2', ':t1')
+        result.result.assertTasksExecutedInOrder(':b:c:t1', ':b:t2', ':t1')
     }
 
     @TargetGradleVersion(">=1.12")
@@ -251,7 +251,7 @@ project(':b:c') {
             it.forLaunchables(selectorBT1, selectorBT3, taskT1)
         }
         then:
-        result.result.assertTasksExecuted(':b:c:t1', ':b:t3', ':t1')
+        result.result.assertTasksExecutedInOrder(':b:c:t1', ':b:t3', ':t1')
     }
 
     def "build tasks and selectors in order cross version"() {
@@ -270,7 +270,7 @@ project(':b:c') {
             it.forLaunchables(taskT1, selectorT1, selectorT2, taskBT2)
         }
         then:
-        result.result.assertTasksExecuted(':t1', ':b:c:t1', ':b:t2', ':b:c:t2')
+        result.result.assertTasksExecutedInOrder(':t1', ':b:c:t1', ':b:t2', ':b:c:t2')
     }
 
     @TargetGradleVersion("=1.12")

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r23/ModelBuilderCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r23/ModelBuilderCrossVersionSpec.groovy
@@ -48,7 +48,7 @@ class ModelBuilderCrossVersionSpec extends ToolingApiSpecification {
 
         then:
         model != null
-        new OutputScrapingExecutionResult(outputStream.toString(), errorStream.toString()).assertTasksExecuted()
+        new OutputScrapingExecutionResult(outputStream.toString(), errorStream.toString()).assertTasksExecutedInOrder()
     }
 
     @ToolingApiVersion(">=2.3")
@@ -72,7 +72,7 @@ class ModelBuilderCrossVersionSpec extends ToolingApiSpecification {
 
         then:
         model != null
-        new OutputScrapingExecutionResult(outputStream.toString(), errorStream.toString()).assertTasksExecuted()
+        new OutputScrapingExecutionResult(outputStream.toString(), errorStream.toString()).assertTasksExecutedInOrder()
     }
 
 }


### PR DESCRIPTION
We have a number of tasks that expect exact ordering of tasks which may become flaky as we make more tasks parallel by default.  This PR relaxes these constraints where ordering is not germane to the test and introduces more robust constraints for declaring task ordering requirements in the face of parallelism.