### PR TITLE
Handle empty `<localRepository/>` in settings.xml

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultMavenSettingsProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultMavenSettingsProvider.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.mvnsettings;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.DefaultSettingsBuilder;
 import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
@@ -56,6 +57,8 @@ public class DefaultMavenSettingsProvider implements MavenSettingsProvider {
 
     /**
      * Read the local repository location from local Maven settings files.
+     *
+     * @return The path to the local repository, or <code>null</code> if not specified in Maven settings.
      */
     @Override
     public String getLocalRepository() {
@@ -73,7 +76,8 @@ public class DefaultMavenSettingsProvider implements MavenSettingsProvider {
         Map<String, ?> options = Collections.singletonMap(SettingsReader.IS_STRICT, Boolean.FALSE);
         SettingsReader settingsReader = new DefaultSettingsReader();
         try {
-            return settingsReader.read(settingsFile, options).getLocalRepository();
+            String localRepository = settingsReader.read(settingsFile, options).getLocalRepository();
+            return StringUtils.isEmpty(localRepository) ? null : localRepository;
         } catch (Exception parseException) {
             throw new CannotLocateLocalMavenRepositoryException("Unable to parse local Maven settings: " + settingsFile.getAbsolutePath(), parseException);
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
@@ -33,7 +33,7 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
     File repo1 = tmpDir.file("repo1")
     File repo2 = tmpDir.file("repo2")
     File userHome1 = tmpDir.file("user_home_1")
-    File userHome2 = tmpDir.file("user_home_2")
+    File defaultM2Repo = new File(userHome1, ".m2/repository")
 
     def setup() {
         locations = new SimpleMavenFileLocations()
@@ -44,10 +44,11 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
         when:
         1 * system.getProperty("user.home") >> userHome1.absolutePath
         then:
-        locator.localMavenRepository == new File(userHome1, ".m2/repository")
+        locator.localMavenRepository == defaultM2Repo
 
         // Ensure that modified user.home is honoured (see http://forums.gradle.org/gradle/topics/override_location_of_the_local_maven_repo)
         when:
+        File userHome2 = tmpDir.file("user_home_2")
         1 * system.getProperty("user.home") >> userHome2.absolutePath
         then:
         locator.localMavenRepository == new File(userHome2, ".m2/repository")
@@ -97,6 +98,48 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
         locator.localMavenRepository == repo1
     }
 
+    def "honors location specified in global settings file"() {
+        writeSettingsFile(locations.globalSettingsFile, repo1)
+
+        expect:
+        locator.localMavenRepository == repo1
+    }
+
+    def "returns default location if user settings file specifies empty local repository"() {
+        when:
+        writeSettingsFile(locations.userSettingsFile, "")
+        1 * system.getProperty("user.home") >> userHome1.absolutePath
+
+        then:
+        locator.localMavenRepository == defaultM2Repo
+    }
+
+    def "returns default location if global settings file specifies empty local repository"() {
+        when:
+        writeSettingsFile(locations.globalSettingsFile, "")
+        1 * system.getProperty("user.home") >> userHome1.absolutePath
+
+        then:
+        locator.localMavenRepository == defaultM2Repo
+    }
+
+    def "returns global location if user settings file specifies empty local repository"() {
+        when:
+        writeSettingsFile(locations.userSettingsFile, "")
+        writeSettingsFile(locations.globalSettingsFile, repo2)
+
+        then:
+        locator.localMavenRepository == repo2
+    }
+
+    def "prefers location specified in user settings file over that in global settings file"() {
+        writeSettingsFile(locations.userSettingsFile, repo1)
+        writeSettingsFile(locations.globalSettingsFile, repo2)
+
+        expect:
+        locator.localMavenRepository == repo1
+    }
+
     def "ignores changes to maven settings file after initial load"() {
         when:
         writeSettingsFile(locations.userSettingsFile, repo1)
@@ -111,21 +154,6 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
         locator.localMavenRepository == repo1
     }
 
-    def "honors location specified in global settings file"() {
-        writeSettingsFile(locations.globalSettingsFile, repo1)
-
-        expect:
-        locator.localMavenRepository == repo1
-    }
-
-    def "prefers location specified in user settings file over that in global settings file"() {
-        writeSettingsFile(locations.userSettingsFile, repo1)
-        writeSettingsFile(locations.globalSettingsFile, repo2)
-
-        expect:
-        locator.localMavenRepository == repo1
-    }
-
     def "handles the case where (potential) location of global settings file cannot be determined"() {
         locations.globalSettingsFile = null
 
@@ -133,7 +161,7 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
         system.getProperty("user.home") >> userHome1.absolutePath
 
         then:
-        locator.localMavenRepository == new File(userHome1, ".m2/repository")
+        locator.localMavenRepository == defaultM2Repo
 
         when:
         writeSettingsFile(locations.userSettingsFile, repo1)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
@@ -107,29 +107,38 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
 
     def "returns default location if user settings file specifies empty local repository"() {
         when:
-        writeSettingsFile(locations.userSettingsFile, "")
+        writeSettingsFile(locations.userSettingsFile, localRepository)
         1 * system.getProperty("user.home") >> userHome1.absolutePath
 
         then:
         locator.localMavenRepository == defaultM2Repo
+
+        where:
+        localRepository << ["<localRepository/>", "<localRepository></localRepository>", ""]
     }
 
     def "returns default location if global settings file specifies empty local repository"() {
         when:
-        writeSettingsFile(locations.globalSettingsFile, "")
+        writeSettingsFile(locations.globalSettingsFile, localRepository)
         1 * system.getProperty("user.home") >> userHome1.absolutePath
 
         then:
         locator.localMavenRepository == defaultM2Repo
+
+        where:
+        localRepository << ["<localRepository/>", "<localRepository></localRepository>", ""]
     }
 
     def "returns global location if user settings file specifies empty local repository"() {
         when:
-        writeSettingsFile(locations.userSettingsFile, "")
+        writeSettingsFile(locations.userSettingsFile, localRepository)
         writeSettingsFile(locations.globalSettingsFile, repo2)
 
         then:
         locator.localMavenRepository == repo2
+
+        where:
+        localRepository << ["<localRepository/>", "<localRepository></localRepository>", ""]
     }
 
     def "prefers location specified in user settings file over that in global settings file"() {
@@ -197,15 +206,16 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
         'env.unknown.ENV_VAR' |   "environment variable"
     }
 
-    private void writeSettingsFile(File settings, File repo) {
-        writeSettingsFile(settings, repo.absolutePath)
+    private static void writeSettingsFile(File settings, File repo) {
+        writeSettingsFile(settings, "<localRepository>${repo.absolutePath}</localRepository>")
     }
 
-    private void writeSettingsFile(File settings, String repo) {
+
+    private static void writeSettingsFile(File settings, String localRepositoryElement) {
         settings.text = """
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <localRepository>$repo</localRepository>
+  $localRepositoryElement
 </settings>"""
     }
 


### PR DESCRIPTION
Use the default `.m2/repository` location when an empty `<localRepository/>` element is found in `settings.xml`. (Previously we resolved an empty file, resulting in the current directory).