### PR TITLE
Renders a deprecation warning to the console for ConfigurableReport.setDestination(Object)

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
@@ -192,8 +192,8 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         when:
         buildFile << """
             checkstyleMain.reports {
-                xml.destination "foo.xml"
-                html.destination "bar.html"
+                xml.destination file("foo.xml")
+                html.destination file("bar.html")
             }
         """
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
@@ -131,7 +131,7 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
             pmdMain {
                 reports {
                     xml.enabled false
-                    html.destination "htmlReport.html"
+                    html.destination file("htmlReport.html")
                 }
             }
         """

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/FindBugsPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/FindBugsPluginTest.groovy
@@ -244,7 +244,7 @@ class FindBugsPluginTest extends AbstractProjectBuilderSpec {
             html {
                 enabled true
             }
-            xml.destination "foo"
+            xml.destination project.file("foo")
         }
 
         then:

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/FindBugsTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/FindBugsTest.groovy
@@ -80,7 +80,7 @@ class FindBugsTest extends Specification {
         findbugs.reports {
             xml {
                 enabled = true
-                destination "build/findbugs.xml"
+                destination = project.file("build/findbugs.xml")
             }
         }
 

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/JDependPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/JDependPluginTest.groovy
@@ -146,7 +146,7 @@ class JDependPluginTest extends AbstractProjectBuilderSpec {
             text {
                 enabled true
             }
-            xml.destination "foo"
+            xml.destination project.file("foo")
         }
 
         then:

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -55,7 +55,7 @@ class JacocoPluginMultiVersionIntegrationTest extends JacocoMultiVersionIntegrat
                 reports {
                     xml.enabled true
                     csv.enabled true
-                    html.destination "\${buildDir}/jacocoHtml"
+                    html.destination file("\${buildDir}/jacocoHtml")
                 }
             }
             """
@@ -216,7 +216,7 @@ public class ThingTest {
             reports {
                 xml.enabled false
                 csv.enabled false
-                html.destination "\${buildDir}/reports/jacoco/integ"
+                html.destination file("\${buildDir}/reports/jacoco/integ")
             }
             executionData test
         }

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/internal/TaskGeneratedReportIntegrationTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/internal/TaskGeneratedReportIntegrationTest.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.reporting.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class TaskGeneratedReportIntegrationTest extends AbstractIntegrationSpec {
+
+    def "renders deprecation message when setting report destination as Object"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            
+            test {
+                reports.junitXml.destination = 'foo'
+            }
+        """
+
+        when:
+        executer.expectDeprecationWarning()
+        succeeds('help')
+
+        then:
+        output.contains("The ConfigurableReport.setDestination(Object) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the method ConfigurableReport.setDestination(File) instead.")
+    }
+}

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/internal/TaskReportContainerIntegTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/internal/TaskReportContainerIntegTest.groovy
@@ -21,9 +21,9 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
 
 class TaskReportContainerIntegTest extends AbstractIntegrationSpec {
-    
+
     def task = ":createReports"
-    
+
     def setup() {
         buildFile << """
             import org.gradle.api.reporting.*
@@ -64,10 +64,10 @@ class TaskReportContainerIntegTest extends AbstractIntegrationSpec {
                 inputs.property "foo", { project.value }
                 reports.all {
                     it.enabled true
-                    destination it.outputType == Report.OutputType.DIRECTORY ? it.name : "\$it.name/file"
+                    destination it.outputType == Report.OutputType.DIRECTORY ? file(it.name) : file("\$it.name/file")
                 }
             }
-        """ 
+        """
     }
 
     @IgnoreIf({GradleContextualExecuter.parallel})

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
@@ -26,6 +26,7 @@ import org.gradle.api.reporting.Report;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
 import org.gradle.util.ConfigureUtil;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.util.concurrent.Callable;
@@ -72,6 +73,7 @@ public class SimpleReport implements ConfigurableReport {
     }
 
     public void setDestination(final Object destination) {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("ConfigurableReport.setDestination(Object)", String.format("Please use the method ConfigurableReport.setDestination(File) instead."));
         this.destination.set(project.provider(new Callable<File>() {
             @Override
             public File call() throws Exception {

--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedReportTest.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedReportTest.groovy
@@ -32,12 +32,13 @@ class TaskGeneratedReportTest extends Specification {
         Project project = ProjectBuilder.builder().build()
         Task task = project.task("task", type: Copy)
         TaskGeneratedReport report = new TaskGeneratedReport("report", Report.OutputType.FILE, task)
-        
+        File destinationFile = project.file("foo")
+
         when:
-        report.destination = "foo"
-        
+        report.destination = destinationFile
+
         then:
-        report.destination == project.file("foo")
+        report.destination == destinationFile
     }
 
 }

--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskReportContainerTest.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskReportContainerTest.groovy
@@ -61,7 +61,7 @@ class TaskReportContainerTest extends Specification {
         def container = project.services.get(Instantiator).newInstance(TestReportContainer, task, c)
         container.all {
             it.enabled true
-            destination it.name
+            destination project.file(it.name)
         }
         task.reports = container
         return container


### PR DESCRIPTION
The method was deprecated but still used internally. Users should be notified by a deprecation message on the console.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
