### PR TITLE
Don't retry adhoc performance tests

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.performance.fixture.GradleSessionProvider
 import org.gradle.performance.fixture.PerformanceTestDirectoryProvider
 import org.gradle.performance.fixture.PerformanceTestIdProvider
 import org.gradle.performance.results.CrossVersionResultsStore
+import org.gradle.performance.results.ResultsStoreHelper
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testing.internal.util.RetryRule
@@ -44,7 +45,7 @@ class AbstractCrossVersionPerformanceTest extends Specification {
 
     @Rule
     RetryRule retry = RetryRule.retryIf(this) { Throwable failure ->
-        failure.message?.contains("slower")
+        failure.message?.contains("slower") && !ResultsStoreHelper.isAdhocPerformanceTest()
     }
 
     private final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
@@ -25,8 +25,8 @@ import org.gradle.performance.fixture.CrossVersionPerformanceTestRunner
 import org.gradle.performance.fixture.GradleSessionProvider
 import org.gradle.performance.fixture.PerformanceTestDirectoryProvider
 import org.gradle.performance.fixture.PerformanceTestIdProvider
+import org.gradle.performance.fixture.PerformanceTestRetryRule
 import org.gradle.performance.results.CrossVersionResultsStore
-import org.gradle.performance.results.ResultsStoreHelper
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testing.internal.util.RetryRule
@@ -44,9 +44,7 @@ class AbstractCrossVersionPerformanceTest extends Specification {
     TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider()
 
     @Rule
-    RetryRule retry = RetryRule.retryIf(this) { Throwable failure ->
-        failure.message?.contains("slower") && !ResultsStoreHelper.isAdhocPerformanceTest()
-    }
+    RetryRule retry = new PerformanceTestRetryRule()
 
     private final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -44,6 +44,7 @@ import org.gradle.performance.fixture.PerformanceTestDirectoryProvider
 import org.gradle.performance.fixture.PerformanceTestGradleDistribution
 import org.gradle.performance.fixture.PerformanceTestIdProvider
 import org.gradle.performance.fixture.PerformanceTestJvmOptions
+import org.gradle.performance.fixture.PerformanceTestRetryRule
 import org.gradle.performance.fixture.TestProjectLocator
 import org.gradle.performance.fixture.TestScenarioSelector
 import org.gradle.performance.results.BuildDisplayInfo
@@ -88,9 +89,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
     PerformanceTestIdProvider performanceTestIdProvider = new PerformanceTestIdProvider()
 
     @Rule
-    RetryRule retry = RetryRule.retryIf(this) { Throwable failure ->
-        failure.message?.contains("slower")  && !ResultsStoreHelper.isAdhocPerformanceTest()
-    }
+    RetryRule retry = new PerformanceTestRetryRule()
 
     public <T> Class<T> tapiClass(Class<T> clazz) {
         tapiClassLoader.loadClass(clazz.name)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -38,7 +38,6 @@ import org.gradle.performance.fixture.BuildExperimentRunner
 import org.gradle.performance.fixture.BuildExperimentSpec
 import org.gradle.performance.fixture.CrossVersionPerformanceTestRunner
 import org.gradle.performance.fixture.DefaultBuildExperimentInvocationInfo
-import org.gradle.performance.util.Git
 import org.gradle.performance.fixture.InvocationSpec
 import org.gradle.performance.fixture.OperationTimer
 import org.gradle.performance.fixture.PerformanceTestDirectoryProvider
@@ -52,6 +51,7 @@ import org.gradle.performance.results.CrossVersionPerformanceResults
 import org.gradle.performance.results.CrossVersionResultsStore
 import org.gradle.performance.results.MeasuredOperationList
 import org.gradle.performance.results.ResultsStoreHelper
+import org.gradle.performance.util.Git
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.file.TestFile
@@ -89,7 +89,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
 
     @Rule
     RetryRule retry = RetryRule.retryIf(this) { Throwable failure ->
-        failure.message?.contains("slower")
+        failure.message?.contains("slower")  && !ResultsStoreHelper.isAdhocPerformanceTest()
     }
 
     public <T> Class<T> tapiClass(Class<T> clazz) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestRetryRule.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestRetryRule.groovy
@@ -16,9 +16,11 @@
 
 package org.gradle.performance.fixture
 
+import groovy.transform.CompileStatic
 import org.gradle.performance.results.ResultsStoreHelper
 import org.gradle.testing.internal.util.RetryRule
 
+@CompileStatic
 class PerformanceTestRetryRule extends RetryRule {
     PerformanceTestRetryRule() {
         super(null, { Throwable failure ->

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestRetryRule.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestRetryRule.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.fixture
+
+import org.gradle.performance.results.ResultsStoreHelper
+import org.gradle.testing.internal.util.RetryRule
+
+class PerformanceTestRetryRule extends RetryRule {
+    PerformanceTestRetryRule() {
+        super(null, { Throwable failure ->
+            failure.message?.contains("slower") && !ResultsStoreHelper.isAdhocPerformanceTest()
+        })
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
@@ -54,4 +54,8 @@ public class ResultsStoreHelper {
     public static String determineChannel() {
         return System.getProperty(SYSPROP_PERFORMANCE_TEST_CHANNEL, "commits");
     }
+
+    public static boolean isAdhocPerformanceTest() {
+        return "adhoc".equals(determineChannel());
+    }
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/RetryRule.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/RetryRule.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.internal.util
 
+import groovy.transform.CompileStatic
 import org.junit.rules.MethodRule
 import org.junit.runners.model.FrameworkMethod
 import org.junit.runners.model.Statement
@@ -34,6 +35,7 @@ import spock.lang.Specification
   If the test method depends on state held in the test instance, then retrying might not behave as expected.
   See this thread for more details: https://groups.google.com/forum/#!msg/spockframework/95ACCVg-aCQ/0SIvxoLhX7UJ:
  */
+@CompileStatic
 class RetryRule implements MethodRule {
 
     private Closure<Boolean> shouldRetry
@@ -85,7 +87,7 @@ class RetryRule implements MethodRule {
                     throw t1
                 }
             }
-        }
+        } as Statement
     }
 
     private void runCleanup(SpecInfo spec) {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/RetryRule.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/RetryRule.groovy
@@ -39,7 +39,7 @@ class RetryRule implements MethodRule {
     private Closure<Boolean> shouldRetry
     private Specification specification
 
-    private RetryRule(Specification specification, Closure<Boolean> shouldRetry) {
+    protected RetryRule(Specification specification, Closure<Boolean> shouldRetry) {
         this.specification = specification
         this.shouldRetry = shouldRetry
     }
@@ -54,6 +54,9 @@ class RetryRule implements MethodRule {
 
     @Override
     Statement apply(Statement base, FrameworkMethod method, Object target) {
+        if (specification == null) {
+            specification = target as Specification
+        }
         return {
             try {
                 base.evaluate()

--- a/subprojects/internal-testing/src/test/groovy/org/gradle/testing/internal/util/RetryRuleTest.groovy
+++ b/subprojects/internal-testing/src/test/groovy/org/gradle/testing/internal/util/RetryRuleTest.groovy
@@ -25,12 +25,12 @@ import static org.gradle.testing.internal.util.RetryRule.retryIf
 class RetryRuleTest extends Specification {
 
     @Rule
-    RetryRule retryRule = retryIf({ t -> t instanceof IOException });
+    RetryRule retryRule = retryIf({ t -> t instanceof IOException })
 
     @Rule
-    ExpectedFailureRule expectedFailureRule = new ExpectedFailureRule();
+    ExpectedFailureRule expectedFailureRule = new ExpectedFailureRule()
 
-    int iteration = 0;
+    int iteration = 0
 
     def "should pass when expected exception happens once"() {
         given:
@@ -56,7 +56,7 @@ class RetryRuleTest extends Specification {
 
     def "should retry and pass when spock expects a specific exception"() {
         given:
-        iteration++;
+        iteration++
 
         when:
         throwWhen(new IOException(), iteration == 1)
@@ -95,7 +95,7 @@ class RetryRuleTest extends Specification {
     @ExpectedFailure(expected = RetryFailure.class)
     def "should fail when expected exception happens consistently"() {
         when:
-        throw new IOException();
+        throw new IOException()
 
         then:
         true
@@ -115,7 +115,7 @@ class RetryRuleTest extends Specification {
 
     private static void throwWhen(Throwable throwable, boolean condition) {
         if (condition) {
-            throw throwable;
+            throw throwable
         }
     }
 }

--- a/subprojects/internal-testing/src/test/groovy/org/gradle/testing/internal/util/RetryRuleWithSetupRerunTest.groovy
+++ b/subprojects/internal-testing/src/test/groovy/org/gradle/testing/internal/util/RetryRuleWithSetupRerunTest.groovy
@@ -24,7 +24,7 @@ import static org.gradle.testing.internal.util.RetryRule.retryIf
 class RetryRuleWithSetupRerunTest extends SuperSpecification {
 
     @Rule
-    RetryRule retryRule = retryIf(this, { t -> t instanceof IOException })
+    RetryRule retryRule = retryIf({ t -> t instanceof IOException })
 
     int iteration = 0
 


### PR DESCRIPTION
### Context
When running `adhoc` performance tests we currently retry the performance tests when they fail. Since we are not interested in the result but flame graphs we should not retry when running `adhoc` performance tests.
