### PR TITLE
Add build operation types to log events

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/BranchBuildOperationDetails.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/BranchBuildOperationDetails.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.progress;
+
+/**
+ * Build Operation Details with knowledge of how many direct children the operation will have.
+ *
+ * @param <R> the type of result
+ * @see BuildOperationDetails
+ * @since 4.0
+ */
+public interface BranchBuildOperationDetails<R> extends BuildOperationDetails<R> {
+    long getChildren();
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/PhaseBuildOperationDetails.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/PhaseBuildOperationDetails.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.progress;
+
+/**
+ * Denotes a build operation representing a phase of a build.
+ *
+ * @param <R> the type of result
+ * @see BuildOperationDetails
+ * @since 4.0
+ */
+public interface PhaseBuildOperationDetails<R> extends BranchBuildOperationDetails<R> {}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.internal.progress.BuildOperationDescriptor
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.BuildOperationState
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
+import org.gradle.internal.progress.TestProgressLoggerFactory
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.time.TimeProvider
 import org.gradle.internal.work.DefaultWorkerLeaseService
@@ -44,7 +45,7 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
     def setupBuildOperationExecutor(int maxThreads) {
         workerRegistry = new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), true, maxThreads)
         buildOperationExecutor = new DefaultBuildOperationExecutor(
-            operationListener, Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            operationListener, Mock(TimeProvider), new TestProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerRegistry), new DefaultExecutorFactory(), maxThreads)
         outerOperationCompletion = workerRegistry.getWorkerLease().start()
         outerOperation = workerRegistry.getCurrentWorkerLease()

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.internal.operations
 
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
+import org.gradle.internal.progress.TestProgressLoggerFactory
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.time.TimeProvider
-import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.work.DefaultWorkerLeaseService
+import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 class MaxWorkersTest extends ConcurrentSpec {
@@ -33,7 +33,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         def maxWorkers = 1
         def registry = buildOperationWorkerRegistry(maxWorkers)
         def processor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new TestProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), maxWorkers)
         def processorWorker = new SimpleWorker()
 
@@ -75,7 +75,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         def maxWorkers = 1
         def registry = buildOperationWorkerRegistry(maxWorkers)
         def processor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new TestProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), maxWorkers)
         def processorWorker = new SimpleWorker()
 
@@ -117,7 +117,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         def maxWorkers = 1
         def registry = buildOperationWorkerRegistry(maxWorkers)
         def processor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new TestProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), maxWorkers)
         def processorWorker = new SimpleWorker()
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -33,6 +33,7 @@ import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.progress.BuildOperationDescriptor;
+import org.gradle.internal.progress.PhaseBuildOperationDetails;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.util.CollectionUtils;
@@ -192,6 +193,29 @@ public class DefaultGradleLauncher implements GradleLauncher {
         }
     }
 
+    private class InitializeBuildOperation implements RunnableBuildOperation {
+        @Override
+        public void run(BuildOperationContext context) {
+            // Evaluate init scripts
+            initScriptHandler.executeScripts(gradle);
+
+            // Build `buildSrc`, load settings.gradle, and construct composite (if appropriate)
+            settings = settingsLoader.findAndLoadSettings(gradle);
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            return BuildOperationDescriptor
+                .displayName("INITIALIZING")
+                .details(new PhaseBuildOperationDetails() {
+                    public long getChildren() {
+                        // Must initialize at least 1 root + N included builds
+                        return 1 + gradle.getIncludedBuilds().size();
+                    }
+                });
+        }
+    }
+
     private class ConfigureBuildBuildOperation implements RunnableBuildOperation {
         @Override
         public void run(BuildOperationContext context) {
@@ -206,7 +230,14 @@ public class DefaultGradleLauncher implements GradleLauncher {
 
         @Override
         public BuildOperationDescriptor.Builder description() {
-            return BuildOperationDescriptor.displayName("Configure build");
+            return BuildOperationDescriptor
+                .displayName("CONFIGURING")
+                .details(new PhaseBuildOperationDetails() {
+                    public long getChildren() {
+                        // TODO(EW): * 2 is for "Clean stale outputs for each project" and + 1 for CalculateTaskGraphBuildOperation
+                        return gradle.getRootProject().getAllprojects().size() * 2 + 1;
+                    }
+                });
         }
     }
 
@@ -243,9 +274,16 @@ public class DefaultGradleLauncher implements GradleLauncher {
             buildExecuter.execute(gradle);
         }
 
+        // FIXME(ew): Build Operations for task execution are not direct children of this
         @Override
         public BuildOperationDescriptor.Builder description() {
-            return BuildOperationDescriptor.displayName("Run tasks");
+            return BuildOperationDescriptor
+                .displayName("EXECUTING")
+                .details(new PhaseBuildOperationDetails() {
+                    public long getChildren() {
+                        return gradle.getTaskGraph().getAllTasks().size();
+                    }
+                });
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/NotifyingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/NotifyingSettingsProcessor.java
@@ -44,6 +44,7 @@ public class NotifyingSettingsProcessor implements SettingsProcessor {
 
             @Override
             public BuildOperationDescriptor.Builder description() {
+                // TODO(ew): better progress display name here
                 return BuildOperationDescriptor.displayName("Configure settings").progressDisplayName("settings");
             }
         });

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
@@ -16,28 +16,16 @@
 
 package org.gradle.internal.progress;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 
 public class BuildProgressLogger implements LoggerProvider {
     public static final String INITIALIZATION_PHASE_DESCRIPTION = "INITIALIZATION PHASE";
-    public static final String INITIALIZATION_PHASE_SHORT_DESCRIPTION = "INITIALIZING";
     public static final String CONFIGURATION_PHASE_DESCRIPTION = "CONFIGURATION PHASE";
-    public static final String CONFIGURATION_PHASE_SHORT_DESCRIPTION = "CONFIGURING";
     public static final String EXECUTION_PHASE_DESCRIPTION = "EXECUTION PHASE";
-    public static final String EXECUTION_PHASE_SHORT_DESCRIPTION = "EXECUTING";
-    public static final int PROGRESS_BAR_WIDTH = 13;
-    public static final String PROGRESS_BAR_PREFIX = "<";
-    public static final char PROGRESS_BAR_COMPLETE_CHAR = '=';
-    public static final char PROGRESS_BAR_INCOMPLETE_CHAR = '-';
-    public static final String PROGRESS_BAR_SUFFIX = ">";
 
     private final ProgressLoggerProvider loggerProvider;
-    private boolean taskGraphPopulated;
-
     private ProgressLogger buildProgress;
-    private ProgressFormatter buildProgressFormatter;
 
     public BuildProgressLogger(ProgressLoggerFactory progressLoggerFactory) {
         this(new ProgressLoggerProvider(progressLoggerFactory, BuildProgressLogger.class));
@@ -48,8 +36,7 @@ public class BuildProgressLogger implements LoggerProvider {
     }
 
     public void buildStarted() {
-        buildProgressFormatter = newProgressBar(INITIALIZATION_PHASE_SHORT_DESCRIPTION, 1);
-        buildProgress = loggerProvider.start(INITIALIZATION_PHASE_DESCRIPTION, buildProgressFormatter.getProgress());
+        buildProgress = loggerProvider.start(INITIALIZATION_PHASE_DESCRIPTION, null);
     }
 
     public void settingsEvaluated() {
@@ -57,35 +44,25 @@ public class BuildProgressLogger implements LoggerProvider {
     }
 
     public void projectsLoaded(int totalProjects) {
-        buildProgressFormatter = newProgressBar(CONFIGURATION_PHASE_SHORT_DESCRIPTION, totalProjects);
-        buildProgress = loggerProvider.start(CONFIGURATION_PHASE_DESCRIPTION, buildProgressFormatter.getProgress());
+        buildProgress = loggerProvider.start(CONFIGURATION_PHASE_DESCRIPTION, null);
     }
 
     public void beforeEvaluate(String projectPath) {}
 
-    public void afterEvaluate(String projectPath) {
-        if (!taskGraphPopulated) {
-            buildProgress.progress(buildProgressFormatter.incrementAndGetProgress());
-        }
-    }
+    public void afterEvaluate(String projectPath) {}
 
     public void graphPopulated(int totalTasks) {
-        taskGraphPopulated = true;
         buildProgress.completed();
-        buildProgressFormatter = newProgressBar(EXECUTION_PHASE_SHORT_DESCRIPTION, totalTasks);
-        buildProgress = loggerProvider.start(EXECUTION_PHASE_DESCRIPTION, buildProgressFormatter.getProgress());
+        buildProgress = loggerProvider.start(EXECUTION_PHASE_DESCRIPTION, null);
     }
 
     public void beforeExecute() {}
 
-    public void afterExecute() {
-        buildProgress.progress(buildProgressFormatter.incrementAndGetProgress());
-    }
+    public void afterExecute() {}
 
     public void buildFinished() {
         buildProgress.completed();
         buildProgress = null;
-        buildProgressFormatter = null;
     }
 
     public ProgressLogger getLogger() {
@@ -93,16 +70,5 @@ public class BuildProgressLogger implements LoggerProvider {
             throw new IllegalStateException("Build logger is unavailable (it hasn't started or is already completed).");
         }
         return buildProgress;
-    }
-
-    @VisibleForTesting
-    public ProgressBar newProgressBar(String initialSuffix, int totalWorkItems) {
-        return new ProgressBar(PROGRESS_BAR_PREFIX,
-            PROGRESS_BAR_WIDTH,
-            PROGRESS_BAR_SUFFIX,
-            PROGRESS_BAR_COMPLETE_CHAR,
-            PROGRESS_BAR_INCOMPLETE_CHAR,
-            initialSuffix,
-            totalWorkItems);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
@@ -169,15 +169,14 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
             Throwable failure = null;
             DefaultBuildOperationContext context = new DefaultBuildOperationContext();
             try {
-                ProgressLogger progressLogger = maybeStartProgressLogging(currentOperation);
+                ProgressLogger progressLogger = createProgressLogger(currentOperation);
 
                 LOGGER.debug("Build operation '{}' started", descriptor.getDisplayName());
                 try {
                     worker.execute(buildOperation, context);
                 } finally {
-                    if (progressLogger != null) {
-                        progressLogger.completed();
-                    }
+                    LOGGER.debug("Completing Build operation '{}'", descriptor.getDisplayName());
+                    progressLogger.completed();
                 }
                 assertParentRunning("Parent operation (%2$s) completed before this operation (%1$s).", descriptor, parent);
             } catch (Throwable t) {
@@ -217,21 +216,10 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
         }
     }
 
-    @Nullable
-    private ProgressLogger maybeStartProgressLogging(DefaultBuildOperationState currentOperation) {
-        if (providesProgressLogging(currentOperation)) {
-            ProgressLogger progressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, (OperationIdentifier) currentOperation.getId());
-            progressLogger.setDescription(currentOperation.getDescription().getDisplayName());
-            progressLogger.setShortDescription(currentOperation.getDescription().getProgressDisplayName());
-            progressLogger.started();
-            return progressLogger;
-        } else {
-            return null;
-        }
-    }
-
-    private boolean providesProgressLogging(DefaultBuildOperationState currentOperation) {
-        return currentOperation.getDescription().getProgressDisplayName() != null;
+    private ProgressLogger createProgressLogger(DefaultBuildOperationState currentOperation) {
+        BuildOperationDescriptor descriptor = currentOperation.getDescription();
+        ProgressLogger progressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, descriptor);
+        return progressLogger.start(descriptor.getDisplayName(), descriptor.getProgressDisplayName());
     }
 
     private DefaultBuildOperationState maybeStartUnmanagedThreadOperation(DefaultBuildOperationState parentState) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -250,9 +250,10 @@ class DefaultGradleLauncherSpec extends Specification {
 
     private void expectedBuildOperationsFired() {
         assert buildOperationExecutor.operations.size() == 3
-        assert buildOperationExecutor.operations[0].displayName == "Configure build"
+//        assert buildOperationExecutor.operations[0].displayName == "INITIALIZING"
+        assert buildOperationExecutor.operations[0].displayName == "CONFIGURING"
         assert buildOperationExecutor.operations[1].displayName == "Calculate task graph"
-        assert buildOperationExecutor.operations[2].displayName == "Run tasks"
+        assert buildOperationExecutor.operations[2].displayName == "EXECUTING"
     }
 
     private void expectInitScriptsExecuted() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
@@ -18,9 +18,6 @@ package org.gradle.internal.progress
 
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.GradleThread
-import org.gradle.internal.logging.events.OperationIdentifier
-import org.gradle.internal.logging.progress.ProgressLogger
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationQueueFactory
 import org.gradle.internal.operations.CallableBuildOperation
@@ -33,7 +30,8 @@ import static org.gradle.internal.progress.BuildOperationDescriptor.displayName
 class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
     def listener = Mock(BuildOperationListener)
     def timeProvider = Mock(TimeProvider)
-    def progressLoggerFactory = Mock(ProgressLoggerFactory)
+    def progressLoggerFactory = Spy(TestProgressLoggerFactory)
+    def progressLogger = new TestProgressLogger()
     def operationExecutor = new DefaultBuildOperationExecutor(listener, timeProvider, progressLoggerFactory, Mock(BuildOperationQueueFactory), Mock(ExecutorFactory), 1)
 
     def "fires events when operation starts and finishes successfully"() {
@@ -42,7 +40,7 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
 
         and:
         def buildOperation = Mock(CallableBuildOperation)
-        def progressLogger = Mock(ProgressLogger)
+        def progressLogger = Spy(TestProgressLogger)
         def details = Mock(BuildOperationDetails)
         def operationDetailsBuilder = displayName("<some-operation>").name("<op>").progressDisplayName("<some-op>").details(details)
         def id
@@ -67,10 +65,8 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         }
 
         then:
-        1 * progressLoggerFactory.newOperation(_, _ as OperationIdentifier) >> progressLogger
-        1 * progressLogger.setDescription("<some-operation>")
-        1 * progressLogger.setShortDescription("<some-op>")
-        1 * progressLogger.started()
+        1 * progressLoggerFactory.newOperation(_ as Class, _ as BuildOperationDescriptor) >> progressLogger
+        1 * progressLogger.start("<some-operation>", "<some-op>")
 
         then:
         1 * buildOperation.call(_) >> "result"
@@ -103,7 +99,7 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         def buildOperation = Mock(RunnableBuildOperation)
         def operationDescriptionBuilder = displayName("<some-operation>").progressDisplayName("<some-op>")
         def failure = new RuntimeException()
-        def progressLogger = Mock(ProgressLogger)
+        def progressLogger = Spy(TestProgressLogger)
         def id
 
         when:
@@ -125,10 +121,8 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         }
 
         then:
-        1 * progressLoggerFactory.newOperation(_, _ as OperationIdentifier) >> progressLogger
-        1 * progressLogger.setDescription("<some-operation>")
-        1 * progressLogger.setShortDescription("<some-op>")
-        1 * progressLogger.started()
+        1 * progressLoggerFactory.newOperation(_ as Class, _ as BuildOperationDescriptor) >> progressLogger
+        1 * progressLogger.start("<some-operation>", "<some-op>")
 
         then:
         1 * buildOperation.run(_) >> { throw failure }
@@ -161,6 +155,9 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         operationExecutor.run(buildOperation)
 
         then:
+        1 * progressLoggerFactory.newOperation(_ as Class, _ as BuildOperationDescriptor) >> progressLogger
+
+        then:
         1 * buildOperation.run(_) >> { BuildOperationContext context -> context.failed(failure) }
 
         then:
@@ -184,6 +181,9 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         operationExecutor.run(buildOperation)
 
         then:
+        1 * progressLoggerFactory.newOperation(_ as Class, _ as BuildOperationDescriptor) >> progressLogger
+
+        then:
         1 * buildOperation.run(_) >> { BuildOperationContext context -> context.result = result }
 
         then:
@@ -193,17 +193,6 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
 
         cleanup:
         GradleThread.setUnmanaged()
-    }
-
-    def "does not generate progress logging when operation has no progress display name"() {
-        def buildOperation = Spy(TestRunnableBuildOperation)
-
-        when:
-        operationExecutor.run(buildOperation)
-
-        then:
-        1 * buildOperation.run(_)
-        0 * progressLoggerFactory._
     }
 
     def "multiple threads can run independent operations concurrently"() {
@@ -438,7 +427,6 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         def ex = thrown(IllegalStateException)
         ex.message == 'No operation is currently running.'
     }
-
 
     def "can nest operations on unmanaged threads"() {
         when:

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/progress/TestProgressLogger.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/progress/TestProgressLogger.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.progress
+
+import org.gradle.internal.logging.progress.ProgressLogger
+
+class TestProgressLogger implements ProgressLogger {
+    String description
+    String shortDescription
+    String loggingHeader
+
+    String getDescription() { description }
+
+    ProgressLogger setDescription(String description) {
+        this.description = description
+        this
+    }
+
+    String getShortDescription() { shortDescription }
+
+    ProgressLogger setShortDescription(String description) {
+        this.shortDescription = description
+        this
+    }
+
+    String getLoggingHeader() { loggingHeader }
+
+    ProgressLogger setLoggingHeader(String header) {
+        this.loggingHeader = header
+        this
+    }
+
+    ProgressLogger start(String description, String shortDescription) {
+        setDescription(description)
+        setShortDescription(shortDescription)
+        started()
+        this
+    }
+
+    void started() {}
+    void started(String status) {}
+    void progress(String status) {}
+    void completed() {}
+    void completed(String status) {}
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/progress/TestProgressLoggerFactory.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/progress/TestProgressLoggerFactory.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.progress
+
+import org.gradle.internal.logging.progress.ProgressLogger
+import org.gradle.internal.logging.progress.ProgressLoggerFactory
+
+class TestProgressLoggerFactory implements ProgressLoggerFactory {
+    ProgressLogger newOperation(String loggerCategory) {
+        throw new UnsupportedOperationException()
+    }
+
+    ProgressLogger newOperation(Class<?> loggerCategory) {
+        throw new UnsupportedOperationException()
+    }
+
+    ProgressLogger newOperation(Class<?> loggerCategory, BuildOperationDescriptor buildOperationDescriptor) {
+        return new TestProgressLogger()
+    }
+
+    ProgressLogger newOperation(Class<?> loggerClass, ProgressLogger parent) {
+        throw new UnsupportedOperationException()
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
@@ -20,12 +20,14 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.logging.events.LogEvent;
 import org.gradle.internal.logging.events.LogLevelChangeEvent;
 import org.gradle.internal.logging.events.OutputEvent;
+import org.gradle.internal.logging.events.PhaseProgressStartEvent;
 import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
 import org.gradle.internal.logging.events.StyledTextOutputEvent;
 import org.gradle.internal.logging.serializer.LogEventSerializer;
 import org.gradle.internal.logging.serializer.LogLevelChangeEventSerializer;
+import org.gradle.internal.logging.serializer.PhaseProgressStartEventSerializer;
 import org.gradle.internal.logging.serializer.ProgressCompleteEventSerializer;
 import org.gradle.internal.logging.serializer.ProgressEventSerializer;
 import org.gradle.internal.logging.serializer.ProgressStartEventSerializer;
@@ -57,6 +59,7 @@ public class DaemonMessageSerializer {
         // Output events
         registry.register(LogEvent.class, new LogEventSerializer(logLevelSerializer, throwableSerializer));
         registry.register(StyledTextOutputEvent.class, new StyledTextOutputEventSerializer(logLevelSerializer, new ListSerializer<StyledTextOutputEvent.Span>(new SpanSerializer(factory.getSerializerFor(StyledTextOutput.Style.class)))));
+        registry.register(PhaseProgressStartEvent.class, new PhaseProgressStartEventSerializer());
         registry.register(ProgressStartEvent.class, new ProgressStartEventSerializer());
         registry.register(ProgressCompleteEvent.class, new ProgressCompleteEventSerializer());
         registry.register(ProgressEvent.class, new ProgressEventSerializer());

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/protocol/DaemonMessageSerializerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/protocol/DaemonMessageSerializerTest.groovy
@@ -18,10 +18,7 @@ package org.gradle.launcher.daemon.protocol
 
 import org.gradle.api.logging.LogLevel
 import org.gradle.internal.logging.events.LogLevelChangeEvent
-import org.gradle.internal.logging.events.OperationIdentifier
 import org.gradle.internal.logging.events.OutputEvent
-import org.gradle.internal.logging.events.ProgressCompleteEvent
-import org.gradle.internal.logging.events.ProgressEvent
 import org.gradle.internal.serialize.PlaceholderException
 import org.gradle.internal.serialize.Serializer
 import org.gradle.internal.serialize.SerializerSpec
@@ -43,29 +40,6 @@ class DaemonMessageSerializerTest extends SerializerSpec {
         def result = serialize(event, serializer)
         result instanceof LogLevelChangeEvent
         result.newLogLevel == LogLevel.LIFECYCLE
-    }
-
-    def "can serialize ProgressCompleteEvent messages"() {
-        expect:
-        def event = new ProgressCompleteEvent(new OperationIdentifier(1234L), 321L, "category", "description", "status")
-        def result = serialize(event, serializer)
-        result instanceof ProgressCompleteEvent
-        result.operationId == new OperationIdentifier(1234L)
-        result.timestamp == 321L
-        result.category == "category"
-        result.description == "description"
-        result.status == "status"
-    }
-
-    def "can serialize ProgressEvent messages"() {
-        expect:
-        def event = new ProgressEvent(new OperationIdentifier(1234L), 321L, "category", "status")
-        def result = serialize(event, serializer)
-        result instanceof ProgressEvent
-        result.operationId == new OperationIdentifier(1234L)
-        result.timestamp == 321L
-        result.category == "category"
-        result.status == "status"
     }
 
     def "can serialize Failure messages"() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/GroupedBuildOperationRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/GroupedBuildOperationRenderer.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console;
+
+import com.google.common.collect.Lists;
+import org.gradle.internal.logging.events.BatchOutputEventListener;
+import org.gradle.internal.logging.events.EndOutputEvent;
+import org.gradle.internal.logging.events.OperationIdentifier;
+import org.gradle.internal.logging.events.OutputEvent;
+import org.gradle.internal.logging.events.PhaseProgressStartEvent;
+import org.gradle.internal.logging.events.ProgressCompleteEvent;
+import org.gradle.internal.logging.events.ProgressStartEvent;
+import org.gradle.internal.logging.events.RenderableOutputEvent;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class GroupedBuildOperationRenderer extends BatchOutputEventListener {
+
+    // FIXME(ew): This breaks OutputEventRendererTest.rendersLogEventsInConsoleWhenLogLevelIsDebug() — perhaps everything is being output as LogEvents from this thing?
+    static final int SCHEDULER_INITIAL_DELAY_MS = 100;
+    static final int SCHEDULER_CHECK_PERIOD_MS = 5000;
+    private final BatchOutputEventListener listener;
+    private final ScheduledExecutorService executor;
+    private final Object lock = new Object();
+    private final Map<OperationIdentifier, Object> progressIdToBuildOperationIdMap = new LinkedHashMap<OperationIdentifier, Object>();
+    private final Map<Object, List<OutputEvent>> groupedTaskBuildOperations = new LinkedHashMap<Object, List<OutputEvent>>();
+    private final RenderState renderState = new RenderState();
+
+    public GroupedBuildOperationRenderer(BatchOutputEventListener listener) {
+        this(listener, true);
+    }
+
+    GroupedBuildOperationRenderer(BatchOutputEventListener listener, boolean enableScheduler) {
+        this.listener = listener;
+        executor = Executors.newSingleThreadScheduledExecutor();
+
+        if (enableScheduler) {
+            scheduleTimedEventForwarding();
+        }
+    }
+
+    private void scheduleTimedEventForwarding() {
+        executor.scheduleAtFixedRate(new ForwardingOutputEventRunnable(), SCHEDULER_INITIAL_DELAY_MS, SCHEDULER_CHECK_PERIOD_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void onOutput(OutputEvent event) {
+        synchronized (lock) {
+            if (event instanceof ProgressStartEvent) {
+                onStart((ProgressStartEvent) event);
+            } else if (event instanceof ProgressCompleteEvent) {
+                onComplete((ProgressCompleteEvent) event);
+            } else if (event instanceof RenderableOutputEvent) {
+                onRenderable((RenderableOutputEvent) event);
+            } else if (event instanceof EndOutputEvent) {
+                onEnd((EndOutputEvent) event);
+            }
+        }
+    }
+
+    private void onStart(ProgressStartEvent event) {
+        // FIXME(ew): logic here is surely off
+        if (event.getBuildOperationId() != null && !(event instanceof PhaseProgressStartEvent)) {
+            progressIdToBuildOperationIdMap.put(event.getProgressOperationId(), event.getBuildOperationId());
+            groupedTaskBuildOperations.put(event.getBuildOperationId(), Lists.newArrayList((OutputEvent) event));
+        } else {
+            forwardEvent(event);
+        }
+    }
+
+    private void onComplete(ProgressCompleteEvent event) {
+        Object operationId = null;
+        if (progressIdToBuildOperationIdMap.containsKey(event.getProgressOperationId())) {
+            operationId = progressIdToBuildOperationIdMap.get(event.getProgressOperationId());
+            if (groupedTaskBuildOperations.containsKey(operationId)) {
+                List<OutputEvent> outputEvents = groupedTaskBuildOperations.get(operationId);
+
+                if (renderState.isCurrentlyRendered(operationId)) {
+                    List<OutputEvent> outputEventsWithoutHeader = outputEvents.subList(1, outputEvents.size());
+                    forwardBatchedEvents(outputEventsWithoutHeader);
+                    renderState.clearCurrentlyRendered(operationId);
+                } else {
+                    forwardBatchedEvents(outputEvents);
+                }
+
+                forwardEvent(event);
+                groupedTaskBuildOperations.remove(operationId);
+            }
+        }
+
+        if (groupedTaskBuildOperations.containsKey(operationId)) {
+            List<OutputEvent> outputEvents = groupedTaskBuildOperations.get(operationId);
+
+            if (renderState.isCurrentlyRendered(operationId)) {
+                List<OutputEvent> outputEventsWithoutHeader = outputEvents.subList(1, outputEvents.size());
+                forwardBatchedEvents(outputEventsWithoutHeader);
+                renderState.clearCurrentlyRendered(operationId);
+            } else {
+                forwardBatchedEvents(outputEvents);
+            }
+
+            forwardEvent(event);
+            groupedTaskBuildOperations.remove(operationId);
+        } else {
+            forwardEvent(event);
+        }
+    }
+
+    private void onRenderable(RenderableOutputEvent event) {
+        Object buildOperationId = event.getBuildOperationId();
+        if (buildOperationId != null && groupedTaskBuildOperations.containsKey(buildOperationId)) {
+            List<OutputEvent> outputEvents = groupedTaskBuildOperations.get(buildOperationId);
+            outputEvents.add(event);
+        } else {
+            forwardEvent(event);
+        }
+    }
+
+    private void onEnd(EndOutputEvent event) {
+        forwardEvent(event);
+        executor.shutdown();
+        groupedTaskBuildOperations.clear();
+        renderState.clear();
+    }
+
+    private void forwardEvent(OutputEvent event) {
+        listener.onOutput(event);
+    }
+
+    private void forwardBatchedEvents(Iterable<OutputEvent> events) {
+        listener.onOutput(events);
+    }
+
+    private class ForwardingOutputEventRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            synchronized (lock) {
+                Iterator<Map.Entry<Object, List<OutputEvent>>> entryIterator = groupedTaskBuildOperations.entrySet().iterator();
+                Map.Entry<Object, List<OutputEvent>> lastEntry = null;
+
+                while (entryIterator.hasNext()) {
+                    lastEntry = entryIterator.next();
+                    forwardOutputEvents(lastEntry);
+                }
+
+                if (lastEntry != null) {
+                    renderState.setCurrentlyRendered(lastEntry.getKey());
+                }
+            }
+        }
+
+        private void forwardOutputEvents(Map.Entry<Object, List<OutputEvent>> groupedEvents) {
+            List<OutputEvent> originalOutputEvents = groupedEvents.getValue();
+            List<OutputEvent> outputEventsWithoutHeader = getOutputEventsWithoutHeader(originalOutputEvents);
+
+            if (renderState.isCurrentlyRendered(groupedEvents.getKey())) {
+                // Only forward output events if there's more than just the header
+                if (!outputEventsWithoutHeader.isEmpty()) {
+                    forwardBatchedEvents(outputEventsWithoutHeader);
+                }
+            } else {
+                forwardBatchedEvents(originalOutputEvents);
+            }
+
+            outputEventsWithoutHeader.clear();
+        }
+
+        private List<OutputEvent> getOutputEventsWithoutHeader(List<OutputEvent> outputEvents) {
+            return outputEvents.subList(1, outputEvents.size());
+        }
+    }
+
+    private static class RenderState {
+
+        private Object currentlyRendered;
+
+        public Object getCurrentlyRendered() {
+            return currentlyRendered;
+        }
+
+        public void setCurrentlyRendered(Object operationId) {
+            currentlyRendered = operationId;
+        }
+
+        public boolean isCurrentlyRendered(Object operationId) {
+            return currentlyRendered != null && currentlyRendered.equals(operationId);
+        }
+
+        public void clearCurrentlyRendered(Object operationId) {
+            if (isCurrentlyRendered(operationId)) {
+                clear();
+            }
+        }
+
+        public void clear() {
+            currentlyRendered = null;
+        }
+    }
+
+    Map<Object, List<OutputEvent>> getGroupedTaskBuildOperations() {
+        return groupedTaskBuildOperations;
+    }
+
+    RenderState getRenderState() {
+        return renderState;
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/WorkInProgressRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/WorkInProgressRenderer.java
@@ -19,12 +19,12 @@ package org.gradle.internal.logging.console;
 import org.gradle.internal.logging.events.BatchOutputEventListener;
 import org.gradle.internal.logging.events.EndOutputEvent;
 import org.gradle.internal.logging.events.MaxWorkerCountChangeEvent;
+import org.gradle.internal.logging.events.OperationIdentifier;
 import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
-import org.gradle.internal.logging.events.OperationIdentifier;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -69,10 +69,10 @@ public class WorkInProgressRenderer extends BatchOutputEventListener {
             attach(op);
         } else if (event instanceof ProgressCompleteEvent) {
             ProgressCompleteEvent completeEvent = (ProgressCompleteEvent) event;
-            detach(operations.complete(completeEvent.getOperationId()));
+            detach(operations.complete(completeEvent.getProgressOperationId()));
         } else if (event instanceof ProgressEvent) {
             ProgressEvent progressEvent = (ProgressEvent) event;
-            operations.progress(progressEvent.getStatus(), progressEvent.getOperationId());
+            operations.progress(progressEvent.getStatus(), progressEvent.getProgressOperationId());
         } else if (event instanceof EndOutputEvent) {
             progressArea.setVisible(false);
         } else if (event instanceof MaxWorkerCountChangeEvent) {
@@ -112,7 +112,7 @@ public class WorkInProgressRenderer extends BatchOutputEventListener {
 
     private void attach(ProgressOperation operation) {
         // Skip attach if a children is already present
-        if (isChildAssociationAlreadyExists(operation.getOperationId())) {
+        if (isChildAssociationAlreadyExists(operation.getOperationId()) || operation.getMessage() == null) {
             return;
         }
 
@@ -170,7 +170,7 @@ public class WorkInProgressRenderer extends BatchOutputEventListener {
     private void removeDirectChildOperationId(OperationIdentifier parentId, OperationIdentifier childId) {
         Set<OperationIdentifier> children = parentIdToChildrenIds.get(parentId);
         if (children == null) {
-            throw new IllegalStateException("");
+            return;
         }
         children.remove(childId);
         if (children.isEmpty()) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/LogEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/LogEvent.java
@@ -44,6 +44,7 @@ public class LogEvent extends RenderableOutputEvent {
     }
 
     public void render(StyledTextOutput output) {
+//        output.text(getBuildOperationId() == null ? "null " : getBuildOperationId() + " ");
         output.text(message);
         output.println();
         if (throwable != null) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/PhaseProgressStartEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/PhaseProgressStartEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.logging.events;
+
+import com.google.common.base.Preconditions;
+import org.gradle.api.Nullable;
+
+/**
+ * Specialized start event for build phases.
+ * These are assumed to be serial for now and have a known number of direct child build operations.
+ */
+public class PhaseProgressStartEvent extends ProgressStartEvent {
+    private final long children;
+
+    public PhaseProgressStartEvent(
+            OperationIdentifier progressOperationId,
+            @Nullable OperationIdentifier parentProgressOperationId,
+            long timestamp,
+            String category,
+            String description,
+            @Nullable String shortDescription,
+            @Nullable String loggingHeader,
+            String status,
+            Object buildOperationId,
+            @Nullable Object parentBuildOperationId,
+            long children) {
+        super(progressOperationId, parentProgressOperationId, timestamp, category, description, shortDescription, loggingHeader, status, buildOperationId, parentBuildOperationId);
+        Preconditions.checkNotNull(buildOperationId, "Cannot start a build phase without a build operation id");
+        this.children = children;
+    }
+
+    public long getChildren() {
+        return children;
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressCompleteEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressCompleteEvent.java
@@ -21,11 +21,11 @@ import org.gradle.api.logging.LogLevel;
 public class ProgressCompleteEvent extends CategorisedOutputEvent {
     private final String status;
     private final String description;
-    private OperationIdentifier operationId;
+    private OperationIdentifier progressOperationId;
 
-    public ProgressCompleteEvent(OperationIdentifier operationId, long timestamp, String category, String description, String status) {
+    public ProgressCompleteEvent(OperationIdentifier progressOperationId, long timestamp, String category, String description, String status) {
         super(timestamp, category, LogLevel.LIFECYCLE);
-        this.operationId = operationId;
+        this.progressOperationId = progressOperationId;
         this.status = status;
         this.description = description;
     }
@@ -43,7 +43,7 @@ public class ProgressCompleteEvent extends CategorisedOutputEvent {
         return "ProgressComplete " + status;
     }
 
-    public OperationIdentifier getOperationId() {
-        return operationId;
+    public OperationIdentifier getProgressOperationId() {
+        return progressOperationId;
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressEvent.java
@@ -20,11 +20,11 @@ import org.gradle.api.logging.LogLevel;
 
 public class ProgressEvent extends CategorisedOutputEvent {
     private final String status;
-    private final OperationIdentifier operationId;
+    private final OperationIdentifier progressOperationId;
 
-    public ProgressEvent(OperationIdentifier operationId, long timestamp, String category, String status) {
+    public ProgressEvent(OperationIdentifier progressOperationId, long timestamp, String category, String status) {
         super(timestamp, category, LogLevel.LIFECYCLE);
-        this.operationId = operationId;
+        this.progressOperationId = progressOperationId;
         this.status = status;
     }
 
@@ -37,7 +37,7 @@ public class ProgressEvent extends CategorisedOutputEvent {
         return "Progress " + status;
     }
 
-    public OperationIdentifier getOperationId() {
-        return operationId;
+    public OperationIdentifier getProgressOperationId() {
+        return progressOperationId;
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressStartEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressStartEvent.java
@@ -27,6 +27,7 @@ public class ProgressStartEvent extends CategorisedOutputEvent {
     private final String loggingHeader;
     private final String status;
     private final Object buildOperationId;
+    private final Object parentBuildOperationId;
 
     public ProgressStartEvent(OperationIdentifier progressOperationId,
                               @Nullable OperationIdentifier parentProgressOperationId,
@@ -36,7 +37,8 @@ public class ProgressStartEvent extends CategorisedOutputEvent {
                               @Nullable String shortDescription,
                               @Nullable String loggingHeader,
                               String status,
-                              @Nullable Object buildOperationId) {
+                              @Nullable Object buildOperationId,
+                              @Nullable Object parentBuildOperationId) {
         super(timestamp, category, LogLevel.LIFECYCLE);
         this.progressOperationId = progressOperationId;
         this.parentProgressOperationId = parentProgressOperationId;
@@ -45,6 +47,7 @@ public class ProgressStartEvent extends CategorisedOutputEvent {
         this.loggingHeader = loggingHeader;
         this.status = status;
         this.buildOperationId = buildOperationId;
+        this.parentBuildOperationId = parentBuildOperationId;
     }
 
     @Nullable
@@ -82,5 +85,10 @@ public class ProgressStartEvent extends CategorisedOutputEvent {
     @Nullable
     public Object getBuildOperationId() {
         return buildOperationId;
+    }
+
+    @Nullable
+    public Object getParentBuildOperationId() {
+        return parentBuildOperationId;
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/StyledTextOutputEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/StyledTextOutputEvent.java
@@ -64,6 +64,7 @@ public class StyledTextOutputEvent extends RenderableOutputEvent {
 
     @Override
     public void render(StyledTextOutput output) {
+//        output.text(getBuildOperationId() == null ? "null " : getBuildOperationId() + " ");
         for (Span span : spans) {
             output.style(span.style);
             output.text(span.text);

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/format/ProgressBarFormatter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/format/ProgressBarFormatter.java
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.progress;
+package org.gradle.internal.logging.format;
 
-public class ProgressBar implements ProgressFormatter {
+public class ProgressBarFormatter {
     private final String progressBarPrefix;
     private int progressBarWidth;
     private final String progressBarSuffix;
     private char fillerChar;
     private int current;
     private final char incompleteChar;
-    private int total;
+    private long total;
     private String suffix;
 
-    public ProgressBar(String progressBarPrefix, int progressBarWidth, String progressBarSuffix, char completeChar, char incompleteChar, String suffix, int total) {
+    public ProgressBarFormatter(String progressBarPrefix, int progressBarWidth, String progressBarSuffix, char completeChar, char incompleteChar, String suffix, long total) {
         this.progressBarPrefix = progressBarPrefix;
         this.progressBarWidth = progressBarWidth;
         this.progressBarSuffix = progressBarSuffix;
@@ -43,6 +43,8 @@ public class ProgressBar implements ProgressFormatter {
 
     public void increment() {
         if (current == total) {
+            // 17:04:18.926 [DEBUG] [org.gradle.internal.progress.DefaultBuildOperationExecutor] Completing Build operation 'Apply plugin org.gradle.help-tasks to root project 'gradle-js-plugin''
+            // FIXME(ew): Sometimes getting "Cannot increment beyond the total of: 1"
             throw new IllegalStateException("Cannot increment beyond the total of: " + total);
         }
         current++;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
@@ -17,10 +17,13 @@
 package org.gradle.internal.logging.progress;
 
 import org.gradle.api.Nullable;
+import org.gradle.internal.logging.events.OperationIdentifier;
+import org.gradle.internal.logging.events.PhaseProgressStartEvent;
 import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
-import org.gradle.internal.logging.events.OperationIdentifier;
+import org.gradle.internal.progress.BuildOperationDescriptor;
+import org.gradle.internal.progress.PhaseBuildOperationDetails;
 import org.gradle.internal.time.TimeProvider;
 import org.gradle.util.GUtil;
 
@@ -41,34 +44,30 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
         return newOperation(loggerCategory.getName());
     }
 
-    public ProgressLogger newOperation(Class loggerCategory, Object operationIdentifier) {
-        return newOperation(loggerCategory.getName());
+    public ProgressLogger newOperation(Class loggerCategory, @Nullable BuildOperationDescriptor buildOperationDescriptor) {
+        return init(loggerCategory.getName(), null, buildOperationDescriptor);
     }
 
     public ProgressLogger newOperation(String loggerCategory) {
         return init(loggerCategory, null, null);
     }
 
-    public ProgressLogger newOperation(String loggerCategory, Object buildOperationId) {
-        return init(loggerCategory, null, buildOperationId);
-    }
-
     public ProgressLogger newOperation(Class loggerClass, ProgressLogger parent) {
         return init(loggerClass.toString(), parent, null);
     }
 
-    private ProgressLogger init(String loggerCategory, @Nullable ProgressLogger parentOperation, @Nullable Object buildOperationId) {
+    private ProgressLogger init(String loggerCategory, @Nullable ProgressLogger parentOperation, @Nullable BuildOperationDescriptor buildOperationDescriptor) {
         if (parentOperation != null && !(parentOperation instanceof ProgressLoggerImpl)) {
             throw new IllegalArgumentException("Unexpected parent logger.");
         }
-        return new ProgressLoggerImpl((ProgressLoggerImpl) parentOperation, new OperationIdentifier(nextId.getAndIncrement()), loggerCategory, progressListener, timeProvider, buildOperationId);
+        return new ProgressLoggerImpl((ProgressLoggerImpl) parentOperation, new OperationIdentifier(nextId.getAndIncrement()), loggerCategory, progressListener, timeProvider, buildOperationDescriptor);
     }
 
     private enum State { idle, started, completed }
 
     private class ProgressLoggerImpl implements ProgressLogger {
         private final OperationIdentifier progressOperationId;
-        private final Object buildOperationId;
+        private final BuildOperationDescriptor buildOperationDescriptor;
         private final String category;
         private final ProgressListener listener;
         private final TimeProvider timeProvider;
@@ -78,13 +77,13 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
         private String loggingHeader;
         private State state = State.idle;
 
-        public ProgressLoggerImpl(ProgressLoggerImpl parent, OperationIdentifier progressOperationId, String category, ProgressListener listener, TimeProvider timeProvider, @Nullable Object buildOperationId) {
+        public ProgressLoggerImpl(ProgressLoggerImpl parent, OperationIdentifier progressOperationId, String category, ProgressListener listener, TimeProvider timeProvider, @Nullable BuildOperationDescriptor buildOperationDescriptor) {
             this.parent = parent;
             this.progressOperationId = progressOperationId;
             this.category = category;
             this.listener = listener;
             this.timeProvider = timeProvider;
-            this.buildOperationId = buildOperationId;
+            this.buildOperationDescriptor = buildOperationDescriptor;
         }
 
         @Override
@@ -145,7 +144,15 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
                 parent.assertRunning();
             }
             current.set(this);
-            listener.started(new ProgressStartEvent(progressOperationId, parent == null ? null : parent.progressOperationId, timeProvider.getCurrentTime(), category, description, shortDescription, loggingHeader, toStatus(status), buildOperationId));
+
+            ProgressStartEvent progressStartEvent;
+            if (buildOperationDescriptor != null && buildOperationDescriptor.getDetails() instanceof PhaseBuildOperationDetails) {
+                progressStartEvent = new PhaseProgressStartEvent(progressOperationId, parent == null ? null : parent.progressOperationId, timeProvider.getCurrentTime(), category, description, shortDescription, loggingHeader, toStatus(status), getBuildOperationId(), getParentBuildOperationId(), ((PhaseBuildOperationDetails) buildOperationDescriptor.getDetails()).getChildren());
+            } else {
+                progressStartEvent = new ProgressStartEvent(progressOperationId, parent == null ? null : parent.progressOperationId, timeProvider.getCurrentTime(), category, description, shortDescription, loggingHeader, toStatus(status), getBuildOperationId(), getParentBuildOperationId());
+            }
+
+            listener.started(progressStartEvent);
         }
 
         public void progress(String status) {
@@ -190,6 +197,14 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
             if (state != State.idle) {
                 throw new IllegalStateException(String.format("Cannot configure this operation (%s) once it has started.", this));
             }
+        }
+
+        private Object getBuildOperationId() {
+            return buildOperationDescriptor == null ? null : buildOperationDescriptor.getId();
+        }
+
+        private Object getParentBuildOperationId() {
+            return buildOperationDescriptor == null ? null : buildOperationDescriptor.getParentId();
         }
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.logging.progress;
 
+import org.gradle.internal.progress.BuildOperationDescriptor;
+
 /**
  * Thread-safe, however the progress logger instances created are not.
  */
@@ -41,10 +43,10 @@ public interface ProgressLoggerFactory {
      * with the given build operation id.
      *
      * @param loggerCategory The logger category.
-     * @param buildOperationId OperationIdentifier to be associated with all logs produced by the new ProgressLogger.
+     * @param buildOperationDescriptor descriptor for the build operation associated with this logger.
      * @return the progress logger for the operation.
      */
-    ProgressLogger newOperation(Class<?> loggerCategory, Object buildOperationId);
+    ProgressLogger newOperation(Class<?> loggerCategory, BuildOperationDescriptor buildOperationDescriptor);
 
     ProgressLogger newOperation(Class<?> loggerClass, ProgressLogger parent);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/PhaseProgressStartEventSerializer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/PhaseProgressStartEventSerializer.java
@@ -17,14 +17,14 @@
 package org.gradle.internal.logging.serializer;
 
 import org.gradle.internal.logging.events.OperationIdentifier;
-import org.gradle.internal.logging.events.ProgressStartEvent;
+import org.gradle.internal.logging.events.PhaseProgressStartEvent;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
-public class ProgressStartEventSerializer implements Serializer<ProgressStartEvent> {
+public class PhaseProgressStartEventSerializer implements Serializer<PhaseProgressStartEvent> {
     @Override
-    public void write(Encoder encoder, ProgressStartEvent event) throws Exception {
+    public void write(Encoder encoder, PhaseProgressStartEvent event) throws Exception {
         encoder.writeSmallLong(event.getProgressOperationId().getId());
         if (event.getParentProgressOperationId() == null) {
             encoder.writeBoolean(false);
@@ -50,10 +50,11 @@ public class ProgressStartEventSerializer implements Serializer<ProgressStartEve
             encoder.writeBoolean(true);
             encoder.writeSmallLong(((OperationIdentifier) event.getParentBuildOperationId()).getId());
         }
+        encoder.writeSmallLong(event.getChildren());
     }
 
     @Override
-    public ProgressStartEvent read(Decoder decoder) throws Exception {
+    public PhaseProgressStartEvent read(Decoder decoder) throws Exception {
         OperationIdentifier progressOperationId = new OperationIdentifier(decoder.readSmallLong());
         OperationIdentifier parentProgressOperationId = decoder.readBoolean() ? new OperationIdentifier(decoder.readSmallLong()) : null;
         long timestamp = decoder.readLong();
@@ -64,6 +65,7 @@ public class ProgressStartEventSerializer implements Serializer<ProgressStartEve
         String status = decoder.readString();
         Object buildOperationId = decoder.readBoolean() ? new OperationIdentifier(decoder.readSmallLong()) : null;
         Object parentBuildOperationId = decoder.readBoolean() ? new OperationIdentifier(decoder.readSmallLong()) : null;
-        return new ProgressStartEvent(progressOperationId, parentProgressOperationId, timestamp, category, description, shortDescription, loggingHeader, status, buildOperationId, parentBuildOperationId);
+        long children = decoder.readSmallLong();
+        return new PhaseProgressStartEvent(progressOperationId, parentProgressOperationId, timestamp, category, description, shortDescription, loggingHeader, status, buildOperationId, parentBuildOperationId, children);
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressCompleteEventSerializer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressCompleteEventSerializer.java
@@ -25,7 +25,7 @@ import org.gradle.internal.serialize.Serializer;
 public class ProgressCompleteEventSerializer implements Serializer<ProgressCompleteEvent> {
     @Override
     public void write(Encoder encoder, ProgressCompleteEvent event) throws Exception {
-        encoder.writeSmallLong(event.getOperationId().getId());
+        encoder.writeSmallLong(event.getProgressOperationId().getId());
         encoder.writeLong(event.getTimestamp());
         encoder.writeString(event.getCategory());
         encoder.writeString(event.getDescription());

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressEventSerializer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressEventSerializer.java
@@ -25,7 +25,7 @@ import org.gradle.internal.serialize.Serializer;
 public class ProgressEventSerializer implements Serializer<ProgressEvent> {
     @Override
     public void write(Encoder encoder, ProgressEvent event) throws Exception {
-        encoder.writeSmallLong(event.getOperationId().getId());
+        encoder.writeSmallLong(event.getProgressOperationId().getId());
         encoder.writeLong(event.getTimestamp());
         encoder.writeString(event.getCategory());
         encoder.writeString(event.getStatus());

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
@@ -73,7 +73,7 @@ public class ProgressLogEventGenerator implements OutputEventListener {
 
     private void onComplete(ProgressCompleteEvent progressCompleteEvent) {
         assert !operations.isEmpty();
-        Operation operation = operations.remove(progressCompleteEvent.getOperationId());
+        Operation operation = operations.remove(progressCompleteEvent.getProgressOperationId());
 
         // Didn't find an operation with that id in the map
         if (operation == null) {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/OutputSpecification.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/OutputSpecification.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.logging
 import org.gradle.api.logging.LogLevel
 import org.gradle.internal.logging.events.LogEvent
 import org.gradle.internal.logging.events.OperationIdentifier
+import org.gradle.internal.logging.events.PhaseProgressStartEvent
 import org.gradle.internal.logging.events.ProgressCompleteEvent
 import org.gradle.internal.logging.events.ProgressEvent
 import org.gradle.internal.logging.events.ProgressStartEvent
@@ -73,10 +74,15 @@ abstract class OutputSpecification extends Specification {
 
     ProgressStartEvent start(Map args) {
         OperationIdentifier parentId = args.containsKey("parentId") ? args.parentId : new OperationIdentifier(counter)
-        OperationIdentifier buildOperationId = args.containsKey("buildOperationId") ? args.buildOperationId : new OperationIdentifier(counter)
+        Object buildOperationId = args.containsKey("buildOperationId") ? args.buildOperationId : null
+        Object parentBuildOperationId = args.containsKey("parentBuildOperationId") ? args.parentBuildOperationId : null
         long id = ++counter
         String category = args.containsKey("category") ? args.category : CATEGORY
-        return new ProgressStartEvent(new OperationIdentifier(id), parentId, tenAm, category, args.description, args.shortDescription, args.loggingHeader, args.status, buildOperationId)
+        return new ProgressStartEvent(new OperationIdentifier(id), parentId, tenAm, category, args.description, args.shortDescription, args.loggingHeader, args.status, buildOperationId, parentBuildOperationId)
+    }
+
+    PhaseProgressStartEvent startPhase(String name, Object buildOperationId, long children) {
+        return new PhaseProgressStartEvent(new OperationIdentifier(++counter), null, tenAm, CATEGORY, name, name, null, null, buildOperationId, null, children)
     }
 
     ProgressEvent progress(String status) {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildStatusRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildStatusRendererTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.logging.console
 import org.gradle.internal.logging.OutputSpecification
 import org.gradle.internal.logging.events.BatchOutputEventListener
 import org.gradle.internal.logging.events.EndOutputEvent
+import org.gradle.internal.logging.events.OperationIdentifier
 import org.gradle.internal.logging.events.OutputEvent
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData
 import org.gradle.internal.time.TimeProvider
@@ -43,7 +44,7 @@ class BuildStatusRendererTest extends OutputSpecification {
     }
 
     def "schedules render at fixed rate once an root progress event is started"() {
-        def event = startRoot("message")
+        def event = startRoot()
 
         when:
         renderer.onOutput([event] as ArrayList<OutputEvent>)
@@ -63,25 +64,25 @@ class BuildStatusRendererTest extends OutputSpecification {
     }
 
     def "correctly format and set the text's label from the event"() {
-        def event1 = startRoot('message')
-        def event2 = event('2')
+        def event1 = startRoot()
+        def event2 = event('message')
 
         when:
         renderer.onOutput([event1] as ArrayList<OutputEvent>)
 
         then:
-        label.display == "message [0s]"
+        label.display == "<-------------> 0% INITIALIZING [0s]"
 
         when:
         currentTimeMs += 1000
         renderer.onOutput([event2] as ArrayList<OutputEvent>)
 
         then:
-        label.display == "message [1s]"
+        label.display == "<-------------> 0% INITIALIZING [1s]"
     }
 
     def "correctly cancel the future once the end event is received"() {
-        def startEvent = startRoot('message')
+        def startEvent = startRoot()
         def end = new EndOutputEvent()
 
         given:
@@ -94,7 +95,7 @@ class BuildStatusRendererTest extends OutputSpecification {
         1 * future.cancel(false)
     }
 
-    def startRoot(String description) {
-        start(parentId: null, category: BuildStatusRenderer.BUILD_PROGRESS_CATEGORY, shortDescription: description)
+    def startRoot() {
+        start(parentId: null, category: 'category', shortDescription: '', buildOperationId: new OperationIdentifier(0L))
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/format/ProgressBarFormatterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/format/ProgressBarFormatterTest.groovy
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.progress
+package org.gradle.internal.logging.format
 
 import spock.lang.Specification
 import spock.lang.Subject
 
-@Subject(ProgressBar)
-class ProgressBarTest extends Specification {
+@Subject(ProgressBarFormatter)
+class ProgressBarFormatterTest extends Specification {
     public static final String INCOMPLETE_CHAR = ' '
     public static final String COMPLETE_CHAR = '#'
     public static final String SUFFIX = ']'
@@ -28,10 +28,10 @@ class ProgressBarTest extends Specification {
     public static final int PROGRESS_BAR_WIDTH = 10
     public static final String BUILD_PHASE = 'EXECUTING'
 
-    ProgressBar progressBar
+    ProgressBarFormatter progressBar
 
     def setup() {
-        progressBar = new ProgressBar(PREFIX, PROGRESS_BAR_WIDTH, SUFFIX, COMPLETE_CHAR as char, INCOMPLETE_CHAR as char, BUILD_PHASE, 10)
+        progressBar = new ProgressBarFormatter(PREFIX, PROGRESS_BAR_WIDTH, SUFFIX, COMPLETE_CHAR as char, INCOMPLETE_CHAR as char, BUILD_PHASE, 10)
     }
 
     def "formats progress bar"() {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/PhaseProgressStartEventSerializerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/PhaseProgressStartEventSerializerTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.logging.serializer
+
+import org.gradle.internal.logging.events.OperationIdentifier
+import org.gradle.internal.logging.events.PhaseProgressStartEvent
+import spock.lang.Subject
+
+@Subject(PhaseProgressStartEventSerializer)
+class PhaseProgressStartEventSerializerTest extends LogSerializerSpec {
+    private static final long TIMESTAMP = 42L
+    private static final String CATEGORY = "category"
+    private static final String DESCRIPTION = "description"
+    private static final OperationIdentifier OPERATION_ID = new OperationIdentifier(1234L)
+
+    PhaseProgressStartEventSerializer serializer = new PhaseProgressStartEventSerializer()
+
+    def "can serialize PhaseProgressStartEvent messages"() {
+        given:
+        def event = new PhaseProgressStartEvent(OPERATION_ID, new OperationIdentifier(5678L), TIMESTAMP, CATEGORY, DESCRIPTION, "short", "header", "status", new OperationIdentifier(42L), new OperationIdentifier(41L), 1)
+
+        when:
+        def result = serialize(event, serializer)
+
+        then:
+        result instanceof PhaseProgressStartEvent
+        result.progressOperationId == OPERATION_ID
+        result.parentProgressOperationId == new OperationIdentifier(5678L)
+        result.timestamp == TIMESTAMP
+        result.category == CATEGORY
+        result.description == DESCRIPTION
+        result.shortDescription == "short"
+        result.loggingHeader == "header"
+        result.status == "status"
+        result.buildOperationId == new OperationIdentifier(42L)
+        result.parentBuildOperationId == new OperationIdentifier(41L)
+        result.children == 1
+    }
+
+    def "can serialize PhaseProgressStartEvent messages with empty fields"() {
+        given:
+        def event = new PhaseProgressStartEvent(OPERATION_ID, null, TIMESTAMP, CATEGORY, DESCRIPTION, null, null, "", new OperationIdentifier(42L), null, 0)
+
+        when:
+        def result = serialize(event, serializer)
+
+        then:
+        result instanceof PhaseProgressStartEvent
+        result.progressOperationId == OPERATION_ID
+        result.parentProgressOperationId == null
+        result.timestamp == TIMESTAMP
+        result.category == CATEGORY
+        result.description == DESCRIPTION
+        result.shortDescription == null
+        result.loggingHeader == null
+        result.status == ""
+        result.buildOperationId == new OperationIdentifier(42L)
+        result.parentBuildOperationId == null
+        result.children == 0
+    }
+}

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressCompleteEventSerializerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressCompleteEventSerializerTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.logging.serializer
+
+import org.gradle.internal.logging.events.OperationIdentifier
+import org.gradle.internal.logging.events.ProgressCompleteEvent
+import spock.lang.Subject
+
+@Subject(ProgressCompleteEventSerializer)
+class ProgressCompleteEventSerializerTest extends LogSerializerSpec {
+    private static final long TIMESTAMP = 42L
+    private static final String DESCRIPTION = "description"
+    private static final String CATEGORY = "category"
+    private static final OperationIdentifier OPERATION_ID = new OperationIdentifier(1234L)
+
+    ProgressCompleteEventSerializer serializer = new ProgressCompleteEventSerializer()
+
+    def "can serialize ProgressCompleteEvent messages"() {
+        given:
+        def event = new ProgressCompleteEvent(OPERATION_ID, TIMESTAMP, "category", DESCRIPTION, "status")
+
+        when:
+        def result = serialize(event, serializer)
+
+        then:
+        result instanceof ProgressCompleteEvent
+        result.progressOperationId == OPERATION_ID
+        result.timestamp == TIMESTAMP
+        result.category == CATEGORY
+        result.status == "status"
+    }
+
+    def "can serialize ProgressCompleteEvent messages with empty fields"() {
+        given:
+        def event = new ProgressCompleteEvent(OPERATION_ID, TIMESTAMP, "category", DESCRIPTION, "")
+
+        when:
+        def result = serialize(event, serializer)
+
+        then:
+        result instanceof ProgressCompleteEvent
+        result.progressOperationId == OPERATION_ID
+        result.timestamp == TIMESTAMP
+        result.category == CATEGORY
+        result.status == ""
+    }
+}

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressEventSerializerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressEventSerializerTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.logging.serializer
+
+import org.gradle.internal.logging.events.OperationIdentifier
+import org.gradle.internal.logging.events.ProgressEvent
+import spock.lang.Subject
+
+@Subject(ProgressEventSerializer)
+class ProgressEventSerializerTest extends LogSerializerSpec {
+    private static final long TIMESTAMP = 42L
+    private static final String CATEGORY = "category"
+    private static final OperationIdentifier OPERATION_ID = new OperationIdentifier(1234L)
+
+    ProgressEventSerializer serializer = new ProgressEventSerializer()
+
+    def "can serialize ProgressEvent messages"() {
+        given:
+        def event = new ProgressEvent(OPERATION_ID, TIMESTAMP, "category", "status")
+
+        when:
+        def result = serialize(event, serializer)
+
+        then:
+        result instanceof ProgressEvent
+        result.progressOperationId == OPERATION_ID
+        result.timestamp == TIMESTAMP
+        result.category == CATEGORY
+        result.status == "status"
+    }
+
+    def "can serialize ProgressEvent messages with empty fields"() {
+        given:
+        def event = new ProgressEvent(OPERATION_ID, TIMESTAMP, "category", "")
+
+        when:
+        def result = serialize(event, serializer)
+
+        then:
+        result instanceof ProgressEvent
+        result.progressOperationId == OPERATION_ID
+        result.timestamp == TIMESTAMP
+        result.category == CATEGORY
+        result.status == ""
+    }
+}

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressStartEventSerializerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressStartEventSerializerTest.groovy
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.serialize
+package org.gradle.internal.logging.serializer
 
-import org.gradle.internal.logging.events.ProgressStartEvent
-import org.gradle.internal.logging.serializer.ProgressStartEventSerializer
 import org.gradle.internal.logging.events.OperationIdentifier
+import org.gradle.internal.logging.events.ProgressStartEvent
 import spock.lang.Subject
 
 @Subject(ProgressStartEventSerializer)
-class ProgressStartEventSerializerTest extends SerializerSpec {
+class ProgressStartEventSerializerTest extends LogSerializerSpec {
     private static final long TIMESTAMP = 42L
     private static final String CATEGORY = "category"
     private static final String DESCRIPTION = "description"
@@ -31,7 +30,7 @@ class ProgressStartEventSerializerTest extends SerializerSpec {
 
     def "can serialize ProgressStartEvent messages"() {
         given:
-        def event = new ProgressStartEvent(OPERATION_ID, new OperationIdentifier(5678L), TIMESTAMP, CATEGORY, DESCRIPTION, "short", "header", "status", new OperationIdentifier(42L))
+        def event = new ProgressStartEvent(OPERATION_ID, new OperationIdentifier(5678L), TIMESTAMP, CATEGORY, DESCRIPTION, "short", "header", "status", new OperationIdentifier(42L), new OperationIdentifier(41L))
 
         when:
         def result = serialize(event, serializer)
@@ -47,11 +46,12 @@ class ProgressStartEventSerializerTest extends SerializerSpec {
         result.loggingHeader == "header"
         result.status == "status"
         result.buildOperationId == new OperationIdentifier(42L)
+        result.parentBuildOperationId == new OperationIdentifier(41L)
     }
 
     def "can serialize ProgressStartEvent messages with empty fields"() {
         given:
-        def event = new ProgressStartEvent(OPERATION_ID, null, TIMESTAMP, CATEGORY, DESCRIPTION, null, null, "", null)
+        def event = new ProgressStartEvent(OPERATION_ID, null, TIMESTAMP, CATEGORY, DESCRIPTION, null, null, "", null, null)
 
         when:
         def result = serialize(event, serializer)
@@ -67,11 +67,12 @@ class ProgressStartEventSerializerTest extends SerializerSpec {
         result.loggingHeader == null
         result.status == ""
         result.buildOperationId == null
+        result.parentBuildOperationId == null
     }
 
     def "can serialize build operation ids with large long values"() {
         given:
-        def event = new ProgressStartEvent(new OperationIdentifier(1_000_000_000_000L), null, TIMESTAMP, CATEGORY, DESCRIPTION, null, null, "", new OperationIdentifier(42_000_000_000_000L))
+        def event = new ProgressStartEvent(new OperationIdentifier(1_000_000_000_000L), null, TIMESTAMP, CATEGORY, DESCRIPTION, null, null, "", new OperationIdentifier(42_000_000_000_000L), null)
 
         when:
         def result = serialize(event, serializer)

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
@@ -19,11 +19,11 @@ import org.gradle.api.internal.tasks.testing.BuildableTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.AggregateTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
+import org.gradle.internal.progress.TestProgressLoggerFactory
 import org.gradle.internal.time.TimeProvider
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestFile
@@ -47,7 +47,7 @@ class DefaultTestReportTest extends Specification {
 
     def reportWithMaxThreads(int numThreads) {
         buildOperationExecutor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new TestProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), numThreads)
         return new DefaultTestReport(buildOperationExecutor)
     }

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -18,12 +18,12 @@ package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.Action
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
 import org.gradle.internal.operations.MultipleBuildOperationFailures
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
+import org.gradle.internal.progress.TestProgressLoggerFactory
 import org.gradle.internal.time.TimeProvider
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -43,7 +43,7 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
 
     def generatorWithMaxThreads(int numThreads) {
         buildOperationExecutor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new TestProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), numThreads)
         Binary2JUnitXmlReportGenerator reportGenerator = new Binary2JUnitXmlReportGenerator(temp.testDirectory, resultsProvider, TestOutputAssociation.WITH_SUITE, buildOperationExecutor, "localhost")
         reportGenerator.xmlWriter = Mock(JUnitXmlResultWriter)

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r25/TaskProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r25/TaskProgressCrossVersionSpec.groovy
@@ -232,7 +232,7 @@ class TaskProgressCrossVersionSpec extends ToolingApiSpecification {
         then:
         events.tasks.size() == 3
 
-        def runTasks = events.operation("Run tasks")
+        def runTasks = events.operation("EXECUTING")
 
         def t1 = events.operation("Task :para1")
         def t2 = events.operation("Task :para2")
@@ -279,7 +279,7 @@ class TaskProgressCrossVersionSpec extends ToolingApiSpecification {
         then:
         events.tasks.size() == 3
 
-        def runTasks = events.operation("Run tasks")
+        def runTasks = events.operation("EXECUTING")
 
         def t1 = events.operation("Task :para1")
         def t2 = events.operation("Task :para2")
@@ -304,7 +304,7 @@ class TaskProgressCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then: 'the parent of the task events is the root build operation'
-        def runTasks = events.operation("Run tasks")
+        def runTasks = events.operation("EXECUTING")
         events.tasks.every { it.descriptor.parent == runTasks.descriptor }
 
         when: 'listening to task progress events when no build operation listener is attached'

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r33/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r33/BuildProgressCrossVersionSpec.groovy
@@ -43,7 +43,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         then:
         events.assertIsABuild()
 
-        def configureBuild = events.operation("Configure build")
+        def configureBuild = events.operation("CONFIGURING")
 
         def configureRootProject = events.operation("Configure project :")
         configureRootProject.parent == configureBuild
@@ -70,7 +70,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         then:
         events.assertIsABuild()
 
-        def configureBuild = events.operation("Configure build")
+        def configureBuild = events.operation("CONFIGURING")
 
         def configureRoot = events.operation("Configure project :")
         configureRoot.parent == configureBuild
@@ -112,7 +112,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
 
         events.assertIsABuild()
 
-        def configureBuild = events.operation("Configure build")
+        def configureBuild = events.operation("CONFIGURING")
         configureBuild.failed
 
         def configureRoot = events.operation("Configure project :")
@@ -154,7 +154,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         then:
         events.assertIsABuild()
 
-        def configureBuild = events.operation("Configure build")
+        def configureBuild = events.operation("CONFIGURING")
 
         def configureRoot = events.operation("Configure project :")
         configureRoot.parent == configureBuild
@@ -299,7 +299,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         then:
         events.assertIsABuild()
 
-        def configureBuild = events.operation("Configure build")
+        def configureBuild = events.operation("CONFIGURING")
 
         def configureRoot = events.operation("Configure project :")
         configureRoot.parent == configureBuild
@@ -340,7 +340,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         def buildSrc = events.operation("Build buildSrc")
-        def configureBuildSrc = buildSrc.child("Configure build")
+        def configureBuildSrc = buildSrc.child("CONFIGURING")
         configureBuildSrc.child("Configure project :buildSrc")
         configureBuildSrc.child("Configure project :buildSrc:a")
         configureBuildSrc.child("Configure project :buildSrc:b")

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r40/PluginApplicationBuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r40/PluginApplicationBuildProgressCrossVersionSpec.groovy
@@ -288,7 +288,7 @@ class PluginApplicationBuildProgressCrossVersionSpec extends ToolingApiSpecifica
 
         events.assertIsABuild()
 
-        def configureBuild = events.operation("Configure build")
+        def configureBuild = events.operation("CONFIGURING")
         configureBuild.failed
 
         def configureRoot = events.operation("Configure project :")
@@ -317,7 +317,7 @@ class PluginApplicationBuildProgressCrossVersionSpec extends ToolingApiSpecifica
         then:
         events.assertIsABuild()
 
-        def configureBuild =  events.operation("Configure build")
+        def configureBuild =  events.operation("CONFIGURING")
 
         def configureRoot = configureBuild.child("Configure project :")
         configureRoot.child("Apply plugin org.gradle.help-tasks to root project 'multi'")
@@ -433,18 +433,18 @@ class PluginApplicationBuildProgressCrossVersionSpec extends ToolingApiSpecifica
         def buildSrc = events.operation("Build buildSrc")
         def groovyPlugin = buildSrc.child("Apply plugin org.gradle.api.plugins.GroovyPlugin to project ':buildSrc'")
 
-        def configureBuildSrcRoot = buildSrc.child("Configure build").child("Configure project :buildSrc")
+        def configureBuildSrcRoot = buildSrc.child("CONFIGURING").child("Configure project :buildSrc")
         configureBuildSrcRoot.child("Apply plugin org.gradle.help-tasks to project ':buildSrc'")
         configureBuildSrcRoot.children("Apply plugin org.gradle.java to project ':buildSrc'").empty
 
         def applyBuildSrcBuildGradle = events.operation("Apply script build.gradle to project ':buildSrc'")
         applyBuildSrcBuildGradle.children("Apply plugin org.gradle.java to project ':buildSrc'").empty
 
-        def configureBuildSrcA = buildSrc.child("Configure build").child("Configure project :buildSrc:a")
+        def configureBuildSrcA = buildSrc.child("CONFIGURING").child("Configure project :buildSrc:a")
         configureBuildSrcA.child("Apply plugin org.gradle.help-tasks to project ':buildSrc:a'")
         configureBuildSrcA.children("Apply plugin org.gradle.java to project ':buildSrc:a'").empty
 
-        def configureBuildSrcB = buildSrc.child("Configure build").child("Configure project :buildSrc:b")
+        def configureBuildSrcB = buildSrc.child("CONFIGURING").child("Configure project :buildSrc:b")
         configureBuildSrcB.child("Apply plugin org.gradle.help-tasks to project ':buildSrc:b'")
         configureBuildSrcB.children("Apply plugin org.gradle.java to project ':buildSrc:b'").empty
 


### PR DESCRIPTION
Introduces a BuildOperationType enum and adds it to the
default `BuildOperationDescriptor`. Passes this information
to the logging infrastructure through the `BuildOperationExecutor`.

This will allow `OutputEventListener`s to react to output events
from different types of operations differently.

`RenderableOutputEvent`s now have an optional, compact, build
operation descriptor that is a small, serializable subset of a
BuildOperationDescriptor (just an id and operation type).

[CI Build](https://builds.gradle.org/project.html?projectId=Gradle_Branches_Checkpoints&branch_Gradle_Branches_Checkpoints=ew-log-event-operation-descriptors)

Issue: #1818

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
