### PR TITLE
Introduce replacement method for avoiding the use of org.gradle.util.Clock

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/time/Clock.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/time/Clock.java
@@ -56,11 +56,13 @@ public class Clock implements Timer {
         return Math.max(timeProvider.getCurrentTimeForDuration() - startInstant, 0);
     }
 
+    @Override
     public void reset() {
         startTime = timeProvider.getCurrentTime();
         startInstant = timeProvider.getCurrentTimeForDuration();
     }
 
+    @Override
     public long getStartTime() {
         return startTime;
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/time/Timer.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/time/Timer.java
@@ -22,4 +22,6 @@ public interface Timer {
     long getElapsedMillis();
 
     void reset();
+
+    long getStartTime();
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildRequestMetaData.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildRequestMetaData.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.initialization;
 
+import org.gradle.internal.time.Timer;
 import org.gradle.util.Clock;
 
 /**
@@ -28,7 +29,17 @@ public interface BuildRequestMetaData {
 
     /**
      * Returns a clock measuring the time since the request was made by the user of the client.
+     *
+     * @deprecated Use the method {@link #getBuildTimer()} instead.
      */
     @Deprecated
     Clock getBuildTimeClock();
+
+    /**
+     * Returns a timer measuring the time since the request was made by the user of the client.
+     *
+     * @return Timer
+     * @since 4.0
+     */
+    Timer getBuildTimer();
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildRequestContext.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildRequestContext.java
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization;
 
+import org.gradle.internal.time.Timer;
 import org.gradle.util.Clock;
 
 public class DefaultBuildRequestContext implements BuildRequestContext {
@@ -47,5 +48,10 @@ public class DefaultBuildRequestContext implements BuildRequestContext {
     @Override
     public Clock getBuildTimeClock() {
         return metaData.getBuildTimeClock();
+    }
+
+    @Override
+    public Timer getBuildTimer() {
+        return metaData.getBuildTimer();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildRequestMetaData.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildRequestMetaData.java
@@ -16,15 +16,18 @@
 package org.gradle.initialization;
 
 import org.gradle.configuration.GradleLauncherMetaData;
+import org.gradle.internal.time.Timer;
 import org.gradle.util.Clock;
 
 public class DefaultBuildRequestMetaData implements BuildRequestMetaData {
     private final BuildClientMetaData clientMetaData;
     private final Clock clock;
+    private final Timer timer;
 
     public DefaultBuildRequestMetaData(BuildClientMetaData clientMetaData, long startTime) {
         this.clientMetaData = clientMetaData;
         clock = new Clock(startTime);
+        timer = new org.gradle.internal.time.Clock(startTime);
     }
 
     public DefaultBuildRequestMetaData(long startTime) {
@@ -34,6 +37,7 @@ public class DefaultBuildRequestMetaData implements BuildRequestMetaData {
     public DefaultBuildRequestMetaData(BuildClientMetaData buildClientMetaData) {
         this.clientMetaData = buildClientMetaData;
         this.clock = new Clock();
+        timer = new org.gradle.internal.time.Clock();
     }
 
     public BuildClientMetaData getClient() {
@@ -42,5 +46,9 @@ public class DefaultBuildRequestMetaData implements BuildRequestMetaData {
 
     public Clock getBuildTimeClock() {
         return clock;
+    }
+
+    public Timer getBuildTimer() {
+        return timer;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
@@ -42,7 +42,7 @@ public class BuildLogger implements BuildListener, TaskExecutionGraphListener {
     public BuildLogger(Logger logger, StyledTextOutputFactory textOutputFactory, StartParameter startParameter, BuildRequestMetaData requestMetaData) {
         this.logger = logger;
         resultLoggers.add(new BuildExceptionReporter(textOutputFactory, startParameter, requestMetaData.getClient()));
-        resultLoggers.add(new BuildResultLogger(textOutputFactory, requestMetaData.getBuildTimeClock(), new TersePrettyDurationFormatter()));
+        resultLoggers.add(new BuildResultLogger(textOutputFactory, requestMetaData.getBuildTimer(), new TersePrettyDurationFormatter()));
     }
 
     public void buildStarted(Gradle gradle) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildResultLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildResultLogger.java
@@ -21,7 +21,7 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.logging.format.DurationFormatter;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
-import org.gradle.internal.time.Clock;
+import org.gradle.internal.time.Timer;
 
 import static org.gradle.internal.logging.text.StyledTextOutput.Style.Failure;
 import static org.gradle.internal.logging.text.StyledTextOutput.Style.Success;
@@ -31,12 +31,12 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style.Success;
  */
 public class BuildResultLogger extends BuildAdapter {
     private final StyledTextOutputFactory textOutputFactory;
-    private final Clock buildTimeClock;
+    private final Timer buildTimer;
     private final DurationFormatter durationFormatter;
 
-    public BuildResultLogger(StyledTextOutputFactory textOutputFactory, Clock buildTimeClock, DurationFormatter durationFormatter) {
+    public BuildResultLogger(StyledTextOutputFactory textOutputFactory, Timer buildTimer, DurationFormatter durationFormatter) {
         this.textOutputFactory = textOutputFactory;
-        this.buildTimeClock = buildTimeClock;
+        this.buildTimer = buildTimer;
         this.durationFormatter = durationFormatter;
     }
 
@@ -50,6 +50,6 @@ public class BuildResultLogger extends BuildAdapter {
             textOutput.withStyle(Failure).text(action + " FAILED");
         }
 
-        textOutput.formatln(" in %s", durationFormatter.format(buildTimeClock.getElapsedMillis()));
+        textOutput.formatln(" in %s", durationFormatter.format(buildTimer.getElapsedMillis()));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/profile/ProfileEventAdapter.java
+++ b/subprojects/core/src/main/java/org/gradle/profile/ProfileEventAdapter.java
@@ -51,7 +51,7 @@ public class ProfileEventAdapter implements BuildListener, ProjectEvaluationList
         long now = timeProvider.getCurrentTime();
         buildProfile = new BuildProfile(gradle.getStartParameter());
         buildProfile.setBuildStarted(now);
-        buildProfile.setProfilingStarted(buildMetaData.getBuildTimeClock().getStartTime());
+        buildProfile.setProfilingStarted(buildMetaData.getBuildTimer().getStartTime());
     }
 
     public void settingsEvaluated(Settings settings) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.BuildResult
 import org.gradle.internal.logging.format.DurationFormatter
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
-import org.gradle.internal.time.Clock
+import org.gradle.internal.time.Timer
 import org.gradle.util.TextUtil
 import spock.lang.Specification
 import spock.lang.Subject
@@ -28,16 +28,16 @@ import spock.lang.Subject
 @Subject(BuildResultLogger)
 class BuildResultLoggerTest extends Specification {
     private StyledTextOutputFactory textOutputFactory = new TestStyledTextOutputFactory()
-    private Clock clock = Mock(Clock)
+    private Timer timer = Mock(Timer)
     private DurationFormatter durationFormatter = Mock(DurationFormatter)
-    private BuildResultLogger subject = new BuildResultLogger(textOutputFactory, clock, durationFormatter)
+    private BuildResultLogger subject = new BuildResultLogger(textOutputFactory, timer, durationFormatter)
 
     def "logs build success with total time"() {
         when:
         subject.buildFinished(new BuildResult("Action", null, null));
 
         then:
-        1 * clock.getElapsedMillis() >> { 10L }
+        1 * timer.getElapsedMillis() >> { 10L }
         1 * durationFormatter.format(10L) >> { "10s" }
         TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}\n{success}ACTION SUCCESSFUL{normal} in 10s\n"
     }
@@ -47,7 +47,7 @@ class BuildResultLoggerTest extends Specification {
         subject.buildFinished(new BuildResult("Action", null, new RuntimeException()));
 
         then:
-        1 * clock.getElapsedMillis() >> { 10L }
+        1 * timer.getElapsedMillis() >> { 10L }
         1 * durationFormatter.format(10L) >> { "10s" }
         TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}\n{failure}ACTION FAILED{normal} in 10s\n"
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonClient.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonClient.java
@@ -126,7 +126,7 @@ public class DaemonClient implements BuildActionExecuter<BuildActionParameters> 
         for (int i = 1; i < saneNumberOfAttempts; i++) {
             final DaemonClientConnection connection = connector.connect(compatibilitySpec);
             try {
-                Build build = new Build(buildId, connection.getDaemon().getToken(), action, requestContext.getClient(), requestContext.getBuildTimeClock().getStartTime(), parameters);
+                Build build = new Build(buildId, connection.getDaemon().getToken(), action, requestContext.getClient(), requestContext.getBuildTimer().getStartTime(), parameters);
                 return executeBuild(build, connection, requestContext.getCancellationToken(), requestContext.getEventConsumer());
             } catch (DaemonInitialConnectException e) {
                 // this exception means that we want to try again.

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/SingleUseDaemonClient.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/SingleUseDaemonClient.java
@@ -51,7 +51,7 @@ public class SingleUseDaemonClient extends DaemonClient {
         LOGGER.lifecycle("{} Please consider using the daemon: {}.", MESSAGE, documentationRegistry.getDocumentationFor("gradle_daemon"));
 
         DaemonClientConnection daemonConnection = getConnector().startDaemon(ExplainingSpecs.<DaemonContext>satisfyAll());
-        Build build = new BuildAndStop(getIdGenerator().generateId(), daemonConnection.getDaemon().getToken(), action, buildRequestContext.getClient(), buildRequestContext.getBuildTimeClock().getStartTime(), parameters);
+        Build build = new BuildAndStop(getIdGenerator().generateId(), daemonConnection.getDaemon().getToken(), action, buildRequestContext.getClient(), buildRequestContext.getBuildTimer().getStartTime(), parameters);
 
         return executeBuild(build, daemonConnection, buildRequestContext.getCancellationToken(), buildRequestContext.getEventConsumer());
     }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuter.java
@@ -97,7 +97,7 @@ public class ContinuousBuildActionExecuter implements BuildActionExecuter<BuildA
         while (!cancellationToken.isCancellationRequested()) {
             if (++counter != 1) {
                 // reset the time the build started so the total time makes sense
-                requestContext.getBuildTimeClock().reset();
+                requestContext.getBuildTimer().reset();
                 logger.println("Change detected, executing build...").println();
             }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/RunBuildActionTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/RunBuildActionTest.groovy
@@ -49,6 +49,7 @@ class RunBuildActionTest extends Specification {
             assert context.cancellationToken instanceof DefaultBuildCancellationToken
             assert context.client == clientMetaData
             assert context.buildTimeClock.startTime == startTime
+            assert context.buildTimer.startTime == startTime
             assert build == parameters
             assert services == sharedServices
         }

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.service.ServiceRegistry
-import org.gradle.util.Clock
+import org.gradle.internal.time.Timer
 import org.gradle.launcher.exec.BuildActionExecuter
 import org.gradle.launcher.exec.BuildActionParameters
 import org.gradle.util.RedirectStdIn
@@ -48,7 +48,7 @@ class ContinuousBuildActionExecuterTest extends Specification {
     def delegate = Mock(BuildActionExecuter)
     def action = Mock(BuildAction)
     def cancellationToken = new DefaultBuildCancellationToken()
-    def clock = Mock(Clock)
+    def timer = Mock(Timer)
     def requestMetadata = Stub(BuildRequestMetaData)
     def requestContext = new DefaultBuildRequestContext(requestMetadata, cancellationToken, new NoOpBuildEventConsumer())
     def actionParameters = Stub(BuildActionParameters)
@@ -63,7 +63,7 @@ class ContinuousBuildActionExecuterTest extends Specification {
     private File file = new File('file')
 
     def setup() {
-        requestMetadata.getBuildTimeClock() >> clock
+        requestMetadata.getBuildTimer() >> timer
         waiterFactory.createChangeWaiter(_) >> waiter
         waiter.isWatching() >> true
     }


### PR DESCRIPTION
### Context

The return type of the existing method cannot be easily changed as the build scan plugin depends on it.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
