### PR TITLE
Default to lifecycle logging when running with --console=plain

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core/src/main/java/org/gradle/StartParameter.java
@@ -114,6 +114,14 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * {@inheritDoc}
      */
     @Override
+    public boolean isLogLevelSet() {
+        return loggingConfiguration.isLogLevelSet();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public ShowStacktrace getShowStacktrace() {
         return loggingConfiguration.getShowStacktrace();
     }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
@@ -255,6 +255,7 @@ public class DefaultCommandLineConverterTest extends CommandLineConverterTestSup
     @Test
     public void withNoColor() {
         expectedConsoleOutput = ConsoleOutput.Plain;
+        expectedLogLevel = LogLevel.LIFECYCLE;
         checkConversion("--console", "plain");
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/CommandLineIntegrationConsoleLoggingSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/CommandLineIntegrationConsoleLoggingSpec.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.cli
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+class CommandLineIntegrationConsoleLoggingSpec extends AbstractIntegrationSpec {
+
+    @Unroll
+    def "Log level is lifecycle with console:plain by default: #flags"() {
+        def message = 'Expected message in the output'
+        buildFile << """
+            task assertLogging {
+                doLast {
+                    assert LogLevel.${logLevel.toUpperCase()} == project.gradle.startParameter.logLevel 
+                    logger.${logLevel} '${message}'
+                    assert logger.${logLevel}Enabled
+                    if ('${nextLevel}') {
+                        assert !logger.${nextLevel}Enabled
+                    }
+                }
+            }
+        """
+        expect:
+        executer.withLifecycleLoggingDisabled().withArguments(flags)
+        succeeds("assertLogging")
+        outputContains(message)
+
+        where:
+        logLevel    | nextLevel   | flags
+        'warn'      | 'lifecycle' | []
+        'lifecycle' | 'info'      | ['--console=plain']
+        'quiet'     | 'warn'      | ['-q', '--console=plain']
+        'quiet'     | 'warn'      | ['-Dorg.gradle.logging.level=quiet', '--console=plain']
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
@@ -34,6 +34,11 @@ public interface LoggingConfiguration {
     void setLogLevel(LogLevel logLevel);
 
     /**
+     * Returns true if the log level has been explicitly set (as opposed to simply relying on the default value)
+     */
+    boolean isLogLevelSet();
+
+    /**
      * Returns the style of logging output that should be written to the console.
      * Defaults to {@link ConsoleOutput#Auto}
      */

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
@@ -26,7 +26,8 @@ import org.gradle.api.logging.configuration.ShowStacktrace;
 import java.io.Serializable;
 
 public class DefaultLoggingConfiguration implements Serializable, LoggingConfiguration {
-    private LogLevel logLevel = LogLevel.WARN;
+    public final static LogLevel DEFAULT_LOG_LEVEL = LogLevel.WARN;
+    private LogLevel logLevel;
     private ShowStacktrace showStacktrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private ConsoleOutput consoleOutput = ConsoleOutput.Auto;
 
@@ -40,12 +41,20 @@ public class DefaultLoggingConfiguration implements Serializable, LoggingConfigu
 
     @Override
     public LogLevel getLogLevel() {
+        if (logLevel == null) {
+            return DEFAULT_LOG_LEVEL;
+        }
         return logLevel;
     }
 
     @Override
     public void setLogLevel(LogLevel logLevel) {
         this.logLevel = logLevel;
+    }
+
+    @Override
+    public boolean isLogLevelSet() {
+        return logLevel != null;
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
@@ -82,6 +82,9 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
             try {
                 ConsoleOutput consoleOutput = ConsoleOutput.valueOf(consoleValue);
                 loggingConfiguration.setConsoleOutput(consoleOutput);
+                if (ConsoleOutput.Plain == consoleOutput && !loggingConfiguration.isLogLevelSet()) {
+                    loggingConfiguration.setLogLevel(LogLevel.LIFECYCLE);
+                }
             } catch (IllegalArgumentException e) {
                 throw new CommandLineArgumentException(String.format("Unrecognized value '%s' for %s.", value, CONSOLE));
             }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
@@ -64,25 +64,26 @@ class LoggingCommandLineConverterTest extends Specification {
     }
 
     def convertsWarnLevel() {
-         expectedConfig.logLevel = LogLevel.WARN
+        expectedConfig.logLevel = LogLevel.WARN
 
-         expect:
-         checkConversion(['-w'])
-         checkConversion(['--warn'])
-     }
+        expect:
+        checkConversion(['-w'])
+        checkConversion(['--warn'])
+    }
 
     def convertsConsole() {
         expectedConfig.consoleOutput = consoleOutput
+        expectedConfig.logLevel = logLevel
 
         expect:
-        checkConversion([arg])
+        ([arg])
 
         where:
-        arg               | consoleOutput
-        "--console=plain" | ConsoleOutput.Plain
-        "--console=auto"  | ConsoleOutput.Auto
-        "--console=AUTO"  | ConsoleOutput.Auto
-        "--console=rich"  | ConsoleOutput.Rich
+        arg               | consoleOutput       | logLevel
+        "--console=plain" | ConsoleOutput.Plain | LogLevel.LIFECYCLE
+        "--console=auto"  | ConsoleOutput.Auto  | LogLevel.WARN
+        "--console=AUTO"  | ConsoleOutput.Auto  | LogLevel.WARN
+        "--console=rich"  | ConsoleOutput.Rich  | LogLevel.WARN
     }
 
     def reportsUnknownConsoleOption() {


### PR DESCRIPTION
### Context
See issue #1943 

### Contributor Checklist
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches&branch_Gradle_Branches=wl-plain-console-logging-level)
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
