### PR TITLE
Include not completed operations in an error message

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationWorkerRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationWorkerRegistry.java
@@ -83,7 +83,13 @@ public class DefaultBuildOperationWorkerRegistry implements BuildOperationWorker
     public void stop() {
         synchronized (lock) {
             if (!threads.isEmpty()) {
-                throw new IllegalStateException("Some build operations have not been marked as completed.");
+                StringBuilder message = new StringBuilder("Some build operations have not been marked as completed:");
+                for (DefaultOperation operation : threads.values()) {
+                    message.append('\n');
+                    message.append(operation.getDisplayName());
+                }
+
+                throw new IllegalStateException(message.toString());
             }
         }
     }


### PR DESCRIPTION
Include not completed operations in an error message for DefaultBuildOperationWorkerRegistry. We are seeing a lot of them in CI and we don't see a way to find out which operation exactly. Seems like a good improvement to UX.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
