### PR TITLE
Settings script detection takes scripting language providers into account

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
@@ -68,7 +68,7 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
 
         and:
         failure.assertHasDescription("A problem occurred evaluating settings 'buildA'.")
-        failure.assertHasCause("Included build 'b1' must have a 'settings.gradle' file.")
+        failure.assertHasCause("Included build 'b1' must have a 'settings.*' file.")
     }
 
     def "reports failure when included build is itself a composite"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
@@ -68,7 +68,7 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
 
         and:
         failure.assertHasDescription("A problem occurred evaluating settings 'buildA'.")
-        failure.assertHasCause("Included build 'b1' must have a 'settings.*' file.")
+        failure.assertHasCause("Included build 'b1' must have a settings file.")
     }
 
     def "reports failure when included build is itself a composite"() {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -28,6 +28,7 @@ import org.gradle.initialization.IncludedBuilds;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.composite.CompositeContextBuilder;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.PluginServiceRegistry;
 
@@ -83,8 +84,8 @@ public class CompositeBuildServices implements PluginServiceRegistry {
     }
 
     private static class CompositeBuildBuildScopeServices {
-        public IncludedBuildFactory createIncludedBuildFactory(Instantiator instantiator, StartParameter startParameter, NestedBuildFactory nestedBuildFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-            return new DefaultIncludedBuildFactory(instantiator, startParameter, nestedBuildFactory, moduleIdentifierFactory);
+        public IncludedBuildFactory createIncludedBuildFactory(Instantiator instantiator, StartParameter startParameter, NestedBuildFactory nestedBuildFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ScriptFileResolver scriptFileResolver) {
+            return new DefaultIncludedBuildFactory(instantiator, startParameter, nestedBuildFactory, moduleIdentifierFactory, scriptFileResolver);
         }
 
         public ProjectArtifactBuilder createProjectArtifactBuilder(IncludedBuildArtifactBuilder builder, BuildIdentity buildIdentity) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -26,6 +26,7 @@ import org.gradle.initialization.IncludedBuildExecuter;
 import org.gradle.initialization.IncludedBuildFactory;
 import org.gradle.initialization.IncludedBuilds;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.composite.CompositeContextBuilder;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scripts.ScriptFileResolver;
@@ -85,7 +86,7 @@ public class CompositeBuildServices implements PluginServiceRegistry {
 
     private static class CompositeBuildBuildScopeServices {
         public IncludedBuildFactory createIncludedBuildFactory(Instantiator instantiator, StartParameter startParameter, NestedBuildFactory nestedBuildFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ScriptFileResolver scriptFileResolver) {
-            return new DefaultIncludedBuildFactory(instantiator, startParameter, nestedBuildFactory, moduleIdentifierFactory, scriptFileResolver);
+            return new DefaultIncludedBuildFactory(instantiator, startParameter, nestedBuildFactory, moduleIdentifierFactory, new BuildLayoutFactory(scriptFileResolver));
         }
 
         public ProjectArtifactBuilder createProjectArtifactBuilder(IncludedBuildArtifactBuilder builder, BuildIdentity buildIdentity) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
@@ -21,7 +21,6 @@ import org.gradle.StartParameter;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.initialization.ConfigurableIncludedBuild;
 import org.gradle.api.initialization.IncludedBuild;
-import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.initialization.GradleLauncher;
@@ -64,7 +63,7 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory, Stoppa
     private void validateIncludedBuild(IncludedBuild includedBuild, SettingsInternal settings) {
         File settingsFile = buildLayoutFactory.findExistingSettingsFileIn(settings.getSettingsDir());
         if (settingsFile == null) {
-            throw new InvalidUserDataException(String.format("Included build '%s' must have a '%s.*' file.", includedBuild.getName(), Settings.DEFAULT_SETTINGS_FILE_BASENAME));
+            throw new InvalidUserDataException(String.format("Included build '%s' must have a settings file.", includedBuild.getName()));
         }
         if (!settings.getIncludedBuilds().isEmpty()) {
             throw new InvalidUserDataException(String.format("Included build '%s' cannot have included builds.", includedBuild.getName()));

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
@@ -27,11 +27,11 @@ import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.IncludedBuildFactory;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.scripts.ScriptFileResolver;
 
 import java.io.File;
 import java.util.Set;
@@ -42,14 +42,14 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory, Stoppa
     private final NestedBuildFactory nestedBuildFactory;
     private final Set<GradleLauncher> launchers = Sets.newHashSet();
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
-    private final ScriptFileResolver scriptFileResolver;
+    private final BuildLayoutFactory buildLayoutFactory;
 
-    public DefaultIncludedBuildFactory(Instantiator instantiator, StartParameter startParameter, NestedBuildFactory nestedBuildFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ScriptFileResolver scriptFileResolver) {
+    public DefaultIncludedBuildFactory(Instantiator instantiator, StartParameter startParameter, NestedBuildFactory nestedBuildFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, BuildLayoutFactory buildLayoutFactory) {
         this.instantiator = instantiator;
         this.startParameter = startParameter;
         this.nestedBuildFactory = nestedBuildFactory;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
-        this.scriptFileResolver = scriptFileResolver;
+        this.buildLayoutFactory = buildLayoutFactory;
     }
 
     private void validateBuildDirectory(File dir) {
@@ -62,8 +62,8 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory, Stoppa
     }
 
     private void validateIncludedBuild(IncludedBuild includedBuild, SettingsInternal settings) {
-        File defaultSettingsFile = new File(settings.getSettingsDir(), Settings.DEFAULT_SETTINGS_FILE);
-        if (!defaultSettingsFile.exists() && scriptFileResolver.resolveScriptFile(settings.getSettingsDir(), Settings.DEFAULT_SETTINGS_FILE_BASENAME) == null) {
+        File settingsFile = buildLayoutFactory.findExistingSettingsFileIn(settings.getSettingsDir());
+        if (settingsFile == null) {
             throw new InvalidUserDataException(String.format("Included build '%s' must have a '%s.*' file.", includedBuild.getName(), Settings.DEFAULT_SETTINGS_FILE_BASENAME));
         }
         if (!settings.getIncludedBuilds().isEmpty()) {

--- a/subprojects/core/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core/src/main/java/org/gradle/api/initialization/Settings.java
@@ -69,6 +69,13 @@ import java.io.File;
 @HasInternalProtocol
 public interface Settings extends PluginAware {
     /**
+     * <p>The default file base name for the settings file.</p>
+     *
+     * @since 4.0
+     */
+    String DEFAULT_SETTINGS_FILE_BASENAME = "settings";
+
+    /**
      * <p>The default name for the settings file.</p>
      */
     String DEFAULT_SETTINGS_FILE = "settings.gradle";

--- a/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
@@ -46,7 +46,7 @@ public class LayoutCommandLineConverter extends AbstractCommandLineConverter<Bui
     }
 
     public void configure(CommandLineParser parser) {
-        parser.option(NO_SEARCH_UPWARDS, "no-search-upward").hasDescription(String.format("Don't search in parent folders for a %s file.", Settings.DEFAULT_SETTINGS_FILE));
+        parser.option(NO_SEARCH_UPWARDS, "no-search-upward").hasDescription(String.format("Don't search in parent folders for a %s.* file.", Settings.DEFAULT_SETTINGS_FILE_BASENAME));
         parser.option(PROJECT_DIR, "project-dir").hasArgument().hasDescription("Specifies the start directory for Gradle. Defaults to current directory.");
         parser.option(GRADLE_USER_HOME, "gradle-user-home").hasArgument().hasDescription("Specifies the gradle user home directory.");
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.initialization.layout;
 
+import org.gradle.api.Nullable;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.resources.MissingResourceException;
 import org.gradle.internal.scripts.ScriptFileResolver;
@@ -56,6 +57,14 @@ public class BuildLayoutFactory {
         return getLayoutFor(currentDir, searchUpwards ? null : currentDir.getParentFile());
     }
 
+    @Nullable
+    public File findExistingSettingsFileIn(File directory) {
+        File defaultSettingsFile = new File(directory, Settings.DEFAULT_SETTINGS_FILE);
+        return defaultSettingsFile.isFile()
+            ? defaultSettingsFile
+            : scriptFileResolver.resolveScriptFile(directory, Settings.DEFAULT_SETTINGS_FILE_BASENAME);
+    }
+
     BuildLayout getLayoutFor(File currentDir, File stopAt) {
         File settingsFile = findExistingSettingsFileIn(currentDir);
         if (settingsFile != null) {
@@ -75,13 +84,5 @@ public class BuildLayoutFactory {
 
     private BuildLayout layout(File rootDir, File settingsDir, File settingsFile) {
         return new BuildLayout(rootDir, settingsDir, settingsFile);
-    }
-
-    private File findExistingSettingsFileIn(File directory) {
-        File defaultSettingsFile = new File(directory, Settings.DEFAULT_SETTINGS_FILE);
-        if (defaultSettingsFile.isFile()) {
-            return defaultSettingsFile;
-        }
-        return scriptFileResolver.resolveScriptFile(directory, Settings.DEFAULT_SETTINGS_FILE_BASENAME);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
@@ -28,6 +28,10 @@ public class DefaultScriptFileResolver implements ScriptFileResolver {
         return new DefaultScriptFileResolver(Collections.<String>emptyList());
     }
 
+    public static ScriptFileResolver forDefaultScriptingLanguages() {
+        return forScriptingLanguages(new DefaultScriptingLanguages());
+    }
+
     public static ScriptFileResolver forScriptingLanguages(Iterable<ScriptingLanguage> scriptingLanguages) {
         List<String> extensions = new ArrayList<String>();
         for (ScriptingLanguage scriptingLanguage : scriptingLanguages) {

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
@@ -19,9 +19,14 @@ import org.gradle.scripts.ScriptingLanguage;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class DefaultScriptFileResolver implements ScriptFileResolver {
+
+    public static ScriptFileResolver empty() {
+        return new DefaultScriptFileResolver(Collections.<String>emptyList());
+    }
 
     public static ScriptFileResolver forScriptingLanguages(Iterable<ScriptingLanguage> scriptingLanguages) {
         List<String> extensions = new ArrayList<String>();

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -151,6 +151,7 @@ import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scan.BuildScanRequest;
 import org.gradle.internal.scan.DefaultBuildScanRequest;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.scripts.ScriptingLanguages;
 import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceRegistry;
@@ -315,13 +316,13 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             get(ProviderFactory.class));
     }
 
-    protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, NestedBuildFactory nestedBuildFactory,
+    protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, ScriptFileResolver scriptFileResolver, NestedBuildFactory nestedBuildFactory,
                                                                 ClassLoaderScopeRegistry classLoaderScopeRegistry, CacheRepository cacheRepository,
                                                                 BuildLoader buildLoader, BuildOperationExecutor buildOperationExecutor,
                                                                 ServiceRegistry serviceRegistry, CachedClasspathTransformer cachedClasspathTransformer,
                                                                 CachingServiceLocator cachingServiceLocator) {
         return new DefaultSettingsLoaderFactory(
-            new DefaultSettingsFinder(new BuildLayoutFactory()),
+            new DefaultSettingsFinder(new BuildLayoutFactory(scriptFileResolver)),
             settingsProcessor,
             new BuildSourceBuilder(
                 nestedBuildFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -75,6 +75,7 @@ import org.gradle.internal.remote.MessagingServer;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.serialize.HashCodeSerializer;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
@@ -171,8 +172,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         }
     }
 
-    CacheLayout createCacheLayout(StartParameter startParameter) {
-        BuildLayout buildLayout = new BuildLayoutFactory().getLayoutFor(new BuildLayoutConfiguration(startParameter));
+    CacheLayout createCacheLayout(StartParameter startParameter, ScriptFileResolver scriptFileResolver) {
+        BuildLayout buildLayout = new BuildLayoutFactory(scriptFileResolver).getLayoutFor(new BuildLayoutConfiguration(startParameter));
         File cacheDir = startParameter.getProjectCacheDir() != null ? startParameter.getProjectCacheDir() : new File(buildLayout.getRootDirectory(), ".gradle");
         return new CacheLayout(cacheDir);
     }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -18,39 +18,96 @@ package org.gradle.initialization.layout
 import org.gradle.StartParameter
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.groovy.scripts.UriScriptSource
+import org.gradle.internal.scripts.DefaultScriptFileResolver
+import org.gradle.internal.scripts.ScriptFileResolver
+import org.gradle.scripts.ScriptingLanguage
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class BuildLayoutFactoryTest extends Specification {
+
+    // This pair of constants is used to unroll most of the tests in this class
+    static final def SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS =
+        [[], ['.gradle.kts'], ['.gradle.kts'], ['.gradle.kts', '.tic'], ['.gradle.kts', '.tac'], ['.tic', '.gradle.kts'], ['.tac', '.gradle.kts']]
+    static final def SETTINGS_FILENAME_PERMUTATIONS =
+        ['settings.gradle', 'settings.gradle', 'settings.gradle.kts', 'settings.gradle', 'settings.gradle.kts', 'settings.gradle', 'settings.gradle.kts']
+
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
-    final BuildLayoutFactory locator = new BuildLayoutFactory()
 
-    def "returns current directory when it contains a settings file"() {
+    @Unroll
+    def "returns current directory when it contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.testDirectory
-        def settingsFile = currentDir.createFile("settings.gradle")
+        def settingsFile = currentDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "looks for sibling directory called 'master' that it contains a settings file"() {
+    @Unroll
+    def "returns current directory when no ancestor directory contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and: "temporary tree created out of the Gradle build tree"
+        def tmpDir = File.createTempFile("stop-", "-at").canonicalFile
+        def stopAt = new File(tmpDir, 'stopAt')
+        def currentDir = new File(new File(stopAt, "intermediate"), 'current')
+        currentDir.mkdirs()
+
+        expect:
+        def layout = locator.getLayoutFor(currentDir, true)
+        layout.rootDirectory == currentDir
+        layout.settingsDir == currentDir
+        isEmpty(layout.settingsScriptSource)
+
+        cleanup: "temporary tree"
+        tmpDir.deleteDir()
+
+        where:
+        extensions << [[], ['.gradle.kts']]
+    }
+
+    @Unroll
+    def "looks for sibling directory called 'master' that it contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("current")
         def masterDir = tmpDir.createDir("master")
-        def settingsFile = masterDir.createFile("settings.gradle")
+        def settingsFile = masterDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == masterDir.parentFile
         layout.settingsDir == masterDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "searches ancestors for a directory called 'master' that contains a settings file"() {
+    @Unroll
+    def "searches ancestors for a directory called 'master' that contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
         def masterDir = tmpDir.createDir("master")
         def settingsFile = masterDir.createFile("settings.gradle")
@@ -60,73 +117,127 @@ class BuildLayoutFactoryTest extends Specification {
         layout.rootDirectory == masterDir.parentFile
         layout.settingsDir == masterDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "ignores 'master' directory when it does not contain a settings file"() {
+    @Unroll
+    def "ignores 'master' directory when it does not contain a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
         def masterDir = tmpDir.createDir("sub/master")
         masterDir.createFile("gradle.properties")
-        def settingsFile = tmpDir.createFile("settings.gradle")
+        def settingsFile = tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == tmpDir.testDirectory
         layout.settingsDir == tmpDir.testDirectory
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "returns closest ancestor directory that contains a settings file"() {
+    @Unroll
+    def "returns closest ancestor directory that contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
         def subDir = tmpDir.createDir("sub")
-        def settingsFile = subDir.createFile("settings.gradle")
-        tmpDir.createFile("settings.gradle")
+        def settingsFile = subDir.createFile(settingsFilename)
+        tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == subDir
         layout.settingsDir == subDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "prefers the current directory as root directory"() {
+    @Unroll
+    def "prefers the current directory as root directory with a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
-        def settingsFile = currentDir.createFile("settings.gradle")
-        tmpDir.createFile("sub/settings.gradle")
-        tmpDir.createFile("settings.gradle")
+        def settingsFile = currentDir.createFile(settingsFilename)
+        tmpDir.createFile("sub/$settingsFilename")
+        tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "prefers the 'master' directory over ancestor directory"() {
+    @Unroll
+    def "prefers the 'master' directory over ancestor directory with a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
         def masterDir = tmpDir.createDir("sub/master")
-        def settingsFile = masterDir.createFile("settings.gradle")
-        tmpDir.createFile("settings.gradle")
+        def settingsFile = masterDir.createFile(settingsFilename)
+        tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == masterDir.parentFile
         layout.settingsDir == masterDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "returns start directory when search upwards is disabled"() {
+    @Unroll
+    def "returns start directory when search upwards is disabled with a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
-        tmpDir.createFile("sub/settings.gradle")
-        tmpDir.createFile("settings.gradle")
+        tmpDir.createFile("sub/$settingsFilename")
+        tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, false)
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         isEmpty(layout.settingsScriptSource)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "returns current directory when no settings or wrapper properties files found"() {
+    @Unroll
+    def "returns current directory when no settings or wrapper properties files found when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
 
         expect:
@@ -134,13 +245,21 @@ class BuildLayoutFactoryTest extends Specification {
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         isEmpty(layout.settingsScriptSource)
+
+        where:
+        extensions << [[], ['.gradle.kts']]
     }
 
-    def "can override build layout by specifying the settings file"() {
+    @Unroll
+    def "can override build layout by specifying the settings file to #overrideSettingsFilename with existing #settingsFilename when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("current")
-        currentDir.createFile("settings.gradle")
+        currentDir.createFile(settingsFilename)
         def rootDir = tmpDir.createDir("root")
-        def settingsFile = rootDir.createFile("some-settings.gradle")
+        def settingsFile = rootDir.createFile(overrideSettingsFilename)
         def startParameter = new StartParameter()
         startParameter.currentDir = currentDir
         startParameter.settingsFile = settingsFile
@@ -151,11 +270,21 @@ class BuildLayoutFactoryTest extends Specification {
         layout.rootDirectory == rootDir
         layout.settingsDir == rootDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        overrideSettingsFilename << SETTINGS_FILENAME_PERMUTATIONS.collect { "some-$it" }
     }
 
-    def "can override build layout by specifying an empty settings script"() {
+    @Unroll
+    def "can override build layout by specifying an empty settings script with existing #settingsFilename when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("current")
-        currentDir.createFile("settings.gradle")
+        currentDir.createFile(settingsFilename)
         def startParameter = new StartParameter()
         startParameter.currentDir = currentDir
         startParameter.useEmptySettings()
@@ -166,6 +295,16 @@ class BuildLayoutFactoryTest extends Specification {
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         isEmpty(layout.settingsScriptSource)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+    }
+
+    ScriptFileResolver scriptFileResolver(List<String> extensions) {
+        DefaultScriptFileResolver.forScriptingLanguages(extensions.collect { extension ->
+            Stub(ScriptingLanguage) { getExtension() >> extension }
+        })
     }
 
     void refersTo(ScriptSource scriptSource, File file) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -46,6 +46,9 @@ import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
+import org.gradle.internal.scripts.DefaultScriptFileResolver;
+import org.gradle.internal.scripts.DefaultScriptingLanguages;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.Main;
 import org.gradle.launcher.cli.ExecuteBuildAction;
 import org.gradle.launcher.cli.Parameters;
@@ -257,7 +260,8 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
         startParameter.setShowStacktrace(ShowStacktrace.ALWAYS);
 
         CommandLineParser parser = new CommandLineParser();
-        ParametersConverter parametersConverter = new ParametersConverter();
+        ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages());
+        ParametersConverter parametersConverter = new ParametersConverter(scriptFileResolver);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);
         parametersConverter.convert(parser.parse(getAllArgs()), parameters);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -47,7 +47,6 @@ import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
-import org.gradle.internal.scripts.DefaultScriptingLanguages;
 import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.Main;
 import org.gradle.launcher.cli.ExecuteBuildAction;
@@ -260,7 +259,7 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
         startParameter.setShowStacktrace(ShowStacktrace.ALWAYS);
 
         CommandLineParser parser = new CommandLineParser();
-        ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages());
+        ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forDefaultScriptingLanguages();
         ParametersConverter parametersConverter = new ParametersConverter(scriptFileResolver);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -44,7 +44,6 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
-import org.gradle.internal.scripts.DefaultScriptingLanguages;
 import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.bootstrap.ExecutionListener;
@@ -68,7 +67,7 @@ public class CommandLineActionFactory {
     private static final String HELP = "h";
     private static final String VERSION = "v";
 
-    private final ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages());
+    private final ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forDefaultScriptingLanguages();
 
     /**
      * <p>Converts the given command-line arguments to an {@link Action} which performs the action requested by the

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -43,6 +43,9 @@ import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.internal.scripts.DefaultScriptFileResolver;
+import org.gradle.internal.scripts.DefaultScriptingLanguages;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.bootstrap.ExecutionListener;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
@@ -65,6 +68,8 @@ public class CommandLineActionFactory {
     private static final String HELP = "h";
     private static final String VERSION = "v";
 
+    private final ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages());
+
     /**
      * <p>Converts the given command-line arguments to an {@link Action} which performs the action requested by the
      * command-line args.
@@ -78,6 +83,7 @@ public class CommandLineActionFactory {
         LoggingConfiguration loggingConfiguration = new DefaultLoggingConfiguration();
 
         return new WithLogging(loggingServices,
+                scriptFileResolver,
                 args,
                 loggingConfiguration,
                 new ExceptionReportingAction(
@@ -87,7 +93,7 @@ public class CommandLineActionFactory {
     }
 
     protected void createActionFactories(ServiceRegistry loggingServices, Collection<CommandLineAction> actions) {
-        actions.add(new BuildActionsFactory(loggingServices, new ParametersConverter(), new CachingJvmVersionDetector(new DefaultJvmVersionDetector(new DefaultExecActionFactory(new IdentityFileResolver())))));
+        actions.add(new BuildActionsFactory(loggingServices, new ParametersConverter(scriptFileResolver), new CachingJvmVersionDetector(new DefaultJvmVersionDetector(new DefaultExecActionFactory(new IdentityFileResolver())))));
     }
 
     private static GradleLauncherMetaData clientMetaData() {
@@ -181,12 +187,14 @@ public class CommandLineActionFactory {
 
     private static class WithLogging implements Action<ExecutionListener> {
         private final ServiceRegistry loggingServices;
+        private final ScriptFileResolver scriptFileResolver;
         private final List<String> args;
         private final LoggingConfiguration loggingConfiguration;
         private final Action<ExecutionListener> action;
 
-        WithLogging(ServiceRegistry loggingServices, List<String> args, LoggingConfiguration loggingConfiguration, Action<ExecutionListener> action) {
+        WithLogging(ServiceRegistry loggingServices, ScriptFileResolver scriptFileResolver, List<String> args, LoggingConfiguration loggingConfiguration, Action<ExecutionListener> action) {
             this.loggingServices = loggingServices;
+            this.scriptFileResolver = scriptFileResolver;
             this.args = args;
             this.loggingConfiguration = loggingConfiguration;
             this.action = action;
@@ -197,7 +205,7 @@ public class CommandLineActionFactory {
             CommandLineConverter<BuildLayoutParameters> buildLayoutConverter = new LayoutCommandLineConverter();
             CommandLineConverter<ParallelismConfiguration> parallelConverter = new ParallelismConfigurationCommandLineConverter();
             CommandLineConverter<Map<String, String>> systemPropertiesCommandLineConverter = new SystemPropertiesCommandLineConverter();
-            LayoutToPropertiesConverter layoutToPropertiesConverter = new LayoutToPropertiesConverter();
+            LayoutToPropertiesConverter layoutToPropertiesConverter = new LayoutToPropertiesConverter(scriptFileResolver);
 
             BuildLayoutParameters buildLayout = new BuildLayoutParameters();
             ParallelismConfiguration parallelismConfiguration = new DefaultParallelismConfiguration();

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
@@ -19,6 +19,7 @@ package org.gradle.launcher.cli;
 import org.gradle.cli.*;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.LayoutCommandLineConverter;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.cli.converter.DaemonCommandLineConverter;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
@@ -57,10 +58,10 @@ public class ParametersConverter extends AbstractCommandLineConverter<Parameters
         this.propertiesToDaemonParametersConverter = propertiesToDaemonParametersConverter;
     }
 
-    public ParametersConverter() {
+    public ParametersConverter(ScriptFileResolver scriptFileResolver) {
         this(new LayoutCommandLineConverter(),
             new SystemPropertiesCommandLineConverter(),
-            new LayoutToPropertiesConverter(),
+            new LayoutToPropertiesConverter(scriptFileResolver),
             new PropertiesToStartParameterConverter(),
             new DefaultCommandLineConverter(),
             new DaemonCommandLineConverter(),

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -23,6 +23,7 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.daemon.configuration.GradleProperties;
 
 import java.io.File;
@@ -34,6 +35,13 @@ import java.util.Map;
 import java.util.Properties;
 
 public class LayoutToPropertiesConverter {
+
+    private final ScriptFileResolver scriptFileResolver;
+
+    public LayoutToPropertiesConverter(ScriptFileResolver scriptFileResolver) {
+        this.scriptFileResolver = scriptFileResolver;
+    }
+
     public Map<String, String> convert(BuildLayoutParameters layout, Map<String, String> properties) {
         configureFromBuildDir(layout.getSearchDir(), layout.getSearchUpwards(), properties);
         configureFromGradleUserHome(layout.getGradleUserHomeDir(), properties);
@@ -57,7 +65,7 @@ public class LayoutToPropertiesConverter {
     }
 
     private void configureFromBuildDir(File currentDir, boolean searchUpwards, Map<String, String> result) {
-        BuildLayoutFactory factory = new BuildLayoutFactory();
+        BuildLayoutFactory factory = new BuildLayoutFactory(scriptFileResolver);
         BuildLayout layout = factory.getLayoutFor(currentDir, searchUpwards);
         maybeConfigureFrom(new File(layout.getRootDirectory(), Project.GRADLE_PROPERTIES), result);
     }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
@@ -20,6 +20,7 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
@@ -60,6 +61,7 @@ public class ConnectionScopeServices {
 
     ProviderConnection createProviderConnection(BuildExecuter buildActionExecuter,
                                                 DaemonClientFactory daemonClientFactory,
+                                                ScriptFileResolver scriptFileResolver,
                                                 ServiceRegistry serviceRegistry,
                                                 JvmVersionDetector jvmVersionDetector,
                                                 // This is here to trigger creation of the ShutdownCoordinator. Could do this in a nicer way
@@ -68,6 +70,7 @@ public class ConnectionScopeServices {
         return new ProviderConnection(
                 serviceRegistry,
                 loggingServices,
+                scriptFileResolver,
                 daemonClientFactory,
                 buildActionExecuter,
                 new PayloadSerializer(

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -31,6 +31,7 @@ import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
@@ -69,14 +70,16 @@ public class ProviderConnection {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProviderConnection.class);
     private final PayloadSerializer payloadSerializer;
     private final LoggingServiceRegistry loggingServices;
+    private final ScriptFileResolver scriptFileResolver;
     private final DaemonClientFactory daemonClientFactory;
     private final BuildActionExecuter<BuildActionParameters> embeddedExecutor;
     private final ServiceRegistry sharedServices;
     private final JvmVersionDetector jvmVersionDetector;
 
-    public ProviderConnection(ServiceRegistry sharedServices, LoggingServiceRegistry loggingServices, DaemonClientFactory daemonClientFactory,
+    public ProviderConnection(ServiceRegistry sharedServices, LoggingServiceRegistry loggingServices, ScriptFileResolver scriptFileResolver, DaemonClientFactory daemonClientFactory,
                               BuildActionExecuter<BuildActionParameters> embeddedExecutor, PayloadSerializer payloadSerializer, JvmVersionDetector jvmVersionDetector) {
         this.loggingServices = loggingServices;
+        this.scriptFileResolver = scriptFileResolver;
         this.daemonClientFactory = daemonClientFactory;
         this.embeddedExecutor = embeddedExecutor;
         this.payloadSerializer = payloadSerializer;
@@ -176,7 +179,7 @@ public class ProviderConnection {
         layout.setProjectDir(operationParameters.getProjectDir());
 
         Map<String, String> properties = new HashMap<String, String>();
-        new LayoutToPropertiesConverter().convert(layout, properties);
+        new LayoutToPropertiesConverter(scriptFileResolver).convert(layout, properties);
 
         DaemonParameters daemonParams = new DaemonParameters(layout);
         new PropertiesToDaemonParametersConverter().convert(properties, daemonParams);

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.launcher.cli.converter
 
 import org.gradle.initialization.BuildLayoutParameters
+import org.gradle.internal.scripts.DefaultScriptFileResolver
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
@@ -29,7 +30,7 @@ class LayoutToPropertiesConverterTest extends Specification {
 
     @Rule SetSystemProperties sysProperties = new SetSystemProperties()
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
-    def converter = new LayoutToPropertiesConverter()
+    def converter = new LayoutToPropertiesConverter(DefaultScriptFileResolver.empty())
     BuildLayoutParameters layout
     Map<String, String> props = new HashMap<String, String>()
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
@@ -21,6 +21,8 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
+import org.gradle.internal.scripts.DefaultScriptFileResolver;
+import org.gradle.internal.scripts.DefaultScriptingLanguages;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.tooling.CancellationTokenSource;
 import org.gradle.tooling.internal.consumer.loader.CachingToolingImplementationLoader;
@@ -75,7 +77,7 @@ public class ConnectorServices {
         }
 
         protected DistributionFactory createDistributionFactory() {
-            return new DistributionFactory();
+            return new DistributionFactory(DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages()));
         }
 
         protected ToolingImplementationLoader createToolingImplementationLoader() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
@@ -22,7 +22,6 @@ import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
-import org.gradle.internal.scripts.DefaultScriptingLanguages;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.tooling.CancellationTokenSource;
 import org.gradle.tooling.internal.consumer.loader.CachingToolingImplementationLoader;
@@ -77,7 +76,7 @@ public class ConnectorServices {
         }
 
         protected DistributionFactory createDistributionFactory() {
-            return new DistributionFactory(DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages()));
+            return new DistributionFactory(DefaultScriptFileResolver.forDefaultScriptingLanguages());
         }
 
         protected ToolingImplementationLoader createToolingImplementationLoader() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
@@ -23,6 +23,7 @@ import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.tooling.BuildCancelledException;
 import org.gradle.tooling.GradleConnectionException;
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener;
@@ -42,7 +43,12 @@ import java.util.concurrent.CancellationException;
 import static org.gradle.internal.FileUtils.hasExtension;
 
 public class DistributionFactory {
+    private final ScriptFileResolver scriptFileResolver;
     private File distributionBaseDir;
+
+    public DistributionFactory(ScriptFileResolver scriptFileResolver) {
+        this.scriptFileResolver = scriptFileResolver;
+    }
 
     public void setDistributionBaseDir(File distributionBaseDir) {
         this.distributionBaseDir = distributionBaseDir;
@@ -52,7 +58,7 @@ public class DistributionFactory {
      * Returns the default distribution to use for the specified project.
      */
     public Distribution getDefaultDistribution(File projectDir, boolean searchUpwards) {
-        BuildLayout layout = new BuildLayoutFactory().getLayoutFor(projectDir, searchUpwards);
+        BuildLayout layout = new BuildLayoutFactory(scriptFileResolver).getLayoutFor(projectDir, searchUpwards);
         WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory(layout.getRootDirectory());
         if (wrapper.getDistribution() != null) {
             return new ZippedDistribution(wrapper.getConfiguration(), distributionBaseDir);

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.tooling.internal.consumer
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.internal.logging.progress.ProgressLogger
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.scripts.DefaultScriptFileResolver
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.tooling.events.FinishEvent
@@ -33,7 +34,7 @@ class DistributionFactoryTest extends Specification {
     final ProgressLoggerFactory progressLoggerFactory = Mock()
     final ProgressLogger progressLogger = Mock()
     final BuildCancellationToken cancellationToken = Mock()
-    final DistributionFactory factory = new DistributionFactory()
+    final DistributionFactory factory = new DistributionFactory(DefaultScriptFileResolver.empty())
     final InternalBuildProgressListener buildProgressListener = Mock()
 
     def setup() {


### PR DESCRIPTION
This PR allows Gradle to detect settings scripts according to available scripting languages.

It builds upon the `ScriptingLanguage` SPI introduced by #1908.

See https://github.com/gradle/gradle-script-kotlin/issues/56

### Gradle Core Team Checklist
- [ ] Verify test coverage and CI build status https://builds.gradle.org/viewQueued.html?itemId=2894994
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
