### PR TITLE
Use Enum.getDeclaringClass() to avoid NPE in comparing enums

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/util/DiffUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/util/DiffUtil.java
@@ -77,7 +77,7 @@ public class DiffUtil {
         // There is a slight risk that two versions of the same enum class are compared,
         // (that's why classloaders are used in equality checks), but checking both name
         // and ordinal should make this very unlikely.
-        return e1.getClass().getCanonicalName().equals(e2.getClass().getCanonicalName())
+        return e1.getDeclaringClass().getCanonicalName().equals(e2.getDeclaringClass().getCanonicalName())
             && e1.ordinal() == e2.ordinal()
             && e1.name().equals(e2.name());
     }

--- a/subprojects/core/src/test/groovy/org/gradle/util/DiffUtilTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/DiffUtilTest.groovy
@@ -115,16 +115,19 @@ class DiffUtilTest extends Specification {
     def "same enum equal"() {
         expect:
         DiffUtil.checkEquality(LocalEnum1.DUCK, LocalEnum1.DUCK)
+        DiffUtil.checkEquality(EnumWithClassBody.DUCK, EnumWithClassBody.DUCK)
     }
 
     def "same enum different constants do not equal"() {
         expect:
         !DiffUtil.checkEquality(LocalEnum1.DUCK, LocalEnum1.GOOSE)
+        !DiffUtil.checkEquality(EnumWithClassBody.DUCK, EnumWithClassBody.GOOSE)
     }
 
     def "different enums do not equal"() {
         expect:
         !DiffUtil.checkEquality(LocalEnum1.DUCK, LocalEnum2.DUCK)
+        !DiffUtil.checkEquality(LocalEnum1.DUCK, EnumWithClassBody.DUCK)
     }
 
     def "different class loaders do not equal"() {

--- a/subprojects/core/src/test/groovy/org/gradle/util/EnumWithClassBody.java
+++ b/subprojects/core/src/test/groovy/org/gradle/util/EnumWithClassBody.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.util;
+
+public enum EnumWithClassBody {
+    DUCK {
+        @Override
+        void foo() {
+        }
+    },
+    GOOSE {
+        @Override
+        void foo() {
+        }
+    };
+
+    abstract void foo();
+}


### PR DESCRIPTION
### Context
Fix #1861 , which is due to a misuse of `Enum.getClass().getCanonicalName()`. In this scenario, `Enum.getDeclaringClass()` should be used. 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`