### PR TITLE
Clearly state the Provider types are not intended for implementation

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/provider/PropertyState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/provider/PropertyState.java
@@ -21,7 +21,9 @@ import org.gradle.api.Incubating;
 /**
  * A {@code Provider} representation for capturing property state. The value can be provided by using the method {@code set()}.
  * <p>
- * You can create a {@code PropertyState} instance using the method {@link org.gradle.api.Project#property(java.lang.Class)}.
+ * <b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created
+ * through the factory methods {@link org.gradle.api.Project#property(java.lang.Class)} or
+ * {@link org.gradle.api.provider.ProviderFactory#property(java.lang.Class)}.
  *
  * @param <T> Type of value represented by property state
  * @since 4.0

--- a/subprojects/core/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/provider/Provider.java
@@ -21,6 +21,10 @@ import org.gradle.api.tasks.Internal;
 
 /**
  * A container object which provides a value of a specific type. The value can be retrieved by the method {@code get()} or {@code getOrNull()}.
+ * <p>
+ * <b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created
+ * through the factory methods {@link org.gradle.api.Project#provider(java.util.concurrent.Callable)} or
+ * {@link org.gradle.api.provider.ProviderFactory#provider(java.util.concurrent.Callable)}.
  *
  * @param <T> Type of value represented by provider
  * @since 4.0

--- a/subprojects/docs/src/docs/userguide/customPlugins.xml
+++ b/subprojects/docs/src/docs/userguide/customPlugins.xml
@@ -165,6 +165,7 @@
             interfaces is attributed to mutability. A <apilink class="org.gradle.api.provider.Provider"/> is immutable and can be created with the method
             <apilink class="org.gradle.api.Project" method="provider(java.util.concurrent.Callable)"/>. <apilink class="org.gradle.api.provider.PropertyState"/> extends the interface
             <apilink class="org.gradle.api.provider.Provider"/>, represents a mutable value and can be created with the method <apilink class="org.gradle.api.Project" method="property(java.lang.Class)"/>.
+            Please note that the provider types are not intended for for implementation by build script or plugin authors.
         </para>
         <note>
             <para>


### PR DESCRIPTION
### Context

Document very clearly that `Provider` and related types are not intended to be implemented by user code. See https://github.com/gradle/gradle-private/issues/842 for more information.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
