### PR TITLE
Implements and tests build cache for ScalaCompile and ScalaDoc

### DIFF
--- a/subprojects/docs/src/docs/userguide/buildCache.adoc
+++ b/subprojects/docs/src/docs/userguide/buildCache.adoc
@@ -135,6 +135,9 @@ Currently, the following built-in Gradle tasks are cacheable:
 * Groovy toolchain:
     api:org.gradle.api.tasks.compile.GroovyCompile[],
     api:org.gradle.api.tasks.javadoc.Groovydoc[]
+* Scala toolchain:
+    api:org.gradle.api.tasks.compile.ScalaCompile[],
+    api:org.gradle.api.tasks.javadoc.Scaladoc[]
 * Testing:
     api:org.gradle.api.tasks.testing.Test[]
 * Code quality tasks:
@@ -150,7 +153,7 @@ Currently, the following built-in Gradle tasks are cacheable:
     api:org.gradle.plugin.devel.tasks.ValidateTaskProperties[],
     api:org.gradle.api.tasks.WriteProperties[]
 
-All other tasks are currently not cacheable, but this may change in the future for other languages (Scala) or domains (native, Android, Play).
+All other tasks are currently not cacheable, but this may change in the future for other languages (Kotlin) or domains (native, Android, Play).
 Some tasks, like api:org.gradle.api.tasks.Copy[] or api:org.gradle.api.tasks.bundling.Jar[], usually do not make sense to make cacheable because Gradle is only copying files from one location to another.
 It also doesn't make sense to make tasks cacheable that do not produce outputs or have no task actions.
 

--- a/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/ScalaCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/ScalaCompileRelocationIntegrationTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.scala
+
+import org.gradle.integtests.fixtures.AbstractTaskRelocationIntegrationTest
+
+import static org.gradle.util.JarUtils.jarWithContents
+
+class ScalaCompileRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest {
+
+    @Override
+    protected String getTaskName() {
+        return ":compile"
+    }
+
+    @Override
+    protected void setupProjectInOriginalLocation() {
+        file("libs").createDir()
+        file("libs/lib1.jar") << jarWithContents("data.txt": "data1")
+        file("libs/lib2.jar") << jarWithContents("data.txt": "data2")
+        file("src/main/scala/sub-dir").createDir()
+        file("src/main/scala/Foo.java") << "class Foo {}"
+
+        buildFile << buildFileWithClasspath("libs")
+    }
+
+    private static String buildFileWithClasspath(String classpath) {
+        """
+            task compile(type: ScalaCompile) {
+                sourceCompatibility = JavaVersion.current()
+                targetCompatibility = JavaVersion.current()
+                destinationDir = file("build/classes")
+                source "src/main/scala"
+                classpath = files('$classpath')
+                scalaClasspath = files()
+                zincClasspath = files()
+            }
+        """
+    }
+
+    @Override
+    protected void moveFilesAround() {
+        file("src/main/scala/Foo.java").moveToDirectory(file("src/main/scala/sub-dir"))
+        file("libs").renameTo(file("lobs"))
+        buildFile.text = buildFileWithClasspath("lobs")
+    }
+
+    @Override
+    protected extractResults() {
+        return file("build/classes/Foo.class").bytes
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.gradle.scala.compile
 
 import org.gradle.AbstractCachedCompileIntegrationTest

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.scala.compile
+
+import org.gradle.AbstractCachedCompileIntegrationTest
+import org.gradle.test.fixtures.file.TestFile
+
+class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegrationTest {
+    String compilationTask = ':compileScala'
+    String compiledFile = "build/classes/scala/main/Hello.class"
+
+    @Override
+    def setupProjectInDirectory(TestFile project = temporaryFolder.testDirectory) {
+        project.with {
+            file('build.gradle').text = """
+            plugins {
+                id 'scala'
+                id 'application'
+            }
+
+            mainClassName = "Hello"
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                compile group: 'org.scala-lang', name: 'scala-library', version: '2.11.8'
+            }
+        """.stripIndent()
+
+        file('src/main/scala/Hello.scala') << """
+            object Hello {
+                def main(args: Array[String]): Unit = {
+                    print("Hello!")
+                }
+            }
+        """.stripIndent()
+        }
+    }
+
+    def "compilation is not cached if we change the version of the Scala library"() {
+        given:
+        populateCache()
+        buildFile.text = """
+            plugins { id 'scala' }
+
+            repositories { mavenCentral() }
+            dependencies { compile group: 'org.scala-lang', name: 'scala-library', version: '2.11.7' }
+        """.stripIndent()
+
+        when:
+        withBuildCache().succeeds compilationTask
+
+        then:
+        compileIsNotCached()
+    }
+
+    def "joint Java and Scala compilation can be cached"() {
+        given:
+        buildScript """
+            plugins {
+                id 'scala'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                compile group: 'org.scala-lang', name: 'scala-library', version: '2.11.8'
+            }
+        """
+        file('src/main/java/RequiredByScala.java') << """
+            public class RequiredByScala {
+                public static void printSomething() {
+                    java.lang.System.out.println("Hello from Java");
+                }
+            }
+        """
+        file('src/main/java/RequiredByScala.java').makeOlder()
+
+        file('src/main/scala/UsesJava.scala') << """
+            class UsesJava {
+                def printSomething(): Unit = {
+                    RequiredByScala.printSomething()
+                }
+            }
+        """
+        file('src/main/scala/UsesJava.scala').makeOlder()
+        def compiledJavaClass = javaClassFile('RequiredByScala.class')
+        def compiledScalaClass = scalaClassFile('UsesJava.class')
+
+        when:
+        withBuildCache().succeeds ':compileJava', ':compileScala'
+
+        then:
+        compiledJavaClass.exists()
+        compiledScalaClass.exists()
+
+        when:
+        withBuildCache().succeeds ':clean', ':compileJava'
+
+        then:
+        skippedTasks.contains(':compileJava')
+
+        when:
+        // This line is crucial to expose the bug
+        // When doing this and then loading the classes for
+        // compileScala from the cache the compiled java
+        // classes are replaced and recorded as changed
+        compiledJavaClass.makeOlder()
+        withBuildCache().succeeds ':compileScala'
+
+        then:
+        skippedTasks.containsAll([':compileJava', ':compileScala'])
+
+        when:
+        file('src/main/java/RequiredByScala.java').text = """
+            public class RequiredByScala {
+                public static void printSomethingNew() {
+                    java.lang.System.out.println("Hello from Java");
+                    // Different
+                }
+            }
+        """
+        file('src/main/scala/UsesJava.scala').text = """
+            class UsesJava {
+                def printSomething(): Unit = {
+                    RequiredByScala.printSomethingNew()
+                    // Some comment
+                }
+            }
+        """
+
+        withBuildCache().succeeds ':compileScala'
+
+        then:
+        compiledJavaClass.exists()
+        compiledScalaClass.exists()
+    }
+}

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.scala.ScalaCompileSpec;
 import org.gradle.api.internal.tasks.scala.ScalaCompilerFactory;
 import org.gradle.api.internal.tasks.scala.ScalaJavaJointCompileSpec;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Nested;
 import org.gradle.language.scala.tasks.AbstractScalaCompile;
@@ -31,6 +32,7 @@ import javax.inject.Inject;
 /**
  * Compiles Scala source files, and optionally, Java source files.
  */
+@CacheableTask
 public class ScalaCompile extends AbstractScalaCompile {
 
     private FileCollection scalaClasspath;

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
@@ -17,6 +17,7 @@ package org.gradle.api.tasks.scala;
 
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.scala.ScalaCompileSpec;
 import org.gradle.api.internal.tasks.scala.ScalaCompilerFactory;
@@ -24,6 +25,8 @@ import org.gradle.api.internal.tasks.scala.ScalaJavaJointCompileSpec;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.language.scala.tasks.AbstractScalaCompile;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
@@ -57,6 +60,15 @@ public class ScalaCompile extends AbstractScalaCompile {
     @Classpath
     public FileCollection getScalaClasspath() {
         return scalaClasspath;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public FileTree getSource() {
+        return super.getSource();
     }
 
     public void setScalaClasspath(FileCollection scalaClasspath) {

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.scala;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.internal.tasks.scala.AntScalaDoc;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
@@ -33,6 +34,7 @@ import java.io.File;
 /**
  * Generates HTML API documentation for Scala source files.
  */
+@CacheableTask
 public class ScalaDoc extends SourceTask {
 
     private File destinationDir;


### PR DESCRIPTION
Issue: #1956

Provides an implementation for ScalaCompile and ScalaDoc that makes
them cacheable.

Also added tests from ScalaCompile and DID NOT add tests for ScalaDoc
as I didn't see tests for the Groovy or Java versions of these

### Context
https://groups.google.com/d/msg/gradle-dev/-2hVXXDiQEU/mIbgR0FRAgAJ

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes