### PR TITLE
Reduce configuration time memory consumption

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -35,8 +35,11 @@ import java.util.Set;
 
 public interface TaskInternal extends Task, Configurable<Task> {
 
-    // Can we just override Task.getActions()?
-    // Would need to change return type on Task API to: List<? super Action<? super Task>> : not certain this is back-compatible
+    /**
+     * A more efficient version of {@link #getActions()}, which circumvents the
+     * validating change listener that normally prevents users from changing tasks
+     * once they start executing.
+     */
     @Internal
     List<ContextAwareTaskAction> getTaskActions();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/coerce/MethodArgumentsTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/coerce/MethodArgumentsTransformer.java
@@ -30,4 +30,10 @@ public interface MethodArgumentsTransformer {
      */
     Object[] transform(CachedClass[] types, Object[] args);
 
+    /*
+     * Returns Whether the transformer can transform
+     * these arguments at all.
+     */
+    boolean canTransform(Object[] args);
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/coerce/StringToEnumTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/coerce/StringToEnumTransformer.java
@@ -57,6 +57,16 @@ public class StringToEnumTransformer implements MethodArgumentsTransformer, Prop
     }
 
     @Override
+    public boolean canTransform(Object[] args) {
+        for (Object arg : args) {
+            if (arg instanceof CharSequence) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public Object transformValue(Class<?> type, Object value) {
         if (value instanceof CharSequence && type.isEnum()) {
             @SuppressWarnings("unchecked") Class<? extends Enum> enumType = (Class<? extends Enum>) type;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -15,10 +15,12 @@
  */
 package org.gradle.api.internal.tasks;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
@@ -44,7 +46,6 @@ import org.gradle.model.internal.core.UnmanagedModelProjection;
 import org.gradle.model.internal.core.rule.describe.SimpleModelRuleDescriptor;
 import org.gradle.model.internal.type.ModelType;
 import org.gradle.util.ConfigureUtil;
-import org.gradle.util.GUtil;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -74,6 +75,10 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         boolean replace = replaceStr != null && "true".equals(replaceStr.toString());
 
         Task task = taskFactory.createTask(mutableOptions);
+        return addTask(task, replace);
+    }
+
+    private <T extends Task> T addTask(T task, boolean replaceExisting) {
         String name = task.getName();
 
         if (placeholders.remove(name)) {
@@ -82,7 +87,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         Task existing = findByNameWithoutRules(name);
         if (existing != null) {
-            if (replace) {
+            if (replaceExisting) {
                 remove(existing);
             } else {
                 throw new InvalidUserDataException(String.format(
@@ -108,11 +113,12 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     public <T extends Task> T create(String name, Class<T> type) {
-        return type.cast(create(GUtil.map(Task.TASK_NAME, name, Task.TASK_TYPE, type)));
+        T task = instantiator.create(name, type);
+        return addTask(task, false);
     }
 
     public Task create(String name) {
-        return create(GUtil.map(Task.TASK_NAME, name));
+        return create(name, DefaultTask.class);
     }
 
     public Task create(String name, Action<? super Task> configureAction) throws InvalidUserDataException {
@@ -130,7 +136,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     public Task replace(String name) {
-        return create(GUtil.map(Task.TASK_NAME, name, Task.TASK_OVERWRITE, true));
+        return replace(name, DefaultTask.class);
     }
 
     public Task create(String name, Closure configureClosure) {
@@ -144,11 +150,12 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     public <T extends Task> T replace(String name, Class<T> type) {
-        return type.cast(create(GUtil.map(Task.TASK_NAME, name, Task.TASK_TYPE, type, Task.TASK_OVERWRITE, true)));
+        T task = instantiator.create(name, type);
+        return addTask(task, true);
     }
 
     public Task findByPath(String path) {
-        if (!GUtil.isTrue(path)) {
+        if (Strings.isNullOrEmpty(path)) {
             throw new InvalidUserDataException("A path must be specified!");
         }
         if (!path.contains(Project.PATH_SEPARATOR)) {
@@ -156,7 +163,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         }
 
         String projectPath = StringUtils.substringBeforeLast(path, Project.PATH_SEPARATOR);
-        ProjectInternal project = this.project.findProject(!GUtil.isTrue(projectPath) ? Project.PATH_SEPARATOR : projectPath);
+        ProjectInternal project = this.project.findProject(Strings.isNullOrEmpty(projectPath) ? Project.PATH_SEPARATOR : projectPath);
         if (project == null) {
             return null;
         }
@@ -166,7 +173,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     public Task resolveTask(String path) {
-        if (!GUtil.isTrue(path)) {
+        if (Strings.isNullOrEmpty(path)) {
             throw new InvalidUserDataException("A path must be specified!");
         }
         return getByPath(path);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks;
 
+import com.google.common.collect.Sets;
 import groovy.lang.Closure;
 import org.gradle.api.Buildable;
 import org.gradle.api.InvalidUserDataException;
@@ -27,7 +28,6 @@ import org.gradle.internal.typeconversion.UnsupportedNotationException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -39,7 +39,7 @@ import static com.google.common.collect.Iterables.toArray;
 import static org.gradle.util.GUtil.uncheckedCall;
 
 public class DefaultTaskDependency extends AbstractTaskDependency {
-    private final Set<Object> values = new HashSet<Object>();
+    private Set<Object> values;
     private final TaskResolver resolver;
 
     public DefaultTaskDependency() {
@@ -52,10 +52,10 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
 
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
-        if (values.isEmpty()) {
+        if (getValues().isEmpty()) {
             return;
         }
-        Deque<Object> queue = new ArrayDeque<Object>(values);
+        Deque<Object> queue = new ArrayDeque<Object>(getValues());
         while (!queue.isEmpty()) {
             Object dependency = queue.removeFirst();
             if (dependency instanceof Buildable) {
@@ -130,11 +130,14 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
     }
 
     public Set<Object> getValues() {
+        if (values == null) {
+            values = Sets.newHashSet();
+        }
         return values;
     }
 
     public void setValues(Iterable<?> values) {
-        this.values.clear();
+        getValues().clear();
         for (Object value : values) {
             addValue(value);
         }
@@ -151,6 +154,6 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
         if (dependency == null) {
             throw new InvalidUserDataException("A dependency must not be empty");
         }
-        this.values.add(dependency);
+        getValues().add(dependency);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuter.java
@@ -36,7 +36,7 @@ public class SkipTaskWithNoActionsExecuter implements TaskExecuter {
     }
 
     public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
-        if (task.getActions().isEmpty()) {
+        if (task.getTaskActions().isEmpty()) {
             LOGGER.info("Skipping {} as it has no actions.", task);
             boolean upToDate = true;
             for (Task dependency : task.getTaskDependencies().getDependencies(task)) {

--- a/subprojects/core/src/main/java/org/gradle/internal/metaobject/BeanDynamicObject.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/metaobject/BeanDynamicObject.java
@@ -491,16 +491,18 @@ public class BeanDynamicObject extends AbstractDynamicObject {
                 return DynamicInvokeResult.found(metaMethod.doMethodInvoke(bean, arguments));
             }
 
-            List<MetaMethod> metaMethods = metaClass.respondsTo(bean, name);
-            for (MetaMethod method : metaMethods) {
-                if (method.getParameterTypes().length != arguments.length) {
-                    continue;
+            if (argsTransformer.canTransform(arguments)) {
+                List<MetaMethod> metaMethods = metaClass.respondsTo(bean, name);
+                for (MetaMethod method : metaMethods) {
+                    if (method.getParameterTypes().length != arguments.length) {
+                        continue;
+                    }
+                    Object[] transformed = argsTransformer.transform(method.getParameterTypes(), arguments);
+                    if (transformed == arguments) {
+                        continue;
+                    }
+                    return DynamicInvokeResult.found(method.doMethodInvoke(bean, transformed));
                 }
-                Object[] transformed = argsTransformer.transform(method.getParameterTypes(), arguments);
-                if (transformed == arguments) {
-                    continue;
-                }
-                return DynamicInvokeResult.found(method.doMethodInvoke(bean, transformed));
             }
 
             if (bean instanceof MethodMixIn) {

--- a/subprojects/core/src/main/java/org/gradle/internal/metaobject/BeanDynamicObject.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/metaobject/BeanDynamicObject.java
@@ -54,14 +54,6 @@ import java.util.Map;
  */
 public class BeanDynamicObject extends AbstractDynamicObject {
     private static final Method META_PROP_METHOD;
-    private static final ThreadLocal<Object[]> META_PROP_ARGUMENT_ARRAY = new ThreadLocal<Object[]>() {
-        @Override
-        protected Object[] initialValue() {
-            Object[] args = new Object[2];
-            args[1] = false;
-            return args;
-        }
-    };
     private static final Field MISSING_PROPERTY_GET_METHOD;
     private static final Field MISSING_PROPERTY_SET_METHOD;
     private static final Field MISSING_METHOD_METHOD;
@@ -342,11 +334,7 @@ public class BeanDynamicObject extends AbstractDynamicObject {
         protected MetaProperty lookupProperty(MetaClass metaClass, String name) {
             if (metaClass instanceof MetaClassImpl) {
                 try {
-                    Object[] args = META_PROP_ARGUMENT_ARRAY.get();
-                    args[0] = name;
-                    MetaProperty result = (MetaProperty) META_PROP_METHOD.invoke(metaClass, args);
-                    args[0] = null;
-                    return result;
+                    return (MetaProperty) META_PROP_METHOD.invoke(metaClass, name, false);
                 } catch (Throwable e) {
                     throw UncheckedException.throwAsUncheckedException(e);
                 }
@@ -468,7 +456,7 @@ public class BeanDynamicObject extends AbstractDynamicObject {
             return false;
         }
 
-        private Class[] inferTypes(Object... arguments) {
+        private Class[] inferTypes(Object[] arguments) {
             if (arguments == null || arguments.length == 0) {
                 return MetaClassHelper.EMPTY_CLASS_ARRAY;
             }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuterTest.groovy
@@ -42,7 +42,7 @@ class SkipTaskWithNoActionsExecuterTest extends Specification {
 
     def skipsTaskWithNoActionsAndMarksUpToDateIfAllItsDependenciesWereSkipped() {
         given:
-        task.actions >> []
+        task.taskActions >> []
         dependencyState.skipped >> true
 
         when:
@@ -57,7 +57,7 @@ class SkipTaskWithNoActionsExecuterTest extends Specification {
 
     def skipsTaskWithNoActionsAndMarksOutOfDateDateIfAnyOfItsDependenciesWereNotSkipped() {
         given:
-        task.actions >> []
+        task.taskActions >> []
         dependencyState.skipped >> false
 
         when:
@@ -72,7 +72,7 @@ class SkipTaskWithNoActionsExecuterTest extends Specification {
 
     def executesTaskWithActions() {
         given:
-        task.actions >> [{} as TaskAction]
+        task.taskActions >> [{} as TaskAction]
 
         when:
         executor.execute(task, state, executionContext)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/metaobject/BeanDynamicObjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/metaobject/BeanDynamicObjectTest.groovy
@@ -745,6 +745,11 @@ class BeanDynamicObjectTest extends Specification {
             }
             return result
         }
+
+        @Override
+        boolean canTransform(Object[] args) {
+            return true
+        }
     }
 
     static class Bean {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
@@ -131,7 +131,7 @@ public abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
         getTask().getActions().add(Actions.doNothing())
 
         then:
-        2 == getTask().getActions().size()
+        getTask().getActions().size() == 2
 
         when:
         List<Action<? super Task>> actions = Lists.newArrayList()
@@ -139,7 +139,7 @@ public abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
         getTask().setActions(actions)
 
         then:
-        1 == getTask().getActions().size()
+        getTask().getActions().size() == 1
     }
 
     def "addAction with null throws"() {


### PR DESCRIPTION
This is another batch of changes based on profiling the gradle/gradle build. It mostly improves task creation and dynamic property lookup by avoiding allocations. The commits are self-contained, so it is best to review them individually.