### PR TITLE
Add support for Play 2.6

### DIFF
--- a/subprojects/docs/src/docs/userguide/playPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/playPlugin.xml
@@ -46,10 +46,7 @@
         <itemizedlist>
             <listitem>
                 <para>
-                    Full support is limited to Play 2.3.x applications.
-                    Limited support is available for Play 2.4.x &amp; 2.5.x applications. Gradle does not include support for a few new build-related features in 2.4.0+
-                    Specifically, Gradle does not yet support aggregate reverse routes.
-                    Future Gradle versions will add more support for Play 2.6.x.
+                    Gradle does not yet support aggregate reverse routes introduced in Play 2.4.x.
                 </para>
             </listitem>
             <listitem>

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayPlatformIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayPlatformIntegrationTest.groovy
@@ -143,7 +143,7 @@ model {
         fails "assemble"
 
         and:
-        failure.assertHasCause "Not a supported Play version: 2.1.0. This plugin is compatible with: [2.5.x, 2.4.x, 2.3.x, 2.2.x]."
+        failure.assertHasCause "Not a supported Play version: 2.1.0. This plugin is compatible with: [2.6.x, 2.5.x, 2.4.x, 2.3.x, 2.2.x]."
     }
 
     def "fails when trying to build for an invalid scala platform"() {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/platform/PlayMajorVersion.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/platform/PlayMajorVersion.java
@@ -28,7 +28,8 @@ public enum PlayMajorVersion {
     PLAY_2_2_X("2.2.x", "2.10"),
     PLAY_2_3_X("2.3.x", "2.11", "2.10"),
     PLAY_2_4_X("2.4.x", "2.11", "2.10"),
-    PLAY_2_5_X("2.5.x", "2.11");
+    PLAY_2_5_X("2.5.x", "2.11"),
+    PLAY_2_6_X("2.6.x", "2.11", "2.12");
 
     private final String name;
     private final List<String> compatibleScalaVersions;
@@ -67,6 +68,8 @@ public enum PlayMajorVersion {
                     return PlayMajorVersion.PLAY_2_4_X;
                 case 5:
                     return PlayMajorVersion.PLAY_2_5_X;
+                case 6:
+                    return PlayMajorVersion.PLAY_2_6_X;
                 default:
                     throw invalidVersion(playVersion);
             }
@@ -76,7 +79,7 @@ public enum PlayMajorVersion {
 
     private static InvalidUserDataException invalidVersion(String playVersion) {
         return new InvalidUserDataException(String.format("Not a supported Play version: %s. "
-            + "This plugin is compatible with: [2.5.x, 2.4.x, 2.3.x, 2.2.x].", playVersion));
+            + "This plugin is compatible with: [2.6.x, 2.5.x, 2.4.x, 2.3.x, 2.2.x].", playVersion));
     }
 
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompilerFactory.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompilerFactory.java
@@ -46,6 +46,8 @@ public class RoutesCompilerFactory {
                 return new RoutesCompilerAdapterV24X(playVersion, scalaVersion);
             case PLAY_2_5_X:
                 return new RoutesCompilerAdapterV24X(playVersion, scalaVersion);
+            case PLAY_2_6_X:
+                return new RoutesCompilerAdapterV24X(playVersion, scalaVersion);
             default:
                 throw new RuntimeException("Could not create routes compile spec for Play version: " + playVersion);
         }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunnerFactory.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunnerFactory.java
@@ -33,6 +33,8 @@ public class PlayApplicationRunnerFactory {
                 return new PlayRunAdapterV24X();
             case PLAY_2_5_X:
                 return new PlayRunAdapterV25X();
+            case PLAY_2_6_X:
+                return new PlayRunAdapterV26X();
             case PLAY_2_3_X:
             default:
                 return new PlayRunAdapterV23X();

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayRunAdapterV26X.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayRunAdapterV26X.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.internal.run;
+
+import org.gradle.scala.internal.reflect.ScalaMethod;
+import org.gradle.scala.internal.reflect.ScalaReflectionUtil;
+
+public class PlayRunAdapterV26X extends PlayRunAdapterV23X {
+    @Override
+    public void runDevHttpServer(ClassLoader classLoader, ClassLoader docsClassLoader, Object buildLink, Object buildDocHandler, int httpPort) throws ClassNotFoundException {
+        ScalaMethod runMethod = ScalaReflectionUtil.scalaMethod(classLoader, "play.core.server.DevServerStart", "mainDevHttpMode", getBuildLinkClass(classLoader), int.class, String.class);
+        runMethod.invoke(buildLink, httpPort, "0.0.0.0");
+    }
+
+    @Override
+    protected String getIOSupportDependencyVersion() {
+        return "0.13.15";
+    }
+}

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompilerFactory.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompilerFactory.java
@@ -20,11 +20,24 @@ import org.gradle.play.internal.platform.PlayMajorVersion;
 import org.gradle.play.platform.PlayPlatform;
 
 public class TwirlCompilerFactory {
+
     public static TwirlCompiler create(PlayPlatform playPlatform) {
-        return new TwirlCompiler(createAdapter(playPlatform));
+        switch (PlayMajorVersion.forPlatform(playPlatform)) {
+            case PLAY_2_6_X:
+                // TODO: create a TwirlJavaCompiler for Twirl 1.3.x that uses the Java compiler interface
+                // Rename TwirlCompiler to TwirlScalaCompiler
+                // Waiting for https://github.com/playframework/twirl/pull/136
+                // and https://github.com/gradle/gradle/pull/2062
+                // We don't want to use the legacy TwirlScalaCompiler for Twirl 3.0 because the interface is more
+                // complicated and it would be really frustrating to deal with typed parameters via reflection,
+                // to create Scala Seqs in Java, etc.
+                return new TwirlCompiler(new TwirlCompilerAdapterV10X("1.1.1", scalaCompatibilityVersion));
+            default:
+                return new TwirlCompiler(createScalaCompilerAdapter(playPlatform));
+        }
     }
 
-    public static VersionedTwirlCompilerAdapter createAdapter(PlayPlatform playPlatform) {
+    public static VersionedTwirlCompilerAdapter createScalaCompilerAdapter(PlayPlatform playPlatform) {
         String playVersion = playPlatform.getPlayVersion();
         String scalaCompatibilityVersion = playPlatform.getScalaPlatform().getScalaCompatibilityVersion();
         switch (PlayMajorVersion.forPlatform(playPlatform)) {

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/PlayPlatformResolverTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/PlayPlatformResolverTest.groovy
@@ -44,7 +44,7 @@ class PlayPlatformResolverTest extends Specification {
 
         then:
         def e = thrown(InvalidUserDataException)
-        e.message == "Not a supported Play version: 2.1.0. This plugin is compatible with: [2.5.x, 2.4.x, 2.3.x, 2.2.x]."
+        e.message == "Not a supported Play version: 2.1.0. This plugin is compatible with: [2.6.x, 2.5.x, 2.4.x, 2.3.x, 2.2.x]."
 
         where:
         requirement << ["play-2.1.0", [play: '2.1.0']]
@@ -69,6 +69,7 @@ class PlayPlatformResolverTest extends Specification {
         "2.3.4"     | "2.11.8"
         "2.4.8"     | "2.11.8"
         "2.5.4"     | "2.11.8"
+        "2.6.2"     | "2.11.8"
     }
 
     private void assertPlayPlatform(Map versions, PlayPlatform platform) {

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/toolchain/DefaultPlayToolProviderTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/toolchain/DefaultPlayToolProviderTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.play.internal.run.PlayRunAdapterV22X
 import org.gradle.play.internal.run.PlayRunAdapterV23X
 import org.gradle.play.internal.run.PlayRunAdapterV24X
 import org.gradle.play.internal.run.PlayRunAdapterV25X
+import org.gradle.play.internal.run.PlayRunAdapterV26X
 import org.gradle.play.platform.PlayPlatform
 import org.gradle.process.internal.worker.WorkerProcessFactory
 import org.gradle.workers.internal.WorkerDaemonFactory
@@ -65,6 +66,7 @@ class DefaultPlayToolProviderTest extends Specification {
         "2.3.x"     | PlayRunAdapterV23X
         "2.4.x"     | PlayRunAdapterV24X
         "2.5.x"     | PlayRunAdapterV25X
+        "2.6.x"     | PlayRunAdapterV26X
     }
 
     def "cannot create tool provider for unsupported play versions"() {
@@ -74,14 +76,14 @@ class DefaultPlayToolProviderTest extends Specification {
 
         then: "fails with meaningful error message"
         def exception = thrown(InvalidUserDataException)
-        exception.message == "Not a supported Play version: ${playVersion}. This plugin is compatible with: [2.5.x, 2.4.x, 2.3.x, 2.2.x]."
+        exception.message == "Not a supported Play version: ${playVersion}. This plugin is compatible with: [2.6.x, 2.5.x, 2.4.x, 2.3.x, 2.2.x]."
 
         and: "no dependencies resolved"
         0 * dependencyHandler.create(_)
         0 * configurationContainer.detachedConfiguration(_)
 
         where:
-        playVersion << ["2.1.x", "2.6.x", "3.0.0"]
+        playVersion << ["2.1.x", "3.0.0"]
     }
 
     def "newCompiler provides decent error for unsupported CompileSpec"() {


### PR DESCRIPTION
### Context
Adds support for Play 2.6, which will soon be released. I'm a committer to Play and employee of LinkedIn

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [X] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [N/A] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew quickCheck :platformPlay:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes