### PR TITLE
Fixed play plugin duplicate artifact error (#1857)

### DIFF
--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
@@ -18,7 +18,6 @@ package org.gradle.play.plugins;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang.StringUtils;

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
@@ -52,6 +52,7 @@ import org.gradle.util.GUtil;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -256,7 +257,7 @@ public class PlayDistributionPlugin extends RuleSource {
 
     static class PrefixArtifactFileNames implements Action<FileCopyDetails>, Function<File, String> {
         private final PlayPluginConfigurations.PlayConfiguration configuration;
-        ImmutableMap<File, String> renames;
+        Map<File, String> renames;
 
         PrefixArtifactFileNames(PlayPluginConfigurations.PlayConfiguration configuration) {
             this.configuration = configuration;
@@ -283,8 +284,8 @@ public class PlayDistributionPlugin extends RuleSource {
             }
         }
 
-        private ImmutableMap<File, String> calculate() {
-            ImmutableMap.Builder<File, String> files = ImmutableMap.builder();
+        private Map<File, String> calculate() {
+            Map<File, String> files = new HashMap<File, String>();
             for (ResolvedArtifact artifact : getResolvedArtifacts()) {
                 boolean isProject = artifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier;
                 if (isProject) {
@@ -302,7 +303,7 @@ public class PlayDistributionPlugin extends RuleSource {
                     }
                 }
             }
-            return files.build();
+            return files;
         }
 
         Set<ResolvedArtifact> getResolvedArtifacts() {


### PR DESCRIPTION
1. Fix for duplicate artifact error "Could not copy MANIFEST.MF / Multiple entries with same key".
After building Gradle with this fix, we're able to build "dist" for the small repro project.
The repro project is attached to the issue #1857.
2. I hope you can wrap it with all the necessary integ test / unit test coverage as needed
because it would be much easier for someone in Gradle team to do it :)
I hope it's fair to give you the fix that works plus clean repro project!
3. Regarding the change from immutable Guava type to standard HashMap:
the field is internal and lightly used so keeping it formally immutable does not bring a lot of value.
This particular Guava type is not optimized for speed but for immutability.
The artifact "rename" value is a exactly the same (we debugged to inspect).
Therefore, it is safe to just replace the value if the key is present.
Simple solution that works :)

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
