### PR TITLE
Fix deadlock in `DefaultDaemonScanInfo`

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfo.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfo.java
@@ -93,6 +93,13 @@ public class DefaultDaemonScanInfo implements DaemonScanInfo {
         final BuildAdapter buildListener = new BuildAdapter() {
             @Override
             public void buildFinished(BuildResult result) {
+                // there's a possibility that this listener is called concurrently with
+                // the daemonExpirationListener. If the message happens to be a graceful expire
+                // one, then there's a large risk that we create a deadlock, because we're trying to
+                // remove the same listener from 2 different notifications. To avoid this, we just
+                // set the reference to null, which says that we're taking care of removing the listener
+                buildListenerReference.set(null);
+                
                 listenerManager.removeListener(daemonExpirationListener);
                 listenerManager.removeListener(this);
             }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfo.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfo.java
@@ -72,7 +72,7 @@ public class DefaultDaemonScanInfo implements DaemonScanInfo {
             Ideally, the value given would describe the problem and not be phrased in terms of why we are shutting down,
             but this is a practical compromise born out of piggy backing on the expiration listener mechanism to implement it.
          */
-        final AtomicReference<BuildAdapter> buildListenerReference = new AtomicReference<BuildAdapter>();
+        final AtomicReference<DaemonExpirationListener> daemonExpirationListenerReference = new AtomicReference<DaemonExpirationListener>();
         final DaemonExpirationListener daemonExpirationListener = new DaemonExpirationListener() {
             @Override
             public void onExpirationEvent(DaemonExpirationResult result) {
@@ -80,31 +80,31 @@ public class DefaultDaemonScanInfo implements DaemonScanInfo {
                     try {
                         listener.execute(result.getReason());
                     } finally {
-                        listenerManager.removeListener(this);
-                        BuildAdapter buildListener = buildListenerReference.get();
-                        if (buildListener != null) {
-                            listenerManager.removeListener(buildListener);
+                        // there's a possibility that this listener is called concurrently with
+                        // the build finished listener. If the message happens to be a graceful expire
+                        // one, then there's a large risk that we create a deadlock, because we're trying to
+                        // remove the same listener from 2 different notifications. To avoid this, we just
+                        // set the reference to null, which says that we're taking care of removing the listener
+                        if (daemonExpirationListenerReference.getAndSet(null) != null) {
+                            listenerManager.removeListener(this);
                         }
                     }
                 }
             }
         };
+        daemonExpirationListenerReference.set(daemonExpirationListener);
         listenerManager.addListener(daemonExpirationListener);
+
         final BuildAdapter buildListener = new BuildAdapter() {
             @Override
             public void buildFinished(BuildResult result) {
-                // there's a possibility that this listener is called concurrently with
-                // the daemonExpirationListener. If the message happens to be a graceful expire
-                // one, then there's a large risk that we create a deadlock, because we're trying to
-                // remove the same listener from 2 different notifications. To avoid this, we just
-                // set the reference to null, which says that we're taking care of removing the listener
-                buildListenerReference.set(null);
-                
-                listenerManager.removeListener(daemonExpirationListener);
+                DaemonExpirationListener daemonExpirationListener = daemonExpirationListenerReference.getAndSet(null);
+                if (daemonExpirationListener != null) {
+                    listenerManager.removeListener(daemonExpirationListener);
+                }
                 listenerManager.removeListener(this);
             }
         };
-        buildListenerReference.set(buildListener);
         listenerManager.addListener(buildListener);
     }
 


### PR DESCRIPTION
This commit fixes a deadlock encountered from time to time on CI. The reason for the deadlock is that we're trying to remove
the same listener from 2 different notifications, one of them being the listener being removed itself. To avoid this, we just
tell the other listener that we're taking care of it by setting the reference to null.
