### PR TITLE
Allow nested usage of BuildOperationProcessor

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationProcessor.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationProcessor.java
@@ -43,11 +43,11 @@ public class DefaultBuildOperationProcessor implements BuildOperationProcessor, 
     private final BuildOperationQueueFactory buildOperationQueueFactory;
     private final StoppableExecutor fixedSizePool;
 
-    public DefaultBuildOperationProcessor(BuildOperationWorkerRegistry buildOperationWorkerRegistry, BuildOperationExecutor buildOperationExecutor, BuildOperationQueueFactory buildOperationQueueFactory, ExecutorFactory executorFactory, int maxWorkerCount) {
+    public DefaultBuildOperationProcessor(BuildOperationWorkerRegistry buildOperationWorkerRegistry, BuildOperationExecutor buildOperationExecutor, BuildOperationQueueFactory buildOperationQueueFactory, ExecutorFactory executorFactory) {
         this.buildOperationWorkerRegistry = buildOperationWorkerRegistry;
         this.buildOperationExecutor = buildOperationExecutor;
         this.buildOperationQueueFactory = buildOperationQueueFactory;
-        this.fixedSizePool = executorFactory.create("build operations", maxWorkerCount);
+        this.fixedSizePool = executorFactory.create("build operations");
     }
 
     @Override

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationProcessorTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationProcessorTest.groovy
@@ -33,7 +33,7 @@ class DefaultBuildOperationProcessorTest extends ConcurrentSpec {
 
     def setupBuildOperationProcessor(int maxThreads) {
         workerRegistry = new DefaultBuildOperationWorkerRegistry(maxThreads)
-        buildOperationProcessor = new DefaultBuildOperationProcessor(workerRegistry, new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory(), maxThreads)
+        buildOperationProcessor = new DefaultBuildOperationProcessor(workerRegistry, new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory())
         outerOperationCompletion = workerRegistry.operationStart();
         outerOperation = workerRegistry.getCurrent()
     }
@@ -43,6 +43,52 @@ class DefaultBuildOperationProcessorTest extends ConcurrentSpec {
             outerOperationCompletion.operationFinish()
             workerRegistry.stop()
         }
+    }
+
+    @Unroll
+    def "all (#operations + 16) operations spread across 8 nested usage levels run to completion when using #maxWorkers workers"() {
+        given:
+        setupBuildOperationProcessor(maxWorkers)
+        def operation = Mock(DefaultBuildOperationQueueTest.TestBuildOperation)
+        def worker = new DefaultBuildOperationQueueTest.SimpleWorker()
+
+        and:
+        def nest
+        nest = { BuildOperationQueue queue, int level ->
+            if (level < 8) {
+                queue.add(operation)
+                queue.add(new DefaultBuildOperationQueueTest.TestBuildOperation() {
+                    @Override
+                    void run() {
+                        buildOperationProcessor.run(worker, { q ->
+                            nest(q, level + 1)
+                        })
+                    }
+                })
+                queue.add(operation)
+            } else {
+                operations.times {
+                    queue.add(operation)
+                }
+            }
+        }
+
+        when:
+        buildOperationProcessor.run(worker, { queue ->
+            nest(queue, 0)
+        })
+
+        then:
+        (operations + 16) * operation.run()
+
+        where:
+        operations | maxWorkers
+        0          | 1
+        1          | 1
+        20         | 1
+        1          | 4
+        4          | 4
+        20         | 4
     }
 
     @Unroll
@@ -192,7 +238,7 @@ class DefaultBuildOperationProcessorTest extends ConcurrentSpec {
         def buildQueue = Mock(BuildOperationQueue)
         def buildOperationQueueFactory = Mock(BuildOperationQueueFactory)
 
-        buildOperationProcessor = new DefaultBuildOperationProcessor(workerRegistry, new TestBuildOperationExecutor(), buildOperationQueueFactory, Stub(ExecutorFactory), 1)
+        buildOperationProcessor = new DefaultBuildOperationProcessor(workerRegistry, new TestBuildOperationExecutor(), buildOperationQueueFactory, Stub(ExecutorFactory))
         def worker = Stub(BuildOperationWorker)
         def operation = Mock(DefaultBuildOperationQueueTest.TestBuildOperation)
 
@@ -224,7 +270,7 @@ class DefaultBuildOperationProcessorTest extends ConcurrentSpec {
         def buildOperationQueueFactory = Mock(BuildOperationQueueFactory) {
             create(_, _, _) >> { buildQueue }
         }
-        def buildOperationProcessor = new DefaultBuildOperationProcessor(workerRegistry, new TestBuildOperationExecutor(), buildOperationQueueFactory, Stub(ExecutorFactory), 1)
+        def buildOperationProcessor = new DefaultBuildOperationProcessor(workerRegistry, new TestBuildOperationExecutor(), buildOperationQueueFactory, Stub(ExecutorFactory))
         def worker = Stub(BuildOperationWorker)
         def operation = Mock(DefaultBuildOperationQueueTest.TestBuildOperation)
 
@@ -254,7 +300,7 @@ class DefaultBuildOperationProcessorTest extends ConcurrentSpec {
         def buildOperationQueueFactory = Mock(BuildOperationQueueFactory) {
             create(_, _, _) >> { buildQueue }
         }
-        def buildOperationProcessor = new DefaultBuildOperationProcessor(workerRegistry, new TestBuildOperationExecutor(), buildOperationQueueFactory, Stub(ExecutorFactory), 1)
+        def buildOperationProcessor = new DefaultBuildOperationProcessor(workerRegistry, new TestBuildOperationExecutor(), buildOperationQueueFactory, Stub(ExecutorFactory))
         def worker = Stub(BuildOperationWorker)
         def operation = Mock(DefaultBuildOperationQueueTest.TestBuildOperation)
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
@@ -26,7 +26,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         given:
         def maxWorkers = 1
         def registry = new DefaultBuildOperationWorkerRegistry(maxWorkers)
-        def processor = new DefaultBuildOperationProcessor(registry, new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory(), maxWorkers)
+        def processor = new DefaultBuildOperationProcessor(registry, new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory())
         def processorWorker = new DefaultBuildOperationQueueTest.SimpleWorker()
 
         when:
@@ -66,7 +66,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         given:
         def maxWorkers = 1
         def registry = new DefaultBuildOperationWorkerRegistry(maxWorkers)
-        def processor = new DefaultBuildOperationProcessor(registry, new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory(), maxWorkers)
+        def processor = new DefaultBuildOperationProcessor(registry, new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory())
         def processorWorker = new DefaultBuildOperationQueueTest.SimpleWorker()
 
         when:
@@ -106,7 +106,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         given:
         def maxWorkers = 1
         def registry = new DefaultBuildOperationWorkerRegistry(maxWorkers)
-        def processor = new DefaultBuildOperationProcessor(registry, new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory(), maxWorkers)
+        def processor = new DefaultBuildOperationProcessor(registry, new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory())
         def processorWorker = new DefaultBuildOperationQueueTest.SimpleWorker()
 
         when:

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -80,8 +80,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new DefaultDeploymentRegistry();
     }
 
-    BuildOperationProcessor createBuildOperationProcessor(BuildOperationWorkerRegistry buildOperationWorkerRegistry, BuildOperationExecutor buildOperationExecutor, StartParameter startParameter, ExecutorFactory executorFactory) {
-        return new DefaultBuildOperationProcessor(buildOperationWorkerRegistry, buildOperationExecutor, new DefaultBuildOperationQueueFactory(), executorFactory, startParameter.getMaxWorkerCount());
+    BuildOperationProcessor createBuildOperationProcessor(BuildOperationWorkerRegistry buildOperationWorkerRegistry, BuildOperationExecutor buildOperationExecutor, ExecutorFactory executorFactory) {
+        return new DefaultBuildOperationProcessor(buildOperationWorkerRegistry, buildOperationExecutor, new DefaultBuildOperationQueueFactory(), executorFactory);
     }
 
     BuildOperationWorkerRegistry createBuildOperationWorkerRegistry(StartParameter startParameter) {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.operations.BuildOperationProcessor
 import org.gradle.internal.operations.BuildOperationWorkerRegistry
 import org.gradle.internal.operations.DefaultBuildOperationProcessor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
+import org.gradle.internal.operations.DefaultBuildOperationWorkerRegistry
 import org.gradle.internal.operations.logging.BuildOperationLogger
 import org.gradle.internal.progress.TestBuildOperationExecutor
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory
@@ -48,7 +49,7 @@ abstract class NativeCompilerTest extends Specification {
 
     protected CommandLineToolInvocationWorker commandLineTool = Mock(CommandLineToolInvocationWorker)
 
-    protected BuildOperationProcessor buildOperationProcessor = new DefaultBuildOperationProcessor(Stub(BuildOperationWorkerRegistry), new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory(), 1)
+    protected BuildOperationProcessor buildOperationProcessor = new DefaultBuildOperationProcessor(new DefaultBuildOperationWorkerRegistry(1), new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory())
 
     def "arguments include source file"() {
         given:

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.internal.operations.BuildOperationProcessor
 import org.gradle.internal.operations.BuildOperationWorkerRegistry
 import org.gradle.internal.operations.DefaultBuildOperationProcessor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
+import org.gradle.internal.operations.DefaultBuildOperationWorkerRegistry
 import org.gradle.internal.progress.TestBuildOperationExecutor
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -41,7 +42,7 @@ class DefaultTestReportTest extends Specification {
     final TestResultsProvider testResultProvider = Mock()
 
     def reportWithMaxThreads(int numThreads) {
-        buildOperationProcessor = new DefaultBuildOperationProcessor(Stub(BuildOperationWorkerRegistry), new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory(), numThreads)
+        buildOperationProcessor = new DefaultBuildOperationProcessor(new DefaultBuildOperationWorkerRegistry(numThreads), new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory())
         return new DefaultTestReport(buildOperationProcessor)
     }
 

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -22,6 +22,7 @@ import org.gradle.internal.operations.BuildOperationProcessor
 import org.gradle.internal.operations.BuildOperationWorkerRegistry
 import org.gradle.internal.operations.DefaultBuildOperationProcessor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
+import org.gradle.internal.operations.DefaultBuildOperationWorkerRegistry
 import org.gradle.internal.operations.MultipleBuildOperationFailures
 import org.gradle.internal.progress.TestBuildOperationExecutor
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -37,7 +38,7 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
     Binary2JUnitXmlReportGenerator generator
 
     def generatorWithMaxThreads(int numThreads) {
-        buildOperationProcessor = new DefaultBuildOperationProcessor(Stub(BuildOperationWorkerRegistry), new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory(), numThreads)
+        buildOperationProcessor = new DefaultBuildOperationProcessor(new DefaultBuildOperationWorkerRegistry(numThreads), new TestBuildOperationExecutor(), new DefaultBuildOperationQueueFactory(), new DefaultExecutorFactory())
         Binary2JUnitXmlReportGenerator reportGenerator = new Binary2JUnitXmlReportGenerator(temp.testDirectory, resultsProvider, TestOutputAssociation.WITH_SUITE, buildOperationProcessor, "localhost")
         reportGenerator.xmlWriter = Mock(JUnitXmlResultWriter)
         return reportGenerator


### PR DESCRIPTION
Use a dynamically sized thread pool in BuildOperationProcessor to allow
nested usage. Maximum in-flight work is managed by worker leases, the
size of that thread pool has nothing to do with that. It being caped
at maxWorkers made it impossible to use BuildOperationProcessor inside
a work enqueued to BuildOperationProcessor up to a certain degree. This
commit fixes that.
