### PR TITLE
Speed up test worker startup

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/SystemProperties.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/SystemProperties.java
@@ -16,51 +16,54 @@
 package org.gradle.internal;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.google.common.collect.ImmutableSet.of;
 
 /**
  * Provides access to frequently used system properties.
  */
 public class SystemProperties {
-    private static final Set<String> STANDARD_PROPERTIES = of(
-            "java.version",
-            "java.vendor",
-            "java.vendor.url",
-            "java.home",
-            "java.vm.specification.version",
-            "java.vm.specification.vendor",
-            "java.vm.specification.name",
-            "java.vm.version",
-            "java.vm.vendor",
-            "java.vm.name",
-            "java.specification.version",
-            "java.specification.vendor",
-            "java.specification.name",
-            "java.class.version",
-            "java.class.path",
-            "java.library.path",
-            "java.io.tmpdir",
-            "java.compiler",
-            "java.ext.dirs",
-            "os.name",
-            "os.arch",
-            "os.version",
-            "file.separator",
-            "path.separator",
-            "line.separator",
-            "user.name",
-            "user.home",
-            "user.dir"
-    );
+    private static final Set<String> STANDARD_PROPERTIES;
 
-    private static final Set<String> IMPORTANT_NON_STANDARD_PROPERTIES = of(
-            "java.runtime.version"
-    );
+    static {
+        Set<String> standardProperties = new HashSet<String>();
+        standardProperties.add("java.version");
+        standardProperties.add("java.vendor");
+        standardProperties.add("java.vendor.url");
+        standardProperties.add("java.home");
+        standardProperties.add("java.vm.specification.version");
+        standardProperties.add("java.vm.specification.vendor");
+        standardProperties.add("java.vm.specification.name");
+        standardProperties.add("java.vm.version");
+        standardProperties.add("java.vm.vendor");
+        standardProperties.add("java.vm.name");
+        standardProperties.add("java.specification.version");
+        standardProperties.add("java.specification.vendor");
+        standardProperties.add("java.specification.name");
+        standardProperties.add("java.class.version");
+        standardProperties.add("java.class.path");
+        standardProperties.add("java.library.path");
+        standardProperties.add("java.io.tmpdir");
+        standardProperties.add("java.compiler");
+        standardProperties.add("java.ext.dirs");
+        standardProperties.add("os.name");
+        standardProperties.add("os.arch");
+        standardProperties.add("os.version");
+        standardProperties.add("file.separator");
+        standardProperties.add("path.separator");
+        standardProperties.add("line.separator");
+        standardProperties.add("user.name");
+        standardProperties.add("user.home");
+        standardProperties.add("user.dir");
+        STANDARD_PROPERTIES = Collections.unmodifiableSet(standardProperties);
+    }
+
+    private static final Set<String> IMPORTANT_NON_STANDARD_PROPERTIES = Collections.singleton("java.runtime.version");
 
     private static final SystemProperties INSTANCE = new SystemProperties();
     private final Lock lock = new ReentrantLock();

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaMethod.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.internal.reflect;
 
-import com.google.common.base.Joiner;
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.GradleException;
 import org.gradle.internal.UncheckedException;
 
@@ -54,7 +54,7 @@ public class JavaMethod<T, R> {
 
         Class<?> parent = target.getSuperclass();
         if (parent == null) {
-            throw new NoSuchMethodException(String.format("Could not find method %s(%s) on %s.", name, Joiner.on(", ").join(paramTypes), origTarget.getSimpleName()));
+            throw new NoSuchMethodException(String.format("Could not find method %s(%s) on %s.", name, StringUtils.join(paramTypes, ", "), origTarget.getSimpleName()));
         } else {
             return findMethod(origTarget, parent, name, allowStatic, paramTypes);
         }

--- a/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
@@ -15,14 +15,10 @@
  */
 package org.gradle.util;
 
-import com.google.common.base.Equivalence;
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
 import org.gradle.api.Nullable;
 import org.gradle.api.Transformer;
@@ -33,7 +29,23 @@ import org.gradle.internal.Pair;
 import org.gradle.internal.Transformers;
 
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 import static org.gradle.internal.Cast.cast;
 
@@ -612,7 +624,7 @@ public abstract class CollectionUtils {
         return target;
     }
 
-    public static <K, V> ImmutableListMultimap<K, V> groupBy(Iterable<? extends V> iterable, Transformer<? extends K, V> grouper) {
+    public static <K, V> Map<K, Collection<V>> groupBy(Iterable<? extends V> iterable, Transformer<? extends K, V> grouper) {
         ImmutableListMultimap.Builder<K, V> builder = ImmutableListMultimap.builder();
 
         for (V element : iterable) {
@@ -620,7 +632,7 @@ public abstract class CollectionUtils {
             builder.put(key, element);
         }
 
-        return builder.build();
+        return builder.build().asMap();
     }
 
     public static <T> Iterable<? extends T> unpack(final Iterable<? extends Factory<? extends T>> factories) {
@@ -649,20 +661,6 @@ public abstract class CollectionUtils {
     public static <T> List<T> nonEmptyOrNull(Iterable<T> iterable) {
         ImmutableList<T> list = ImmutableList.copyOf(iterable);
         return list.isEmpty() ? null : list;
-    }
-
-    public static <T> List<T> dedup(Iterable<T> source, final Equivalence<? super T> equivalence) {
-        Iterable<Equivalence.Wrapper<T>> wrappers = Iterables.transform(source, new Function<T, Equivalence.Wrapper<T>>() {
-            public Equivalence.Wrapper<T> apply(@Nullable T input) {
-                return equivalence.wrap(input);
-            }
-        });
-        Set<Equivalence.Wrapper<T>> deduped = ImmutableSet.copyOf(wrappers);
-        return ImmutableList.copyOf(Iterables.transform(deduped, new Function<Equivalence.Wrapper<T>, T>() {
-            public T apply(Equivalence.Wrapper<T> input) {
-                return input.get();
-            }
-        }));
     }
 
     public static String asCommandLine(Iterable<String> arguments) {

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/CollectionUtilsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/CollectionUtilsTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.util
 
-import com.google.common.base.Equivalence
 import org.gradle.api.Action
 import org.gradle.api.Transformer
 import org.gradle.api.internal.ClosureBackedAction
@@ -376,17 +375,10 @@ class CollectionUtilsTest extends Specification {
 
     def "grouping"() {
         expect:
-        groupBy([1, 2, 3], transformer { "a" }).asMap() == ["a": [1, 2, 3]]
-        groupBy(["a", "b", "c"], transformer { it.toUpperCase() }).asMap() == ["A": ["a"], "B": ["b"], "C": ["c"]]
+        groupBy([1, 2, 3], transformer { "a" }) == ["a": [1, 2, 3]]
+        groupBy(["a", "b", "c"], transformer { it.toUpperCase() }) == ["A": ["a"], "B": ["b"], "C": ["c"]]
         groupBy([], transformer { throw new AssertionError("shouldn't be called") }).isEmpty()
     }
-
-    def "dedup"() {
-        expect:
-        dedup([1, 2, 3, 2], Equivalence.equals()) == [1, 2, 3]
-        dedup([], Equivalence.equals()) == []
-    }
-
     def unpack() {
         expect:
         unpack([{ 1 } as org.gradle.internal.Factory, { 2 } as org.gradle.internal.Factory, { 3 } as org.gradle.internal.Factory]).toList() == [1, 2, 3]

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -16,22 +16,23 @@
 
 package org.gradle.plugin.use.internal;
 
-import com.google.common.collect.ListMultimap;
 import org.gradle.api.Transformer;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.exceptions.LocationAwareException;
 import org.gradle.plugin.management.internal.DefaultPluginRequest;
 import org.gradle.plugin.management.internal.DefaultPluginRequests;
-import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.management.internal.InvalidPluginRequestException;
+import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.management.internal.PluginRequests;
 import org.gradle.plugin.use.PluginDependenciesSpec;
 import org.gradle.plugin.use.PluginDependencySpec;
 import org.gradle.plugin.use.PluginId;
 import org.gradle.util.CollectionUtils;
 
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import static org.gradle.util.CollectionUtils.collect;
 
@@ -95,7 +96,7 @@ public class PluginRequestCollector {
             }
         });
 
-        ListMultimap<PluginId, PluginRequestInternal> groupedById = CollectionUtils.groupBy(pluginRequests, new Transformer<PluginId, PluginRequestInternal>() {
+        Map<PluginId, Collection<PluginRequestInternal>> groupedById = CollectionUtils.groupBy(pluginRequests, new Transformer<PluginId, PluginRequestInternal>() {
             public PluginId transform(PluginRequestInternal pluginRequest) {
                 return pluginRequest.getId();
             }
@@ -103,7 +104,7 @@ public class PluginRequestCollector {
 
         // Check for duplicates
         for (PluginId key : groupedById.keySet()) {
-            List<PluginRequestInternal> pluginRequestsForId = groupedById.get(key);
+            Collection<PluginRequestInternal> pluginRequestsForId = groupedById.get(key);
             if (pluginRequestsForId.size() > 1) {
                 PluginRequestInternal first = pluginRequests.get(0);
                 PluginRequestInternal second = pluginRequests.get(1);

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
@@ -16,8 +16,8 @@
 
 package org.gradle.plugins.ide.eclipse.model.internal;
 
-import com.google.common.base.Equivalence;
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.file.DirectoryTree;
 import org.gradle.api.internal.DynamicObjectUtil;
@@ -147,7 +147,7 @@ public class SourceFoldersCreator {
         }
 
         List<String> allIncludes = CollectionUtils.flattenCollections(String.class, includesByType);
-        return CollectionUtils.dedup(allIncludes, Equivalence.equals());
+        return ImmutableSet.copyOf(allIncludes).asList();
     }
 
     private List<Set<String>> getFiltersForTreeGroupedByType(SourceSet sourceSet, DirectoryTree directoryTree, String filterOperation) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
@@ -69,7 +69,6 @@ class GradleVsMavenPerformanceTestRunner extends AbstractGradleBuildPerformanceT
             invocationCount = runs
             projectName(testProject).displayName("Maven $commonBaseDisplayName").invocation {
                 tasksToRun(equivalentMavenTasks.split(' ')).mavenOpts(jvmOpts.collect {it.toString()}).args(mvnArgs.collect {it.toString()})
-                    .args('-q', '-Dsurefire.printSummary=false')
             }
         }
         super.run()

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/StyledTextOutputBackedRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/StyledTextOutputBackedRenderer.java
@@ -32,8 +32,8 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style.Normal;
 
 public class StyledTextOutputBackedRenderer extends BatchOutputEventListener {
     private final OutputEventTextOutputImpl textOutput;
-    private final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
     private boolean debugOutput;
+    private SimpleDateFormat dateFormat;
     private RenderableOutputEvent lastEvent;
 
     public StyledTextOutputBackedRenderer(StyledTextOutput textOutput) {
@@ -44,6 +44,9 @@ public class StyledTextOutputBackedRenderer extends BatchOutputEventListener {
         if (event instanceof LogLevelChangeEvent) {
             LogLevelChangeEvent changeEvent = (LogLevelChangeEvent) event;
             debugOutput = changeEvent.getNewLogLevel() == LogLevel.DEBUG;
+            if (debugOutput && dateFormat == null) {
+                dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+            }
         }
         if (event instanceof RenderableOutputEvent) {
             RenderableOutputEvent outputEvent = (RenderableOutputEvent) event;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
@@ -28,7 +28,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 
 public class ConsoleConfigureAction {
-    public void execute(OutputEventRenderer renderer, ConsoleOutput consoleOutput) {
+    public static void execute(OutputEventRenderer renderer, ConsoleOutput consoleOutput) {
         if (consoleOutput == ConsoleOutput.Plain) {
             return;
         }

--- a/subprojects/messaging/messaging.gradle
+++ b/subprojects/messaging/messaging.gradle
@@ -6,7 +6,6 @@ dependencies {
     api project(':baseServices')
     api libraries.slf4j_api
 
-    implementation libraries.guava
     implementation libraries.kryo
 }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
@@ -16,16 +16,17 @@
 
 package org.gradle.internal.event;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.gradle.internal.dispatch.Dispatch;
 import org.gradle.internal.dispatch.MethodInvocation;
 import org.gradle.internal.dispatch.ProxyDispatchAdapter;
 import org.gradle.internal.dispatch.ReflectionDispatch;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -128,12 +129,12 @@ public class DefaultListenerManager implements ListenerManager {
 
         private volatile ProxyDispatchAdapter<T> source;
         private final Set<ListenerDetails> listeners = new LinkedHashSet<ListenerDetails>();
-        private final List<Runnable> queuedOperations = Lists.newLinkedList();
+        private final List<Runnable> queuedOperations = new LinkedList<Runnable>();
         private final ReentrantLock broadcasterLock = new ReentrantLock();
         private ListenerDetails logger;
         private Dispatch<MethodInvocation> parentDispatch;
-        private ImmutableList<Dispatch<MethodInvocation>> allWithLogger = ImmutableList.of();
-        private ImmutableList<Dispatch<MethodInvocation>> allWithNoLogger = ImmutableList.of();
+        private List<Dispatch<MethodInvocation>> allWithLogger = Collections.emptyList();
+        private List<Dispatch<MethodInvocation>> allWithNoLogger = Collections.emptyList();
 
         EventBroadcast(Class<T> type) {
             this.type = type;
@@ -242,16 +243,16 @@ public class DefaultListenerManager implements ListenerManager {
             logger = candidate;
         }
 
-        private ImmutableList<Dispatch<MethodInvocation>> startNotification(boolean includeLogger) {
+        private List<Dispatch<MethodInvocation>> startNotification(boolean includeLogger) {
             takeOwnership();
 
             // Take a snapshot while holding lock
-            ImmutableList<Dispatch<MethodInvocation>> result = includeLogger ? allWithLogger : allWithNoLogger;
+            List<Dispatch<MethodInvocation>> result = includeLogger ? allWithLogger : allWithNoLogger;
             doStartNotification(result);
             return result;
         }
 
-        private void doStartNotification(ImmutableList<Dispatch<MethodInvocation>> result) {
+        private void doStartNotification(List<Dispatch<MethodInvocation>> result) {
             for (Dispatch<MethodInvocation> dispatch : result) {
                 if (dispatch instanceof ListenerDetails) {
                     ListenerDetails listenerDetails = (ListenerDetails) dispatch;
@@ -262,20 +263,20 @@ public class DefaultListenerManager implements ListenerManager {
 
         private void ensureAllWithoutLoggerInitialized() {
             if (parentDispatch == null && listeners.isEmpty()) {
-                allWithNoLogger = ImmutableList.of();
+                allWithNoLogger = Collections.emptyList();
             } else {
-                ImmutableList.Builder<Dispatch<MethodInvocation>> dispatchers = ImmutableList.builder();
+                List<Dispatch<MethodInvocation>> dispatchers = new ArrayList<Dispatch<MethodInvocation>>();
                 if (parentDispatch != null) {
                     dispatchers.add(parentDispatch);
                 }
                 dispatchers.addAll(listeners);
-                allWithNoLogger = dispatchers.build();
+                allWithNoLogger = dispatchers;
             }
         }
 
         private void ensureAllWithLoggerInitialized() {
             if (logger == null && parentDispatch == null && listeners.isEmpty()) {
-                allWithLogger = ImmutableList.of();
+                allWithLogger = Collections.emptyList();
             } else {
                 allWithLogger = buildAllWithLogger();
             }
@@ -290,17 +291,15 @@ public class DefaultListenerManager implements ListenerManager {
             broadcasterLock.lock();
         }
 
-        private ImmutableList<Dispatch<MethodInvocation>> buildAllWithLogger() {
-            ImmutableList<Dispatch<MethodInvocation>> result;
-            ImmutableList.Builder<Dispatch<MethodInvocation>> dispatchers = ImmutableList.builder();
+        private List<Dispatch<MethodInvocation>> buildAllWithLogger() {
+            List<Dispatch<MethodInvocation>> result = new ArrayList<Dispatch<MethodInvocation>>();
             if (logger != null) {
-                dispatchers.add(logger);
+                result.add(logger);
             }
             if (parentDispatch != null) {
-                dispatchers.add(parentDispatch);
+                result.add(parentDispatch);
             }
-            dispatchers.addAll(listeners);
-            result = dispatchers.build();
+            result.addAll(listeners);
             return result;
         }
 
@@ -335,7 +334,7 @@ public class DefaultListenerManager implements ListenerManager {
 
             @Override
             public void dispatch(MethodInvocation invocation) {
-                ImmutableList<Dispatch<MethodInvocation>> dispatchers = startNotification(includeLogger);
+                List<Dispatch<MethodInvocation>> dispatchers = startNotification(includeLogger);
                 try {
                     if (!dispatchers.isEmpty()) {
                         dispatch(invocation, dispatchers.iterator());

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerBroadcast.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerBroadcast.java
@@ -21,6 +21,8 @@ import org.gradle.internal.dispatch.Dispatch;
 import org.gradle.internal.dispatch.MethodInvocation;
 import org.gradle.internal.dispatch.ProxyDispatchAdapter;
 
+import java.util.Collection;
+
 /**
  * <p>Manages a set of listeners of type T. Provides an implementation of T which can be used to broadcast to all
  * registered listeners.</p>
@@ -86,7 +88,7 @@ public class ListenerBroadcast<T> implements Dispatch<MethodInvocation> {
      *
      * @param listeners The listeners
      */
-    public void addAll(Iterable<? extends T> listeners) {
+    public void addAll(Collection<? extends T> listeners) {
         broadcast = broadcast.addAll(listeners);
     }
 
@@ -118,7 +120,7 @@ public class ListenerBroadcast<T> implements Dispatch<MethodInvocation> {
      *
      * @param listeners The listeners
      */
-    public void removeAll(Iterable<?> listeners) {
+    public void removeAll(Collection<?> listeners) {
         broadcast = broadcast.removeAll(listeners);
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHubBackedObjectConnection.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHubBackedObjectConnection.java
@@ -36,7 +36,6 @@ import org.gradle.internal.remote.internal.hub.protocol.InterHubMessage;
 import org.gradle.internal.serialize.SerializerRegistry;
 import org.gradle.internal.serialize.StatefulSerializer;
 import org.gradle.internal.serialize.kryo.TypeSafeSerializer;
-import org.gradle.util.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +98,7 @@ public class MessageHubBackedObjectConnection implements ObjectConnection {
         if (methodParamClassLoaders.size() == 0) {
             methodParamClassLoader = getClass().getClassLoader();
         } else if (methodParamClassLoaders.size() == 1) {
-            methodParamClassLoader = CollectionUtils.single(methodParamClassLoaders);
+            methodParamClassLoader = methodParamClassLoaders.iterator().next();
         } else {
             methodParamClassLoader = new CachingClassLoader(new MultiParentClassLoader(methodParamClassLoaders));
         }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
@@ -60,17 +60,15 @@ class JavaTestGradleVsMavenPerformanceTest extends AbstractGradleVsMavenPerforma
         def results = runner.run()
 
         then:
-        if (gradleTask != "test" || testProject != MEDIUM_JAVA_MULTI_PROJECT) { //there seems to be some inefficiency when testing with --parallel
-            results.assertFasterThanMaven()
-        }
+        results.assertFasterThanMaven()
 
         where:
         testProject                    | gradleTask    | mavenTask | gradleCleanupTask | mavenCleanupTask
         MEDIUM_MONOLITHIC_JAVA_PROJECT | 'assemble'    | 'package' | 'clean'           | 'clean'
-        MEDIUM_MONOLITHIC_JAVA_PROJECT | 'test'        | 'test'    | 'cleanTest'       | 'help'
+        MEDIUM_MONOLITHIC_JAVA_PROJECT | 'test'        | 'test'    | 'cleanTest'       | '-help'
 
         MEDIUM_JAVA_MULTI_PROJECT      | 'assemble'    | 'package' | 'clean'           | 'clean'
-        MEDIUM_JAVA_MULTI_PROJECT      | 'test'        | 'test'    | 'cleanTest'       | 'help'
+        MEDIUM_JAVA_MULTI_PROJECT      | 'test'        | 'test'    | 'cleanTest'       | '-help'
     }
 
     @Unroll

--- a/subprojects/process-services/src/main/java/org/gradle/process/internal/health/memory/DefaultMemoryManager.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/internal/health/memory/DefaultMemoryManager.java
@@ -79,7 +79,7 @@ public class DefaultMemoryManager implements MemoryManager, Stoppable {
     }
 
     private void start() {
-        scheduler.scheduleAtFixedRate(new MemoryCheck(), 0, STATUS_INTERVAL_SECONDS, TimeUnit.SECONDS);
+        scheduler.scheduleAtFixedRate(new MemoryCheck(), STATUS_INTERVAL_SECONDS, STATUS_INTERVAL_SECONDS, TimeUnit.SECONDS);
         LOGGER.debug("Memory status broadcaster started");
         if (osMemoryStatusSupported) {
             addListener(osMemoryStatusListener);

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -15,7 +15,8 @@
  */
 package org.gradle.api.internal.tasks.testing.filter;
 
-import com.google.common.base.Splitter;
+
+import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,7 +36,7 @@ public class TestSelectionMatcher {
 
     private Pattern preparePattern(String input) {
         StringBuilder pattern = new StringBuilder();
-        Iterable<String> split = Splitter.on('*').split(input);
+        String[] split = StringUtils.splitPreserveAllTokens(input, '*');
         for (String s : split) {
             if (s.equals("")) {
                 pattern.append(".*"); //replace wildcard '*' with '.*'

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -99,7 +99,6 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
             moduleRegistry.getModule("gradle-testing-base").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getModule("gradle-testing-jvm").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getModule("gradle-process-services").getImplementationClasspath().getAsURLs(),
-            moduleRegistry.getExternalModule("guava-jdk5").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getExternalModule("slf4j-api").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getExternalModule("jul-to-slf4j").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getExternalModule("native-platform").getImplementationClasspath().getAsURLs(),

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -72,6 +72,7 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
         builder.setBaseName("Gradle Test Executor");
         builder.setImplementationClasspath(getTestWorkerImplementationClasspath());
         builder.applicationClasspath(classPath);
+        builder.getJavaCommand().jvmArgs("-Dorg.gradle.native=false");
         options.copyTo(builder.getJavaCommand());
         buildConfigAction.execute(builder);
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
@@ -67,8 +67,8 @@ class ForkingTestClassProcessorTest extends Specification {
 
         then:
         10 * moduleRegistry.getModule(_) >> { module(it[0]) }
-        7 * moduleRegistry.getExternalModule(_) >> { module(it[0]) }
-        1 * workerProcessBuilder.setImplementationClasspath(_) >> { assert it[0].size() == 17 }
+        6 * moduleRegistry.getExternalModule(_) >> { module(it[0]) }
+        1 * workerProcessBuilder.setImplementationClasspath(_) >> { assert it[0].size() == 16 }
     }
 
     def module(String module) {

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.remote.ObjectConnection
 import org.gradle.process.JavaForkOptions
+import org.gradle.process.internal.JavaExecHandleBuilder
 import org.gradle.process.internal.worker.WorkerProcess
 import org.gradle.process.internal.worker.WorkerProcessBuilder
 import org.gradle.process.internal.worker.WorkerProcessFactory
@@ -60,6 +61,7 @@ class ForkingTestClassProcessorTest extends Specification {
         setup:
         1 * workerProcessFactory.create(_) >> workerProcessBuilder
         1 * workerProcessBuilder.build() >> workerProcess
+        _ * workerProcessBuilder.getJavaCommand() >> Stub (JavaExecHandleBuilder)
         1 * workerProcess.getConnection() >> Stub(ObjectConnection) { addOutgoing(_) >> Stub(RemoteTestClassProcessor) }
 
         when:

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactory.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactory.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.tasks.testing.testng;
 
-import com.google.common.base.Objects;
 import org.gradle.internal.reflect.JavaMethod;
 import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.testng.ISuiteListener;
@@ -24,6 +23,7 @@ import org.testng.ITestListener;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Arrays;
 
 class TestNGListenerAdapterFactory {
     private final ClassLoader classLoader;
@@ -111,7 +111,7 @@ class TestNGListenerAdapterFactory {
 
         private int proxyHashCode(Object proxy) {
             AdaptedListener invocationHandler = (AdaptedListener) Proxy.getInvocationHandler(proxy);
-            return Objects.hashCode(invocationHandler.getClass(), invocationHandler.delegate.getClass());
+            return Arrays.hashCode(new Object[] {invocationHandler.getClass(), invocationHandler.delegate.getClass()});
         }
     }
 }


### PR DESCRIPTION
Our test processes are very fast compared to other build tools, once they are warmed up. But in the "100 projects with only 100 tests each" scenario, we were ~10% slower than Maven, because our test processes take a bit longer to start up because of that added complexity.

These changes mitigate that by:

- doing less classloading (especially Guava)
- not initializing the native services for test workers
- starting the worker health check only after the first delay
- making some logging services cheaper to create

This closes the performance gap for the scenario above and should also slightly improve the Gradle client startup time.