### PR TITLE
Version sorting performance improvements

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
@@ -80,8 +80,9 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
                 applyTo(metadataProvider, result);
                 return;
             }
+            String version = candidate.getVersion().getSource();
             if (!versionMatches) {
-                result.notMatched(candidate.getVersion());
+                result.notMatched(version);
                 continue;
             }
 
@@ -97,7 +98,7 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
                 return;
             }
 
-            result.rejected(candidate.getVersion());
+            result.rejected(version);
             if (requestedVersion.matchesUniqueVersion()) {
                 // Only consider one candidate
                 break;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -21,6 +21,8 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
@@ -262,14 +264,14 @@ public class DynamicVersionResolver implements DependencyToComponentIdResolver {
         private final ModuleComponentRepository repository;
         private final AttemptCollector attemptCollector;
         private final DependencyMetadata dependencyMetadata;
-        private final String version;
+        private final Version version;
         private boolean searchedLocally;
         private boolean searchedRemotely;
         private final DefaultBuildableModuleComponentMetaDataResolveResult result = new DefaultBuildableModuleComponentMetaDataResolveResult();
 
         public CandidateResult(DependencyMetadata dependencyMetadata, String version, ModuleComponentRepository repository, AttemptCollector attemptCollector) {
             this.dependencyMetadata = dependencyMetadata;
-            this.version = version;
+            this.version = VersionParser.INSTANCE.transform(version);
             this.repository = repository;
             this.attemptCollector = attemptCollector;
             ModuleVersionSelector requested = dependencyMetadata.getRequested();
@@ -282,7 +284,7 @@ public class DynamicVersionResolver implements DependencyToComponentIdResolver {
         }
 
         @Override
-        public String getVersion() {
+        public Version getVersion() {
             return version;
         }
 
@@ -312,7 +314,7 @@ public class DynamicVersionResolver implements DependencyToComponentIdResolver {
         }
 
         private void process(ModuleComponentRepositoryAccess access) {
-            DependencyMetadata dependency = dependencyMetadata.withRequestedVersion(version);
+            DependencyMetadata dependency = dependencyMetadata.withRequestedVersion(version.getSource());
             access.resolveComponentMetaData(identifier, DefaultComponentOverrideMetadata.forDependency(dependency), result);
             attemptCollector.execute(result);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainModuleResolution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainModuleResolution.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 
-class RepositoryChainModuleResolution implements Versioned {
+class RepositoryChainModuleResolution implements StringVersioned {
     public final ModuleComponentRepository repository;
     public final ModuleComponentResolveMetadata module;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StringVersioned.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StringVersioned.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
-
-public interface Versioned {
-    Version getVersion();
+public interface StringVersioned {
+    String getVersion();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/VersionInfo.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/VersionInfo.java
@@ -15,22 +15,22 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
+
 public class VersionInfo implements Versioned {
-    private final String version;
+    private final Version version;
 
     public VersionInfo(String version) {
-        this.version = version;
+        this.version = VersionParser.INSTANCE.transform(version);
     }
 
-    public String getVersion() {
+    public Version getVersion() {
         return version;
     }
 
     public boolean equals(Object other) {
-        if (!(other instanceof VersionInfo)) {
-            return false;
-        }
-        return version.equals(((VersionInfo) other).getVersion());
+        return other instanceof VersionInfo && version.equals(((VersionInfo) other).getVersion());
     }
 
     public int hashCode() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractStringVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractStringVersionSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
-public interface Versioned {
-    Version getVersion();
+public abstract class AbstractStringVersionSelector extends AbstractVersionSelector {
+    protected AbstractStringVersionSelector(String selector) {
+        super(selector);
+    }
+
+    @Override
+    public boolean accept(Version candidate) {
+        return accept(candidate.getSource());
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractVersionSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,14 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
 import org.gradle.api.artifacts.ComponentMetadata;
 
-public abstract class AbstractVersionSelector implements VersionSelector {
+abstract class AbstractVersionSelector implements VersionSelector {
     private final String selector;
 
     protected AbstractVersionSelector(String selector) {
         this.selector = selector;
     }
 
-    protected String getSelector() {
+    protected final String getSelector() {
         return selector;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractVersionVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractVersionVersionSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
-public interface Versioned {
-    Version getVersion();
+public abstract class AbstractVersionVersionSelector extends AbstractVersionSelector {
+    protected AbstractVersionVersionSelector(String selector) {
+        super(selector);
+    }
+
+    @Override
+    public boolean accept(String candidate) {
+        return accept(VersionParser.INSTANCE.transform(candidate));
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparator.java
@@ -21,27 +21,15 @@ import java.util.Comparator;
 
 public class DefaultVersionComparator implements VersionComparator {
     private final Comparator<Version> baseComparator = new StaticVersionComparator();
-    private final VersionParser versionParser = new VersionParser();
-    private final Comparator<String> stringComparator = new Comparator<String>() {
-        @Override
-        public int compare(String string1, String string2) {
-            return baseComparator.compare(versionParser.transform(string1), versionParser.transform(string2));
-        }
-    };
 
     public int compare(Versioned element1, Versioned element2) {
-        String version1 = element1.getVersion();
-        String version2 = element2.getVersion();
-        return stringComparator.compare(version1, version2);
+        Version version1 = element1.getVersion();
+        Version version2 = element2.getVersion();
+        return baseComparator.compare(version1, version2);
     }
 
     @Override
     public Comparator<Version> asVersionComparator() {
         return baseComparator;
-    }
-
-    @Override
-    public Comparator<String> asStringComparator() {
-        return stringComparator;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
@@ -25,7 +25,7 @@ public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
 
     public VersionSelector parseSelector(String selectorString) {
         if (VersionRangeSelector.ALL_RANGE.matcher(selectorString).matches()) {
-            return new VersionRangeSelector(selectorString, versionComparator.asStringComparator());
+            return new VersionRangeSelector(selectorString, versionComparator.asVersionComparator());
         }
 
         if (selectorString.endsWith("+")) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/ExactVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/ExactVersionSelector.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 /**
  * Version matcher for "static" version selectors (1.0, 1.2.3, etc.).
  */
-public class ExactVersionSelector extends AbstractVersionSelector {
+public class ExactVersionSelector extends AbstractStringVersionSelector {
     public ExactVersionSelector(String selector) {
         super(selector);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelector.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
 import org.gradle.api.artifacts.ComponentMetadata;
 
-public class LatestVersionSelector extends AbstractVersionSelector {
+public class LatestVersionSelector extends AbstractStringVersionSelector {
     private final String selectorStatus;
 
     public LatestVersionSelector(String selector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
@@ -36,14 +36,23 @@ class StaticVersionComparator implements Comparator<Version> {
 
         String[] parts1 = version1.getParts();
         String[] parts2 = version2.getParts();
+        Long[] numericParts1 = version1.getNumericParts();
+        Long[] numericParts2 = version2.getNumericParts();
 
         int i = 0;
         for (; i < parts1.length && i < parts2.length; i++) {
-            if (parts1[i].equals(parts2[i])) {
+            String part1 = parts1[i];
+            String part2 = parts2[i];
+
+            Long numericPart1 = numericParts1[i];
+            Long numericPart2 = numericParts2[i];
+
+            boolean is1Number = numericPart1 != null;
+            boolean is2Number = numericPart2 != null;
+
+            if (part1.equals(part2)) {
                 continue;
             }
-            boolean is1Number = isNumber(parts1[i]);
-            boolean is2Number = isNumber(parts2[i]);
             if (is1Number && !is2Number) {
                 return 1;
             }
@@ -51,11 +60,11 @@ class StaticVersionComparator implements Comparator<Version> {
                 return -1;
             }
             if (is1Number && is2Number) {
-                return Long.valueOf(parts1[i]).compareTo(Long.valueOf(parts2[i]));
+                return numericPart1.compareTo(numericPart2);
             }
             // both are strings, we compare them taking into account special meaning
-            Integer sm1 = SPECIAL_MEANINGS.get(parts1[i].toLowerCase(Locale.US));
-            Integer sm2 = SPECIAL_MEANINGS.get(parts2[i].toLowerCase(Locale.US));
+            Integer sm1 = SPECIAL_MEANINGS.get(part1.toLowerCase(Locale.US));
+            Integer sm2 = SPECIAL_MEANINGS.get(part2.toLowerCase(Locale.US));
             if (sm1 != null) {
                 sm2 = sm2 == null ? 0 : sm2;
                 return sm1 - sm2;
@@ -63,19 +72,15 @@ class StaticVersionComparator implements Comparator<Version> {
             if (sm2 != null) {
                 return -sm2;
             }
-            return parts1[i].compareTo(parts2[i]);
+            return part1.compareTo(part2);
         }
         if (i < parts1.length) {
-            return isNumber(parts1[i]) ? 1 : -1;
+            return numericParts1[i] == null ? -1 : 1;
         }
         if (i < parts2.length) {
-            return isNumber(parts2[i]) ? -1 : 1;
+            return numericParts2[i] == null ? 1 : -1;
         }
 
         return 0;
-    }
-
-    private boolean isNumber(String str) {
-        return str.matches("\\d+");
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/SubVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/SubVersionSelector.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 /**
  * Version matcher for dynamic version selectors ending in '+'.
  */
-public class SubVersionSelector extends AbstractVersionSelector {
+public class SubVersionSelector extends AbstractStringVersionSelector {
     private final String prefix;
 
     public SubVersionSelector(String selector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/Version.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/Version.java
@@ -23,6 +23,11 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
  */
 public interface Version {
     /**
+     * Returns the original {@link String} representation of the version.
+     */
+    String getSource();
+
+    /**
      * Returns all the parts of this version. e.g. 1.2.3 returns [1,2,3] or 1.2-beta4 returns [1,2,beta,4].
      */
     String[] getParts();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/Version.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/Version.java
@@ -28,6 +28,11 @@ public interface Version {
     String[] getParts();
 
     /**
+     * Returns all the numeric parts of this version as {@link Long}, with nulls in non-numeric positions. eg. 1.2.3 returns [1,2,3] or 1.2-beta4 returns [1,2,null,4].
+     */
+    Long[] getNumericParts();
+
+    /**
      * Returns the base version for this version, which removes any qualifiers. Generally this is the first '.' separated parts of this version.
      * e.g. 1.2.3-beta-4 returns 1.2.3, or 7.0.12beta5 returns 7.0.12.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionComparator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionComparator.java
@@ -26,6 +26,4 @@ public interface VersionComparator extends Comparator<Versioned> {
     int compare(Versioned element1, Versioned element2);
 
     Comparator<Version> asVersionComparator();
-
-    Comparator<String> asStringComparator();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
+import com.google.common.primitives.Longs;
 import org.gradle.api.Transformer;
 
 import java.util.ArrayList;
@@ -75,11 +76,16 @@ public class VersionParser implements Transformer<Version, String> {
     private static class DefaultVersion implements Version {
         private final String source;
         private final String[] parts;
+        private final Long[] numericParts;
         private final DefaultVersion baseVersion;
 
         public DefaultVersion(String source, List<String> parts, DefaultVersion baseVersion) {
             this.source = source;
             this.parts = parts.toArray(new String[0]);
+            this.numericParts = new Long[this.parts.length];
+            for (int i = 0; i < parts.size(); i++) {
+                this.numericParts[i] = Longs.tryParse(this.parts[i]);
+            }
             this.baseVersion = baseVersion == null ? this : baseVersion;
         }
 
@@ -117,6 +123,11 @@ public class VersionParser implements Transformer<Version, String> {
 
         public String[] getParts() {
             return parts;
+        }
+
+        @Override
+        public Long[] getNumericParts() {
+            return numericParts;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
@@ -23,6 +23,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class VersionParser implements Transformer<Version, String> {
+    public static final VersionParser INSTANCE = new VersionParser();
+
+    private VersionParser() {
+    }
+
     @Override
     public Version transform(String original) {
         List<String> parts = new ArrayList<String>();
@@ -128,6 +133,11 @@ public class VersionParser implements Transformer<Version, String> {
         @Override
         public Long[] getNumericParts() {
             return numericParts;
+        }
+
+        @Override
+        public String getSource() {
+            return source;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class VersionParser implements Transformer<Version, String> {
     public static final VersionParser INSTANCE = new VersionParser();
 
-    private VersionParser() {
+    public VersionParser() {
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  * accept(). Note that it can't work with latest time strategy, cause no time is known for the
  * limits of the range. Therefore only purely revision based LatestStrategy can be used.
  */
-public class VersionRangeSelector extends AbstractVersionSelector {
+public class VersionRangeSelector extends AbstractVersionVersionSelector {
     private static final String OPEN_INC = "[";
 
     private static final String OPEN_EXC = "]";
@@ -94,12 +94,14 @@ public class VersionRangeSelector extends AbstractVersionSelector {
             + LOWER_INFINITE_PATTERN + "|" + UPPER_INFINITE_PATTERN + "|" + SINGLE_VALUE_RANGE);
 
     private final String upperBound;
+    private final Version upperBoundVersion;
     private final boolean upperInclusive;
     private final String lowerBound;
     private final boolean lowerInclusive;
-    private final Comparator<String> comparator;
+    private final Version lowerBoundVersion;
+    private final Comparator<Version> comparator;
 
-    public VersionRangeSelector(String selector, Comparator<String> comparator) {
+    public VersionRangeSelector(String selector, Comparator<Version> comparator) {
         super(selector);
         this.comparator = comparator;
 
@@ -137,6 +139,8 @@ public class VersionRangeSelector extends AbstractVersionSelector {
                 }
             }
         }
+        lowerBoundVersion = lowerBound == null ? null : VersionParser.INSTANCE.transform(lowerBound);
+        upperBoundVersion = upperBound == null ? null : VersionParser.INSTANCE.transform(upperBound);
     }
 
     public boolean isDynamic() {
@@ -151,11 +155,11 @@ public class VersionRangeSelector extends AbstractVersionSelector {
         return false;
     }
 
-    public boolean accept(String candidate) {
-        if (lowerBound != null && !isHigher(candidate, lowerBound, lowerInclusive)) {
+    public boolean accept(Version candidate) {
+        if (lowerBound != null && !isHigher(candidate, lowerBoundVersion, lowerInclusive)) {
             return false;
         }
-        if (upperBound != null && !isLower(candidate, upperBound, upperInclusive)) {
+        if (upperBound != null && !isLower(candidate, upperBoundVersion, upperInclusive)) {
             return false;
         }
         return true;
@@ -164,7 +168,7 @@ public class VersionRangeSelector extends AbstractVersionSelector {
     /**
      * Tells if version1 is lower than version2.
      */
-    private boolean isLower(String version1, String version2, boolean inclusive) {
+    private boolean isLower(Version version1, Version version2, boolean inclusive) {
         int result = comparator.compare(version1, version2);
         return result <= (inclusive ? 0 : -1);
     }
@@ -172,7 +176,7 @@ public class VersionRangeSelector extends AbstractVersionSelector {
     /**
      * Tells if version1 is higher than version2.
      */
-    private boolean isHigher(String version1, String version2, boolean inclusive) {
+    private boolean isHigher(Version version1, Version version2, boolean inclusive) {
         int result = comparator.compare(version1, version2);
         return result >= (inclusive ? 0 : 1);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionSelector.java
@@ -44,6 +44,14 @@ public interface VersionSelector {
     public boolean accept(String candidate);
 
     /**
+     * Indicates if the selector matches the given candidate version.
+     * Only called if {@link #requiresMetadata()} returned {@code false}.
+     *
+     * @param candidate the candidate version
+     */
+    public boolean accept(Version candidate);
+
+    /**
      * Indicates if the selector matches the given candidate version
      * (whose metadata is provided). May also be called if {@link #isDynamic} returned
      * {@code false}, in which case it should return the same result as

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
@@ -18,10 +18,10 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 import org.gradle.api.Nullable;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.Versioned;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StringVersioned;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 
-public interface ComponentResolutionState extends Versioned {
+public interface ComponentResolutionState extends StringVersioned {
     ModuleVersionIdentifier getId();
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
@@ -24,7 +24,6 @@ import java.util.*;
 
 class LatestModuleConflictResolver implements ModuleConflictResolver {
     private final Comparator<Version> versionComparator;
-    private final VersionParser versionParser = new VersionParser();
 
     LatestModuleConflictResolver(VersionComparator versionComparator) {
         this.versionComparator = versionComparator.asVersionComparator();
@@ -35,7 +34,7 @@ class LatestModuleConflictResolver implements ModuleConflictResolver {
         Version baseVersion = null;
         Map<Version, T> matches = new LinkedHashMap<Version, T>();
         for (T candidate : candidates) {
-            Version version = versionParser.transform(candidate.getVersion());
+            Version version = VersionParser.INSTANCE.transform(candidate.getVersion());
             if (baseVersion == null || versionComparator.compare(version.getBaseVersion(), baseVersion) > 0) {
                 matches.clear();
                 baseVersion = version.getBaseVersion();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.specs.Specs
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
@@ -108,10 +109,10 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * dependency.requested >> selector
-        _ * a.version >> "1.2"
-        _ * b.version >> "1.3"
+        _ * a.version >> version("1.2")
+        _ * b.version >> version("1.3")
         _ * b.id >> selected
-        _ * c.version >> "2.0"
+        _ * c.version >> version("2.0")
         _ * componentSelectionRules.rules >> []
         0 * _
 
@@ -135,10 +136,10 @@ class DefaultVersionedComponentChooserTest extends Specification {
         then:
         _ * dependency.requested >> selector
         _ * dependency.withRequestedVersion(_) >> Stub(DependencyMetadata)
-        _ * a.version >> "1.2"
-        _ * b.version >> "1.3"
+        _ * a.version >> version("1.2")
+        _ * b.version >> version("1.3")
         _ * b.id >> selected
-        _ * c.version >> "2.0"
+        _ * c.version >> version("2.0")
         1 * c.resolve() >> resolvedWithStatus("integration")
         1 * c.getComponentMetadataSupplier()
         1 * b.resolve() >> resolvedWithStatus("milestone")
@@ -165,10 +166,10 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * dependency.getRequested() >> selector
-        _ * a.version >> "1.2"
-        _ * b.version >> "1.3"
+        _ * a.version >> version("1.2")
+        _ * b.version >> version("1.3")
         _ * b.id >> selected
-        _ * c.version >> "2.0"
+        _ * c.version >> version("2.0")
         _ * componentSelectionRules.rules >> rules({ComponentSelection selection ->
             if (selection.candidate.version != '1.3') {
                 selection.reject("rejected")
@@ -196,10 +197,10 @@ class DefaultVersionedComponentChooserTest extends Specification {
         then:
         _ * dependency.requested >> selector
         _ * dependency.withRequestedVersion(_) >> Stub(DependencyMetadata)
-        _ * a.version >> "1.2"
-        _ * b.version >> "1.3"
+        _ * a.version >> version("1.2")
+        _ * b.version >> version("1.3")
         _ * b.id >> selected
-        _ * c.version >> "2.0"
+        _ * c.version >> version("2.0")
         1 * c.resolve() >> resolvedWithStatus("milestone")
         1 * c.getComponentMetadataSupplier()
         1 * b.resolve() >> resolvedWithStatus("release")
@@ -231,9 +232,9 @@ class DefaultVersionedComponentChooserTest extends Specification {
         then:
         _ * dependency.requested >> selector
         _ * componentSelectionRules.rules >> []
-        _ * a.version >> "1.2"
-        _ * b.version >> "1.3"
-        _ * c.version >> "2.0"
+        _ * a.version >> version("1.2")
+        _ * b.version >> version("1.3")
+        _ * c.version >> version("2.0")
         0 * _
 
         and:
@@ -254,9 +255,9 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * dependency.getRequested() >> selector
-        _ * a.version >> "1.2"
-        _ * b.version >> "1.3"
-        _ * c.version >> "2.0"
+        _ * a.version >> version("1.2")
+        _ * b.version >> version("1.3")
+        _ * c.version >> version("2.0")
         1 * a.resolve() >> resolvedWithStatus("integration")
         1 * a.getComponentMetadataSupplier()
         1 * b.resolve() >> resolvedWithStatus("integration")
@@ -284,11 +285,11 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * dependency.getRequested() >> selector
-        _ * a.version >> "1.2"
+        _ * a.version >> version("1.2")
         _ * a.id >> Stub(ModuleComponentIdentifier)
-        _ * b.version >> "1.3"
+        _ * b.version >> version("1.3")
         _ * b.id >> Stub(ModuleComponentIdentifier)
-        _ * c.version >> "2.0"
+        _ * c.version >> version("2.0")
         _ * c.id >> Stub(ModuleComponentIdentifier)
         _ * componentSelectionRules.rules >> rules({ ComponentSelection selection ->
             selection.reject("Rejecting everything")
@@ -313,9 +314,9 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * dependency.getRequested() >> selector
-        _ * a.version >> "1.2"
-        _ * b.version >> "1.3"
-        _ * c.version >> "2.0"
+        _ * a.version >> version("1.2")
+        _ * b.version >> version("1.3")
+        _ * c.version >> version("2.0")
         1 * c.resolve() >> resolvedWithStatus("integration")
         1 * c.getComponentMetadataSupplier()
         1 * b.resolve() >> resolvedWithFailure()
@@ -350,5 +351,9 @@ class DefaultVersionedComponentChooserTest extends Specification {
                     Specs.<ComponentSelection>satisfyAll()
             )
         ]
+    }
+
+    def version(String version) {
+        return VersionParser.INSTANCE.transform(version)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractStringVersionSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractStringVersionSelectorTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy
 import org.gradle.api.artifacts.ComponentMetadata
 import spock.lang.Specification
 
-abstract class AbstractVersionSelectorTest extends Specification {
+abstract class AbstractStringVersionSelectorTest extends Specification {
     abstract VersionSelector getSelector(String selector);
 
     def accept(String s1, String s2) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
@@ -185,12 +185,6 @@ class DefaultVersionComparatorTest extends Specification {
         "1.0"                     | "1.1-20150201.121010-12"
     }
 
-    def "can compare version strings"() {
-        expect:
-        def stringComparator = comparator.asStringComparator()
-        stringComparator.compare("1.2", "1.3") < 0
-    }
-
     def "can compare Version objects"() {
         def v1 = Stub(Version) {
             getParts() >> ["1", "2"]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
@@ -194,9 +194,11 @@ class DefaultVersionComparatorTest extends Specification {
     def "can compare Version objects"() {
         def v1 = Stub(Version) {
             getParts() >> ["1", "2"]
+            getNumericParts() >> [1, 2]
         }
         def v2 = Stub(Version) {
             getParts() >> ["1", "3"]
+            getNumericParts() >> [1, 3]
         }
 
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/ExactVersionSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/ExactVersionSelectorTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy
 import org.gradle.api.artifacts.ComponentMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 
-class ExactVersionSelectorTest extends AbstractVersionSelectorTest {
+class ExactVersionSelectorTest extends AbstractStringVersionSelectorTest {
     def "considers selector as static"() {
         expect:
         !isDynamic("1.0")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelectorTest.groovy
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy
 
 import org.gradle.api.artifacts.ComponentMetadata
 
-class LatestVersionSelectorTest extends AbstractVersionSelectorTest {
+class LatestVersionSelectorTest extends AbstractStringVersionSelectorTest {
 
     def "all handled selectors are dynamic"() {
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/SubVersionSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/SubVersionSelectorTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy
 import org.gradle.api.artifacts.ComponentMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 
-class SubVersionSelectorTest extends AbstractVersionSelectorTest {
+class SubVersionSelectorTest extends AbstractStringVersionSelectorTest {
     def "all handled selectors are dynamic"() {
         expect:
         isDynamic("1+")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParserTest.groovy
@@ -21,8 +21,6 @@ import spock.lang.Specification
 import static org.gradle.util.Matchers.strictlyEqual
 
 class VersionParserTest extends Specification {
-    def versionParser = new VersionParser()
-
     def "parsed version is equal when source string is equal"() {
         def v = parse("1.2.b")
         def equal = parse("1.2.b")
@@ -118,6 +116,6 @@ class VersionParserTest extends Specification {
     }
 
     def parse(String v) {
-        return versionParser.transform(v)
+        return VersionParser.INSTANCE.transform(v)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParserTest.groovy
@@ -97,6 +97,26 @@ class VersionParserTest extends Specification {
         '-a b c-  ' | ['', 'a b c', '  ']
     }
 
+    def "numeric parts are parsed"() {
+        expect:
+        def version = parse(versionStr)
+        version.numericParts == numericParts.collect { it == null ? null : it.toLong() }.toArray()
+
+        where:
+        versionStr        | numericParts
+        "1.2.3"           | [1, 2, 3]
+        "1.2-3"           | [1, 2, 3]
+        "1.2-beta_3+0000" | [1, 2, null, 3, 0]
+        "1.2b3"           | [1, 2, null, 3]
+        "1-alpha"         | [1, null]
+        "abc.1-3"         | [null, 1, 3]
+        "123"             | [123]
+        "abc"             | [null]
+        "a.b.c.1.2"       | [null, null, null, 1, 2]
+        "1b2.1.2.3"       | [1, null, 2, 1, 2, 3]
+        "b1-2-3.3"        | [null, 1, 2, 3 ,3]
+    }
+
     def parse(String v) {
         return versionParser.transform(v)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy
 import org.gradle.api.artifacts.ComponentMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 
-public class VersionRangeSelectorTest extends AbstractVersionSelectorTest {
+public class VersionRangeSelectorTest extends AbstractStringVersionSelectorTest {
     def "all handled selectors are dynamic"() {
         expect:
         isDynamic("[1.0,2.0]")
@@ -163,6 +163,6 @@ public class VersionRangeSelectorTest extends AbstractVersionSelectorTest {
 
     @Override
     VersionSelector getSelector(String selector) {
-        return new VersionRangeSelector(selector, new DefaultVersionComparator().asStringComparator())
+        return new VersionRangeSelector(selector, new DefaultVersionComparator().asVersionComparator())
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorter.java
@@ -16,7 +16,13 @@
 
 package org.gradle.api.tasks.diagnostics.internal.insight;
 
-import org.gradle.api.artifacts.component.*;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.VersionInfo;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.DependencyEdge;
@@ -37,11 +43,11 @@ public class DependencyResultSorter {
 
     private static class DependencyComparator implements Comparator<DependencyEdge> {
         private final VersionSelectorScheme versionSelectorScheme;
-        private final Comparator<String> versionComparator;
+        private final VersionComparator versionComparator;
 
         private DependencyComparator(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator) {
             this.versionSelectorScheme = versionSelectorScheme;
-            this.versionComparator = versionComparator.asStringComparator();
+            this.versionComparator = versionComparator;
         }
 
         @Override
@@ -187,7 +193,7 @@ public class DependencyResultSorter {
         }
 
         private int compareVersions(String left, String right) {
-            return versionComparator.compare(left, right);
+            return versionComparator.compare(new VersionInfo(left), new VersionInfo(right));
         }
 
         private boolean isLeftAndRightFromProjectComponentIdentifier(ComponentIdentifier left, ComponentIdentifier right) {


### PR DESCRIPTION
## Context
As documented on issue #1600, version comparison and sorting have performance issues:

- CPU and object allocation head due to use of plain `String.matches` to determine if version parts are numeric
- Object allocation overhead during version sorting, due to versions being parsed for each call to `compare`

This pull requests removes the String version comparator, to ensure that a callee either parses the `Version` outside of the comparator, or for classes involved in sorting, parse instances on construction and hold them for their lifetime.

#### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

#### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
