### PR TITLE
Fix memory leak in DefaultDaemonScanInfo

### DIFF
--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfoSpec.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfoSpec.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.daemon.server.scaninfo
+
+import org.gradle.BuildListener
+import org.gradle.BuildResult
+import org.gradle.api.Action
+import org.gradle.internal.event.ListenerManager
+import org.gradle.launcher.daemon.registry.DaemonRegistry
+import org.gradle.launcher.daemon.server.expiry.DaemonExpirationListener
+import org.gradle.launcher.daemon.server.expiry.DaemonExpirationResult
+import org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus
+import org.gradle.launcher.daemon.server.stats.DaemonRunningStats
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultDaemonScanInfoSpec extends Specification {
+    @Unroll
+    def "should unregister both listeners #scenario"() {
+        given:
+        def listenerManager = Mock(ListenerManager)
+        def notifyAction = Mock(Action)
+        def daemonScanInfo = new DefaultDaemonScanInfo(Stub(DaemonRunningStats), 0, Stub(DaemonRegistry), listenerManager)
+        DaemonExpirationListener daemonExpirationListener
+        BuildListener buildListener
+
+        when:
+        daemonScanInfo.notifyOnUnhealthy(notifyAction)
+
+        then:
+        1 * listenerManager.addListener({ it instanceof DaemonExpirationListener }) >> { DaemonExpirationListener listener ->
+            daemonExpirationListener = listener
+        }
+        1 * listenerManager.addListener({ it instanceof BuildListener }) >> { BuildListener listener ->
+            buildListener = listener
+        }
+
+        when:
+        switch (scenario) {
+            case Scenario.ON_EXPIRATION:
+                daemonExpirationListener.onExpirationEvent(new DaemonExpirationResult(DaemonExpirationStatus.GRACEFUL_EXPIRE, "reason"))
+                break
+            case Scenario.ON_BUILD_FINISHED:
+                buildListener.buildFinished(Stub(BuildResult))
+                break
+        }
+
+        then:
+        1 * listenerManager.removeListener(daemonExpirationListener)
+        1 * listenerManager.removeListener(buildListener)
+
+        where:
+        scenario << [Scenario.ON_EXPIRATION, Scenario.ON_BUILD_FINISHED]
+    }
+
+    private enum Scenario {
+        ON_EXPIRATION("on graceful expiration"), ON_BUILD_FINISHED("on build finished")
+        String description
+
+        Scenario(String description) {
+            this.description = description
+        }
+
+        String toString() {
+            description
+        }
+    }
+}


### PR DESCRIPTION
### Context

Fixes #1730 which is a memory leak in DefaultDaemonScanInfo

- also unregister the listener that was listening for the buildFinished event

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
