### PR TITLE
Introduce ScriptingLanguage SPI

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/configuration/ScriptPluginFactoryProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/ScriptPluginFactoryProvider.java
@@ -20,7 +20,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Nullable;
 
 /**
- * A {@link ScriptPluginFactory} SPI suitable for use with Java's {@code ServiceLoader}.
+ * A {@link ScriptPluginFactory} SPI.
  *
  * The SPI implementation can get access to Gradle services via {@link javax.inject.Inject}
  * style dependency injection.
@@ -29,6 +29,7 @@ import org.gradle.api.Nullable;
  * @since 2.14
  */
 @Incubating
+// TODO:pm Remove old scripting provider SPI support
 public interface ScriptPluginFactoryProvider {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptingLanguages.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptingLanguages.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.scripts;
+
+import org.gradle.internal.service.DefaultServiceLocator;
+import org.gradle.scripts.ScriptingLanguage;
+
+import java.util.Iterator;
+
+public class DefaultScriptingLanguages implements ScriptingLanguages {
+
+    private final Iterable<ScriptingLanguage> scriptingLanguages;
+
+    public DefaultScriptingLanguages() {
+        scriptingLanguages = new DefaultServiceLocator(getClass().getClassLoader()).getAll(ScriptingLanguage.class);
+    }
+
+    @Override
+    public Iterator<ScriptingLanguage> iterator() {
+        return scriptingLanguages.iterator();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/ScriptingLanguages.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/ScriptingLanguages.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.scripts;
+
+import org.gradle.scripts.ScriptingLanguage;
+
+/**
+ * Registry of scripting languages.
+ */
+public interface ScriptingLanguages extends Iterable<ScriptingLanguage> {
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -151,6 +151,7 @@ import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scan.BuildScanRequest;
 import org.gradle.internal.scan.DefaultBuildScanRequest;
+import org.gradle.internal.scripts.ScriptingLanguages;
 import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
@@ -289,10 +290,11 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             classLoaderHierarchyHasher);
     }
 
-    protected ScriptPluginFactory createScriptPluginFactory(BuildOperationExecutor buildOperationExecutor) {
+    protected ScriptPluginFactory createScriptPluginFactory(ScriptingLanguages scriptingLanguages, InstantiatorFactory instantiatorFactory, BuildOperationExecutor buildOperationExecutor) {
         DefaultScriptPluginFactory defaultScriptPluginFactory = defaultScriptPluginFactory();
+        ScriptPluginFactorySelector.ProviderInstantiator instantiator = ScriptPluginFactorySelector.defaultProviderInstantiatorFor(instantiatorFactory.inject(this));
         DependencyInjectingServiceLoader serviceLoader = new DependencyInjectingServiceLoader(this);
-        ScriptPluginFactorySelector scriptPluginFactorySelector = new ScriptPluginFactorySelector(defaultScriptPluginFactory, serviceLoader, buildOperationExecutor);
+        ScriptPluginFactorySelector scriptPluginFactorySelector = new ScriptPluginFactorySelector(defaultScriptPluginFactory, scriptingLanguages, instantiator, serviceLoader, buildOperationExecutor);
         defaultScriptPluginFactory.setScriptPluginFactory(scriptPluginFactorySelector);
         return scriptPluginFactorySelector;
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -94,6 +94,8 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.remote.MessagingServer;
 import org.gradle.internal.remote.internal.inet.InetAddressFactory;
 import org.gradle.internal.remote.services.MessagingServices;
+import org.gradle.internal.scripts.DefaultScriptingLanguages;
+import org.gradle.internal.scripts.ScriptingLanguages;
 import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceLocator;
 import org.gradle.internal.service.ServiceRegistration;
@@ -374,5 +376,9 @@ public class GlobalScopeServices {
 
     ProviderFactory createProviderFactory() {
         return new DefaultProviderFactory();
+    }
+
+    ScriptingLanguages createScriptingLanguages() {
+        return new DefaultScriptingLanguages();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/scripts/ScriptingLanguage.java
+++ b/subprojects/core/src/main/java/org/gradle/scripts/ScriptingLanguage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.scripts;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Scripting language provider SPI.
+ *
+ * Implementations are not managed and do not benefit from e.g. injection.
+ *
+ * @since 4.0
+ */
+@Incubating
+public interface ScriptingLanguage {
+
+    /**
+     * Returns the file extension (including the leading dot) for scripts written in this scripting language.
+     */
+    String getExtension();
+
+    /**
+     * Returns the fully qualified class name of the scripting language provider for this scripting language.
+     *
+     * Implementations can benefit from injection using {@link javax.inject.Inject}.
+     */
+    String getProvider();
+
+}

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/ScriptPluginFactorySelectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/ScriptPluginFactorySelectorTest.groovy
@@ -23,14 +23,18 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.progress.TestBuildOperationExecutor
 import org.gradle.internal.resource.StringTextResource
+import org.gradle.internal.scripts.ScriptingLanguages
+import org.gradle.scripts.ScriptingLanguage
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class ScriptPluginFactorySelectorTest extends Specification {
 
+    def scriptingLanguages = Mock(ScriptingLanguages)
+    def providerInstantiator = Mock(ScriptPluginFactorySelector.ProviderInstantiator)
     def defaultScriptPluginFactory = Mock(ScriptPluginFactory)
-    def serviceLoader = Mock(DependencyInjectingServiceLoader)
-    def selector = new ScriptPluginFactorySelector(defaultScriptPluginFactory, serviceLoader, new TestBuildOperationExecutor())
+    def serviceLoader = Mock(DependencyInjectingServiceLoader) // TODO:pm Remove old scripting provider SPI support
+    def selector = new ScriptPluginFactorySelector(defaultScriptPluginFactory, scriptingLanguages, providerInstantiator, serviceLoader, new TestBuildOperationExecutor())
 
     def scriptHandler = Mock(ScriptHandler)
     def targetScope = Mock(ClassLoaderScope)
@@ -45,7 +49,8 @@ class ScriptPluginFactorySelectorTest extends Specification {
     @Unroll
     def "selects default scripting support short circuiting provider lookup for #fileName"() {
         given:
-        0 * serviceLoader._
+        0 * scriptingLanguages._
+        0 * serviceLoader._ // TODO:pm Remove old scripting provider SPI support
         def scriptSource = scriptSourceFor(fileName)
         def target = new Object()
 
@@ -65,7 +70,8 @@ class ScriptPluginFactorySelectorTest extends Specification {
 
     def "given no scripting provider then falls back to default scripting support for any extension"() {
         given:
-        1 * serviceLoader.load(*_) >> []
+        1 * scriptingLanguages.iterator() >> [].iterator()
+        1 * serviceLoader.load(*_) >> [] // TODO:pm Remove old scripting provider SPI support
         def scriptSource = scriptSourceFor('build.any')
         def target = new Object()
 
@@ -82,9 +88,37 @@ class ScriptPluginFactorySelectorTest extends Specification {
 
     def "given matching scripting provider then selects it"() {
         given:
+        def fooLanguage = Mock(ScriptingLanguage) {
+            getExtension() >> '.foo'
+            getProvider() >> 'foo.Provider'
+        }
         def fooScriptPlugin = Mock(ScriptPlugin)
-        def fooScriptPluginFactoryProvider = scriptPluginFactoryProviderFor('foo', fooScriptPlugin)
+        def fooScriptPluginFactory = scriptPluginFactoryFor(fooScriptPlugin)
+        1 * scriptingLanguages.iterator() >> [fooLanguage].iterator()
+        1 * providerInstantiator.instantiate(fooLanguage.getProvider()) >> fooScriptPluginFactory
+        0 * serviceLoader._ // TODO:pm Remove old scripting provider SPI support
+        def scriptSource = scriptSourceFor('build.foo')
+        def target = new Object()
+
+        when:
+        def scriptPlugin = selector.create(scriptSource, scriptHandler, targetScope, baseScope, false)
+
+        and:
+        scriptPlugin.apply(target)
+
+        then:
+        1 * fooScriptPlugin.source >> scriptSource
+        1 * fooScriptPlugin.apply(target)
+    }
+
+    // TODO:pm Remove old scripting provider SPI support
+    def "given matching old scripting provider then selects it"() {
+        given:
+        def fooScriptPlugin = Mock(ScriptPlugin)
+        def fooScriptPluginFactoryProvider = scriptPluginFactoryProviderFor('.foo', fooScriptPlugin)
+        1 * scriptingLanguages.iterator() >> [].iterator()
         1 * serviceLoader.load(*_) >> [fooScriptPluginFactoryProvider]
+        0 * providerInstantiator._
         def scriptSource = scriptSourceFor('build.foo')
         def target = new Object()
 
@@ -107,6 +141,13 @@ class ScriptPluginFactorySelectorTest extends Specification {
         }
     }
 
+    private ScriptPluginFactory scriptPluginFactoryFor(ScriptPlugin scriptPluginMock) {
+        return Mock(ScriptPluginFactory) {
+            create(*_) >> scriptPluginMock
+        }
+    }
+
+    // TODO:pm Remove old scripting provider SPI support
     private ScriptPluginFactoryProvider scriptPluginFactoryProviderFor(String extension, ScriptPlugin scriptPluginMock) {
         def scriptPluginFactory = Mock(ScriptPluginFactory) {
             create(*_) >> scriptPluginMock


### PR DESCRIPTION
See https://github.com/gradle/gradle-script-kotlin/issues/37 for context and motivation.

This PR is a first step and keep the support for loading `ScriptPluginFactoryProvider` implementations directly. A subsequent PR will remove the double lookup.

### Gradle Core Team Checklist
- [x] Verify test coverage and CI build status https://builds.gradle.org/viewLog.html?buildId=2825162
  - [x] Commit phase
  - [x] Performance
  - [x] Coverage phase
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
