### PR TITLE
Use Internal annotation on interface to avoid task property validation issues

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.PropertyState;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Internal;
 
 import java.util.concurrent.Callable;
 
@@ -52,7 +51,6 @@ public class DefaultPropertyState<T> implements PropertyState<T> {
         return provider.get();
     }
 
-    @Internal
     @Override
     public T getOrNull() {
         return isPresent() ? provider.getOrNull() : null;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Internal;
 import org.gradle.internal.UncheckedException;
 
 import java.util.concurrent.Callable;
@@ -32,7 +31,6 @@ public class DefaultProvider<T> implements Provider<T> {
         this.value = value;
     }
 
-    @Internal
     @Override
     public T get() {
         T evaluatedValue = getOrNull();
@@ -44,7 +42,6 @@ public class DefaultProvider<T> implements Provider<T> {
         return evaluatedValue;
     }
 
-    @Internal
     @Override
     public T getOrNull() {
         try {

--- a/subprojects/core/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/provider/Provider.java
@@ -17,6 +17,7 @@
 package org.gradle.api.provider;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.tasks.Internal;
 
 /**
  * A container object which provides a value of a specific type. The value can be retrieved by the method {@code get()} or {@code getOrNull()}.
@@ -40,6 +41,7 @@ public interface Provider<T> {
      *
      * @return Value
      */
+    @Internal
     T getOrNull();
 
     /**
@@ -47,5 +49,6 @@ public interface Provider<T> {
      *
      * @return {@code true} if there is a value present, otherwise {@code false}
      */
+    @Internal
     boolean isPresent();
 }


### PR DESCRIPTION
During task property validation it seems that the `@Nested` annotation looks at the type of the property and not the type of the getter method. Therefore, getter methods on the interface `Provider` are validated which they probably shouldn't.

Question from my end: This issue might be indicative of a validation implementation that should be improved. Is it good practice to add `@Internal` annotation to a public interface instead of an implementation?