### PR TITLE
Make Path more efficient

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterSpec.groovy
@@ -153,7 +153,7 @@ class DefaultTaskGraphExecuterSpec extends Specification {
     def task(String name) {
         def mock = Mock(TaskInternal)
         _ * mock.name >> name
-        _ * mock.identityPath >> project.identityPath.resolve(name)
+        _ * mock.identityPath >> project.identityPath.child(name)
         _ * mock.project >> project
         _ * mock.state >> Stub(TaskStateInternal) {
             getFailure() >> null
@@ -172,7 +172,7 @@ class DefaultTaskGraphExecuterSpec extends Specification {
     def brokenTask(String name, RuntimeException failure) {
         def mock = Mock(TaskInternal)
         _ * mock.name >> name
-        _ * mock.identityPath >> project.identityPath.resolve(name)
+        _ * mock.identityPath >> project.identityPath.child(name)
         _ * mock.project >> project
         _ * mock.state >> Stub(TaskStateInternal) {
             getFailure() >> failure

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultProjectDescriptorTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultProjectDescriptorTest.java
@@ -72,7 +72,7 @@ public class DefaultProjectDescriptorTest {
         final ProjectDescriptorRegistry projectDescriptorRegistryMock = context.mock(ProjectDescriptorRegistry.class);
         projectDescriptor.setProjectDescriptorRegistry(projectDescriptorRegistryMock);
         context.checking(new Expectations() {{
-            one(projectDescriptorRegistryMock).changeDescriptorPath(Path.path(TEST_NAME), Path.path(Project.PATH_SEPARATOR + newName));
+            one(projectDescriptorRegistryMock).changeDescriptorPath(Path.path(Project.PATH_SEPARATOR + TEST_NAME), Path.path(Project.PATH_SEPARATOR + newName));
         }});
         projectDescriptor.setName(newName);
         assertEquals(newName, projectDescriptor.getName());

--- a/subprojects/core/src/test/groovy/org/gradle/util/PathTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/PathTest.groovy
@@ -38,7 +38,8 @@ class PathTest extends Specification {
         strictlyEquals(Path.ROOT, Path.ROOT)
         strictlyEquals(Path.path('path'), Path.path('path'))
         strictlyEquals(Path.path(':a:path'), Path.path(':a:path'))
-        Path.path(':a') != Path.path(':b')
+        !strictlyEquals(Path.path(':a'), Path.path(':b'))
+        !strictlyEquals(Path.path(':a'), Path.path('a'))
     }
 
     def canGetParent() {
@@ -72,14 +73,12 @@ class PathTest extends Specification {
 
         then:
         path.absolutePath('path') == ':path'
-        path.resolve('path') == Path.path(':path')
 
         when:
         path = Path.path(':sub')
 
         then:
         path.absolutePath('path') == ':sub:path'
-        path.resolve('path') == Path.path(':sub:path')
     }
 
     def convertsAbsolutePathToAbsolutePath() {
@@ -88,8 +87,6 @@ class PathTest extends Specification {
         expect:
         path.absolutePath(':') == ':'
         path.absolutePath(':path') == ':path'
-        path.resolve(':') == Path.path(':')
-        path.resolve(':path') == Path.path(':path')
     }
 
     def convertsAbsolutePathToRelativePath() {


### PR DESCRIPTION
The segments in paths are very repetitive (e.g. core:integTest, ide:integTest, ...),
so interning them compacts their memory usage quite a bit. In order to benefit more
from that, we should use `Path` instead of `String` in more places.