### PR TITLE
Fix incremental compiler not detecting removal of a jar on classpath

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarChangeProcessor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarChangeProcessor.java
@@ -24,18 +24,15 @@ import org.gradle.api.tasks.incremental.InputFileDetails;
 public class JarChangeProcessor {
 
     private final FileOperations fileOperations;
-    private final JarClasspathSnapshot jarClasspathSnapshot;
-    private final PreviousCompilation previousCompilation;
+    private final JarChangeDependentsFinder dependentsFinder;
 
     public JarChangeProcessor(FileOperations fileOperations, JarClasspathSnapshot jarClasspathSnapshot, PreviousCompilation previousCompilation) {
         this.fileOperations = fileOperations;
-        this.jarClasspathSnapshot = jarClasspathSnapshot;
-        this.previousCompilation = previousCompilation;
+        this.dependentsFinder = new JarChangeDependentsFinder(jarClasspathSnapshot, previousCompilation);
     }
 
     public void processChange(InputFileDetails input, RecompilationSpec spec) {
         JarArchive jarArchive = new JarArchive(input.getFile(), fileOperations.zipTree(input.getFile()));
-        JarChangeDependentsFinder dependentsFinder = new JarChangeDependentsFinder(jarClasspathSnapshot, previousCompilation);
         DependentsSet actualDependents = dependentsFinder.getActualDependents(input, jarArchive);
         if (actualDependents.isDependencyToAll()) {
             spec.setFullRebuildCause(actualDependents.getDescription(), input.getFile());

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarClasspathSnapshot.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarClasspathSnapshot.java
@@ -37,6 +37,14 @@ public class JarClasspathSnapshot {
         return jarSnapshots.get(jarArchive.file);
     }
 
+    public JarSnapshot getSnapshot(File file) {
+        return jarSnapshots.get(file);
+    }
+
+    public Set<File> getJars() {
+        return jarSnapshots.keySet();
+    }
+
     public boolean isAnyClassDuplicated(Set<String> classNames) {
         boolean noCommonElements = Collections.disjoint(data.getDuplicateClasses(), classNames);
         return !noCommonElements;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/PreviousCompilation.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/PreviousCompilation.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysis;
 import org.gradle.api.internal.tasks.compile.incremental.deps.DependentsSet;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,5 +57,13 @@ public class PreviousCompilation {
     public DependentsSet getDependents(String className, Set<Integer> newConstants) {
         Set<Integer> constants = Sets.difference(analysis.getData().getConstants(className), newConstants);
         return analysis.getRelevantDependents(className, constants);
+    }
+
+    public Map<File, JarSnapshot> getJarSnapshots() {
+        if (jarSnapshots == null) {
+            JarClasspathSnapshotData data = classpathSnapshotStore.get();
+            jarSnapshots = jarSnapshotCache.getJarSnapshots(data.getJarHashes());
+        }
+        return Collections.unmodifiableMap(jarSnapshots);
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalJavaCompileAvoidanceAgainstJarIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalJavaCompileAvoidanceAgainstJarIntegrationSpec.groovy
@@ -16,9 +16,62 @@
 
 package org.gradle.java.compile
 
+import spock.lang.Issue
+import spock.lang.Unroll
+
 class IncrementalJavaCompileAvoidanceAgainstJarIntegrationSpec extends AbstractJavaCompileAvoidanceAgainstJarIntegrationSpec {
     def setup() {
         useJar()
         useIncrementalCompile()
+    }
+
+    @Unroll
+    @Issue("gradle/gradle#1913")
+    def "detects changes in compile classpath with #config change"() {
+        given:
+        buildFile << """
+            apply plugin: 'java-library'
+               
+            repositories {
+               jcenter()
+            }
+            
+            dependencies {
+               if (project.hasProperty('useCommons')) {
+                  $config 'org.apache.commons:commons-lang3:3.5'
+               }
+               
+               // There MUST be at least 3 dependencies, in that specific order, for the bug to show up.
+               // The reason is that `IncrementalTaskInputs` reports wrong information about deletions at the
+               // beginning of a list, when the collection is ordered. It has been agreed not to fix it now, but
+               // rather change the incremental compiler not to rely on this incorrect information
+               
+               implementation 'net.jcip:jcip-annotations:1.0'
+               implementation 'org.slf4j:slf4j-api:1.7.10'
+            }
+        """
+        file("src/main/java/Client.java") << """import org.apache.commons.lang3.exception.ExceptionUtils;
+            public class Client {
+                public void doSomething() {
+                    ExceptionUtils.rethrow(new RuntimeException("ok"));
+                }
+            }
+        """
+
+        when:
+        executer.withArgument('-PuseCommons')
+        succeeds ':compileJava'
+
+        then:
+        noExceptionThrown()
+
+        when: "Apache Commons is removed from classpath"
+        fails ':compileJava'
+
+        then:
+        failure.assertHasCause('Compilation failed; see the compiler error output for details.')
+
+        where:
+        config << ['api', 'implementation', 'compile']
     }
 }


### PR DESCRIPTION
This commit fixes #1913 by making the incremental compiler rely on the previous compilation jar snapshot
to detect whether a jar has been removed or not. The rationale for this change is that the incremental task
inputs detection has a bug when the collection is ordered: while it will properly detect that something has
changed, the information it returns is incorrect: it would notify of modified jars for jars which haven't
changed, notify of removal jars which have not been removed, and eventually miss the real removal.

A proper fix for incremental task inputs change detection will be issued later. In the meantime, we will
use the information the incremental compiler already knows as the basis for analysis.

This pull request also incidentally fixes #1761 , which was actually due to wrong information reported by `IncrementalTaskInputs`.