### PR TITLE
Remove task inputs/outputs deprecations

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.LocalBuildCacheFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
-import spock.lang.Ignore
 import spock.lang.IgnoreIf
 
 class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec implements LocalBuildCacheFixture {
@@ -300,23 +299,6 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
         then:
         skippedTasks.containsAll ":compileJava"
         file("build/classes/main/Hello.class").exists()
-    }
-
-    @Ignore("Must fix for 4.0")
-    def "using `doNotCacheIf` without reason is deprecated"() {
-        given:
-        buildFile << """
-            task adHocTask {
-                outputs.doNotCacheIf { true }
-            }
-        """
-
-        when:
-        executer.expectDeprecationWarning()
-        withBuildCache().succeeds 'adHocTask'
-
-        then:
-        output.contains "The doNotCacheIf(Spec) method has been deprecated and is scheduled to be removed in Gradle 4.0. Please use the doNotCacheIf(String, Spec) method instead."
     }
 
     def "error message contains spec which failed to evaluate"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
@@ -87,8 +87,6 @@ class ExecutionTimeTaskConfigurationIntegrationTest extends AbstractIntegrationS
         "inputs.dir('a')"                                           | "TaskInputs.dir(Object)"
         "inputs.property('key', 'value')"                           | "TaskInputs.property(String, Object)"
         "inputs.properties([key: 'value'])"                         | "TaskInputs.properties(Map)"
-        "inputs.source('a')"                                        | "TaskInputs.source(Object)"
-        "inputs.sourceDir('a')"                                     | "TaskInputs.sourceDir(Object)"
         "outputs.upToDateWhen { }"                                  | "TaskOutputs.upToDateWhen(Closure)"
         "outputs.upToDateWhen({ } as Spec)"                         | "TaskOutputs.upToDateWhen(Spec)"
         "outputs.cacheIf({ } as Spec)"                              | "TaskOutputs.cacheIf(Spec)"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
@@ -90,7 +90,6 @@ class ExecutionTimeTaskConfigurationIntegrationTest extends AbstractIntegrationS
         "outputs.upToDateWhen { }"                                  | "TaskOutputs.upToDateWhen(Closure)"
         "outputs.upToDateWhen({ } as Spec)"                         | "TaskOutputs.upToDateWhen(Spec)"
         "outputs.cacheIf({ } as Spec)"                              | "TaskOutputs.cacheIf(Spec)"
-        "outputs.doNotCacheIf({ } as Spec)"                         | "TaskOutputs.doNotCacheIf(Spec)"
         "outputs.file('a')"                                         | "TaskOutputs.file(Object)"
         "outputs.files('a')"                                        | "TaskOutputs.files(Object...)"
         "outputs.dirs(['prop':'a'])"                                | "TaskOutputs.dirs(Object...)"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -207,29 +207,6 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
         succeeds "test"
     }
 
-    @Ignore("Must fix for 4.0")
-    @Unroll("deprecation warning printed when TaskInputs.#method is called")
-    def "deprecation warning printed when deprecated source method is used"() {
-        buildFile << """
-            task test {
-                inputs.${call}
-            }
-        """
-        executer.expectDeprecationWarning()
-        executer.requireGradleDistribution()
-
-        expect:
-        succeeds "test"
-        outputContains "The TaskInputs.${method} method has been deprecated and is scheduled to be removed in Gradle 4.0. " +
-            "Please use TaskInputs.${replacementMethod}.skipWhenEmpty() instead."
-
-        where:
-        method              | replacementMethod  | call
-        "source(Object)"    | "file(Object)"     | 'source("a")'
-        "sourceDir(Object)" | "dir(Object)"      | 'sourceDir("a")'
-        "source(Object...)" | "files(Object...)" | 'source("a", "b")'
-    }
-
     def "no deprecation warning printed when @Classpath annotation is used"() {
         buildFile << """
             class TaskWithClasspathProperty extends DefaultTask {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks
 import org.gradle.api.file.FileCollection
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.Actions
-import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -184,8 +183,7 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
         skipped ':test'
     }
 
-    @Ignore("Must fix for 4.0")
-    def "no deprecation warning printed when @OutputDirectories or @OutputFiles is used on Map property"() {
+    def "can annotate Map property with @OutputDirectories and @OutputFiles"() {
         file("buildSrc/src/main/groovy/TaskWithOutputFilesProperty.groovy") << """
             import org.gradle.api.*
             import org.gradle.api.tasks.*

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -241,6 +241,25 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
         "files(Object...)"  | 'files("a", "b")'
     }
 
+    @Unroll
+    def "fails when outputs calls are chained (#method)"() {
+        buildFile << """
+            task test {
+                outputs.${call}.${call}
+            }
+        """
+
+        expect:
+        fails "test"
+        failureCauseContains "Chaining of the TaskOutputs.$method method is not supported since Gradle 4.0."
+
+        where:
+        method             | call
+        "file(Object)"     | 'file("a")'
+        "dir(Object)"      | 'dir("a")'
+        "files(Object...)" | 'files("a", "b")'
+    }
+
     def "task depends on other task whose outputs are its inputs"() {
         buildFile << """
             task a {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -245,27 +245,23 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
         succeeds "test"
     }
 
-    @Ignore("Must fix for 4.0")
     @Unroll
-    def "deprecation warning printed when inputs calls are chained"() {
+    def "fails when inputs calls are chained (#method)"() {
         buildFile << """
             task test {
-                ${what}.${call}.${call}
+                inputs.${call}.${call}
             }
         """
-        executer.expectDeprecationWarning()
-        executer.requireGradleDistribution()
 
         expect:
-        succeeds "test"
-        outputContains "The chaining of the ${method} method has been deprecated and is scheduled to be removed in Gradle 4.0. " +
-            "Please use the ${method} method on Task${what.capitalize()} directly instead."
+        fails "test"
+        failureCauseContains "Chaining of the TaskInputs.$method method is not supported since Gradle 4.0."
 
         where:
-        what     | method              | call
-        "inputs" | "file(Object)"      | 'file("a")'
-        "inputs" | "dir(Object)"       | 'dir("a")'
-        "inputs" | "files(Object...)"  | 'files("a", "b")'
+        method              | call
+        "file(Object)"      | 'file("a")'
+        "dir(Object)"       | 'dir("a")'
+        "files(Object...)"  | 'files("a", "b")'
     }
 
     def "task depends on other task whose outputs are its inputs"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -207,21 +207,6 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
         succeeds "test"
     }
 
-    def "no deprecation warning printed when @Classpath annotation is used"() {
-        buildFile << """
-            class TaskWithClasspathProperty extends DefaultTask {
-                @Classpath @InputFiles def classpath = project.files()
-                @TaskAction void action() {}
-            }
-
-            task test(type: TaskWithClasspathProperty) {
-            }
-        """
-
-        expect:
-        succeeds "test"
-    }
-
     @Unroll
     def "fails when inputs calls are chained (#method)"() {
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputPropertySpec.java
@@ -23,17 +23,12 @@ import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStra
 import org.gradle.api.internal.changedetection.state.TaskFilePropertySnapshotNormalizationStrategy;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
-import org.gradle.api.tasks.TaskOutputs;
 
 import static org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy.OUTPUT;
 
 abstract class AbstractTaskOutputPropertySpec extends AbstractTaskOutputsDeprecatingTaskPropertyBuilder implements TaskOutputPropertySpecAndBuilder {
     private boolean optional;
     private SnapshotNormalizationStrategy snapshotNormalizationStrategy = TaskFilePropertySnapshotNormalizationStrategy.ABSOLUTE;
-
-    protected AbstractTaskOutputPropertySpec(TaskOutputs taskOutputs) {
-        super(taskOutputs);
-    }
 
     @Override
     public TaskOutputFilePropertyBuilder withPropertyName(String propertyName) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputsDeprecatingTaskPropertyBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputsDeprecatingTaskPropertyBuilder.java
@@ -22,79 +22,72 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 import org.gradle.api.tasks.TaskOutputs;
-import org.gradle.util.DeprecationLogger;
 
 abstract class AbstractTaskOutputsDeprecatingTaskPropertyBuilder extends AbstractTaskPropertyBuilder implements TaskOutputs {
-    protected final TaskOutputs taskOutputs;
+    // --- See CompatibilityAdapterForTaskOutputs for an explanation for why these methods are here
 
-    public AbstractTaskOutputsDeprecatingTaskPropertyBuilder(TaskOutputs taskOutputs) {
-        this.taskOutputs = taskOutputs;
-    }
-
-    private TaskOutputs getTaskOutputs(String method) {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("chaining of the " + method, String.format("Use '%s' on TaskOutputs directly instead.", method));
-        return taskOutputs;
+    private UnsupportedOperationException failWithUnsupportedMethod(String method) {
+        throw new UnsupportedOperationException(String.format("Chaining of the TaskOutputs.%s method is not supported since Gradle 4.0.", method));
     }
 
     @Override
     public void upToDateWhen(Closure upToDateClosure) {
-        getTaskOutputs("upToDateWhen(Closure)").upToDateWhen(upToDateClosure);
+        throw failWithUnsupportedMethod("upToDateWhen(Closure)");
     }
 
     @Override
     public void upToDateWhen(Spec<? super Task> upToDateSpec) {
-        getTaskOutputs("upToDateWhen(Spec)").upToDateWhen(upToDateSpec);
+        throw failWithUnsupportedMethod("upToDateWhen(Spec)");
     }
 
     @Override
     public void cacheIf(Spec<? super Task> spec) {
-        getTaskOutputs("cacheIf(Spec)").cacheIf(spec);
+        throw failWithUnsupportedMethod("cacheIf(Spec)");
     }
 
     @Override
     public void cacheIf(String cachingEnabledReason, Spec<? super Task> spec) {
-        getTaskOutputs("cacheIf(String, Spec)").cacheIf(cachingEnabledReason, spec);
+        throw failWithUnsupportedMethod("cacheIf(String, Spec)");
     }
 
-    @Override
     public void doNotCacheIf(Spec<? super Task> spec) {
-        getTaskOutputs("doNotCacheIf(Spec)").doNotCacheIf(spec);
+        throw failWithUnsupportedMethod("doNotCacheIf(Spec)");
     }
 
     @Override
     public void doNotCacheIf(String cachingDisabledReason, Spec<? super Task> spec) {
-        getTaskOutputs("doNotCacheIf(String, Spec)").doNotCacheIf(cachingDisabledReason, spec);
+        throw failWithUnsupportedMethod("doNotCacheIf(String, Spec)");
     }
 
     @Override
     public boolean getHasOutput() {
-        return getTaskOutputs("getHasOutput()").getHasOutput();
+        throw failWithUnsupportedMethod("getHasOutput()");
     }
 
     @Override
     public FileCollection getFiles() {
-        return getTaskOutputs("getFiles()").getFiles();
+        throw failWithUnsupportedMethod("getFiles()");
     }
 
     @Override
     @Deprecated
     public TaskOutputFilePropertyBuilder files(Object... paths) {
-        return getTaskOutputs("files(Object...)").files(paths);
+        throw failWithUnsupportedMethod("files(Object...)");
     }
 
     @Override
     @Deprecated
     public TaskOutputFilePropertyBuilder dirs(Object... paths) {
-        return getTaskOutputs("dirs(Object...)").dirs(paths);
+        throw failWithUnsupportedMethod("dirs(Object...)");
     }
 
     @Override
     public TaskOutputFilePropertyBuilder file(Object path) {
-        return getTaskOutputs("file(Object)").file(path);
+        throw failWithUnsupportedMethod("file(Object)");
     }
 
     @Override
     public TaskOutputFilePropertyBuilder dir(Object path) {
-        return getTaskOutputs("dir(Object)").dir(path);
+        throw failWithUnsupportedMethod("dir(Object)");
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CompositeTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CompositeTaskOutputPropertySpec.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.util.GFileUtils;
 
 import java.io.File;
@@ -33,8 +32,7 @@ public class CompositeTaskOutputPropertySpec extends AbstractTaskOutputPropertyS
     private final String taskName;
     private final FileResolver resolver;
 
-    public CompositeTaskOutputPropertySpec(TaskOutputs taskOutputs, String taskName, FileResolver resolver, CacheableTaskOutputFilePropertySpec.OutputType outputType, Object[] paths) {
-        super(taskOutputs);
+    public CompositeTaskOutputPropertySpec(String taskName, FileResolver resolver, CacheableTaskOutputFilePropertySpec.OutputType outputType, Object[] paths) {
         this.taskName = taskName;
         this.resolver = resolver;
         this.outputType = outputType;
@@ -71,7 +69,7 @@ public class CompositeTaskOutputPropertySpec extends AbstractTaskOutputPropertyS
             };
         } else {
             return Iterators.<TaskOutputFilePropertySpec>singletonIterator(
-                new NonCacheableTaskOutputPropertySpec(taskOutputs, taskName, this, resolver, unpackedPaths)
+                new NonCacheableTaskOutputPropertySpec(taskName, this, resolver, unpackedPaths)
             );
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultCacheableTaskOutputFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultCacheableTaskOutputFilePropertySpec.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.util.GFileUtils;
 
 import java.io.File;
@@ -29,8 +28,7 @@ public class DefaultCacheableTaskOutputFilePropertySpec extends AbstractTaskOutp
     private final FileResolver resolver;
     private final Object path;
 
-    public DefaultCacheableTaskOutputFilePropertySpec(TaskOutputs taskOutputs, String taskName, FileResolver resolver, OutputType outputType, Object path) {
-        super(taskOutputs);
+    public DefaultCacheableTaskOutputFilePropertySpec(String taskName, FileResolver resolver, OutputType outputType, Object path) {
         this.resolver = resolver;
         this.outputType = outputType;
         this.path = path;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
@@ -39,9 +39,8 @@ public class DefaultTaskInputPropertySpec extends AbstractTaskPropertyBuilder im
     private SnapshotNormalizationStrategy snapshotNormalizationStrategy = ABSOLUTE;
     private Class<? extends FileCollectionSnapshotter> snapshotter = GenericFileCollectionSnapshotter.class;
 
-    public DefaultTaskInputPropertySpec(String taskName, boolean skipWhenEmpty, FileResolver resolver, Object paths) {
+    public DefaultTaskInputPropertySpec(String taskName, FileResolver resolver, Object paths) {
         this.files = new TaskPropertyFileCollection(taskName, "input", this, resolver, paths);
-        this.skipWhenEmpty = skipWhenEmpty;
     }
 
     @Override
@@ -176,21 +175,6 @@ public class DefaultTaskInputPropertySpec extends AbstractTaskPropertyBuilder im
     @Override
     public FileCollection getSourceFiles() {
         throw failWithUnsupportedMethod("getSourceFiles()");
-    }
-
-    @Override
-    public TaskInputs source(Object... paths) {
-        throw failWithUnsupportedMethod("source(Object...)");
-    }
-
-    @Override
-    public TaskInputs source(Object path) {
-        throw failWithUnsupportedMethod("source(Object)");
-    }
-
-    @Override
-    public TaskInputs sourceDir(Object path) {
-        throw failWithUnsupportedMethod("sourceDir(Object)");
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
 import org.gradle.api.tasks.TaskInputs;
-import org.gradle.util.DeprecationLogger;
 
 import java.util.Map;
 
@@ -34,15 +33,13 @@ import static org.gradle.api.internal.changedetection.state.TaskFilePropertySnap
 
 public class DefaultTaskInputPropertySpec extends AbstractTaskPropertyBuilder implements TaskInputPropertySpecAndBuilder {
 
-    private final TaskInputs taskInputs;
     private final TaskPropertyFileCollection files;
     private boolean skipWhenEmpty;
     private boolean optional;
     private SnapshotNormalizationStrategy snapshotNormalizationStrategy = ABSOLUTE;
     private Class<? extends FileCollectionSnapshotter> snapshotter = GenericFileCollectionSnapshotter.class;
 
-    public DefaultTaskInputPropertySpec(TaskInputs taskInputs, String taskName, boolean skipWhenEmpty, FileResolver resolver, Object paths) {
-        this.taskInputs = taskInputs;
+    public DefaultTaskInputPropertySpec(String taskName, boolean skipWhenEmpty, FileResolver resolver, Object paths) {
         this.files = new TaskPropertyFileCollection(taskName, "input", this, resolver, paths);
         this.skipWhenEmpty = skipWhenEmpty;
     }
@@ -125,79 +122,75 @@ public class DefaultTaskInputPropertySpec extends AbstractTaskPropertyBuilder im
         return getPropertyName() + " (" + snapshotNormalizationStrategy + ")";
     }
 
-    // --- Deprecated delegate methods
+    // --- See CompatibilityAdapterForTaskInputs for an explanation for why these methods are here
 
-    private TaskInputs getTaskInputs(String method) {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("chaining of the " + method, String.format("Please use the %s method on TaskInputs directly instead.", method));
-        return taskInputs;
+    private UnsupportedOperationException failWithUnsupportedMethod(String method) {
+        throw new UnsupportedOperationException(String.format("Chaining of the TaskInputs.%s method is not supported since Gradle 4.0.", method));
     }
 
     @Override
     public boolean getHasInputs() {
-        return getTaskInputs("getHasInputs()").getHasInputs();
+        throw failWithUnsupportedMethod("getHasInputs()");
     }
 
     @Override
     public FileCollection getFiles() {
-        return getTaskInputs("getFiles()").getFiles();
+        throw failWithUnsupportedMethod("getFiles()");
     }
 
     @Override
     public TaskInputFilePropertyBuilder files(Object... paths) {
-        return getTaskInputs("files(Object...)").files(paths);
+        throw failWithUnsupportedMethod("files(Object...)");
     }
 
     @Override
     public TaskInputFilePropertyBuilder file(Object path) {
-        return getTaskInputs("file(Object)").file(path);
+        throw failWithUnsupportedMethod("file(Object)");
     }
 
     @Override
     public TaskInputFilePropertyBuilder dir(Object dirPath) {
-        return getTaskInputs("dir(Object)").dir(dirPath);
+        throw failWithUnsupportedMethod("dir(Object)");
     }
 
     @Override
     public Map<String, Object> getProperties() {
-        return getTaskInputs("getProperties()").getProperties();
+        throw failWithUnsupportedMethod("getProperties()");
     }
 
     @Override
     public TaskInputs property(String name, Object value) {
-        return getTaskInputs("property(String, Object)").property(name, value);
+        throw failWithUnsupportedMethod("property(String, Object)");
     }
 
     @Override
     public TaskInputs properties(Map<String, ?> properties) {
-        return getTaskInputs("properties(Map)").properties(properties);
+        throw failWithUnsupportedMethod("properties(Map)");
     }
 
     @Override
     public boolean getHasSourceFiles() {
-        return getTaskInputs("getHasSourceFiles()").getHasSourceFiles();
+        throw failWithUnsupportedMethod("getHasSourceFiles()");
     }
 
     @Override
     public FileCollection getSourceFiles() {
-        return getTaskInputs("getSourceFiles()").getSourceFiles();
+        throw failWithUnsupportedMethod("getSourceFiles()");
     }
 
     @Override
-    @Deprecated
     public TaskInputs source(Object... paths) {
-        return getTaskInputs("source(Object...)").source(paths);
+        throw failWithUnsupportedMethod("source(Object...)");
     }
 
     @Override
-    @Deprecated
     public TaskInputs source(Object path) {
-        return getTaskInputs("source(Object)").source(path);
+        throw failWithUnsupportedMethod("source(Object)");
     }
 
     @Override
-    @Deprecated
     public TaskInputs sourceDir(Object path) {
-        return getTaskInputs("sourceDir(Object)").sourceDir(path);
+        throw failWithUnsupportedMethod("sourceDir(Object)");
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -161,7 +161,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
     }
 
     private TaskInputFilePropertyBuilderInternal addSpec(Object paths, boolean skipWhenEmpty) {
-        DefaultTaskInputPropertySpec spec = new DefaultTaskInputPropertySpec(this, task.getName(), skipWhenEmpty, resolver, paths);
+        DefaultTaskInputPropertySpec spec = new DefaultTaskInputPropertySpec(task.getName(), skipWhenEmpty, resolver, paths);
         filePropertiesInternal.add(spec);
         return spec;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.file.CompositeFileCollection;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.tasks.TaskInputs;
-import org.gradle.util.DeprecationLogger;
 
 import java.util.HashMap;
 import java.util.List;
@@ -120,48 +119,8 @@ public class DefaultTaskInputs implements TaskInputsInternal {
         return allSourceFiles;
     }
 
-    @Override
-    public TaskInputs source(final Object... paths) {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("TaskInputs.source(Object...)", "Please use TaskInputs.files(Object...).skipWhenEmpty() instead.");
-        taskMutator.mutate("TaskInputs.source(Object...)", new Runnable() {
-            @Override
-            public void run() {
-                addSpec(paths, true);
-            }
-        });
-        return this;
-    }
-
-    @Override
-    public TaskInputs source(final Object path) {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("TaskInputs.source(Object)", "Please use TaskInputs.file(Object).skipWhenEmpty() instead.");
-        taskMutator.mutate("TaskInputs.source(Object)", new Runnable() {
-            @Override
-            public void run() {
-                addSpec(path, true);
-            }
-        });
-        return this;
-    }
-
-    @Override
-    public TaskInputs sourceDir(final Object path) {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("TaskInputs.sourceDir(Object)", "Please use TaskInputs.dir(Object).skipWhenEmpty() instead.");
-        taskMutator.mutate("TaskInputs.sourceDir(Object)", new Runnable() {
-            @Override
-            public void run() {
-                addSpec(resolver.resolveFilesAsTree(path), true);
-            }
-        });
-        return this;
-    }
-
     private TaskInputFilePropertyBuilderInternal addSpec(Object paths) {
-        return addSpec(paths, false);
-    }
-
-    private TaskInputFilePropertyBuilderInternal addSpec(Object paths, boolean skipWhenEmpty) {
-        DefaultTaskInputPropertySpec spec = new DefaultTaskInputPropertySpec(task.getName(), skipWhenEmpty, resolver, paths);
+        DefaultTaskInputPropertySpec spec = new DefaultTaskInputPropertySpec(task.getName(), resolver, paths);
         filePropertiesInternal.add(spec);
         return spec;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -37,7 +37,6 @@ import org.gradle.api.internal.tasks.execution.SelfDescribingSpec;
 import org.gradle.api.specs.AndSpec;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
-import org.gradle.util.DeprecationLogger;
 
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -157,12 +156,6 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
                 cacheIfSpecs.add(new SelfDescribingSpec<TaskInternal>(spec, cachingEnabledReason));
             }
         });
-    }
-
-    @Override
-    public void doNotCacheIf(final Spec<? super Task> spec) {
-        DeprecationLogger.nagUserOfReplacedMethod("doNotCacheIf(Spec)", "doNotCacheIf(String, Spec)");
-        doNotCacheIf("Task outputs not cacheable", spec);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -213,7 +213,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
         return taskMutator.mutate("TaskOutputs.file(Object)", new Callable<TaskOutputFilePropertyBuilder>() {
             @Override
             public TaskOutputFilePropertyBuilder call() throws Exception {
-                return addSpec(new DefaultCacheableTaskOutputFilePropertySpec(DefaultTaskOutputs.this, task.getName(), resolver, OutputType.FILE, path));
+                return addSpec(new DefaultCacheableTaskOutputFilePropertySpec(task.getName(), resolver, OutputType.FILE, path));
             }
         });
     }
@@ -223,7 +223,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
         return taskMutator.mutate("TaskOutputs.dir(Object)", new Callable<TaskOutputFilePropertyBuilder>() {
             @Override
             public TaskOutputFilePropertyBuilder call() throws Exception {
-                return addSpec(new DefaultCacheableTaskOutputFilePropertySpec(DefaultTaskOutputs.this, task.getName(), resolver, OutputType.DIRECTORY, path));
+                return addSpec(new DefaultCacheableTaskOutputFilePropertySpec(task.getName(), resolver, OutputType.DIRECTORY, path));
             }
         });
     }
@@ -233,7 +233,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
         return taskMutator.mutate("TaskOutputs.files(Object...)", new Callable<TaskOutputFilePropertyBuilder>() {
             @Override
             public TaskOutputFilePropertyBuilder call() throws Exception {
-                return addSpec(new CompositeTaskOutputPropertySpec(DefaultTaskOutputs.this, task.getName(), resolver, OutputType.FILE, paths));
+                return addSpec(new CompositeTaskOutputPropertySpec(task.getName(), resolver, OutputType.FILE, paths));
             }
         });
     }
@@ -243,7 +243,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
         return taskMutator.mutate("TaskOutputs.dirs(Object...)", new Callable<TaskOutputFilePropertyBuilder>() {
             @Override
             public TaskOutputFilePropertyBuilder call() throws Exception {
-                return addSpec(new CompositeTaskOutputPropertySpec(DefaultTaskOutputs.this, task.getName(), resolver, OutputType.DIRECTORY, paths));
+                return addSpec(new CompositeTaskOutputPropertySpec(task.getName(), resolver, OutputType.DIRECTORY, paths));
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.SnapshotNormalizationStrategy;
 import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.TaskPropertyBuilder;
 
 public class NonCacheableTaskOutputPropertySpec extends AbstractTaskOutputsDeprecatingTaskPropertyBuilder implements TaskOutputFilePropertySpec {
@@ -29,8 +28,7 @@ public class NonCacheableTaskOutputPropertySpec extends AbstractTaskOutputsDepre
     private final CompositeTaskOutputPropertySpec parent;
     private final FileCollection files;
 
-    public NonCacheableTaskOutputPropertySpec(TaskOutputs taskOutputs, String taskName, CompositeTaskOutputPropertySpec parent, FileResolver resolver, Object paths) {
-        super(taskOutputs);
+    public NonCacheableTaskOutputPropertySpec(String taskName, CompositeTaskOutputPropertySpec parent, FileResolver resolver, Object paths) {
         this.parent = parent;
         this.files = new TaskPropertyFileCollection(taskName, "output", this, resolver, paths);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -78,14 +78,6 @@ public class TaskStateInternal implements TaskState {
         return taskOutputCaching;
     }
 
-    /**
-     * @deprecated Use {@link #getTaskOutputCaching()} instead.
-     */
-    @Deprecated
-    public boolean isCacheable() {
-        return getTaskOutputCaching().isEnabled();
-    }
-
     public Throwable getFailure() {
         return failure;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/TaskInputFilePropertyBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/TaskInputFilePropertyBuilder.java
@@ -69,7 +69,7 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     TaskInputFilePropertyBuilder withPathSensitivity(PathSensitivity sensitivity);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#getHasInputs()} directly instead.
      */
@@ -78,7 +78,7 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     boolean getHasInputs();
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#getFiles()} directly instead.
      */
@@ -87,7 +87,7 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     FileCollection getFiles();
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#files(Object...)} directly instead.
      */
@@ -96,7 +96,7 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     TaskInputFilePropertyBuilder files(Object... paths);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#file(Object)} directly instead.
      */
@@ -105,7 +105,7 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     TaskInputFilePropertyBuilder file(Object path);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#dir(Object)} directly instead.
      */
@@ -114,7 +114,7 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     TaskInputFilePropertyBuilder dir(Object dirPath);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#getProperties()} directly instead.
      */
@@ -123,7 +123,7 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     Map<String, Object> getProperties();
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#property(String, Object)} directly instead.
      */
@@ -132,7 +132,7 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     TaskInputs property(String name, Object value);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#properties(Map)} directly instead.
      */
@@ -141,7 +141,7 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     TaskInputs properties(Map<String, ?> properties);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#getHasSourceFiles()} directly instead.
      */
@@ -150,38 +150,11 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder, T
     boolean getHasSourceFiles();
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskInputs#getSourceFiles()} directly instead.
      */
     @Deprecated
     @Override
     FileCollection getSourceFiles();
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated Use {@link TaskInputs#source(Object...)} directly instead.
-     */
-    @Deprecated
-    @Override
-    TaskInputs source(Object... paths);
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated Use {@link TaskInputs#source(Object)} directly instead.
-     */
-    @Deprecated
-    @Override
-    TaskInputs source(Object path);
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated Use {@link TaskInputs#sourceDir(Object)} directly instead.
-     */
-    @Deprecated
-    @Override
-    TaskInputs sourceDir(Object path);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -110,40 +110,4 @@ public interface TaskInputs extends CompatibilityAdapterForTaskInputs {
      * @return The set of source files for this task.
      */
     FileCollection getSourceFiles();
-
-    /**
-     * Registers some source files for this task. Note that source files are also considered input files, so calling this method implies
-     * a call to {@link #files(Object...)}.
-     *
-     * @param paths The paths. These are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
-     * @return this
-     *
-     * @deprecated Use {@link #files(Object...)} instead and set {@code skipWhenEmpty} to {@code true}.
-     */
-    @Deprecated
-    TaskInputs source(Object... paths);
-
-    /**
-     * Registers some source files for this task. Note that source files are also considered input files, so calling this method implies
-     * a call to {@link #files(Object...)}.
-     *
-     * @param path The path. This is evaluated as per {@link org.gradle.api.Project#files(Object...)}.
-     * @return this
-     *
-     * @deprecated Use {@link #file(Object)} instead and set {@code skipWhenEmpty} to {@code true}.
-     */
-    @Deprecated
-    TaskInputs source(Object path);
-
-    /**
-     * Registers a source directory for this task. All files under this directory are treated as source files for this task. Note that
-     * source files are also considered input files, so calling this method implies a call to {@link #dir(Object)}.
-     *
-     * @param path The path. This is evaluated as per {@link org.gradle.api.Project#file(Object)}.
-     * @return this
-     *
-     * @deprecated Use {@link #dir(Object)} instead and set {@code skipWhenEmpty} to {@code true}.
-     */
-    @Deprecated
-    TaskInputs sourceDir(Object path);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/TaskOutputFilePropertyBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/TaskOutputFilePropertyBuilder.java
@@ -56,7 +56,7 @@ public interface TaskOutputFilePropertyBuilder extends TaskFilePropertyBuilder, 
     TaskOutputFilePropertyBuilder withPathSensitivity(PathSensitivity sensitivity);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskOutputs#upToDateWhen(Closure)} instead.
      */
@@ -65,7 +65,7 @@ public interface TaskOutputFilePropertyBuilder extends TaskFilePropertyBuilder, 
     void upToDateWhen(Closure upToDateClosure);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskOutputs#upToDateWhen(Spec)} instead.
      */
@@ -74,7 +74,7 @@ public interface TaskOutputFilePropertyBuilder extends TaskFilePropertyBuilder, 
     void upToDateWhen(Spec<? super Task> upToDateSpec);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskOutputs#getHasOutput()} instead.
      */
@@ -83,7 +83,7 @@ public interface TaskOutputFilePropertyBuilder extends TaskFilePropertyBuilder, 
     boolean getHasOutput();
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskOutputs#getFiles()} instead.
      */
@@ -92,7 +92,7 @@ public interface TaskOutputFilePropertyBuilder extends TaskFilePropertyBuilder, 
     FileCollection getFiles();
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskOutputs#files(Object...)} instead.
      */
@@ -101,7 +101,7 @@ public interface TaskOutputFilePropertyBuilder extends TaskFilePropertyBuilder, 
     TaskOutputFilePropertyBuilder files(Object... paths);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskOutputs#file(Object)} instead.
      */
@@ -110,7 +110,7 @@ public interface TaskOutputFilePropertyBuilder extends TaskFilePropertyBuilder, 
     TaskOutputFilePropertyBuilder file(Object path);
 
     /**
-     * {@inheritDoc}
+     * Throws {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link TaskOutputs#dir(Object)} instead.
      */

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/TaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/TaskOutputs.java
@@ -88,22 +88,6 @@ public interface TaskOutputs extends CompatibilityAdapterForTaskOutputs {
     void cacheIf(String cachingEnabledReason, final Spec<? super Task> spec);
 
     /**
-     /**
-     * <p>Disable caching the results of the task if the given spec is satisfied. The spec will be evaluated at task execution time, not
-     * during configuration. If the spec is not satisfied, the results of the task will be cached according to {@link #cacheIf(Spec)}.</p>
-     *
-     * <p>You may add multiple such predicates. The results of the task are not cached if any of the predicates return {@code true},
-     * or if any of the predicates passed to {@link #cacheIf(String, Spec)} returns {@code false}.</p>
-     *
-     * @param spec specifies if the results of the task should not be cached.
-     *
-     * @deprecated Use {@link #doNotCacheIf(String, Spec)} to give a reason for not caching.
-     * @since 3.3
-     */
-    @Deprecated
-    void doNotCacheIf(Spec<? super Task> spec);
-
-    /**
      * <p>Disable caching the results of the task if the given spec is satisfied. The spec will be evaluated at task execution time, not
      * during configuration. If the spec is not satisfied, the results of the task will be cached according to {@link #cacheIf(Spec)}.</p>
      *

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -191,7 +191,7 @@ class DefaultTaskInputsTest extends Specification {
 
     def canRegisterSourceFile() {
         when:
-        inputs.source('file')
+        inputs.file('file').skipWhenEmpty()
 
         then:
         inputs.sourceFiles.files == ([new File('file')] as Set)
@@ -199,7 +199,7 @@ class DefaultTaskInputsTest extends Specification {
 
     def canRegisterSourceFiles() {
         when:
-        inputs.source('file', 'file2')
+        inputs.files('file', 'file2').skipWhenEmpty()
 
         then:
         inputs.sourceFiles.files == ([new File('file'), new File('file2')] as Set)
@@ -207,7 +207,7 @@ class DefaultTaskInputsTest extends Specification {
 
     def canRegisterSourceDir() {
         when:
-        inputs.sourceDir('dir')
+        inputs.dir('dir').skipWhenEmpty()
 
         then:
         inputs.sourceFiles.files == [treeFile] as Set
@@ -215,7 +215,7 @@ class DefaultTaskInputsTest extends Specification {
 
     def sourceFilesAreAlsoInputFiles() {
         when:
-        inputs.source('file')
+        inputs.file('file').skipWhenEmpty()
 
         then:
         inputs.sourceFiles.files == ([new File('file')] as Set)
@@ -251,7 +251,7 @@ class DefaultTaskInputsTest extends Specification {
 
     def hasInputsWhenEmptySourceFilesRegistered() {
         when:
-        inputs.source([])
+        inputs.files([]).skipWhenEmpty()
 
         then:
         inputs.hasInputs
@@ -260,7 +260,7 @@ class DefaultTaskInputsTest extends Specification {
 
     def hasInputsWhenSourceFilesRegistered() {
         when:
-        inputs.source('a')
+        inputs.file('a').skipWhenEmpty()
 
         then:
         inputs.hasInputs

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -307,7 +307,7 @@ class DefaultTaskOutputsTest extends Specification {
         !outputs.cachingState.enabled
 
         when:
-        outputs.doNotCacheIf { false }
+        outputs.doNotCacheIf("test") { false }
         then:
         !outputs.cachingState.enabled
 
@@ -317,7 +317,7 @@ class DefaultTaskOutputsTest extends Specification {
         outputs.cachingState.enabled
 
         when:
-        outputs.doNotCacheIf { true }
+        outputs.doNotCacheIf("test") { true }
         then:
         !outputs.cachingState.enabled
     }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -177,6 +177,9 @@ The following are the newly deprecated items in this Gradle release. If you have
 - Removed Ant <depend> related classes `AntDepend`, `AntDependsStaleClassCleaner`, and `DependOptions`
 - Removed `Javadoc#setOptions`
 - Removed `Manifest.writeTo(Writer)`. Please use `Manifest.writeTo(Object)`
+- Removed `TaskInputs.source()` and `sourceDir()`. Please use `TaskInputs.file().skipWhenEmpty()`, `files().skipWhenEmpty()` and `dir().skipWhenEmpty()`.
+- Chaining calls to `TaskInputs.file()`, `files()`, `dir()` and `TaskOutputs.file()`, `files()` and `dir()` are not supported anymore.
+- Removed `TaskOutputs.doNotCacheIf(Spec)`, use `doNotCacheIf(String, Spec)` instead.
 
 The deprecated `jetty` plugin has been removed. We recommend using the [Gretty plugin](https://github.com/akhikhl/gretty) for developing Java web applications.
 The deprecated `pluginRepositories` block for declaring custom plugin repositories has been removed in favor of `pluginManagement.repositories`.


### PR DESCRIPTION
Deprecations scheduled to be removed in 4.0 related to task input/output handling.
