### PR TITLE
Show console on all LogLevel

### DIFF
--- a/subprojects/docs/src/docs/userguide/logging.xml
+++ b/subprojects/docs/src/docs/userguide/logging.xml
@@ -54,6 +54,12 @@
             <td>Debug messages</td>
         </tr>
     </table>
+    <note>
+        <para>The rich components of the console (build status and work in progress area) are displayed regardless of
+            the log level used. Before Gradle 4.0 those rich components were only displayed at log level
+            <literal>LIFECYCLE</literal> or below.
+        </para>
+    </note>
     <section id="sec:choosing_a_log_level">
         <title>Choosing a log level</title>
         <para>You can use the command line switches shown in <xref linkend='logLevelCommandLineOptions'/> to choose

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildLogLevelFilterRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildLogLevelFilterRenderer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console;
+
+import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.logging.events.LogLevelChangeEvent;
+import org.gradle.internal.logging.events.OutputEvent;
+import org.gradle.internal.logging.events.OutputEventListener;
+
+public class BuildLogLevelFilterRenderer implements OutputEventListener {
+    private final OutputEventListener listener;
+    private LogLevel logLevel = LogLevel.LIFECYCLE;
+
+    public BuildLogLevelFilterRenderer(OutputEventListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void onOutput(OutputEvent event) {
+        if (event.getLogLevel() != null && event.getLogLevel().compareTo(logLevel) < 0) {
+            return;
+        }
+        if (event instanceof LogLevelChangeEvent) {
+            LogLevelChangeEvent changeEvent = (LogLevelChangeEvent) event;
+            logLevel = changeEvent.getNewLogLevel();
+        }
+        listener.onOutput(event);
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildLogLevelFilterRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildLogLevelFilterRenderer.java
@@ -23,7 +23,7 @@ import org.gradle.internal.logging.events.OutputEventListener;
 
 public class BuildLogLevelFilterRenderer implements OutputEventListener {
     private final OutputEventListener listener;
-    private LogLevel logLevel = LogLevel.LIFECYCLE;
+    private LogLevel logLevel = LogLevel.WARN;
 
     public BuildLogLevelFilterRenderer(OutputEventListener listener) {
         this.listener = listener;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildLogLevelFilterRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildLogLevelFilterRenderer.java
@@ -23,7 +23,7 @@ import org.gradle.internal.logging.events.OutputEventListener;
 
 public class BuildLogLevelFilterRenderer implements OutputEventListener {
     private final OutputEventListener listener;
-    private LogLevel logLevel = LogLevel.WARN;
+    private LogLevel logLevel = LogLevel.LIFECYCLE;
 
     public BuildLogLevelFilterRenderer(OutputEventListener listener) {
         this.listener = listener;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -24,6 +24,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.logging.config.LoggingRouter;
 import org.gradle.internal.logging.console.AnsiConsole;
+import org.gradle.internal.logging.console.BuildLogLevelFilterRenderer;
 import org.gradle.internal.logging.console.BuildStatusRenderer;
 import org.gradle.internal.logging.console.ColorMap;
 import org.gradle.internal.logging.console.Console;
@@ -219,9 +220,10 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
         final OutputEventListener consoleChain = new ThrottlingOutputEventListener(
              new BuildStatusRenderer(
                 new WorkInProgressRenderer(
-                    new ProgressLogEventGenerator(
-                        new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), true),
-                    console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
+                    new BuildLogLevelFilterRenderer(
+                        new ProgressLogEventGenerator(
+                            new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), true)),
+                        console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
                 console.getStatusBar(), console, consoleMetaData, timeProvider),
             timeProvider);
         synchronized (lock) {
@@ -307,9 +309,6 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     @Override
     public void onOutput(OutputEvent event) {
-        if (event.getLogLevel() != null && event.getLogLevel().compareTo(logLevel.get()) < 0) {
-            return;
-        }
         if (event instanceof LogLevelChangeEvent) {
             LogLevelChangeEvent changeEvent = (LogLevelChangeEvent) event;
             LogLevel newLogLevel = changeEvent.getNewLogLevel();

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildLogLevelFilterRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildLogLevelFilterRendererTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.internal.logging.OutputSpecification
+import org.gradle.internal.logging.events.LogEvent
+import org.gradle.internal.logging.events.LogLevelChangeEvent
+import org.gradle.internal.logging.events.OutputEventListener
+import spock.lang.Subject
+
+@Subject(BuildLogLevelFilterRenderer)
+public class BuildLogLevelFilterRendererTest extends OutputSpecification {
+    def listener = Mock(OutputEventListener)
+    def renderer = new BuildLogLevelFilterRenderer(listener)
+
+    def "consume correctly LogLevelChangeEvent"() {
+        when:
+        renderer.onOutput(new LogLevelChangeEvent(LogLevel.WARN))
+        renderer.onOutput(event("lifecycle", LogLevel.LIFECYCLE))
+        renderer.onOutput(event("warn", LogLevel.WARN))
+
+        then:
+        1 * listener.onOutput({it instanceof LogLevelChangeEvent})
+        1 * listener.onOutput({it instanceof LogEvent && it.message == "warn"})
+        0 * _
+    }
+
+    def "default to LogLevel.LIFECYCLE log level"() {
+        when:
+        renderer.onOutput(event("lifecycle", LogLevel.LIFECYCLE))
+        renderer.onOutput(event("debug", LogLevel.DEBUG))
+
+        then:
+        1 * listener.onOutput({it.message == "lifecycle"})
+        0 * _
+    }
+
+    def "forward the event unmodified to the listener"() {
+        given:
+        def event = event("event", LogLevel.LIFECYCLE)
+
+        when:
+        renderer.onOutput(event)
+
+        then:
+        1 * listener.onOutput(event)
+        0 * _
+    }
+}

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildLogLevelFilterRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildLogLevelFilterRendererTest.groovy
@@ -40,19 +40,20 @@ public class BuildLogLevelFilterRendererTest extends OutputSpecification {
         0 * _
     }
 
-    def "default to LogLevel.LIFECYCLE log level"() {
+    def "default to LogLevel.WARN log level"() {
         when:
+        renderer.onOutput(event("warn", LogLevel.WARN))
         renderer.onOutput(event("lifecycle", LogLevel.LIFECYCLE))
         renderer.onOutput(event("debug", LogLevel.DEBUG))
 
         then:
-        1 * listener.onOutput({it.message == "lifecycle"})
+        1 * listener.onOutput({it.message == "warn"})
         0 * _
     }
 
     def "forward the event unmodified to the listener"() {
         given:
-        def event = event("event", LogLevel.LIFECYCLE)
+        def event = event("event", LogLevel.WARN)
 
         when:
         renderer.onOutput(event)

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildLogLevelFilterRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildLogLevelFilterRendererTest.groovy
@@ -40,20 +40,19 @@ public class BuildLogLevelFilterRendererTest extends OutputSpecification {
         0 * _
     }
 
-    def "default to LogLevel.WARN log level"() {
+    def "default to LogLevel.LIFECYCLE log level"() {
         when:
-        renderer.onOutput(event("warn", LogLevel.WARN))
         renderer.onOutput(event("lifecycle", LogLevel.LIFECYCLE))
         renderer.onOutput(event("debug", LogLevel.DEBUG))
 
         then:
-        1 * listener.onOutput({it.message == "warn"})
+        1 * listener.onOutput({it.message == "lifecycle"})
         0 * _
     }
 
     def "forward the event unmodified to the listener"() {
         given:
-        def event = event("event", LogLevel.WARN)
+        def event = event("event", LogLevel.LIFECYCLE)
 
         when:
         renderer.onOutput(event)

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData
 import org.gradle.util.RedirectStdOutAndErr
 import org.junit.Rule
+import spock.lang.Unroll
 
 class OutputEventRendererTest extends OutputSpecification {
     @Rule public final RedirectStdOutAndErr outputs = new RedirectStdOutAndErr()
@@ -170,6 +171,30 @@ class OutputEventRendererTest extends OutputSpecification {
         then:
         1 * listener.onOutput(event)
         0 * listener._
+    }
+
+    @Unroll("forward progress events to listener for #logLevel log level")
+    def forwardsProgressEventsToListenerRegardlessOfTheLogLevel() {
+        OutputEventListener listener = Mock()
+        def start = start('start')
+        def progress = progress('progress')
+        def complete = complete('complete')
+
+        when:
+        renderer.configure(logLevel)
+        renderer.addOutputEventListener(listener)
+        renderer.onOutput(start)
+        renderer.onOutput(progress)
+        renderer.onOutput(complete)
+
+        then:
+        1 * listener.onOutput(start)
+        1 * listener.onOutput(progress)
+        1 * listener.onOutput(complete)
+        0 * listener._
+
+        where:
+        logLevel << [LogLevel.ERROR, LogLevel.QUIET, LogLevel.WARN, LogLevel.LIFECYCLE, LogLevel.INFO, LogLevel.DEBUG]
     }
 
     def doesNotForwardOutputEventsToRemovedListener() {


### PR DESCRIPTION
### Context
* Move log level filtering from OutputEventRender to BuildLogLevelFilterRenderer
* Send to client all progress event regardless of their LogLevel

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify [test coverage and CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches_Checkpoints&branch_Gradle_Branches_Checkpoints=dl-issue-780)
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
