### PR TITLE
Remove deprecated constructors on DirectoryFileTree

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -71,7 +71,7 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
         this.instantiator = instantiator;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
         this.resourceHandler = new DefaultResourceHandler(this, temporaryFileProvider);
-        this.fileCopier = new FileCopier(this.instantiator, this.fileResolver, fileLookup);
+        this.fileCopier = new FileCopier(this.instantiator, this.fileResolver, fileLookup, directoryFileTreeFactory);
         this.fileSystem = fileLookup.getFileSystem();
         this.deleter = new Deleter(fileResolver, fileSystem);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.internal.nativeintegration.services.FileSystems;
 import org.gradle.util.GUtil;
 
 import java.io.File;
@@ -214,7 +215,7 @@ public class DefaultFileCollectionResolveContext implements ResolvableFileCollec
 
         private void convertFileToFileTree(File file, Collection<? super FileTreeInternal> result) {
             if (file.isDirectory()) {
-                result.add(new FileTreeAdapter(new DirectoryFileTree(file, patternSetFactory.create())));
+                result.add(new FileTreeAdapter(new DirectoryFileTree(file, patternSetFactory.create(), FileSystems.getDefault())));
             } else if (file.isFile()) {
                 result.add(new FileTreeAdapter(new SingletonFileTree(file)));
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -59,14 +59,6 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
     private final FileSystem fileSystem;
     private final Factory<DirectoryWalker> directoryWalkerFactory;
 
-    /**
-     * Use {@link DirectoryFileTreeFactory} instead.
-     */
-    @Deprecated
-    public DirectoryFileTree(File dir, PatternSet patternSet) {
-        this(dir, patternSet, FileSystems.getDefault());
-    }
-
     public DirectoryFileTree(File dir, PatternSet patternSet, FileSystem fileSystem) {
         this(FileUtils.canonicalize(dir), patternSet, DEFAULT_DIRECTORY_WALKER_FACTORY, fileSystem, false);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -63,14 +63,6 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
      * Use {@link DirectoryFileTreeFactory} instead.
      */
     @Deprecated
-    public DirectoryFileTree(File dir) {
-        this(dir, new PatternSet(), FileSystems.getDefault());
-    }
-
-    /**
-     * Use {@link DirectoryFileTreeFactory} instead.
-     */
-    @Deprecated
     public DirectoryFileTree(File dir, PatternSet patternSet) {
         this(dir, patternSet, FileSystems.getDefault());
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/FileBackedDirectoryFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/FileBackedDirectoryFileTree.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.file.collections;
 
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.nativeintegration.services.FileSystems;
 
 import java.io.File;
 
@@ -24,7 +25,7 @@ public class FileBackedDirectoryFileTree extends DirectoryFileTree {
     private final File file;
 
     public FileBackedDirectoryFileTree(File file) {
-        super(file.getParentFile(), new PatternSet().include(file.getName()));
+        super(file.getParentFile(), new PatternSet().include(file.getName()), FileSystems.getDefault());
         this.file = file;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/MapFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/MapFileTree.java
@@ -48,18 +48,20 @@ public class MapFileTree implements MinimalFileTree, FileSystemMirroringFileTree
     private final Map<RelativePath, Action<OutputStream>> elements = new LinkedHashMap<RelativePath, Action<OutputStream>>();
     private final Factory<File> tmpDirSource;
     private final Chmod chmod;
+    private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public MapFileTree(final File tmpDir, Chmod chmod) {
+    public MapFileTree(final File tmpDir, Chmod chmod, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this(new Factory<File>() {
                 public File create() {
                     return tmpDir;
                 }
-        }, chmod);
+        }, chmod, directoryFileTreeFactory);
     }
 
-    public MapFileTree(Factory<File> tmpDirSource, Chmod chmod) {
+    public MapFileTree(Factory<File> tmpDirSource, Chmod chmod, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this.tmpDirSource = tmpDirSource;
         this.chmod = chmod;
+        this.directoryFileTreeFactory = directoryFileTreeFactory;
     }
 
     private File getTmpDir() {
@@ -71,7 +73,7 @@ public class MapFileTree implements MinimalFileTree, FileSystemMirroringFileTree
     }
 
     public DirectoryFileTree getMirror() {
-        return new DirectoryFileTree(getTmpDir());
+        return directoryFileTreeFactory.create(getTmpDir());
     }
 
     public void visit(FileVisitor visitor) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
@@ -78,7 +78,7 @@ public class SingleIncludePatternFileTree implements MinimalFileTree {
             PatternSet patternSet = new PatternSet();
             patternSet.include(includePattern);
             patternSet.exclude(excludeSpec);
-            DirectoryFileTree fileTree = new DirectoryFileTree(baseDir, patternSet, FileSystems.getDefault());
+            DirectoryFileTree fileTree = new DirectoryFileTree(baseDir, patternSet, fileSystem);
             fileTree.visitFrom(visitor, file, new RelativePath(file.isFile(), relativePath.toArray(new String[relativePath.size()])));
         } else if (segment.contains("*") || segment.contains("?")) {
             PatternStep step = PatternStepFactory.getStep(segment, false);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
@@ -78,7 +78,7 @@ public class SingleIncludePatternFileTree implements MinimalFileTree {
             PatternSet patternSet = new PatternSet();
             patternSet.include(includePattern);
             patternSet.exclude(excludeSpec);
-            DirectoryFileTree fileTree = new DirectoryFileTree(baseDir, patternSet);
+            DirectoryFileTree fileTree = new DirectoryFileTree(baseDir, patternSet, FileSystems.getDefault());
             fileTree.visitFrom(visitor, file, new RelativePath(file.isFile(), relativePath.toArray(new String[relativePath.size()])));
         } else if (segment.contains("*") || segment.contains("?")) {
             PatternStep step = PatternStepFactory.getStep(segment, false);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopier.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -28,11 +29,13 @@ public class FileCopier {
     private final Instantiator instantiator;
     private final FileResolver fileResolver;
     private final FileLookup fileLookup;
+    private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public FileCopier(Instantiator instantiator, FileResolver fileResolver, FileLookup fileLookup) {
+    public FileCopier(Instantiator instantiator, FileResolver fileResolver, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this.instantiator = instantiator;
         this.fileResolver = fileResolver;
         this.fileLookup = fileLookup;
+        this.directoryFileTreeFactory = directoryFileTreeFactory;
     }
 
     private DestinationRootCopySpec createCopySpec(Action<? super CopySpec> action) {
@@ -52,7 +55,7 @@ public class FileCopier {
     public WorkResult sync(Action<? super CopySpec> action) {
         DestinationRootCopySpec copySpec = createCopySpec(action);
         File destinationDir = copySpec.getDestinationDir();
-        return doCopy(copySpec, new SyncCopyActionDecorator(destinationDir, getCopyVisitor(destinationDir)));
+        return doCopy(copySpec, new SyncCopyActionDecorator(destinationDir, getCopyVisitor(destinationDir), directoryFileTreeFactory));
     }
 
     private FileCopyAction getCopyVisitor(File destination) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
@@ -20,7 +20,7 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
-import org.gradle.api.internal.file.collections.DirectoryFileTree;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.specs.Spec;
@@ -37,15 +37,17 @@ public class SyncCopyActionDecorator implements CopyAction {
     private final File baseDestDir;
     private final CopyAction delegate;
     private final PatternFilterable preserveSpec;
+    private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public SyncCopyActionDecorator(File baseDestDir, CopyAction delegate) {
-        this(baseDestDir, delegate, null);
+    public SyncCopyActionDecorator(File baseDestDir, CopyAction delegate, DirectoryFileTreeFactory directoryFileTreeFactory) {
+        this(baseDestDir, delegate, null, directoryFileTreeFactory);
     }
 
-    public SyncCopyActionDecorator(File baseDestDir, CopyAction delegate, PatternFilterable preserveSpec) {
+    public SyncCopyActionDecorator(File baseDestDir, CopyAction delegate, PatternFilterable preserveSpec, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this.baseDestDir = baseDestDir;
         this.delegate = delegate;
         this.preserveSpec = preserveSpec;
+        this.directoryFileTreeFactory = directoryFileTreeFactory;
     }
 
     public WorkResult execute(final CopyActionProcessingStream stream) {
@@ -64,7 +66,7 @@ public class SyncCopyActionDecorator implements CopyAction {
 
         SyncCopyActionDecoratorFileVisitor fileVisitor = new SyncCopyActionDecoratorFileVisitor(visited, preserveSpec);
 
-        MinimalFileTree walker = new DirectoryFileTree(baseDestDir).postfix();
+        MinimalFileTree walker = directoryFileTreeFactory.create(baseDestDir).postfix();
         walker.visit(fileVisitor);
         visited.clear();
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.copy.ClosureBackedTransformer;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopyActionExecuter;
@@ -169,6 +170,11 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
 
     @Inject
     protected FileLookup getFileLookup() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected DirectoryFileTreeFactory getDirectoryFileTreeFactory() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -74,7 +74,7 @@ public class Sync extends AbstractCopyTask {
         if (destinationDir == null) {
             throw new InvalidUserDataException("No copy destination directory has been specified, use 'into' to specify a target directory.");
         }
-        return new SyncCopyActionDecorator(destinationDir, new FileCopyAction(getFileLookup().getFileResolver(destinationDir)), preserveInDestination);
+        return new SyncCopyActionDecorator(destinationDir, new FileCopyAction(getFileLookup().getFileResolver(destinationDir)), preserveInDestination, getDirectoryFileTreeFactory());
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionTest.java
@@ -17,7 +17,9 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -155,8 +157,9 @@ public class CompositeFileCollectionTest {
 
     @Test
     public void getAsFileTreesReturnsUnionOfFileTrees() {
-        final DirectoryFileTree set1 = new DirectoryFileTree(new File("dir1").getAbsoluteFile());
-        final DirectoryFileTree set2 = new DirectoryFileTree(new File("dir2").getAbsoluteFile());
+        final DirectoryFileTreeFactory directoryFileTreeFactory = new DefaultDirectoryFileTreeFactory();
+        final DirectoryFileTree set1 = directoryFileTreeFactory.create(new File("dir1").getAbsoluteFile());
+        final DirectoryFileTree set2 = directoryFileTreeFactory.create(new File("dir2").getAbsoluteFile());
 
         context.checking(new Expectations() {{
             oneOf(source1).getAsFileTrees();

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTreeTest.groovy
@@ -54,7 +54,7 @@ class DefaultConfigurableFileTreeTest extends AbstractTestForPatternSet {
     @Rule public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     File testDir = tmpDir.testDirectory
     FileResolver fileResolverStub = resolver(testDir)
-    FileCopier fileCopier = new FileCopier(DirectInstantiator.INSTANCE, fileResolverStub, context.mock(FileLookup))
+    FileCopier fileCopier
 
     PatternFilterable getPatternSet() {
         return fileSet
@@ -64,6 +64,7 @@ class DefaultConfigurableFileTreeTest extends AbstractTestForPatternSet {
         super.setUp()
         NativeServicesTestFixture.initialize()
         fileSet = new DefaultConfigurableFileTree(testDir, fileResolverStub, taskResolverStub, fileCopier, directoryFileTreeFactory())
+        fileCopier = new FileCopier(DirectInstantiator.INSTANCE, fileResolverStub, context.mock(FileLookup), new DefaultDirectoryFileTreeFactory())
     }
 
     @Test public void testFileSetConstructionWithBaseDir() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTreeTest.groovy
@@ -64,7 +64,7 @@ class DefaultConfigurableFileTreeTest extends AbstractTestForPatternSet {
         super.setUp()
         NativeServicesTestFixture.initialize()
         fileSet = new DefaultConfigurableFileTree(testDir, fileResolverStub, taskResolverStub, fileCopier, directoryFileTreeFactory())
-        fileCopier = new FileCopier(DirectInstantiator.INSTANCE, fileResolverStub, context.mock(FileLookup), new DefaultDirectoryFileTreeFactory())
+        fileCopier = new FileCopier(DirectInstantiator.INSTANCE, fileResolverStub, context.mock(FileLookup), directoryFileTreeFactory())
     }
 
     @Test public void testFileSetConstructionWithBaseDir() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -65,7 +65,8 @@ class FileTreeAdapterTest extends Specification {
     def getAsFileTreesConvertsMirroringFileTreeByVisitingAllElementsAndReturningLocalMirror() {
         FileSystemMirroringFileTree tree = Mock()
         FileTreeAdapter adapter = new FileTreeAdapter(tree)
-        DirectoryFileTree mirror = new DirectoryFileTree(new File('a'))
+        DirectoryFileTreeFactory directoryFileTreeFactory = new DefaultDirectoryFileTreeFactory()
+        DirectoryFileTree mirror = directoryFileTreeFactory.create(new File('a'))
 
         when:
         def result = adapter.asFileTrees
@@ -147,7 +148,8 @@ class FileTreeAdapterTest extends Specification {
 
     def visitsBackingDirectoryTree() {
         def visitor = Mock(FileCollectionVisitor)
-        def tree = new DirectoryFileTree(new File("dir"))
+        def directoryFileTreeFactory = new DefaultDirectoryFileTreeFactory()
+        def tree = directoryFileTreeFactory.create(new File("dir"))
         def adapter = new FileTreeAdapter(tree)
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.gradle.api.file.FileVisitorUtil.assertCanStopVisiting;
 import static org.gradle.api.file.FileVisitorUtil.assertVisits;
+import static org.gradle.api.internal.file.TestFiles.directoryFileTreeFactory;
 import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForAllTypes;
 import static org.gradle.util.WrapUtil.toList;
 import static org.hamcrest.Matchers.equalTo;
@@ -48,8 +49,7 @@ public class MapFileTreeTest {
     @Before
     public void setup() {
         NativeServicesTestFixture.initialize();
-        DirectoryFileTreeFactory directoryFileTreeFactory = new DefaultDirectoryFileTreeFactory();
-        tree = new MapFileTree(rootDir, TestFiles.fileSystem(), directoryFileTreeFactory);
+        tree = new MapFileTree(rootDir, TestFiles.fileSystem(), directoryFileTreeFactory());
     }
 
     @Test

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
@@ -20,6 +20,8 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.file.TestFiles;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
+import org.gradle.testfixtures.internal.NativeServicesTestFixture;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -41,7 +43,14 @@ public class MapFileTreeTest {
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
     private TestFile rootDir = tmpDir.getTestDirectory();
-    private final MapFileTree tree = new MapFileTree(rootDir, TestFiles.fileSystem());
+    private MapFileTree tree;
+
+    @Before
+    public void setup() {
+        NativeServicesTestFixture.initialize();
+        DirectoryFileTreeFactory directoryFileTreeFactory = new DefaultDirectoryFileTreeFactory();
+        tree = new MapFileTree(rootDir, TestFiles.fileSystem(), directoryFileTreeFactory);
+    }
 
     @Test
     public void isEmptyByDefault() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/SyncCopyActionDecoratorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/SyncCopyActionDecoratorTest.groovy
@@ -17,15 +17,18 @@ package org.gradle.api.internal.file.copy
 
 import org.gradle.api.Action
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.test.fixtures.file.WorkspaceTest
+import org.gradle.util.UsesNativeServices
 
+@UsesNativeServices
 class SyncCopyActionDecoratorTest extends WorkspaceTest {
 
     FileCopier copier
 
     def setup() {
-        copier = new FileCopier(DirectInstantiator.INSTANCE, TestFiles.resolver(testDirectory), TestFiles.fileLookup())
+        copier = new FileCopier(DirectInstantiator.INSTANCE, TestFiles.resolver(testDirectory), TestFiles.fileLookup(), new DefaultDirectoryFileTreeFactory())
     }
 
     void deletesExtraFilesFromDestinationDirectoryAtTheEndOfVisit() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -66,6 +66,7 @@ import org.gradle.api.internal.cache.GeneratedGradleJarCache;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore;
 import org.gradle.api.internal.notations.ClientModuleNotationParserFactory;
 import org.gradle.api.internal.notations.DependencyNotationParser;
@@ -144,8 +145,8 @@ class DependencyManagementBuildScopeServices {
             projectDependencyFactory);
     }
 
-    RuntimeShadedJarFactory createRuntimeShadedJarFactory(GeneratedGradleJarCache jarCache, ProgressLoggerFactory progressLoggerFactory) {
-        return new RuntimeShadedJarFactory(jarCache, progressLoggerFactory);
+    RuntimeShadedJarFactory createRuntimeShadedJarFactory(GeneratedGradleJarCache jarCache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory) {
+        return new RuntimeShadedJarFactory(jarCache, progressLoggerFactory, directoryFileTreeFactory);
     }
 
     BuildCommencedTimeProvider createBuildTimeProvider() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/PackageListGenerator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/PackageListGenerator.java
@@ -20,7 +20,7 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.internal.file.collections.DirectoryFileTree;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -29,6 +29,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
 
+import javax.inject.Inject;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
@@ -99,6 +100,11 @@ public class PackageListGenerator extends DefaultTask {
         this.excludes = excludes;
     }
 
+    @Inject
+    protected DirectoryFileTreeFactory getDirectoryFileTreeFactory() {
+        throw new UnsupportedOperationException();
+    }
+
     @TaskAction
     public void generate() {
         IoActions.writeTextFile(getOutputFile(), new ErroringAction<BufferedWriter>() {
@@ -132,7 +138,7 @@ public class PackageListGenerator extends DefaultTask {
     }
 
     private void processDirectory(File file, final Trie.Builder builder) {
-        new DirectoryFileTree(file).visit(new FileVisitor() {
+        getDirectoryFileTreeFactory().create(file).visit(new FileVisitor() {
             @Override
             public void visitDir(FileVisitDetails dirDetails) {
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
@@ -24,7 +24,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.internal.file.collections.DirectoryFileTree;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
@@ -79,10 +79,12 @@ class RuntimeShadedJarCreator {
 
     private final ProgressLoggerFactory progressLoggerFactory;
     private final ImplementationDependencyRelocator remapper;
+    private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public RuntimeShadedJarCreator(ProgressLoggerFactory progressLoggerFactory, ImplementationDependencyRelocator remapper) {
+    public RuntimeShadedJarCreator(ProgressLoggerFactory progressLoggerFactory, ImplementationDependencyRelocator remapper, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this.progressLoggerFactory = progressLoggerFactory;
         this.remapper = remapper;
+        this.directoryFileTreeFactory = directoryFileTreeFactory;
     }
 
     public void create(final File outputJar, final Iterable<? extends File> files) {
@@ -169,7 +171,7 @@ class RuntimeShadedJarCreator {
 
     private void processDirectory(final ZipOutputStream outputStream, File file, final byte[] buffer, final HashSet<String> seenPaths, final Map<String, List<String>> services) {
         final List<FileVisitDetails> fileVisitDetails = new ArrayList<FileVisitDetails>();
-        new DirectoryFileTree(file).visit(new FileVisitor() {
+        directoryFileTreeFactory.create(file).visit(new FileVisitor() {
             @Override
             public void visitDir(FileVisitDetails dirDetails) {
                 fileVisitDetails.add(dirDetails);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarFactory.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.runtimeshaded;
 
 import org.gradle.api.Action;
 import org.gradle.api.internal.cache.GeneratedGradleJarCache;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,10 +32,12 @@ public class RuntimeShadedJarFactory {
 
     private final GeneratedGradleJarCache cache;
     private final ProgressLoggerFactory progressLoggerFactory;
+    private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public RuntimeShadedJarFactory(GeneratedGradleJarCache cache, ProgressLoggerFactory progressLoggerFactory) {
+    public RuntimeShadedJarFactory(GeneratedGradleJarCache cache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this.cache = cache;
         this.progressLoggerFactory = progressLoggerFactory;
+        this.directoryFileTreeFactory = directoryFileTreeFactory;
     }
 
     public File get(final RuntimeShadedJarType type, final Collection<? extends File> classpath) {
@@ -43,7 +46,8 @@ public class RuntimeShadedJarFactory {
             public void execute(File file) {
                 RuntimeShadedJarCreator creator = new RuntimeShadedJarCreator(
                     progressLoggerFactory,
-                    new ImplementationDependencyRelocator(type)
+                    new ImplementationDependencyRelocator(type),
+                    directoryFileTreeFactory
                 );
                 creator.create(file, classpath);
              }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
@@ -21,6 +21,7 @@ import groovy.transform.stc.SimpleType
 import org.apache.ivy.core.settings.IvySettings
 import org.cyberneko.html.xercesbridge.XercesBridge
 import org.gradle.api.Action
+import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.internal.IoActions
 import org.gradle.internal.installation.GradleRuntimeShadedJarDetector
 import org.gradle.internal.logging.progress.ProgressLogger
@@ -51,8 +52,12 @@ class RuntimeShadedJarCreatorTest extends Specification {
 
     def progressLoggerFactory = Mock(ProgressLoggerFactory)
     def progressLogger = Mock(ProgressLogger)
-    def relocatedJarCreator = new RuntimeShadedJarCreator(progressLoggerFactory, new ImplementationDependencyRelocator(RuntimeShadedJarType.API))
+    def relocatedJarCreator
     def outputJar = tmpDir.testDirectory.file('gradle-api.jar')
+
+    def setup() {
+        relocatedJarCreator = new RuntimeShadedJarCreator(progressLoggerFactory, new ImplementationDependencyRelocator(RuntimeShadedJarType.API), new DefaultDirectoryFileTreeFactory())
+    }
 
     def "creates JAR file for input directory"() {
         given:

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -106,7 +106,7 @@ public class Ear extends Jar {
             public FileTreeAdapter call() {
                 final DeploymentDescriptor descriptor = getDeploymentDescriptor();
                 if (descriptor != null) {
-                    MapFileTree descriptorSource = new MapFileTree(getTemporaryDirFactory(), getFileSystem());
+                    MapFileTree descriptorSource = new MapFileTree(getTemporaryDirFactory(), getFileSystem(), getDirectoryFileTreeFactory());
                     if (descriptor.getLibraryDirectory() == null) {
                         descriptor.setLibraryDirectory(getLibDirName());
                     }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/jar/DefaultJarSnapshotterTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/jar/DefaultJarSnapshotterTest.groovy
@@ -22,7 +22,7 @@ import com.google.common.hash.HashCode
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.file.DefaultFileVisitDetails
-import org.gradle.api.internal.file.collections.DirectoryFileTree
+import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.file.collections.FileTreeAdapter
 import org.gradle.api.internal.hash.FileHasher
 import org.gradle.api.internal.tasks.compile.incremental.analyzer.ClassDependenciesAnalyzer
@@ -44,7 +44,7 @@ class DefaultJarSnapshotterTest extends Specification {
 
     def "creates snapshot for an empty jar"() {
         expect:
-        def snapshot = snapshotter.createSnapshot(HashCode.fromInt(123), new JarArchive(new File("a.jar"), new FileTreeAdapter(new DirectoryFileTree(new File("missing")))))
+        def snapshot = snapshotter.createSnapshot(HashCode.fromInt(123), new JarArchive(new File("a.jar"), new FileTreeAdapter(new DefaultDirectoryFileTreeFactory().create(new File("missing")))))
         snapshot.hashes.isEmpty()
         snapshot.analysis
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
@@ -61,7 +61,7 @@ public class Jar extends Zip {
         metaInf = (CopySpecInternal) getRootSpec().addFirst().into("META-INF");
         metaInf.addChild().from(new Callable<FileTreeAdapter>() {
             public FileTreeAdapter call() throws Exception {
-                MapFileTree manifestSource = new MapFileTree(getTemporaryDirFactory(), getFileSystem());
+                MapFileTree manifestSource = new MapFileTree(getTemporaryDirFactory(), getFileSystem(), getDirectoryFileTreeFactory());
                 manifestSource.add("MANIFEST.MF", new Action<OutputStream>() {
                     public void execute(OutputStream outputStream) {
                         Manifest manifest = getManifest();


### PR DESCRIPTION
Using the `DirectoryFileTreeFactory` becomes fairly excessive as it has to be pulled through the whole hierarchy of things. 

@adammurdoch Do we really want to do that for `DefaultFileCollectionResolveContext.java`, `FileBackedDirectoryFileTree.java` and `SingleIncludePatternFileTree.java` as well? It would require touching a lot of files if we want to use the `DirectoryFileTreeFactory` created by the global service.