### PR TITLE
Fix Java component publishing

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -146,6 +146,11 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 ## Potential breaking changes
 
+### maven-publish and ivy-publish mirror multi-project behavior
+
+When using the `java` plugin, all `compile` and `runtime` dependencies will now be mapped to the `compile` scope, i.e. "leaked" into the consumer's compile classpath. This is in line with how
+ these legacy configurations work in multi-project builds. We strongly encourage you to use the `api`(java-library plugin only), `implementation` and `runtimeOnly` configurations instead. These
+ are mapped as expected, with `api` being exposed to the consumer's compile classpath and `implementation` and `runtimeOnly` only available on the consumer's runtime classpath.
 <!--
 ### Example breaking change
 -->

--- a/subprojects/docs/src/samples/ivy-publish/java-multi-project/build.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/java-multi-project/build.gradle
@@ -48,7 +48,7 @@ subprojects {
                 from components.java
                 artifact(sourceJar) {
                     type "source"
-                    conf "runtime"
+                    conf "compile"
                 }
 // END SNIPPET publish-custom-artifact
                 descriptor.withXml {

--- a/subprojects/docs/src/samples/ivy-publish/java-multi-project/output-ivy.xml
+++ b/subprojects/docs/src/samples/ivy-publish/java-multi-project/output-ivy.xml
@@ -7,16 +7,16 @@
   </info>
   <configurations>
     <conf name="compile" visibility="public"/>
-    <conf name="default" visibility="public" extends="runtime,compile"/>
+    <conf name="default" visibility="public" extends="compile,runtime"/>
     <conf name="runtime" visibility="public"/>
   </configurations>
   <publications>
-    <artifact name="project1" type="jar" ext="jar" conf="runtime"/>
-    <artifact name="project1" type="source" ext="jar" conf="runtime" m:classifier="source" xmlns:m="http://ant.apache.org/ivy/maven"/>
+    <artifact name="project1" type="jar" ext="jar" conf="compile"/>
+    <artifact name="project1" type="source" ext="jar" conf="compile" m:classifier="source" xmlns:m="http://ant.apache.org/ivy/maven"/>
   </publications>
   <dependencies>
-    <dependency org="junit" name="junit" rev="4.12" conf="runtime-&gt;default"/>
-    <dependency org="org.gradle.sample" name="project2" rev="1.0" conf="runtime-&gt;default"/>
+    <dependency org="junit" name="junit" rev="4.12" conf="compile-&gt;default"/>
+    <dependency org="org.gradle.sample" name="project2" rev="1.0" conf="compile-&gt;default"/>
   </dependencies>
 </ivy-module>
 <!-- END SNIPPET content -->

--- a/subprojects/docs/src/samples/ivy-publish/multiple-publications/build.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/multiple-publications/build.gradle
@@ -66,12 +66,12 @@ project(":project2") {
     // END SNIPPET multiple-publications
                 configurations {
                     "default" {
-                        extend "runtime"
+                        extend "compile"
                     }
-                    runtime {}
+                    compile {}
                 }
                 artifact(apiJar) {
-                    conf "runtime"
+                    conf "compile"
                 }
 
     // START SNIPPET multiple-publications

--- a/subprojects/docs/src/samples/ivy-publish/multiple-publications/output/project1.ivy.xml
+++ b/subprojects/docs/src/samples/ivy-publish/multiple-publications/output/project1.ivy.xml
@@ -6,13 +6,13 @@
   </info>
   <configurations>
     <conf name="compile" visibility="public"/>
-    <conf name="default" visibility="public" extends="runtime,compile"/>
+    <conf name="default" visibility="public" extends="compile,runtime"/>
     <conf name="runtime" visibility="public"/>
   </configurations>
   <publications>
-    <artifact name="project1-sample" type="jar" ext="jar" conf="runtime"/>
+    <artifact name="project1-sample" type="jar" ext="jar" conf="compile"/>
   </publications>
   <dependencies>
-    <dependency org="junit" name="junit" rev="4.12" conf="runtime-&gt;default"/>
+    <dependency org="junit" name="junit" rev="4.12" conf="compile-&gt;default"/>
   </dependencies>
 </ivy-module>

--- a/subprojects/docs/src/samples/ivy-publish/multiple-publications/output/project2-api.ivy.xml
+++ b/subprojects/docs/src/samples/ivy-publish/multiple-publications/output/project2-api.ivy.xml
@@ -3,11 +3,11 @@
 <ivy-module version="2.0">
   <info organisation="org.gradle.sample" module="project2-api" revision="2" status="integration" publication="«PUBLICATION-TIME-STAMP»"/>
   <configurations>
-    <conf name="default" visibility="public" extends="runtime"/>
-    <conf name="runtime" visibility="public"/>
+    <conf name="compile" visibility="public"/>
+    <conf name="default" visibility="public" extends="compile"/>
   </configurations>
   <publications>
-    <artifact name="project2-api" type="jar" ext="jar" conf="runtime"/>
+    <artifact name="project2-api" type="jar" ext="jar" conf="compile"/>
   </publications>
   <dependencies/>
 </ivy-module>

--- a/subprojects/docs/src/samples/ivy-publish/multiple-publications/output/project2-impl.ivy.xml
+++ b/subprojects/docs/src/samples/ivy-publish/multiple-publications/output/project2-impl.ivy.xml
@@ -4,14 +4,14 @@
   <info organisation="org.gradle.sample.impl" module="project2-impl" revision="2.3" status="integration" publication="«PUBLICATION-TIME-STAMP»"/>
   <configurations>
     <conf name="compile" visibility="public"/>
-    <conf name="default" visibility="public" extends="runtime,compile"/>
+    <conf name="default" visibility="public" extends="compile,runtime"/>
     <conf name="runtime" visibility="public"/>
   </configurations>
   <publications>
-    <artifact name="project2-impl" type="jar" ext="jar" conf="runtime"/>
+    <artifact name="project2-impl" type="jar" ext="jar" conf="compile"/>
   </publications>
   <dependencies>
-    <dependency org="commons-collections" name="commons-collections" rev="3.2.2" conf="runtime-&gt;default"/>
-    <dependency org="org.gradle.sample" name="project1-sample" rev="1.1" conf="runtime-&gt;default"/>
+    <dependency org="commons-collections" name="commons-collections" rev="3.2.2" conf="compile-&gt;default"/>
+    <dependency org="org.gradle.sample" name="project1-sample" rev="1.1" conf="compile-&gt;default"/>
   </dependencies>
 </ivy-module>

--- a/subprojects/docs/src/samples/maven-publish/multiple-publications/output/project1.pom.xml
+++ b/subprojects/docs/src/samples/maven-publish/multiple-publications/output/project1.pom.xml
@@ -11,7 +11,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.10</version>
-      <scope>runtime</scope>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/subprojects/docs/src/samples/maven-publish/multiple-publications/output/project2-impl.pom.xml
+++ b/subprojects/docs/src/samples/maven-publish/multiple-publications/output/project2-impl.pom.xml
@@ -11,13 +11,13 @@
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <version>3.2.2</version>
-      <scope>runtime</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.gradle.sample</groupId>
       <artifactId>project1-sample</artifactId>
       <version>1.1</version>
-      <scope>runtime</scope>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -351,7 +351,7 @@ ivyFileWriter << '</ivy-module>'
     void assertPublishedAsJavaModule() {
         assertPublished()
         assertArtifactsPublished("${module}-${revision}.jar", "ivy-${revision}.xml")
-        parsedIvy.expectArtifact(module, "jar").hasAttributes("jar", "jar", ["runtime"], null)
+        parsedIvy.expectArtifact(module, "jar").hasAttributes("jar", "jar", ["compile"], null)
     }
 
     void assertPublishedAsWebModule() {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
@@ -97,13 +97,13 @@ public class IvyPublishCoordinatesIntegTest extends AbstractIvyPublishIntegTest 
                         module "custom-api"
                         revision "2"
                         configurations {
-                            runtime {}
+                            compile {}
                             "default" {
-                                extend "runtime"
+                                extend "compile"
                             }
                         }
                         artifact(apiJar) {
-                            conf "runtime"
+                            conf "compile"
                         }
                     }
                 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
@@ -113,7 +113,7 @@ class IvyPublishDescriptorCustomizationIntegTest extends AbstractIvyPublishInteg
         then:
         file('generated-ivy.xml').assertIsFile()
         IvyDescriptor ivy = new IvyDescriptor(file('generated-ivy.xml'))
-        ivy.expectArtifact(moduleName).hasAttributes("jar", "jar", ["runtime"])
+        ivy.expectArtifact(moduleName).hasAttributes("jar", "jar", ["compile"])
         module.ivyFile.assertDoesNotExist()
     }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -45,9 +45,9 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
             configurations["default"].extend == ["runtime", "compile"] as Set
             configurations["runtime"].extend == null
 
-            expectArtifact("publishTest").hasAttributes("jar", "jar", ["runtime"])
+            expectArtifact("publishTest").hasAttributes("jar", "jar", ["compile"])
         }
-        ivyModule.parsedIvy.assertDependsOn("commons-collections:commons-collections:3.2.2@runtime", "commons-io:commons-io:1.4@runtime")
+        ivyModule.parsedIvy.assertDependsOn("commons-collections:commons-collections:3.2.2@compile", "commons-io:commons-io:1.4@compile")
 
         and:
         resolveArtifacts(ivyModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
@@ -157,10 +157,10 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         dependency.exclusions[0].org == 'commons-logging'
         dependency.exclusions[0].module == 'commons-logging'
 
-        ivyModule.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].hasConf("runtime->default")
+        ivyModule.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].hasConf("compile->default")
         ivyModule.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].exclusions[0].org == 'commons-logging'
         !ivyModule.parsedIvy.dependencies["commons-dbcp:commons-dbcp:1.4"].transitiveEnabled()
-        ivyModule.parsedIvy.dependencies["org.apache.camel:camel-jackson:2.15.3"].hasConf("runtime->default")
+        ivyModule.parsedIvy.dependencies["org.apache.camel:camel-jackson:2.15.3"].hasConf("compile->default")
         ivyModule.parsedIvy.dependencies["org.apache.camel:camel-jackson:2.15.3"].exclusions[0].module == 'camel-core'
 
         and:

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
@@ -29,10 +29,10 @@ class IvyPublishMultiProjectIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         project1.assertPublishedAsJavaModule()
-        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@runtime", "org.gradle.test:project3:3.0@runtime")
+        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@compile", "org.gradle.test:project3:3.0@compile")
 
         project2.assertPublishedAsJavaModule()
-        project2.parsedIvy.assertDependsOn("org.gradle.test:project3:3.0@runtime")
+        project2.parsedIvy.assertDependsOn("org.gradle.test:project3:3.0@compile")
 
         project3.assertPublishedAsJavaModule()
         project3.parsedIvy.dependencies.isEmpty()
@@ -61,10 +61,10 @@ project(":project3") {
 
         then:
         project1.assertPublishedAsJavaModule()
-        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@runtime", "changed.org:changed-module:changed@runtime")
+        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@compile", "changed.org:changed-module:changed@compile")
 
         project2.assertPublishedAsJavaModule()
-        project2.parsedIvy.assertDependsOn("changed.org:changed-module:changed@runtime")
+        project2.parsedIvy.assertDependsOn("changed.org:changed-module:changed@compile")
 
         project3.assertPublishedAsJavaModule()
         project3.parsedIvy.dependencies.isEmpty()
@@ -109,11 +109,11 @@ project(":project2") {
 
         then:
         project1.assertPublishedAsJavaModule()
-        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@runtime", "org.gradle.test:project3:3.0@runtime")
+        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@compile", "org.gradle.test:project3:3.0@compile")
 
         // published with the correct coordinates, even though artifact has different name
         project2.assertPublishedAsJavaModule()
-        project2.parsedIvy.assertDependsOn("org.gradle.test:project3:3.0@runtime")
+        project2.parsedIvy.assertDependsOn("org.gradle.test:project3:3.0@compile")
 
         project3.assertPublishedAsJavaModule()
         project3.parsedIvy.dependencies.isEmpty()
@@ -161,7 +161,7 @@ project(":project2") {
 
         then:
         project1.assertPublishedAsJavaModule()
-        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:1.0@runtime")
+        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:1.0@compile")
     }
 
     def "ivy-publish plugin publishes project dependency excludes in descriptor"() {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishVersionRangeIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishVersionRangeIntegTest.groovy
@@ -57,11 +57,11 @@ class IvyPublishVersionRangeIntegTest extends AbstractIvyPublishIntegTest {
         then:
         ivyModule.assertPublishedAsJavaModule()
         ivyModule.parsedIvy.assertDependsOn(
-            "group:projectA:latest.release@runtime",
-            "group:projectB:latest.integration@runtime",
-            "group:projectC:1.+@runtime",
-            "group:projectD:[1.0,2.0)@runtime",
-            "group:projectE:[1.0]@runtime"
+            "group:projectA:latest.release@compile",
+            "group:projectB:latest.integration@compile",
+            "group:projectC:1.+@compile",
+            "group:projectD:[1.0,2.0)@compile",
+            "group:projectE:[1.0]@compile"
         )
     }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
@@ -59,7 +59,7 @@ public class SamplesIvyPublishIntegrationTest extends AbstractIntegrationSpec {
 
         project1module.parsedIvy.configurations.keySet() == ['default', 'compile', 'runtime'] as Set
         project1module.parsedIvy.description == "The first project"
-        project1module.parsedIvy.assertDependsOn("junit:junit:4.12@runtime", "org.gradle.sample:project2:1.0@runtime")
+        project1module.parsedIvy.assertDependsOn("junit:junit:4.12@compile", "org.gradle.sample:project2:1.0@compile")
 
         and:
         project2module.assertPublished()
@@ -67,7 +67,7 @@ public class SamplesIvyPublishIntegrationTest extends AbstractIntegrationSpec {
 
         project2module.parsedIvy.configurations.keySet() == ['default', 'compile', 'runtime'] as Set
         project2module.parsedIvy.description == "The second project"
-        project2module.parsedIvy.assertDependsOn('commons-collections:commons-collections:3.2.2@runtime')
+        project2module.parsedIvy.assertDependsOn('commons-collections:commons-collections:3.2.2@compile')
 
         def actualIvyXmlText = project1module.ivyFile.text.replaceFirst('publication="\\d+"', 'publication="«PUBLICATION-TIME-STAMP»"').trim()
         actualIvyXmlText == getExpectedIvyOutput(javaProject.dir.file("output-ivy.xml"))

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -173,7 +173,7 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
 
         then: "wildcard exclusions are applied to the dependency"
         def pom = localModule.parsedPom
-        def exclusions = pom.scopes.runtime.dependencies['commons-collections:commons-collections:3.2.2'].exclusions
+        def exclusions = pom.scopes.compile.dependencies['commons-collections:commons-collections:3.2.2'].exclusions
         exclusions.size() == 1 && exclusions[0].groupId=='*' && exclusions[0].artifactId=='*'
     }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
@@ -57,8 +57,8 @@ class MavenPublishDependenciesIntegTest extends AbstractIntegrationSpec {
 
         then:
         repoModule.assertPublishedAsJavaModule()
-        repoModule.parsedPom.scopes.runtime.expectDependency('group:projectA:RELEASE')
-        repoModule.parsedPom.scopes.runtime.expectDependency('group:projectB:LATEST')
+        repoModule.parsedPom.scopes.compile.expectDependency('group:projectA:RELEASE')
+        repoModule.parsedPom.scopes.compile.expectDependency('group:projectB:LATEST')
     }
 
     @Issue("GRADLE-3233")
@@ -97,8 +97,8 @@ class MavenPublishDependenciesIntegTest extends AbstractIntegrationSpec {
 
         then:
         repoModule.assertPublishedAsJavaModule()
-        repoModule.parsedPom.scopes.runtime.assertDependsOn("group:projectA:")
-        def dependency = repoModule.parsedPom.scopes.runtime.dependencies.get("group:projectA:")
+        repoModule.parsedPom.scopes.compile.assertDependsOn("group:projectA:")
+        def dependency = repoModule.parsedPom.scopes.compile.dependencies.get("group:projectA:")
         dependency.groupId == "group"
         dependency.artifactId == "projectA"
         dependency.version == ""
@@ -158,11 +158,15 @@ class MavenPublishDependenciesIntegTest extends AbstractIntegrationSpec {
 
         where:
         plugin         | gradleConfiguration  | mavenScope
-        'java'         | 'compile'            | 'runtime'
+        'java'         | 'compile'            | 'compile'
+        'java'         | 'runtime'            | 'compile'
         'java'         | 'implementation'     | 'runtime'
+        'java'         | 'runtimeOnly'        | 'runtime'
 
         'java-library' | 'api'                | 'compile'
         'java-library' | 'compile'            | 'compile'
+        'java-library' | 'runtime'            | 'compile'
+        'java-library' | 'runtimeOnly'        | 'runtime'
         'java-library' | 'implementation'     | 'runtime'
 
     }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
@@ -151,10 +151,10 @@ subprojects {
 
         then:
         def mainPom = mavenRepo.module('my.org', 'main', '1.0').parsedPom
-        mainPom.scopes.runtime.expectDependency('my.org:util:1.0')
+        mainPom.scopes.compile.expectDependency('my.org:util:1.0')
 
         def utilPom = mavenRepo.module('my.org', 'util', '1.0').parsedPom
-        utilPom.scopes.runtime.expectDependency('org.gradle:dep:1.1')
+        utilPom.scopes.compile.expectDependency('org.gradle:dep:1.1')
     }
 
     @Issue("GRADLE-2945")
@@ -199,7 +199,7 @@ subprojects {
 
         then:
         def mainPom = mavenRepo.module('org.gradle', 'root', '1.0').parsedPom
-        def dependency = mainPom.scopes.runtime.expectDependency('org.gradle:pom-excludes:0.1')
+        def dependency = mainPom.scopes.compile.expectDependency('org.gradle:pom-excludes:0.1')
         dependency.exclusions.size() == 3
         def sorted = dependency.exclusions.sort { it.groupId }
         sorted[0].groupId == "*"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -40,12 +40,12 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         then:
         mavenModule.assertPublishedAsJavaModule()
 
-        mavenModule.parsedPom.scopes.keySet() == ["runtime"] as Set
-        mavenModule.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:3.2.2", "commons-io:commons-io:1.4", "org.springframework:spring-core:2.5.6", "commons-beanutils:commons-beanutils:1.8.3", "commons-dbcp:commons-dbcp:1.4", "org.apache.camel:camel-jackson:2.15.3")
-        assert mavenModule.parsedPom.scopes.runtime.hasDependencyExclusion("org.springframework:spring-core:2.5.6", new MavenDependencyExclusion("commons-logging", "commons-logging"))
-        assert mavenModule.parsedPom.scopes.runtime.hasDependencyExclusion("commons-beanutils:commons-beanutils:1.8.3", new MavenDependencyExclusion("commons-logging", "*"))
-        assert mavenModule.parsedPom.scopes.runtime.hasDependencyExclusion("commons-dbcp:commons-dbcp:1.4", new MavenDependencyExclusion("*", "*"))
-        assert mavenModule.parsedPom.scopes.runtime.hasDependencyExclusion("org.apache.camel:camel-jackson:2.15.3", new MavenDependencyExclusion("*", "camel-core"))
+        mavenModule.parsedPom.scopes.keySet() == ["compile"] as Set
+        mavenModule.parsedPom.scopes.compile.assertDependsOn("commons-collections:commons-collections:3.2.2", "commons-io:commons-io:1.4", "org.springframework:spring-core:2.5.6", "commons-beanutils:commons-beanutils:1.8.3", "commons-dbcp:commons-dbcp:1.4", "org.apache.camel:camel-jackson:2.15.3")
+        assert mavenModule.parsedPom.scopes.compile.hasDependencyExclusion("org.springframework:spring-core:2.5.6", new MavenDependencyExclusion("commons-logging", "commons-logging"))
+        assert mavenModule.parsedPom.scopes.compile.hasDependencyExclusion("commons-beanutils:commons-beanutils:1.8.3", new MavenDependencyExclusion("commons-logging", "*"))
+        assert mavenModule.parsedPom.scopes.compile.hasDependencyExclusion("commons-dbcp:commons-dbcp:1.4", new MavenDependencyExclusion("*", "*"))
+        assert mavenModule.parsedPom.scopes.compile.hasDependencyExclusion("org.apache.camel:camel-jackson:2.15.3", new MavenDependencyExclusion("*", "camel-core"))
 
         and:
         resolveArtifacts(mavenModule) == [

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -54,13 +54,13 @@ project(":project3") {
 
         then:
         project1.assertPublishedAsJavaModule()
-        project1.parsedPom.scopes.runtime.assertDependsOn("changed.group:changed-artifact-id:changed", "org.gradle.test:project2:2.0")
+        project1.parsedPom.scopes.compile.assertDependsOn("changed.group:changed-artifact-id:changed", "org.gradle.test:project2:2.0")
 
         project2.assertPublishedAsJavaModule()
-        project2.parsedPom.scopes.runtime.assertDependsOn("changed.group:changed-artifact-id:changed")
+        project2.parsedPom.scopes.compile.assertDependsOn("changed.group:changed-artifact-id:changed")
 
         project3.assertPublishedAsJavaModule()
-        project3.parsedPom.scopes.runtime == null
+        project3.parsedPom.scopes.compile == null
 
         and:
         resolveArtifacts(project1) == ['changed-artifact-id-changed.jar', 'project1-1.0.jar', 'project2-2.0.jar']
@@ -128,10 +128,10 @@ project(":project2") {
 
     private def projectsCorrectlyPublished() {
         project1.assertPublishedAsJavaModule()
-        project1.parsedPom.scopes.runtime.assertDependsOn("org.gradle.test:project2:2.0", "org.gradle.test:project3:3.0")
+        project1.parsedPom.scopes.compile.assertDependsOn("org.gradle.test:project2:2.0", "org.gradle.test:project3:3.0")
 
         project2.assertPublishedAsJavaModule()
-        project2.parsedPom.scopes.runtime.assertDependsOn("org.gradle.test:project3:3.0")
+        project2.parsedPom.scopes.compile.assertDependsOn("org.gradle.test:project3:3.0")
 
         project3.assertPublishedAsJavaModule()
         project3.parsedPom.scopes == null
@@ -186,7 +186,7 @@ project(":project2") {
         then:
 
         project1.assertPublishedAsJavaModule()
-        project1.parsedPom.scopes.runtime.assertDependsOn("org.gradle.test:project2:2.0")
+        project1.parsedPom.scopes.compile.assertDependsOn("org.gradle.test:project2:2.0")
     }
 
     @Issue("GRADLE-3366")
@@ -244,7 +244,7 @@ project(":project2") {
 
         then:
         project2.assertPublishedAsJavaModule()
-        def dependency = project2.parsedPom.scopes.runtime.expectDependency("org.gradle.test:project1:1.0")
+        def dependency = project2.parsedPom.scopes.compile.expectDependency("org.gradle.test:project1:1.0")
         dependency.exclusions.size() == 2
         def sorted = dependency.exclusions.sort { it.groupId }
         sorted[0].groupId == "*"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishVersionRangeIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishVersionRangeIntegTest.groovy
@@ -57,8 +57,8 @@ class MavenPublishVersionRangeIntegTest extends AbstractMavenPublishIntegTest {
         then:
         mavenModule.assertPublishedAsJavaModule()
 
-        mavenModule.parsedPom.scopes.keySet() == ["runtime"] as Set
-        mavenModule.parsedPom.scopes.runtime.assertDependsOn(
+        mavenModule.parsedPom.scopes.keySet() == ["compile"] as Set
+        mavenModule.parsedPom.scopes.compile.assertDependsOn(
             "group:projectA:RELEASE",
             "group:projectB:LATEST",
             "group:projectC:1.+",
@@ -99,7 +99,7 @@ class MavenPublishVersionRangeIntegTest extends AbstractMavenPublishIntegTest {
 
         then:
         mavenModule.assertPublishedAsJavaModule()
-        mavenModule.parsedPom.scopes.runtime.assertDependsOn("group:projectA:", "group:projectB:")
+        mavenModule.parsedPom.scopes.compile.assertDependsOn("group:projectA:", "group:projectB:")
     }
 
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
@@ -80,7 +80,7 @@ public class SamplesMavenPublishIntegrationTest extends AbstractIntegrationSpec 
         module.assertPublished()
         module.assertArtifactsPublished("javaProject-1.0.jar", "javaProject-1.0-sources.jar", "javaProject-1.0.pom")
         module.parsedPom.packaging == null
-        module.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:3.2.2")
+        module.parsedPom.scopes.compile.assertDependsOn("commons-collections:commons-collections:3.2.2")
     }
 
     def pomCustomization() {
@@ -126,11 +126,11 @@ public class SamplesMavenPublishIntegrationTest extends AbstractIntegrationSpec 
     }
 
     private void verifyPomFile(MavenFileModule module, String outputFileName) {
-        def actualIvyXmlText = module.pomFile.text.replaceFirst('publication="\\d+"', 'publication="«PUBLICATION-TIME-STAMP»"').trim()
-        assert actualIvyXmlText == getExpectedIvyOutput(multiPublish.dir.file(outputFileName))
+        def actualPomXmlText = module.pomFile.text.replaceFirst('publication="\\d+"', 'publication="«PUBLICATION-TIME-STAMP»"').trim()
+        assert actualPomXmlText == getExpectedPomOutput(multiPublish.dir.file(outputFileName))
     }
 
-    String getExpectedIvyOutput(File outputFile) {
+    String getExpectedPomOutput(File outputFile) {
         assert outputFile.file
         outputFile.readLines()[1..-1].join(TextUtil.getPlatformLineSeparator()).trim()
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.java;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ModuleDependency;
@@ -30,7 +29,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static org.gradle.api.plugins.JavaPlugin.*;
+import static org.gradle.api.plugins.JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME;
+import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME;
 
 /**
  * A SoftwareComponent representing a library that runs on a java virtual machine.
@@ -104,12 +104,7 @@ public class JavaLibrary implements SoftwareComponentInternal {
 
         public Set<ModuleDependency> getDependencies() {
             if (dependencies == null) {
-                Configuration apiConfiguration = configurations.findByName(API_CONFIGURATION_NAME);
-                if (apiConfiguration != null) {
-                    dependencies = apiConfiguration.getAllDependencies();
-                } else {
-                    return Collections.emptySet();
-                }
+                dependencies = configurations.findByName(API_ELEMENTS_CONFIGURATION_NAME).getAllDependencies();
             }
             return dependencies.withType(ModuleDependency.class);
         }


### PR DESCRIPTION
When we introduced the `java-library` plugin, we made sure
the published POM reflects what a downstream project in the
same build would see: `api` dependencies are exposed, `implementation`
dependencies are hidden. The legacy `compile`/`runtime` dependencies
are exposed as well for backwards compatibility.

We forgot to adjust the tests for the existing `java` plugin,
leading to a confusing difference in behavior. The `java` plugin
was still hiding the legacy `compile` and `runtime` dependencies from
consumers. This was due to a bug in the implementation of `JavaLibrary`,
which was looking for the `api` configuration instead of the `apiElements`
configuration.