### PR TITLE
Avoid intermediate objects for occasional failures

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactFailuresCollector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactFailuresCollector.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
+
+import org.gradle.api.artifacts.ResolvedArtifact;
+
+interface ArtifactFailuresCollector {
+    void addFailure(ResolvedArtifact resolvedArtifact, Throwable err);
+}


### PR DESCRIPTION
Fix for performance regression introduced by the parallel download of artifacts.

See gradle/performance#512