### PR TITLE
Gradle will now cache `apply from: 'http://bla'`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ExternalScriptExecutionIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ExternalScriptExecutionIntegrationSpec.groovy
@@ -15,9 +15,9 @@
  */
 package org.gradle.api
 
+import org.apache.commons.lang3.StringUtils
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.server.http.HttpServer
-import spock.lang.IgnoreRest
 
 class ExternalScriptExecutionIntegrationSpec extends AbstractIntegrationSpec {
     @org.junit.Rule
@@ -83,10 +83,7 @@ task check {
 
         and:
         def scriptFile = file("script.gradle")
-        scriptFile.setText("""
-task check {
-}
-""", "UTF-8")
+        scriptFile.setText("""task check { }""", "UTF-8")
         server.expectGet('/' + scriptName, scriptFile)
 
         and:
@@ -96,21 +93,22 @@ task check {
         succeeds 'check'
 
         and:
-        server.stop()
-
         when:
-        scriptFile.setText("""
-task check {
-throw new GradleException()
-}
-""", "UTF-8")
+        server.stop()
+        scriptFile.setText("""task check { throw new GradleException() }""", "UTF-8")
 
         then:
+        fails 'check'
+        errorOutput.contains("Could not get resource")
+
+        and:
+        when:
         args("--offline")
+
+        then:
         succeeds 'check'
     }
 
-    @IgnoreRest
     def "will cache settings.gradle when offline"() {
         given:
         String scriptName = "script-${System.currentTimeMillis()}.gradle"
@@ -128,6 +126,7 @@ throw new GradleException()
 
         expect:
         succeeds 'check'
+        output.contains("from script")
 
         and:
         when:
@@ -136,5 +135,109 @@ throw new GradleException()
         then:
         args("--offline")
         succeeds 'check'
+        output.contains("from script")
+    }
+
+    def "will cache initscript when offline"() {
+        given:
+        String scriptName = "script-${System.currentTimeMillis()}.gradle"
+        executer.withDefaultCharacterEncoding("ISO-8859-15")
+        server.start()
+
+        and:
+        def scriptFile = file("script.gradle")
+        scriptFile.setText("""println 'from init'""", "UTF-8")
+        server.expectGet('/' + scriptName, scriptFile)
+
+        and:
+        File initScript = file("init-script.gradle")
+        initScript << "apply from: 'http://localhost:${server.port}/${scriptName}'"
+        buildFile << "task check { println 'from build.gradle' }"
+
+        expect:
+        args("-I", initScript.absolutePath)
+        succeeds 'check'
+        output.contains("from init")
+
+        and:
+        when:
+        server.stop()
+
+        then:
+        args("--offline", "-I", initScript.absolutePath)
+        succeeds 'check'
+        output.contains("from init")
+    }
+
+    def "will reuse request"() {
+        given:
+        String scriptName = "script-${System.currentTimeMillis()}.gradle"
+        executer.withDefaultCharacterEncoding("ISO-8859-15")
+        server.start()
+
+        and:
+        def scriptFile = file("script.gradle")
+        scriptFile.setText("""println 'from applied'""", "UTF-8")
+        server.expectGet('/' + scriptName, scriptFile)
+
+        and:
+        file("projA/build.gradle") << "apply from: 'http://localhost:${server.port}/${scriptName}'"
+        file("projB/build.gradle") << "apply from: 'http://localhost:${server.port}/${scriptName}'"
+
+        and:
+        settingsFile << "include ':projA'\n"
+        settingsFile << "include ':projB'\n"
+
+        expect:
+        succeeds 'tasks'
+        2 == StringUtils.countMatches(output, "from applied")
+
+        and:
+        when:
+        server.stop()
+
+        then:
+        args("--offline")
+        succeeds 'tasks'
+        2 == StringUtils.countMatches(output, "from applied")
+    }
+
+    def "cached values will be overwritten with second request"() {
+        given:
+        String scriptName = "script-${System.currentTimeMillis()}.gradle"
+        executer.withDefaultCharacterEncoding("ISO-8859-15")
+        server.start()
+
+        and:
+        File scriptFile = file("script.gradle")
+        scriptFile.setText("""println 'in script 1'""", "UTF-8")
+        server.expectGet('/' + scriptName, scriptFile)
+        server.expectHead('/' + scriptName, scriptFile)
+        server.expectGetMissing('/' + scriptName + '.sha1')
+        server.expectGet('/' + scriptName, scriptFile)
+
+        and:
+        buildFile << "apply from: 'http://localhost:${server.port}/${scriptName}'"
+
+        expect:
+        succeeds 'tasks'
+        output.contains('in script 1')
+
+        and:
+        when:
+        scriptFile.setText("""println 'in script 2'""", "UTF-8")
+
+        then:
+        succeeds 'tasks'
+        output.contains('in script 2')
+
+        and:
+        when:
+        server.stop()
+        args("--offline")
+
+        then:
+        succeeds 'tasks'
+        output.contains('in script 2')
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/UriTextResourceLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/UriTextResourceLoader.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import org.gradle.internal.resource.TextResource;
+
+import java.net.URI;
+
+public interface UriTextResourceLoader {
+    TextResource getResource(URI source);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
@@ -26,7 +26,6 @@ import org.gradle.api.plugins.PluginAware;
 import org.gradle.configuration.ScriptPlugin;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.groovy.scripts.ScriptSource;
-import org.gradle.groovy.scripts.UriScriptSource;
 import org.gradle.groovy.scripts.internal.ScriptSourceProvider;
 import org.gradle.util.GUtil;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
@@ -27,6 +27,7 @@ import org.gradle.configuration.ScriptPlugin;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.groovy.scripts.UriScriptSource;
+import org.gradle.groovy.scripts.internal.ScriptSourceProvider;
 import org.gradle.util.GUtil;
 
 import java.net.URI;
@@ -41,13 +42,17 @@ public class DefaultObjectConfigurationAction implements ObjectConfigurationActi
     private final Set<Object> targets = new LinkedHashSet<Object>();
     private final Set<Runnable> actions = new LinkedHashSet<Runnable>();
     private final ClassLoaderScope classLoaderScope;
+    private final ScriptSourceProvider scriptSourceProvider;
     private final Object defaultTarget;
 
-    public DefaultObjectConfigurationAction(FileResolver resolver, ScriptPluginFactory configurerFactory, ScriptHandlerFactory scriptHandlerFactory, ClassLoaderScope classLoaderScope, Object defaultTarget) {
+    public DefaultObjectConfigurationAction(FileResolver resolver, ScriptPluginFactory configurerFactory,
+                                            ScriptHandlerFactory scriptHandlerFactory, ClassLoaderScope classLoaderScope,
+                                            ScriptSourceProvider scriptSourceProvider, Object defaultTarget) {
         this.resolver = resolver;
         this.configurerFactory = configurerFactory;
         this.scriptHandlerFactory = scriptHandlerFactory;
         this.classLoaderScope = classLoaderScope;
+        this.scriptSourceProvider = scriptSourceProvider;
         this.defaultTarget = defaultTarget;
     }
 
@@ -94,7 +99,7 @@ public class DefaultObjectConfigurationAction implements ObjectConfigurationActi
 
     private void applyScript(Object script) {
         URI scriptUri = resolver.resolveUri(script);
-        ScriptSource scriptSource = new UriScriptSource("script", scriptUri);
+        ScriptSource scriptSource = scriptSourceProvider.from(scriptUri);
         ClassLoaderScope classLoaderScopeChild = classLoaderScope.createChild("script-" + scriptUri.toString());
         ScriptHandler scriptHandler = scriptHandlerFactory.create(scriptSource, classLoaderScopeChild);
         ScriptPlugin configurer = configurerFactory.create(scriptSource, scriptHandler, classLoaderScopeChild, classLoaderScope, false);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -52,6 +52,7 @@ import org.gradle.api.internal.NoConventionMapping;
 import org.gradle.api.internal.ProcessOperations;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UriTextResourceLoader;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
@@ -75,6 +76,7 @@ import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.configuration.project.ProjectEvaluator;
 import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.groovy.scripts.internal.ScriptSourceProvider;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
@@ -1209,7 +1211,13 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
 
     @Override
     protected DefaultObjectConfigurationAction createObjectConfigurationAction() {
-        return new DefaultObjectConfigurationAction(getFileResolver(), getScriptPluginFactory(), getScriptHandlerFactory(), getBaseClassLoaderScope(), this);
+        return new DefaultObjectConfigurationAction(getFileResolver(), getScriptPluginFactory(), getScriptHandlerFactory(), getBaseClassLoaderScope(), new ScriptSourceProvider(getCachingUrlRequester()), this);
+    }
+
+    @Inject
+    public UriTextResourceLoader getCachingUrlRequester() {
+        // Decoration takes care of the implementation
+        throw new UnsupportedOperationException();
     }
 
     @Inject

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
@@ -20,6 +20,7 @@ import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UriTextResourceLoader;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
@@ -49,11 +50,11 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.model.dsl.internal.transform.ClosureCreationInterceptingVerifier;
 import org.gradle.model.internal.inspect.ModelRuleSourceDetector;
+import org.gradle.plugin.management.internal.PluginRequests;
+import org.gradle.plugin.management.internal.PluginRequestsSerializer;
 import org.gradle.plugin.repository.internal.PluginRepositoryFactory;
 import org.gradle.plugin.repository.internal.PluginRepositoryRegistry;
 import org.gradle.plugin.use.internal.PluginRequestApplicator;
-import org.gradle.plugin.management.internal.PluginRequests;
-import org.gradle.plugin.management.internal.PluginRequestsSerializer;
 
 public class DefaultScriptPluginFactory implements ScriptPluginFactory {
     private final static StringInterner INTERNER = new StringInterner();
@@ -72,6 +73,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
     private final PluginRepositoryRegistry pluginRepositoryRegistry;
     private final PluginRepositoryFactory pluginRepositoryFactory;
     private final ProviderFactory providerFactory;
+    private final UriTextResourceLoader uriTextResourceLoader;
     private ScriptPluginFactory scriptPluginFactory;
 
     public DefaultScriptPluginFactory(ScriptCompilerFactory scriptCompilerFactory,
@@ -85,7 +87,8 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
                                       ModelRuleSourceDetector modelRuleSourceDetector,
                                       PluginRepositoryRegistry pluginRepositoryRegistry,
                                       PluginRepositoryFactory pluginRepositoryFactory,
-                                      ProviderFactory providerFactory) {
+                                      ProviderFactory providerFactory,
+                                      UriTextResourceLoader uriTextResourceLoader) {
         this.scriptCompilerFactory = scriptCompilerFactory;
         this.loggingManagerFactory = loggingManagerFactory;
         this.instantiator = instantiator;
@@ -98,6 +101,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
         this.pluginRepositoryRegistry = pluginRepositoryRegistry;
         this.pluginRepositoryFactory = pluginRepositoryFactory;
         this.providerFactory = providerFactory;
+        this.uriTextResourceLoader = uriTextResourceLoader;
         this.scriptPluginFactory = this;
     }
 
@@ -146,6 +150,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
             services.add(PluginRepositoryRegistry.class, pluginRepositoryRegistry);
             services.add(PluginRepositoryFactory.class, pluginRepositoryFactory);
             services.add(ProviderFactory.class, providerFactory);
+            services.add(UriTextResourceLoader.class, uriTextResourceLoader);
 
             final ScriptTarget initialPassScriptTarget = initialPassTarget(target);
 

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -27,6 +27,7 @@ import org.gradle.api.file.DeleteSpec;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.ProcessOperations;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UriTextResourceLoader;
 import org.gradle.api.internal.file.DefaultFileOperations;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileOperations;
@@ -44,6 +45,7 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.configuration.ScriptPluginFactory;
+import org.gradle.groovy.scripts.internal.ScriptSourceProvider;
 import org.gradle.internal.Actions;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistry;
@@ -102,6 +104,7 @@ public abstract class DefaultScript extends BasicScript {
             __scriptServices.get(ScriptPluginFactory.class),
             __scriptServices.get(ScriptHandlerFactory.class),
             classLoaderScope,
+            new ScriptSourceProvider(__scriptServices.get(UriTextResourceLoader.class)),
             getScriptTarget()
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/ScriptSourceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/ScriptSourceProvider.java
@@ -23,7 +23,7 @@ import org.gradle.groovy.scripts.UriScriptSource;
 import java.net.URI;
 
 public class ScriptSourceProvider {
-    private static final String[] SUPPORTED_SCHEMAS = {"http", "https", "s3", "sftp"};
+    private static final String[] SUPPORTED_SCHEMAS = {"http", "https"};
 
     private final UriTextResourceLoader uriTextResourceLoader;
 

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/ScriptSourceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/ScriptSourceProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts.internal;
+
+import org.gradle.api.internal.artifacts.dsl.dependencies.UriTextResourceLoader;
+import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.groovy.scripts.UriScriptSource;
+
+import java.net.URI;
+
+public class ScriptSourceProvider {
+    private static final String[] SUPPORTED_SCHEMAS = {"http", "https", "s3", "sftp"};
+
+    private final UriTextResourceLoader uriTextResourceLoader;
+
+    public ScriptSourceProvider(UriTextResourceLoader uriTextResourceLoader) {
+        this.uriTextResourceLoader = uriTextResourceLoader;
+    }
+
+    public ScriptSource from(URI scriptUri) {
+        for (String supportedSchema : SUPPORTED_SCHEMAS) {
+            if (supportedSchema.equalsIgnoreCase(scriptUri.getScheme())) {
+                return new UriScriptSource("cached-script", uriTextResourceLoader.getResource(scriptUri).getFile());
+            }
+        }
+
+        return new UriScriptSource("script", scriptUri);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -25,6 +25,7 @@ import org.gradle.api.initialization.ProjectDescriptor;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UriTextResourceLoader;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
@@ -35,6 +36,7 @@ import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.groovy.scripts.internal.ScriptSourceProvider;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.service.ServiceRegistry;
@@ -204,7 +206,7 @@ public class DefaultSettings extends AbstractPluginAware implements SettingsInte
 
     @Override
     protected DefaultObjectConfigurationAction createObjectConfigurationAction() {
-        return new DefaultObjectConfigurationAction(getFileResolver(), getScriptPluginFactory(), getScriptHandlerFactory(), getRootClassLoaderScope(), this);
+        return new DefaultObjectConfigurationAction(getFileResolver(), getScriptPluginFactory(), getScriptHandlerFactory(), getRootClassLoaderScope(), new ScriptSourceProvider(getCachingUrlRequester()), this);
     }
 
     public ClassLoaderScope getRootClassLoaderScope() {
@@ -217,6 +219,12 @@ public class DefaultSettings extends AbstractPluginAware implements SettingsInte
 
     protected ServiceRegistry getServices() {
         return services;
+    }
+
+    @Inject
+    public UriTextResourceLoader getCachingUrlRequester() {
+        // Decoration takes care of the implementation
+        throw new UnsupportedOperationException();
     }
 
     @Inject

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -223,7 +223,6 @@ public class DefaultSettings extends AbstractPluginAware implements SettingsInte
 
     @Inject
     public UriTextResourceLoader getCachingUrlRequester() {
-        // Decoration takes care of the implementation
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/DefaultGroupedAndNamedUniqueFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/DefaultGroupedAndNamedUniqueFileStore.java
@@ -26,7 +26,7 @@ import java.util.Set;
 /**
  * A file store that stores items grouped by some provided function over the key and an SHA1 hash of the value. This means that files are only ever added and never modified once added, so a resource from this store can be used without locking. Locking is required to add entries.
  */
-public class GroupedAndNamedUniqueFileStore<K> implements FileStore<K>, FileStoreSearcher<K> {
+public class DefaultGroupedAndNamedUniqueFileStore<K> implements GroupedAndNamedUniqueFileStore<K> {
 
     private PathKeyFileStore delegate;
     private final TemporaryFileProvider temporaryFileProvider;
@@ -34,7 +34,7 @@ public class GroupedAndNamedUniqueFileStore<K> implements FileStore<K>, FileStor
     private final Transformer<String, K> namer;
 
 
-    public GroupedAndNamedUniqueFileStore(PathKeyFileStore delegate, TemporaryFileProvider temporaryFileProvider, Transformer<String, K> grouper, Transformer<String, K> namer) {
+    public DefaultGroupedAndNamedUniqueFileStore(PathKeyFileStore delegate, TemporaryFileProvider temporaryFileProvider, Transformer<String, K> grouper, Transformer<String, K> namer) {
         this.delegate = delegate;
         this.temporaryFileProvider = temporaryFileProvider;
         this.grouper = grouper;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.artifacts.DefaultModule;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UriTextResourceLoader;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.classpath.PluginModuleRegistry;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
@@ -40,6 +41,7 @@ import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
+import org.gradle.api.internal.filestore.url.UrlFileStore;
 import org.gradle.api.internal.hash.FileHasher;
 import org.gradle.api.internal.initialization.DefaultScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
@@ -310,7 +312,8 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             get(ModelRuleSourceDetector.class),
             get(PluginRepositoryRegistry.class),
             get(PluginRepositoryFactory.class),
-            get(ProviderFactory.class));
+            get(ProviderFactory.class),
+            get(UriTextResourceLoader.class));
     }
 
     protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, NestedBuildFactory nestedBuildFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -41,7 +41,6 @@ import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
-import org.gradle.api.internal.filestore.url.UrlFileStore;
 import org.gradle.api.internal.hash.FileHasher;
 import org.gradle.api.internal.initialization.DefaultScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -29,6 +29,7 @@ import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UriTextResourceLoader;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
@@ -40,6 +41,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.execution.TaskGraphExecuter;
+import org.gradle.groovy.scripts.internal.ScriptSourceProvider;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
 import org.gradle.internal.MutableActionSet;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -356,12 +358,18 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     protected DefaultObjectConfigurationAction createObjectConfigurationAction() {
-        return new DefaultObjectConfigurationAction(getFileResolver(), getScriptPluginFactory(), getScriptHandlerFactory(), getClassLoaderScope(), this);
+        return new DefaultObjectConfigurationAction(getFileResolver(), getScriptPluginFactory(), getScriptHandlerFactory(), getClassLoaderScope(), new ScriptSourceProvider(getCachingUrlRequester()), this);
     }
 
     @Override
     public ClassLoaderScope getClassLoaderScope() {
         return classLoaderScope;
+    }
+
+    @Inject
+    public UriTextResourceLoader getCachingUrlRequester() {
+        // Decoration takes care of the implementation
+        throw new UnsupportedOperationException();
     }
 
     @Inject

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.initialization.ScriptHandlerFactory
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.configuration.ScriptPlugin
 import org.gradle.configuration.ScriptPluginFactory
+import org.gradle.groovy.scripts.internal.ScriptSourceProvider
 import org.junit.Test
 import spock.lang.Specification
 
@@ -34,9 +35,10 @@ class DefaultObjectConfigurationActionTest extends Specification {
     def scriptHandler = Mock(ScriptHandlerInternal)
     def scriptCompileScope = Mock(ClassLoaderScope)
     def parentCompileScope = Mock(ClassLoaderScope)
+    def scriptSourceProvider = Mock(ScriptSourceProvider)
     def configurer = Mock(ScriptPlugin)
 
-    DefaultObjectConfigurationAction action = new DefaultObjectConfigurationAction(resolver, scriptPluginFactory, scriptHandlerFactory, parentCompileScope, target)
+    DefaultObjectConfigurationAction action = new DefaultObjectConfigurationAction(resolver, scriptPluginFactory, scriptHandlerFactory, parentCompileScope, scriptSourceProvider, target)
 
     void doesNothingWhenNothingSpecified() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.api.internal.artifacts.dsl.dependencies.UriTextResourceLoader
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.internal.initialization.ClassLoaderScope
@@ -74,9 +75,10 @@ class DefaultScriptPluginFactoryTest extends Specification {
     def pluginRepositoryRegistry = Mock(PluginRepositoryRegistry)
     def pluginRepositoryFactory = Mock(PluginRepositoryFactory)
     def providerFactory = Mock(ProviderFactory)
+    def uriTextResourceLoader = Mock(UriTextResourceLoader)
 
     def factory = new DefaultScriptPluginFactory(scriptCompilerFactory, loggingManagerFactory, instantiator, scriptHandlerFactory, pluginRequestApplicator, fileLookup,
-        directoryFileTreeFactory, documentationRegistry, new ModelRuleSourceDetector(), pluginRepositoryRegistry, pluginRepositoryFactory, providerFactory)
+        directoryFileTreeFactory, documentationRegistry, new ModelRuleSourceDetector(), pluginRepositoryRegistry, pluginRepositoryFactory, providerFactory, uriTextResourceLoader)
 
     def setup() {
         def configurations = Mock(ConfigurationContainer)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -72,7 +72,7 @@ import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore;
-import org.gradle.api.internal.filestore.url.UrlFileStore;
+import org.gradle.api.internal.filestore.url.DefaultUrlFileStore;
 import org.gradle.api.internal.notations.ClientModuleNotationParserFactory;
 import org.gradle.api.internal.notations.DependencyNotationParser;
 import org.gradle.api.internal.notations.ProjectDependencyFactory;
@@ -214,15 +214,15 @@ class DependencyManagementBuildScopeServices {
         return new ExternalResourceFileStore(cacheScopeMapping.getBaseDirectory(null, "external-resources", VersionStrategy.SharedCache), new TmpDirTemporaryFileProvider());
     }
 
-    UrlFileStore createUrlFileStore(ArtifactCacheMetaData artifactCacheMetaData) {
-        return new UrlFileStore(new UniquePathKeyFileStore(artifactCacheMetaData.getFileStoreDirectory()), new TmpDirTemporaryFileProvider());
+    DefaultUrlFileStore createUrlFileStore(ArtifactCacheMetaData artifactCacheMetaData) {
+        return new DefaultUrlFileStore(new UniquePathKeyFileStore(artifactCacheMetaData.getFileStoreDirectory()), new TmpDirTemporaryFileProvider());
     }
 
-    DefaultExternalResourceUrlResolver createDefaultExternalResourceUrlResolver(UrlFileStore urlFileStore, RepositoryTransportFactory repositoryTransportFactory) {
+    DefaultExternalResourceUrlResolver createDefaultExternalResourceUrlResolver(DefaultUrlFileStore defaultUrlFileStore, RepositoryTransportFactory repositoryTransportFactory) {
         HashSet<String> schemas = Sets.newHashSet("https", "http");
         RepositoryTransport transport = repositoryTransportFactory.createTransport(schemas, "http auth", Collections.<Authentication>emptyList());
-        LocallyAvailableResourceFinderSearchableFileStoreAdapter<URL> locallyAvailableResourceFinder = new LocallyAvailableResourceFinderSearchableFileStoreAdapter<URL>(urlFileStore);
-        return new DefaultExternalResourceUrlResolver(urlFileStore, transport.getResourceAccessor(), locallyAvailableResourceFinder);
+        LocallyAvailableResourceFinderSearchableFileStoreAdapter<URL> locallyAvailableResourceFinder = new LocallyAvailableResourceFinderSearchableFileStoreAdapter<URL>(defaultUrlFileStore);
+        return new DefaultExternalResourceUrlResolver(defaultUrlFileStore, transport.getResourceAccessor(), locallyAvailableResourceFinder);
     }
 
     DefaultUriTextResourceLoader createDefaultCachingUrlRequester(ExternalResourceUrlResolver resolver) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts;
 
+import com.google.common.collect.Sets;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
@@ -60,6 +61,9 @@ import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenFileLocations;
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenSettingsProvider;
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
 import org.gradle.api.internal.artifacts.mvnsettings.MavenSettingsProvider;
+import org.gradle.api.internal.artifacts.repositories.resolver.DefaultExternalResourceUrlResolver;
+import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceUrlResolver;
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.cache.GeneratedGradleJarCache;
@@ -68,12 +72,14 @@ import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore;
+import org.gradle.api.internal.filestore.url.UrlFileStore;
 import org.gradle.api.internal.notations.ClientModuleNotationParserFactory;
 import org.gradle.api.internal.notations.DependencyNotationParser;
 import org.gradle.api.internal.notations.ProjectDependencyFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory;
+import org.gradle.authentication.Authentication;
 import org.gradle.cache.internal.CacheScopeMapping;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.cache.internal.VersionStrategy;
@@ -90,12 +96,17 @@ import org.gradle.internal.resource.cached.ExternalResourceFileStore;
 import org.gradle.internal.resource.cached.ivy.ArtifactAtRepositoryCachedArtifactIndex;
 import org.gradle.internal.resource.connector.ResourceConnectorFactory;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
+import org.gradle.internal.resource.local.LocallyAvailableResourceFinderSearchableFileStoreAdapter;
 import org.gradle.internal.resource.local.UniquePathKeyFileStore;
 import org.gradle.internal.resource.local.ivy.LocallyAvailableResourceFinderFactory;
+import org.gradle.internal.resource.transfer.DefaultUriTextResourceLoader;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.util.BuildCommencedTimeProvider;
 
 import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -201,6 +212,21 @@ class DependencyManagementBuildScopeServices {
 
     ExternalResourceFileStore createExternalResourceFileStore(CacheScopeMapping cacheScopeMapping) {
         return new ExternalResourceFileStore(cacheScopeMapping.getBaseDirectory(null, "external-resources", VersionStrategy.SharedCache), new TmpDirTemporaryFileProvider());
+    }
+
+    UrlFileStore createUrlFileStore(ArtifactCacheMetaData artifactCacheMetaData) {
+        return new UrlFileStore(new UniquePathKeyFileStore(artifactCacheMetaData.getFileStoreDirectory()), new TmpDirTemporaryFileProvider());
+    }
+
+    DefaultExternalResourceUrlResolver createDefaultExternalResourceUrlResolver(UrlFileStore urlFileStore, RepositoryTransportFactory repositoryTransportFactory) {
+        HashSet<String> schemas = Sets.newHashSet("https", "http");
+        RepositoryTransport transport = repositoryTransportFactory.createTransport(schemas, "http auth", Collections.<Authentication>emptyList());
+        LocallyAvailableResourceFinderSearchableFileStoreAdapter<URL> locallyAvailableResourceFinder = new LocallyAvailableResourceFinderSearchableFileStoreAdapter<URL>(urlFileStore);
+        return new DefaultExternalResourceUrlResolver(urlFileStore, transport.getResourceAccessor(), locallyAvailableResourceFinder);
+    }
+
+    DefaultUriTextResourceLoader createDefaultCachingUrlRequester(ExternalResourceUrlResolver resolver) {
+        return new DefaultUriTextResourceLoader(resolver);
     }
 
     MavenSettingsProvider createMavenSettingsProvider() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementSettingsScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementSettingsScopeServices.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+import com.google.common.collect.Sets;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheMetaData;
+import org.gradle.api.internal.artifacts.repositories.resolver.DefaultExternalResourceUrlResolver;
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
+import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
+import org.gradle.api.internal.filestore.url.DefaultUrlFileStore;
+import org.gradle.authentication.Authentication;
+import org.gradle.cache.internal.CacheScopeMapping;
+import org.gradle.cache.internal.VersionStrategy;
+import org.gradle.internal.resource.cached.ExternalResourceFileStore;
+import org.gradle.internal.resource.local.LocallyAvailableResourceFinderSearchableFileStoreAdapter;
+import org.gradle.internal.resource.local.UniquePathKeyFileStore;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+
+/**
+ * The set of dependency management services that are created per build.
+ */
+class DependencyManagementSettingsScopeServices {
+
+    ExternalResourceFileStore createExternalResourceFileStore(CacheScopeMapping cacheScopeMapping) {
+        return new ExternalResourceFileStore(cacheScopeMapping.getBaseDirectory(null, "external-resources", VersionStrategy.SharedCache), new TmpDirTemporaryFileProvider());
+    }
+
+    DefaultUrlFileStore createUrlFileStore(ArtifactCacheMetaData artifactCacheMetaData) {
+        return new DefaultUrlFileStore(new UniquePathKeyFileStore(artifactCacheMetaData.getFileStoreDirectory()), new TmpDirTemporaryFileProvider());
+    }
+
+    DefaultExternalResourceUrlResolver createDefaultExternalResourceUrlResolver(DefaultUrlFileStore defaultUrlFileStore, RepositoryTransportFactory repositoryTransportFactory) {
+        HashSet<String> schemas = Sets.newHashSet("https", "http");
+        RepositoryTransport transport = repositoryTransportFactory.createTransport(schemas, "http auth", Collections.<Authentication>emptyList());
+        LocallyAvailableResourceFinderSearchableFileStoreAdapter<URL> locallyAvailableResourceFinder = new LocallyAvailableResourceFinderSearchableFileStoreAdapter<URL>(defaultUrlFileStore);
+        return new DefaultExternalResourceUrlResolver(defaultUrlFileStore, transport.getResourceAccessor(), locallyAvailableResourceFinder);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
@@ -28,8 +28,9 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.GradleUserHomeScopePluginServices;
 import org.gradle.internal.service.scopes.PluginServiceRegistry;
+import org.gradle.internal.service.scopes.SettingScopePluginServiceRegistry;
 
-public class DependencyServices implements PluginServiceRegistry, GradleUserHomeScopePluginServices {
+public class DependencyServices implements PluginServiceRegistry, GradleUserHomeScopePluginServices, SettingScopePluginServiceRegistry {
     public void registerGlobalServices(ServiceRegistration registration) {
         registration.addProvider(new DependencyManagementGlobalScopeServices());
     }
@@ -61,5 +62,10 @@ public class DependencyServices implements PluginServiceRegistry, GradleUserHome
     }
 
     public void registerProjectServices(ServiceRegistration registration) {
+    }
+
+    @Override
+    public void registerSettingsServices(ServiceRegistration registration) {
+        registration.addProvider(new DependencyManagementSettingsScopeServices());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceUrlResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceUrlResolver.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import org.gradle.api.Nullable;
+import org.gradle.api.internal.filestore.url.UrlFileStore;
+import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
+import org.gradle.internal.resource.ResourceExceptions;
+import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
+import org.gradle.internal.resource.local.LocallyAvailableResource;
+import org.gradle.internal.resource.local.LocallyAvailableResourceCandidates;
+import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
+import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class DefaultExternalResourceUrlResolver implements ExternalResourceUrlResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExternalResourceUrlResolver.class);
+
+    private final UrlFileStore urlFileStore;
+    private final CacheAwareExternalResourceAccessor resourceAccessor;
+    private final LocallyAvailableResourceFinder<URL> locallyAvailableResourceFinder;
+
+    public DefaultExternalResourceUrlResolver(UrlFileStore urlFileStore, CacheAwareExternalResourceAccessor resourceAccessor, LocallyAvailableResourceFinder<URL> locallyAvailableResourceFinder) {
+        this.urlFileStore = urlFileStore;
+        this.resourceAccessor = resourceAccessor;
+        this.locallyAvailableResourceFinder = locallyAvailableResourceFinder;
+    }
+
+    @Nullable
+    @Override
+    public LocallyAvailableExternalResource resolveUrl(URL url, ResourceAwareResolveResult result) {
+        LOGGER.debug("Loading {}", url.toString());
+        return downloadStaticResource(url, result);
+    }
+
+    @Override
+    public boolean artifactExists(URL url, ResourceAwareResolveResult result) {
+        result.attempted(url.toString());
+        LOGGER.debug("Loading {}", url.toString());
+
+        return !urlFileStore.search(url).isEmpty();
+    }
+
+    private LocallyAvailableExternalResource downloadStaticResource(final URL url, ResourceAwareResolveResult result) {
+        result.attempted(url.toString());
+        LOGGER.debug("Loading {}", url.toString());
+        LocallyAvailableResourceCandidates localCandidates = locallyAvailableResourceFinder.findCandidates(url);
+
+        URI uriLocation;
+        try {
+            uriLocation = url.toURI();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+
+        try {
+            return resourceAccessor.getResource(uriLocation, new CacheAwareExternalResourceAccessor.ResourceFileStore() {
+                public LocallyAvailableResource moveIntoCache(File downloadedResource) {
+                    return urlFileStore.move(url, downloadedResource);
+                }
+            }, localCandidates);
+        } catch (Exception e) {
+            throw ResourceExceptions.getFailed(uriLocation, e);
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceUrlResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceUrlResolver.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.Nullable;
-import org.gradle.api.internal.filestore.url.UrlFileStore;
+import org.gradle.api.internal.filestore.url.DefaultUrlFileStore;
 import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.gradle.internal.resource.ResourceExceptions;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
@@ -37,12 +37,12 @@ public class DefaultExternalResourceUrlResolver implements ExternalResourceUrlRe
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExternalResourceUrlResolver.class);
 
-    private final UrlFileStore urlFileStore;
+    private final DefaultUrlFileStore defaultUrlFileStore;
     private final CacheAwareExternalResourceAccessor resourceAccessor;
     private final LocallyAvailableResourceFinder<URL> locallyAvailableResourceFinder;
 
-    public DefaultExternalResourceUrlResolver(UrlFileStore urlFileStore, CacheAwareExternalResourceAccessor resourceAccessor, LocallyAvailableResourceFinder<URL> locallyAvailableResourceFinder) {
-        this.urlFileStore = urlFileStore;
+    public DefaultExternalResourceUrlResolver(DefaultUrlFileStore defaultUrlFileStore, CacheAwareExternalResourceAccessor resourceAccessor, LocallyAvailableResourceFinder<URL> locallyAvailableResourceFinder) {
+        this.defaultUrlFileStore = defaultUrlFileStore;
         this.resourceAccessor = resourceAccessor;
         this.locallyAvailableResourceFinder = locallyAvailableResourceFinder;
     }
@@ -59,7 +59,7 @@ public class DefaultExternalResourceUrlResolver implements ExternalResourceUrlRe
         result.attempted(url.toString());
         LOGGER.debug("Loading {}", url.toString());
 
-        return !urlFileStore.search(url).isEmpty();
+        return !defaultUrlFileStore.search(url).isEmpty();
     }
 
     private LocallyAvailableExternalResource downloadStaticResource(final URL url, ResourceAwareResolveResult result) {
@@ -77,7 +77,7 @@ public class DefaultExternalResourceUrlResolver implements ExternalResourceUrlRe
         try {
             return resourceAccessor.getResource(uriLocation, new CacheAwareExternalResourceAccessor.ResourceFileStore() {
                 public LocallyAvailableResource moveIntoCache(File downloadedResource) {
-                    return urlFileStore.move(url, downloadedResource);
+                    return defaultUrlFileStore.move(url, downloadedResource);
                 }
             }, localCandidates);
         } catch (Exception e) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceUrlResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceUrlResolver.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import org.gradle.api.Nullable;
+import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
+import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
+
+import java.net.URL;
+
+public interface ExternalResourceUrlResolver {
+    @Nullable
+    LocallyAvailableExternalResource resolveUrl(URL url, ResourceAwareResolveResult result);
+
+    boolean artifactExists(URL url, ResourceAwareResolveResult result);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/ivy/ArtifactIdentifierFileStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/ivy/ArtifactIdentifierFileStore.java
@@ -19,10 +19,10 @@ package org.gradle.api.internal.filestore.ivy;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
-import org.gradle.internal.resource.local.GroupedAndNamedUniqueFileStore;
+import org.gradle.internal.resource.local.DefaultGroupedAndNamedUniqueFileStore;
 import org.gradle.internal.resource.local.PathKeyFileStore;
 
-public class ArtifactIdentifierFileStore extends GroupedAndNamedUniqueFileStore<ModuleComponentArtifactIdentifier> {
+public class ArtifactIdentifierFileStore extends DefaultGroupedAndNamedUniqueFileStore<ModuleComponentArtifactIdentifier> {
     private static final Transformer<String, ModuleComponentArtifactIdentifier> GROUP = new Transformer<String, ModuleComponentArtifactIdentifier>() {
         @Override
         public String transform(ModuleComponentArtifactIdentifier artifactId) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/url/DefaultUrlFileStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/url/DefaultUrlFileStore.java
@@ -20,12 +20,12 @@ package org.gradle.api.internal.filestore.url;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.internal.hash.HashUtil;
-import org.gradle.internal.resource.local.GroupedAndNamedUniqueFileStore;
+import org.gradle.internal.resource.local.DefaultGroupedAndNamedUniqueFileStore;
 import org.gradle.internal.resource.local.PathKeyFileStore;
 
 import java.net.URL;
 
-public class UrlFileStore extends GroupedAndNamedUniqueFileStore<URL> {
+public class DefaultUrlFileStore extends DefaultGroupedAndNamedUniqueFileStore<URL> implements UrlFileStore {
     private static final Transformer<String, URL> SERVER = new Transformer<String, URL>() {
         @Override
         public String transform(URL url) {
@@ -39,7 +39,7 @@ public class UrlFileStore extends GroupedAndNamedUniqueFileStore<URL> {
         }
     };
 
-    public UrlFileStore(PathKeyFileStore pathKeyFileStore, TemporaryFileProvider temporaryFileProvider) {
+    public DefaultUrlFileStore(PathKeyFileStore pathKeyFileStore, TemporaryFileProvider temporaryFileProvider) {
         super(pathKeyFileStore, temporaryFileProvider, SERVER, PATH);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/url/UrlFileStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/url/UrlFileStore.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.filestore.url;
+
+
+import org.gradle.api.Transformer;
+import org.gradle.api.internal.file.TemporaryFileProvider;
+import org.gradle.internal.hash.HashUtil;
+import org.gradle.internal.resource.local.GroupedAndNamedUniqueFileStore;
+import org.gradle.internal.resource.local.PathKeyFileStore;
+
+import java.net.URL;
+
+public class UrlFileStore extends GroupedAndNamedUniqueFileStore<URL> {
+    private static final Transformer<String, URL> SERVER = new Transformer<String, URL>() {
+        @Override
+        public String transform(URL url) {
+            return url.getHost();
+        }
+    };
+    private static final Transformer<String, URL> PATH = new Transformer<String, URL>() {
+        @Override
+        public String transform(URL url) {
+            return HashUtil.createHash(url.toString(), "SHA1").asHexString();
+        }
+    };
+
+    public UrlFileStore(PathKeyFileStore pathKeyFileStore, TemporaryFileProvider temporaryFileProvider) {
+        super(pathKeyFileStore, temporaryFileProvider, SERVER, PATH);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ExternalResourceFileStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ExternalResourceFileStore.java
@@ -17,12 +17,12 @@ package org.gradle.internal.resource.cached;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.file.TemporaryFileProvider;
-import org.gradle.internal.resource.local.GroupedAndNamedUniqueFileStore;
+import org.gradle.internal.resource.local.DefaultGroupedAndNamedUniqueFileStore;
 import org.gradle.internal.resource.local.PathKeyFileStore;
 
 import java.io.File;
 
-public class ExternalResourceFileStore extends GroupedAndNamedUniqueFileStore<String> {
+public class ExternalResourceFileStore extends DefaultGroupedAndNamedUniqueFileStore<String> {
 
     private static final Transformer<String, String> GROUPER = new Transformer<String, String>() {
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultUriTextResourceLoader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultUriTextResourceLoader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transfer;
+
+import org.gradle.api.UncheckedIOException;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UriTextResourceLoader;
+import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceUrlResolver;
+import org.gradle.internal.resolve.result.DefaultResourceAwareResolveResult;
+import org.gradle.internal.resource.CachingTextResource;
+import org.gradle.internal.resource.TextResource;
+import org.gradle.internal.resource.UriTextResource;
+import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+
+public class DefaultUriTextResourceLoader implements UriTextResourceLoader {
+
+    private final ExternalResourceUrlResolver externalResourceUrlResolver;
+
+    public DefaultUriTextResourceLoader(ExternalResourceUrlResolver externalResourceUrlResolver) {
+        this.externalResourceUrlResolver = externalResourceUrlResolver;
+    }
+
+    @Override
+    public TextResource getResource(URI source) {
+        DefaultResourceAwareResolveResult defaultResourceAwareResolveResult = new DefaultResourceAwareResolveResult();
+        try {
+            LocallyAvailableExternalResource resource = externalResourceUrlResolver.resolveUrl(source.toURL(), defaultResourceAwareResolveResult);
+            if(resource == null) {
+                throw new RuntimeException("Unable to find " + source.toString());
+            }
+            return new CachingTextResource(new UriTextResource("cached-script", resource.getLocalResource().getFile()));
+        } catch (MalformedURLException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/subprojects/resources/src/main/java/org/gradle/api/internal/filestore/url/UrlFileStore.java
+++ b/subprojects/resources/src/main/java/org/gradle/api/internal/filestore/url/UrlFileStore.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.filestore.url;
+
+import org.gradle.internal.resource.local.GroupedAndNamedUniqueFileStore;
+
+import java.net.URL;
+
+public interface UrlFileStore extends GroupedAndNamedUniqueFileStore<URL> {
+}

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStore.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStore.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.local;
+
+public interface GroupedAndNamedUniqueFileStore<K> extends FileStore<K>, FileStoreSearcher<K> {
+}


### PR DESCRIPTION
This will allow Gradle to use resources that are only avaliable when
offline. This also makes it so that when you apply from the same url in
a lot of projects, the request will only be made once.


### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
