### PR TITLE
Only use sourceSet.output as findbugs directories

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
@@ -186,7 +186,7 @@ public class FindBugsPlugin extends AbstractCodeQualityPlugin<FindBugs> {
         taskMapping.map("classes", new Callable<FileCollection>() {
             @Override
             public FileCollection call() {
-                return sourceSet.getOutput().getClassesDirs().getAsFileTree();
+                return sourceSet.getOutput();
             }
         });
         taskMapping.map("classpath", new Callable<FileCollection>() {


### PR DESCRIPTION
### Context
FindbugsSpecBuilder takes the source *directories* as an input - not the individual classes. Using all the classes as an input yields to problems like #1094.

There are still some tests failing - they should be easy to fix. Would this be a good change for Gradle 4.0 given we recently changed the code due to the new output directories?

I stumbled across this while working on a PR for the Jenkins Gradle plugin: https://github.com/jenkinsci/gradle-plugin/pull/48