### PR TITLE
Make BasicScript faster

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
@@ -16,12 +16,15 @@
 
 package org.gradle.groovy.scripts;
 
-import groovy.lang.MetaClass;
+import groovy.lang.Binding;
+import groovy.lang.MissingMethodException;
+import groovy.lang.MissingPropertyException;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.DynamicObjectUtil;
 import org.gradle.api.internal.ProcessOperations;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.internal.logging.StandardOutputCapture;
+import org.gradle.internal.metaobject.AbstractDynamicObject;
 import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.DynamicObject;
@@ -33,9 +36,7 @@ import java.util.Map;
 public abstract class BasicScript extends org.gradle.groovy.scripts.Script implements org.gradle.api.Script, FileOperations, ProcessOperations, DynamicObjectAware {
     private StandardOutputCapture standardOutputCapture;
     private Object target;
-    private DynamicObject dynamicTarget;
-    private final BeanDynamicObject externalScriptObject = new BeanDynamicObject(this);
-    private final DynamicObject scriptObject = externalScriptObject.withNotImplementsMissing();
+    private DynamicObject dynamicObject = new ScriptDynamicObject(this, null);
 
     public void init(Object target, ServiceRegistry services) {
         standardOutputCapture = services.get(StandardOutputCapture.class);
@@ -48,7 +49,7 @@ public abstract class BasicScript extends org.gradle.groovy.scripts.Script imple
 
     private void setScriptTarget(Object target) {
         this.target = target;
-        this.dynamicTarget = DynamicObjectUtil.asDynamicObject(target);
+        this.dynamicObject = new ScriptDynamicObject(this, target);
     }
 
     public StandardOutputCapture getStandardOutputCapture() {
@@ -61,71 +62,112 @@ public abstract class BasicScript extends org.gradle.groovy.scripts.Script imple
 
     @Override
     public Object getProperty(String property) {
-        // Refactoring of groovy.lang.Script.getProperty logic
-        // to avoid unnecessary MissingPropertyException in binding variable lookup
-        if (getBinding().hasVariable(property)) {
-            return super.getProperty(property);
-        }
-        DynamicInvokeResult result = scriptObject.tryGetProperty(property);
-        if (result.isFound()) {
-            return result.getValue();
-        }
-        result = dynamicTarget.tryGetProperty(property);
-        if (result.isFound()) {
-            return result.getValue();
-        }
-        throw dynamicTarget.getMissingProperty(property);
+        return dynamicObject.getProperty(property);
     }
 
     @Override
     public void setProperty(String property, Object newValue) {
-        if ("metaClass".equals(property)) {
-            setMetaClass((MetaClass) newValue);
-        } else if ("scriptTarget".equals(property)) {
-            setScriptTarget(newValue);
-        } else {
-            dynamicTarget.setProperty(property, newValue);
-        }
+        dynamicObject.setProperty(property, newValue);
     }
 
     public Map<String, ?> getProperties() {
-        return dynamicTarget.getProperties();
+        return dynamicObject.getProperties();
     }
 
     public boolean hasProperty(String property) {
-        return getBinding().hasVariable(property) || scriptObject.hasProperty(property) || dynamicTarget.hasProperty(property);
+        return dynamicObject.hasProperty(property);
     }
 
     @Override
     public Object invokeMethod(String name, Object args) {
-        Object[] arguments = (Object[]) args;
-        DynamicInvokeResult result = scriptObject.tryInvokeMethod(name, arguments);
-        if (result.isFound()) {
-            return result.getValue();
-        }
-        result = dynamicTarget.tryInvokeMethod(name, arguments);
-        if (result.isFound()) {
-            return result.getValue();
-        }
-        throw dynamicTarget.methodMissingException(name, arguments);
-    }
-
-    public Object methodMissing(String name, Object args) {
-        return invokeMethod(name, args);
-    }
-
-    public Object propertyMissing(String name) {
-        return getProperty(name);
-    }
-
-    public void propertyMissing(String name, Object value) {
-        setProperty(name, value);
+        return dynamicObject.invokeMethod(name, (Object[]) args);
     }
 
     @Override
     public DynamicObject getAsDynamicObject() {
-        return externalScriptObject;
+        return dynamicObject;
     }
+
+    /**
+     * This is a performance optimization which avoids using BeanDynamicObject to wrap the Script object.
+     * Using BeanDynamicObject would be wasteful, because most of the interesting properties and methods
+     * are delegated to the script target. Doing this delegation explicitly avoids
+     * us going through the methodMissing/propertyMissing protocol that BeanDynamicObject would use.
+     */
+    private static final class ScriptDynamicObject extends AbstractDynamicObject {
+
+        private final Binding binding;
+        private final DynamicObject scriptObject;
+        private final DynamicObject dynamicTarget;
+
+        ScriptDynamicObject(BasicScript script, Object target) {
+            this.binding = script.getBinding();
+            scriptObject = new BeanDynamicObject(script).withNotImplementsMissing();
+            dynamicTarget = target == null ? scriptObject : DynamicObjectUtil.asDynamicObject(target);
+        }
+
+        @Override
+        public Map<String, ?> getProperties() {
+            return dynamicTarget.getProperties();
+        }
+
+        @Override
+        public boolean hasMethod(String name, Object... arguments) {
+            return scriptObject.hasMethod(name, arguments) || dynamicTarget.hasMethod(name, arguments);
+        }
+
+        @Override
+        public boolean hasProperty(String name) {
+            return binding.hasVariable(name) || scriptObject.hasProperty(name) || dynamicTarget.hasProperty(name);
+        }
+
+        @Override
+        public DynamicInvokeResult tryInvokeMethod(String name, Object... arguments) {
+            DynamicInvokeResult result = scriptObject.tryInvokeMethod(name, arguments);
+            if (result.isFound()) {
+                return result;
+            }
+            return dynamicTarget.tryInvokeMethod(name, arguments);
+        }
+
+        @Override
+        public DynamicInvokeResult tryGetProperty(String property) {
+            if (binding.hasVariable(property)) {
+                return DynamicInvokeResult.found(binding.getVariable(property));
+            }
+            DynamicInvokeResult result = scriptObject.tryGetProperty(property);
+            if (result.isFound()) {
+                return result;
+            }
+            return dynamicTarget.tryGetProperty(property);
+        }
+
+        @Override
+        public DynamicInvokeResult trySetProperty(String property, Object newValue) {
+            return dynamicTarget.trySetProperty(property, newValue);
+        }
+
+        @Override
+        public MissingPropertyException getMissingProperty(String name) {
+            return dynamicTarget.getMissingProperty(name);
+        }
+
+        @Override
+        public MissingMethodException methodMissingException(String name, Object... params) {
+            return dynamicTarget.methodMissingException(name, params);
+        }
+
+        @Override
+        public MissingPropertyException setMissingProperty(String name) {
+            return dynamicTarget.setMissingProperty(name);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return dynamicTarget.toString();
+        }
+    }
+
 }
 
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -32,7 +32,7 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.tasksToRun = ['tasks']
         runner.args = ['--recompile-scripts'] // This is an approximation of first use: we recompile the scripts
         runner.useDaemon = false
-        runner.targetVersions = ["3.5-20170221000043+0000"]
+        runner.targetVersions = ["4.0-20170406000015+0000"]
 
         when:
         def result = runner.run()


### PR DESCRIPTION
Avoid reflection by implementing the delegation
to the script target by hand.

Accept the performance regression in script compilation caused
by adding the `asDynamicObject` method. The faster run time is worth
the additional time spent compiling.