### PR TITLE
Fix a broken method from the signing subproject.

### DIFF
--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -240,7 +240,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
     /**
      * Changes the signature file representation for the signatures.
      */
-    public void signatureType(SignatureType type) {
+    public void signatureType(SignatureType signatureType) {
         this.signatureType = signatureType;
     }
 

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -238,13 +238,6 @@ public class Sign extends DefaultTask implements SignatureSpec {
     }
 
     /**
-     * Changes the signature file representation for the signatures.
-     */
-    public void signatureType(SignatureType signatureType) {
-        this.signatureType = signatureType;
-    }
-
-    /**
      * Changes the signatory of the signatures.
      */
     public void signatory(Signatory signatory) {

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningConfigurationsSpec.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningConfigurationsSpec.groovy
@@ -15,6 +15,8 @@
  */
 package org.gradle.plugins.signing
 
+import org.gradle.plugins.signing.type.pgp.ArmoredSignatureType
+
 class SigningConfigurationsSpec extends SigningProjectSpec {
     
     def setup() {
@@ -56,9 +58,21 @@ class SigningConfigurationsSpec extends SigningProjectSpec {
         signing {
             sign configurations.produced
         }
-        
+
         then:
         configurations.signatures.artifacts.size() == 3
         signProduced.signatures.every { it in configurations.signatures.artifacts }
+    }
+
+    def "sign configuration with custom type"() {
+        def signingTasks
+        when:
+        signing {
+            signingTasks = sign configurations.produced
+            signingTasks[0].signatureType new ArmoredSignatureType()
+        }
+
+        then:
+        signingTasks[0].getSignatureType() instanceof ArmoredSignatureType
     }
 }


### PR DESCRIPTION
## Context
This method doesn't work. Note that `this.signatureType` is assigned `signatureType` rather than `type` (self-assignment).

#### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

#### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
