### PR TITLE
Do not detect Mac OS 9 new line on other system

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
@@ -132,7 +132,7 @@ public abstract class AbstractLineChoppingStyledTextOutput extends AbstractStyle
         @Override
         public void execute(StateContext context) {
             if (context.seenCharsFromEol < context.eolChars.length) {
-                if (context.isCurrentCharEquals(context.eolChars[context.seenCharsFromEol])) {
+                if (!context.eol.equals("\r\n") && context.isCurrentCharEquals(context.eolChars[context.seenCharsFromEol])) {
                     context.seenCharsFromEol++;
                     if (context.seenCharsFromEol == context.eolChars.length) {
                         context.flushLineText();

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/StyledTextOutputBackedRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/StyledTextOutputBackedRendererTest.groovy
@@ -134,6 +134,6 @@ class StyledTextOutputBackedRendererTest extends OutputSpecification {
         output.value == "$headerLine\n$firstLine\n$secondLine\n$thirdLine\n$fourthLine\n$fifthLine\n$footerLine"
 
         where:
-        eol << [SystemProperties.instance.lineSeparator, "\n", "\r\n", "\r"]
+        eol << [SystemProperties.instance.lineSeparator, "\n", "\r\n"]
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
@@ -112,7 +112,7 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
     }
 
     def "can append eol in chunks"() {
-        System.setProperty("line.separator", "----");
+        System.setProperty("line.separator", "----")
         def output = output()
 
         when:
@@ -129,7 +129,7 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
     }
 
     def "can append eol prefix"() {
-        System.setProperty("line.separator", "----");
+        System.setProperty("line.separator", "----")
         def output = output()
 
         when:
@@ -148,7 +148,7 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
     }
 
     def "can split eol across style changes"() {
-        System.setProperty("line.separator", "----");
+        System.setProperty("line.separator", "----")
         def output = output()
 
         when:

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
@@ -183,7 +183,9 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
         result.toString() == "{eol}"
     }
 
-    def "Mac OS 9 eol aren't detected as new line"() {
+    @Unroll
+    def "Mac OS 9 eol aren't detected as new line [#type]"() {
+        System.setProperty("line.separator", eol)
         def output = output()
 
         when:
@@ -191,6 +193,9 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         then:
         result.toString() == "[some\rtext]"
+
+        where:
+        [type, eol] << EOLS
     }
 
     def output() {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
@@ -29,8 +29,7 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
     private static final def EOLS = [
         ["System", SYSTEM_EOL],
         ["*nix", NIX_EOL],
-        ["Windows", WINDOWS_EOL],
-        ["Mac OS 9", MACOS9_EOL]
+        ["Windows", WINDOWS_EOL]
     ]
     @Rule final SetSystemProperties systemProperties = new SetSystemProperties()
     final StringBuilder result = new StringBuilder()
@@ -166,11 +165,10 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         when:
         output.text(SYSTEM_EOL)
-        output.text(MACOS9_EOL)
         output.text("$WINDOWS_EOL$NIX_EOL")
 
         then:
-        result.toString() == "{eol}{start}{eol}{start}{eol}{start}{eol}"
+        result.toString() == "{eol}{start}{eol}{start}{eol}"
     }
 
     def "can split Windows eol across multiple call on non-Windows eol default"() {
@@ -185,16 +183,14 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
         result.toString() == "{eol}"
     }
 
-    def "can correctly detect Mac OS 9 eol on Windows eol default"() {
-        System.setProperty("line.separator", "\r\n");
+    def "Mac OS 9 eol aren't detected as new line"() {
         def output = output()
 
         when:
-        output.text(MACOS9_EOL)
-        output.text("${MACOS9_EOL}a")
+        output.text("some${MACOS9_EOL}text")
 
         then:
-        result.toString() == "{eol}{start}{eol}{start}[a]"
+        result.toString() == "[some\rtext]"
     }
 
     def output() {
@@ -218,7 +214,7 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
             @Override
             protected void doEndLine(CharSequence endOfLine) {
-                assert endOfLine in [System.getProperty("line.separator"), NIX_EOL, WINDOWS_EOL, MACOS9_EOL]
+                assert endOfLine in [System.getProperty("line.separator"), NIX_EOL, WINDOWS_EOL]
                 result.append("{eol}")
             }
         }


### PR DESCRIPTION
It fix the issue gradle/gradle#1646 where Findbugs use Carriage Returns
to rewrite the current line.

#### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

#### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
