### PR TITLE
Group logs by project and task

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/BuildOperationDescriptor.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/BuildOperationDescriptor.java
@@ -30,14 +30,16 @@ public final class BuildOperationDescriptor {
     private final String name;
     private final String progressDisplayName;
     private final BuildOperationDetails<?> details;
+    private final BuildOperationType operationType;
 
-    private BuildOperationDescriptor(Object id, Object parentId, String name, String displayName, String progressDisplayName, BuildOperationDetails<?> details) {
+    private BuildOperationDescriptor(Object id, Object parentId, String name, String displayName, String progressDisplayName, BuildOperationDetails<?> details, BuildOperationType operationType) {
         this.id = id;
         this.parentId = parentId;
         this.name = name;
         this.displayName = displayName;
         this.progressDisplayName = progressDisplayName;
         this.details = details;
+        this.operationType = operationType;
     }
 
     public Object getId() {
@@ -88,6 +90,10 @@ public final class BuildOperationDescriptor {
         return parentId;
     }
 
+    public BuildOperationType getOperationType() {
+        return operationType;
+    }
+
     public static Builder displayName(String displayName) {
         return new Builder(displayName);
     }
@@ -98,6 +104,7 @@ public final class BuildOperationDescriptor {
         private String progressDisplayName;
         private BuildOperationDetails<?> details;
         private BuildOperationState parent;
+        private BuildOperationType operationType = BuildOperationType.UNCATEGORIZED;
 
         private Builder(String displayName) {
             this.displayName = displayName;
@@ -116,6 +123,11 @@ public final class BuildOperationDescriptor {
 
         public Builder details(BuildOperationDetails<?> details) {
             this.details = details;
+            return this;
+        }
+
+        public Builder operationType(BuildOperationType operationType) {
+            this.operationType = operationType;
             return this;
         }
 
@@ -138,7 +150,7 @@ public final class BuildOperationDescriptor {
         }
 
         BuildOperationDescriptor build(@Nullable Object id, @Nullable Object defaultParentId) {
-            return new BuildOperationDescriptor(id, parent == null ? defaultParentId : parent.getId(), name, displayName, progressDisplayName, details);
+            return new BuildOperationDescriptor(id, parent == null ? defaultParentId : parent.getId(), name, displayName, progressDisplayName, details, operationType);
         }
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/BuildOperationType.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/BuildOperationType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.progress;
+
+public enum BuildOperationType {
+    CONFIGURE_PROJECT, TASK, UNCATEGORIZED
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
@@ -21,11 +21,11 @@ import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.logging.events.OperationIdentifier
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.progress.BuildOperationDescriptor
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.BuildOperationState
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.time.TimeProvider
 import org.gradle.internal.work.DefaultWorkerLeaseService
@@ -44,7 +44,7 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
     def setupBuildOperationExecutor(int maxThreads) {
         workerRegistry = new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), true, maxThreads)
         buildOperationExecutor = new DefaultBuildOperationExecutor(
-            operationListener, Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            operationListener, Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerRegistry), new DefaultExecutorFactory(), maxThreads)
         outerOperationCompletion = workerRegistry.getWorkerLease().start()
         outerOperation = workerRegistry.getCurrentWorkerLease()
@@ -205,7 +205,7 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
             create(_, _) >> { buildQueue }
         }
 
-        def buildOperationExecutor = new DefaultBuildOperationExecutor(operationListener, Mock(TimeProvider), Mock(ProgressLoggerFactory),
+        def buildOperationExecutor = new DefaultBuildOperationExecutor(operationListener, Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             buildOperationQueueFactory, Stub(ExecutorFactory), 1)
         def worker = Stub(BuildOperationWorker)
         def operation = Mock(DefaultBuildOperationQueueTest.TestBuildOperation)
@@ -233,7 +233,7 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
             create(_, _) >> { buildQueue }
         }
         def buildOperationExecutor = new DefaultBuildOperationExecutor(
-            operationListener, Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            operationListener, Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             buildOperationQueueFactory, Stub(ExecutorFactory), 1)
         def worker = Stub(BuildOperationWorker)
         def operation = Mock(DefaultBuildOperationQueueTest.TestBuildOperation)

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.internal.operations
 
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.time.TimeProvider
-import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.work.DefaultWorkerLeaseService
+import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 class MaxWorkersTest extends ConcurrentSpec {
@@ -33,7 +33,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         def maxWorkers = 1
         def registry = buildOperationWorkerRegistry(maxWorkers)
         def processor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), maxWorkers)
         def processorWorker = new SimpleWorker()
 
@@ -75,7 +75,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         def maxWorkers = 1
         def registry = buildOperationWorkerRegistry(maxWorkers)
         def processor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), maxWorkers)
         def processorWorker = new SimpleWorker()
 
@@ -117,7 +117,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         def maxWorkers = 1
         def registry = buildOperationWorkerRegistry(maxWorkers)
         def processor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), maxWorkers)
         def processorWorker = new SimpleWorker()
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
@@ -23,6 +23,7 @@ import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.progress.BuildOperationDescriptor;
+import org.gradle.internal.progress.BuildOperationType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,8 +106,9 @@ public class LifecycleProjectEvaluator implements ProjectEvaluator {
         @Override
         public BuildOperationDescriptor.Builder description() {
             String name = "Configure project " + project.getIdentityPath().toString();
-            return BuildOperationDescriptor.displayName(name).details(
-                new ConfigureProjectBuildOperationDetails(project.getProjectPath(), project.getGradle().getIdentityPath()));
+            return BuildOperationDescriptor.displayName(name)
+                .operationType(BuildOperationType.CONFIGURE_PROJECT)
+                .details(new ConfigureProjectBuildOperationDetails(project.getProjectPath(), project.getGradle().getIdentityPath()));
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskGraphExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskGraphExecuter.java
@@ -45,6 +45,7 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.progress.BuildOperationDescriptor;
 import org.gradle.internal.progress.BuildOperationState;
+import org.gradle.internal.progress.BuildOperationType;
 import org.gradle.internal.progress.OperationFinishEvent;
 import org.gradle.internal.progress.OperationStartEvent;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
@@ -253,8 +254,11 @@ public class DefaultTaskGraphExecuter implements TaskGraphExecuter {
                 @Override
                 public BuildOperationDescriptor.Builder description() {
                     TaskOperationDetails taskOperation = new TaskOperationDetails(task);
-                    return BuildOperationDescriptor.displayName("Task " + task.getIdentityPath()).name(task.getIdentityPath().toString()).
-                        details(taskOperation).parent(parentOperation);
+                    return BuildOperationDescriptor.displayName("Task " + task.getIdentityPath())
+                        .name(task.getIdentityPath().toString())
+                        .parent(parentOperation)
+                        .operationType(BuildOperationType.TASK)
+                        .details(taskOperation);
                 }
             });
         }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/progress/NoOpProgressLoggerFactory.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/progress/NoOpProgressLoggerFactory.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.progress
+
+import org.gradle.internal.logging.progress.ProgressLogger
+import org.gradle.internal.logging.progress.ProgressLoggerFactory
+
+class NoOpProgressLoggerFactory implements ProgressLoggerFactory {
+    ProgressLogger newOperation(String loggerCategory) {
+        throw new UnsupportedOperationException()
+    }
+
+    ProgressLogger newOperation(Class<?> loggerCategory) {
+        throw new UnsupportedOperationException()
+    }
+
+    ProgressLogger newOperation(Class<?> loggerCategory, BuildOperationDescriptor buildOperationDescriptor) {
+        return new Logger()
+    }
+
+    ProgressLogger newOperation(Class<?> loggerClass, ProgressLogger parent) {
+        throw new UnsupportedOperationException()
+    }
+
+    static class Logger implements ProgressLogger {
+        String description
+        String shortDescription
+        String loggingHeader
+
+        String getDescription() { description }
+
+        ProgressLogger setDescription(String description) {
+            this.description = description
+            this
+        }
+
+        String getShortDescription() { shortDescription }
+
+        ProgressLogger setShortDescription(String description) {
+            this.shortDescription = description
+            this
+        }
+
+        String getLoggingHeader() { loggingHeader }
+
+        ProgressLogger setLoggingHeader(String header) {
+            this.loggingHeader = header
+            this
+        }
+
+        ProgressLogger start(String description, String shortDescription) {
+            setDescription(description)
+            setShortDescription(shortDescription)
+            started()
+            this
+        }
+
+        void started() {}
+        void started(String status) {}
+        void progress(String status) {}
+        void completed() {}
+        void completed(String status) {}
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyClassPathNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyClassPathNotationConverterTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarType
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.installation.CurrentGradleInstallation
 import org.gradle.internal.installation.GradleInstallation
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.typeconversion.NotationParserBuilder
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -46,7 +46,7 @@ class DependencyClassPathNotationConverterTest extends Specification {
     def classPathRegistry = Mock(ClassPathRegistry)
     def fileResolver = TestFiles.resolver()
     def cache = Mock(GeneratedGradleJarCache)
-    def progressLoggerFactory = Mock(ProgressLoggerFactory)
+    def progressLoggerFactory = new NoOpProgressLoggerFactory()
     def shadedJarFactory = Mock(RuntimeShadedJarFactory)
     def gradleInstallation = Mock(CurrentGradleInstallation)
     def factory = new DependencyClassPathNotationConverter(instantiator, classPathRegistry, fileResolver, shadedJarFactory, gradleInstallation)

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
@@ -32,6 +32,7 @@ import org.gradle.internal.logging.serializer.ProgressStartEventSerializer;
 import org.gradle.internal.logging.serializer.SpanSerializer;
 import org.gradle.internal.logging.serializer.StyledTextOutputEventSerializer;
 import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.progress.BuildOperationType;
 import org.gradle.internal.serialize.BaseSerializerFactory;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.DefaultSerializer;
@@ -45,6 +46,7 @@ public class DaemonMessageSerializer {
         BaseSerializerFactory factory = new BaseSerializerFactory();
         Serializer<LogLevel> logLevelSerializer = factory.getSerializerFor(LogLevel.class);
         Serializer<Throwable> throwableSerializer = factory.getSerializerFor(Throwable.class);
+        Serializer<BuildOperationType> buildOperationTypeSerializer = factory.getSerializerFor(BuildOperationType.class);
         DefaultSerializerRegistry registry = new DefaultSerializerRegistry();
 
         registry.register(BuildEvent.class, new BuildEventSerializer());
@@ -57,7 +59,7 @@ public class DaemonMessageSerializer {
         // Output events
         registry.register(LogEvent.class, new LogEventSerializer(logLevelSerializer, throwableSerializer));
         registry.register(StyledTextOutputEvent.class, new StyledTextOutputEventSerializer(logLevelSerializer, new ListSerializer<StyledTextOutputEvent.Span>(new SpanSerializer(factory.getSerializerFor(StyledTextOutput.Style.class)))));
-        registry.register(ProgressStartEvent.class, new ProgressStartEventSerializer());
+        registry.register(ProgressStartEvent.class, new ProgressStartEventSerializer(buildOperationTypeSerializer));
         registry.register(ProgressCompleteEvent.class, new ProgressCompleteEventSerializer());
         registry.register(ProgressEvent.class, new ProgressEventSerializer());
         registry.register(LogLevelChangeEvent.class, new LogLevelChangeEventSerializer(logLevelSerializer));

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildLogLevelFilterRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildLogLevelFilterRenderer.java
@@ -17,11 +17,12 @@
 package org.gradle.internal.logging.console;
 
 import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.logging.events.BatchOutputEventListener;
 import org.gradle.internal.logging.events.LogLevelChangeEvent;
 import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
 
-public class BuildLogLevelFilterRenderer implements OutputEventListener {
+public class BuildLogLevelFilterRenderer extends BatchOutputEventListener {
     private final OutputEventListener listener;
     private LogLevel logLevel = LogLevel.LIFECYCLE;
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/DefaultColorMap.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/DefaultColorMap.java
@@ -47,7 +47,7 @@ public class DefaultColorMap implements ColorMap {
     public DefaultColorMap() {
         addDefault(Info, "yellow");
         addDefault(Error, "default");
-        addDefault(Header, "default");
+        addDefault(Header, "bold");
         addDefault(Description, "yellow");
         addDefault(ProgressStatus, "yellow");
         addDefault(Identifier, "green");

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/LogGroupingOutputEventListener.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/LogGroupingOutputEventListener.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.Nullable;
+import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.SystemProperties;
+import org.gradle.internal.logging.events.BatchOutputEventListener;
+import org.gradle.internal.logging.events.CategorisedOutputEvent;
+import org.gradle.internal.logging.events.EndOutputEvent;
+import org.gradle.internal.logging.events.LogEvent;
+import org.gradle.internal.logging.events.OperationIdentifier;
+import org.gradle.internal.logging.events.OutputEvent;
+import org.gradle.internal.logging.events.ProgressCompleteEvent;
+import org.gradle.internal.logging.events.ProgressEvent;
+import org.gradle.internal.logging.events.ProgressStartEvent;
+import org.gradle.internal.logging.events.RenderableOutputEvent;
+import org.gradle.internal.logging.events.StyledTextOutputEvent;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.progress.BuildOperationType;
+import org.gradle.internal.time.TimeProvider;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class LogGroupingOutputEventListener extends BatchOutputEventListener {
+    public static final String EOL = SystemProperties.getInstance().getLineSeparator();
+    private final BatchOutputEventListener listener;
+    private final ScheduledExecutorService executor;
+    private final TimeProvider timeProvider;
+    private final Object lock = new Object();
+
+    // Allows us to map progress and complete events to start events
+    private final Map<OperationIdentifier, Object> progressToBuildOpIdMap = new LinkedHashMap<OperationIdentifier, Object>();
+
+    // Maintain a hierarchy of all build operation ids — heads up: this is a *forest*, not just 1 tree
+    private final Map<Object, Object> buildOpIdHierarchy = new LinkedHashMap<Object, Object>();
+
+    // Event groups that are in-progress and have not been completed
+    private final Map<Object, ArrayList<CategorisedOutputEvent>> outputEventGroups = new LinkedHashMap<Object, ArrayList<CategorisedOutputEvent>>();
+    private Object lastRenderedBuildOpId;
+    private boolean needsHeader;
+
+    public LogGroupingOutputEventListener(BatchOutputEventListener listener, TimeProvider timeProvider) {
+        this(listener, Executors.newSingleThreadScheduledExecutor(), timeProvider);
+    }
+
+    LogGroupingOutputEventListener(BatchOutputEventListener listener, ScheduledExecutorService executor, TimeProvider timeProvider) {
+        this.listener = listener;
+        this.executor = executor;
+        this.timeProvider = timeProvider;
+    }
+
+    @Override
+    public void onOutput(OutputEvent event) {
+        synchronized (lock) {
+            if (event instanceof EndOutputEvent) {
+                renderAllGroups(outputEventGroups);
+                listener.onOutput(event);
+            } else if (event instanceof ProgressStartEvent) {
+                onStart((ProgressStartEvent) event);
+            } else if (event instanceof ProgressEvent) {
+                ProgressEvent progressEvent = (ProgressEvent) event;
+                groupOrForward(progressToBuildOpIdMap.get(progressEvent.getProgressOperationId()), progressEvent);
+            } else if (event instanceof RenderableOutputEvent) {
+                RenderableOutputEvent renderableOutputEvent = (RenderableOutputEvent) event;
+                groupOrForward(renderableOutputEvent.getBuildOperationId(), renderableOutputEvent);
+            } else if (event instanceof ProgressCompleteEvent) {
+                onComplete((ProgressCompleteEvent) event);
+            } else {
+                listener.onOutput(event);
+            }
+        }
+    }
+
+    private void onStart(ProgressStartEvent event) {
+        Object buildOpId = event.getBuildOperationId();
+        if (buildOpId != null) {
+            buildOpIdHierarchy.put(buildOpId, event.getParentBuildOperationId());
+            progressToBuildOpIdMap.put(event.getProgressOperationId(), buildOpId);
+
+            if (event.getBuildOperationType() == BuildOperationType.TASK || event.getBuildOperationType() == BuildOperationType.CONFIGURE_PROJECT) {
+                // Add header to the group now to avoid having to track it in yet another collection or using a more complicated Map type
+                List<StyledTextOutputEvent.Span> header = Collections.singletonList(makeHeader(event));
+                CategorisedOutputEvent headerEvent = new StyledTextOutputEvent(event.getTimestamp(), event.getCategory(), LogLevel.QUIET, buildOpId, header);
+                outputEventGroups.put(buildOpId, Lists.newArrayList(headerEvent, event));
+            } else {
+                groupOrForward(buildOpId, event);
+            }
+        } else {
+            listener.onOutput(event);
+        }
+    }
+
+    private StyledTextOutputEvent.Span makeHeader(ProgressStartEvent event) {
+        final String message;
+        if (event.getLoggingHeader() != null) {
+            message = event.getLoggingHeader();
+        } else if (event.getShortDescription() != null) {
+            message = event.getShortDescription();
+        } else {
+            message = event.getDescription();
+        }
+        return new StyledTextOutputEvent.Span(StyledTextOutput.Style.Header, "> " + message + EOL);
+    }
+
+    private void onComplete(ProgressCompleteEvent event) {
+        Object buildOpId = progressToBuildOpIdMap.get(event.getProgressOperationId());
+        Object groupId;
+
+        if (outputEventGroups.containsKey(buildOpId)) {
+            // Render group if complete
+            List<OutputEvent> group = new ArrayList<OutputEvent>(outputEventGroups.remove(buildOpId));
+            group.add(event);
+            renderGroup(buildOpId, group);
+        } else if ((groupId = getGroupId(buildOpId)) != null) {
+            // Add to group if possible
+            outputEventGroups.get(groupId).add(event);
+        } else {
+            // Otherwise just forward the event
+            listener.onOutput(event);
+        }
+    }
+
+    // Return the id of the group, checking up the build operation id hierarchy
+    // We are assuming that the average height of the build operation id forest is very low
+    private Object getGroupId(@Nullable final Object buildOperationId) {
+        Object current = buildOperationId;
+        while (current != null) {
+            if (outputEventGroups.containsKey(current)) {
+                return current;
+            }
+            current = buildOpIdHierarchy.get(current);
+        }
+        return null;
+    }
+
+    private void groupOrForward(Object buildOpId, CategorisedOutputEvent event) {
+        Object groupId = getGroupId(buildOpId);
+        if (groupId != null) {
+            outputEventGroups.get(groupId).add(event);
+        } else {
+            if (event instanceof RenderableOutputEvent) {
+                needsHeader = true;
+            }
+            listener.onOutput(event);
+        }
+    }
+
+    private boolean hasRenderableEvents(List<OutputEvent> group) {
+        // First element is always the renderable header.
+        // Prefer just iterating tail of the list instead of making a new collection or using a LinkedList which has other perf implications.
+        for (int i = 1; i < group.size(); i++) {
+            if (group.get(i) instanceof RenderableOutputEvent) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean renderGroup(Object buildOpId, List<OutputEvent> group) {
+        if (hasRenderableEvents(group)) {
+            // Visually indicate group by adding surrounding lines
+            if (needsHeader) {
+                renderNewLine();
+                needsHeader = false;
+            }
+
+            listener.onOutput(group);
+
+            // Visually indicate a new group by adding a line if not appending to last rendered group
+            if (!buildOpId.equals(lastRenderedBuildOpId)) {
+                renderNewLine();
+            }
+            lastRenderedBuildOpId = buildOpId;
+            return true;
+        }
+        return false;
+    }
+
+    private void renderNewLine() {
+        listener.onOutput(new LogEvent(timeProvider.getCurrentTime(), LogGroupingOutputEventListener.class.toString(), LogLevel.QUIET, "", null));
+    }
+
+    private void renderAllGroups(Map<Object, ArrayList<CategorisedOutputEvent>> groups) {
+        for (Map.Entry<Object, ArrayList<CategorisedOutputEvent>> entry : groups.entrySet()) {
+            ArrayList<OutputEvent> group = new ArrayList<OutputEvent>(entry.getValue());
+            if (renderGroup(entry.getKey(), group)) {
+                // Preserve header
+                entry.setValue(Lists.newArrayList((CategorisedOutputEvent) group.get(0)));
+            }
+        }
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/WorkInProgressRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/WorkInProgressRenderer.java
@@ -19,12 +19,12 @@ package org.gradle.internal.logging.console;
 import org.gradle.internal.logging.events.BatchOutputEventListener;
 import org.gradle.internal.logging.events.EndOutputEvent;
 import org.gradle.internal.logging.events.MaxWorkerCountChangeEvent;
+import org.gradle.internal.logging.events.OperationIdentifier;
 import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
-import org.gradle.internal.logging.events.OperationIdentifier;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -111,7 +111,7 @@ public class WorkInProgressRenderer extends BatchOutputEventListener {
     }
 
     private void attach(ProgressOperation operation) {
-        // Skip attach if a children is already present
+        // Skip attach if a child is already present or no progress message to display
         if (isChildAssociationAlreadyExists(operation.getOperationId())) {
             return;
         }
@@ -129,7 +129,7 @@ public class WorkInProgressRenderer extends BatchOutputEventListener {
         }
 
         // No parent? Try to use a new label
-        if (association == null && !unusedProgressLabels.isEmpty()) {
+        if (!unusedProgressLabels.isEmpty()) {
             association = new AssociationLabel(operation, unusedProgressLabels.pop());
         }
 
@@ -170,7 +170,7 @@ public class WorkInProgressRenderer extends BatchOutputEventListener {
     private void removeDirectChildOperationId(OperationIdentifier parentId, OperationIdentifier childId) {
         Set<OperationIdentifier> children = parentIdToChildrenIds.get(parentId);
         if (children == null) {
-            throw new IllegalStateException("");
+            return;
         }
         children.remove(childId);
         if (children.isEmpty()) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressStartEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressStartEvent.java
@@ -18,6 +18,7 @@ package org.gradle.internal.logging.events;
 
 import org.gradle.api.Nullable;
 import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.progress.BuildOperationType;
 
 public class ProgressStartEvent extends CategorisedOutputEvent {
     private final OperationIdentifier progressOperationId;
@@ -27,6 +28,8 @@ public class ProgressStartEvent extends CategorisedOutputEvent {
     private final String loggingHeader;
     private final String status;
     private final Object buildOperationId;
+    private final Object parentBuildOperationId;
+    private BuildOperationType buildOperationType;
 
     public ProgressStartEvent(OperationIdentifier progressOperationId,
                               @Nullable OperationIdentifier parentProgressOperationId,
@@ -36,7 +39,9 @@ public class ProgressStartEvent extends CategorisedOutputEvent {
                               @Nullable String shortDescription,
                               @Nullable String loggingHeader,
                               String status,
-                              @Nullable Object buildOperationId) {
+                              @Nullable Object buildOperationId,
+                              @Nullable Object parentBuildOperationId,
+                              BuildOperationType buildOperationType) {
         super(timestamp, category, LogLevel.LIFECYCLE);
         this.progressOperationId = progressOperationId;
         this.parentProgressOperationId = parentProgressOperationId;
@@ -45,6 +50,8 @@ public class ProgressStartEvent extends CategorisedOutputEvent {
         this.loggingHeader = loggingHeader;
         this.status = status;
         this.buildOperationId = buildOperationId;
+        this.parentBuildOperationId = parentBuildOperationId;
+        this.buildOperationType = buildOperationType;
     }
 
     @Nullable
@@ -82,5 +89,14 @@ public class ProgressStartEvent extends CategorisedOutputEvent {
     @Nullable
     public Object getBuildOperationId() {
         return buildOperationId;
+    }
+
+    @Nullable
+    public Object getParentBuildOperationId() {
+        return parentBuildOperationId;
+    }
+
+    public BuildOperationType getBuildOperationType() {
+        return buildOperationType;
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
@@ -17,10 +17,12 @@
 package org.gradle.internal.logging.progress;
 
 import org.gradle.api.Nullable;
+import org.gradle.internal.logging.events.OperationIdentifier;
 import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
-import org.gradle.internal.logging.events.OperationIdentifier;
+import org.gradle.internal.progress.BuildOperationDescriptor;
+import org.gradle.internal.progress.BuildOperationType;
 import org.gradle.internal.time.TimeProvider;
 import org.gradle.util.GUtil;
 
@@ -29,7 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
     private final ProgressListener progressListener;
     private final TimeProvider timeProvider;
-    private final AtomicLong nextId = new AtomicLong(-1);
+    private final AtomicLong nextId = new AtomicLong(ROOT_PROGRESS_OPERATION_ID);
     private final ThreadLocal<ProgressLoggerImpl> current = new ThreadLocal<ProgressLoggerImpl>();
 
     public DefaultProgressLoggerFactory(ProgressListener progressListener, TimeProvider timeProvider) {
@@ -41,34 +43,30 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
         return newOperation(loggerCategory.getName());
     }
 
-    public ProgressLogger newOperation(Class loggerCategory, Object operationIdentifier) {
-        return newOperation(loggerCategory.getName());
+    public ProgressLogger newOperation(Class loggerCategory, @Nullable BuildOperationDescriptor buildOperationDescriptor) {
+        return init(loggerCategory.getName(), null, buildOperationDescriptor);
     }
 
     public ProgressLogger newOperation(String loggerCategory) {
         return init(loggerCategory, null, null);
     }
 
-    public ProgressLogger newOperation(String loggerCategory, Object buildOperationId) {
-        return init(loggerCategory, null, buildOperationId);
-    }
-
     public ProgressLogger newOperation(Class loggerClass, ProgressLogger parent) {
         return init(loggerClass.toString(), parent, null);
     }
 
-    private ProgressLogger init(String loggerCategory, @Nullable ProgressLogger parentOperation, @Nullable Object buildOperationId) {
+    private ProgressLogger init(String loggerCategory, @Nullable ProgressLogger parentOperation, @Nullable BuildOperationDescriptor buildOperationDescriptor) {
         if (parentOperation != null && !(parentOperation instanceof ProgressLoggerImpl)) {
             throw new IllegalArgumentException("Unexpected parent logger.");
         }
-        return new ProgressLoggerImpl((ProgressLoggerImpl) parentOperation, new OperationIdentifier(nextId.getAndIncrement()), loggerCategory, progressListener, timeProvider, buildOperationId);
+        return new ProgressLoggerImpl((ProgressLoggerImpl) parentOperation, new OperationIdentifier(nextId.getAndIncrement()), loggerCategory, progressListener, timeProvider, buildOperationDescriptor);
     }
 
     private enum State { idle, started, completed }
 
     private class ProgressLoggerImpl implements ProgressLogger {
         private final OperationIdentifier progressOperationId;
-        private final Object buildOperationId;
+        private final BuildOperationDescriptor buildOperationDescriptor;
         private final String category;
         private final ProgressListener listener;
         private final TimeProvider timeProvider;
@@ -78,13 +76,13 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
         private String loggingHeader;
         private State state = State.idle;
 
-        public ProgressLoggerImpl(ProgressLoggerImpl parent, OperationIdentifier progressOperationId, String category, ProgressListener listener, TimeProvider timeProvider, @Nullable Object buildOperationId) {
+        public ProgressLoggerImpl(ProgressLoggerImpl parent, OperationIdentifier progressOperationId, String category, ProgressListener listener, TimeProvider timeProvider, @Nullable BuildOperationDescriptor buildOperationDescriptor) {
             this.parent = parent;
             this.progressOperationId = progressOperationId;
             this.category = category;
             this.listener = listener;
             this.timeProvider = timeProvider;
-            this.buildOperationId = buildOperationId;
+            this.buildOperationDescriptor = buildOperationDescriptor;
         }
 
         @Override
@@ -145,7 +143,7 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
                 parent.assertRunning();
             }
             current.set(this);
-            listener.started(new ProgressStartEvent(progressOperationId, parent == null ? null : parent.progressOperationId, timeProvider.getCurrentTime(), category, description, shortDescription, loggingHeader, toStatus(status), buildOperationId));
+            listener.started(new ProgressStartEvent(progressOperationId, parent == null ? null : parent.progressOperationId, timeProvider.getCurrentTime(), category, description, shortDescription, loggingHeader, toStatus(status), getBuildOperationId(), getParentBuildOperationId(), getBuildOperationType()));
         }
 
         public void progress(String status) {
@@ -190,6 +188,18 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
             if (state != State.idle) {
                 throw new IllegalStateException(String.format("Cannot configure this operation (%s) once it has started.", this));
             }
+        }
+
+        private Object getBuildOperationId() {
+            return buildOperationDescriptor == null ? null : buildOperationDescriptor.getId();
+        }
+
+        private Object getParentBuildOperationId() {
+            return buildOperationDescriptor == null ? null : buildOperationDescriptor.getParentId();
+        }
+
+        private BuildOperationType getBuildOperationType() {
+            return buildOperationDescriptor == null ? BuildOperationType.UNCATEGORIZED : buildOperationDescriptor.getOperationType();
         }
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
@@ -16,10 +16,14 @@
 
 package org.gradle.internal.logging.progress;
 
+import org.gradle.internal.progress.BuildOperationDescriptor;
+
 /**
  * Thread-safe, however the progress logger instances created are not.
  */
 public interface ProgressLoggerFactory {
+    long ROOT_PROGRESS_OPERATION_ID = -1;
+
     /**
      * Creates a new long-running operation which has not been started.
      *
@@ -41,10 +45,10 @@ public interface ProgressLoggerFactory {
      * with the given build operation id.
      *
      * @param loggerCategory The logger category.
-     * @param buildOperationId OperationIdentifier to be associated with all logs produced by the new ProgressLogger.
+     * @param buildOperationDescriptor descriptor for the build operation associated with this logger.
      * @return the progress logger for the operation.
      */
-    ProgressLogger newOperation(Class<?> loggerCategory, Object buildOperationId);
+    ProgressLogger newOperation(Class<?> loggerCategory, BuildOperationDescriptor buildOperationDescriptor);
 
     ProgressLogger newOperation(Class<?> loggerClass, ProgressLogger parent);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressStartEventSerializer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressStartEventSerializer.java
@@ -18,11 +18,18 @@ package org.gradle.internal.logging.serializer;
 
 import org.gradle.internal.logging.events.OperationIdentifier;
 import org.gradle.internal.logging.events.ProgressStartEvent;
+import org.gradle.internal.progress.BuildOperationType;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
 public class ProgressStartEventSerializer implements Serializer<ProgressStartEvent> {
+    private final Serializer<BuildOperationType> buildOperationTypeSerializer;
+
+    public ProgressStartEventSerializer(Serializer<BuildOperationType> buildOperationTypeSerializer) {
+        this.buildOperationTypeSerializer = buildOperationTypeSerializer;
+    }
+
     @Override
     public void write(Encoder encoder, ProgressStartEvent event) throws Exception {
         encoder.writeSmallLong(event.getProgressOperationId().getId());
@@ -44,6 +51,13 @@ public class ProgressStartEventSerializer implements Serializer<ProgressStartEve
             encoder.writeBoolean(true);
             encoder.writeSmallLong(((OperationIdentifier) event.getBuildOperationId()).getId());
         }
+        if (event.getParentBuildOperationId() == null) {
+            encoder.writeBoolean(false);
+        } else {
+            encoder.writeBoolean(true);
+            encoder.writeSmallLong(((OperationIdentifier) event.getParentBuildOperationId()).getId());
+        }
+        buildOperationTypeSerializer.write(encoder, event.getBuildOperationType());
     }
 
     @Override
@@ -57,6 +71,8 @@ public class ProgressStartEventSerializer implements Serializer<ProgressStartEve
         String loggingHeader = decoder.readNullableString();
         String status = decoder.readString();
         Object buildOperationId = decoder.readBoolean() ? new OperationIdentifier(decoder.readSmallLong()) : null;
-        return new ProgressStartEvent(progressOperationId, parentProgressOperationId, timestamp, category, description, shortDescription, loggingHeader, status, buildOperationId);
+        Object parentBuildOperationId = decoder.readBoolean() ? new OperationIdentifier(decoder.readSmallLong()) : null;
+        BuildOperationType buildOperationType = buildOperationTypeSerializer.read(decoder);
+        return new ProgressStartEvent(progressOperationId, parentProgressOperationId, timestamp, category, description, shortDescription, loggingHeader, status, buildOperationId, parentBuildOperationId, buildOperationType);
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -31,6 +31,7 @@ import org.gradle.internal.logging.console.Console;
 import org.gradle.internal.logging.console.ConsoleLayoutCalculator;
 import org.gradle.internal.logging.console.DefaultColorMap;
 import org.gradle.internal.logging.console.DefaultWorkInProgressFormatter;
+import org.gradle.internal.logging.console.LogGroupingOutputEventListener;
 import org.gradle.internal.logging.console.StyledTextOutputBackedRenderer;
 import org.gradle.internal.logging.console.ThrottlingOutputEventListener;
 import org.gradle.internal.logging.console.WorkInProgressRenderer;
@@ -181,7 +182,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
     private void addStandardErrorListener() {
         synchronized (lock) {
             originalStdErr = System.err;
-            if(stdErrListener != null) {
+            if (stdErrListener != null) {
                 stderrListeners.remove(stdErrListener);
             }
             stdErrListener = new StreamBackedStandardOutputListener((Appendable) System.err);
@@ -200,7 +201,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     private void removeStandardErrorListener() {
         synchronized (lock) {
-            if(stdErrListener != null) {
+            if (stdErrListener != null) {
                 stderrListeners.remove(stdErrListener);
                 stdErrListener = null;
             }
@@ -221,12 +222,14 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     public OutputEventRenderer addConsole(Console console, boolean stdout, boolean stderr, ConsoleMetaData consoleMetaData) {
         final OutputEventListener consoleChain = new ThrottlingOutputEventListener(
-             new BuildStatusRenderer(
+            new BuildStatusRenderer(
                 new WorkInProgressRenderer(
-                    new BuildLogLevelFilterRenderer(
-                        new ProgressLogEventGenerator(
-                            new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), true)),
-                        console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
+                    new LogGroupingOutputEventListener(
+                        new BuildLogLevelFilterRenderer(
+                            new ProgressLogEventGenerator(
+                                new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), true)),
+                        timeProvider),
+                    console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
                 console.getStatusBar(), console, consoleMetaData, timeProvider),
             timeProvider);
         synchronized (lock) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
@@ -18,6 +18,7 @@ package org.gradle.internal.logging.sink;
 
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.SystemProperties;
+import org.gradle.internal.logging.events.BatchOutputEventListener;
 import org.gradle.internal.logging.events.OperationIdentifier;
 import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
@@ -40,7 +41,7 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style;
  * An {@code org.gradle.logging.internal.OutputEventListener} implementation which generates output events to log the
  * progress of operations.
  */
-public class ProgressLogEventGenerator implements OutputEventListener {
+public class ProgressLogEventGenerator extends BatchOutputEventListener {
     private static final String EOL = SystemProperties.getInstance().getLineSeparator();
 
     private final OutputEventListener listener;

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/OutputSpecification.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/OutputSpecification.groovy
@@ -21,6 +21,7 @@ import org.gradle.internal.logging.events.OperationIdentifier
 import org.gradle.internal.logging.events.ProgressCompleteEvent
 import org.gradle.internal.logging.events.ProgressEvent
 import org.gradle.internal.logging.events.ProgressStartEvent
+import org.gradle.internal.progress.BuildOperationType
 import org.gradle.util.TextUtil
 import spock.lang.Specification
 
@@ -55,6 +56,10 @@ abstract class OutputSpecification extends Specification {
         return new LogEvent(tenAm, 'category', logLevel, text, null)
     }
 
+    LogEvent event(String text, LogLevel logLevel, Object buildOperationId) {
+        return new LogEvent(tenAm, 'category', logLevel, text, null, buildOperationId)
+    }
+
     LogEvent event(long timestamp, String text, LogLevel logLevel) {
         return new LogEvent(timestamp, 'category', logLevel, text, null)
     }
@@ -73,10 +78,12 @@ abstract class OutputSpecification extends Specification {
 
     ProgressStartEvent start(Map args) {
         OperationIdentifier parentId = args.containsKey("parentId") ? args.parentId : new OperationIdentifier(counter)
-        OperationIdentifier buildOperationId = args.containsKey("buildOperationId") ? args.buildOperationId : new OperationIdentifier(counter)
+        Object buildOperationId = args.containsKey("buildOperationId") ? args.buildOperationId : null
+        Object parentBuildOperationId = args.containsKey("parentBuildOperationId") ? args.parentBuildOperationId : null
+        BuildOperationType buildOperationType = args.containsKey("buildOperationType") ? args.buildOperationType : BuildOperationType.UNCATEGORIZED
         long id = ++counter
         String category = args.containsKey("category") ? args.category : CATEGORY
-        return new ProgressStartEvent(new OperationIdentifier(id), parentId, tenAm, category, args.description, args.shortDescription, args.loggingHeader, args.status, buildOperationId)
+        return new ProgressStartEvent(new OperationIdentifier(id), parentId, tenAm, category, args.description, args.shortDescription, args.loggingHeader, args.status, buildOperationId, parentBuildOperationId, buildOperationType)
     }
 
     ProgressEvent progress(String status) {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleFunctionalTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleFunctionalTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.logging.events.ProgressEvent
 import org.gradle.internal.logging.events.ProgressStartEvent
 import org.gradle.internal.logging.sink.OutputEventRenderer
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData
+import org.gradle.internal.progress.BuildOperationType
 import org.gradle.internal.time.TimeProvider
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.util.RedirectStdOutAndErr
@@ -37,7 +38,8 @@ class ConsoleFunctionalTest extends Specification {
     private final ConsoleMetaData metaData = Mock(ConsoleMetaData)
     private OutputEventRenderer renderer
     private long currentTimeMs;
-    public static final String IDLE = '> IDLE'
+    private static final String IDLE = '> IDLE'
+    private static final String CATEGORY = 'CATEGORY'
 
     def setup() {
         renderer = new OutputEventRenderer(timeProvider)
@@ -253,11 +255,11 @@ class ConsoleFunctionalTest extends Specification {
     ProgressStartEvent startEvent(Long id, Long parentId=null, category='CATEGORY', description='DESCRIPTION', shortDescription='SHORT_DESCRIPTION', loggingHeader='LOGGING_HEADER', status='STATUS') {
         long timestamp = timeProvider.currentTime
         OperationIdentifier parent = parentId ? new OperationIdentifier(parentId) : null
-        new ProgressStartEvent(new OperationIdentifier(id), parent, timestamp, category, description, shortDescription, loggingHeader, status, null)
+        new ProgressStartEvent(new OperationIdentifier(id), parent, timestamp, category, description, shortDescription, loggingHeader, status, null, null, BuildOperationType.UNCATEGORIZED)
     }
 
     ProgressStartEvent startEvent(Long id, String status) {
-        new ProgressStartEvent(new OperationIdentifier(id), null, timeProvider.currentTime, null, null, null, null, status, null)
+        new ProgressStartEvent(new OperationIdentifier(id), null, timeProvider.currentTime, null, null, null, null, status, null, null, BuildOperationType.UNCATEGORIZED)
     }
 
     ProgressEvent progressEvent(Long id, category='CATEGORY', status='STATUS') {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/LogGroupingOutputEventListenerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/LogGroupingOutputEventListenerTest.groovy
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.internal.logging.OutputSpecification
+import org.gradle.internal.logging.events.BatchOutputEventListener
+import org.gradle.internal.logging.events.EndOutputEvent
+import org.gradle.internal.logging.events.LogLevelChangeEvent
+import org.gradle.internal.logging.events.OperationIdentifier
+import org.gradle.internal.logging.events.OutputEvent
+import org.gradle.internal.logging.events.ProgressCompleteEvent
+import org.gradle.internal.logging.events.ProgressStartEvent
+import org.gradle.internal.progress.BuildOperationType
+import org.gradle.util.MockExecutor
+import org.gradle.util.MockTimeProvider
+import spock.lang.Subject
+
+class LogGroupingOutputEventListenerTest extends OutputSpecification {
+    def downstreamListener = Mock(BatchOutputEventListener)
+    def timeProvider = new MockTimeProvider()
+    def executor = new MockExecutor()
+
+    @Subject listener = new LogGroupingOutputEventListener(downstreamListener, executor, timeProvider)
+
+    def "forwards uncategorized events"() {
+        def logLevelChangeEvent = new LogLevelChangeEvent(LogLevel.LIFECYCLE)
+
+        when:
+        listener.onOutput(logLevelChangeEvent)
+
+        then:
+        1 * downstreamListener.onOutput(logLevelChangeEvent)
+        0 * _
+    }
+
+    def "forwards logs with no group"() {
+        given:
+        def event = event('message')
+
+        when:
+        listener.onOutput(event)
+
+        then:
+        1 * downstreamListener.onOutput(event)
+        0 * _
+    }
+
+    def "forwards a group of logs for a task"() {
+        given:
+        def taskStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), tenAm, CATEGORY, "Execute :foo", ":foo", null, null, new OperationIdentifier(2L), null, BuildOperationType.TASK)
+        def warningMessage = event('Warning: some deprecation or something', LogLevel.WARN, taskStartEvent.buildOperationId)
+
+        when:
+        listener.onOutput([taskStartEvent, warningMessage])
+
+        then:
+        0 * _
+
+        when:
+        listener.onOutput(new ProgressCompleteEvent(taskStartEvent.progressOperationId, tenAm, CATEGORY, 'Complete: :foo', null))
+
+        then:
+        1 * downstreamListener.onOutput(_ as List<OutputEvent>)
+        1 * downstreamListener.onOutput({ it.getMessage() == "" })
+        0 * _
+    }
+
+    def "groups logs for child operations of tasks"() {
+        given:
+        def taskStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), tenAm, CATEGORY, "Execute :foo", ":foo", null, null, new OperationIdentifier(2L), null, BuildOperationType.TASK)
+        def subtaskStartEvent = new ProgressStartEvent(new OperationIdentifier(-4L), new OperationIdentifier(-5L), tenAm, CATEGORY, ":foo subtask", "subtask", null, null, new OperationIdentifier(3L), taskStartEvent.buildOperationId, BuildOperationType.UNCATEGORIZED)
+        def warningMessage = event('Child task log message', LogLevel.WARN, subtaskStartEvent.buildOperationId)
+        def subTaskCompleteEvent = new ProgressCompleteEvent(subtaskStartEvent.progressOperationId, tenAm, CATEGORY, 'Complete: subtask', 'subtask complete')
+        def taskCompleteEvent = new ProgressCompleteEvent(taskStartEvent.progressOperationId, tenAm, CATEGORY, 'Complete: :foo', 'UP-TO-DATE')
+
+        when:
+        listener.onOutput([taskStartEvent, subtaskStartEvent, warningMessage, subTaskCompleteEvent])
+
+        then:
+        0 * _
+
+        when:
+        listener.onOutput(taskCompleteEvent)
+
+        then:
+        1 * downstreamListener.onOutput(_ as List<OutputEvent>)
+        1 * downstreamListener.onOutput({ it.getMessage() == "" })
+        0 * _
+    }
+
+    def "flushes all remaining groups on end of build"() {
+        given:
+        def taskStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), tenAm, CATEGORY, "Execute :foo", ":foo", null, null, new OperationIdentifier(2L), null, BuildOperationType.TASK)
+        def warningMessage = event('Warning: some deprecation or something', LogLevel.WARN, taskStartEvent.buildOperationId)
+        def endBuildEvent = new EndOutputEvent()
+
+        when:
+        listener.onOutput([taskStartEvent, warningMessage, endBuildEvent])
+
+        then:
+        1 * downstreamListener.onOutput(_ as List<OutputEvent>)
+        1 * downstreamListener.onOutput(endBuildEvent)
+        1 * downstreamListener.onOutput(_ as OutputEvent)
+        0 * _
+    }
+
+    def "does not forward group with no logs"() {
+        given:
+        def taskStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), tenAm, CATEGORY, "Execute :foo", ":foo", null, null, new OperationIdentifier(2L), null, BuildOperationType.TASK)
+        def completeEvent = new ProgressCompleteEvent(taskStartEvent.progressOperationId, tenAm, CATEGORY, 'Complete: :foo', null)
+
+        when:
+        listener.onOutput([taskStartEvent, completeEvent])
+
+        then:
+        0 * _
+    }
+
+    void flush() {
+        executor.runNow()
+    }
+}

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -21,12 +21,12 @@ import org.gradle.api.internal.file.BaseDirFileResolver
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.GradleThread
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
 import org.gradle.internal.operations.logging.BuildOperationLogger
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.time.TimeProvider
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory
@@ -57,7 +57,7 @@ abstract class NativeCompilerTest extends Specification {
 
     private BuildOperationListener buildOperationListener = Mock(BuildOperationListener)
     private TimeProvider timeProvider = Mock(TimeProvider)
-    protected BuildOperationExecutor buildOperationExecutor = new DefaultBuildOperationExecutor(buildOperationListener, timeProvider, Mock(ProgressLoggerFactory),
+    protected BuildOperationExecutor buildOperationExecutor = new DefaultBuildOperationExecutor(buildOperationListener, timeProvider, new NoOpProgressLoggerFactory(),
         new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), 1)
 
     def setup() {

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
@@ -19,11 +19,11 @@ import org.gradle.api.internal.tasks.testing.BuildableTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.AggregateTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.time.TimeProvider
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestFile
@@ -47,7 +47,7 @@ class DefaultTestReportTest extends Specification {
 
     def reportWithMaxThreads(int numThreads) {
         buildOperationExecutor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), numThreads)
         return new DefaultTestReport(buildOperationExecutor)
     }

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -18,12 +18,12 @@ package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.Action
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
 import org.gradle.internal.operations.MultipleBuildOperationFailures
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.time.TimeProvider
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -43,7 +43,7 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
 
     def generatorWithMaxThreads(int numThreads) {
         buildOperationExecutor = new DefaultBuildOperationExecutor(
-            Mock(BuildOperationListener), Mock(TimeProvider), Mock(ProgressLoggerFactory),
+            Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), numThreads)
         Binary2JUnitXmlReportGenerator reportGenerator = new Binary2JUnitXmlReportGenerator(temp.testDirectory, resultsProvider, TestOutputAssociation.WITH_SUITE, buildOperationExecutor, "localhost")
         reportGenerator.xmlWriter = Mock(JUnitXmlResultWriter)

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
 import org.gradle.api.tasks.testing.TestExecutionException
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.internal.progress.BuildOperationDescriptor
+import org.gradle.internal.progress.BuildOperationType
 import org.gradle.internal.progress.OperationStartEvent
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction
@@ -90,7 +91,7 @@ class TestExecutionResultEvaluatorTest extends Specification {
 
         def testTask = Mock(TaskInternal)
         1 * testTask.getPath() >> ":someproject:someTestTask"
-        def buildOperation = new BuildOperationDescriptor(1, 2, "<task>", "<task>",  "<task>", new TaskOperationDetails(testTask))
+        def buildOperation = new BuildOperationDescriptor(1, 2, "<task>", "<task>",  "<task>", new TaskOperationDetails(testTask), BuildOperationType.TASK)
 
         when:
         evaluator.started(buildOperation, new OperationStartEvent(0))


### PR DESCRIPTION
Introduces a BuildOperationType enum and adds it to the
default BuildOperationDescriptor. Passes this information
to the logging infrastructure through the BuildOperationExecutor.

All BuildOperations now have a ProgressLogger. This allows
progress logging to maintain a heirarchy of build operations,
otherwise we would not be able to group many log events.

ProgressStartEvents are given additional information in a
compact form to allow a tree of build operations to be
maintained and their operation types associated. This allows us
to associate log events who aren't fired by progress logging to
still be grouped.

A LogGroupingOutputEventListener uses these build operation
types and the build operation heirarchy to buffer and output
logs related to tasks and project configurations.

[CI Build](https://builds.gradle.org/viewQueued.html?itemId=2872390)

Issue: #1818

### Context
This has been a part of the [console/logging design spec](https://github.com/gradle/gradle/blob/master/design-docs/improved-console.md#milestone-3---logging-improvements).

This PR supersedes #1891 

### Contributor Checklist
- [x] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
