### PR TITLE
MavenConversionIntegrationTest: Use replace() instead of replaceAll()

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -247,7 +247,7 @@ it.exclude group: '*', module: 'badArtifact'
         withSharedResources()
         def repo = mavenHttpServer()
         //update pom with test repo url
-        file("pom.xml").text = file("pom.xml").text.replaceAll('LOCAL_MAVEN_REPO_URL', repo.getUri().toString())
+        file("pom.xml").text = file("pom.xml").text.replace('LOCAL_MAVEN_REPO_URL', repo.getUri().toString())
 
         expectParentPomRequest(repo)
 
@@ -289,7 +289,7 @@ it.exclude group: '*', module: 'badArtifact'
         withSharedResources()
         def repo = mavenHttpServer()
         //update pom with test repo url
-        file("pom.xml").text = file("pom.xml").text.replaceAll('LOCAL_MAVEN_REPO_URL', repo.getUri().toString())
+        file("pom.xml").text = file("pom.xml").text.replace('LOCAL_MAVEN_REPO_URL', repo.getUri().toString())
 
         expectParentPomRequest(repo)
 


### PR DESCRIPTION
### Context
replaceAll() takes a regex, but we do not provide one. Use replace()
instead, which despite its name also replaces all matching substrings.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective (already existing since this is a fix to tests)
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
