### PR TITLE
Fix no-daemon performance tests

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -45,4 +45,24 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
         LARGE_MONOLITHIC_JAVA_PROJECT | _
         LARGE_JAVA_MULTI_PROJECT      | _
     }
+
+    @Unroll
+    def "cold daemon on #testProject"() {
+        given:
+        runner.testProject = testProject
+        runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
+        runner.tasksToRun = ['tasks']
+        runner.useDaemon = false
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        where:
+        testProject                   | _
+        LARGE_MONOLITHIC_JAVA_PROJECT | _
+        LARGE_JAVA_MULTI_PROJECT      | _
+    }
 }


### PR DESCRIPTION
Pass the jvm args to the client VM, so Gradle isn't forced to start
a single-use daemon.

Adds a test for a cold daemon, but without recompling scripts, i.e.
what a developer usually experiences in the morning when they turn
on their laptop.