### PR TITLE
Can configure @DeferredConfigurable extensions by name

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
@@ -203,6 +203,11 @@ public class DefaultConvention implements Convention, ExtensionContainerInternal
     }
 
     @Override
+    public <T> void configure(String name, Action<? super T> action) {
+        extensionsStorage.configureExtension(name, action);
+    }
+
+    @Override
     public Map<String, Object> getAsMap() {
         return extensionsStorage.getAsMap();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
@@ -223,6 +223,17 @@ public interface ExtensionContainer {
     <T> void configure(TypeOf<T> type, Action<? super T> action);
 
     /**
+     * Looks for the extension with the specified name and configures it with the supplied action.
+     *
+     * @param name extension name
+     * @param action the configure action
+     * @throws UnknownDomainObjectException if no extension is found.
+     * @since 4.0
+     */
+    @Incubating
+    <T> void configure(String name, Action<? super T> action);
+
+    /**
      * The extra properties extension in this extension container.
      *
      * This extension is always present in the container, with the name “ext”.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.plugins
 
+import org.gradle.api.Action
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.internal.ThreadGlobalInstantiator
 import org.gradle.api.plugins.ExtensionAware
@@ -250,6 +251,17 @@ class ExtensionContainerTest extends Specification {
                              foo: typeOf(Parent),
                              bar: typeOf(Capability),
                              baz: new TypeOf<List<String>>() {}]
+    }
+
+    def "can configure extensions by name"() {
+        given:
+        container.add "foo", extension
+
+        when:
+        container.configure "foo", { FooExtension foo -> foo.message = "bar" } as Action
+
+        then:
+        extension.message == "bar"
     }
 }
 


### PR DESCRIPTION
Before this commit there was no way to configure a `@DeferredConfigurable`
extension by name. This commit adds a method to ExtensionContainer in
this regard.

See gradle/gradle-script-kotlin#328
