### PR TITLE
Fix parallel test execution worker leases handling

### DIFF
--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -81,13 +81,14 @@ public class DefaultTestExecuter implements TestExecuter {
                 return new RestartEveryNTestClassProcessor(forkingProcessorFactory, testTask.getForkEvery());
             }
         };
-        Factory<TestClassProcessor> maxNParallelTestProcessorFactory = new Factory<TestClassProcessor>() {
+        final Factory<TestClassProcessor> workerLeaseHolderProcessorFactory = new Factory<TestClassProcessor>() {
+            @Override
             public TestClassProcessor create() {
-                return new MaxNParallelTestClassProcessor(getMaxParallelForks(testTask), reforkingProcessorFactory, actorFactory);
+                return new WorkerLeaseHolderTestClassProcessor(currentOperation, reforkingProcessorFactory);
             }
         };
 
-        TestClassProcessor processor = new WorkerLeaseHolderTestClassProcessor(currentOperation, maxNParallelTestProcessorFactory);
+        TestClassProcessor processor = new MaxNParallelTestClassProcessor(getMaxParallelForks(testTask), workerLeaseHolderProcessorFactory, actorFactory);
 
         final FileTree testClassFiles = testTask.getCandidateClassFiles();
 


### PR DESCRIPTION
Before this commit, worker leases were taken around dispatching test
execution, not actual test execution. Meaning we could use more than
maxWorkers workers.

This commits fix this by moving the worker leases holder after test
execution dispatch.
