### PR TITLE
Enable parallel download of metadata

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/PathKeyFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/PathKeyFileStore.java
@@ -203,20 +203,28 @@ public class PathKeyFileStore implements FileStore<String>, FileStoreSearcher<St
     }
 
     protected LocallyAvailableResource entryAt(final String path) {
-        return new AbstractLocallyAvailableResource() {
-            public File getFile() {
-                // Calculated on demand to deal with moves
-                return new File(baseDir, path);
-            }
-        };
+        return new RelativeToBaseDirResource(path);
     }
 
     public LocallyAvailableResource get(String key) {
         final File file = getFileWhileCleaningInProgress(key);
         if (file.exists()) {
-            return entryAt(file);
+            return new RelativeToBaseDirResource(key);
         } else {
             return null;
+        }
+    }
+
+    private class RelativeToBaseDirResource extends AbstractLocallyAvailableResource {
+        private final String path;
+
+        public RelativeToBaseDirResource(String path) {
+            this.path = path;
+        }
+
+        public File getFile() {
+            // Calculated on demand to deal with moves
+            return new File(baseDir, path);
         }
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
@@ -599,7 +599,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                 conf 'org.utils:impl:1.3', 'org.stuff:foo:2.0', 'org.stuff:bar:2.0'
             }
 
-            List requested = []
+            List requested = [].asSynchronized()
 
             configurations.conf.resolutionStrategy {
                 eachDependency {
@@ -610,7 +610,8 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
             task check {
                 doLast {
                     configurations.conf.resolve()
-                    assert requested == ['impl:1.3', 'foo:2.0', 'bar:2.0', 'api:1.3', 'api:1.5']
+                    requested = requested.sort()
+                    assert requested == ['api:1.3', 'api:1.5', 'bar:2.0', 'foo:2.0', 'impl:1.3']
                 }
             }
 """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -1078,7 +1078,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 conf 'org.utils:impl:1.3', 'org.stuff:foo:2.0', 'org.stuff:bar:2.0'
             }
 
-            List requested = []
+            List requested = [].asSynchronized()
 
             configurations.conf.resolutionStrategy {
                 dependencySubstitution {
@@ -1091,7 +1091,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
             task check {
                 doLast {
                     configurations.conf.resolve()
-                    assert requested == ['impl:1.3', 'foo:2.0', 'bar:2.0', 'api:1.3', 'api:1.5']
+                    requested = requested.sort()
+                    assert requested == [ 'api:1.3', 'api:1.5', 'bar:2.0', 'foo:2.0', 'impl:1.3']
                 }
             }
 """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -699,7 +699,7 @@ dependencies {
 
 task checkDeps(dependsOn: configurations.compile) {
     doLast {
-        assert configurations.compile*.name == ['a-2.jar', 'c-2.jar', 'b-1.jar']
+        assert configurations.compile*.name.sort() == ['a-2.jar', 'b-1.jar', 'c-2.jar']
         assert configurations.compile.incoming.resolutionResult.allComponents.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'b' }.dependencies.size() == 1
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -217,8 +217,10 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
             }
         """
 
-        server.expectSerialExecution(server.file(m1.pom.path, m1.pom.file))
-        server.expectSerialExecution(server.file(m2.pom.path, m2.pom.file))
+        server.expectConcurrentExecutionTo([
+            server.file(m1.pom.path, m1.pom.file),
+            server.file(m2.pom.path, m2.pom.file)
+        ])
 
         def handle = server.blockOnConcurrentExecutionAnyOfToResources(4, [
             server.resource("a.jar"),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -271,8 +271,10 @@ class DependencyManagementBuildScopeServices {
                                                                 VersionComparator versionComparator,
                                                                 List<ResolverProviderFactory> resolverFactories,
                                                                 ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                                                                ModuleExclusions moduleExclusions) {
+                                                                ModuleExclusions moduleExclusions,
+                                                                BuildOperationExecutor buildOperationExecutor) {
         return new DefaultArtifactDependencyResolver(
+            buildOperationExecutor,
             resolverFactories,
             resolveIvyFactory,
             dependencyDescriptorFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
@@ -18,11 +18,17 @@ package org.gradle.api.internal.artifacts.configurations;
 import org.gradle.api.artifacts.Configuration;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class Configurations {
     public static Set<String> getNames(Collection<Configuration> configurations) {
+        if (configurations.isEmpty()) {
+            return Collections.emptySet();
+        } else if (configurations.size()==1) {
+            return Collections.singleton(configurations.iterator().next().getName());
+        }
         Set<String> names = new LinkedHashSet<String>(configurations.size());
         for (Configuration configuration : configurations) {
             names.add(configuration.getName());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -328,6 +328,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     public Set<Configuration> getHierarchy() {
+        if (extendsFrom.isEmpty()) {
+            return Collections.<Configuration>singleton(this);
+        }
         Set<Configuration> result = WrapUtil.<Configuration>toLinkedSet(this);
         collectSuperConfigs(this, result);
         return result;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -58,6 +58,11 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         }
     }
 
+    @Override
+    public boolean isAvailableLocally(ComponentIdentifier identifier) {
+        return resolver.isAvailableLocally(identifier);
+    }
+
     private void addClientModuleDependencies(ClientModule clientModule, MutableModuleComponentResolveMetadata clientModuleMetaData) {
         List<DependencyMetadata> dependencies = Lists.newArrayList();
         for (ModuleDependency moduleDependency : clientModule.getDependencies()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -59,8 +59,8 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
     }
 
     @Override
-    public boolean isAvailableLocally(ComponentIdentifier identifier) {
-        return resolver.isAvailableLocally(identifier);
+    public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
+        return resolver.isFetchingMetadataCheap(identifier);
     }
 
     private void addClientModuleDependencies(ClientModule clientModule, MutableModuleComponentResolveMetadata clientModuleMetaData) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
@@ -63,4 +63,9 @@ public class BaseModuleComponentRepositoryAccess implements ModuleComponentRepos
     public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
         delegate.resolveArtifact(artifact, moduleSource, result);
     }
+
+    @Override
+    public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
+        return delegate.isMetadataAvailableLocally(moduleComponentIdentifier);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -65,7 +66,7 @@ public class BaseModuleComponentRepositoryAccess implements ModuleComponentRepos
     }
 
     @Override
-    public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-        return delegate.isMetadataAvailableLocally(moduleComponentIdentifier);
+    public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+        return delegate.estimateMetadataFetchingCost(moduleComponentIdentifier);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePoli
 import org.gradle.api.internal.artifacts.ivyservice.dynamicversions.ModuleVersionsCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleArtifactsCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetaDataCache;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.external.model.FixedComponentArtifacts;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
@@ -266,10 +267,11 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         }
 
         @Override
-        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return delegate.getLocalAccess().isMetadataAvailableLocally(moduleComponentIdentifier) // cheap
-                || isMetadataAvailableInCacheAndUpToDate(moduleComponentIdentifier) // quite cheap, but requires reading binary descriptor
-                || delegate.getRemoteAccess().isMetadataAvailableLocally(moduleComponentIdentifier); // very expensive
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            if (isMetadataAvailableInCacheAndUpToDate(moduleComponentIdentifier)) {
+                return MetadataFetchingCost.FAST;
+            }
+            return delegate.getRemoteAccess().estimateMetadataFetchingCost(moduleComponentIdentifier);
         }
 
         private boolean isMetadataAvailableInCacheAndUpToDate(ModuleComponentIdentifier moduleComponentIdentifier) {
@@ -408,8 +410,8 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         }
 
         @Override
-        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return delegate.getLocalAccess().isMetadataAvailableLocally(moduleComponentIdentifier);
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return delegate.getLocalAccess().estimateMetadataFetchingCost(moduleComponentIdentifier);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -267,7 +267,8 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
 
         @Override
         public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return delegate.getLocalAccess().isMetadataAvailableLocally(moduleComponentIdentifier) // in-memory check first
+            ModuleComponentRepositoryAccess localAccess = delegate.getLocalAccess();
+            return localAccess.isMetadataAvailableLocally(moduleComponentIdentifier) // in-memory check first
                 || isMetadataAvailableInCacheAndUpToDate(moduleComponentIdentifier);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -17,11 +17,11 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ArtifactIdentifier;
+import org.gradle.api.artifacts.ComponentMetadataSupplier;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.artifacts.ComponentMetadataSupplier;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -243,7 +243,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
 
             if (cachedModuleArtifacts != null) {
                 if (!cachePolicy.mustRefreshModuleArtifacts(component.getId(), null, cachedModuleArtifacts.getAgeMillis(),
-                        cachedModuleSource.isChangingModule(), moduleDescriptorHash.equals(cachedModuleArtifacts.getDescriptorHash()))) {
+                    cachedModuleSource.isChangingModule(), moduleDescriptorHash.equals(cachedModuleArtifacts.getDescriptorHash()))) {
                     result.resolved(cachedModuleArtifacts.getArtifacts());
                     return;
                 }
@@ -267,9 +267,9 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
 
         @Override
         public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            ModuleComponentRepositoryAccess localAccess = delegate.getLocalAccess();
-            return localAccess.isMetadataAvailableLocally(moduleComponentIdentifier) // in-memory check first
-                || isMetadataAvailableInCacheAndUpToDate(moduleComponentIdentifier);
+            return delegate.getLocalAccess().isMetadataAvailableLocally(moduleComponentIdentifier) // cheap
+                || isMetadataAvailableInCacheAndUpToDate(moduleComponentIdentifier) // quite cheap, but requires reading binary descriptor
+                || delegate.getRemoteAccess().isMetadataAvailableLocally(moduleComponentIdentifier); // very expensive
         }
 
         private boolean isMetadataAvailableInCacheAndUpToDate(ModuleComponentIdentifier moduleComponentIdentifier) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -21,6 +21,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
+import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
@@ -58,10 +59,13 @@ public class DynamicVersionResolver implements DependencyToComponentIdResolver {
     private final List<String> repositoryNames = new ArrayList<String>();
     private final VersionedComponentChooser versionedComponentChooser;
     private final Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory;
+    private final CacheLockingManager cacheLockingManager;
 
-    public DynamicVersionResolver(VersionedComponentChooser versionedComponentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory) {
+    public DynamicVersionResolver(VersionedComponentChooser versionedComponentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory,
+                                  CacheLockingManager cacheLockingManager) {
         this.versionedComponentChooser = versionedComponentChooser;
         this.metaDataFactory = metaDataFactory;
+        this.cacheLockingManager = cacheLockingManager;
     }
 
     public void add(ModuleComponentRepository repository) {
@@ -201,7 +205,12 @@ public class DynamicVersionResolver implements DependencyToComponentIdResolver {
         }
 
         void resolve() {
-            versionListingResult.resolve();
+            cacheLockingManager.useCache(new Runnable() {
+                @Override
+                public void run() {
+                    versionListingResult.resolve();
+                }
+            });
             switch (versionListingResult.result.getState()) {
                 case Failed:
                     resolveResult.failed(versionListingResult.result.getFailure());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -128,5 +128,10 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
                 result.failed(new ArtifactResolveException(artifact.getId(), throwable));
             }
         }
+
+        @Override
+        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return delegate.isMetadataAvailableLocally(moduleComponentIdentifier);
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -130,8 +131,8 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
         }
 
         @Override
-        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return delegate.isMetadataAvailableLocally(moduleComponentIdentifier);
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return delegate.estimateMetadataFetchingCost(moduleComponentIdentifier);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -97,6 +97,11 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
                 delegate.getRemoteAccess().resolveArtifact(artifact, moduleSource, result);
             }
         }
+
+        @Override
+        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return delegate.getLocalAccess().isMetadataAvailableLocally(moduleComponentIdentifier);
+        }
     }
 
     private static class RemoteAccess implements ModuleComponentRepositoryAccess {
@@ -123,6 +128,11 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
 
         @Override
         public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+        }
+
+        @Override
+        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return false;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -100,7 +100,8 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
 
         @Override
         public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return delegate.getLocalAccess().isMetadataAvailableLocally(moduleComponentIdentifier);
+            return delegate.getLocalAccess().isMetadataAvailableLocally(moduleComponentIdentifier)
+                || delegate.getRemoteAccess().isMetadataAvailableLocally(moduleComponentIdentifier);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -99,9 +100,8 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
         }
 
         @Override
-        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return delegate.getLocalAccess().isMetadataAvailableLocally(moduleComponentIdentifier)
-                || delegate.getRemoteAccess().isMetadataAvailableLocally(moduleComponentIdentifier);
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return delegate.getRemoteAccess().estimateMetadataFetchingCost(moduleComponentIdentifier);
         }
     }
 
@@ -132,8 +132,8 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
         }
 
         @Override
-        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return false;
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return MetadataFetchingCost.EXPENSIVE;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
@@ -62,4 +62,6 @@ public interface ModuleComponentRepositoryAccess {
      * Resolves the given artifact. Any failures are packaged up in the result.
      */
     void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result);
+
+    boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -63,5 +64,5 @@ public interface ModuleComponentRepositoryAccess {
      */
     void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result);
 
-    boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier);
+    MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
@@ -63,6 +63,11 @@ public class NoRepositoriesResolver implements ComponentResolvers, DependencyToC
     }
 
     @Override
+    public boolean isAvailableLocally(ComponentIdentifier identifier) {
+        return false;
+    }
+
+    @Override
     public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
         throw new UnsupportedOperationException();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
@@ -63,8 +63,8 @@ public class NoRepositoriesResolver implements ComponentResolvers, DependencyToC
     }
 
     @Override
-    public boolean isAvailableLocally(ComponentIdentifier identifier) {
-        return false;
+    public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
+        return true;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -59,6 +59,18 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
         resolveModule((ModuleComponentIdentifier) identifier, componentOverrideMetadata, result);
     }
 
+    @Override
+    public boolean isAvailableLocally(ComponentIdentifier identifier) {
+        if (identifier instanceof ModuleComponentIdentifier) {
+            for (ModuleComponentRepository repository : repositories) {
+                if (repository.getLocalAccess().isMetadataAvailableLocally((ModuleComponentIdentifier) identifier)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private void resolveModule(ModuleComponentIdentifier identifier, ComponentOverrideMetadata componentOverrideMetadata, BuildableComponentResolveResult result) {
         LOGGER.debug("Attempting to resolve component for {} using repositories {}", identifier, repositoryNames);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -60,16 +61,19 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
     }
 
     @Override
-    public boolean isAvailableLocally(ComponentIdentifier identifier) {
+    public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
         if (identifier instanceof ModuleComponentIdentifier) {
             for (ModuleComponentRepository repository : repositories) {
                 ModuleComponentRepositoryAccess localAccess = repository.getLocalAccess();
-                if (localAccess.isMetadataAvailableLocally((ModuleComponentIdentifier) identifier)) {
+                MetadataFetchingCost fetchingCost = localAccess.estimateMetadataFetchingCost((ModuleComponentIdentifier) identifier);
+                if (fetchingCost.isFast()) {
                     return true;
+                } else if (fetchingCost.isExpensive()) {
+                    return false;
                 }
             }
         }
-        return false;
+        return true;
     }
 
     private void resolveModule(ModuleComponentIdentifier identifier, ComponentOverrideMetadata componentOverrideMetadata, BuildableComponentResolveResult result) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -63,7 +63,8 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
     public boolean isAvailableLocally(ComponentIdentifier identifier) {
         if (identifier instanceof ModuleComponentIdentifier) {
             for (ModuleComponentRepository repository : repositories) {
-                if (repository.getLocalAccess().isMetadataAvailableLocally((ModuleComponentIdentifier) identifier)) {
+                ModuleComponentRepositoryAccess localAccess = repository.getLocalAccess();
+                if (localAccess.isMetadataAvailableLocally((ModuleComponentIdentifier) identifier)) {
                     return true;
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
@@ -20,6 +20,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
@@ -32,10 +33,10 @@ public class RepositoryChainDependencyToComponentIdResolver implements Dependenc
     private final DynamicVersionResolver dynamicRevisionResolver;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
 
-    public RepositoryChainDependencyToComponentIdResolver(VersionSelectorScheme versionSelectorScheme, VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+    public RepositoryChainDependencyToComponentIdResolver(VersionSelectorScheme versionSelectorScheme, VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, CacheLockingManager cacheLockingManager) {
         this.versionSelectorScheme = versionSelectorScheme;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
-        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, metaDataFactory);
+        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, metaDataFactory, cacheLockingManager);
     }
 
     public void add(ModuleComponentRepository repository) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -172,6 +172,11 @@ public class ResolveIvyFactory {
         }
 
         @Override
+        public boolean isAvailableLocally(ComponentIdentifier identifier) {
+            return delegate.getComponentResolver().isAvailableLocally(identifier);
+        }
+
+        @Override
         public void resolveArtifactsWithType(final ComponentResolveMetadata component, final ArtifactType artifactType, final BuildableArtifactSetResolveResult result) {
             cacheLockingManager.useCache(new Runnable() {
                 public void run() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -93,7 +93,7 @@ public class ResolveIvyFactory {
 
         startParameterResolutionOverride.addResolutionRules(resolutionRules);
 
-        UserResolverChain moduleResolver = new UserResolverChain(versionSelectorScheme, versionComparator, resolutionStrategy.getComponentSelection(), moduleIdentifierFactory);
+        UserResolverChain moduleResolver = new UserResolverChain(versionSelectorScheme, versionComparator, resolutionStrategy.getComponentSelection(), moduleIdentifierFactory, cacheLockingManager);
         ParentModuleLookupResolver parentModuleResolver = new ParentModuleLookupResolver(versionSelectorScheme, versionComparator, cacheLockingManager, moduleIdentifierFactory);
 
         for (ResolutionAwareRepository repository : repositories) {
@@ -133,7 +133,7 @@ public class ResolveIvyFactory {
         private final UserResolverChain delegate;
 
         public ParentModuleLookupResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, CacheLockingManager cacheLockingManager, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-            this.delegate = new UserResolverChain(versionSelectorScheme, versionComparator, new DefaultComponentSelectionRules(moduleIdentifierFactory), moduleIdentifierFactory);
+            this.delegate = new UserResolverChain(versionSelectorScheme, versionComparator, new DefaultComponentSelectionRules(moduleIdentifierFactory), moduleIdentifierFactory, cacheLockingManager);
             this.cacheLockingManager = cacheLockingManager;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -172,8 +172,8 @@ public class ResolveIvyFactory {
         }
 
         @Override
-        public boolean isAvailableLocally(ComponentIdentifier identifier) {
-            return delegate.getComponentResolver().isAvailableLocally(identifier);
+        public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
+            return delegate.getComponentResolver().isFetchingMetadataCheap(identifier);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -142,6 +142,11 @@ public class StartParameterResolutionOverride {
         public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
             result.failed(new ArtifactResolveException(artifact.getId(), "No cached version available for offline mode"));
         }
+
+        @Override
+        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return false;
+        }
     }
 
     public ExternalResourceCachePolicy overrideExternalResourceCachePolicy(ExternalResourceCachePolicy original) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.cache.ModuleResolutionControl;
 import org.gradle.api.artifacts.cache.ResolutionRules;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.resources.ResourceException;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -144,8 +145,8 @@ public class StartParameterResolutionOverride {
         }
 
         @Override
-        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return false;
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return MetadataFetchingCost.CHEAP;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
@@ -32,11 +33,11 @@ public class UserResolverChain implements ComponentResolvers {
     private final RepositoryChainArtifactResolver artifactResolver;
     private final ComponentSelectionRulesInternal componentSelectionRules;
 
-    public UserResolverChain(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, ComponentSelectionRulesInternal componentSelectionRules, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+    public UserResolverChain(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, ComponentSelectionRulesInternal componentSelectionRules, ImmutableModuleIdentifierFactory moduleIdentifierFactory, CacheLockingManager cacheLockingManager) {
         this.componentSelectionRules = componentSelectionRules;
         VersionedComponentChooser componentChooser = new DefaultVersionedComponentChooser(versionComparator, versionSelectorScheme, componentSelectionRules);
         ModuleTransformer metaDataFactory = new ModuleTransformer();
-        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(versionSelectorScheme, componentChooser, metaDataFactory, moduleIdentifierFactory);
+        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(versionSelectorScheme, componentChooser, metaDataFactory, moduleIdentifierFactory, cacheLockingManager);
         componentResolver = new RepositoryChainComponentMetaDataResolver(componentChooser, metaDataFactory);
         artifactResolver = new RepositoryChainArtifactResolver();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepository.java
@@ -110,10 +110,11 @@ class InMemoryCachedModuleComponentRepository extends BaseModuleComponentReposit
 
         @Override
         public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            if (metaDataCache.isMetadataCached(moduleComponentIdentifier)) {
-                return true;
+            Boolean cached = metaDataCache.isMetadataCached(moduleComponentIdentifier);
+            if (cached != null) {
+                return cached;
             }
-            return super.isMetadataAvailableLocally(moduleComponentIdentifier);
+            return metaDataCache.cacheMetadataAvailability(moduleComponentIdentifier, super.isMetadataAvailableLocally(moduleComponentIdentifier));
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepository.java
@@ -115,19 +115,23 @@ class InMemoryCachedModuleComponentRepository extends BaseModuleComponentReposit
 
         @Override
         public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            Boolean cached = isMetadataCached(moduleComponentIdentifier);
+            if (metaDataCache.isMetadataCached(moduleComponentIdentifier)) {
+                // check the global cache first: if any repo has it cached, we don't need to check locally
+                return true;
+            }
+            Boolean cached =  locallyAvailableMetaData.get(moduleComponentIdentifier);
             if (cached != null) {
+                // then check if for this specific repository, we already tried this component
                 return cached;
             }
             return cacheMetadataAvailability(moduleComponentIdentifier, super.isMetadataAvailableLocally(moduleComponentIdentifier));
         }
 
-        public Boolean isMetadataCached(ModuleComponentIdentifier requested) {
-            return locallyAvailableMetaData.get(requested);
-        }
-
-        public boolean cacheMetadataAvailability(ModuleComponentIdentifier requested, boolean answer) {
+        private boolean cacheMetadataAvailability(ModuleComponentIdentifier requested, boolean answer) {
             locallyAvailableMetaData.put(requested, answer);
+            if (answer) {
+                metaDataCache.cacheMetadataAvailability(requested);
+            }
             return answer;
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepository.java
@@ -107,5 +107,13 @@ class InMemoryCachedModuleComponentRepository extends BaseModuleComponentReposit
                 artifactsCache.newArtifact(artifact.getId(), result);
             }
         }
+
+        @Override
+        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
+            if (metaDataCache.isMetadataCached(moduleComponentIdentifier)) {
+                return true;
+            }
+            return super.isMetadataAvailableLocally(moduleComponentIdentifier);
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.memcache;
 
+import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
@@ -30,6 +31,15 @@ import static org.gradle.internal.resolve.result.BuildableModuleVersionListingRe
 class InMemoryMetaDataCache {
     private final Map<ModuleVersionSelector, Set<String>> moduleVersionListing = new HashMap<ModuleVersionSelector, Set<String>>();
     private final Map<ModuleComponentIdentifier, CachedModuleVersionResult> metaData = new HashMap<ModuleComponentIdentifier, CachedModuleVersionResult>();
+    private final Set<ModuleComponentIdentifier> locallyAvailableMetaData = Sets.newHashSet();
+
+    public boolean isMetadataCached(ModuleComponentIdentifier requested) {
+        return locallyAvailableMetaData.contains(requested);
+    }
+
+    public void cacheMetadataAvailability(ModuleComponentIdentifier requested) {
+        locallyAvailableMetaData.add(requested);
+    }
 
     public boolean supplyModuleVersions(ModuleVersionSelector requested, BuildableModuleVersionListingResolveResult result) {
         Set<String> versions = moduleVersionListing.get(requested);
@@ -59,6 +69,7 @@ class InMemoryMetaDataCache {
         CachedModuleVersionResult cachedResult = new CachedModuleVersionResult(result);
         if (cachedResult.isCacheable()) {
             metaData.put(requested, cachedResult);
+            locallyAvailableMetaData.add(requested);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.memcache;
 
-import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
@@ -31,16 +30,6 @@ import static org.gradle.internal.resolve.result.BuildableModuleVersionListingRe
 class InMemoryMetaDataCache {
     private final Map<ModuleVersionSelector, Set<String>> moduleVersionListing = new HashMap<ModuleVersionSelector, Set<String>>();
     private final Map<ModuleComponentIdentifier, CachedModuleVersionResult> metaData = new HashMap<ModuleComponentIdentifier, CachedModuleVersionResult>();
-    private final Map<ModuleComponentIdentifier, Boolean> locallyAvailableMetaData = Maps.newHashMap();
-
-    public Boolean isMetadataCached(ModuleComponentIdentifier requested) {
-        return locallyAvailableMetaData.get(requested);
-    }
-
-    public boolean cacheMetadataAvailability(ModuleComponentIdentifier requested, boolean answer) {
-        locallyAvailableMetaData.put(requested, answer);
-        return answer;
-    }
 
     public boolean supplyModuleVersions(ModuleVersionSelector requested, BuildableModuleVersionListingResolveResult result) {
         Set<String> versions = moduleVersionListing.get(requested);
@@ -70,7 +59,6 @@ class InMemoryMetaDataCache {
         CachedModuleVersionResult cachedResult = new CachedModuleVersionResult(result);
         if (cachedResult.isCacheable()) {
             metaData.put(requested, cachedResult);
-            locallyAvailableMetaData.put(requested, Boolean.TRUE);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.memcache;
 
+import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
@@ -30,9 +31,15 @@ import static org.gradle.internal.resolve.result.BuildableModuleVersionListingRe
 class InMemoryMetaDataCache {
     private final Map<ModuleVersionSelector, Set<String>> moduleVersionListing = new HashMap<ModuleVersionSelector, Set<String>>();
     private final Map<ModuleComponentIdentifier, CachedModuleVersionResult> metaData = new HashMap<ModuleComponentIdentifier, CachedModuleVersionResult>();
+    private final Map<ModuleComponentIdentifier, Boolean> locallyAvailableMetaData = Maps.newHashMap();
 
-    public boolean isMetadataCached(ModuleComponentIdentifier requested) {
-        return metaData.get(requested) != null;
+    public Boolean isMetadataCached(ModuleComponentIdentifier requested) {
+        return locallyAvailableMetaData.get(requested);
+    }
+
+    public boolean cacheMetadataAvailability(ModuleComponentIdentifier requested, boolean answer) {
+        locallyAvailableMetaData.put(requested, answer);
+        return answer;
     }
 
     public boolean supplyModuleVersions(ModuleVersionSelector requested, BuildableModuleVersionListingResolveResult result) {
@@ -63,6 +70,7 @@ class InMemoryMetaDataCache {
         CachedModuleVersionResult cachedResult = new CachedModuleVersionResult(result);
         if (cachedResult.isCacheable()) {
             metaData.put(requested, cachedResult);
+            locallyAvailableMetaData.put(requested, Boolean.TRUE);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
@@ -24,16 +24,15 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 import static org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult.State.Listed;
 
 class InMemoryMetaDataCache {
-    private final Map<ModuleVersionSelector, Set<String>> moduleVersionListing = new HashMap<ModuleVersionSelector, Set<String>>();
-    private final Map<ModuleComponentIdentifier, CachedModuleVersionResult> metaData = new HashMap<ModuleComponentIdentifier, CachedModuleVersionResult>();
-    private final Map<ModuleComponentIdentifier, MetadataFetchingCost> fetchingCosts = Maps.newHashMap();
+    private final Map<ModuleVersionSelector, Set<String>> moduleVersionListing = Maps.newConcurrentMap();
+    private final Map<ModuleComponentIdentifier, CachedModuleVersionResult> metaData = Maps.newConcurrentMap();
+    private final Map<ModuleComponentIdentifier, MetadataFetchingCost> fetchingCosts = Maps.newConcurrentMap();
 
     public boolean supplyModuleVersions(ModuleVersionSelector requested, BuildableModuleVersionListingResolveResult result) {
         Set<String> versions = moduleVersionListing.get(requested);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
@@ -31,6 +31,10 @@ class InMemoryMetaDataCache {
     private final Map<ModuleVersionSelector, Set<String>> moduleVersionListing = new HashMap<ModuleVersionSelector, Set<String>>();
     private final Map<ModuleComponentIdentifier, CachedModuleVersionResult> metaData = new HashMap<ModuleComponentIdentifier, CachedModuleVersionResult>();
 
+    public boolean isMetadataCached(ModuleComponentIdentifier requested) {
+        return metaData.get(requested) != null;
+    }
+
     public boolean supplyModuleVersions(ModuleVersionSelector requested, BuildableModuleVersionListingResolveResult result) {
         Set<String> versions = moduleVersionListing.get(requested);
         if (versions == null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryMetaDataCache.java
@@ -16,9 +16,10 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.memcache;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 
@@ -31,15 +32,7 @@ import static org.gradle.internal.resolve.result.BuildableModuleVersionListingRe
 class InMemoryMetaDataCache {
     private final Map<ModuleVersionSelector, Set<String>> moduleVersionListing = new HashMap<ModuleVersionSelector, Set<String>>();
     private final Map<ModuleComponentIdentifier, CachedModuleVersionResult> metaData = new HashMap<ModuleComponentIdentifier, CachedModuleVersionResult>();
-    private final Set<ModuleComponentIdentifier> locallyAvailableMetaData = Sets.newHashSet();
-
-    public boolean isMetadataCached(ModuleComponentIdentifier requested) {
-        return locallyAvailableMetaData.contains(requested);
-    }
-
-    public void cacheMetadataAvailability(ModuleComponentIdentifier requested) {
-        locallyAvailableMetaData.add(requested);
-    }
+    private final Map<ModuleComponentIdentifier, MetadataFetchingCost> locallyAvailableMetaData = Maps.newHashMap();
 
     public boolean supplyModuleVersions(ModuleVersionSelector requested, BuildableModuleVersionListingResolveResult result) {
         Set<String> versions = moduleVersionListing.get(requested);
@@ -69,7 +62,6 @@ class InMemoryMetaDataCache {
         CachedModuleVersionResult cachedResult = new CachedModuleVersionResult(result);
         if (cachedResult.isCacheable()) {
             metaData.put(requested, cachedResult);
-            locallyAvailableMetaData.add(requested);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -81,6 +81,14 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
     }
 
     @Override
+    public boolean isAvailableLocally(ComponentIdentifier identifier) {
+        if (isProjectModule(identifier)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
         if (isProjectModule(component.getComponentId())) {
             throw new UnsupportedOperationException("Resolving artifacts by type is not yet supported for project modules");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -81,11 +81,8 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
     }
 
     @Override
-    public boolean isAvailableLocally(ComponentIdentifier identifier) {
-        if (isProjectModule(identifier)) {
-            return true;
-        }
-        return false;
+    public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
+        return true;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
@@ -85,6 +85,16 @@ public class ComponentResolversChain implements ComponentResolvers {
                 resolver.resolve(identifier, componentOverrideMetadata, result);
             }
         }
+
+        @Override
+        public boolean isAvailableLocally(ComponentIdentifier identifier) {
+            for (ComponentMetaDataResolver resolver : resolvers) {
+                if (resolver.isAvailableLocally(identifier)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     private static class ArtifactResolverChain implements ArtifactResolver {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
@@ -87,13 +87,13 @@ public class ComponentResolversChain implements ComponentResolvers {
         }
 
         @Override
-        public boolean isAvailableLocally(ComponentIdentifier identifier) {
+        public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
             for (ComponentMetaDataResolver resolver : resolvers) {
-                if (resolver.isAvailableLocally(identifier)) {
-                    return true;
+                if (!resolver.isFetchingMetadataCheap(identifier)) {
+                    return false;
                 }
             }
-            return false;
+            return true;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
@@ -259,7 +259,7 @@ public class DependencyGraphBuilder {
         for (DependencyEdge dependency : dependencies) {
             ModuleVersionResolveState state = dependency.targetModuleRevision;
             if (state != null && !state.fastResolve() && performPreemptiveDownload(state.state)) {
-                if (!metaDataResolver.isAvailableLocally(toComponentId(state.getId(), componentIdentifierCache))) {
+                if (!metaDataResolver.isFetchingMetadataCheap(toComponentId(state.getId(), componentIdentifierCache))) {
                     dependenciesToBeResolvedInParallel.add(dependency);
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphBuilder.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ModuleIdentifier;
@@ -37,6 +39,9 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflict
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.specs.Spec;
+import org.gradle.cache.internal.DefaultProducerGuard;
+import org.gradle.cache.internal.ProducerGuard;
+import org.gradle.internal.Factory;
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -46,6 +51,11 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.id.LongIdGenerator;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationQueue;
+import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.progress.BuildOperationDescriptor;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
@@ -60,6 +70,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -78,11 +89,15 @@ public class DependencyGraphBuilder {
     private final AttributesSchemaInternal attributesSchema;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final ModuleExclusions moduleExclusions;
+    private final BuildOperationExecutor buildOperationExecutor;
+    private final ProducerGuard<ConcurrentDependencyEdgeResolutionLock> guard = new DefaultProducerGuard<ConcurrentDependencyEdgeResolutionLock>();
 
     public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver, ComponentMetaDataResolver componentMetaDataResolver,
                                   ResolveContextToComponentResolver resolveContextToComponentResolver,
-                                  ConflictHandler conflictHandler, Spec<? super DependencyMetadata> edgeFilter, AttributesSchemaInternal attributesSchema,
-                                  ImmutableModuleIdentifierFactory moduleIdentifierFactory, ModuleExclusions moduleExclusions) {
+                                  ConflictHandler conflictHandler, Spec<? super DependencyMetadata> edgeFilter,
+                                  AttributesSchemaInternal attributesSchema,
+                                  ImmutableModuleIdentifierFactory moduleIdentifierFactory, ModuleExclusions moduleExclusions,
+                                  BuildOperationExecutor buildOperationExecutor) {
         this.idResolver = componentIdResolver;
         this.metaDataResolver = componentMetaDataResolver;
         this.moduleResolver = resolveContextToComponentResolver;
@@ -91,81 +106,48 @@ public class DependencyGraphBuilder {
         this.attributesSchema = attributesSchema;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.moduleExclusions = moduleExclusions;
+        this.buildOperationExecutor = buildOperationExecutor;
     }
 
-    public void resolve(ResolveContext resolveContext, DependencyGraphVisitor modelVisitor) {
+    public void resolve(final ResolveContext resolveContext, final DependencyGraphVisitor modelVisitor) {
+
         IdGenerator<Long> idGenerator = new LongIdGenerator();
         DefaultBuildableComponentResolveResult rootModule = new DefaultBuildableComponentResolveResult();
         moduleResolver.resolve(resolveContext, rootModule);
 
-        ResolveState resolveState = new ResolveState(idGenerator, rootModule, resolveContext.getName(), idResolver, metaDataResolver, edgeFilter, attributesSchema, moduleIdentifierFactory, moduleExclusions);
+        final ResolveState resolveState = new ResolveState(idGenerator, rootModule, resolveContext.getName(), idResolver, metaDataResolver, edgeFilter, attributesSchema, moduleIdentifierFactory, moduleExclusions);
         conflictHandler.registerResolver(new DirectDependencyForcingResolver(resolveState.root.moduleRevision));
 
-        traverseGraph(resolveState, conflictHandler);
+        traverseGraph(resolveState);
+
         resolveState.root.moduleRevision.setSelectionReason(VersionSelectionReasons.ROOT);
 
         assembleResult(resolveState, modelVisitor);
+
     }
 
     /**
      * Traverses the dependency graph, resolving conflicts and building the paths from the root configuration.
      */
-    private void traverseGraph(final ResolveState resolveState, final ConflictHandler conflictHandler) {
+    private void traverseGraph(final ResolveState resolveState) {
         resolveState.onMoreSelected(resolveState.root);
+        final List<DependencyEdge> dependencies = Lists.newArrayList();
+        final List<DependencyEdge> dependenciesToBeResolvedSerially = Lists.newArrayList();
+        final List<DependencyEdge> dependenciesToBeResolvedInParallel = Lists.newArrayList();
 
-        List<DependencyEdge> dependencies = new ArrayList<DependencyEdge>();
         while (resolveState.peek() != null || conflictHandler.hasConflicts()) {
             if (resolveState.peek() != null) {
-                ConfigurationNode node = resolveState.pop();
+                final ConfigurationNode node = resolveState.pop();
                 LOGGER.debug("Visiting configuration {}.", node);
 
                 // Calculate the outgoing edges of this configuration
                 dependencies.clear();
+                dependenciesToBeResolvedInParallel.clear();
+                dependenciesToBeResolvedSerially.clear();
                 node.visitOutgoingDependencies(dependencies);
 
-                for (DependencyEdge dependency : dependencies) {
-                    LOGGER.debug("Visiting dependency {}", dependency);
+                resolveEdges(node, dependencies, dependenciesToBeResolvedSerially, dependenciesToBeResolvedInParallel, guard, resolveState);
 
-                    // Resolve dependency to a particular revision
-                    ModuleVersionResolveState moduleRevision = dependency.resolveModuleRevisionId();
-                    if (moduleRevision == null) {
-                        // Failed to resolve.
-                        continue;
-                    }
-                    ModuleIdentifier moduleId = moduleRevision.id.getModule();
-
-                    // Check for a new conflict
-                    if (moduleRevision.state == ModuleState.New) {
-                        ModuleResolveState module = resolveState.getModule(moduleId);
-
-                        // A new module revision. Check for conflict
-                        PotentialConflict c = conflictHandler.registerModule(module);
-                        if (!c.conflictExists()) {
-                            // No conflict. Select it for now
-                            LOGGER.debug("Selecting new module version {}", moduleRevision);
-                            module.select(moduleRevision);
-                        } else {
-                            // We have a conflict
-                            LOGGER.debug("Found new conflicting module version {}", moduleRevision);
-
-                            // Deselect the currently selected version, and remove all outgoing edges from the version
-                            // This will propagate through the graph and prune configurations that are no longer required
-                            // For each module participating in the conflict (many times there is only one participating module that has multiple versions)
-                            c.withParticipatingModules(new Action<ModuleIdentifier>() {
-                                public void execute(ModuleIdentifier module) {
-                                    ModuleVersionResolveState previouslySelected = resolveState.getModule(module).clearSelection();
-                                    if (previouslySelected != null) {
-                                        for (ConfigurationNode configuration : previouslySelected.configurations) {
-                                            configuration.deselect();
-                                        }
-                                    }
-                                }
-                            });
-                        }
-                    }
-
-                    dependency.attachToTargetConfigurations();
-                }
             } else {
                 // We have some batched up conflicts. Resolve the first, and continue traversing the graph
                 conflictHandler.resolveNextConflict(new Action<ConflictResolutionResult>() {
@@ -181,6 +163,123 @@ public class DependencyGraphBuilder {
                     }
                 });
             }
+
+        }
+    }
+
+    private void performSelection(final ResolveState resolveState, ModuleVersionResolveState moduleRevision) {
+        ModuleIdentifier moduleId = moduleRevision.id.getModule();
+
+        // Check for a new conflict
+        if (moduleRevision.state == ModuleState.New) {
+            ModuleResolveState module = resolveState.getModule(moduleId);
+            // A new module revision. Check for conflict
+            PotentialConflict c;
+            synchronized (conflictHandler) {
+                c = conflictHandler.registerModule(module);
+            }
+            if (!c.conflictExists()) {
+                // No conflict. Select it for now
+                LOGGER.debug("Selecting new module version {}", moduleRevision);
+                module.select(moduleRevision);
+            } else {
+                // We have a conflict
+                LOGGER.debug("Found new conflicting module version {}", moduleRevision);
+
+                // Deselect the currently selected version, and remove all outgoing edges from the version
+                // This will propagate through the graph and prune configurations that are no longer required
+                // For each module participating in the conflict (many times there is only one participating module that has multiple versions)
+                c.withParticipatingModules(new Action<ModuleIdentifier>() {
+                    public void execute(ModuleIdentifier module) {
+                        synchronized (conflictHandler) {
+                            ModuleVersionResolveState previouslySelected = resolveState.getModule(module).clearSelection();
+                            if (previouslySelected != null) {
+                                for (ConfigurationNode configuration : previouslySelected.configurations) {
+                                    configuration.deselect();
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    private void resolveEdges(final ConfigurationNode node,
+                              final List<DependencyEdge> dependencies,
+                              final List<DependencyEdge> dependenciesToBeResolvedSerially,
+                              final List<DependencyEdge> dependenciesToBeResolvedInParallel,
+                              final ProducerGuard<ConcurrentDependencyEdgeResolutionLock> guard,
+                              final ResolveState resolveState) {
+        if (dependencies.isEmpty()) {
+            return;
+        }
+        prepareForResolution(dependencies, dependenciesToBeResolvedSerially, dependenciesToBeResolvedInParallel);
+
+        resolveEdgesSerially(dependenciesToBeResolvedSerially, resolveState);
+        resolveEdgesConcurrently(node, dependenciesToBeResolvedInParallel, guard, resolveState);
+
+        // the following only needs to be done serially to preserve ordering of dependencies in the graph: we have visited the edges
+        // but we still didn't add the result to the queue. Doing it from resolve threads would result in non-reproducible graphs, where
+        // edges could be added in different order. To avoid this, the addition of new edges is done serially.
+        for (DependencyEdge dependency : dependencies) {
+            if (dependency.targetModuleRevision != null) {
+                dependency.attachToTargetConfigurations();
+            }
+        }
+
+    }
+
+    private void resolveEdgesConcurrently(ConfigurationNode node, final List<DependencyEdge> dependencies, final ProducerGuard<ConcurrentDependencyEdgeResolutionLock> guard, final ResolveState resolveState) {
+        if (dependencies.isEmpty()) {
+            return;
+        }
+        LOGGER.debug("Submitting {} dependency edges to resolve in parallel for {}", dependencies.size(), node);
+        buildOperationExecutor.runAll(new Action<BuildOperationQueue<RunnableBuildOperation>>() {
+            @Override
+            public void execute(BuildOperationQueue<RunnableBuildOperation> buildOperationQueue) {
+                for (final DependencyEdge dependency : dependencies) {
+                    if (dependency.targetModuleRevision != null) {
+                        buildOperationQueue.add(new ResolveDependencyEdgeOperation(guard, dependency, resolveState));
+                    }
+                }
+            }
+        });
+    }
+
+    private void resolveEdgesSerially(List<DependencyEdge> dependencies, ResolveState resolveState) {
+        for (DependencyEdge dependency : dependencies) {
+            ModuleVersionResolveState moduleRevision = dependency.targetModuleRevision;
+            if (moduleRevision != null) {
+                performSelection(resolveState, moduleRevision);
+            }
+        }
+    }
+
+    /**
+     * Prepares the resolution of edges, either serially or concurrently. It uses a simple heuristic to determine
+     * if we should perform concurrent resolution, based on the the number of edges, and whether they have unresolved
+     * metadata. Determining this requires calls to `resolveModuleRevisionId`, which will *not* trigger metadata download.
+     *
+     * @param dependencies the dependencies to be resolved  @return true if they should be resolved serially, false if they should be resolved concurrently
+     * @param dependenciesToBeResolvedInParallel output, edges which will need parallel resolution
+     * @param dependenciesToBeResolvedSerially output, edges which will need serial resolution
+     */
+    private void prepareForResolution(List<DependencyEdge> dependencies, List<DependencyEdge> dependenciesToBeResolvedSerially, List<DependencyEdge> dependenciesToBeResolvedInParallel) {
+        for (DependencyEdge dependency : dependencies) {
+            ModuleVersionResolveState state = dependency.resolveModuleRevisionId();
+            if (state != null) {
+                if (state.getMetadata() != null) {
+                    dependenciesToBeResolvedSerially.add(dependency);
+                } else {
+                    dependenciesToBeResolvedInParallel.add(dependency);
+                }
+            }
+        }
+        if (dependenciesToBeResolvedInParallel.size()==1) {
+            // no parallel download if a single dependency
+            dependenciesToBeResolvedSerially.addAll(dependenciesToBeResolvedInParallel);
+            dependenciesToBeResolvedInParallel.clear();
         }
     }
 
@@ -212,6 +311,45 @@ public class DependencyGraphBuilder {
         visitor.finish(resolveState.root);
     }
 
+    private static class ConcurrentDependencyEdgeResolutionLock {
+        private final String group;
+        private final String name;
+        private final int hashCode;
+
+        private ConcurrentDependencyEdgeResolutionLock(String group, String name) {
+            this.group = group;
+            this.name = name;
+            this.hashCode = 31 * group.hashCode() + name.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ConcurrentDependencyEdgeResolutionLock that = (ConcurrentDependencyEdgeResolutionLock) o;
+
+            if (!group.equals(that.group)) {
+                return false;
+            }
+            return name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public String toString() {
+            return "Lock for resolution of module " + group + ":" + name;
+        }
+    }
+
     /**
      * Represents the edges in the dependency graph.
      */
@@ -223,6 +361,8 @@ public class DependencyGraphBuilder {
         private final ResolveState resolveState;
         private final ModuleExclusion moduleExclusion;
         private final Set<ConfigurationNode> targetConfigurations = new LinkedHashSet<ConfigurationNode>();
+        private final ConcurrentDependencyEdgeResolutionLock lock;
+
         private ModuleVersionResolveState targetModuleRevision;
 
         DependencyEdge(ConfigurationNode from, DependencyMetadata dependencyMetadata, ModuleExclusion moduleExclusion, ResolveState resolveState) {
@@ -230,7 +370,8 @@ public class DependencyGraphBuilder {
             this.dependencyMetadata = dependencyMetadata;
             this.moduleExclusion = moduleExclusion;
             this.resolveState = resolveState;
-            selector = resolveState.getSelector(dependencyMetadata);
+            this.selector = resolveState.getSelector(dependencyMetadata);
+            this.lock = new ConcurrentDependencyEdgeResolutionLock(dependencyMetadata.getRequested().getGroup(), dependencyMetadata.getRequested().getName());
         }
 
         @Override
@@ -251,7 +392,7 @@ public class DependencyGraphBuilder {
         /**
          * @return The resolved module version
          */
-        public ModuleVersionResolveState resolveModuleRevisionId() {
+        public synchronized ModuleVersionResolveState resolveModuleRevisionId() {
             if (targetModuleRevision == null) {
                 targetModuleRevision = selector.resolveModuleRevisionId();
                 selector.getSelectedModule().addUnattachedDependency(this);
@@ -263,7 +404,7 @@ public class DependencyGraphBuilder {
             return from.isTransitive() && dependencyMetadata.isTransitive();
         }
 
-        public void attachToTargetConfigurations() {
+        public synchronized void attachToTargetConfigurations() {
             if (targetModuleRevision.state != ModuleState.Selected) {
                 return;
             }
@@ -276,7 +417,7 @@ public class DependencyGraphBuilder {
             }
         }
 
-        public void removeFromTargetConfigurations() {
+        public synchronized void removeFromTargetConfigurations() {
             for (ConfigurationNode targetConfiguration : targetConfigurations) {
                 targetConfiguration.removeIncomingEdge(this);
             }
@@ -286,7 +427,7 @@ public class DependencyGraphBuilder {
             }
         }
 
-        public void restart(ModuleVersionResolveState selected) {
+        public synchronized void restart(ModuleVersionResolveState selected) {
             removeFromTargetConfigurations();
             targetModuleRevision = selected;
             attachToTargetConfigurations();
@@ -377,7 +518,7 @@ public class DependencyGraphBuilder {
         private final IdGenerator<Long> idGenerator;
         private final DependencyToComponentIdResolver idResolver;
         private final ComponentMetaDataResolver metaDataResolver;
-        private final Set<ConfigurationNode> queued = new HashSet<ConfigurationNode>();
+        private final Set<ConfigurationNode> queued = Sets.newHashSet();
         private final LinkedList<ConfigurationNode> queue = new LinkedList<ConfigurationNode>();
         private final AttributesSchemaInternal attributesSchema;
         private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
@@ -400,7 +541,7 @@ public class DependencyGraphBuilder {
             root.moduleRevision.module.select(root.moduleRevision);
         }
 
-        public ModuleResolveState getModule(ModuleIdentifier id) {
+        public synchronized ModuleResolveState getModule(ModuleIdentifier id) {
             ModuleResolveState module = modules.get(id);
             if (module == null) {
                 module = new ModuleResolveState(idGenerator, id, this, metaDataResolver);
@@ -495,7 +636,7 @@ public class DependencyGraphBuilder {
         final Map<ModuleVersionIdentifier, ModuleVersionResolveState> versions = new LinkedHashMap<ModuleVersionIdentifier, ModuleVersionResolveState>();
         final Set<ModuleVersionSelectorResolveState> selectors = new HashSet<ModuleVersionSelectorResolveState>();
         final ResolveState resolveState;
-        ModuleVersionResolveState selected;
+        volatile ModuleVersionResolveState selected;
 
         private ModuleResolveState(IdGenerator<Long> idGenerator, ModuleIdentifier id, ResolveState resolveState, ComponentMetaDataResolver metaDataResolver) {
             this.idGenerator = idGenerator;
@@ -519,7 +660,7 @@ public class DependencyGraphBuilder {
             return versions.values();
         }
 
-        public void select(ModuleVersionResolveState selected) {
+        public synchronized void select(ModuleVersionResolveState selected) {
             assert this.selected == null;
             this.selected = selected;
             for (ModuleVersionResolveState version : versions.values()) {
@@ -528,7 +669,7 @@ public class DependencyGraphBuilder {
             selected.state = ModuleState.Selected;
         }
 
-        public ModuleVersionResolveState clearSelection() {
+        public synchronized ModuleVersionResolveState clearSelection() {
             ModuleVersionResolveState previousSelection = selected;
             selected = null;
             for (ModuleVersionResolveState version : versions.values()) {
@@ -537,7 +678,7 @@ public class DependencyGraphBuilder {
             return previousSelection;
         }
 
-        public void restart(ModuleVersionResolveState selected) {
+        public synchronized void restart(ModuleVersionResolveState selected) {
             select(selected);
             for (ModuleVersionResolveState version : versions.values()) {
                 version.restart(selected);
@@ -560,17 +701,20 @@ public class DependencyGraphBuilder {
         }
 
         public ModuleVersionResolveState getVersion(ModuleVersionIdentifier id) {
-            ModuleVersionResolveState moduleRevision = versions.get(id);
-            if (moduleRevision == null) {
-                moduleRevision = new ModuleVersionResolveState(idGenerator.generateId(), this, id, metaDataResolver);
-                versions.put(id, moduleRevision);
+            synchronized (versions) {
+                ModuleVersionResolveState moduleRevision = versions.get(id);
+                if (moduleRevision == null) {
+                    moduleRevision = new ModuleVersionResolveState(idGenerator.generateId(), this, id, metaDataResolver);
+                    versions.put(id, moduleRevision);
+                }
+                return moduleRevision;
             }
-
-            return moduleRevision;
         }
 
         public void addSelector(ModuleVersionSelectorResolveState selector) {
-            selectors.add(selector);
+            synchronized (selectors) {
+                selectors.add(selector);
+            }
         }
     }
 
@@ -789,7 +933,8 @@ public class DependencyGraphBuilder {
                 return;
             }
 
-            List<DependencyEdge> transitiveIncoming = new ArrayList<DependencyEdge>();
+            boolean hasIncomingEdges = !incomingEdges.isEmpty();
+            List<DependencyEdge> transitiveIncoming = hasIncomingEdges ? new ArrayList<DependencyEdge>() : Collections.<DependencyEdge>emptyList();
             for (DependencyEdge edge : incomingEdges) {
                 if (edge.isTransitive()) {
                     transitiveIncoming.add(edge);
@@ -800,10 +945,10 @@ public class DependencyGraphBuilder {
                 if (previousTraversalExclusions != null) {
                     removeOutgoingEdges();
                 }
-                if (incomingEdges.isEmpty()) {
-                    LOGGER.debug("{} has no incoming edges. ignoring.", this);
-                } else {
+                if (hasIncomingEdges) {
                     LOGGER.debug("{} has no transitive incoming edges. ignoring outgoing edges.", this);
+                } else {
+                    LOGGER.debug("{} has no incoming edges. ignoring.", this);
                 }
                 return;
             }
@@ -1018,6 +1163,39 @@ public class DependencyGraphBuilder {
                 }
             }
             return null;
+        }
+    }
+
+    private class ResolveDependencyEdgeOperation implements RunnableBuildOperation {
+        private final ProducerGuard<ConcurrentDependencyEdgeResolutionLock> guard;
+        private final DependencyEdge dependency;
+        private final ResolveState resolveState;
+
+        public ResolveDependencyEdgeOperation(ProducerGuard<ConcurrentDependencyEdgeResolutionLock> guard, DependencyEdge dependency, ResolveState resolveState) {
+            this.guard = guard;
+            this.dependency = dependency;
+            this.resolveState = resolveState;
+        }
+
+        @Override
+        public void run(BuildOperationContext context) {
+            guard.guardByKey(dependency.lock, new Factory<Void>() {
+                @Override
+                public Void create() {
+                    // Resolve dependency to a particular revision
+                    ModuleVersionResolveState moduleRevision = dependency.targetModuleRevision;
+                    performSelection(resolveState, moduleRevision);
+                    // forcefully resolve metadata, so that it happens pre-emptively and concurrently
+                    // (this may trigger the download of metadata files, so do it concurrently if possible)
+                    moduleRevision.getMetaData();
+                    return null;
+                }
+            });
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            return BuildOperationDescriptor.displayName("Resolving " + dependency);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -440,6 +440,11 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
 
         }
+
+        @Override
+        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return false;
+        }
     }
 
     protected abstract class RemoteRepositoryAccess extends AbstractRepositoryAccess {
@@ -486,6 +491,13 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
             ExternalResourceResolver.this.resolveArtifact(artifact, moduleSource, result);
         }
+
+
+        @Override
+        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return false;
+        }
+
     }
 
     private static String generateId(ExternalResourceResolver resolver) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -508,10 +508,6 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         @Override
         public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
             if (ExternalResourceResolver.this.local) {
-                ModuleComponentArtifactMetadata artifact = getMetaDataArtifactFor(moduleComponentIdentifier);
-                if (createArtifactResolver().artifactExists(artifact, NoOpResourceAwareResolveResult.INSTANCE)) {
-                    return MetadataFetchingCost.FAST;
-                }
                 return MetadataFetchingCost.CHEAP;
             }
             return MetadataFetchingCost.EXPENSIVE;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -508,6 +508,10 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         @Override
         public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
             if (ExternalResourceResolver.this.local) {
+                ModuleComponentArtifactMetadata artifact = getMetaDataArtifactFor(moduleComponentIdentifier);
+                if (createArtifactResolver().artifactExists(artifact, NoOpResourceAwareResolveResult.INSTANCE)) {
+                    return MetadataFetchingCost.FAST;
+                }
                 return MetadataFetchingCost.CHEAP;
             }
             return MetadataFetchingCost.EXPENSIVE;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -454,8 +454,8 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         }
 
         @Override
-        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return false;
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return MetadataFetchingCost.CHEAP;
         }
     }
 
@@ -506,9 +506,15 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
 
 
         @Override
-        public boolean isMetadataAvailableLocally(ModuleComponentIdentifier moduleComponentIdentifier) {
-            ModuleComponentArtifactMetadata artifact = getMetaDataArtifactFor(moduleComponentIdentifier);
-            return createArtifactResolver().artifactExists(artifact, NoOpResourceAwareResolveResult.INSTANCE);
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            if (ExternalResourceResolver.this.local) {
+                ModuleComponentArtifactMetadata artifact = getMetaDataArtifactFor(moduleComponentIdentifier);
+                if (createArtifactResolver().artifactExists(artifact, NoOpResourceAwareResolveResult.INSTANCE)) {
+                    return MetadataFetchingCost.FAST;
+                }
+                return MetadataFetchingCost.CHEAP;
+            }
+            return MetadataFetchingCost.EXPENSIVE;
         }
 
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
@@ -54,6 +54,8 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final Factory<ComponentMetadataSupplier> componentMetadataSupplierFactory;
     private boolean m2Compatible;
+    private final IvyLocalRepositoryAccess localRepositoryAccess;
+    private final IvyRemoteRepositoryAccess remoteRepositoryAccess;
 
     public IvyResolver(String name, RepositoryTransport transport,
                        LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
@@ -64,6 +66,8 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
         this.metaDataParser = new IvyContextualMetaDataParser<MutableIvyModuleResolveMetadata>(ivyContextManager, new DownloadedIvyModuleDescriptorParser(new IvyModuleDescriptorConverter(moduleIdentifierFactory), moduleIdentifierFactory));
         this.dynamicResolve = dynamicResolve;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
+        this.localRepositoryAccess = new IvyLocalRepositoryAccess();
+        this.remoteRepositoryAccess = new IvyRemoteRepositoryAccess();
     }
 
     @Override
@@ -112,11 +116,11 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
     }
 
     public ModuleComponentRepositoryAccess getLocalAccess() {
-        return new IvyLocalRepositoryAccess();
+        return localRepositoryAccess;
     }
 
     public ModuleComponentRepositoryAccess getRemoteAccess() {
-        return new IvyRemoteRepositoryAccess();
+        return remoteRepositoryAccess;
     }
 
     public ComponentMetadataSupplier createMetadataSupplier() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -65,6 +65,8 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
 
     private static final Pattern UNIQUE_SNAPSHOT = Pattern.compile("(?:.+)-(\\d{8}\\.\\d{6}-\\d+)");
+    private final MavenLocalRepositoryAccess localAccess = new MavenLocalRepositoryAccess();
+    private final MavenRemoteRepositoryAccess remoteAccess = new MavenRemoteRepositoryAccess();
 
     public MavenResolver(String name, URI rootUri, RepositoryTransport transport,
                          LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
@@ -206,11 +208,11 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
     }
 
     public ModuleComponentRepositoryAccess getLocalAccess() {
-        return new MavenLocalRepositoryAccess();
+        return localAccess;
     }
 
     public ModuleComponentRepositoryAccess getRemoteAccess() {
-        return new MavenRemoteRepositoryAccess();
+        return remoteAccess;
     }
 
     public ComponentMetadataSupplier createMetadataSupplier() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MetadataFetchingCost.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MetadataFetchingCost.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+public enum MetadataFetchingCost {
+    /**
+     * Can return metadata immediately. It must <b>not</b> be used in case the metadata is missing,
+     * even if it's cheap to tell it's missing. Use {@link #CHEAP} in that case.
+     */
+    FAST,
+    /**
+     * Can return metadata in a cheap way, or tell that it's missing in a cheap way. The difference with
+     * {@link #FAST} is that we can use it for missing metadata.
+     */
+    CHEAP,
+    /**
+     * Cannot return metadata without an expensive call, typically involving parsing a descriptor
+     * or accessing the network
+     */
+    EXPENSIVE;
+
+    public boolean isFast() {
+        return this == FAST;
+    }
+
+    public boolean isExpensive() {
+        return this == EXPENSIVE;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ComponentMetaDataResolver.java
@@ -25,4 +25,6 @@ public interface ComponentMetaDataResolver {
      * Resolves the meta-data for a component instance. Failures should be attached to the returned result.
      */
     void resolve(ComponentIdentifier identifier, ComponentOverrideMetadata componentOverrideMetadata, BuildableComponentResolveResult result);
+
+    boolean isAvailableLocally(ComponentIdentifier identifier);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ComponentMetaDataResolver.java
@@ -26,5 +26,5 @@ public interface ComponentMetaDataResolver {
      */
     void resolve(ComponentIdentifier identifier, ComponentOverrideMetadata componentOverrideMetadata, BuildableComponentResolveResult result);
 
-    boolean isAvailableLocally(ComponentIdentifier identifier);
+    boolean isFetchingMetadataCheap(ComponentIdentifier identifier);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepositoryTest.groovy
@@ -118,6 +118,7 @@ class InMemoryCachedModuleComponentRepositoryTest extends Specification {
         1 * localDelegate.resolveComponentMetaData(lib, componentRequestMetaData, metaDataResult)
         1 * localMetaDataCache.newDependencyResult(lib, metaDataResult)
         1 * metaDataResult.getState()
+        1 * localMetaDataCache.cacheFetchingCost(lib, _)
         0 * _
     }
 
@@ -139,6 +140,7 @@ class InMemoryCachedModuleComponentRepositoryTest extends Specification {
         1 * remoteDelegate.resolveComponentMetaData(lib, componentRequestMetaData, metaDataResult)
         1 * remoteMetaDataCache.newDependencyResult(lib, metaDataResult)
         1 * metaDataResult.getState()
+        1 * remoteMetaDataCache.cacheFetchingCost(lib, _)
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/memcache/InMemoryCachedModuleComponentRepositoryTest.groovy
@@ -117,6 +117,7 @@ class InMemoryCachedModuleComponentRepositoryTest extends Specification {
         1 * localMetaDataCache.supplyMetaData(lib, metaDataResult) >> false
         1 * localDelegate.resolveComponentMetaData(lib, componentRequestMetaData, metaDataResult)
         1 * localMetaDataCache.newDependencyResult(lib, metaDataResult)
+        1 * metaDataResult.getState()
         0 * _
     }
 
@@ -137,6 +138,7 @@ class InMemoryCachedModuleComponentRepositoryTest extends Specification {
         1 * remoteMetaDataCache.supplyMetaData(lib, metaDataResult) >> false
         1 * remoteDelegate.resolveComponentMetaData(lib, componentRequestMetaData, metaDataResult)
         1 * remoteMetaDataCache.newDependencyResult(lib, metaDataResult)
+        1 * metaDataResult.getState()
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -47,7 +47,7 @@ import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.component.model.IvyArtifactName
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
-import org.gradle.internal.operations.BuildOperationProcessor
+import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationQueue
 import org.gradle.internal.resolve.ModuleVersionNotFoundException
 import org.gradle.internal.resolve.ModuleVersionResolveException
@@ -80,13 +80,13 @@ class DependencyGraphBuilderTest extends Specification {
         }
     }
     def moduleExclusions = new ModuleExclusions(moduleIdentifierFactory)
-    def buildOperationProcessor = Mock(BuildOperationProcessor) {
+    def buildOperationProcessor = Mock(BuildOperationExecutor) {
         def queue = Mock(BuildOperationQueue) {
             add(_) >> { args ->
                 args[0].run()
             }
         }
-        run(_) >> { args ->
+        runAll(_) >> { args ->
             args[0].execute(queue)
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -132,7 +132,7 @@ class DependencyGraphBuilderTest extends Specification {
         def c = revision('c') //transitive of evicted a
         def d = revision('d')
 
-        traverses root, a
+        doesNotTraverse root, a
         traverses root, b
         doesNotResolve a, c
         traverses b, d
@@ -373,7 +373,7 @@ class DependencyGraphBuilderTest extends Specification {
         def c = revision('c')
         traverses root, selected
         traverses selected, b
-        traverses root, evicted // this is traversed because of concurrent edge resolution, but will not appear in final result
+        doesNotTraverse root, evicted
         doesNotResolve evicted, c
 
         when:
@@ -399,7 +399,7 @@ class DependencyGraphBuilderTest extends Specification {
         def b = revision('b')
         def c = revision('c')
         def d = revision('d')
-        traverses root, evicted  // this is traversed because of concurrent edge resolution, but will not appear in final result
+        doesNotTraverse root, evicted
         doesNotResolve evicted, d
         traverses root, selected
         traverses selected, c
@@ -430,10 +430,10 @@ class DependencyGraphBuilderTest extends Specification {
         def selectedB = revision('b', '2.2')
         def evictedB = revision('b', '2.1')
         def c = revision('c')
-        traverses root, evictedA1  // this is traversed because of concurrent edge resolution, but will not appear in final result
+        doesNotTraverse root, evictedA1
         traverses root, selectedA
         traverses selectedA, c
-        traverses root, evictedB  // this is traversed because of concurrent edge resolution, but will not appear in final result
+        doesNotTraverse root, evictedB
         traverses root, selectedB
         doesNotTraverse selectedB, evictedA2
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
@@ -65,7 +65,7 @@ class AbstractCrossVersionPerformanceTest extends Specification {
         performanceTestIdProvider.testSpec = runner
     }
 
-    def getRunner() {
+    CrossVersionPerformanceTestRunner getRunner() {
         runner
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/WithExternalRepository.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/WithExternalRepository.groovy
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-package org.gradle.performance.fixture
+package org.gradle.performance
 
 import groovy.transform.CompileStatic
 import groovy.transform.SelfType
 import org.apache.mina.util.AvailablePortFinder
-import org.gradle.performance.AbstractCrossVersionPerformanceTest
+import org.gradle.performance.fixture.TestProjectLocator
 import org.mortbay.jetty.Server
 import org.mortbay.jetty.servlet.Context
 import org.mortbay.jetty.webapp.WebAppContext
 import org.mortbay.resource.Resource
-
 
 @CompileStatic
 @SelfType(AbstractCrossVersionPerformanceTest)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BuildExperimentInvocationInfo.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BuildExperimentInvocationInfo.java
@@ -28,4 +28,8 @@ public interface BuildExperimentInvocationInfo {
     int getIterationNumber();
 
     int getIterationMax();
+
+    File getGradleUserHome();
+
+    File getBuildLog();
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/DefaultBuildExperimentInvocationInfo.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/DefaultBuildExperimentInvocationInfo.java
@@ -56,4 +56,14 @@ public class DefaultBuildExperimentInvocationInfo implements BuildExperimentInvo
     public int getIterationMax() {
         return iterationMax;
     }
+
+    @Override
+    public File getGradleUserHome() {
+        return new File(projectDir, "gradle-user-home");
+    }
+
+    @Override
+    public File getBuildLog() {
+        return new File(projectDir, "log.txt");
+    }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/ForkingGradleSession.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/ForkingGradleSession.groovy
@@ -74,7 +74,7 @@ class ForkingGradleSession implements GradleSession {
             args << "cmd.exe" << "/C"
         }
         args << new File(invocation.gradleDistribution.gradleHomeDir, "bin/gradle").absolutePath
-        args << "--gradle-user-home" << new File(invocationInfo.projectDir, "gradle-user-home").absolutePath
+        args << "--gradle-user-home" << invocationInfo.gradleUserHome.absolutePath
         args << "--no-search-upward"
         args << "--stacktrace"
         if (invocation.useDaemon) {
@@ -92,21 +92,17 @@ class ForkingGradleSession implements GradleSession {
 
         def exitCode = run.start().waitFor()
         if (exitCode != 0 && !invocation.expectFailure) {
-            throw new IllegalStateException("Build failed, see ${getBuildLog(invocationInfo)} for details")
+            throw new IllegalStateException("Build failed, see ${invocationInfo.buildLog} for details")
         }
     }
 
-    private ProcessBuilder newProcessBuilder(BuildExperimentInvocationInfo invocationInfo, List<String> args, Map<String, String> env) {
+    private static ProcessBuilder newProcessBuilder(BuildExperimentInvocationInfo invocationInfo, List<String> args, Map<String, String> env) {
         def builder = new ProcessBuilder()
             .directory(invocationInfo.projectDir)
-            .redirectOutput(Redirect.appendTo(getBuildLog(invocationInfo)))
-            .redirectError(Redirect.appendTo(getBuildLog(invocationInfo)))
+            .redirectOutput(Redirect.appendTo(invocationInfo.buildLog))
+            .redirectError(Redirect.appendTo(invocationInfo.buildLog))
             .command(args)
         builder.environment().putAll(env)
         builder
-    }
-
-    private File getBuildLog(BuildExperimentInvocationInfo invocationInfo) {
-        new File(invocationInfo.projectDir, "log.txt")
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/WithExternalRepository.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/WithExternalRepository.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.fixture
+
+import groovy.transform.CompileStatic
+import groovy.transform.SelfType
+import org.apache.mina.util.AvailablePortFinder
+import org.gradle.performance.AbstractCrossVersionPerformanceTest
+import org.mortbay.jetty.Server
+import org.mortbay.jetty.servlet.Context
+import org.mortbay.jetty.webapp.WebAppContext
+import org.mortbay.resource.Resource
+
+
+@CompileStatic
+@SelfType(AbstractCrossVersionPerformanceTest)
+trait WithExternalRepository {
+    Server server
+    int serverPort
+
+    File getRepoDir() {
+        new File(new TestProjectLocator().findProjectDir(runner.testProject), 'repository')
+    }
+
+    Context createContext() {
+        def context = new WebAppContext()
+        context.setContextPath("/")
+        context.setBaseResource(Resource.newResource(repoDir.getAbsolutePath()))
+        context
+    }
+
+    void startServer() {
+        try {
+            serverPort = AvailablePortFinder.getNextAvailable(5000)
+            server = new Server(serverPort)
+            Context context = createContext()
+            context.setContextPath("/")
+            context.setBaseResource(Resource.newResource(repoDir.getAbsolutePath()))
+            server.addHandler(context)
+            server.start()
+        } catch (IllegalArgumentException ex) {
+            server = null // repository not found, probably running on coordinator. If not, error will be caught later
+        }
+    }
+
+    void stopServer() {
+        server?.stop()
+    }
+}

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
@@ -18,6 +18,7 @@ package org.gradle.internal.serialize;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.HashCode;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -36,6 +37,7 @@ public class BaseSerializerFactory {
     public static final Serializer<byte[]> BYTE_ARRAY_SERIALIZER = new ByteArraySerializer();
     public static final Serializer<Map<String, String>> NO_NULL_STRING_MAP_SERIALIZER = new StringMapSerializer();
     public static final Serializer<Throwable> THROWABLE_SERIALIZER = new ThrowableSerializer();
+    public static final Serializer<HashCode> HASHCODE_SERIALIZER = new HashCodeSerializer();
 
     public <T> Serializer<T> getSerializerFor(Class<T> type) {
         if (type.equals(String.class)) {
@@ -58,6 +60,9 @@ public class BaseSerializerFactory {
         }
         if (Throwable.class.isAssignableFrom(type)) {
             return (Serializer<T>) THROWABLE_SERIALIZER;
+        }
+        if (HashCode.class.isAssignableFrom(type)) {
+            return (Serializer<T>) HASHCODE_SERIALIZER;
         }
         return new DefaultSerializer<T>(type.getClassLoader());
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -32,4 +32,18 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
         then:
         result.assertCurrentVersionHasNotRegressed()
     }
+
+    def "merge exclude rules (parallel)"() {
+        given:
+        runner.testProject = "excludeRuleMergingBuild"
+        runner.tasksToRun = ['resolveDependencies']
+        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.args = ["--parallel"]
+        runner.targetVersions = ["3.5"]
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+    }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -63,7 +63,7 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
         runner.testProject = TEST_PROJECT_NAME
         runner.tasksToRun = ['resolveDependencies']
         runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
-        runner.args = ['-PuseHttp', "-PhttpPort=${server.port}", "--parallel"]
+        runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}", "--parallel"]
         runner.targetVersions = ["4.0-20170419000017+0000"]
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.performance.regression.corefeature
 
 import org.apache.mina.util.AvailablePortFinder
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
+import org.gradle.performance.fixture.TestProjectLocator
 import org.mortbay.jetty.Server
 import org.mortbay.jetty.webapp.WebAppContext
 import org.mortbay.resource.Resource
@@ -34,7 +35,7 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
         server = new Server(serverPort)
         WebAppContext context = new WebAppContext()
         context.setContextPath("/")
-        context.setBaseResource(Resource.newResource(new File(runner.testProjectLocator.findProjectDir('excludeRuleMergingBuild'), 'repository').getAbsolutePath()))
+        context.setBaseResource(Resource.newResource(new File(new TestProjectLocator().findProjectDir(TEST_PROJECT_NAME), 'repository').getAbsolutePath()))
         server.addHandler(context)
         server.start()
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -31,8 +31,8 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
     int serverPort
 
     private void startServer() {
-        def repoDir = new File(new TestProjectLocator().findProjectDir(TEST_PROJECT_NAME), 'repository')
-        if (repoDir.exists()) {
+        try {
+            def repoDir = new File(new TestProjectLocator().findProjectDir(TEST_PROJECT_NAME), 'repository')
             serverPort = AvailablePortFinder.getNextAvailable(5000)
             server = new Server(serverPort)
             WebAppContext context = new WebAppContext()
@@ -40,6 +40,8 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
             context.setBaseResource(Resource.newResource(repoDir.getAbsolutePath()))
             server.addHandler(context)
             server.start()
+        } catch (IllegalArgumentException ex) {
+            server = null // repository not found, probably running on coordinator. If not, error will be caught later
         }
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.performance.regression.corefeature
 
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
-import org.gradle.performance.fixture.WithExternalRepository
+import org.gradle.performance.WithExternalRepository
 
 class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -16,44 +16,18 @@
 
 package org.gradle.performance.regression.corefeature
 
-import org.apache.mina.util.AvailablePortFinder
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
-import org.gradle.performance.fixture.TestProjectLocator
-import org.mortbay.jetty.Server
-import org.mortbay.jetty.webapp.WebAppContext
-import org.mortbay.resource.Resource
+import org.gradle.performance.fixture.WithExternalRepository
 
-class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceTest {
+class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
 
     private final static TEST_PROJECT_NAME = 'excludeRuleMergingBuild'
 
-    Server server
-    int serverPort
-
-    private void startServer() {
-        try {
-            def repoDir = new File(new TestProjectLocator().findProjectDir(TEST_PROJECT_NAME), 'repository')
-            serverPort = AvailablePortFinder.getNextAvailable(5000)
-            server = new Server(serverPort)
-            WebAppContext context = new WebAppContext()
-            context.setContextPath("/")
-            context.setBaseResource(Resource.newResource(repoDir.getAbsolutePath()))
-            server.addHandler(context)
-            server.start()
-        } catch (IllegalArgumentException ex) {
-            server = null // repository not found, probably running on coordinator. If not, error will be caught later
-        }
-    }
-
-    private void stopServer() {
-        server?.stop()
-    }
-
     def "merge exclude rules"() {
+        runner.testProject = TEST_PROJECT_NAME
         startServer()
 
         given:
-        runner.testProject = TEST_PROJECT_NAME
         runner.tasksToRun = ['resolveDependencies']
         runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
         runner.targetVersions = ["4.0-20170419000017+0000"]
@@ -70,10 +44,10 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
     }
 
     def "merge exclude rules (parallel)"() {
+        runner.testProject = TEST_PROJECT_NAME
         startServer()
 
         given:
-        runner.testProject = TEST_PROJECT_NAME
         runner.tasksToRun = ['resolveDependencies']
         runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
         runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}", "--parallel"]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.regression.corefeature
+
+import org.gradle.performance.AbstractCrossVersionPerformanceTest
+import org.gradle.performance.fixture.BuildExperimentInvocationInfo
+import org.gradle.performance.fixture.BuildExperimentListener
+import org.gradle.performance.fixture.BuildExperimentListenerAdapter
+import org.gradle.performance.fixture.WithExternalRepository
+import org.gradle.performance.measure.MeasuredOperation
+import org.mortbay.jetty.Handler
+import org.mortbay.jetty.servlet.Context
+import org.mortbay.jetty.webapp.WebAppContext
+
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import java.util.concurrent.atomic.AtomicInteger
+
+class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
+    private final static String TEST_PROJECT_NAME = 'springBootApp'
+
+    File _repoDir = temporaryFolder.createDir('repository')
+
+    @Override
+    File getRepoDir() {
+        _repoDir
+    }
+
+    def setup() {
+        runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {
+            @Override
+            void afterInvocation(BuildExperimentInvocationInfo invocationInfo, MeasuredOperation operation, BuildExperimentListener.MeasurementCallback measurementCallback) {
+                cleanupCache(invocationInfo.gradleUserHome)
+                println invocationInfo.buildLog
+            }
+
+            private void cleanupCache(File userHomeDir) {
+                ['modules-2/metadata-2.23/descriptors', 'modules-2/files-2.1', 'external-resources'].each {
+                    new File("$userHomeDir/caches/$it").deleteDir()
+                }
+            }
+        })
+    }
+
+    def "resolves dependencies"() {
+        runner.testProject = TEST_PROJECT_NAME
+        startServer()
+
+        given:
+        runner.tasksToRun = ['resolveDependencies']
+        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.targetVersions = ["4.0-20170427092838+0000"]
+        runner.args = ['-I', 'init.gradle', "-PmirrorPath=${repoDir.absolutePath}", "-PmavenRepoURL=http://localhost:${serverPort}/"]
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        cleanup:
+        stopServer()
+    }
+
+    def "resolves dependencies (parallel)"() {
+        runner.testProject = TEST_PROJECT_NAME
+        startServer()
+
+        given:
+        runner.tasksToRun = ['resolveDependencies']
+        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.targetVersions = ["4.0-20170427092838+0000"]
+        runner.args = ['-I', 'init.gradle', "-PmirrorPath=${repoDir.absolutePath}", "-PmavenRepoURL=http://localhost:${serverPort}/", '--parallel']
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        cleanup:
+        stopServer()
+    }
+
+
+    @Override
+    Context createContext() {
+        def context = new WebAppContext()
+        context.addFilter(SimulatedDownloadLatencyFilter, '/*', Handler.DEFAULT)
+        context
+    }
+
+    static class SimulatedDownloadLatencyFilter implements Filter {
+        // don't put those numbers too high, or the test is going to be really slow for each iteration!
+        private final static int[] DELAYS = [2, 3, 5, 8, 13, 21, 34, 55]
+
+        private final static boolean LOG = false
+        private final static Map<String, Integer> FACTORS = [
+            'jar': 10,
+            'xml': 3,
+            'pom': 3
+        ].withDefault { 1 }
+
+        private final AtomicInteger concurrency = new AtomicInteger()
+
+        @Override
+        void init(FilterConfig filterConfig) throws ServletException {
+
+        }
+
+        @Override
+        void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+            HttpServletRequest httpRequest = (HttpServletRequest) request
+            def path = httpRequest.servletPath
+            // compute a digest based on the path, allowing us to use the same latency for the same request each time
+            int sig = DELAYS[path.bytes.sum() % DELAYS.length]
+            def ext = path.contains('.') ? path.substring(1 + path.lastIndexOf('.')) : ''
+            int latency = sig * FACTORS[ext]
+            def file = path.substring(path.lastIndexOf('/'))
+            if (LOG) {
+                println "File ${file} : ${latency}ms - concurrent requests: ${concurrency.incrementAndGet()}"
+            }
+            if (latency) {
+                sleep latency
+            }
+            concurrency.decrementAndGet()
+            chain.doFilter(request, response)
+        }
+
+        @Override
+        void destroy() {
+
+        }
+    }
+
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
 import org.gradle.performance.fixture.BuildExperimentListener
 import org.gradle.performance.fixture.BuildExperimentListenerAdapter
-import org.gradle.performance.fixture.WithExternalRepository
+import org.gradle.performance.WithExternalRepository
 import org.gradle.performance.measure.MeasuredOperation
 import org.mortbay.jetty.Handler
 import org.mortbay.jetty.servlet.Context
@@ -38,11 +38,11 @@ import java.util.concurrent.atomic.AtomicInteger
 class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
     private final static String TEST_PROJECT_NAME = 'springBootApp'
 
-    File _repoDir = temporaryFolder.createDir('repository')
+    File tmpRepoDir = temporaryFolder.createDir('repository')
 
     @Override
     File getRepoDir() {
-        _repoDir
+        tmpRepoDir
     }
 
     def setup() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -61,7 +61,7 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
         })
     }
 
-    def "resolves dependencies"() {
+    def "resolves dependencies from external repository"() {
         runner.testProject = TEST_PROJECT_NAME
         startServer()
 
@@ -81,7 +81,7 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
         stopServer()
     }
 
-    def "resolves dependencies (parallel)"() {
+    def "resolves dependencies from external repository (parallel)"() {
         runner.testProject = TEST_PROJECT_NAME
         startServer()
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -46,11 +46,12 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
     }
 
     def setup() {
+        runner.warmUpRuns = 5
+        runner.runs = 15
         runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {
             @Override
             void afterInvocation(BuildExperimentInvocationInfo invocationInfo, MeasuredOperation operation, BuildExperimentListener.MeasurementCallback measurementCallback) {
                 cleanupCache(invocationInfo.gradleUserHome)
-                println invocationInfo.buildLog
             }
 
             private void cleanupCache(File userHomeDir) {

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -250,6 +250,12 @@ task excludeRuleMergingBuild(type: RemoteProject) {
     subdirectory = 'exclude-merging'
 }
 
+task springBootApp(type: RemoteProject) {
+    remoteUri = 'https://github.com/gradle/performance-comparisons.git'
+    branch = 'master'
+    subdirectory = 'parallel-downloads'
+}
+
 task largeNativeBuild(type: RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-native-large'
     branch = 'master'

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
@@ -152,6 +152,11 @@ public class LocalLibraryDependencyResolver implements DependencyToComponentIdRe
         }
     }
 
+    @Override
+    public boolean isAvailableLocally(ComponentIdentifier identifier) {
+        return true;
+    }
+
     private boolean isLibrary(ComponentIdentifier identifier) {
         return identifier instanceof LibraryBinaryIdentifier;
     }

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
@@ -153,7 +153,7 @@ public class LocalLibraryDependencyResolver implements DependencyToComponentIdRe
     }
 
     @Override
-    public boolean isAvailableLocally(ComponentIdentifier identifier) {
+    public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
         return true;
     }
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r40/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r40/BuildProgressCrossVersionSpec.groovy
@@ -191,11 +191,11 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
 
         applyBuildScript.child("Resolve dependencies of :compile").with {
             it.child "Configure project :a"
-            it.child "Download http://localhost:${server.port}${projectB.pomPath}"
-            it.child "Download http://localhost:${server.port}/repo/group/projectC/maven-metadata.xml"
-            it.child "Download http://localhost:${server.port}${projectC.pomPath}"
-            it.child "Download http://localhost:${server.port}${projectD.metaDataPath}"
-            it.child "Download http://localhost:${server.port}${projectD.pomPath}"
+            it.descendant "Download http://localhost:${server.port}${projectB.pomPath}"
+            it.descendant "Download http://localhost:${server.port}/repo/group/projectC/maven-metadata.xml"
+            it.descendant "Download http://localhost:${server.port}${projectC.pomPath}"
+            it.descendant "Download http://localhost:${server.port}${projectD.metaDataPath}"
+            it.descendant "Download http://localhost:${server.port}${projectD.pomPath}"
         }
 
         resolveArtifacts.child("Resolve artifact a.jar (project :a)").children.isEmpty()

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
@@ -81,7 +81,9 @@ class ProgressEvents implements ProgressListener {
                             || descriptor.displayName.startsWith('Configure project ')
                             || descriptor.displayName.startsWith('Cross-configure project ')
                             || descriptor.displayName.startsWith('Resolve artifacts')
-                            || descriptor.displayName.startsWith('Executing ')) {
+                            || descriptor.displayName.startsWith('Executing ')
+                            || descriptor.displayName.startsWith('Resolving ')
+                        ) {
                             // Ignore this for now
                         } else {
                             def duplicateName = operations.find({


### PR DESCRIPTION
This pull request follows the spirit of parallel download of artifacts, but instead enables parallel download of _metadata_. By that, we mean that when a _configuration_ is resolved, the graph is built sequentially, as before, but during its creation, some steps may be done in parallel.

The current implementation limits the scope of what can be done in parallel to downloading the dependencies of a single edge in parallel. In other words, imagine that we have the following dependency graph:

- the root, `A` depends on `B` and `C`.
- then `B` depends on `D`, and `C` depends on `E` and `F`

Then, since we don't have the metadata for `A` available, we don't know pre-emptively which nodes are going to appear, so the graph is built this way:

- `A` is added. 
- `B` and `C` are added to the queue, then metadata for `B` and `C` is downloaded concurrently. 
- `B` is popped off the queue, processed and `D` is a single node so added to the queue and its metadata is downloaded serially. 
- `C` is popped off the queue. which triggers addition of `E` and `F` to the queue and the downloading of metadata of `E` and `F`.
- `D`, `E` and `F` are popped, but don't have any dependency.

It means that the speedup of parallel metadata download largely depends on the shape of the graph. Best performance boost will be seen when a node in the graph has a lot of dependencies for which we don't have the metadata available locally.

In a performance test using a sample Spring Boot app, we measure between 3 and 18% speedup, corresponding to the "first use" case, that is to say often seen when someone checks out a project and builds it, but doesn't have the dependencies locally. However, for other projects, there might not be any visible change, or little speedup. This is mostly going to affect "clean" repositories or when dependencies are added.

It's worth noting that an initial implementation performed _resolution of the graph_ concurrently. This pull request _includes_ the commits which lead to this implementation, so that it is possible to re-implement later. However, to make it efficient, we need to rework our internal work parallelism infrastructure (we need to implement cheaper locking).

