### PR TITLE
Adding the ability for ivy repo's to use a non-standard pattern

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/plugin/repository/IvyPluginRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/repository/IvyPluginRepository.java
@@ -16,8 +16,11 @@
 
 package org.gradle.plugin.repository;
 
+import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.repositories.AuthenticationSupported;
+import org.gradle.api.artifacts.repositories.RepositoryLayout;
 
 import java.net.URI;
 
@@ -44,4 +47,103 @@ public interface IvyPluginRepository extends PluginRepository, AuthenticationSup
      * @param url The base URL.
      */
     void setUrl(Object url);
+
+    /**
+     * Adds an independent pattern that will be used to locate artifact files in this repository. This pattern will be used to locate ivy files as well, unless a specific
+     * ivy pattern is supplied via {@link #ivyPattern(String)}.
+     *
+     * If this pattern is not a fully-qualified URL, it will be interpreted as a file relative to the project directory.
+     * It is not interpreted relative the URL specified in {@link #setUrl(Object)}.
+     *
+     * Patterns added in this way will be in addition to any layout-based patterns added via {@link #setUrl}.
+     *
+     * @param pattern The artifact pattern.
+     */
+    void artifactPattern(String pattern);
+
+    /**
+     * Adds an independent pattern that will be used to locate ivy files in this repository.
+     *
+     * If this pattern is not a fully-qualified URL, it will be interpreted as a file relative to the project directory.
+     * It is not interpreted relative the URL specified in {@link #setUrl(Object)}.
+     *
+     * Patterns added in this way will be in addition to any layout-based patterns added via {@link #setUrl}.
+     *
+     * @param pattern The ivy pattern.
+     */
+    void ivyPattern(String pattern);
+
+    /**
+     * Specifies the layout to use with this repository, based on the root url.
+     * See {@link #layout(String, Closure)}.
+     *
+     * @param layoutName The name of the layout to use.
+     */
+    void layout(String layoutName);
+
+    /**
+     * Specifies how the items of the repository are organized.
+     * <p>
+     * The layout is configured with the supplied closure.
+     * <p>
+     * Recognised values are as follows:
+     * </p>
+     * <h4>'gradle'</h4>
+     * <p>
+     * A Repository Layout that applies the following patterns:
+     * <ul>
+     *     <li>Artifacts: <code>$baseUri/{@value #GRADLE_ARTIFACT_PATTERN}</code></li>
+     *     <li>Ivy: <code>$baseUri/{@value #GRADLE_IVY_PATTERN}</code></li>
+     * </ul>
+     * </p>
+     * <h4>'maven'</h4>
+     * <p>
+     * A Repository Layout that applies the following patterns:
+     * <ul>
+     *     <li>Artifacts: <code>$baseUri/{@value #MAVEN_ARTIFACT_PATTERN}</code></li>
+     *     <li>Ivy: <code>$baseUri/{@value #MAVEN_IVY_PATTERN}</code></li>
+     * </ul>
+     * </p>
+     * <p>
+     * Following the Maven convention, the 'organisation' value is further processed by replacing '.' with '/'.
+     * </p>
+     * <h4>'ivy'</h4>
+     * <p>
+     * A Repository Layout that applies the following patterns:
+     * <ul>
+     *     <li>Artifacts: <code>$baseUri/{@value #IVY_ARTIFACT_PATTERN}</code></li>
+     *     <li>Ivy: <code>$baseUri/{@value #IVY_ARTIFACT_PATTERN}</code></li>
+     * </ul>
+     * </p>
+     * <p><b>Note:</b> this pattern is currently {@link org.gradle.api.Incubating incubating}.</p>
+     * <h4>'pattern'</h4>
+     * <p>
+     * A repository layout that allows custom patterns to be defined. eg:
+     * <pre autoTested="">
+     * repositories {
+     *     ivy {
+     *         layout 'pattern' , {
+     *             artifact '[module]/[revision]/[artifact](.[ext])'
+     *             ivy '[module]/[revision]/ivy.xml'
+     *         }
+     *     }
+     * }
+     * </pre>
+     * </p>
+     * <p>The available pattern tokens are listed as part of <a href="http://ant.apache.org/ivy/history/latest-milestone/concept.html#patterns">Ivy's Main Concepts documentation</a>.</p>
+     *
+     * @param layoutName The name of the layout to use.
+     * @param config The action used to configure the layout.
+     * @since 2.3 (feature was already present in Groovy DSL, this particular method introduced in 2.3)
+     */
+    void layout(String layoutName, Action<? extends RepositoryLayout> config);
+
+    /**
+     * Specifies how the items of the repository are organized. See {@link #layout(String, org.gradle.api.Action)}
+     *
+     * @param layoutName The name of the layout to use.
+     * @param config The closure used to configure the layout.
+     * An instance of {@link RepositoryLayout} is passed as a parameter to the closure.
+     */
+    void layout(String layoutName, Closure config);
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/repository/IvyPluginRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/repository/IvyPluginRepository.java
@@ -16,10 +16,10 @@
 
 package org.gradle.plugin.repository;
 
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.repositories.AuthenticationSupported;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.RepositoryLayout;
 
 import java.net.URI;
@@ -75,7 +75,7 @@ public interface IvyPluginRepository extends PluginRepository, AuthenticationSup
 
     /**
      * Specifies the layout to use with this repository, based on the root url.
-     * See {@link #layout(String, Closure)}.
+     * See {@link #layout(String, Action)}.
      *
      * @param layoutName The name of the layout to use.
      */
@@ -92,16 +92,16 @@ public interface IvyPluginRepository extends PluginRepository, AuthenticationSup
      * <p>
      * A Repository Layout that applies the following patterns:
      * <ul>
-     *     <li>Artifacts: <code>$baseUri/{@value #GRADLE_ARTIFACT_PATTERN}</code></li>
-     *     <li>Ivy: <code>$baseUri/{@value #GRADLE_IVY_PATTERN}</code></li>
+     *     <li>Artifacts: <code>$baseUri/{@value IvyArtifactRepository#GRADLE_ARTIFACT_PATTERN}</code></li>
+     *     <li>Ivy: <code>$baseUri/{@value IvyArtifactRepository#GRADLE_IVY_PATTERN}</code></li>
      * </ul>
      * </p>
      * <h4>'maven'</h4>
      * <p>
      * A Repository Layout that applies the following patterns:
      * <ul>
-     *     <li>Artifacts: <code>$baseUri/{@value #MAVEN_ARTIFACT_PATTERN}</code></li>
-     *     <li>Ivy: <code>$baseUri/{@value #MAVEN_IVY_PATTERN}</code></li>
+     *     <li>Artifacts: <code>$baseUri/{@value IvyArtifactRepository#MAVEN_ARTIFACT_PATTERN}</code></li>
+     *     <li>Ivy: <code>$baseUri/{@value IvyArtifactRepository#MAVEN_IVY_PATTERN}</code></li>
      * </ul>
      * </p>
      * <p>
@@ -111,8 +111,8 @@ public interface IvyPluginRepository extends PluginRepository, AuthenticationSup
      * <p>
      * A Repository Layout that applies the following patterns:
      * <ul>
-     *     <li>Artifacts: <code>$baseUri/{@value #IVY_ARTIFACT_PATTERN}</code></li>
-     *     <li>Ivy: <code>$baseUri/{@value #IVY_ARTIFACT_PATTERN}</code></li>
+     *     <li>Artifacts: <code>$baseUri/{@value IvyArtifactRepository#IVY_ARTIFACT_PATTERN}</code></li>
+     *     <li>Ivy: <code>$baseUri/{@value IvyArtifactRepository#IVY_ARTIFACT_PATTERN}</code></li>
      * </ul>
      * </p>
      * <p><b>Note:</b> this pattern is currently {@link org.gradle.api.Incubating incubating}.</p>
@@ -137,13 +137,4 @@ public interface IvyPluginRepository extends PluginRepository, AuthenticationSup
      * @since 2.3 (feature was already present in Groovy DSL, this particular method introduced in 2.3)
      */
     void layout(String layoutName, Action<? extends RepositoryLayout> config);
-
-    /**
-     * Specifies how the items of the repository are organized. See {@link #layout(String, org.gradle.api.Action)}
-     *
-     * @param layoutName The name of the layout to use.
-     * @param config The closure used to configure the layout.
-     * An instance of {@link RepositoryLayout} is passed as a parameter to the closure.
-     */
-    void layout(String layoutName, Closure config);
 }

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
@@ -230,6 +230,45 @@ class PluginManagementDslSpec extends AbstractIntegrationSpec {
         succeeds 'help'
     }
 
+    def "pluginManagement block supports defining repositories with layouts"() {
+        given:
+        settingsFile << """
+            pluginManagement {
+                repositories {
+                    ivy {
+                        url "http://repo.internal.net/ivy"
+                        layout("pattern") {
+                            ivy = '[organisation]/[module]/[revision]/[module]-[revision].ivy'
+                            artifact = '[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]'
+                            m2compatible true
+                        }
+                    }
+                    ivy {
+                        url "http://repo.internal.net/ivy"
+                        layout("maven")
+                    }
+                    ivy {
+                        url "http://repo.internal.net/ivy"
+                        layout("ivy")
+                    }
+                    ivy {
+                        url "http://repo.internal.net/ivy"
+                        layout("gradle")
+                    }
+                    ivy {
+                        url "http://repo.internal.net/ivy"
+                        artifactPattern '[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]'
+                        ivyPattern '[organisation]/[module]/[revision]/[module]-[revision].ivy'
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds 'help'
+    }
+
+
     void includesLinkToUserguide() {
         failure.assertThatCause(containsString("https://docs.gradle.org/${GradleVersion.current().getVersion()}/userguide/plugins.html#sec:plugin_management"))
     }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/repository/internal/DefaultIvyPluginRepository.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/repository/internal/DefaultIvyPluginRepository.java
@@ -16,7 +16,6 @@
 
 package org.gradle.plugin.repository.internal;
 
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
@@ -29,7 +28,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionS
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal;
 import org.gradle.plugin.repository.IvyPluginRepository;
-import org.gradle.util.ConfigureUtil;
 
 class DefaultIvyPluginRepository extends AbstractArtifactPluginRepository implements IvyPluginRepository {
     private static final String IVY = "ivy";
@@ -92,14 +90,12 @@ class DefaultIvyPluginRepository extends AbstractArtifactPluginRepository implem
         this.ivyPattern = pattern;
     }
 
+    @Override
     public void layout(String layoutName) {
         this.layoutName = layoutName;
     }
 
-    public void layout(String layoutName, Closure config) {
-        layout(layoutName, ConfigureUtil.<RepositoryLayout>configureUsing(config));
-    }
-
+    @Override
     public void layout(String layoutName, Action<? extends RepositoryLayout> config) {
         layout(layoutName);
         layoutAction = config;

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/repository/internal/DefaultIvyPluginRepository.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/repository/internal/DefaultIvyPluginRepository.java
@@ -16,20 +16,28 @@
 
 package org.gradle.plugin.repository.internal;
 
+import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
+import org.gradle.api.artifacts.repositories.RepositoryLayout;
 import org.gradle.api.credentials.Credentials;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal;
 import org.gradle.plugin.repository.IvyPluginRepository;
+import org.gradle.util.ConfigureUtil;
 
 class DefaultIvyPluginRepository extends AbstractArtifactPluginRepository implements IvyPluginRepository {
     private static final String IVY = "ivy";
+
+    private String layoutName;
+    private Action<? extends RepositoryLayout> layoutAction;
+    private String artifactPattern;
+    private String ivyPattern;
 
     public DefaultIvyPluginRepository(
         FileResolver fileResolver, DependencyResolutionServices dependencyResolutionServices,
@@ -54,7 +62,46 @@ class DefaultIvyPluginRepository extends AbstractArtifactPluginRepository implem
                         }
                     });
                 }
+
+                if(layoutName != null) {
+                    if(layoutAction != null) {
+                        ivyArtifactRepository.layout(layoutName, layoutAction);
+                    } else {
+                        ivyArtifactRepository.layout(layoutName);
+                    }
+                }
+
+                if(artifactPattern != null) {
+                    ivyArtifactRepository.artifactPattern(artifactPattern);
+                }
+
+                if(ivyPattern != null) {
+                    ivyArtifactRepository.ivyPattern(ivyPattern);
+                }
             }
         });
+    }
+
+    @Override
+    public void artifactPattern(String pattern) {
+        this.artifactPattern = pattern;
+    }
+
+    @Override
+    public void ivyPattern(String pattern) {
+        this.ivyPattern = pattern;
+    }
+
+    public void layout(String layoutName) {
+        this.layoutName = layoutName;
+    }
+
+    public void layout(String layoutName, Closure config) {
+        layout(layoutName, ConfigureUtil.<RepositoryLayout>configureUsing(config));
+    }
+
+    public void layout(String layoutName, Action<? extends RepositoryLayout> config) {
+        layout(layoutName);
+        layoutAction = config;
     }
 }


### PR DESCRIPTION
With the current implementation of the PluginRepositories it's not
possible for the user to be able to specify a repo that doens't meet the
"ivy" standard layout. Many people do not, so it's impossible to use
this feature.

This change will allow for users to specify more info about their
repositories.


### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
