### PR TITLE
Remove deprecated method from EclipseProjectDependency

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -180,6 +180,7 @@ The following are the newly deprecated items in this Gradle release. If you have
 - Removed the method `registerWatchPoints(FileSystemSubset.Builder)` from `FileCollectionDependency`.
 - Removed the method `getConfiguration()` from `ModuleDependency`.
 - Removed the method `getProjectConfiguration()` from `ProjectDependency`.
+- Removed the method `getTargetProject()` from `EclipseProjectDependency`.
 - Removed class `BuildCache`.
 - Removed class `MapBasedBuildCache`.
 - Removed class `ActionBroadcast`.

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/m3/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/m3/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -165,7 +165,7 @@ dependencies {
 
         eclipseProject.classpath.size() == 2
         eclipseProject.classpath.every { it instanceof ExternalDependency }
-        eclipseProject.classpath.collect { it.file.name } as Set == ['commons-lang-2.5.jar', 'commons-io-1.4.jar' ] as Set
+        eclipseProject.classpath.collect { it.file.name } as Set == ['commons-lang-2.5.jar', 'commons-io-1.4.jar'] as Set
         eclipseProject.classpath.collect { it.source?.name } as Set == ['commons-lang-2.5-sources.jar', 'commons-io-1.4-sources.jar'] as Set
         eclipseProject.classpath.collect { it.javadoc?.name } as Set == [null, null] as Set
     }
@@ -216,7 +216,7 @@ project(':a') {
 
         minimalProject.projectDependencies.any { it.path == 'root' }
         minimalProject.projectDependencies.any { it.path == 'b' }
-        if( currentVersion < GradleVersion.version('4.0')) {
+        if (currentVersion < GradleVersion.version('4.0')) {
             minimalProject.projectDependencies.any { it.path == 'root' && it.targetProject == minimalModel }
             minimalProject.projectDependencies.any { it.path == 'b' && it.targetProject == minimalProject.children[0] }
         }
@@ -231,7 +231,7 @@ project(':a') {
 
         fullProject.projectDependencies.any { it.path == 'root' }
         fullProject.projectDependencies.any { it.path == 'b' }
-        if( currentVersion < GradleVersion.version('4.0')) {
+        if (currentVersion < GradleVersion.version('4.0')) {
             fullProject.projectDependencies.any { it.path == 'root' && it.targetProject == fullModel }
             fullProject.projectDependencies.any { it.path == 'b' && it.targetProject == fullProject.children[0] }
         }
@@ -265,20 +265,20 @@ project(':c') {
         EclipseProject rootProject = loadToolingModel(EclipseProject)
 
         then:
-        def projectC = rootProject.children.find { it.name == 'c'}
-        def projectA = rootProject.children.find { it.name == 'a'}
+        def projectC = rootProject.children.find { it.name == 'c' }
+        def projectA = rootProject.children.find { it.name == 'a' }
         def projectAB = projectA.children.find { it.name == 'b' }
 
-        if( currentVersion < GradleVersion.version('4.0')) {
-            projectC.projectDependencies.any {it.targetProject == projectAB}
-            projectA.projectDependencies.any {it.targetProject == projectAB}
-            projectA.projectDependencies.any {it.targetProject == projectC}
-            projectA.projectDependencies.any {it.targetProject == rootProject}
+        if (currentVersion < GradleVersion.version('4.0')) {
+            projectC.projectDependencies.any { it.targetProject == projectAB }
+            projectA.projectDependencies.any { it.targetProject == projectAB }
+            projectA.projectDependencies.any { it.targetProject == projectC }
+            projectA.projectDependencies.any { it.targetProject == rootProject }
         }
-        projectC.projectDependencies.any {projectAB.name.contains(it.path)}
-        projectA.projectDependencies.any {projectAB.name.contains(it.path)}
-        projectA.projectDependencies.any {projectC.name.contains(it.path)}
-        projectA.projectDependencies.any {rootProject.name.contains(it.path)}
+        projectC.projectDependencies.any { projectAB.name.contains(it.path) }
+        projectA.projectDependencies.any { projectAB.name.contains(it.path) }
+        projectA.projectDependencies.any { projectC.name.contains(it.path) }
+        projectA.projectDependencies.any { rootProject.name.contains(it.path) }
     }
 
     def "can build the eclipse project hierarchy for a multi-project build"() {
@@ -357,7 +357,7 @@ configure(project(':bar')) {
         when:
         HierarchicalEclipseProject rootProject = loadToolingModel(HierarchicalEclipseProject)
         then:
-        rootProject.children.any { it.name == 'foo'}
-        rootProject.children.any { it.name == 'customized-bar'}
+        rootProject.children.any { it.name == 'foo' }
+        rootProject.children.any { it.name == 'customized-bar' }
     }
 }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/m3/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/m3/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -19,6 +19,7 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.ExternalDependency
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.eclipse.HierarchicalEclipseProject
+import org.gradle.util.GradleVersion
 
 class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
 
@@ -213,8 +214,12 @@ project(':a') {
 
         minimalProject.projectDependencies.size() == 2
 
-        minimalProject.projectDependencies.any { it.path == 'root' && it.targetProject == minimalModel }
-        minimalProject.projectDependencies.any { it.path == 'b' && it.targetProject == minimalProject.children[0] }
+        minimalProject.projectDependencies.any { it.path == 'root' }
+        minimalProject.projectDependencies.any { it.path == 'b' }
+        if( currentVersion < GradleVersion.version('4.0')) {
+            minimalProject.projectDependencies.any { it.path == 'root' && it.targetProject == minimalModel }
+            minimalProject.projectDependencies.any { it.path == 'b' && it.targetProject == minimalProject.children[0] }
+        }
 
         when:
         EclipseProject fullModel = loadToolingModel(EclipseProject)
@@ -224,8 +229,12 @@ project(':a') {
 
         fullProject.projectDependencies.size() == 2
 
-        fullProject.projectDependencies.any { it.path == 'root' && it.targetProject == fullModel }
-        fullProject.projectDependencies.any { it.path == 'b' && it.targetProject == fullProject.children[0] }
+        fullProject.projectDependencies.any { it.path == 'root' }
+        fullProject.projectDependencies.any { it.path == 'b' }
+        if( currentVersion < GradleVersion.version('4.0')) {
+            fullProject.projectDependencies.any { it.path == 'root' && it.targetProject == fullModel }
+            fullProject.projectDependencies.any { it.path == 'b' && it.targetProject == fullProject.children[0] }
+        }
     }
 
     def "can build project dependencies with targetProject references for complex scenarios"() {
@@ -260,11 +269,16 @@ project(':c') {
         def projectA = rootProject.children.find { it.name == 'a'}
         def projectAB = projectA.children.find { it.name == 'b' }
 
-        projectC.projectDependencies.any {it.targetProject == projectAB}
-
-        projectA.projectDependencies.any {it.targetProject == projectAB}
-        projectA.projectDependencies.any {it.targetProject == projectC}
-        projectA.projectDependencies.any {it.targetProject == rootProject}
+        if( currentVersion < GradleVersion.version('4.0')) {
+            projectC.projectDependencies.any {it.targetProject == projectAB}
+            projectA.projectDependencies.any {it.targetProject == projectAB}
+            projectA.projectDependencies.any {it.targetProject == projectC}
+            projectA.projectDependencies.any {it.targetProject == rootProject}
+        }
+        projectC.projectDependencies.any {projectAB.name.contains(it.path)}
+        projectA.projectDependencies.any {projectAB.name.contains(it.path)}
+        projectA.projectDependencies.any {projectC.name.contains(it.path)}
+        projectA.projectDependencies.any {rootProject.name.contains(it.path)}
     }
 
     def "can build the eclipse project hierarchy for a multi-project build"() {

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r25/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r25/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -66,7 +66,7 @@ configure(project(':a')){
         EclipseProject rootProject = loadToolingModel(EclipseProject)
 
         then:
-        rootProject.projectDependencies.find {it.path == "a"}.exported ==false
+        rootProject.projectDependencies.find { it.path == "a" }.exported == false
         rootProject.classpath.find { it.file.name.contains("guava") }.exported == false
         rootProject.classpath.find { it.file.name.contains("slf4j-log4j") }.exported == false
     }
@@ -117,9 +117,9 @@ configure(project(':c')) {
 
         when:
         EclipseProject rootProject = loadToolingModel(EclipseProject)
-        EclipseProject aProject = rootProject.children.find { it.name == 'a'}
-        EclipseProject bProject = rootProject.children.find { it.name == 'b'}
-        EclipseProject cProject = rootProject.children.find { it.name == 'c'}
+        EclipseProject aProject = rootProject.children.find { it.name == 'a' }
+        EclipseProject bProject = rootProject.children.find { it.name == 'b' }
+        EclipseProject cProject = rootProject.children.find { it.name == 'c' }
         then:
         aProject.classpath.find { it.file.name == "someArtifact-17.0.jar" }
         bProject.classpath.find { it.file.name == "someArtifact-16.0.1.jar" }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r25/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r25/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -66,7 +66,7 @@ configure(project(':a')){
         EclipseProject rootProject = loadToolingModel(EclipseProject)
 
         then:
-        rootProject.projectDependencies.find {it.targetProject.name == "a"}.exported ==false
+        rootProject.projectDependencies.find {it.path == "a"}.exported ==false
         rootProject.classpath.find { it.file.name.contains("guava") }.exported == false
         rootProject.classpath.find { it.file.name.contains("slf4j-log4j") }.exported == false
     }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r28/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r28/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.tooling.r28
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.eclipse.EclipseProject
+import org.gradle.util.GradleVersion
 
 class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
 
@@ -55,8 +56,14 @@ project(':contrib:impl') {
         EclipseProject contribApiProject = contribProject.children.find { it.name == 'contrib-api' }
 
         then:
-        contribImplProject.projectDependencies.any { it.path == 'contrib-api' && it.targetProject == contribApiProject }
-        rootImplProject.projectDependencies.any { it.path == 'root-api' && it.targetProject == rootApiProject }
-
+        if( currentVersion < GradleVersion.version('4.0')) {
+            contribImplProject.projectDependencies.any { it.path == 'contrib-api' && it.targetProject == contribApiProject }
+            rootImplProject.projectDependencies.any { it.path == 'root-api' && it.targetProject == rootApiProject }
+        } else {
+            rootApiProject
+            contribApiProject
+            contribImplProject.projectDependencies.any { it.path == 'contrib-api' }
+            rootImplProject.projectDependencies.any { it.path == 'root-api' }
+        }
     }
 }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r28/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r28/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -56,7 +56,7 @@ project(':contrib:impl') {
         EclipseProject contribApiProject = contribProject.children.find { it.name == 'contrib-api' }
 
         then:
-        if( currentVersion < GradleVersion.version('4.0')) {
+        if (currentVersion < GradleVersion.version('4.0')) {
             contribImplProject.projectDependencies.any { it.path == 'contrib-api' && it.targetProject == contribApiProject }
             rootImplProject.projectDependencies.any { it.path == 'root-api' && it.targetProject == rootApiProject }
         } else {

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/AdHocCompositeDependencySubstitutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/AdHocCompositeDependencySubstitutionCrossVersionSpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.idea.IdeaModuleDependency
 import org.gradle.tooling.model.idea.IdeaProject
+import org.gradle.util.GradleVersion
 
 /**
  * Dependency substitution is performed for models in a composite build
@@ -63,7 +64,9 @@ class AdHocCompositeDependencySubstitutionCrossVersionSpec extends ToolingApiSpe
         assert eclipseProject.projectDependencies.size() == 1
         with(eclipseProject.projectDependencies.first()) {
             it.path == 'b1'
-            it.targetProject == null
+            if(currentVersion < GradleVersion.version('4.0')) {
+                it.targetProject == null
+            }
         }
     }
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/AdHocCompositeDependencySubstitutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/AdHocCompositeDependencySubstitutionCrossVersionSpec.groovy
@@ -64,7 +64,7 @@ class AdHocCompositeDependencySubstitutionCrossVersionSpec extends ToolingApiSpe
         assert eclipseProject.projectDependencies.size() == 1
         with(eclipseProject.projectDependencies.first()) {
             it.path == 'b1'
-            if(currentVersion < GradleVersion.version('4.0')) {
+            if (currentVersion < GradleVersion.version('4.0')) {
                 it.targetProject == null
             }
         }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
@@ -65,7 +65,7 @@ class PersistentCompositeDependencySubstitutionCrossVersionSpec extends ToolingA
         assert eclipseProject.projectDependencies.size() == 1
         with(eclipseProject.projectDependencies.first()) {
             it.path == 'b1'
-            if(currentVersion < GradleVersion.version('4.0')) {
+            if (currentVersion < GradleVersion.version('4.0')) {
                 it.targetProject == null
             }
         }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
@@ -23,6 +23,8 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.idea.IdeaModuleDependency
 import org.gradle.tooling.model.idea.IdeaProject
+import org.gradle.util.GradleVersion
+
 /**
  * Dependency substitution is performed for models in a composite build
  */
@@ -63,7 +65,9 @@ class PersistentCompositeDependencySubstitutionCrossVersionSpec extends ToolingA
         assert eclipseProject.projectDependencies.size() == 1
         with(eclipseProject.projectDependencies.first()) {
             it.path == 'b1'
-            it.targetProject == null
+            if(currentVersion < GradleVersion.version('4.0')) {
+                it.targetProject == null
+            }
         }
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseProjectDependency.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseProjectDependency.java
@@ -22,14 +22,6 @@ import org.gradle.tooling.model.ProjectDependency;
  */
 public interface EclipseProjectDependency extends ProjectDependency, EclipseClasspathEntry {
     /**
-    * Returns the target of this dependency.
-    *
-    * @return The target project, or null for a dependency on a different build within a composite.
-    */
-    @Deprecated
-    HierarchicalEclipseProject getTargetProject();
-
-    /**
      * Returns the path to use for this project dependency.
      */
     String getPath();

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -242,4 +242,11 @@ abstract class ToolingApiSpecification extends Specification {
     protected static GradleVersion getTargetVersion() {
         GradleVersion.version(targetDist.version.baseVersion.version)
     }
+
+    /**
+     * @return the current <b>base</b> version of Gradle being used to run this test
+     */
+    protected static GradleVersion getCurrentVersion() {
+        GradleVersion.current().baseVersion
+    }
 }


### PR DESCRIPTION
### Context
Fixes https://github.com/gradle/gradle/issues/1724

### Contributor Checklist
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches_Checkpoints&tab=projectOverview&branch_Gradle_Branches_Checkpoints=wl-tooling-api-dep-removal-eclipse)
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
