### PR TITLE
Kill daemons before any other task

### DIFF
--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -321,10 +321,10 @@ project(":") {
             }
         }
     }
-}
-
-allprojects {
-    tasks.whenTaskAdded {
-        it.dependsOn(':killExistingDaemons')
+    allprojects {
+        tasks.whenTaskAdded {
+            it.dependsOn(':killExistingDaemons')
+        }
     }
 }
+


### PR DESCRIPTION
The "killExistingDaemons" setup was broken. It was only adding a
dependency on projects that do use integration testing. But we
want the killing to happen before *any* task. Otherwise it will
kill compiler daemons of projects like baseServices, which comes
early and has no integration tests.