### PR TITLE
Updated base dependencies before migration to JDK9

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,35 +14,38 @@
  * limitations under the License.
  */
 
+apply plugin: 'distribution'
 apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
-
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
     // TODO Remove if no Groovy snapshot is being used
     maven { url "https://repo.gradle.org/gradle/libs-snapshots" }
+    jcenter()
 }
 
 dependencies {
-    compile 'org.ow2.asm:asm-all:5.0.3'
+    compile 'org.ow2.asm:asm-all:6.0_ALPHA'
     compile gradleApi()
-    compile 'com.google.guava:guava-jdk5:14.0.1@jar'
-    compile 'commons-lang:commons-lang:2.6@jar'
+    compile 'com.google.guava:guava:21.0'
+    compile 'commons-lang:commons-lang:2.6'
     compile localGroovy()
     compile('org.codehaus.groovy.modules.http-builder:http-builder:0.7.2') {
         exclude(module: 'groovy')
         exclude(module: 'xercesImpl')
     }
     testCompile 'junit:junit:4.12@jar'
-    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4@jar', 'cglib:cglib-nodep:2.2', 'org.objenesis:objenesis:1.2'
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4@jar',
+                'cglib:cglib-nodep:3.2.5',
+                'org.objenesis:objenesis:2.5.1'
     testCompile 'org.hamcrest:hamcrest-core:1.3'
 
     compile "org.pegdown:pegdown:1.6.0"
-    compile "org.jsoup:jsoup:1.6.3"
+    compile "org.jsoup:jsoup:1.10.2"
 }
 
 ext.isCiServer = System.getenv().containsKey("CI")

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-apply plugin: 'distribution'
 apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'eclipse'


### PR DESCRIPTION
### Context
After install JDK9_167, I found gradle is not working. To deal with the problem, I hope to upgrade base packages to latest version and upgrade target JDK to JDK 8, before apply JDK 9, it is a better approach to use the most updated base package.  This build works on JDK8_131.

### Contributor Checklist
- [ v] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ v] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ v] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ v] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
Followed original tests
- [v ] Provide unit tests (under `<subproject>/src/test`) to verify logic
Followed original tests
- [x ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
Ralic : Not sure which doc is related to buildSrc, no change to javadoc so far
- [ v] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`
Passed all tests using JDK8_131, Gradle 4 snapshot with --parallel on 4 core Mac2013.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
