### PR TITLE
Use a synchronized WeakHashMap to avoid potential hangs

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultHashingClassLoaderFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultHashingClassLoaderFactory.java
@@ -22,13 +22,14 @@ import com.google.common.hash.Hashing;
 import org.gradle.internal.classpath.ClassPath;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 
 public class DefaultHashingClassLoaderFactory extends DefaultClassLoaderFactory implements HashingClassLoaderFactory {
     private final ClasspathHasher classpathHasher;
-    private final Map<ClassLoader, HashCode> hashCodes = new WeakHashMap<ClassLoader, HashCode>();
+    private final Map<ClassLoader, HashCode> hashCodes = Collections.synchronizedMap(new WeakHashMap<ClassLoader, HashCode>());
 
     public DefaultHashingClassLoaderFactory(ClasspathHasher classpathHasher) {
         this.classpathHasher = classpathHasher;


### PR DESCRIPTION
There is a known issue where WeakHashMap can go into an endless loop when accessed concurrently.  I observed a hang locally due to this issue and this may be the cause behind some of the hangs we've seen with the `WorkerExecutor` integration tests.