### PR TITLE
Cache root component metadata creation

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -33,7 +33,6 @@ import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.FileCollectionDependency;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.artifacts.ResolutionStrategy;
@@ -63,10 +62,11 @@ import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedArtifactCollectingVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedFilesCollectingVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.ConfigurationComponentMetaDataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfiguration;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -86,7 +86,6 @@ import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
@@ -145,6 +144,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
     };
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+    private final RootComponentMetadataBuilder rootComponentMetadataBuilder;
+    private final ConfigurationsProvider configurationsProvider;
 
     private final Path identityPath;
     // These fields are not covered by mutation lock
@@ -156,7 +157,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private boolean transitive = true;
     private Set<Configuration> extendsFrom = new LinkedHashSet<Configuration>();
     private String description;
-    private ConfigurationsProvider configurationsProvider;
     private Set<ExcludeRule> excludeRules = new LinkedHashSet<ExcludeRule>();
 
     private final Object observationLock = new Object();
@@ -251,6 +251,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }, inheritedArtifacts, fileCollectionFactory);
 
         outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, artifacts, allArtifacts, configurationAttributes, instantiator, artifactNotationParser, fileCollectionFactory, attributesFactory);
+        rootComponentMetadataBuilder = new DefaultRootComponentMetadataBuilder(
+            metaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, projectFinder, configurationComponentMetaDataBuilder, configurationsProvider
+        );
     }
 
     private static Action<Void> validateMutationType(final MutationValidator mutationValidator, final MutationType type) {
@@ -711,14 +714,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     public ComponentResolveMetadata toRootComponentMetaData() {
-        Module module = getModule();
-        ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
-        ModuleVersionIdentifier moduleVersionIdentifier = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
-        ProjectInternal project = projectFinder.findProject(module.getProjectPath());
-        AttributesSchemaInternal schema = project == null ? null : (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
-        DefaultLocalComponentMetadata metaData = new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), schema);
-        configurationComponentMetaDataBuilder.addConfigurations(metaData, configurationsProvider.getAll());
-        return metaData;
+        return rootComponentMetadataBuilder.toRootComponentMetaData();
     }
 
     public String getPath() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -30,6 +30,8 @@ import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactor
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.ConfigurationComponentMetaDataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -45,7 +47,7 @@ import java.util.Collection;
 import java.util.Set;
 
 public class DefaultConfigurationContainer extends AbstractNamedDomainObjectContainer<Configuration>
-        implements ConfigurationContainerInternal, ConfigurationsProvider {
+    implements ConfigurationContainerInternal, ConfigurationsProvider {
     public static final String DETACHED_CONFIGURATION_DEFAULT_NAME = "detachedConfiguration";
 
     private final ConfigurationResolver resolver;
@@ -55,16 +57,14 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
     private final DependencyMetaDataProvider dependencyMetaDataProvider;
     private final ProjectAccessListener projectAccessListener;
     private final ProjectFinder projectFinder;
-    private final ConfigurationComponentMetaDataBuilder configurationComponentMetaDataBuilder;
     private final FileCollectionFactory fileCollectionFactory;
-    private final ComponentIdentifierFactory componentIdentifierFactory;
     private final BuildOperationExecutor buildOperationExecutor;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
     private final ImmutableAttributesFactory attributesFactory;
-    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
 
     private int detachedConfigurationDefaultNameCounter = 1;
     private final Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
+    private final RootComponentMetadataBuilder rootComponentMetadataBuilder;
 
     public DefaultConfigurationContainer(ConfigurationResolver resolver,
                                          final Instantiator instantiator, DomainObjectContext context, ListenerManager listenerManager,
@@ -83,11 +83,8 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
         this.projectAccessListener = projectAccessListener;
         this.projectFinder = projectFinder;
-        this.configurationComponentMetaDataBuilder = configurationComponentMetaDataBuilder;
         this.fileCollectionFactory = fileCollectionFactory;
-        this.componentIdentifierFactory = componentIdentifierFactory;
         this.buildOperationExecutor = buildOperationExecutor;
-        this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.artifactNotationParser = new PublishArtifactNotationParserFactory(instantiator, dependencyMetaDataProvider, taskResolver).create();
         this.attributesFactory = attributesFactory;
         resolutionStrategyFactory = new Factory<ResolutionStrategyInternal>() {
@@ -96,13 +93,15 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
                 return instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, componentIdentifierFactory, moduleIdentifierFactory);
             }
         };
+        this.rootComponentMetadataBuilder = new DefaultRootComponentMetadataBuilder(dependencyMetaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, projectFinder, configurationComponentMetaDataBuilder, this);
     }
 
     @Override
     protected Configuration doCreate(String name) {
-        return instantiator.newInstance(DefaultConfiguration.class, context.identityPath(name), context.projectPath(name), name, this, resolver,
-                listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
-                configurationComponentMetaDataBuilder, fileCollectionFactory, componentIdentifierFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, moduleIdentifierFactory);
+        DefaultConfiguration configuration = instantiator.newInstance(DefaultConfiguration.class, context.identityPath(name), context.projectPath(name), name, this, resolver,
+            listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
+            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, rootComponentMetadataBuilder);
+        return configuration;
     }
 
     public Set<? extends ConfigurationInternal> getAll() {
@@ -128,9 +127,9 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         String name = DETACHED_CONFIGURATION_DEFAULT_NAME + detachedConfigurationDefaultNameCounter++;
         DetachedConfigurationsProvider detachedConfigurationsProvider = new DetachedConfigurationsProvider();
         DefaultConfiguration detachedConfiguration = instantiator.newInstance(DefaultConfiguration.class,
-                context.identityPath(name), context.projectPath(name), name, detachedConfigurationsProvider, resolver,
-                listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
-                configurationComponentMetaDataBuilder, fileCollectionFactory, componentIdentifierFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, moduleIdentifierFactory);
+            context.identityPath(name), context.projectPath(name), name, detachedConfigurationsProvider, resolver,
+            listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
+            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, rootComponentMetadataBuilder.withConfigurationsProvider(detachedConfigurationsProvider));
         DomainObjectSet<Dependency> detachedDependencies = detachedConfiguration.getDependencies();
         for (Dependency dependency : dependencies) {
             detachedDependencies.add(dependency.copy());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -31,7 +31,6 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.ConfigurationComponentMetaDataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -64,7 +63,7 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
 
     private int detachedConfigurationDefaultNameCounter = 1;
     private final Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
-    private final RootComponentMetadataBuilder rootComponentMetadataBuilder;
+    private final DefaultRootComponentMetadataBuilder rootComponentMetadataBuilder;
 
     public DefaultConfigurationContainer(ConfigurationResolver resolver,
                                          final Instantiator instantiator, DomainObjectContext context, ListenerManager listenerManager,
@@ -101,6 +100,7 @@ public class DefaultConfigurationContainer extends AbstractNamedDomainObjectCont
         DefaultConfiguration configuration = instantiator.newInstance(DefaultConfiguration.class, context.identityPath(name), context.projectPath(name), name, this, resolver,
             listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
             fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, rootComponentMetadataBuilder);
+        configuration.addMutationValidator(rootComponentMetadataBuilder.getValidator());
         return configuration;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.api.internal.artifacts.Module;
+import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
+import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+
+public class DefaultRootComponentMetadataBuilder implements RootComponentMetadataBuilder {
+    private final DependencyMetaDataProvider metaDataProvider;
+    private final ComponentIdentifierFactory componentIdentifierFactory;
+    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+    private final ProjectFinder projectFinder;
+    private final ConfigurationComponentMetaDataBuilder configurationComponentMetaDataBuilder;
+    private final ConfigurationsProvider configurationsProvider;
+
+    public DefaultRootComponentMetadataBuilder(DependencyMetaDataProvider metaDataProvider,
+                                               ComponentIdentifierFactory componentIdentifierFactory,
+                                               ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                                               ProjectFinder projectFinder,
+                                               ConfigurationComponentMetaDataBuilder configurationComponentMetaDataBuilder,
+                                               ConfigurationsProvider configurationsProvider) {
+        this.metaDataProvider = metaDataProvider;
+        this.componentIdentifierFactory = componentIdentifierFactory;
+        this.moduleIdentifierFactory = moduleIdentifierFactory;
+        this.projectFinder = projectFinder;
+        this.configurationComponentMetaDataBuilder = configurationComponentMetaDataBuilder;
+        this.configurationsProvider = configurationsProvider;
+    }
+
+    @Override
+    public ComponentResolveMetadata toRootComponentMetaData() {
+        Module module = metaDataProvider.getModule();
+        ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
+        ModuleVersionIdentifier moduleVersionIdentifier = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
+        ProjectInternal project = projectFinder.findProject(module.getProjectPath());
+        AttributesSchemaInternal schema = project == null ? null : (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
+        DefaultLocalComponentMetadata metaData = new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), schema);
+        configurationComponentMetaDataBuilder.addConfigurations(metaData, configurationsProvider.getAll());
+        return metaData;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.configurations.MutationValidator;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -35,6 +36,7 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
     private final ProjectFinder projectFinder;
     private final ConfigurationComponentMetaDataBuilder configurationComponentMetaDataBuilder;
     private final ConfigurationsProvider configurationsProvider;
+    private final MetadataHolder holder;
 
     public DefaultRootComponentMetadataBuilder(DependencyMetaDataProvider metaDataProvider,
                                                ComponentIdentifierFactory componentIdentifierFactory,
@@ -48,17 +50,23 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
         this.projectFinder = projectFinder;
         this.configurationComponentMetaDataBuilder = configurationComponentMetaDataBuilder;
         this.configurationsProvider = configurationsProvider;
+        this.holder = new MetadataHolder();
     }
 
     @Override
     public ComponentResolveMetadata toRootComponentMetaData() {
         Module module = metaDataProvider.getModule();
         ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
+        DefaultLocalComponentMetadata metaData = holder.tryCached(componentIdentifier);
+        if (metaData != null) {
+            return metaData;
+        }
         ModuleVersionIdentifier moduleVersionIdentifier = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
         ProjectInternal project = projectFinder.findProject(module.getProjectPath());
         AttributesSchemaInternal schema = project == null ? null : (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
-        DefaultLocalComponentMetadata metaData = new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), schema);
+        metaData = new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), schema);
         configurationComponentMetaDataBuilder.addConfigurations(metaData, configurationsProvider.getAll());
+        holder.cachedValue = metaData;
         return metaData;
     }
 
@@ -66,5 +74,30 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
         return new DefaultRootComponentMetadataBuilder(
             metaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, projectFinder, configurationComponentMetaDataBuilder, alternateProvider
         );
+    }
+
+    public MutationValidator getValidator() {
+        return holder;
+    }
+
+    private static class MetadataHolder implements MutationValidator {
+        private DefaultLocalComponentMetadata cachedValue;
+
+        @Override
+        public void validateMutation(MutationType type) {
+            if (type == MutationType.DEPENDENCIES) {
+                cachedValue = null;
+            }
+        }
+
+        DefaultLocalComponentMetadata tryCached(ComponentIdentifier id) {
+            if (cachedValue != null) {
+                if (cachedValue.getComponentId().equals(id)) {
+                    return cachedValue;
+                }
+                cachedValue = null;
+            }
+            return null;
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -85,7 +85,7 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
 
         @Override
         public void validateMutation(MutationType type) {
-            if (type == MutationType.DEPENDENCIES) {
+            if (type == MutationType.DEPENDENCIES || type == MutationType.ARTIFACTS) {
                 cachedValue = null;
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -61,4 +61,10 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
         configurationComponentMetaDataBuilder.addConfigurations(metaData, configurationsProvider.getAll());
         return metaData;
     }
+
+    public RootComponentMetadataBuilder withConfigurationsProvider(ConfigurationsProvider alternateProvider) {
+        return new DefaultRootComponentMetadataBuilder(
+            metaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, projectFinder, configurationComponentMetaDataBuilder, alternateProvider
+        );
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/RootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/RootComponentMetadataBuilder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
+
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+
+public interface RootComponentMetadataBuilder {
+    ComponentResolveMetadata toRootComponentMetaData();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/RootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/RootComponentMetadataBuilder.java
@@ -15,8 +15,10 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
 
+import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 
 public interface RootComponentMetadataBuilder {
     ComponentResolveMetadata toRootComponentMetaData();
+    RootComponentMetadataBuilder withConfigurationsProvider(ConfigurationsProvider provider);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -38,10 +38,9 @@ import org.gradle.api.internal.artifacts.DefaultExcludeRule
 import org.gradle.api.internal.artifacts.DefaultResolverResults
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ResolverResults
-import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.ConfigurationComponentMetaDataBuilder
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet
@@ -78,10 +77,9 @@ class DefaultConfigurationSpec extends Specification {
     def resolutionStrategy = Mock(ResolutionStrategyInternal)
     def projectAccessListener = Mock(ProjectAccessListener)
     def projectFinder = Mock(ProjectFinder)
-    def metaDataBuilder = Mock(ConfigurationComponentMetaDataBuilder)
-    def componentIdentifierFactory = Mock(ComponentIdentifierFactory)
     def immutableAttributesFactory = new DefaultImmutableAttributesFactory()
     def moduleIdentifierFactory = Mock(ImmutableModuleIdentifierFactory)
+    def rootComponentMetadataBuilder = Mock(RootComponentMetadataBuilder)
 
     def setup() {
         _ * listenerManager.createAnonymousBroadcaster(DependencyResolutionListener) >> { new ListenerBroadcast<DependencyResolutionListener>(DependencyResolutionListener) }
@@ -1607,8 +1605,8 @@ All Artifacts:
 
     private DefaultConfiguration conf(String confName = "conf", String path = ":conf") {
         new DefaultConfiguration(Path.path(path), Path.path(path), confName, configurationsProvider, resolver, listenerManager, metaDataProvider,
-            Factories.constant(resolutionStrategy), projectAccessListener, projectFinder, metaDataBuilder, TestFiles.fileCollectionFactory(), componentIdentifierFactory,
-            new TestBuildOperationExecutor(), instantiator, Stub(NotationParser), immutableAttributesFactory, moduleIdentifierFactory)
+            Factories.constant(resolutionStrategy), projectAccessListener, projectFinder, TestFiles.fileCollectionFactory(),
+            new TestBuildOperationExecutor(), instantiator, Stub(NotationParser), immutableAttributesFactory, rootComponentMetadataBuilder)
     }
 
     private DefaultPublishArtifact artifact(String name) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.moduleconverter
+
+import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.Module
+import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
+import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider
+import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider
+import org.gradle.api.internal.artifacts.configurations.MutationValidator
+import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultRootComponentMetadataBuilderTest extends Specification {
+
+    DependencyMetaDataProvider metaDataProvider = Mock() {
+        getModule() >> Mock(Module)
+    }
+    ComponentIdentifierFactory componentIdentifierFactory = Mock()
+    ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
+    ProjectFinder projectFinder = Mock()
+    ConfigurationComponentMetaDataBuilder configurationComponentMetaDataBuilder = Mock()
+    ConfigurationsProvider configurationsProvider = Mock()
+
+    def builder = new DefaultRootComponentMetadataBuilder(
+        metaDataProvider,
+        componentIdentifierFactory,
+        moduleIdentifierFactory,
+        projectFinder,
+        configurationComponentMetaDataBuilder,
+        configurationsProvider)
+
+    def "caches root component metadata"() {
+        componentIdentifierFactory.createComponentIdentifier(_) >> {
+            new DefaultModuleComponentIdentifier('foo', 'bar', '1.0')
+        }
+        def root = builder.toRootComponentMetaData()
+
+        when:
+        def otherRoot = builder.toRootComponentMetaData()
+
+        then:
+        otherRoot.is(root)
+    }
+
+    def "doesn't cache root component metadata when module identifier changes"() {
+        1 * componentIdentifierFactory.createComponentIdentifier(_) >> {
+            new DefaultModuleComponentIdentifier('foo', 'bar', '1.0')
+        }
+        def root = builder.toRootComponentMetaData()
+
+        when:
+        componentIdentifierFactory.createComponentIdentifier(_) >> {
+            new DefaultModuleComponentIdentifier('foo', 'baz', '1.0')
+        }
+
+        def otherRoot = builder.toRootComponentMetaData()
+
+        then:
+        !otherRoot.is(root)
+    }
+
+    @Unroll
+    def "caching of component metadata when #mutationType change"() {
+        componentIdentifierFactory.createComponentIdentifier(_) >> {
+            new DefaultModuleComponentIdentifier('foo', 'bar', '1.0')
+        }
+        def root = builder.toRootComponentMetaData()
+
+        when:
+        builder.validator.validateMutation(mutationType)
+        def otherRoot = builder.toRootComponentMetaData()
+
+        then:
+        otherRoot.is(root) == cached
+
+        where:
+        mutationType                                | cached
+        MutationValidator.MutationType.DEPENDENCIES | false
+        MutationValidator.MutationType.ARTIFACTS    | false
+        MutationValidator.MutationType.ROLE         | true
+        MutationValidator.MutationType.STRATEGY     | true
+    }
+
+}


### PR DESCRIPTION
This pull request introduces caching of root component metadata in configurations. There are several benefits:

- root component metadata creation can be very expensive. The more configurations there are, the slower it is, so caching allows us to reduce the overhead
- the creation is now externalized, meaning there's nothing specific to a `Configuration`, allowing us to reuse the component in different configurations of the same project
- if a configuration is resolved several times, the same root component metadata is reused

Caching makes sure that we don't cache if any of the configurations have been mutated in between. This PR, however, does **not** introduce laziness in the root component metadata, so we still eagerly build all configuration metadata for the whole component.

See gradle/performance#532
 