### PR TITLE
Type safe tasks/conventions/extensions/dsl-types properties

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -234,6 +234,22 @@ public class AntlrTask extends SourceTask {
     }
 
     /**
+     * Sets the source for this task. Delegates to {@link SourceTask#setSource(FileTree)}.
+     *
+     * If the source is of type {@link SourceDirectorySet}, then the relative path of each source grammar files
+     * is used to determine the relative output path of the generated source
+     * If the source is not of type {@link SourceDirectorySet}, then the generated source files end up
+     * flattened in the specified output directory.
+     *
+     * @param source The source.
+     */
+    @Override
+    public void setSource(FileTree source) {
+        super.setSource(source);
+        handleSourceDirectorySet(source);
+    }
+
+    /**
      * Sets the source for this task. Delegates to {@link SourceTask#setSource(Object)}.
      *
      * If the source is of type {@link SourceDirectorySet}, then the relative path of each source grammar files
@@ -246,6 +262,10 @@ public class AntlrTask extends SourceTask {
     @Override
     public void setSource(Object source) {
         super.setSource(source);
+        handleSourceDirectorySet(source);
+    }
+
+    private void handleSourceDirectorySet(Object source) {
         if (source instanceof SourceDirectorySet) {
             this.sourceDirectorySet = (SourceDirectorySet) source;
         }

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -245,8 +245,7 @@ public class AntlrTask extends SourceTask {
      */
     @Override
     public void setSource(FileTree source) {
-        super.setSource(source);
-        handleSourceDirectorySet(source);
+        setSource((Object) source);
     }
 
     /**
@@ -262,10 +261,6 @@ public class AntlrTask extends SourceTask {
     @Override
     public void setSource(Object source) {
         super.setSource(source);
-        handleSourceDirectorySet(source);
-    }
-
-    private void handleSourceDirectorySet(Object source) {
         if (source instanceof SourceDirectorySet) {
             this.sourceDirectorySet = (SourceDirectorySet) source;
         }

--- a/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/CompareGradleBuilds.java
+++ b/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/CompareGradleBuilds.java
@@ -202,6 +202,16 @@ public class CompareGradleBuilds extends DefaultTask implements VerificationTask
     /**
      * Sets the directory that will contain the HTML comparison report and any other report files.
      *
+     * @param reportDir The directory that will contain the HTML comparison report and any other report files.
+     * @since 4.0
+     */
+    public void setReportDir(File reportDir) {
+        setReportDir((Object) reportDir);
+    }
+
+    /**
+     * Sets the directory that will contain the HTML comparison report and any other report files.
+     *
      * The value will be evaluated by {@link org.gradle.api.Project#file(Object) project.file()}.
      *
      * @param reportDir The directory that will contain the HTML comparison report and any other report files.

--- a/subprojects/build-init/src/main/groovy/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/groovy/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -187,6 +187,15 @@ public class Wrapper extends DefaultTask {
 
     /**
      * The file to write the wrapper script to.
+     *
+     * @since 4.0
+     */
+    public void setScriptFile(File scriptFile) {
+        this.scriptFile = scriptFile;
+    }
+
+    /**
+     * The file to write the wrapper script to.
      */
     public void setScriptFile(Object scriptFile) {
         this.scriptFile = scriptFile;
@@ -207,6 +216,15 @@ public class Wrapper extends DefaultTask {
     @OutputFile
     public File getJarFile() {
         return getProject().file(jarFile);
+    }
+
+    /**
+     * The file to write the wrapper jar file to.
+     *
+     * @since 4.0
+     */
+    public void setJarFile(File jarFile) {
+        this.jarFile = jarFile;
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -77,6 +77,16 @@ public class PmdExtension extends CodeQualityExtension {
     /**
      * Sets the target jdk used with pmd.
      *
+     * @value The target jdk
+     * @since 4.0
+     */
+    public void setTargetJdk(TargetJdk targetJdk) {
+        this.targetJdk = targetJdk;
+    }
+
+    /**
+     * Sets the target jdk used with pmd.
+     *
      * @value The value for the target jdk as defined by {@link TargetJdk#toVersion(Object)}
      */
     public void setTargetJdk(Object value) {

--- a/subprojects/core/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/java/org/gradle/api/Project.java
@@ -260,6 +260,15 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
 
     /**
      * <p>Sets the build directory of this project. The build directory is the directory which all artifacts are
+     * generated into.</p>
+     *
+     * @param path The build directory
+     * @since 4.0
+     */
+    void setBuildDir(File path);
+
+    /**
+     * <p>Sets the build directory of this project. The build directory is the directory which all artifacts are
      * generated into. The path parameter is evaluated as described for {@link #file(Object)}. This mean you can use,
      * amongst other things, a relative or absolute path or File object to specify the build directory.</p>
      *

--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/repositories/FlatDirectoryArtifactRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/repositories/FlatDirectoryArtifactRepository.java
@@ -65,6 +65,14 @@ public interface FlatDirectoryArtifactRepository extends ArtifactRepository {
     /**
      * Sets the directories where this repository will look for artifacts.
      *
+     * @param dirs the directories.
+     * @since 4.0
+     */
+    void setDirs(Set<File> dirs);
+
+    /**
+     * Sets the directories where this repository will look for artifacts.
+     *
      * <p>The provided values are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
      *
      * @param dirs the directories.

--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
@@ -73,6 +73,14 @@ public interface MavenArtifactRepository extends ArtifactRepository, Authenticat
     /**
      * Sets the additional URLs to use to find artifact files. Note that these URLs are not used to find POM files.
      *
+     * @param urls The URLs.
+     * @since 4.0
+     */
+    void setArtifactUrls(Set<URI> urls);
+
+    /**
+     * Sets the additional URLs to use to find artifact files. Note that these URLs are not used to find POM files.
+     *
      * <p>The provided values are evaluated as per {@link org.gradle.api.Project#uri(Object)}. This means, for example, you can pass in a {@code File} object, or a relative path to be evaluated
      * relative to the project directory.
      *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -701,6 +701,11 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     }
 
     @Override
+    public void setBuildDir(File path) {
+        setBuildDir((Object) path);
+    }
+
+    @Override
     public void setBuildDir(Object path) {
         buildDir = path;
         buildDirCached = null;

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
@@ -89,6 +89,14 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
     /**
      * {@inheritDoc}
      */
+    public T setArgs(List<String> arguments) {
+        execAction.setArgs(arguments);
+        return taskType.cast(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public T setArgs(Iterable<?> arguments) {
         execAction.setArgs(arguments);
         return taskType.cast(this);
@@ -108,6 +116,13 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
     @Internal
     public List<String> getCommandLine() {
         return execAction.getCommandLine();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setCommandLine(List<String> args) {
+        execAction.setCommandLine(args);
     }
 
     /**
@@ -135,6 +150,13 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
     /**
      * {@inheritDoc}
      */
+    public void setExecutable(String executable) {
+        execAction.setExecutable(executable);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void setExecutable(Object executable) {
         execAction.setExecutable(executable);
     }
@@ -154,6 +176,13 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
     // TODO:LPTR Should be a content-less @InputDirectory
     public File getWorkingDir() {
         return execAction.getWorkingDir();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setWorkingDir(File dir) {
+        execAction.setWorkingDir(dir);
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Delete.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Delete.java
@@ -95,6 +95,16 @@ public class Delete extends ConventionTask implements DeleteSpec {
     /**
      * Sets the files to be deleted by this task.
      *
+     * @param targets A set of any type of object accepted by {@link org.gradle.api.Project#files(Object...)}
+     * @since 4.0
+     */
+    public void setDelete(Set<Object> targets) {
+        this.delete = targets;
+    }
+
+    /**
+     * Sets the files to be deleted by this task.
+     *
      * @param target Any type of object accepted by {@link org.gradle.api.Project#files(Object...)}
      */
     public void setDelete(Object target) {

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
@@ -70,6 +70,16 @@ public class GradleBuild extends ConventionTask {
      * Sets the project directory for the build.
      *
      * @param dir The project directory. Should not be null.
+     * @since 4.0
+     */
+    public void setDir(File dir) {
+        setDir((Object) dir);
+    }
+
+    /**
+     * Sets the project directory for the build.
+     *
+     * @param dir The project directory. Should not be null.
      */
     public void setDir(Object dir) {
         getStartParameter().setCurrentDir(getProject().file(dir));
@@ -90,6 +100,16 @@ public class GradleBuild extends ConventionTask {
      * Sets the build file that should be used for this build.
      *
      * @param file The build file. May be null to use the default build file for the build.
+     * @since 4.0
+     */
+    public void setBuildFile(File file) {
+        setBuildFile((Object) file);
+    }
+
+    /**
+     * Sets the build file that should be used for this build.
+     *
+     * @param file The build file. May be null to use the default build file for the build.
      */
     public void setBuildFile(Object file) {
         getStartParameter().setBuildFile(getProject().file(file));
@@ -103,6 +123,16 @@ public class GradleBuild extends ConventionTask {
     @Input
     public List<String> getTasks() {
         return getStartParameter().getTaskNames();
+    }
+
+    /**
+     * Sets the tasks that should be executed for this build.
+     *
+     * @param tasks The task names. May be empty or null to use the default tasks for the build.
+     * @since 4.0
+     */
+    public void setTasks(List<String> tasks) {
+        setTasks((Collection<String>) tasks);
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -84,6 +84,13 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     /**
      * {@inheritDoc}
      */
+    public void setAllJvmArgs(List<String> arguments) {
+        javaExecHandleBuilder.setAllJvmArgs(arguments);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void setAllJvmArgs(Iterable<?> arguments) {
         javaExecHandleBuilder.setAllJvmArgs(arguments);
     }
@@ -93,6 +100,13 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     public List<String> getJvmArgs() {
         return javaExecHandleBuilder.getJvmArgs();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setJvmArgs(List<String> arguments) {
+        javaExecHandleBuilder.setJvmArgs(arguments);
     }
 
     /**
@@ -266,6 +280,14 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     /**
      * {@inheritDoc}
      */
+    public JavaExec setArgs(List<String> applicationArgs) {
+        javaExecHandleBuilder.setArgs(applicationArgs);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public JavaExec setArgs(Iterable<?> applicationArgs) {
         javaExecHandleBuilder.setArgs(applicationArgs);
         return this;
@@ -329,6 +351,13 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     /**
      * {@inheritDoc}
      */
+    public void setExecutable(String executable) {
+        javaExecHandleBuilder.setExecutable(executable);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void setExecutable(Object executable) {
         javaExecHandleBuilder.setExecutable(executable);
     }
@@ -347,6 +376,13 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     @Internal
     public File getWorkingDir() {
         return javaExecHandleBuilder.getWorkingDir();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setWorkingDir(File dir) {
+        javaExecHandleBuilder.setWorkingDir(dir);
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
@@ -60,6 +60,16 @@ public class SourceTask extends ConventionTask implements PatternFilterable {
     }
 
     /**
+     * Sets the source for this task.
+     *
+     * @param source The source.
+     */
+    public void setSource(FileTree source) {
+        this.source.clear();
+        this.source.add(source);
+    }
+
+    /**
      * Sets the source for this task. The given source object is evaluated as per {@link org.gradle.api.Project#files(Object...)}.
      *
      * @param source The source.

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
@@ -66,8 +66,7 @@ public class SourceTask extends ConventionTask implements PatternFilterable {
      * @since 4.0
      */
     public void setSource(FileTree source) {
-        this.source.clear();
-        this.source.add(source);
+        doSetSource(source);
     }
 
     /**
@@ -76,6 +75,10 @@ public class SourceTask extends ConventionTask implements PatternFilterable {
      * @param source The source.
      */
     public void setSource(Object source) {
+        doSetSource(source);
+    }
+
+    private void doSetSource(Object source) {
         this.source.clear();
         this.source.add(source);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
@@ -63,6 +63,7 @@ public class SourceTask extends ConventionTask implements PatternFilterable {
      * Sets the source for this task.
      *
      * @param source The source.
+     * @since 4.0
      */
     public void setSource(FileTree source) {
         this.source.clear();

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
@@ -66,7 +66,7 @@ public class SourceTask extends ConventionTask implements PatternFilterable {
      * @since 4.0
      */
     public void setSource(FileTree source) {
-        doSetSource(source);
+        setSource((Object) source);
     }
 
     /**
@@ -75,10 +75,6 @@ public class SourceTask extends ConventionTask implements PatternFilterable {
      * @param source The source.
      */
     public void setSource(Object source) {
-        doSetSource(source);
-    }
-
-    private void doSetSource(Object source) {
         this.source.clear();
         this.source.add(source);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
@@ -198,6 +198,15 @@ public class WriteProperties extends DefaultTask {
 
     /**
      * Sets the output file to write the properties to.
+     *
+     * @since 4.0
+     */
+    public void setOutputFile(File outputFile) {
+        this.outputFile = outputFile;
+    }
+
+    /**
+     * Sets the output file to write the properties to.
      */
     public void setOutputFile(Object outputFile) {
         this.outputFile = outputFile;

--- a/subprojects/core/src/main/java/org/gradle/process/JavaExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/JavaExecSpec.java
@@ -71,6 +71,16 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      * @param args Args for the main class.
      *
      * @return this
+     * @since 4.0
+     */
+    JavaExecSpec setArgs(List<String> args);
+
+    /**
+     * Sets the args for the main class to be executed.
+     *
+     * @param args Args for the main class.
+     *
+     * @return this
      */
     JavaExecSpec setArgs(Iterable<?> args);
 

--- a/subprojects/core/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -124,6 +124,15 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * and minimum/maximum heap size are updated.
      *
      * @param arguments The arguments. Must not be null.
+     * @since 4.0
+     */
+    void setJvmArgs(List<String> arguments);
+
+    /**
+     * Sets the extra arguments to use to launch the JVM for the process. System properties
+     * and minimum/maximum heap size are updated.
+     *
+     * @param arguments The arguments. Must not be null.
      */
     void setJvmArgs(Iterable<?> arguments);
 
@@ -208,6 +217,15 @@ public interface JavaForkOptions extends ProcessForkOptions {
      */
     @Internal
     List<String> getAllJvmArgs();
+
+    /**
+     * Sets the full set of arguments to use to launch the JVM for the process. Overwrites any previously set system
+     * properties, minimum/maximum heap size, assertions, and bootstrap classpath.
+     *
+     * @param arguments The arguments. Must not be null.
+     * @since 4.0
+     */
+    void setAllJvmArgs(List<String> arguments);
 
     /**
      * Sets the full set of arguments to use to launch the JVM for the process. Overwrites any previously set system

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandleBuilder.java
@@ -55,6 +55,10 @@ public class DefaultExecHandleBuilder extends AbstractExecHandleBuilder implemen
         return this;
     }
 
+    public void setCommandLine(List<String> args) {
+        commandLine(args);
+    }
+
     public void setCommandLine(Object... args) {
         commandLine(args);
     }
@@ -73,6 +77,12 @@ public class DefaultExecHandleBuilder extends AbstractExecHandleBuilder implemen
 
     public DefaultExecHandleBuilder args(Iterable<?> args) {
         GUtil.addToCollection(arguments, args);
+        return this;
+    }
+
+    public DefaultExecHandleBuilder setArgs(List<String> arguments) {
+        this.arguments.clear();
+        this.arguments.addAll(arguments);
         return this;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -42,12 +42,20 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
         return options.getAllJvmArgs();
     }
 
+    public void setAllJvmArgs(List<String> arguments) {
+        options.setAllJvmArgs(arguments);
+    }
+
     public void setAllJvmArgs(Iterable<?> arguments) {
         options.setAllJvmArgs(arguments);
     }
 
     public List<String> getJvmArgs() {
         return options.getJvmArgs();
+    }
+
+    public void setJvmArgs(List<String> arguments) {
+        options.setJvmArgs(arguments);
     }
 
     public void setJvmArgs(Iterable<?> arguments) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
@@ -40,6 +40,10 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
         return executable == null ? null : executable.toString();
     }
 
+    public void setExecutable(String executable) {
+        this.executable = executable;
+    }
+
     public void setExecutable(Object executable) {
         this.executable = executable;
     }
@@ -51,6 +55,10 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
 
     public File getWorkingDir() {
         return workingDir.create();
+    }
+
+    public void setWorkingDir(File dir) {
+        this.workingDir = resolver.resolveLater(dir);
     }
 
     public void setWorkingDir(Object dir) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -54,12 +54,20 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
         return allArgs;
     }
 
+    public void setAllJvmArgs(List<String> arguments) {
+        throw new UnsupportedOperationException();
+    }
+
     public void setAllJvmArgs(Iterable<?> arguments) {
         throw new UnsupportedOperationException();
     }
 
     public List<String> getJvmArgs() {
         return javaOptions.getJvmArgs();
+    }
+
+    public void setJvmArgs(List<String> arguments) {
+        javaOptions.setJvmArgs(arguments);
     }
 
     public void setJvmArgs(Iterable<?> arguments) {
@@ -162,6 +170,12 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
             args.add(applicationArg.toString());
         }
         return args;
+    }
+
+    public JavaExecHandleBuilder setArgs(List<String> applicationArgs) {
+        this.applicationArgs.clear();
+        args(applicationArgs);
+        return this;
     }
 
     public JavaExecHandleBuilder setArgs(Iterable<?> applicationArgs) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -278,8 +278,8 @@ public class DefaultJavaForkOptionsTest {
 
         JavaForkOptions target = context.mock(JavaForkOptions.class)
         context.checking {
-            one(target).setExecutable('executable')
-            one(target).setJvmArgs(['arg'])
+            one(target).setExecutable('executable' as Object)
+            one(target).setJvmArgs(['arg'] as Iterable<?>)
             one(target).setSystemProperties(key: 12)
             one(target).setMinHeapSize('64m')
             one(target).setMaxHeapSize('1g')

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultProcessForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultProcessForkOptionsTest.groovy
@@ -99,7 +99,7 @@ public class DefaultProcessForkOptionsTest {
 
         ProcessForkOptions target = context.mock(ProcessForkOptions.class)
         context.checking {
-            one(target).setExecutable('executable')
+            one(target).setExecutable('executable' as Object)
             one(target).setWorkingDir(workingDir)
             one(target).setEnvironment(withParam(not(isEmptyMap())))
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
@@ -64,6 +64,10 @@ public class DefaultFlatDirArtifactRepository extends AbstractArtifactRepository
         return fileResolver.resolveFiles(dirs).getFiles();
     }
 
+    public void setDirs(Set<File> dirs) {
+        setDirs((Iterable<?>) dirs);
+    }
+
     public void setDirs(Iterable<?> dirs) {
         this.dirs = Lists.newArrayList(dirs);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -93,6 +93,11 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         additionalUrls.addAll(Lists.newArrayList(urls));
     }
 
+    @Override
+    public void setArtifactUrls(Set<URI> urls) {
+        setArtifactUrls((Iterable<?>) urls);
+    }
+
     public void setArtifactUrls(Iterable<?> urls) {
         additionalUrls = Lists.newArrayList(urls);
     }

--- a/subprojects/docs/src/docs/userguide/signingPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/signingPlugin.xml
@@ -161,7 +161,7 @@ gradle.taskGraph.whenReady { taskGraph ->
             <para>
                 In this example, we only want to require signing if we are building a release version and we are going to publish it. Because we are inspecting the task
                 graph to determine if we are going to be publishing, we must set the <literal>signing.required</literal> property to a closure to defer the evaluation. See
-                <apilink class="org.gradle.plugins.signing.SigningExtension" method="setRequired" /> for more information.
+                <apilink class="org.gradle.plugins.signing.SigningExtension" method="setRequired(java.lang.Object)" /> for more information.
             </para>
         </section>
     </section>

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseJdt.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseJdt.java
@@ -81,6 +81,15 @@ public class EclipseJdt {
         return sourceCompatibility;
     }
 
+    /**
+     * Sets source compatibility.
+     *
+     * @since 4.0
+     */
+    public void setSourceCompatibility(JavaVersion sourceCompatibility) {
+        setSourceCompatibility((Object) sourceCompatibility);
+    }
+
     public void setSourceCompatibility(Object sourceCompatibility) {
         JavaVersion version = JavaVersion.toVersion(sourceCompatibility);
         if (version != null) {
@@ -95,6 +104,15 @@ public class EclipseJdt {
      */
     public JavaVersion getTargetCompatibility() {
         return targetCompatibility;
+    }
+
+    /**
+     * Sets target compatibility.
+     *
+     * @since 4.0
+     */
+    public void setTargetCompatibility(JavaVersion targetCompatibility) {
+        setTargetCompatibility((Object) targetCompatibility);
     }
 
     public void setTargetCompatibility(Object targetCompatibility) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaProject.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaProject.java
@@ -223,6 +223,18 @@ public class IdeaProject {
 
     /**
      * Sets the java language level for the project.
+     * <p>
+     * When explicitly set in the build script, this setting overrides any calculated values for Idea project
+     * and Idea module.
+     *
+     * @since 4.0
+     */
+    public void setLanguageLevel(IdeaLanguageLevel languageLevel) {
+        this.languageLevel = languageLevel;
+    }
+
+    /**
+     * Sets the java language level for the project.
      * Pass a valid Java version number (e.g. '1.5') or IDEA language level (e.g. 'JDK_1_5').
      * <p>
      * See the examples in the docs for {@link IdeaProject}.

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
@@ -82,6 +82,16 @@ public class GenerateIvyDescriptor extends DefaultTask {
     /**
      * Sets the destination the descriptor will be written to.
      *
+     * @param destination The file the descriptor will be written to.
+     * @since 4.0
+     */
+    public void setDestination(File destination) {
+        this.destination = destination;
+    }
+
+    /**
+     * Sets the destination the descriptor will be written to.
+     *
      * The value is resolved with {@link org.gradle.api.Project#file(Object)}
      *
      * @param destination The file the descriptor will be written to.

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/CoffeeScriptCompile.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/CoffeeScriptCompile.java
@@ -52,6 +52,15 @@ public class CoffeeScriptCompile extends SourceTask {
         return getProject().files(coffeeScriptJs);
     }
 
+    /**
+     * Sets Coffee Script Javascript file.
+     *
+     * @since 4.0
+     */
+    public void setCoffeeScriptJs(FileCollection coffeeScriptJs) {
+        this.coffeeScriptJs = coffeeScriptJs;
+    }
+
     public void setCoffeeScriptJs(Object coffeeScriptJs) {
         this.coffeeScriptJs = coffeeScriptJs;
     }
@@ -61,6 +70,15 @@ public class CoffeeScriptCompile extends SourceTask {
         return getProject().files(rhinoClasspath);
     }
 
+    /**
+     * Sets Rhino classpath.
+     *
+     * @since 4.0
+     */
+    public void setRhinoClasspath(FileCollection rhinoClasspath) {
+        this.rhinoClasspath = rhinoClasspath;
+    }
+
     public void setRhinoClasspath(Object rhinoClasspath) {
         this.rhinoClasspath = rhinoClasspath;
     }
@@ -68,6 +86,15 @@ public class CoffeeScriptCompile extends SourceTask {
     @OutputDirectory
     public File getDestinationDir() {
         return getProject().file(destinationDir);
+    }
+
+    /**
+     * Sets destination directory.
+     *
+     * @since 4.0
+     */
+    public void setDestinationDir(File destinationDir) {
+        this.destinationDir = destinationDir;
     }
 
     public void setDestinationDir(Object destinationDir) {

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/envjs/browser/BrowserEvaluate.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/envjs/browser/BrowserEvaluate.java
@@ -48,6 +48,15 @@ public class BrowserEvaluate extends DefaultTask {
         return content == null ? null : getProject().files(content).getSingleFile();
     }
 
+    /**
+     * Sets content.
+     *
+     * @since 4.0
+     */
+    public void setContent(File content) {
+        this.content = content;
+    }
+
     public void setContent(Object content) {
         this.content = content;
     }
@@ -55,6 +64,15 @@ public class BrowserEvaluate extends DefaultTask {
     @Input
     public String getResource() {
         return resource.toString();
+    }
+
+    /**
+     * Sets resource.
+     *
+     * @since 4.0
+     */
+    public void setResource(String resource) {
+        this.resource = resource;
     }
 
     public void setResource(Object resource) {
@@ -74,6 +92,15 @@ public class BrowserEvaluate extends DefaultTask {
     @OutputFile
     public File getResult() {
         return result == null ? null : getProject().file(result);
+    }
+
+    /**
+     * Sets result.
+     *
+     * @since 4.0
+     */
+    public void setResult(File result) {
+        this.result = result;
     }
 
     public void setResult(Object result) {

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/jshint/JsHint.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/jshint/JsHint.java
@@ -62,6 +62,15 @@ public class JsHint extends SourceTask {
         return getProject().files(rhinoClasspath);
     }
 
+    /**
+     * Sets Rhino classpath.
+     *
+     * @since 4.0
+     */
+    public void setRhinoClasspath(FileCollection rhinoClasspath) {
+        this.rhinoClasspath = rhinoClasspath;
+    }
+
     public void setRhinoClasspath(Object rhinoClasspath) {
         this.rhinoClasspath = rhinoClasspath;
     }
@@ -69,6 +78,15 @@ public class JsHint extends SourceTask {
     @InputFiles
     public FileCollection getJsHint() {
         return getProject().files(jsHint);
+    }
+
+    /**
+     * Sets jshint file.
+     *
+     * @since 4.0
+     */
+    public void setJsHint(FileCollection jsHint) {
+        this.jsHint = jsHint;
     }
 
     public void setJsHint(Object jsHint) {
@@ -87,6 +105,15 @@ public class JsHint extends SourceTask {
     @OutputFile
     public File getJsonReport() {
         return jsonReport == null ? null : getProject().file(jsonReport);
+    }
+
+    /**
+     * Sets JSON report file.
+     *
+     * @since 4.0
+     */
+    public void setJsonReport(File jsonReport) {
+        this.jsonReport = jsonReport;
     }
 
     public void setJsonReport(Object jsonReport) {

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
@@ -44,6 +44,15 @@ public class RhinoShellExec extends JavaExec {
         return CollectionUtils.stringize(rhinoOptions);
     }
 
+    /**
+     * Sets Rhino options.
+     *
+     * @since 4.0
+     */
+    public void setRhinoOptions(List<String> rhinoOptions) {
+        this.rhinoOptions = new LinkedList<Object>(rhinoOptions);
+    }
+
     public void setRhinoOptions(Object... rhinoOptions) {
         this.rhinoOptions = new LinkedList<Object>(Arrays.asList(rhinoOptions));
     }
@@ -55,6 +64,15 @@ public class RhinoShellExec extends JavaExec {
     @Internal("Represented as part of args")
     public List<String> getScriptArgs() {
         return CollectionUtils.stringize(scriptArgs);
+    }
+
+    /**
+     * Sets script arguments.
+     *
+     * @since 4.0
+     */
+    public void setScriptArgs(List<String> scriptArgs) {
+        this.scriptArgs = new LinkedList<Object>(scriptArgs);
     }
 
     public void setScriptArgs(Object... scriptArgs) {
@@ -69,6 +87,15 @@ public class RhinoShellExec extends JavaExec {
     @Optional
     public File getScript() {
         return script == null ? null : getProject().file(script);
+    }
+
+    /**
+     * Sets script file.
+     *
+     * @since 4.0
+     */
+    public void setScript(File script) {
+        this.script = script;
     }
 
     public void setScript(Object script) {

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
@@ -115,6 +115,11 @@ public class RhinoShellExec extends JavaExec {
     }
 
     @Override
+    public JavaExec setArgs(List<String> applicationArgs) {
+        throw argsUnsupportOperationException();
+    }
+
+    @Override
     public JavaExec setArgs(Iterable<?> applicationArgs) {
         throw argsUnsupportOperationException();
     }

--- a/subprojects/maven/src/main/java/org/gradle/api/plugins/MavenPluginConvention.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/plugins/MavenPluginConvention.java
@@ -71,6 +71,16 @@ public class MavenPluginConvention implements MavenPomMetaInfoProvider {
     /**
      * Sets the directory to generate Maven POMs into.
      *
+     * @param pomDir The new POM directory.
+     * @since 4.0
+     */
+    public void setMavenPomDir(File pomDir) {
+        setMavenPomDir((Object) pomDir);
+    }
+
+    /**
+     * Sets the directory to generate Maven POMs into.
+     *
      * @param pomDir The new POM directory. Evaluated as per {@link org.gradle.api.Project#file(Object)}.
      */
     public void setMavenPomDir(Object pomDir) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
@@ -85,6 +85,16 @@ public class GenerateMavenPom extends DefaultTask {
     /**
      * Sets the destination the descriptor will be written to.
      *
+     * @param destination The file the descriptor will be written to.
+     * @since 4.0
+     */
+    public void setDestination(File destination) {
+        this.destination = destination;
+    }
+
+    /**
+     * Sets the destination the descriptor will be written to.
+     *
      * The value is resolved with {@link org.gradle.api.Project#file(Object)}
      *
      * @param destination The file the descriptor will be written to.

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
@@ -90,6 +90,15 @@ public class GeneratePluginDescriptors extends ConventionTask {
         return getProject().file(outputDirectory);
     }
 
+    /**
+     * Sets the output directory.
+     *
+     * @since 4.0
+     */
+    public void setOutputDirectory(File outputDirectory) {
+        setOutputDirectory((Object) outputDirectory);
+    }
+
     public void setOutputDirectory(Object outputDirectory) {
         this.outputDirectory = outputDirectory;
     }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -319,6 +319,15 @@ public class ValidateTaskProperties extends DefaultTask implements VerificationT
 
     /**
      * Sets the output file to store the report in.
+     *
+     * @since 4.0
+     */
+    public void setOutputFile(File outputFile) {
+        setOutputFile((Object) outputFile);
+    }
+
+    /**
+     * Sets the output file to store the report in.
      */
     public void setOutputFile(Object outputFile) {
         this.outputFile = outputFile;

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
@@ -67,6 +67,11 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
         return fileResolver.resolve(classesDir);
     }
 
+    @Override
+    public void setClassesDir(File classesDir) {
+        this.classesDir = classesDir;
+    }
+
     public void setClassesDir(Object classesDir) {
         this.classesDir = classesDir;
     }
@@ -76,6 +81,11 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
             return null;
         }
         return fileResolver.resolve(resourcesDir);
+    }
+
+    @Override
+    public void setResourcesDir(File resourcesDir) {
+        this.resourcesDir = resourcesDir;
     }
 
     public void setResourcesDir(Object resourcesDir) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
@@ -95,6 +95,16 @@ public interface SourceSetOutput extends FileCollection {
      * See example at {@link SourceSetOutput}
      *
      * @param classesDir the classes dir. Should not be null.
+     * @since 4.0
+     */
+    void setClassesDir(File classesDir);
+
+    /**
+     * Sets the directory to assemble the compiled classes into.
+     * <p>
+     * See example at {@link SourceSetOutput}
+     *
+     * @param classesDir the classes dir. Should not be null.
      */
     void setClassesDir(Object classesDir);
 
@@ -106,6 +116,16 @@ public interface SourceSetOutput extends FileCollection {
      * @return The dir resources are copied to.
      */
     File getResourcesDir();
+
+    /**
+     * Sets the output directory for resources
+     * <p>
+     * See example at {@link SourceSetOutput}
+     *
+     * @param resourcesDir the classes dir. Should not be null.
+     * @since 4.0
+     */
+    void setResourcesDir(File resourcesDir);
 
     /**
      * Sets the output directory for resources

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -150,6 +150,16 @@ public class War extends Jar {
      * Sets the classpath to include in the WAR archive.
      *
      * @param classpath The classpath. Must not be null.
+     * @since 4.0
+     */
+    public void setClasspath(FileCollection classpath) {
+        setClasspath((Object) classpath);
+    }
+
+    /**
+     * Sets the classpath to include in the WAR archive.
+     *
+     * @param classpath The classpath. Must not be null.
      */
     public void setClasspath(Object classpath) {
         this.classpath = getProject().files(classpath);

--- a/subprojects/process-services/src/main/java/org/gradle/process/ExecSpec.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/ExecSpec.java
@@ -25,6 +25,14 @@ public interface ExecSpec extends BaseExecSpec {
      * Sets the full command line, including the executable to be executed plus its arguments.
      *
      * @param args the command plus the args to be executed
+     * @since 4.0
+     */
+    void setCommandLine(List<String> args);
+
+    /**
+     * Sets the full command line, including the executable to be executed plus its arguments.
+     *
+     * @param args the command plus the args to be executed
      */
     void setCommandLine(Object... args);
 
@@ -66,6 +74,15 @@ public interface ExecSpec extends BaseExecSpec {
      * @return this
      */
     ExecSpec args(Iterable<?> args);
+
+    /**
+     * Sets the arguments for the command to be executed.
+     *
+     * @param args args for the command
+     * @return this
+     * @since 4.0
+     */
+    ExecSpec setArgs(List<String> args);
 
     /**
      * Sets the arguments for the command to be executed.

--- a/subprojects/process-services/src/main/java/org/gradle/process/ProcessForkOptions.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/ProcessForkOptions.java
@@ -33,6 +33,14 @@ public interface ProcessForkOptions {
      * Sets the name of the executable to use.
      *
      * @param executable The executable. Must not be null.
+     * @since 4.0
+     */
+    void setExecutable(String executable);
+
+    /**
+     * Sets the name of the executable to use.
+     *
+     * @param executable The executable. Must not be null.
      */
     void setExecutable(Object executable);
 
@@ -50,6 +58,14 @@ public interface ProcessForkOptions {
      * @return The working directory. Never returns null.
      */
     File getWorkingDir();
+
+    /**
+     * Sets the working directory for the process.
+     *
+     * @param dir The working directory. Must not be null.
+     * @since 4.0
+     */
+    void setWorkingDir(File dir);
 
     /**
      * Sets the working directory for the process. The supplied argument is evaluated as per {@link

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/ReportingExtension.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/ReportingExtension.java
@@ -76,6 +76,16 @@ public class ReportingExtension {
 
     /**
      * Sets the base directory to use for all reports
+     *
+     * @param baseDir The base directory to use for all reports
+     * @since 4.0
+     */
+    public void setBaseDir(File baseDir) {
+        setBaseDir((Object) baseDir);
+    }
+
+    /**
+     * Sets the base directory to use for all reports
      * <p>
      * The value will be converted to a {@code File} on demand via {@link Project#file(Object)}.
      *

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -100,6 +100,14 @@ public class SigningExtension {
 
     /**
      * Whether or not this task should fail if no signatory or signature type are configured at generation time.
+     * @since 4.0
+     */
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    /**
+     * Whether or not this task should fail if no signatory or signature type are configured at generation time.
      *
      * If {@code required} is a {@link Callable}, it will be stored and "called" on demand (i.e. when {@link #isRequired()} is called) and the return value will be interpreting according to the Groovy
      * Truth. For example:

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
@@ -115,6 +115,11 @@ public class DefaultTestLogging implements TestLogging {
     }
 
     @Override
+    public void setExceptionFormat(TestExceptionFormat exceptionFormat) {
+        setExceptionFormat((Object) exceptionFormat);
+    }
+
+    @Override
     public void setExceptionFormat(Object exceptionFormat) {
         this.exceptionFormat = toEnum(TestExceptionFormat.class, exceptionFormat);
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
@@ -130,6 +130,11 @@ public class DefaultTestLogging implements TestLogging {
     }
 
     @Override
+    public void setStackTraceFilters(Set<TestStackTraceFilter> stackTraceFilters) {
+        this.stackTraceFilters = EnumSet.copyOf(stackTraceFilters);
+    }
+
+    @Override
     public void setStackTraceFilters(Iterable<?> filters) {
         stackTraceFilters = toEnumSet(TestStackTraceFilter.class, filters);
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
@@ -40,6 +40,11 @@ public class DefaultTestLogging implements TestLogging {
     }
 
     @Override
+    public void setEvents(Set<TestLogEvent> events) {
+        this.events = EnumSet.copyOf(events);
+    }
+
+    @Override
     public void setEvents(Iterable<?> events) {
         this.events = toEnumSet(TestLogEvent.class, events);
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainer.java
@@ -217,6 +217,11 @@ public class DefaultTestLoggingContainer implements TestLoggingContainer {
     }
 
     @Override
+    public void setExceptionFormat(TestExceptionFormat exceptionFormat) {
+        setExceptionFormat((Object) exceptionFormat);
+    }
+
+    @Override
     public void setExceptionFormat(Object exceptionFormat) {
         getLifecycle().setExceptionFormat(exceptionFormat);
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainer.java
@@ -232,6 +232,11 @@ public class DefaultTestLoggingContainer implements TestLoggingContainer {
     }
 
     @Override
+    public void setStackTraceFilters(Set<TestStackTraceFilter> stackTraces) {
+        getLifecycle().setStackTraceFilters(stackTraces);
+    }
+
+    @Override
     public void setStackTraceFilters(Iterable<?> stackTraces) {
         getLifecycle().setStackTraceFilters(stackTraces);
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainer.java
@@ -142,6 +142,11 @@ public class DefaultTestLoggingContainer implements TestLoggingContainer {
     }
 
     @Override
+    public void setEvents(Set<TestLogEvent> events) {
+        getLifecycle().setEvents(events);
+    }
+
+    @Override
     public void setEvents(Iterable<?> events) {
         getLifecycle().setEvents(events);
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLogging.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLogging.java
@@ -171,6 +171,14 @@ public interface TestLogging {
      * Sets the set of filters to be used for sanitizing test stack traces.
      *
      * @param stackTraces the set of filters to be used for sanitizing test stack traces
+     * @since 4.0
+     */
+    void setStackTraceFilters(Set<TestStackTraceFilter> stackTraces);
+
+    /**
+     * Sets the set of filters to be used for sanitizing test stack traces.
+     *
+     * @param stackTraces the set of filters to be used for sanitizing test stack traces
      */
     void setStackTraceFilters(Iterable<?> stackTraces);
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLogging.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLogging.java
@@ -33,6 +33,14 @@ public interface TestLogging {
      * Sets the events to be logged.
      *
      * @param events the events to be logged
+     * @since 4.0
+     */
+    void setEvents(Set<TestLogEvent> events);
+
+    /**
+     * Sets the events to be logged.
+     *
+     * @param events the events to be logged
      */
     void setEvents(Iterable<?> events);
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLogging.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLogging.java
@@ -149,6 +149,14 @@ public interface TestLogging {
      * Sets the format to be used for logging test exceptions. Only relevant if {@code showStackTraces} is {@code true}.
      *
      * @param exceptionFormat the format to be used for logging test exceptions
+     * @since 4.0
+     */
+    void setExceptionFormat(TestExceptionFormat exceptionFormat);
+
+    /**
+     * Sets the format to be used for logging test exceptions. Only relevant if {@code showStackTraces} is {@code true}.
+     *
+     * @param exceptionFormat the format to be used for logging test exceptions
      */
     void setExceptionFormat(Object exceptionFormat);
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -288,6 +288,14 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
      * {@inheritDoc}
      */
     @Override
+    public void setWorkingDir(File dir) {
+        forkOptions.setWorkingDir(dir);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setWorkingDir(Object dir) {
         forkOptions.setWorkingDir(dir);
     }
@@ -327,6 +335,14 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
     public Test executable(Object executable) {
         forkOptions.executable(executable);
         return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setExecutable(String executable) {
+        forkOptions.setExecutable(executable);
     }
 
     /**
@@ -456,6 +472,14 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
      * {@inheritDoc}
      */
     @Override
+    public void setJvmArgs(List<String> arguments) {
+        forkOptions.setJvmArgs(arguments);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setJvmArgs(Iterable<?> arguments) {
         forkOptions.setJvmArgs(arguments);
     }
@@ -517,6 +541,14 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
     @Override
     public List<String> getAllJvmArgs() {
         return forkOptions.getAllJvmArgs();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAllJvmArgs(List<String> arguments) {
+        forkOptions.setAllJvmArgs(arguments);
     }
 
     /**


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle-script-kotlin/issues/341

Kotlin recognize JavaBean properties only if both the getter and setter use the same property type.
In various places we have typed getters with setters taking `Object` to have the opportunity to apply conversions. This PR adds type safe setters in those cases.

Let's look at the `GradleBuild` task for example.
Usage in a Kotlin build script before this PR:
```kotlin
val someBuild by tasks.creating(GradleBuild::class) {
  setDir(file("some/path"))
  setTasks(listOf("foo", "bar"))
}
```
After this PR:
```kotlin
val someBuild by tasks.creating(GradleBuild::class) {
  dir = file("some/path")
  tasks = listOf("foo", "bar")
}
```

The existing untyped setters are kept and still usable to profit from conversions until we tackle implicit conversions in Kotlin build script support, see https://github.com/gradle/gradle-script-kotlin/issues/335

### Gradle Core Team Checklist
- [x] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Verify backwards compatibility
