### PR TITLE
Enable parallel by default on the Gradle build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.parallel=true
+


### PR DESCRIPTION
This enables the `--parallel` flag by default on our own build. This is not the long term solution, but we want to exercise more the builds now that we have a finer grained locking mechanism around dependency resolution. This will help us discover (and fix) thread-safety issues.