### PR TITLE
Make task execution plan faster

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -558,6 +558,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
 
                         selected.set(taskInfo);
                         iterator.remove();
+                        taskInfo.setProjectLock(projectLock);
                         if (taskInfo.allDependenciesSuccessful()) {
                             taskInfo.startExecution();
                             recordTaskStarted(taskInfo);
@@ -585,7 +586,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
                 taskExecution.execute(selectedTask);
             }
         } finally {
-            coordinationService.withStateLock(unlock(workerLease, getProjectLock(selectedTask)));
+            coordinationService.withStateLock(unlock(workerLease, selectedTask.getProjectLock()));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -19,8 +19,19 @@ package org.gradle.execution.taskgraph;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.StandardSystemProperty;
-import com.google.common.collect.*;
-import org.gradle.api.*;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.gradle.api.Action;
+import org.gradle.api.BuildCancelledException;
+import org.gradle.api.CircularReferenceException;
+import org.gradle.api.Nullable;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.Transformer;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -42,16 +53,31 @@ import org.gradle.internal.graph.GraphNodeRenderer;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
+import org.gradle.internal.resources.ResourceLockState;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.internal.work.WorkerLeaseService;
-import org.gradle.internal.resources.ResourceLockState;
 import org.gradle.util.CollectionUtils;
 import org.gradle.util.TextUtil;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -70,6 +96,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     private final TaskDependencyGraph graph = new TaskDependencyGraph();
     private final LinkedHashMap<Task, TaskInfo> executionPlan = new LinkedHashMap<Task, TaskInfo>();
     private final List<TaskInfo> executionQueue = new LinkedList<TaskInfo>();
+    private final Set<ResourceLock> projectLocks = Sets.newHashSet();
     private final List<Throwable> failures = new ArrayList<Throwable>();
     private Spec<? super Task> filter = Specs.satisfyAll();
 
@@ -292,6 +319,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
                 visitingNodes.remove(taskNode, currentSegment);
                 path.pop();
                 executionPlan.put(taskNode.getTask(), taskNode);
+                projectLocks.add(getProjectLock(taskNode));
                 // Add any finalizers to the queue
                 ArrayList<TaskInfo> finalizerTasks = new ArrayList<TaskInfo>();
                 addAllReversed(finalizerTasks, taskNode.getFinalizers());
@@ -304,6 +332,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
         }
         executionQueue.clear();
         executionQueue.addAll(executionPlan.values());
+
     }
 
     private void maybeRemoveProcessedShouldRunAfterEdge(Stack<GraphEdge> walkedShouldRunAfterEdges, TaskInfo taskNode) {
@@ -448,6 +477,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
                 entryTasks.clear();
                 executionPlan.clear();
                 executionQueue.clear();
+                projectLocks.clear();
                 failures.clear();
                 canonicalizedOutputCache.clear();
                 runningTasks.clear();
@@ -474,10 +504,9 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     }
 
     @Override
-    public boolean executeWithTask(WorkerLease parentWorkerLease, final Action<TaskInfo> taskExecution) {
+    public boolean executeWithTask(final WorkerLease workerLease, final Action<TaskInfo> taskExecution) {
         final AtomicReference<TaskInfo> selected = new AtomicReference<TaskInfo>();
-        final AtomicBoolean canExecute = new AtomicBoolean();
-        final ResourceLock workerLease = parentWorkerLease.createChild();
+        final AtomicBoolean workRemaining = new AtomicBoolean();
         coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
             @Override
             public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {
@@ -487,39 +516,18 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
                     }
                 }
 
-                final Iterator<TaskInfo> iterator = executionQueue.iterator();
-                while (iterator.hasNext()) {
-                    final TaskInfo taskInfo = iterator.next();
-                    if (taskInfo.isReady() && taskInfo.allDependenciesComplete()) {
-                        coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
-                            @Override
-                            public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {
-                                ResourceLock projectLock = getProjectLock(taskInfo);
-                                // TODO: convert output file checks to a resource lock
-                                if (projectLock.tryLock() && workerLease.tryLock() && canRunWithWithCurrentlyExecutedTasks(taskInfo)) {
-                                    selected.set(taskInfo);
-                                    iterator.remove();
-                                    if (taskInfo.allDependenciesSuccessful()) {
-                                        taskInfo.startExecution();
-                                        recordTaskStarted(taskInfo);
-                                        canExecute.set(true);
-                                    } else {
-                                        taskInfo.skipExecution();
-                                    }
-                                    return FINISHED;
-                                } else {
-                                    return FAILED;
-                                }
-                            }
-                        });
-
-                        if (selected.get() != null) {
-                            break;
-                        }
-                    }
+                workRemaining.set(workRemaining());
+                if (!workRemaining.get()) {
+                    return FINISHED;
                 }
 
-                if (selected.get() == null && !allTasksComplete()) {
+                if (allProjectsLocked()) {
+                    return RETRY;
+                }
+
+                selected.set(selectNextTask(workerLease));
+
+                if (selected.get() == null && workRemaining.get()) {
                     return RETRY;
                 } else {
                     return FINISHED;
@@ -528,20 +536,66 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
         });
 
 
-        if (selected.get() != null) {
-            try {
-                if (canExecute.get()) {
-                    taskExecution.execute(selected.get());
+        TaskInfo selectedTask = selected.get();
+        execute(selectedTask, workerLease, taskExecution);
+        return workRemaining.get();
+    }
+
+    private TaskInfo selectNextTask(final WorkerLease workerLease) {
+        final AtomicReference<TaskInfo> selected = new AtomicReference<TaskInfo>();
+        final Iterator<TaskInfo> iterator = executionQueue.iterator();
+        while (iterator.hasNext()) {
+            final TaskInfo taskInfo = iterator.next();
+            if (taskInfo.isReady() && taskInfo.allDependenciesComplete()) {
+                coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
+                    @Override
+                    public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {
+                        ResourceLock projectLock = getProjectLock(taskInfo);
+                        // TODO: convert output file checks to a resource lock
+                        if (!projectLock.tryLock() || !workerLease.tryLock() || !canRunWithCurrentlyExecutedTasks(taskInfo)) {
+                            return FAILED;
+                        }
+
+                        selected.set(taskInfo);
+                        iterator.remove();
+                        if (taskInfo.allDependenciesSuccessful()) {
+                            taskInfo.startExecution();
+                            recordTaskStarted(taskInfo);
+                        } else {
+                            taskInfo.skipExecution();
+                        }
+                        return FINISHED;
+                    }
+                });
+
+                if (selected.get() != null) {
+                    break;
                 }
-            } finally {
-                TaskInfo taskInfo = selected.get();
-                ResourceLock projectLock = getProjectLock(taskInfo);
-                coordinationService.withStateLock(unlock(projectLock, workerLease));
             }
         }
+        return selected.get();
+    }
 
-        // If all tasks are complete, we're done
-        return !allTasksComplete();
+    private void execute(TaskInfo selectedTask, WorkerLease workerLease, Action<TaskInfo> taskExecution) {
+        if (selectedTask == null) {
+            return;
+        }
+        try {
+            if (!selectedTask.isComplete()) {
+                taskExecution.execute(selectedTask);
+            }
+        } finally {
+            coordinationService.withStateLock(unlock(workerLease, getProjectLock(selectedTask)));
+        }
+    }
+
+    private boolean allProjectsLocked() {
+        for (ResourceLock lock : projectLocks) {
+            if (!lock.isLocked()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private ResourceLock getProjectLock(TaskInfo taskInfo) {
@@ -551,7 +605,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
         return workerLeaseService.getProjectLock(gradlePath, projectPath);
     }
 
-    private boolean canRunWithWithCurrentlyExecutedTasks(TaskInfo taskInfo) {
+    private boolean canRunWithCurrentlyExecutedTasks(TaskInfo taskInfo) {
         TaskInternal task = taskInfo.getTask();
 
         Pair<TaskInternal, String> overlap = firstTaskWithOverlappingOutput(task);
@@ -644,7 +698,6 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
 
                 taskInfo.finishExecution();
                 recordTaskCompleted(taskInfo);
-
                 return FINISHED;
             }
         });
@@ -744,6 +797,15 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
             }
         }
         return true;
+    }
+
+    private boolean workRemaining() {
+        for (TaskInfo taskInfo : executionQueue) {
+            if (!taskInfo.isComplete()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static class GraphEdge {

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
@@ -90,9 +90,10 @@ class DefaultTaskPlanExecutor implements TaskPlanExecutor {
             Timer totalTimer = Timers.startTimer();
             final Timer taskTimer = Timers.startTimer();
 
+            WorkerLease childLease = parentWorkerLease.createChild();
             boolean moreTasksToExecute = true;
             while (moreTasksToExecute) {
-                moreTasksToExecute = taskExecutionPlan.executeWithTask(parentWorkerLease, new Action<TaskInfo>() {
+                moreTasksToExecute = taskExecutionPlan.executeWithTask(childLease, new Action<TaskInfo>() {
                     @Override
                     public void execute(TaskInfo task) {
                         final String taskPath = task.getTask().getPath();

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
@@ -18,6 +18,7 @@ package org.gradle.execution.taskgraph;
 
 import com.google.common.collect.Iterables;
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.internal.resources.ResourceLock;
 
 import java.util.TreeSet;
 
@@ -31,6 +32,7 @@ public class TaskInfo implements Comparable<TaskInfo> {
     private TaskExecutionState state;
     private Throwable executionFailure;
     private boolean dependenciesProcessed;
+    private ResourceLock projectLock;
     private final TreeSet<TaskInfo> dependencyPredecessors = new TreeSet<TaskInfo>();
     private final TreeSet<TaskInfo> dependencySuccessors = new TreeSet<TaskInfo>();
     private final TreeSet<TaskInfo> mustSuccessors = new TreeSet<TaskInfo>();
@@ -194,6 +196,14 @@ public class TaskInfo implements Comparable<TaskInfo> {
 
     public void removeShouldRunAfterSuccessor(TaskInfo toNode) {
         shouldSuccessors.remove(toNode);
+    }
+
+    public ResourceLock getProjectLock() {
+        return projectLock;
+    }
+
+    public void setProjectLock(ResourceLock projectLock) {
+        this.projectLock = projectLock;
     }
 
     public int compareTo(TaskInfo otherInfo) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
@@ -49,11 +49,20 @@ class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
     def cancellationHandler = Mock(BuildCancellationToken)
     def workerLeaseService = Mock(WorkerLeaseService)
     def coordinationService = Mock(ResourceLockCoordinationService)
-    def parentWorkerLease = Mock(WorkerLeaseRegistry.WorkerLease)
+    def workerLease = Mock(WorkerLeaseRegistry.WorkerLease)
 
     def setup() {
         root = createRootProject(temporaryFolder.testDirectory);
         executionPlan = new DefaultTaskExecutionPlan(cancellationHandler, coordinationService, workerLeaseService)
+        _ * workerLeaseService.getProjectLock(_, _) >> Mock(ResourceLock) {
+            _ * isLocked() >> false
+            _ * tryLock() >> true
+        }
+        _ * workerLease.tryLock() >> true
+        _ * coordinationService.withStateLock(_) >> { args ->
+            args[0].transform(Mock(ResourceLockState))
+            return true
+        }
     }
 
     def "schedules tasks in dependency order"() {
@@ -878,19 +887,9 @@ class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
 
     def getExecutedTasks() {
         def tasks = []
-        _ * parentWorkerLease.createChild() >> Mock(WorkerLeaseRegistry.WorkerLease) {
-            _ * tryLock() >> true
-        }
-        _ * workerLeaseService.getProjectLock(_, _) >> Mock(ResourceLock) {
-            _ * tryLock() >> true
-        }
-        _ * coordinationService.withStateLock(_) >> { args ->
-            args[0].transform(Mock(ResourceLockState))
-            return true
-        }
         def moreTasks = true
         while (moreTasks) {
-            moreTasks = executionPlan.executeWithTask(parentWorkerLease, new Action<TaskInfo>() {
+            moreTasks = executionPlan.executeWithTask(workerLease, new Action<TaskInfo>() {
                 @Override
                 void execute(TaskInfo taskInfo) {
                     tasks << taskInfo.task

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskPlanExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskPlanExecutorTest.groovy
@@ -30,7 +30,7 @@ class DefaultTaskPlanExecutorTest extends Specification {
     def taskPlan = Mock(TaskExecutionPlan)
     def worker = Mock(Action)
     def executorFactory = Mock(ExecutorFactory)
-    def executor = new DefaultTaskPlanExecutor(1, executorFactory, Mock(WorkerLeaseService))
+    def executor = new DefaultTaskPlanExecutor(1, executorFactory, Stub(WorkerLeaseService))
 
     def "executes tasks until no further tasks remain"() {
         def gradle = Mock(Gradle)


### PR DESCRIPTION
The method that determines the next task was unnecessarily expensive.
This was always the case, but got more pressing as we introduced
the new state lock abstraction, which lead to calling this method
much more often.

We were creating a new worker lease on every iteration, even though
in most cases it would go unused, e.g. because no task is ready or
because all projects are locked. Creating a worker lease is currently
an expensive operation that leads to a lot of garbage. This change
makes sure we only create them when we are almost certain to execute
a task.

The exit condition for the method was also very expensive, iterating
over the whole execution plan on every iteration. It now only iterates
over the remaining tasks instead, which will usually yield a yes/no
decision after checking very few elements.

Since we now use --max-workers task workers even when --parallel is not
active, we have several threads fighting over the single build model lock.
Instead of iterating over all tasks, only to fail on the model lock check
each time, we check whether there is any project lock available at all.
Since the number of projects is generally much smaller than the number
of tasks, this saves a lot of time.

This speeds up the native non-parallel test case by 10%, making it faster than before we introduced the lock coordination service. It also speeds up most other scenarios, though by a much smaller amount. 