### PR TITLE
Add distributionSha256Sum config to wrapper task

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.plugins.StartScriptGenerator;
 import org.gradle.api.internal.tasks.options.Option;
 import org.gradle.api.internal.tasks.options.OptionValues;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.IoActions;
@@ -93,6 +94,7 @@ public class Wrapper extends DefaultTask {
     private String distributionPath;
     private PathBase distributionBase = PathBase.GRADLE_USER_HOME;
     private String distributionUrl;
+    private String distributionSha256Sum;
     private GradleVersion gradleVersion;
     private DistributionType distributionType = DistributionType.BIN;
     private String archivePath;
@@ -172,6 +174,9 @@ public class Wrapper extends DefaultTask {
     private void writeProperties(File propertiesFileDestination) {
         Properties wrapperProperties = new Properties();
         wrapperProperties.put(WrapperExecutor.DISTRIBUTION_URL_PROPERTY, getDistributionUrl());
+        if (distributionSha256Sum != null) {
+            wrapperProperties.put(WrapperExecutor.DISTRIBUTION_SHA_256_SUM, distributionSha256Sum);
+        }
         wrapperProperties.put(WrapperExecutor.DISTRIBUTION_BASE_PROPERTY, distributionBase.toString());
         wrapperProperties.put(WrapperExecutor.DISTRIBUTION_PATH_PROPERTY, distributionPath);
         wrapperProperties.put(WrapperExecutor.ZIP_STORE_BASE_PROPERTY, archiveBase.toString());
@@ -356,6 +361,35 @@ public class Wrapper extends DefaultTask {
     }
 
     /**
+     * The SHA-256 hash sum of the gradle distribution.
+     *
+     * <p>If not set, the hash sum of the gradle distribution is not verified.
+     *
+     * <p>The wrapper allows for verification of the downloaded Gradle distribution via SHA-256 hash sum comparison.
+     * This increases security against targeted attacks by preventing a man-in-the-middle attacker from tampering with
+     * the downloaded Gradle distribution.
+     */
+    @Input
+    @Optional
+    public String getDistributionSha256Sum() {
+        return distributionSha256Sum;
+    }
+
+    /**
+     * The SHA-256 hash sum of the gradle distribution.
+     *
+     * <p>If not set, the hash sum of the gradle distribution is not verified.
+     *
+     * <p>The wrapper allows for verification of the downloaded Gradle distribution via SHA-256 hash sum comparison.
+     * This increases security against targeted attacks by preventing a man-in-the-middle attacker from tampering with
+     * the downloaded Gradle distribution.
+     */
+    @Option(option = "gradle-distribution-sha256-sum", description = "The SHA-256 hash sum of the gradle distribution.")
+    public void setDistributionSha256Sum(String distributionSha256Sum) {
+        this.distributionSha256Sum = distributionSha256Sum;
+    }
+
+    /**
      * The distribution base specifies whether the unpacked wrapper distribution should be stored in the project or in
      * the gradle user home dir.
      */
@@ -405,5 +439,4 @@ public class Wrapper extends DefaultTask {
     public void setArchiveBase(PathBase archiveBase) {
         this.archiveBase = archiveBase;
     }
-
 }

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -41,6 +41,7 @@ class WrapperTest extends AbstractTaskTest {
                 targetWrapperJarPath + "/gradle-wrapper.properties")
         new File(getProject().getProjectDir(), targetWrapperJarPath).mkdirs()
         wrapper.setDistributionPath("somepath")
+        wrapper.setDistributionSha256Sum("somehash")
     }
 
     AbstractTask getTask() {
@@ -61,6 +62,7 @@ class WrapperTest extends AbstractTaskTest {
         Wrapper.PathBase.GRADLE_USER_HOME == wrapper.getDistributionBase()
         Wrapper.PathBase.GRADLE_USER_HOME == wrapper.getArchiveBase()
         wrapper.getDistributionUrl() != null
+        wrapper.getDistributionSha256Sum() == null
     }
 
     def "determines Windows script path from unix script path"() {
@@ -118,6 +120,14 @@ class WrapperTest extends AbstractTaskTest {
         "http://some-url" == wrapper.getDistributionUrl()
     }
 
+    def "uses explicitly defined distribution sha256 sum"() {
+        given:
+        wrapper.setDistributionSha256Sum("somehash")
+
+        expect:
+        "somehash" == wrapper.getDistributionSha256Sum()
+    }
+
     def "execute with non extant wrapper jar parent directory"() {
         when:
         def unjarDir = temporaryFolder.createDir("unjar")
@@ -128,6 +138,7 @@ class WrapperTest extends AbstractTaskTest {
         then:
         unjarDir.file(GradleWrapperMain.class.getName().replace(".", "/") + ".class").assertIsFile()
         properties.getProperty(WrapperExecutor.DISTRIBUTION_URL_PROPERTY) == wrapper.getDistributionUrl()
+        properties.getProperty(WrapperExecutor.DISTRIBUTION_SHA_256_SUM) == wrapper.getDistributionSha256Sum()
         properties.getProperty(WrapperExecutor.DISTRIBUTION_BASE_PROPERTY) == wrapper.getDistributionBase().toString()
         properties.getProperty(WrapperExecutor.DISTRIBUTION_PATH_PROPERTY) == wrapper.getDistributionPath()
         properties.getProperty(WrapperExecutor.ZIP_STORE_BASE_PROPERTY) == wrapper.getArchiveBase().toString()
@@ -137,7 +148,8 @@ class WrapperTest extends AbstractTaskTest {
     def "check inputs"() {
         expect:
         wrapper.getInputs().getProperties().keySet() == WrapUtil.toSet(
-            "distributionBase", "distributionPath", "distributionUrl", "distributionType", "archiveBase", "archivePath", "gradleVersion")
+            "distributionBase", "distributionPath", "distributionUrl", "distributionSha256Sum",
+            "distributionType", "archiveBase", "archivePath", "gradleVersion")
     }
 
     def "execute with extant wrapper jar parent directory and extant wraper jar"() {
@@ -159,6 +171,7 @@ class WrapperTest extends AbstractTaskTest {
         then:
         unjarDir.file(GradleWrapperMain.class.getName().replace(".", "/") + ".class").assertIsFile()
         properties.getProperty(WrapperExecutor.DISTRIBUTION_URL_PROPERTY) == wrapper.getDistributionUrl()
+        properties.getProperty(WrapperExecutor.DISTRIBUTION_SHA_256_SUM) == wrapper.getDistributionSha256Sum()
         properties.getProperty(WrapperExecutor.DISTRIBUTION_BASE_PROPERTY) == wrapper.getDistributionBase().toString()
         properties.getProperty(WrapperExecutor.DISTRIBUTION_PATH_PROPERTY) == wrapper.getDistributionPath()
         properties.getProperty(WrapperExecutor.ZIP_STORE_BASE_PROPERTY) == wrapper.getArchiveBase().toString()

--- a/subprojects/docs/src/docs/userguide/gradleWrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/gradleWrapper.adoc
@@ -164,7 +164,7 @@ You can download the `.sha256` file by clicking on one of the `sha256` links on 
 
 The format of the file is a single line of text that is the SHA-256 hash of the corresponding zip file.
 
-Add the downloaded hash sum to the `gradle-wrapper.properties` using the `distributionSha256Sum` property.
+Add the downloaded hash sum to `gradle-wrapper.properties` using the `distributionSha256Sum` property or use `--gradle-distribution-sha256-sum` on the command-line.
 
 .Configuring SHA-256 checksum verification
 ====

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -106,4 +106,12 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         then:
         file("gradle/wrapper/gradle-wrapper.properties").text.contains("distributionUrl=http\\://localhost\\:8080/gradlew/dist")
     }
+
+    def "generated wrapper scripts for given distribution SHA-256 hash sum from command-line"() {
+        when:
+        run "wrapper", "--gradle-distribution-sha256-sum", "somehash"
+
+        then:
+        file("gradle/wrapper/gradle-wrapper.properties").text.contains("distributionSha256Sum=somehash")
+    }
 }


### PR DESCRIPTION
### Context
This existing property allows the wrapper to verify distribution SHA-256 hash sums but it is not configurable via the wrapper task like most other wrapper properties. It is more difficult to generate gradle-wrapper.properties with SHA-256 verification without a task property.

I posted https://groups.google.com/forum/#!topic/gradle-dev/KlESiTScHbg earlier today to propose this idea and created this pull request because the code change is relatively small and self-explanatory.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
