### PR TITLE
Throw `UnknownDomainObjectException` instead of NPE for unknown configuration

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -82,7 +82,7 @@ public class DefaultDependencyHandler extends GroovyObjectSupport implements Dep
 
     @Override
     public Dependency add(String configurationName, Object dependencyNotation, Closure configureClosure) {
-        return doAdd(configurationContainer.findByName(configurationName), dependencyNotation, configureClosure);
+        return doAdd(configurationContainer.getByName(configurationName), dependencyNotation, configureClosure);
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.dsl.dependencies
 
+import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.ClientModule
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
@@ -31,7 +32,10 @@ import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory
 import spock.lang.Specification
 
 class DefaultDependencyHandlerTest extends Specification {
+
     private static final String TEST_CONF_NAME = "someConf"
+    private static final String UNKNOWN_TEST_CONF_NAME = "unknown"
+
     private ConfigurationContainer configurationContainer = Mock()
     private DependencyFactory dependencyFactory = Mock()
     private Configuration configuration = Mock()
@@ -44,7 +48,8 @@ class DefaultDependencyHandlerTest extends Specification {
 
     void setup() {
         _ * configurationContainer.findByName(TEST_CONF_NAME) >> configuration
-        _ * configurationContainer.getAt(TEST_CONF_NAME) >> configuration
+        _ * configurationContainer.getByName(TEST_CONF_NAME) >> configuration
+        _ * configurationContainer.getByName(UNKNOWN_TEST_CONF_NAME) >> { throw new UnknownDomainObjectException("") }
         _ * configuration.dependencies >> dependencySet
     }
 
@@ -299,10 +304,10 @@ class DefaultDependencyHandlerTest extends Specification {
 
     void "cannot add dependency to unknown configuration"() {
         when:
-        dependencyHandler.unknown("someNotation")
+        dependencyHandler.add(UNKNOWN_TEST_CONF_NAME, "someNotation")
 
         then:
-        thrown(MissingMethodException)
+        thrown(UnknownDomainObjectException)
     }
 
     void "reasonable error when supplying null as a dependency notation"() {


### PR DESCRIPTION
When adding a dependency to an unknown configuration, Gradle should throw an informative `UnknownDomainObjectException` instead of just failing with a `NullPointerException`.

Related to gradle/gradle-script-kotlin#312

### Gradle Core Team Checklist
- [X] Verify test coverage and CI build status
