### PR TITLE
Optimizations for project creation

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/FileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/FileUtils.java
@@ -124,26 +124,11 @@ public class FileUtils {
      * Canonicalizes the given file.
      */
     public static File canonicalize(File src) {
-        if (src instanceof CanonicalFile || src == null) {
-            return src;
-        }
         try {
-            File canonicalFile = src.getCanonicalFile();
-            return new CanonicalFile(canonicalFile.getParentFile(), canonicalFile.getName());
+            return src.getCanonicalFile();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    private static class CanonicalFile extends File {
-
-        public CanonicalFile(File parent, String child) {
-            super(parent, child);
-        }
-
-        @Override
-        public File getCanonicalFile() throws IOException {
-            return this;
-        }
-    }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/FileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/FileUtils.java
@@ -124,11 +124,26 @@ public class FileUtils {
      * Canonicalizes the given file.
      */
     public static File canonicalize(File src) {
+        if (src instanceof CanonicalFile || src == null) {
+            return src;
+        }
         try {
-            return src.getCanonicalFile();
+            File canonicalFile = src.getCanonicalFile();
+            return new CanonicalFile(canonicalFile.getParentFile(), canonicalFile.getName());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
+    private static class CanonicalFile extends File {
+
+        public CanonicalFile(File parent, String child) {
+            super(parent, child);
+        }
+
+        @Override
+        public File getCanonicalFile() throws IOException {
+            return this;
+        }
+    }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/AbstractServiceMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/AbstractServiceMethod.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+abstract class AbstractServiceMethod implements ServiceMethod {
+    private final Method method;
+    private final Class<?> owner;
+    private final String name;
+    private final Type[] parameterTypes;
+    private final Type serviceType;
+
+    AbstractServiceMethod(Method target) {
+        this.method = target;
+        this.owner = target.getDeclaringClass();
+        this.name = target.getName();
+        this.parameterTypes = target.getGenericParameterTypes();
+        this.serviceType = target.getGenericReturnType();
+    }
+
+    @Override
+    public Type getServiceType() {
+        return serviceType;
+    }
+
+    @Override
+    public Type[] getParameterTypes() {
+        return parameterTypes;
+    }
+
+    @Override
+    public Class<?> getOwner() {
+        return owner;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Method getMethod() {
+        return method;
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceMethodFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceMethodFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import java.lang.reflect.Method;
+
+/**
+ * A service method factory that will try to use method handles if available, otherwise fallback on reflection.
+ */
+class DefaultServiceMethodFactory implements ServiceMethodFactory {
+    private final ServiceMethodFactory delegate;
+
+    DefaultServiceMethodFactory() {
+        ServiceMethodFactory factory;
+        try {
+            factory = (ServiceMethodFactory) Class.forName("org.gradle.internal.service.MethodHandleBasedServiceMethodFactory").newInstance();
+        } catch (Exception e) {
+            factory = new ReflectionBasedServiceMethodFactory();
+        }
+        delegate = factory;
+    }
+
+    @Override
+    public ServiceMethod toServiceMethod(Method method) {
+        return delegate.toServiceMethod(method);
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.service;
 
+import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.api.Nullable;
 import org.gradle.api.specs.Spec;
@@ -29,19 +30,15 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Formatter;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +56,9 @@ import java.util.concurrent.ConcurrentMap;
  * <li>Calling {@link #addProvider(Object)} to register a service provider bean. A provider bean may have factory, decorator and configuration methods as described below.</li>
  *
  * <li>Adding a factory method. A factory method should have a name that starts with 'create', and have a non-void return type. For example, <code>protected SomeService createSomeService() { ....
- * }</code>. Parameters are injected using services from this registry or its parents. Parameter of type {@link ServiceRegistry} will receive the service registry that owns the service. Parameter ot type {@code List<T>} will receive all services of type T, if any. Note that factory methods with a single parameter and an return type equal to that parameter type are interpreted as decorator methods.</li>
+ * }</code>. Parameters are injected using services from this registry or its parents. Parameter of type {@link ServiceRegistry} will receive the service registry that owns the service. Parameter ot
+ * type {@code List<T>} will receive all services of type T, if any. Note that factory methods with a single parameter and an return type equal to that parameter type are interpreted as decorator
+ * methods.</li>
  *
  * <li>Adding a decorator method. A decorator method should have a name that starts with 'decorate', take a single parameter, and a have return type equal to the parameter type. Before invoking the
  * method, the parameter is located in the parent service registry and then passed to the method.</li>
@@ -77,10 +76,10 @@ import java.util.concurrent.ConcurrentMap;
  * <p>Service registries are arranged in a hierarchy. If a service of a given type cannot be located, the registry uses its parent registry, if any, to locate the service.</p>
  */
 public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
+    private final static ServiceRegistry[] NO_PARENTS = new ServiceRegistry[0];
 
-    private static final ConcurrentMap<Class<?>, RelevantMethods> METHODS_CACHE = new ConcurrentHashMap<Class<?>, RelevantMethods>();
     private static final ConcurrentMap<Type, BiFunction<ServiceProvider, LookupContext, Provider>> SERVICE_TYPE_PROVIDER_CACHE = new ConcurrentHashMap<Type, BiFunction<ServiceProvider, LookupContext, Provider>>();
-    private final Map<Type, ServiceProvider> providerCache = new HashMap<Type, ServiceProvider>();
+    private final Map<Type, ServiceProvider> providerCache = new IdentityHashMap<Type, ServiceProvider>();
 
     private final Object lock = new Object();
     private final OwnServices ownServices;
@@ -90,12 +89,14 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
     private boolean closed;
     private boolean mutable = true; // access under lock
 
+    private Provider asParentServicesProvider;
+
     public DefaultServiceRegistry() {
-        this(null, Collections.<ServiceRegistry>emptyList());
+        this(null, NO_PARENTS);
     }
 
     public DefaultServiceRegistry(String displayName) {
-        this(displayName, Collections.<ServiceRegistry>emptyList());
+        this(displayName, NO_PARENTS);
     }
 
     public DefaultServiceRegistry(ServiceRegistry... parents) {
@@ -103,32 +104,45 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
     }
 
     public DefaultServiceRegistry(String displayName, ServiceRegistry... parents) {
-        this(displayName, Arrays.asList(parents));
-    }
-
-    public DefaultServiceRegistry(String displayName, Collection<? extends ServiceRegistry> parents) {
         this.displayName = displayName;
         this.ownServices = new OwnServices();
-        if (parents.isEmpty()) {
+        if (parents.length == 0) {
             this.parentServices = null;
-            this.allServices = ownServices;
+            this.allServices = CachingProvider.of(ownServices);
         } else {
-            if (parents.size() == 1) {
-                this.parentServices = new ParentServices(parents.iterator().next());
-            } else {
-                List<Provider> providers = new ArrayList<Provider>(parents.size());
-                for (ServiceRegistry parent : parents) {
-                    providers.add(new ParentServices(parent));
-                }
-                this.parentServices = new CompositeProvider(providers);
-            }
-            List<Provider> allProviders = new ArrayList<Provider>(2);
-            allProviders.add(ownServices);
-            allProviders.add(parentServices);
-            allServices = new CachingProvider(new CompositeProvider(allProviders));
+            parentServices = setupParentServices(parents);
+            allServices = new CompositeProvider(CachingProvider.of(ownServices), parentServices);
         }
 
         findProviderMethods(this);
+    }
+
+    private static Provider setupParentServices(ServiceRegistry[] parents) {
+        Provider parentServices;
+        if (parents.length == 1) {
+            parentServices = toParentServices(parents[0]);
+        } else {
+            Provider[] parentProviders = new Provider[parents.length];
+            for (int i = 0; i < parents.length; i++) {
+                parentProviders[i] = toParentServices(parents[i]);
+            }
+            parentServices = new CompositeProvider(parentProviders);
+        }
+        return parentServices;
+    }
+
+    private Provider asProvider() {
+        if (asParentServicesProvider == null) {
+            asParentServicesProvider = CachingProvider.of(new ParentServices(this));
+        }
+        return asParentServicesProvider;
+    }
+
+    private static Provider toParentServices(ServiceRegistry serviceRegistry) {
+        if (serviceRegistry instanceof DefaultServiceRegistry) {
+            return ((DefaultServiceRegistry) serviceRegistry).asProvider();
+        }
+        return new ParentServices(serviceRegistry);
     }
 
     /**
@@ -151,51 +165,9 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
         return getDisplayName();
     }
 
-    static class RelevantMethods {
-        final List<Method> decorators;
-        final List<Method> factories;
-        final List<Method> configurers;
-
-        public RelevantMethods(List<Method> decorators, List<Method> factories, List<Method> configurers) {
-            this.decorators = decorators;
-            this.factories = factories;
-            this.configurers = configurers;
-        }
-    }
-
-    static class RelevantMethodsBuilder {
-        final List<Method> remainingMethods;
-        final Class<?> type;
-        final LinkedList<Method> decorators = new LinkedList<Method>();
-        final LinkedList<Method> factories = new LinkedList<Method>();
-        final LinkedList<Method> configurers = new LinkedList<Method>();
-        final Set<String> seen = new HashSet<String>();
-
-        public RelevantMethodsBuilder(Class<?> type) {
-            this.type = type;
-            this.remainingMethods = new LinkedList<Method>();
-
-            for (Class<?> clazz = type; clazz != Object.class && clazz != DefaultServiceRegistry.class; clazz = clazz.getSuperclass()) {
-                remainingMethods.addAll(Arrays.asList(clazz.getDeclaredMethods()));
-            }
-        }
-
-        void add(Iterator<Method> iterator, List<Method> builder, Method method) {
-            if (seen.add(method.getName())) {
-                builder.add(method);
-            }
-            iterator.remove();
-        }
-
-        RelevantMethods build() {
-            return new RelevantMethods(decorators, factories, configurers);
-        }
-    }
-
-
     private void findProviderMethods(Object target) {
         Class<?> type = target.getClass();
-        RelevantMethods methods = getMethods(type);
+        RelevantMethods methods = RelevantMethods.getMethods(type);
         for (Method method : methods.decorators) {
             if (parentServices == null) {
                 throw new ServiceLookupException(String.format("Cannot use decorator method %s.%s() when no parent registry is provided.", type.getSimpleName(), method.getName()));
@@ -208,26 +180,6 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
         for (Method method : methods.configurers) {
             applyConfigureMethod(method, target);
         }
-    }
-
-    private RelevantMethods getMethods(Class<?> type) {
-        RelevantMethods relevantMethods = METHODS_CACHE.get(type);
-        if (relevantMethods == null) {
-            relevantMethods = buildRelevantMethods(type);
-            METHODS_CACHE.putIfAbsent(type, relevantMethods);
-        }
-
-        return relevantMethods;
-    }
-
-    private RelevantMethods buildRelevantMethods(Class<?> type) {
-        RelevantMethods relevantMethods;
-        RelevantMethodsBuilder builder = new RelevantMethodsBuilder(type);
-        addDecoratorMethods(builder);
-        addFactoryMethods(builder);
-        addConfigureMethods(builder);
-        relevantMethods = builder.build();
-        return relevantMethods;
     }
 
     private void applyConfigureMethod(Method method, Object target) {
@@ -254,49 +206,6 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
             throw new ServiceLookupException(String.format("Could not configure services using %s.%s().",
                 method.getDeclaringClass().getSimpleName(),
                 method.getName()), e);
-        }
-    }
-
-    private static void addConfigureMethods(RelevantMethodsBuilder builder) {
-        Class<?> type = builder.type;
-        Iterator<Method> iterator = builder.remainingMethods.iterator();
-        while (iterator.hasNext()) {
-            Method method = iterator.next();
-            if (method.getName().equals("configure")) {
-                if (!method.getReturnType().equals(Void.TYPE)) {
-                    throw new ServiceLookupException(String.format("Method %s.%s() must return void.", type.getSimpleName(), method.getName()));
-                }
-                builder.add(iterator, builder.configurers, method);
-            }
-        }
-    }
-
-    private static void addFactoryMethods(RelevantMethodsBuilder builder) {
-        Class<?> type = builder.type;
-        Iterator<Method> iterator = builder.remainingMethods.iterator();
-        while (iterator.hasNext()) {
-            Method method = iterator.next();
-            if (method.getName().startsWith("create") && !Modifier.isStatic(method.getModifiers())) {
-                if (method.getReturnType().equals(Void.TYPE)) {
-                    throw new ServiceLookupException(String.format("Method %s.%s() must not return void.", type.getSimpleName(), method.getName()));
-                }
-                builder.add(iterator, builder.factories, method);
-            }
-        }
-    }
-
-    private static void addDecoratorMethods(RelevantMethodsBuilder builder) {
-        Class<?> type = builder.type;
-        Iterator<Method> iterator = builder.remainingMethods.iterator();
-        while (iterator.hasNext()) {
-            Method method = iterator.next();
-            if ((method.getName().startsWith("create") || method.getName().startsWith("decorate"))
-                && method.getParameterTypes().length == 1 && method.getParameterTypes()[0].equals(method.getReturnType())) {
-                if (method.getReturnType().equals(Void.TYPE)) {
-                    throw new ServiceLookupException(String.format("Method %s.%s() must not return void.", type.getSimpleName(), method.getName()));
-                }
-                builder.add(iterator, builder.decorators, method);
-            }
         }
     }
 
@@ -388,11 +297,19 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
         return type.toString();
     }
 
+    public boolean hasService(Class<?> serviceType) {
+        assertValidServiceType(serviceType);
+        return allServices.hasService(serviceType);
+    }
+
     public <T> List<T> getAll(Class<T> serviceType) throws ServiceLookupException {
         synchronized (lock) {
             mutable = false;
             if (closed) {
                 throw new IllegalStateException(String.format("Cannot locate service of type %s, as %s has been closed.", format(serviceType), getDisplayName()));
+            }
+            if (!hasService(serviceType)) {
+                return Collections.emptyList();
             }
             List<ServiceProvider> providers = new ArrayList<ServiceProvider>();
             DefaultLookupContext context = new DefaultLookupContext();
@@ -430,11 +347,23 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
     }
 
     private ServiceProvider getServiceProvider(Type serviceType) {
-        ServiceProvider provider = new DefaultLookupContext().find(serviceType, allServices);
+        Type lookupType = extractServiceType(serviceType);
+        ServiceProvider provider = hasService(unwrap(lookupType)) ? new DefaultLookupContext().find(serviceType, allServices) : null;
         if (provider == null) {
             throw new UnknownServiceException(serviceType, String.format("No service of type %s available in %s.", format(serviceType), getDisplayName()));
         }
         return provider;
+    }
+
+    private static Type extractServiceType(Type mayBeFactoryType) {
+        Type serviceType = mayBeFactoryType;
+        if (mayBeFactoryType instanceof ParameterizedType) {
+            Type rawType = ((ParameterizedType) mayBeFactoryType).getRawType();
+            if (rawType == List.class) {
+                serviceType = ((ParameterizedType) mayBeFactoryType).getActualTypeArguments()[0];
+            }
+        }
+        return serviceType;
     }
 
     public <T> Factory<T> getFactory(Class<T> type) {
@@ -442,13 +371,13 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
             if (closed) {
                 throw new IllegalStateException(String.format("Cannot locate factory for objects of type %s, as %s has been closed.", format(type), getDisplayName()));
             }
-
-            DefaultLookupContext context = new DefaultLookupContext();
-            ServiceProvider factory = allServices.getFactory(context, type);
-            if (factory != null) {
-                return (Factory<T>) factory.get();
+            if (hasService(Factory.class)) {
+                DefaultLookupContext context = new DefaultLookupContext();
+                ServiceProvider factory = allServices.getFactory(context, type);
+                if (factory != null) {
+                    return (Factory<T>) factory.get();
+                }
             }
-
             throw new UnknownServiceException(type, String.format("No factory for objects of type %s available in %s.", format(type), getDisplayName()));
         }
     }
@@ -490,6 +419,8 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
          * Collects all services of the given type.
          */
         void getAll(LookupContext context, Class<?> serviceType, List<ServiceProvider> result);
+
+        boolean hasService(Class<?> type);
     }
 
     private class OwnServices implements Provider {
@@ -497,7 +428,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
 
         @Override
         public ServiceProvider getFactory(LookupContext context, Class<?> type) {
-            if (providers == null) {
+            if (!hasService(Factory.class)) {
                 return null;
             }
             List<ServiceProvider> candidates = new ArrayList<ServiceProvider>();
@@ -529,7 +460,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
 
         @Override
         public ServiceProvider getService(LookupContext context, TypeSpec serviceType) {
-            if (providers == null) {
+            if (!hasService(unwrap(serviceType.getType()))) {
                 return null;
             }
             ServiceProvider singleCandidate = null;
@@ -552,7 +483,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
             if (candidates == null && singleCandidate == null) {
                 return null;
             }
-            if (candidates==null) {
+            if (candidates == null) {
                 return singleCandidate;
             }
 
@@ -571,12 +502,24 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
 
         @Override
         public void getAll(LookupContext context, Class<?> serviceType, List<ServiceProvider> result) {
-            if (providers == null) {
+            if (!hasService(serviceType)) {
                 return;
             }
             for (Provider provider : providers) {
                 provider.getAll(context, serviceType, result);
             }
+        }
+
+        public boolean hasService(Class<?> serviceType) {
+            if (providers == null) {
+                return false;
+            }
+            for (Provider provider : providers) {
+                if (provider.hasService(serviceType)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Override
@@ -588,10 +531,26 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
         }
 
         public void add(Provider provider) {
+            assertMutable();
             if (providers == null) {
                 providers = new ArrayList<Provider>();
             }
             this.providers.add(provider);
+        }
+    }
+
+    private static Class<?> unwrap(Type type) {
+        if (type instanceof Class) {
+            return (Class) type;
+        } else {
+            if (type instanceof WildcardType) {
+                final WildcardType wildcardType = (WildcardType) type;
+                if (wildcardType.getUpperBounds()[0] instanceof Class && wildcardType.getLowerBounds().length == 0) {
+                    return (Class<?>) wildcardType.getUpperBounds()[0];
+                }
+            }
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            return (Class) parameterizedType.getRawType();
         }
     }
 
@@ -641,7 +600,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
 
         SingletonService(Type serviceType) {
             this.serviceType = serviceType;
-            serviceClass = toClass(serviceType);
+            serviceClass = unwrap(serviceType);
         }
 
         @Override
@@ -689,7 +648,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
         }
 
         private boolean isFactory(Type type, Class<?> elementType) {
-            Class c = toClass(type);
+            Class c = unwrap(type);
             if (!Factory.class.isAssignableFrom(c)) {
                 return false;
             }
@@ -715,13 +674,9 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
             return false;
         }
 
-        private Class toClass(Type type) {
-            if (type instanceof Class) {
-                return (Class) type;
-            } else {
-                ParameterizedType parameterizedType = (ParameterizedType) type;
-                return (Class) parameterizedType.getRawType();
-            }
+        @Override
+        public boolean hasService(Class<?> type) {
+            return type.isAssignableFrom(serviceClass);
         }
     }
 
@@ -801,7 +756,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
         }
 
         public String getDisplayName() {
-            return "Service " + format(method.getGenericReturnType()) + " at " + method.getDeclaringClass().getSimpleName() + "." +  method.getName() + "()";
+            return "Service " + format(method.getGenericReturnType()) + " at " + method.getDeclaringClass().getSimpleName() + "." + method.getName() + "()";
         }
 
         protected Type[] getParameterTypes() {
@@ -970,11 +925,19 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
         private static final Object ABSENT = new Object();
         private final ConcurrentMap<Object, Object> seen = new ConcurrentHashMap<Object, Object>();
         private final ConcurrentMap<Class<?>, List<ServiceProvider>> allServicesCache = new ConcurrentHashMap<Class<?>, List<ServiceProvider>>();
+        private final Map<Class<?>, Boolean> serviceTypes = Maps.newConcurrentMap();
 
         private final Provider delegate;
 
         private CachingProvider(Provider delegate) {
             this.delegate = delegate;
+        }
+
+        private static Provider of(Provider delegate) {
+            if (delegate instanceof CachingProvider) {
+                return delegate;
+            }
+            return new CachingProvider(delegate);
         }
 
         @Override
@@ -1018,6 +981,17 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
         }
 
         @Override
+        public boolean hasService(Class<?> type) {
+            Boolean val = serviceTypes.get(type);
+            if (val != null) {
+                return val;
+            }
+            val = delegate.hasService(type);
+            serviceTypes.put(type, val);
+            return val;
+        }
+
+        @Override
         public void stop() {
             delegate.stop();
             seen.clear();
@@ -1026,18 +1000,20 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
     }
 
     private static class CompositeProvider implements Provider {
-        private final Collection<Provider> providers;
+        private final Provider[] providers;
 
-        private CompositeProvider(Collection<Provider> providers) {
+        private CompositeProvider(Provider... providers) {
             this.providers = providers;
         }
 
         @Override
         public ServiceProvider getService(LookupContext context, TypeSpec serviceType) {
-            for (Provider provider : providers) {
-                ServiceProvider service = provider.getService(context, serviceType);
-                if (service != null) {
-                    return service;
+            if (hasService(unwrap(extractServiceType(serviceType.getType())))) {
+                for (Provider provider : providers) {
+                    ServiceProvider service = provider.getService(context, serviceType);
+                    if (service != null) {
+                        return service;
+                    }
                 }
             }
             return null;
@@ -1045,10 +1021,12 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
 
         @Override
         public ServiceProvider getFactory(LookupContext context, Class<?> type) {
-            for (Provider provider : providers) {
-                ServiceProvider factory = provider.getFactory(context, type);
-                if (factory != null) {
-                    return factory;
+            if (hasService(Factory.class)) {
+                for (Provider provider : providers) {
+                    ServiceProvider factory = provider.getFactory(context, type);
+                    if (factory != null) {
+                        return factory;
+                    }
                 }
             }
             return null;
@@ -1056,22 +1034,36 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
 
         @Override
         public void getAll(LookupContext context, Class<?> serviceType, List<ServiceProvider> result) {
-            for (Provider provider : providers) {
-                provider.getAll(context, serviceType, result);
+            if (hasService(serviceType)) {
+                for (Provider provider : providers) {
+                    provider.getAll(context, serviceType, result);
+                }
             }
+        }
+
+        @Override
+        public boolean hasService(Class<?> type) {
+            for (Provider provider : providers) {
+                if (provider.hasService(type)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Override
         public void stop() {
             try {
-                CompositeStoppable.stoppable(providers).stop();
+                CompositeStoppable.stoppable(Arrays.asList(providers)).stop();
             } finally {
-                providers.clear();
+                for (int i = 0; i < providers.length; i++) {
+                    providers[i] = null;
+                }
             }
         }
     }
 
-    private class ParentServices implements Provider {
+    private static class ParentServices implements Provider {
         private final ServiceRegistry parent;
 
         private ParentServices(ServiceRegistry parent) {
@@ -1129,6 +1121,11 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
             for (Object service : services) {
                 result.add(wrap(service));
             }
+        }
+
+        @Override
+        public boolean hasService(Class<?> type) {
+            return parent.hasService(type);
         }
 
         @Override
@@ -1350,12 +1347,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
                 return new ParameterizedTypeSpec(serviceType, toSpec(parameterizedType.getRawType()), paramSpecs);
             } else if (serviceType instanceof Class) {
                 Class<?> serviceClass = (Class<?>) serviceType;
-                if (serviceClass.isArray()) {
-                    throw new ServiceValidationException("Locating services with array type is not supported.");
-                }
-                if (serviceClass.isAnnotation()) {
-                    throw new ServiceValidationException("Locating services with annotation type is not supported.");
-                }
+                assertValidServiceType(serviceClass);
                 return new ClassSpec(serviceClass);
             }
 
@@ -1408,6 +1400,15 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
                 }
                 return new CollectionServiceProvider(elementClass, services, providers);
             }
+        }
+    }
+
+    private static void assertValidServiceType(Class<?> serviceClass) {
+        if (serviceClass.isArray()) {
+            throw new ServiceValidationException("Locating services with array type is not supported.");
+        }
+        if (serviceClass.isAnnotation()) {
+            throw new ServiceValidationException("Locating services with annotation type is not supported.");
         }
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -80,24 +80,6 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable {
     private static final ConcurrentMap<Type, BiFunction<ServiceProvider, LookupContext, Provider>> SERVICE_TYPE_PROVIDER_CACHE = new ConcurrentHashMap<Type, BiFunction<ServiceProvider, LookupContext, Provider>>();
     private final Map<Type, ServiceProvider> providerCache = new IdentityHashMap<Type, ServiceProvider>();
 
-    private final static Object lookup = createLookup();
-
-
-    /**
-     * This method is intentionally weakly typed, so that we don't depend on JDK 7+ types.
-     */
-    static Object getLookup() {
-        return lookup;
-    }
-
-    private static Object createLookup() {
-        try {
-            return Class.forName("java.lang.invoke.MethodHandles").getDeclaredMethod("lookup").invoke(null);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
     private final Object lock = new Object();
     private final OwnServices ownServices;
     private final Provider allServices;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethod.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import org.gradle.internal.UncheckedException;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+
+class MethodHandleBasedServiceMethod extends AbstractServiceMethod {
+    private final static MethodHandles.Lookup LOOKUP = (MethodHandles.Lookup) DefaultServiceRegistry.getLookup();
+    private final MethodHandle method;
+
+    MethodHandleBasedServiceMethod(Method target) throws IllegalAccessException {
+        super(target);
+        this.method = LOOKUP.unreflect(target);
+    }
+
+    @Override
+    public Object invoke(Object target, Object... args) {
+        try {
+            return method.bindTo(target).invokeWithArguments(args);
+        } catch (Throwable e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethod.java
@@ -22,7 +22,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 
 class MethodHandleBasedServiceMethod extends AbstractServiceMethod {
-    private final static MethodHandles.Lookup LOOKUP = (MethodHandles.Lookup) DefaultServiceRegistry.getLookup();
+    private final static MethodHandles.Lookup LOOKUP = (MethodHandles.Lookup) MethodHandles.publicLookup();
     private final MethodHandle method;
 
     MethodHandleBasedServiceMethod(Method target) throws IllegalAccessException {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethodFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethodFactory.java
@@ -16,14 +16,18 @@
 package org.gradle.internal.service;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 class MethodHandleBasedServiceMethodFactory implements ServiceMethodFactory {
     @Override
     public ServiceMethod toServiceMethod(Method method) {
-        try {
-            return new MethodHandleBasedServiceMethod(method);
-        } catch (IllegalAccessException ex) {
-            return new ReflectionBasedServiceMethod(method);
+        if (Modifier.isPublic(method.getModifiers()) && Modifier.isPublic(method.getDeclaringClass().getModifiers())) {
+            try {
+                return new MethodHandleBasedServiceMethod(method);
+            } catch (IllegalAccessException ex) {
+                return new ReflectionBasedServiceMethod(method);
+            }
         }
+        return new ReflectionBasedServiceMethod(method);
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethodFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethodFactory.java
@@ -15,10 +15,22 @@
  */
 package org.gradle.internal.service;
 
+import org.gradle.internal.UncheckedException;
+
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 class MethodHandleBasedServiceMethodFactory implements ServiceMethodFactory {
+
+    public MethodHandleBasedServiceMethodFactory() {
+        try {
+            // Force loading to check if method handle is supported
+            Class.forName("java.lang.invoke.MethodHandle");
+        } catch (ClassNotFoundException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
     @Override
     public ServiceMethod toServiceMethod(Method method) {
         if (Modifier.isPublic(method.getModifiers()) && Modifier.isPublic(method.getDeclaringClass().getModifiers())) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethodFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/MethodHandleBasedServiceMethodFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import java.lang.reflect.Method;
+
+class MethodHandleBasedServiceMethodFactory implements ServiceMethodFactory {
+    @Override
+    public ServiceMethod toServiceMethod(Method method) {
+        try {
+            return new MethodHandleBasedServiceMethod(method);
+        } catch (IllegalAccessException ex) {
+            return new ReflectionBasedServiceMethod(method);
+        }
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ReflectionBasedServiceMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ReflectionBasedServiceMethod.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.reflect.JavaMethod;
+import org.gradle.internal.reflect.JavaReflectionUtil;
+
+import java.lang.reflect.Method;
+
+class ReflectionBasedServiceMethod extends AbstractServiceMethod {
+    private final JavaMethod<Object, Object> javaMethod;
+
+    ReflectionBasedServiceMethod(Method target) {
+        super(target);
+        javaMethod = JavaReflectionUtil.method(Object.class, target);
+    }
+
+    @Override
+    public Object invoke(Object target, Object... args) {
+        try {
+            return javaMethod.invoke(target, args);
+        } catch (Exception e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ReflectionBasedServiceMethodFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ReflectionBasedServiceMethodFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import java.lang.reflect.Method;
+
+class ReflectionBasedServiceMethodFactory implements ServiceMethodFactory {
+    @Override
+    public ServiceMethod toServiceMethod(Method method) {
+        return new ReflectionBasedServiceMethod(method);
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/RelevantMethods.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/RelevantMethods.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class RelevantMethods {
+    private static final ConcurrentMap<Class<?>, RelevantMethods> METHODS_CACHE = new ConcurrentHashMap<Class<?>, RelevantMethods>();
+
+    final List<Method> decorators;
+    final List<Method> factories;
+    final List<Method> configurers;
+
+    RelevantMethods(List<Method> decorators, List<Method> factories, List<Method> configurers) {
+        this.decorators = decorators;
+        this.factories = factories;
+        this.configurers = configurers;
+    }
+
+    public static RelevantMethods getMethods(Class<?> type) {
+        RelevantMethods relevantMethods = METHODS_CACHE.get(type);
+        if (relevantMethods == null) {
+            relevantMethods = buildRelevantMethods(type);
+            METHODS_CACHE.putIfAbsent(type, relevantMethods);
+        }
+
+        return relevantMethods;
+    }
+
+    private static RelevantMethods buildRelevantMethods(Class<?> type) {
+        RelevantMethodsBuilder builder = new RelevantMethodsBuilder(type);
+        RelevantMethods relevantMethods;
+        addDecoratorMethods(builder);
+        addFactoryMethods(builder);
+        addConfigureMethods(builder);
+        relevantMethods = builder.build();
+        return relevantMethods;
+    }
+
+    private static void addConfigureMethods(RelevantMethodsBuilder builder) {
+        Class<?> type = builder.type;
+        Iterator<Method> iterator = builder.remainingMethods.iterator();
+        while (iterator.hasNext()) {
+            Method method = iterator.next();
+            if (method.getName().equals("configure")) {
+                if (!method.getReturnType().equals(Void.TYPE)) {
+                    throw new ServiceLookupException(String.format("Method %s.%s() must return void.", type.getSimpleName(), method.getName()));
+                }
+                builder.add(iterator, builder.configurers, method);
+            }
+        }
+    }
+
+    private static void addFactoryMethods(RelevantMethodsBuilder builder) {
+        Class<?> type = builder.type;
+        Iterator<Method> iterator = builder.remainingMethods.iterator();
+        while (iterator.hasNext()) {
+            Method method = iterator.next();
+            if (method.getName().startsWith("create") && !Modifier.isStatic(method.getModifiers())) {
+                if (method.getReturnType().equals(Void.TYPE)) {
+                    throw new ServiceLookupException(String.format("Method %s.%s() must not return void.", type.getSimpleName(), method.getName()));
+                }
+                builder.add(iterator, builder.factories, method);
+            }
+        }
+    }
+
+    private static void addDecoratorMethods(RelevantMethodsBuilder builder) {
+        Class<?> type = builder.type;
+        Iterator<Method> iterator = builder.remainingMethods.iterator();
+        while (iterator.hasNext()) {
+            Method method = iterator.next();
+            if ((method.getName().startsWith("create") || method.getName().startsWith("decorate"))
+                && method.getParameterTypes().length == 1 && method.getParameterTypes()[0].equals(method.getReturnType())) {
+                if (method.getReturnType().equals(Void.TYPE)) {
+                    throw new ServiceLookupException(String.format("Method %s.%s() must not return void.", type.getSimpleName(), method.getName()));
+                }
+                builder.add(iterator, builder.decorators, method);
+            }
+        }
+    }
+
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/RelevantMethods.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/RelevantMethods.java
@@ -15,11 +15,6 @@
  */
 package org.gradle.internal.service;
 
-import org.gradle.api.JavaVersion;
-import org.gradle.internal.UncheckedException;
-
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/RelevantMethodsBuilder.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/RelevantMethodsBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+class RelevantMethodsBuilder {
+    final List<Method> remainingMethods;
+    final Class<?> type;
+    final LinkedList<Method> decorators = new LinkedList<Method>();
+    final LinkedList<Method> factories = new LinkedList<Method>();
+    final LinkedList<Method> configurers = new LinkedList<Method>();
+
+    private final Set<String> seen = new HashSet<String>();
+
+    RelevantMethodsBuilder(Class<?> type) {
+        this.type = type;
+        this.remainingMethods = new LinkedList<Method>();
+
+        for (Class<?> clazz = type; clazz != Object.class && clazz != DefaultServiceRegistry.class; clazz = clazz.getSuperclass()) {
+            remainingMethods.addAll(Arrays.asList(clazz.getDeclaredMethods()));
+        }
+    }
+
+    void add(Iterator<Method> iterator, List<Method> builder, Method method) {
+        if (seen.add(method.getName())) {
+            builder.add(method);
+        }
+        iterator.remove();
+    }
+
+    RelevantMethods build() {
+        return new RelevantMethods(decorators, factories, configurers);
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceMethod.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+public interface ServiceMethod {
+    Class<?> getOwner();
+
+    String getName();
+
+    Type getServiceType();
+
+    Type[] getParameterTypes();
+
+    Object invoke(Object target, Object... args);
+
+    Method getMethod();
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceMethodFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceMethodFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.service;
+
+import java.lang.reflect.Method;
+
+interface ServiceMethodFactory {
+    ServiceMethod toServiceMethod(Method method);
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistry.java
@@ -75,4 +75,7 @@ public interface ServiceRegistry {
      * @throws ServiceLookupException On failure to lookup the specified service factory.
      */
     <T> T newInstance(Class<T> type) throws UnknownServiceException, ServiceLookupException;
+
+    boolean hasService(Class<?> serviceType);
+
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistryBuilder.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistryBuilder.java
@@ -47,7 +47,7 @@ public class ServiceRegistryBuilder {
     }
 
     public ServiceRegistry build() {
-        DefaultServiceRegistry registry = new DefaultServiceRegistry(displayName, parents);
+        DefaultServiceRegistry registry = new DefaultServiceRegistry(displayName, parents.toArray(new ServiceRegistry[0]));
         for (Object provider : providers) {
             registry.addProvider(provider);
         }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -50,6 +50,7 @@ class DefaultServiceRegistryTest extends Specification {
         result == value
 
         and:
+        _ * parent.hasService(BigDecimal) >> true
         1 * parent.get(BigDecimal) >> value
     }
 
@@ -67,6 +68,7 @@ class DefaultServiceRegistryTest extends Specification {
 
         and:
         1 * parent1.get(BigDecimal) >> { throw new UnknownServiceException(BigDecimal, "fail") }
+        _ * parent2.hasService(BigDecimal) >> true
         1 * parent2.get(BigDecimal) >> value
     }
 
@@ -214,6 +216,7 @@ class DefaultServiceRegistryTest extends Specification {
         result == '123'
 
         and:
+        _ * parent.hasService(Number) >> true
         1 * parent.get(Number) >> 123
     }
 
@@ -722,6 +725,8 @@ class DefaultServiceRegistryTest extends Specification {
         });
 
         given:
+        _ * parent1.hasService(Number) >> true
+        _ * parent2.hasService(Number) >> true
         _ * parent1.getAll(Number) >> [123L]
         _ * parent2.getAll(Number) >> [456]
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultProjectDescriptor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultProjectDescriptor.java
@@ -37,6 +37,7 @@ public class DefaultProjectDescriptor implements ProjectDescriptor, ProjectIdent
     private final PathToFileResolver fileResolver;
     private final ScriptFileResolver scriptFileResolver;
     private File dir;
+    private File canonicalDir;
     private DefaultProjectDescriptor parent;
     private Set<ProjectDescriptor> children = new LinkedHashSet<ProjectDescriptor>();
     private ProjectDescriptorRegistry projectDescriptorRegistry;
@@ -54,7 +55,7 @@ public class DefaultProjectDescriptor implements ProjectDescriptor, ProjectIdent
         this.parent = parent;
         this.name = name;
         this.fileResolver = fileResolver;
-        this.dir = FileUtils.canonicalize(dir);
+        this.dir = dir;
         this.projectDescriptorRegistry = projectDescriptorRegistry;
         this.path = path(name);
         projectDescriptorRegistry.addProject(this);
@@ -90,10 +91,14 @@ public class DefaultProjectDescriptor implements ProjectDescriptor, ProjectIdent
     }
 
     public File getProjectDir() {
-        return dir;
+        if (canonicalDir == null) {
+            canonicalDir = FileUtils.canonicalize(dir);
+        }
+        return canonicalDir;
     }
 
     public void setProjectDir(File dir) {
+        this.canonicalDir = null;
         this.dir = fileResolver.resolve(dir);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -17,6 +17,7 @@ package org.gradle.initialization.layout;
 
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.resources.MissingResourceException;
+import org.gradle.internal.FileUtils;
 
 import java.io.File;
 
@@ -67,6 +68,6 @@ public class BuildLayoutFactory {
     }
 
     private BuildLayout layout(File rootDir, File settingsDir, File settingsFile) {
-        return new BuildLayout(rootDir, settingsDir, settingsFile);
+        return new BuildLayout(rootDir, settingsDir, FileUtils.canonicalize(settingsFile));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
@@ -48,23 +48,29 @@ public class BuildLogger implements BuildListener, TaskExecutionGraphListener {
     public void buildStarted(Gradle gradle) {
         StartParameter startParameter = gradle.getStartParameter();
         logger.info("Starting Build");
-        logger.debug("Gradle user home: {}", startParameter.getGradleUserHomeDir());
-        logger.debug("Current dir: {}", startParameter.getCurrentDir());
-        logger.debug("Settings file: {}", startParameter.getSettingsFile());
-        logger.debug("Build file: {}", startParameter.getBuildFile());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Gradle user home: {}", startParameter.getGradleUserHomeDir());
+            logger.debug("Current dir: {}", startParameter.getCurrentDir());
+            logger.debug("Settings file: {}", startParameter.getSettingsFile());
+            logger.debug("Build file: {}", startParameter.getBuildFile());
+        }
     }
 
     public void settingsEvaluated(Settings settings) {
         SettingsInternal settingsInternal = (SettingsInternal) settings;
-        logger.info("Settings evaluated using {}.",
+        if (logger.isInfoEnabled()) {
+            logger.info("Settings evaluated using {}.",
                 settingsInternal.getSettingsScript().getDisplayName());
+        }
     }
 
     public void projectsLoaded(Gradle gradle) {
-        ProjectInternal projectInternal = (ProjectInternal) gradle.getRootProject();
-        logger.info("Projects loaded. Root project using {}.",
+        if (logger.isInfoEnabled()) {
+            ProjectInternal projectInternal = (ProjectInternal) gradle.getRootProject();
+            logger.info("Projects loaded. Root project using {}.",
                 projectInternal.getBuildScriptSource().getDisplayName());
-        logger.info("Included projects: {}", projectInternal.getAllprojects());
+            logger.info("Included projects: {}", projectInternal.getAllprojects());
+        }
     }
 
     public void projectsEvaluated(Gradle gradle) {
@@ -72,7 +78,9 @@ public class BuildLogger implements BuildListener, TaskExecutionGraphListener {
     }
 
     public void graphPopulated(TaskExecutionGraph graph) {
-        logger.info("Tasks to be executed: {}", graph.getAllTasks());
+        if (logger.isInfoEnabled()) {
+            logger.info("Tasks to be executed: {}", graph.getAllTasks());
+        }
     }
 
     public void buildFinished(BuildResult result) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -157,8 +157,8 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
     }
 
     private static class WorkerServices extends DefaultServiceRegistry {
-        public WorkerServices(ServiceRegistry... parents) {
-            super(parents);
+        public WorkerServices(ServiceRegistry parent) {
+            super(parent);
         }
 
         ListenerManager createListenerManager() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildScopeServicesTest.groovy
@@ -123,6 +123,7 @@ class BuildScopeServicesTest extends Specification {
         sessionServices.get(ListenerManager) >> parentListenerManager
         parentListenerManager.createChild() >> listenerManager
         sessionServices.getAll(_) >> []
+        sessionServices.hasService(_) >> true
 
         registry = new BuildScopeServices(sessionServices, startParameter)
     }
@@ -146,6 +147,7 @@ class BuildScopeServicesTest extends Specification {
         given:
         def sessionServices = Mock(BuildSessionScopeServices) {
             getAll(PluginServiceRegistry) >> [plugin1, plugin2]
+            hasService(_) >> true
         }
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildSessionScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildSessionScopeServicesTest.groovy
@@ -64,6 +64,7 @@ class BuildSessionScopeServicesTest extends Specification {
         parent.get(ModuleRegistry) >> new DefaultModuleRegistry(CurrentGradleInstallation.get())
         parent.get(FileResolver) >> Stub(FileResolver)
         parent.get(OutputEventListener) >> Stub(OutputEventListener)
+        parent.hasService(_) >> true
     }
 
     def "provides a DeploymentRegistry"() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleScopeServicesTest.groovy
@@ -76,6 +76,7 @@ public class GradleScopeServicesTest extends Specification {
         parent.get(WorkerLeaseRegistry) >> Stub(WorkerLeaseRegistry)
         gradle.getStartParameter() >> startParameter
         pluginRegistryParent.createChild(_, _, _) >> pluginRegistryChild
+        parent.hasService(_) >> true
     }
 
     def "can create services for a project instance"() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
@@ -108,6 +108,7 @@ class ProjectScopeServicesTest extends Specification {
         parent.get(DependencyInjectingInstantiator.ConstructorCache) >> Stub(DependencyInjectingInstantiator.ConstructorCache)
         parent.get(ToolingModelBuilderRegistry) >> Mock(ToolingModelBuilderRegistry)
         parent.get(InstantiatorFactory) >> instantiatorFactory
+        parent.hasService(_) >> true
         registry = new ProjectScopeServices(parent, project, loggingManagerInternalFactory)
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/SettingsScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/SettingsScopeServicesTest.groovy
@@ -38,6 +38,7 @@ class SettingsScopeServicesTest extends Specification {
         parent.get(org.gradle.internal.nativeintegration.filesystem.FileSystem) >> Stub(org.gradle.internal.nativeintegration.filesystem.FileSystem)
         parent.get(PluginRegistry) >> pluginRegistryParent
         parent.get(ModelRuleSourceDetector) >> Stub(ModelRuleSourceDetector)
+        parent.hasService(_) >> true
         pluginRegistryParent.createChild(_, _, _) >> pluginRegistryChild
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultDependencyManagementServicesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultDependencyManagementServicesTest.groovy
@@ -46,6 +46,7 @@ class DefaultDependencyManagementServicesTest extends Specification {
         _ * parent.get({it instanceof Class}) >> { Class t -> Stub(t) }
         _ * parent.get({it instanceof ParameterizedType}) >> { ParameterizedType t -> Stub(t.rawType) }
         _ * parent.getAll({it instanceof Class}) >> { Class t -> [Stub(t)]}
+        _ * parent.hasService(_) >> true
     }
 
     def "can create dependency resolution DSL services"() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -78,6 +78,7 @@ class BuildActionsFactoryTest extends Specification {
         _ * loggingServices.get(FileSystem) >> Mock(FileSystem)
         _ * loggingServices.getFactory(LoggingManagerInternal) >> Mock(Factory)
         _ * loggingServices.getAll(PluginServiceRegistry) >> []
+        _ * loggingServices.hasService(_) >> true
         _ * loggingServices.getAll(_) >> []
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryServicesTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryServicesTest.groovy
@@ -36,6 +36,7 @@ class DaemonRegistryServicesTest extends Specification {
     def parent = Mock(ServiceRegistry) {
         get(FileLockManager) >> new DefaultFileLockManager(Stub(ProcessMetaDataProvider), Stub(FileLockContentionHandler))
         get(Chmod) >> Stub(Chmod)
+        hasService(_) >> true
     }
 
     def registry(baseDir) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ProjectCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ProjectCreationPerformanceTest.groovy
@@ -24,7 +24,7 @@ class ProjectCreationPerformanceTest extends AbstractCrossVersionPerformanceTest
         given:
         runner.testProject = "bigEmpty"
         runner.tasksToRun = ['help']
-        runner.gradleOpts = ['-Xms1g', '-Xmx1g']
+        runner.gradleOpts = ['-Xms1500m', '-Xmx1500m']
         runner.targetVersions = ["3.5-20170221000043+0000"]
 
         when:

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/UriTextResource.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/UriTextResource.java
@@ -19,6 +19,7 @@ package org.gradle.internal.resource;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Nullable;
 import org.gradle.api.resources.MissingResourceException;
+import org.gradle.internal.FileUtils;
 import org.gradle.internal.SystemProperties;
 import org.gradle.util.GradleVersion;
 
@@ -43,21 +44,13 @@ public class UriTextResource implements TextResource {
 
     public UriTextResource(String description, File sourceFile) {
         this.description = description;
-        this.sourceFile = canonicalise(sourceFile);
+        this.sourceFile = FileUtils.canonicalize(sourceFile);
         this.sourceUri = sourceFile.toURI();
-    }
-
-    private File canonicalise(File file) {
-        try {
-            return file.getCanonicalFile();
-        } catch (IOException e) {
-            return file.getAbsoluteFile();
-        }
     }
 
     public UriTextResource(String description, URI sourceUri) {
         this.description = description;
-        this.sourceFile = sourceUri.getScheme().equals("file") ? canonicalise(new File(sourceUri.getPath())) : null;
+        this.sourceFile = sourceUri.getScheme().equals("file") ? FileUtils.canonicalize(new File(sourceUri.getPath())) : null;
         this.sourceUri = sourceUri;
     }
 


### PR DESCRIPTION
This pull request introduces some performance improvements fixing the regression seen on "create many empty projects". This PR:

- reduces the number of file canonicalizations
- introduces improved caching on service registry

The improved caching requires the "many empty" project scenario to raise memory usage from 1g to 1.5g (but it's the only scenario which requires that). Branch 5 stage build passed, and performance reports shows improvement in [almost all scenarios](https://builds.gradle.org/repository/download/Gradle_Branches_Performance_PerformanceTestCoordinatorLinux/2890268:id/results/performance/build/performance-tests/scenario-report.html).