### PR TITLE
Fix perf regression in native scenarios

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/AbstractResourceLockRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/AbstractResourceLockRegistry.java
@@ -71,7 +71,7 @@ public abstract class AbstractResourceLockRegistry<T extends ResourceLock> imple
         return new Action<ResourceLock>() {
             @Override
             public void execute(ResourceLock resourceLock) {
-                threadResourceLockMap.put(Thread.currentThread().getId(), resourceLock);
+                threadResourceLockMap.put(resourceLock.getOwner().getId(), resourceLock);
             }
         };
     }
@@ -80,7 +80,7 @@ public abstract class AbstractResourceLockRegistry<T extends ResourceLock> imple
         return new Action<ResourceLock>() {
             @Override
             public void execute(ResourceLock resourceLock) {
-                threadResourceLockMap.remove(Thread.currentThread().getId(), resourceLock);
+                threadResourceLockMap.remove(resourceLock.getOwner().getId(), resourceLock);
             }
         };
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/AbstractTrackedResourceLock.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/AbstractTrackedResourceLock.java
@@ -28,6 +28,7 @@ public abstract class AbstractTrackedResourceLock implements ResourceLock {
     private final ResourceLockCoordinationService coordinationService;
     private final Action<ResourceLock> lockAction;
     private final Action<ResourceLock> unlockAction;
+    private Thread owner;
 
     public AbstractTrackedResourceLock(String displayName, ResourceLockCoordinationService coordinationService, Action<ResourceLock> lockAction, Action<ResourceLock> unlockAction) {
         this.displayName = displayName;
@@ -37,11 +38,12 @@ public abstract class AbstractTrackedResourceLock implements ResourceLock {
     }
 
     @Override
-    public boolean tryLock() {
+    public boolean tryLock(Thread owner) {
         failIfNotInResourceLockStateChange();
-        if (!isLockedByCurrentThread()) {
+        if (!isLockedByThread(owner)) {
             if (acquireLock()) {
-                LOGGER.debug("{}: acquired lock on {}", Thread.currentThread().getName(), displayName);
+                LOGGER.debug("{}: acquired lock on {}", owner.getName(), displayName);
+                this.owner = owner;
                 lockAction.execute(this);
                 coordinationService.getCurrent().registerLocked(this);
                 return true;
@@ -54,12 +56,18 @@ public abstract class AbstractTrackedResourceLock implements ResourceLock {
     }
 
     @Override
+    public boolean tryLock() {
+        return tryLock(Thread.currentThread());
+    }
+
+    @Override
     public void unlock() {
         failIfNotInResourceLockStateChange();
-        if (isLockedByCurrentThread()) {
+        if (isLockedByThread(Thread.currentThread())) {
             releaseLock();
             LOGGER.debug("{}: released lock on {}", Thread.currentThread().getName(), displayName);
             unlockAction.execute(this);
+            owner = null;
             coordinationService.notifyStateChange();
         }
     }
@@ -70,10 +78,19 @@ public abstract class AbstractTrackedResourceLock implements ResourceLock {
         return doIsLocked();
     }
 
+    boolean isLockedByThread(Thread owner) {
+        return owner == getOwner();
+    }
+
     @Override
     public boolean isLockedByCurrentThread() {
         failIfNotInResourceLockStateChange();
-        return doIsLockedByCurrentThread();
+        return isLockedByThread(Thread.currentThread());
+    }
+
+    @Override
+    public Thread getOwner() {
+        return owner;
     }
 
     private void failIfNotInResourceLockStateChange() {
@@ -87,8 +104,6 @@ public abstract class AbstractTrackedResourceLock implements ResourceLock {
     abstract protected void releaseLock();
 
     abstract protected boolean doIsLocked();
-
-    abstract protected boolean doIsLockedByCurrentThread();
 
     @Override
     public String getDisplayName() {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ExclusiveAccessResourceLock.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ExclusiveAccessResourceLock.java
@@ -18,10 +18,10 @@ package org.gradle.internal.resources;
 
 import org.gradle.api.Action;
 
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.Semaphore;
 
 public class ExclusiveAccessResourceLock extends AbstractTrackedResourceLock {
-    private ReentrantLock lock = new ReentrantLock();
+    private Semaphore lock = new Semaphore(1);
 
     public ExclusiveAccessResourceLock(String displayName, ResourceLockCoordinationService coordinationService, Action<ResourceLock> lockAction, Action<ResourceLock> unlockAction) {
         super(displayName, coordinationService, lockAction, unlockAction);
@@ -29,21 +29,16 @@ public class ExclusiveAccessResourceLock extends AbstractTrackedResourceLock {
 
     @Override
     protected boolean acquireLock() {
-        return lock.tryLock();
+        return lock.tryAcquire();
     }
 
     @Override
     protected void releaseLock() {
-        lock.unlock();
-    }
-
-    @Override
-    protected boolean doIsLockedByCurrentThread() {
-        return lock.isHeldByCurrentThread();
+        lock.release();
     }
 
     @Override
     protected boolean doIsLocked() {
-        return lock.isLocked();
+        return lock.availablePermits() == 0;
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLock.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLock.java
@@ -56,5 +56,13 @@ public interface ResourceLock extends Describable {
      */
     void unlock();
 
+    /**
+     * Returns the thread that owns this lock
+     */
     Thread getOwner();
+
+    /**
+     * Returns the thread that acquired the lock.  This may or may not be the same as the owner.
+     */
+    Thread getLockingThread();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLock.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLock.java
@@ -45,7 +45,16 @@ public interface ResourceLock extends Describable {
     boolean tryLock();
 
     /**
+     * Attempt to lock this resource using the provided thread as the owner.  Does not block.
+     *
+     * @return true if resource was locked, false otherwise.
+     */
+    boolean tryLock(Thread owner);
+
+    /**
      * Unlock this resource if it's held by the calling thread.
      */
     void unlock();
+
+    Thread getOwner();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockState.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockState.java
@@ -29,4 +29,9 @@ public interface ResourceLockState {
      * @param resourceLock
      */
     void registerLocked(ResourceLock resourceLock);
+
+    /**
+     * Roll back any locks that have been acquired.
+     */
+    void reset();
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/AbstractTrackedResourceLockTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/AbstractTrackedResourceLockTest.groovy
@@ -112,5 +112,8 @@ class AbstractTrackedResourceLockTest extends Specification {
 
         then:
         noExceptionThrown()
+
+        and:
+        !lock.isLocked()
     }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/DefaultResourceLockCoordinationServiceTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/DefaultResourceLockCoordinationServiceTest.groovy
@@ -46,7 +46,7 @@ class DefaultResourceLockCoordinationServiceTest extends ConcurrentSpec {
         then:
         lock1.lockedState == lock1Locked || (!lock1Locked && !lock2Locked)
         lock2.lockedState == lock2Locked || (!lock1Locked && !lock2Locked)
-        result == (lock1.doIsLockedByCurrentThread() && lock2.doIsLockedByCurrentThread())
+        result == (lock1.owner == Thread.currentThread() && lock2.owner == Thread.currentThread())
 
         where:
         lock1Locked | lock2Locked
@@ -80,8 +80,8 @@ class DefaultResourceLockCoordinationServiceTest extends ConcurrentSpec {
                         }
                     }
                 })
-                assert lock1.doIsLockedByCurrentThread()
-                assert lock2.doIsLockedByCurrentThread()
+                assert lock1.owner == Thread.currentThread()
+                assert lock2.owner == Thread.currentThread()
             }
 
             thread.blockUntil.executed1
@@ -215,8 +215,8 @@ class DefaultResourceLockCoordinationServiceTest extends ConcurrentSpec {
         disposition == expectedDisposition
 
         and:
-        lock1.doIsLockedByCurrentThread() == !lock1Locked
-        lock2.doIsLockedByCurrentThread() == (!lock1Locked && !lock2Locked)
+        lock1.owner == Thread.currentThread() == !lock1Locked
+        lock2.owner == Thread.currentThread() == (!lock1Locked && !lock2Locked)
 
         where:
         lock1Locked | lock2Locked | expectedDisposition
@@ -244,8 +244,8 @@ class DefaultResourceLockCoordinationServiceTest extends ConcurrentSpec {
         disposition == expectedDisposition
 
         and:
-        lock1.doIsLockedByCurrentThread() == !lock1Locked
-        lock2.doIsLockedByCurrentThread() == (!lock1Locked && !lock2Locked)
+        lock1.owner == Thread.currentThread() == !lock1Locked
+        lock2.owner == Thread.currentThread() == (!lock1Locked && !lock2Locked)
         where:
         lock1Locked | lock2Locked | expectedDisposition
         true        | true        | RETRY

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/ExclusiveAccessResourceLockTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/ExclusiveAccessResourceLockTest.groovy
@@ -45,14 +45,12 @@ class ExclusiveAccessResourceLockTest extends ConcurrentSpec {
 
         then:
         resourceLock.doIsLocked()
-        resourceLock.doIsLockedByCurrentThread()
 
         when:
         coordinationService.withStateLock(unlock(resourceLock))
 
         then:
         !resourceLock.doIsLocked()
-        !resourceLock.doIsLockedByCurrentThread()
     }
 
     def "can lock a resource that is already locked"() {
@@ -66,7 +64,6 @@ class ExclusiveAccessResourceLockTest extends ConcurrentSpec {
         then:
         noExceptionThrown()
         resourceLock.doIsLocked()
-        resourceLock.doIsLockedByCurrentThread()
     }
 
     def "can unlock a resource that is already unlocked"() {
@@ -76,7 +73,6 @@ class ExclusiveAccessResourceLockTest extends ConcurrentSpec {
         then:
         noExceptionThrown()
         !resourceLock.doIsLocked()
-        !resourceLock.doIsLockedByCurrentThread()
     }
 
     def "cannot lock a resource that is already locked by another thread"() {
@@ -86,7 +82,7 @@ class ExclusiveAccessResourceLockTest extends ConcurrentSpec {
 
             start {
                 assert !coordinationService.withStateLock(tryLock(resourceLock))
-                assert !resourceLock.doIsLockedByCurrentThread()
+                assert resourceLock.owner != Thread.currentThread()
                 instant.child1Finished
             }
 
@@ -95,7 +91,7 @@ class ExclusiveAccessResourceLockTest extends ConcurrentSpec {
 
             start {
                 assert coordinationService.withStateLock(tryLock(resourceLock))
-                assert resourceLock.doIsLockedByCurrentThread()
+                assert resourceLock.owner == Thread.currentThread()
             }
         }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/TestTrackedResourceLock.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/TestTrackedResourceLock.groovy
@@ -47,7 +47,7 @@ class TestTrackedResourceLock extends AbstractTrackedResourceLock {
     }
 
     @Override
-    boolean doIsLockedByCurrentThread() {
+    boolean isLockedByThread(Thread thread) {
         return hasLock.get()
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
@@ -35,8 +35,8 @@ class DefaultWorkerLeaseServiceTest extends Specification {
         workerLeaseService.withLocks(lock1, lock2).execute {
             assert lock1.lockedState
             assert lock2.lockedState
-            assert lock1.doIsLockedByCurrentThread()
-            assert lock2.doIsLockedByCurrentThread()
+            assert lock1.owner == Thread.currentThread()
+            assert lock2.owner == Thread.currentThread()
             executed = true
         }
 
@@ -60,8 +60,8 @@ class DefaultWorkerLeaseServiceTest extends Specification {
             workerLeaseService.withoutLocks(lock1, lock2).execute {
                 assert !lock1.lockedState
                 assert !lock2.lockedState
-                assert !lock1.doIsLockedByCurrentThread()
-                assert !lock2.doIsLockedByCurrentThread()
+                assert lock1.owner != Thread.currentThread()
+                assert lock2.owner != Thread.currentThread()
                 executed = true
             }
             assert lock1.lockedState

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -42,7 +42,6 @@ import org.gradle.internal.graph.GraphNodeRenderer;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
-import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.internal.resources.ResourceLockState;
 import org.gradle.util.CollectionUtils;
@@ -476,13 +475,13 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     }
 
     @Override
-    public void processExecutionQueue(WorkerLease parentWorkerLease, TaskExecutorPool taskExecutorPool) {
+    public void processExecutionQueue(TaskExecutorPool taskExecutorPool) {
         try {
             while (true) {
                 final TaskExecutor taskWorker = taskExecutorPool.getAvailableExecutor();
                 final AtomicReference<TaskInfo> selected = new AtomicReference<TaskInfo>();
                 final AtomicBoolean shouldExecute = new AtomicBoolean();
-                final ResourceLock workerLease = parentWorkerLease.createChild();
+                final ResourceLock workerLease = taskWorker.getWorkerLease();
 
                 coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
                     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
@@ -49,10 +49,16 @@ class DefaultTaskPlanExecutor implements TaskPlanExecutor {
     }
 
     @Override
-    public void process(TaskExecutionPlan taskExecutionPlan, Action<? super TaskInternal> taskWorker) {
+    public void process(final TaskExecutionPlan taskExecutionPlan, Action<? super TaskInternal> taskWorker) {
         StoppableExecutor executor = executorFactory.create("Task worker");
         try {
             WorkerLease parentWorkerLease = workerLeaseService.getCurrentWorkerLease();
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    taskExecutionPlan.populateReadyTaskQueue();
+                }
+            });
             startAdditionalWorkers(taskExecutionPlan, taskWorker, executor, parentWorkerLease);
             taskWorker(taskExecutionPlan, taskWorker, parentWorkerLease).run();
             taskExecutionPlan.awaitCompletion();

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
@@ -16,10 +16,12 @@
 
 package org.gradle.execution.taskgraph;
 
+import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.StoppableExecutor;
 import org.gradle.internal.time.Timer;
@@ -27,7 +29,9 @@ import org.gradle.internal.time.Timers;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.internal.work.WorkerLeaseService;
 
+import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.gradle.internal.time.Clock.prettyTime;
@@ -37,6 +41,7 @@ class DefaultTaskPlanExecutor implements TaskPlanExecutor {
     private final int executorCount;
     private final ExecutorFactory executorFactory;
     private final WorkerLeaseService workerLeaseService;
+    private final TaskExecutorPool taskExecutorPool = new DefaultTaskExecutorPool();
 
     public DefaultTaskPlanExecutor(int numberOfParallelExecutors, ExecutorFactory executorFactory, WorkerLeaseService workerLeaseService) {
         this.executorFactory = executorFactory;
@@ -52,67 +57,116 @@ class DefaultTaskPlanExecutor implements TaskPlanExecutor {
     public void process(final TaskExecutionPlan taskExecutionPlan, Action<? super TaskInternal> taskWorker) {
         StoppableExecutor executor = executorFactory.create("Task worker");
         try {
-            WorkerLease parentWorkerLease = workerLeaseService.getCurrentWorkerLease();
+            final WorkerLease parentWorkerLease = workerLeaseService.getCurrentWorkerLease();
+            taskExecutorPool.reset();
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    taskExecutionPlan.populateReadyTaskQueue();
+                    taskExecutionPlan.processExecutionQueue(parentWorkerLease, taskExecutorPool);
                 }
             });
-            startAdditionalWorkers(taskExecutionPlan, taskWorker, executor, parentWorkerLease);
-            taskWorker(taskExecutionPlan, taskWorker, parentWorkerLease).run();
+            startAdditionalWorkers(taskExecutionPlan, taskWorker, executor);
+            taskWorker(taskExecutionPlan, taskWorker).run();
             taskExecutionPlan.awaitCompletion();
         } finally {
             executor.stop();
         }
     }
 
-    private void startAdditionalWorkers(TaskExecutionPlan taskExecutionPlan, Action<? super TaskInternal> taskWorker, Executor executor, WorkerLease parentWorkerLease) {
+    private void startAdditionalWorkers(TaskExecutionPlan taskExecutionPlan, Action<? super TaskInternal> taskWorker, Executor executor) {
         LOGGER.debug("Using {} parallel executor threads", executorCount);
 
         for (int i = 1; i < executorCount; i++) {
-            Runnable worker = taskWorker(taskExecutionPlan, taskWorker, parentWorkerLease);
+            Runnable worker = taskWorker(taskExecutionPlan, taskWorker);
             executor.execute(worker);
         }
     }
 
-    private Runnable taskWorker(TaskExecutionPlan taskExecutionPlan, Action<? super TaskInternal> taskWorker, WorkerLease parentWorkerLease) {
-        return new TaskExecutorWorker(taskExecutionPlan, taskWorker, parentWorkerLease);
+    private Runnable taskWorker(TaskExecutionPlan taskExecutionPlan, Action<? super TaskInternal> taskWorker) {
+        return new TaskExecutorWorker(taskExecutionPlan, taskWorker, taskExecutorPool);
     }
 
-    private static class TaskExecutorWorker implements Runnable {
+    static class TaskExecutorWorker implements Runnable, TaskExecutor {
         private final TaskExecutionPlan taskExecutionPlan;
         private final Action<? super TaskInternal> taskWorker;
-        private final WorkerLease parentWorkerLease;
+        private final TaskExecutorPool taskExecutorPool;
+        private final Object taskToExecute = new Object();
+        private volatile boolean stopped;
+        private volatile TaskInfo currentTask;
+        private Thread executorThread;
 
-        private TaskExecutorWorker(TaskExecutionPlan taskExecutionPlan, Action<? super TaskInternal> taskWorker, WorkerLease parentWorkerLease) {
+        private TaskExecutorWorker(TaskExecutionPlan taskExecutionPlan, Action<? super TaskInternal> taskWorker, TaskExecutorPool taskExecutorPool) {
             this.taskExecutionPlan = taskExecutionPlan;
             this.taskWorker = taskWorker;
-            this.parentWorkerLease = parentWorkerLease;
+            this.taskExecutorPool = taskExecutorPool;
+        }
+
+        @Override
+        public void executeTask(TaskInfo taskInfo) {
+            synchronized (taskToExecute) {
+                currentTask = taskInfo;
+
+                // if we received a null task, this is the signal to stop
+                if (taskInfo == null) {
+                    stopped = true;
+                }
+
+                taskToExecute.notify();
+            }
+        }
+
+        @Override
+        public boolean isBusy() {
+            synchronized (taskToExecute) {
+                return currentTask != null;
+            }
+        }
+
+        @Override
+        public Thread getThread() {
+            return executorThread;
         }
 
         public void run() {
+            executorThread = Thread.currentThread();
+            taskExecutorPool.registerExecutor(this);
+
             final AtomicLong busy = new AtomicLong(0);
             Timer totalTimer = Timers.startTimer();
             final Timer taskTimer = Timers.startTimer();
 
-            boolean moreTasksToExecute = true;
-            while (moreTasksToExecute) {
-                moreTasksToExecute = taskExecutionPlan.executeWithTask(parentWorkerLease, new Action<TaskInfo>() {
-                    @Override
-                    public void execute(TaskInfo task) {
-                        final String taskPath = task.getTask().getPath();
-                        LOGGER.info("{} ({}) started.", taskPath, Thread.currentThread());
-                        taskTimer.reset();
-                        processTask(task);
-                        long taskDuration = taskTimer.getElapsedMillis();
-                        busy.addAndGet(taskDuration);
-                        if (LOGGER.isInfoEnabled()) {
-                            LOGGER.info("{} ({}) completed. Took {}.", taskPath, Thread.currentThread(), prettyTime(taskDuration));
+            try {
+                while (true) {
+                    synchronized (taskToExecute) {
+                        if (!stopped && currentTask == null) {
+                            try {
+                                taskToExecute.wait();
+                            } catch (InterruptedException e) {
+                                LOGGER.error("Task worker interrupted", e);
+                                throw UncheckedException.throwAsUncheckedException(e);
+                            }
+                        }
+
+                        if (stopped) {
+                            break;
                         }
                     }
-                });
+
+                    final String taskPath = currentTask.getTask().getPath();
+                    LOGGER.info("{} ({}) started.", taskPath, Thread.currentThread());
+                    taskTimer.reset();
+                    processTask(currentTask);
+                    long taskDuration = taskTimer.getElapsedMillis();
+                    busy.addAndGet(taskDuration);
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info("{} ({}) completed. Took {}.", taskPath, Thread.currentThread(), prettyTime(taskDuration));
+                    }
+                }
+            } catch (Throwable e) {
+                LOGGER.error("Task worker stopped unexpectedly", e);
             }
+
+            taskExecutorPool.removeExecutor(this);
 
             long total = totalTimer.getElapsedMillis();
 
@@ -128,7 +182,85 @@ class DefaultTaskPlanExecutor implements TaskPlanExecutor {
                 taskInfo.setExecutionFailure(e);
             } finally {
                 taskExecutionPlan.taskComplete(taskInfo);
+                synchronized (taskToExecute) {
+                    currentTask = null;
+                }
+                taskExecutorPool.notifyAvailable();
             }
+        }
+    }
+
+    static class DefaultTaskExecutorPool implements TaskExecutorPool {
+        private final Set<TaskExecutor> taskExecutors = Sets.newConcurrentHashSet();
+        private final Object workersAvailable = new Object();
+        private final AtomicBoolean stopped = new AtomicBoolean();
+
+        @Override
+        public TaskExecutor getAvailableExecutor() {
+            while (true) {
+                synchronized (workersAvailable) {
+                    synchronized (taskExecutors) {
+                        if (!taskExecutors.isEmpty()) {
+                            for (TaskExecutor taskExecutor : taskExecutors) {
+                                if (!taskExecutor.isBusy()) {
+                                    return taskExecutor;
+                                }
+                            }
+                        }
+                    }
+                    waitForAvailableExecutor();
+                }
+            }
+        }
+
+        private void waitForAvailableExecutor() {
+            synchronized (workersAvailable) {
+                try {
+                    workersAvailable.wait();
+                } catch (InterruptedException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            }
+        }
+
+        @Override
+        public void registerExecutor(TaskExecutor taskExecutor) {
+            taskExecutors.add(taskExecutor);
+
+            if (stopped.get()) {
+                taskExecutor.executeTask(null);
+            }
+
+            notifyAvailable();
+        }
+
+        @Override
+        public void notifyAvailable() {
+            synchronized (workersAvailable) {
+                workersAvailable.notifyAll();
+            }
+        }
+
+        @Override
+        public void removeExecutor(TaskExecutor taskExecutor) {
+            taskExecutors.remove(taskExecutor);
+        }
+
+        @Override
+        public void stop() {
+            synchronized (taskExecutors) {
+                stopped.set(true);
+            }
+
+            for (TaskExecutor executor : taskExecutors) {
+                executor.executeTask(null);
+            }
+        }
+
+        @Override
+        public void reset() {
+            taskExecutors.clear();
+            stopped.set(false);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
@@ -51,4 +51,10 @@ public interface TaskExecutionPlan {
      * @return true if there are more tasks waiting to execute, false if all tasks have executed.
      */
     boolean executeWithTask(WorkerLeaseRegistry.WorkerLease parentWorkerLease, Action<TaskInfo> taskExecution);
+
+    /**
+     * Selects all tasks that are ready to execute and pushes them to the queue that {@link #executeWithTask(WorkerLeaseRegistry.WorkerLease, Action)} drains from.
+     * If no tasks are ready, blocks until one becomes ready.  Exits once all tasks have been executed.
+     */
+    void populateReadyTaskQueue();
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
@@ -16,7 +16,6 @@
 
 package org.gradle.execution.taskgraph;
 
-import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 
@@ -43,18 +42,9 @@ public interface TaskExecutionPlan {
     List<Task> getTasks();
 
     /**
-     * Selects a task that's ready to execute and executes the provided action against it.  If no tasks are ready, blocks until one
-     * can be executed.  If all tasks have been executed, returns false.
+     * Iterates over the task execution queue handing tasks that are ready to execute over to the provided task workers.  If no tasks are ready, blocks until one
+     * can be executed.  Exits when all tasks have been executed.
      *
-     * @param parentWorkerLease
-     * @param taskExecution
-     * @return true if there are more tasks waiting to execute, false if all tasks have executed.
      */
-    boolean executeWithTask(WorkerLeaseRegistry.WorkerLease parentWorkerLease, Action<TaskInfo> taskExecution);
-
-    /**
-     * Selects all tasks that are ready to execute and pushes them to the queue that {@link #executeWithTask(WorkerLeaseRegistry.WorkerLease, Action)} drains from.
-     * If no tasks are ready, blocks until one becomes ready.  Exits once all tasks have been executed.
-     */
-    void populateReadyTaskQueue();
+    void processExecutionQueue(WorkerLeaseRegistry.WorkerLease parentWorkerLease, TaskExecutorPool taskExecutorPool);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
@@ -17,7 +17,6 @@
 package org.gradle.execution.taskgraph;
 
 import org.gradle.api.Task;
-import org.gradle.internal.work.WorkerLeaseRegistry;
 
 import java.util.List;
 
@@ -46,5 +45,5 @@ public interface TaskExecutionPlan {
      * can be executed.  Exits when all tasks have been executed.
      *
      */
-    void processExecutionQueue(WorkerLeaseRegistry.WorkerLease parentWorkerLease, TaskExecutorPool taskExecutorPool);
+    void processExecutionQueue(TaskExecutorPool taskExecutorPool);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutor.java
@@ -16,10 +16,14 @@
 
 package org.gradle.execution.taskgraph;
 
+import org.gradle.internal.work.WorkerLeaseRegistry;
+
 public interface TaskExecutor {
     void executeTask(TaskInfo taskInfo);
 
     boolean isBusy();
 
     Thread getThread();
+
+    WorkerLeaseRegistry.WorkerLease getWorkerLease();
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.taskgraph;
+
+public interface TaskExecutor {
+    void executeTask(TaskInfo taskInfo);
+
+    boolean isBusy();
+
+    Thread getThread();
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutorPool.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutorPool.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.taskgraph;
+
+import org.gradle.internal.concurrent.Stoppable;
+
+public interface TaskExecutorPool extends Stoppable {
+    TaskExecutor getAvailableExecutor();
+
+    void registerExecutor(TaskExecutor taskExecutor);
+
+    void notifyAvailable();
+
+    void removeExecutor(TaskExecutor taskExecutor);
+
+    void reset();
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
@@ -36,6 +36,7 @@ public class TaskInfo implements Comparable<TaskInfo> {
     private final TreeSet<TaskInfo> mustSuccessors = new TreeSet<TaskInfo>();
     private final TreeSet<TaskInfo> shouldSuccessors = new TreeSet<TaskInfo>();
     private final TreeSet<TaskInfo> finalizers = new TreeSet<TaskInfo>();
+    private boolean dependenciesComplete;
 
     public TaskInfo(TaskInternal task) {
         this.task = task;
@@ -130,11 +131,17 @@ public class TaskInfo implements Comparable<TaskInfo> {
     }
 
     public boolean allDependenciesComplete() {
+        if (dependenciesComplete) {
+            return true;
+        }
+
         for (TaskInfo dependency : Iterables.concat(mustSuccessors, dependencySuccessors)) {
             if (!dependency.isComplete()) {
                 return false;
             }
         }
+
+        dependenciesComplete = true;
         return true;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
@@ -16,9 +16,10 @@
 
 package org.gradle.execution.taskgraph;
 
-import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import org.gradle.api.internal.TaskInternal;
 
+import java.util.Set;
 import java.util.TreeSet;
 
 public class TaskInfo implements Comparable<TaskInfo> {
@@ -36,6 +37,7 @@ public class TaskInfo implements Comparable<TaskInfo> {
     private final TreeSet<TaskInfo> mustSuccessors = new TreeSet<TaskInfo>();
     private final TreeSet<TaskInfo> shouldSuccessors = new TreeSet<TaskInfo>();
     private final TreeSet<TaskInfo> finalizers = new TreeSet<TaskInfo>();
+    private Set<TaskInfo> allDependencies;
     private boolean dependenciesComplete;
 
     public TaskInfo(TaskInternal task) {
@@ -135,7 +137,12 @@ public class TaskInfo implements Comparable<TaskInfo> {
             return true;
         }
 
-        for (TaskInfo dependency : Iterables.concat(mustSuccessors, dependencySuccessors)) {
+        if (allDependencies == null) {
+            allDependencies = Sets.newHashSet(mustSuccessors);
+            allDependencies.addAll(dependencySuccessors);
+        }
+
+        for (TaskInfo dependency : allDependencies) {
             if (!dependency.isComplete()) {
                 return false;
             }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
@@ -72,6 +72,7 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
         expect:
         addToGraphAndPopulate(foo, bar, baz)
         async {
+            populateReadyQueue()
             def taskWorker1 = taskWorker()
             def taskWorker2 = taskWorker()
             def taskWorker3 = taskWorker()
@@ -104,6 +105,7 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
         when:
         addToGraphAndPopulate(fooA, barA, fooB, barB)
         async {
+            populateReadyQueue()
             def taskWorker1 = taskWorker()
             def taskWorker2 = taskWorker()
 
@@ -131,6 +133,7 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
         expect:
         addToGraphAndPopulate(foo, bar)
         async {
+            populateReadyQueue()
             def taskWorker1 = taskWorker()
             def taskWorker2 = taskWorker()
 
@@ -201,6 +204,7 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
         expect:
         addToGraphAndPopulate(a, b)
         async {
+            populateReadyQueue()
             def taskWorker1 = taskWorker()
             def taskWorker2 = taskWorker()
 
@@ -405,6 +409,7 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
     }
 
     void startTaskWorkers(int count) {
+        populateReadyQueue()
         count.times {
             taskWorker()
         }
@@ -413,6 +418,12 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
     void releaseTasks(Task... tasks) {
         tasks.each { Task task ->
             instant."complete${task.path}"
+        }
+    }
+
+    void populateReadyQueue() {
+        start {
+            executionPlan.populateReadyTaskQueue()
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
@@ -425,7 +425,7 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
 
     void startQueueProcessing() {
         start {
-            executionPlan.processExecutionQueue(parentWorkerLease, taskExecutorPool)
+            executionPlan.processExecutionQueue(taskExecutorPool)
         }
     }
 
@@ -446,7 +446,7 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
                 }
             }
         }
-        start new DefaultTaskPlanExecutor.TaskExecutorWorker(executionPlan, taskAction, taskExecutorPool)
+        start new DefaultTaskPlanExecutor.TaskExecutorWorker(executionPlan, taskAction, taskExecutorPool, parentWorkerLease)
         return tasks
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
@@ -879,7 +879,6 @@ public class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
             _ * tryLock() >> true
             _ * tryLock(_) >> true
         }
-        _ * parentWorkerLease.createChild() >> childLease
         _ * workerLeaseService.getCurrentWorkerLease() >> childLease
         _ * coordinationService.withStateLock(_) >> { args ->
             args[0].transform(Mock(ResourceLockState))
@@ -888,11 +887,12 @@ public class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
         _ * taskExecutorPool.getAvailableExecutor() >> taskExecutor
         _ * taskExecutorPool.getExecutors() >> []
         _ * taskExecutor.getThread() >> Thread.currentThread()
+        _ * taskExecutor.getWorkerLease() >> childLease
         _ * taskExecutor.executeTask(_) >> { args ->
             tasks << args[0].task
             executionPlan.taskComplete(args[0])
         }
-        executionPlan.processExecutionQueue(parentWorkerLease, taskExecutorPool)
+        executionPlan.processExecutionQueue(taskExecutorPool)
         return tasks
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.execution.taskgraph
 
-import org.gradle.api.Action
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.CircularReferenceException
 import org.gradle.api.Task
@@ -50,12 +49,15 @@ public class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
     def workerLeaseService = Mock(WorkerLeaseService)
     def coordinationService = Mock(ResourceLockCoordinationService)
     def parentWorkerLease = Mock(WorkerLeaseRegistry.WorkerLease)
+    def taskExecutorPool = Mock(TaskExecutorPool)
+    def taskExecutor = Mock(TaskExecutor)
 
     def setup() {
         root = createRootProject(temporaryFolder.testDirectory);
         executionPlan = new DefaultTaskExecutionPlan(cancellationHandler, coordinationService, workerLeaseService)
         _ * workerLeaseService.getProjectLock(_, _) >> Mock(ResourceLock) {
             _ * tryLock() >> true
+            _ * tryLock(_) >> true
         }
     }
 
@@ -536,7 +538,7 @@ public class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
         addToGraphAndPopulate([e, h])
 
         then:
-        executedTasks == [a, d, b, c, e, f, g, h]
+        executedTasks == [a, d, e, b, c, f, g, h]
     }
 
     @Issue("GRADLE-3166")
@@ -612,7 +614,7 @@ public class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
     }
 
     def "stops returning tasks when build is cancelled"() {
-        5 * cancellationHandler.cancellationRequested >>> [false, false, true, true, true]
+        2 * cancellationHandler.cancellationRequested >>> [false, true]
         Task a = task("a");
         Task b = task("b");
 
@@ -873,25 +875,24 @@ public class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
 
     def getExecutedTasks() {
         def tasks = []
-        _ * parentWorkerLease.createChild() >> Mock(WorkerLeaseRegistry.WorkerLease) {
+        def childLease = Mock(WorkerLeaseRegistry.WorkerLease) {
             _ * tryLock() >> true
+            _ * tryLock(_) >> true
         }
+        _ * parentWorkerLease.createChild() >> childLease
+        _ * workerLeaseService.getCurrentWorkerLease() >> childLease
         _ * coordinationService.withStateLock(_) >> { args ->
             args[0].transform(Mock(ResourceLockState))
             return true
         }
-        def moreTasks = true
-        executionPlan.populateReadyTaskQueue()
-        while (moreTasks) {
-            moreTasks = executionPlan.executeWithTask(parentWorkerLease, new Action<TaskInfo>() {
-                @Override
-                void execute(TaskInfo taskInfo) {
-                    tasks << taskInfo.task
-                    executionPlan.taskComplete(taskInfo)
-                }
-            })
-            executionPlan.populateReadyTaskQueue()
+        _ * taskExecutorPool.getAvailableExecutor() >> taskExecutor
+        _ * taskExecutorPool.getExecutors() >> []
+        _ * taskExecutor.getThread() >> Thread.currentThread()
+        _ * taskExecutor.executeTask(_) >> { args ->
+            tasks << args[0].task
+            executionPlan.taskComplete(args[0])
         }
+        executionPlan.processExecutionQueue(parentWorkerLease, taskExecutorPool)
         return tasks
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterTest.java
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.execution.TaskFailureHandler;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.Factories;
+import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
@@ -80,7 +81,7 @@ public class DefaultTaskGraphExecuterTest {
     final WorkerLeaseService workerLeases = new DefaultWorkerLeaseService(resourceLockCoordinationService, true, 1);
     private WorkerLeaseRegistry.WorkerLease parentWorkerLease;
     final TaskExecuter executer = context.mock(TaskExecuter.class);
-    final ExecutorFactory executorFactory = context.mock(ExecutorFactory.class);
+    final ExecutorFactory executorFactory = new DefaultExecutorFactory();
     DefaultTaskGraphExecuter taskExecuter;
     ProjectInternal root;
     List<Task> executedTasks = new ArrayList<Task>();
@@ -102,7 +103,6 @@ public class DefaultTaskGraphExecuterTest {
             will(returnValue(taskExecutionListener));
             ignoring(taskExecutionListener);
             allowing(listenerManager);
-            allowing(executorFactory);
         }});
 
         parentWorkerLease = workerLeases.getWorkerLease();
@@ -180,7 +180,7 @@ public class DefaultTaskGraphExecuterTest {
         taskExecuter.addTasks(toList(e));
         taskExecuter.execute();
 
-        assertThat(executedTasks, equalTo(toList(a, b, c, d, e)));
+        assertThat(executedTasks, equalTo(toList(a, b, d, c, e)));
     }
 
     @Test

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterTest.java
@@ -180,7 +180,7 @@ public class DefaultTaskGraphExecuterTest {
         taskExecuter.addTasks(toList(e));
         taskExecuter.execute();
 
-        assertThat(executedTasks, equalTo(toList(a, b, d, c, e)));
+        assertThat(executedTasks, equalTo(toList(a, b, c, d, e)));
     }
 
     @Test

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -823,6 +823,7 @@ allprojects {
                         file("dir1.classes").mkdirs()
                         file("dir1.classes/file2.txt").text = 'new file'
                     }
+                    mustRunAfter(':app:resolve')
                 }
             }
             

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -436,7 +436,13 @@ task someTask(dependsOn: [someDep, someOtherDep])
         succeeds 'a', 'd'
 
         then:
-        executedTasks == [':c', ':b', ':a', ':d']
+        result.assertTasksExecutedInOrder(
+            any(
+                exact(':c', ':b'),
+                exact(':b', ':a'),
+                exact(':c', ':d')
+            )
+        )
     }
 
     def "multiple should run after ordering can be ignored for one execution plan"() {
@@ -472,7 +478,16 @@ task someTask(dependsOn: [someDep, someOtherDep])
         succeeds 'a', 'd'
 
         then:
-        executedTasks == [':g', ':c', ':b', ':h', ':a', ':f', ':d', ':e']
+        result.assertTasksExecutedInOrder(
+            any(
+                exact(any(':b', ':h'), ':a'),
+                exact(':c', ':b'),
+                exact(':g', ':c'),
+                exact(':f', ':d', ':e'),
+                exact(':c', ':f'),
+                exact(':b', ':h')
+            )
+        )
     }
 
     @Issue("GRADLE-3575")

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
@@ -218,6 +218,7 @@ version = 1.0
 task signature {
     ext.destFile = file("\$buildDir/signature.sig")
     doLast {
+        destFile.parentFile.mkdirs()
         destFile.text = 'signature'
     }
 }


### PR DESCRIPTION
Introduces a "ready" queue in the task execution plan so that only a single thread is iterating over the whole execution queue and pushing tasks into the ready queue when their dependencies are met.  Task workers just pull tasks from the ready queue.

One side effect of this is that it changes the order of task execution in some cases.  The task order is still predictable (when not running in parallel) and it still strictly honors modeled order relationships, but when order is not prescribed, it may be slightly different than before (hence the minor adjustments to task order requirements in the tests).