### PR TITLE
Use String.intern for interning

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/internal/cache/StringInterner.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/internal/cache/StringInterner.java
@@ -20,10 +20,8 @@ import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 
 public class StringInterner implements Interner<String> {
-    private final Interner<String> interner;
 
     public StringInterner() {
-        this.interner = Interners.newWeakInterner();
     }
 
     @Override
@@ -31,6 +29,6 @@ public class StringInterner implements Interner<String> {
         if (sample == null) {
             return null;
         }
-        return interner.intern(sample);
+        return sample.intern();
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/api/internal/cache/StringInterner.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/internal/cache/StringInterner.java
@@ -15,9 +15,7 @@
  */
 
 package org.gradle.api.internal.cache;
-
 import com.google.common.collect.Interner;
-import com.google.common.collect.Interners;
 
 public class StringInterner implements Interner<String> {
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/api/internal/cache/StringInternerTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/api/internal/cache/StringInternerTest.groovy
@@ -33,12 +33,12 @@ class StringInternerTest extends Specification {
         given:
         def strings = (1..5).collect { new String('hello') }
         assert strings.collect { System.identityHashCode(it) }.unique().size() == 5
-        def firstInstance = strings.first()
         when:
         def internedStrings = strings.collect { stringInterner.intern(it) }
         then:
-        internedStrings.collect { System.identityHashCode(it) }.unique().size() == 1
-        internedStrings.every { it.is(firstInstance) }
+        internedStrings.collect { System.identityHashCode(it)}.unique().size() == 1
+        def firstInstance = internedStrings.first()
+	    internedStrings.every { it.is(firstInstance) }
     }
 
     def "should only intern similar strings"() {


### PR DESCRIPTION
## Context
We are running a build with a rather large project using the gradle daemon and I'm concerned about the memory usage of the daemon. 
I did some analysis with the Eclipse memory analyzer (see my really old blog post here http://kohlerm.blogspot.de/search?updated-max=2009-07-09T13:35:00-07:00) using the group by value feature and found that there a still quite a few String duplicates. Also the current implementation of the String Interner, does have a relatively high overhead because it uses a complicated data structure to make concurrent access to the strings fast. 
Now since Java 7 the integrated String.intern function is IMHO good enough under most circumstances, because the pool size can be configured and because the strings don't get allocated in perm space anymore . For some performance data check http://java-performance.info/string-intern-in-java-6-7-8/.

Therefore, here comes a small patch that just uses String.intern for interning. 
In my test cases there is a significant reduction in memory usage without a noticeable change in performance.

I had to change  one unit test slightly because it returns a strange NPE from the test framework.


#### Contributor Checklist
- [ x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x ] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

#### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
