### PR TITLE
Add Isolatable<T> interface

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractScalarValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractScalarValueSnapshot.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
+
 /**
  * A snapshot of an immutable scalar value. Should only be used for immutable JVM provided or core Gradle types.
  *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractScalarValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractScalarValueSnapshot.java
@@ -21,7 +21,7 @@ package org.gradle.api.internal.changedetection.state;
  *
  * @param <T>
  */
-public abstract class AbstractScalarValueSnapshot<T> implements ValueSnapshot {
+public abstract class AbstractScalarValueSnapshot<T> implements ValueSnapshot, Isolatable<T> {
     private final T value;
 
     public AbstractScalarValueSnapshot(T value) {
@@ -30,6 +30,10 @@ public abstract class AbstractScalarValueSnapshot<T> implements ValueSnapshot {
 
     public T getValue() {
         return value;
+    }
+
+    public T isolate() {
+        return getValue();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractScalarValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractScalarValueSnapshot.java
@@ -47,6 +47,14 @@ public abstract class AbstractScalarValueSnapshot<T> implements ValueSnapshot, I
     }
 
     @Override
+    public ValueSnapshot isolatableSnapshot(Object value, ValueSnapshotter snapshotter) {
+        if (this.value.equals(value)) {
+            return this;
+        }
+        return snapshotter.isolatableSnapshot(value);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ArrayValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ArrayValueSnapshot.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
+import org.gradle.api.internal.changedetection.state.isolation.IsolationException;
 import org.gradle.caching.internal.BuildCacheHasher;
 
 import java.util.Arrays;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ArrayValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ArrayValueSnapshot.java
@@ -20,7 +20,7 @@ import org.gradle.caching.internal.BuildCacheHasher;
 
 import java.util.Arrays;
 
-public class ArrayValueSnapshot implements ValueSnapshot {
+public class ArrayValueSnapshot implements ValueSnapshot, Isolatable<Object[]> {
     public static final ValueSnapshot EMPTY = new ArrayValueSnapshot(new ValueSnapshot[0]);
     private final ValueSnapshot[] elements;
 
@@ -68,5 +68,20 @@ public class ArrayValueSnapshot implements ValueSnapshot {
     @Override
     public int hashCode() {
         return Arrays.hashCode(elements);
+    }
+
+    @Override
+    public Object[] isolate() {
+        ValueSnapshot[] elements = getElements();
+        Object[] toReturn = new Object[elements.length];
+        for (int i = 0; i < elements.length; i++) {
+            ValueSnapshot snapshot = elements[i];
+            if (snapshot instanceof Isolatable) {
+                toReturn[i] = ((Isolatable) snapshot).isolate();
+            } else {
+                throw new IsolationException("Attempted to isolate an object which is not Isolatable.");
+            }
+        }
+        return toReturn;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ArrayValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ArrayValueSnapshot.java
@@ -46,13 +46,29 @@ public class ArrayValueSnapshot implements ValueSnapshot, Isolatable<Object[]> {
     @Override
     public ValueSnapshot snapshot(Object value, ValueSnapshotter snapshotter) {
         ValueSnapshot other = snapshotter.snapshot(value);
+        if (isEqualArrayValueSnapshot(other)) {
+            return this;
+        }
+        return other;
+    }
+
+    @Override
+    public ValueSnapshot isolatableSnapshot(Object value, ValueSnapshotter snapshotter) {
+        ValueSnapshot other = snapshotter.isolatableSnapshot(value);
+        if (isEqualArrayValueSnapshot(other)) {
+            return this;
+        }
+        return other;
+    }
+
+    private boolean isEqualArrayValueSnapshot(ValueSnapshot other) {
         if (other instanceof ArrayValueSnapshot) {
             ArrayValueSnapshot otherArray = (ArrayValueSnapshot) other;
             if (Arrays.equals(elements, otherArray.elements)) {
-                return this;
+                return true;
             }
         }
-        return other;
+        return false;
     }
 
     @Override
@@ -81,7 +97,7 @@ public class ArrayValueSnapshot implements ValueSnapshot, Isolatable<Object[]> {
             if (snapshot instanceof Isolatable) {
                 toReturn[i] = ((Isolatable) snapshot).isolate();
             } else {
-                throw new IsolationException("Attempted to isolate an object which is not Isolatable.");
+                throw new IsolationException(snapshot);
             }
         }
         return toReturn;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/Isolatable.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/Isolatable.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+/**
+ * Isolatable objects can return an isolated instance of the given type T from which this object was created.
+ * An <b>isolated</b> instance has the same internal state as the original object on which this isolatable was based,
+ * but it is guaranteed not to retain any references to mutable state from the original instance.
+ * <p>
+ * The primary reason to need such an isolated instance of an object is to ensure that work can be done in parallel using the instance without
+ * fear that it's internal state is changing while the work is being carried out.
+ */
+public interface Isolatable<T> {
+    T isolate();
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IsolationException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IsolationException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+/**
+ * Represents a problem while attempting to isolate an instance.
+ */
+public class IsolationException extends RuntimeException {
+
+    public IsolationException(String msg) {
+        super(msg);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ListValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ListValueSnapshot.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
+import org.gradle.api.internal.changedetection.state.isolation.IsolationException;
 import org.gradle.caching.internal.BuildCacheHasher;
 
 import java.util.ArrayList;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ListValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ListValueSnapshot.java
@@ -18,10 +18,11 @@ package org.gradle.api.internal.changedetection.state;
 
 import org.gradle.caching.internal.BuildCacheHasher;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class ListValueSnapshot implements ValueSnapshot {
+public class ListValueSnapshot implements ValueSnapshot, Isolatable<List> {
     public static final ValueSnapshot EMPTY = new ListValueSnapshot(new ValueSnapshot[0]);
 
     private final ValueSnapshot[] elements;
@@ -94,5 +95,20 @@ public class ListValueSnapshot implements ValueSnapshot {
     @Override
     public int hashCode() {
         return Arrays.hashCode(elements);
+    }
+
+    @Override
+    public List isolate() {
+        List list = new ArrayList();
+        ValueSnapshot[] elements = getElements();
+        for (int i = 0; i < elements.length; i++) {
+            ValueSnapshot snapshot = elements[i];
+            if (snapshot instanceof Isolatable) {
+                list.add(((Isolatable) snapshot).isolate());
+            } else {
+                throw new IsolationException("Attempted to isolate an object which is not Isolatable.");
+            }
+        }
+        return list;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/MapValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/MapValueSnapshot.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
 import org.gradle.api.internal.changedetection.state.isolation.IsolationException;
 import org.gradle.caching.internal.BuildCacheHasher;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class MapValueSnapshot implements ValueSnapshot, Isolatable<Map> {
@@ -82,7 +82,7 @@ public class MapValueSnapshot implements ValueSnapshot, Isolatable<Map> {
 
     @Override
     public Map isolate() {
-        Map map = new HashMap();
+        Map map = new LinkedHashMap();
         for (Map.Entry<ValueSnapshot, ValueSnapshot> entry : entries.entrySet()) {
             if (entry.getKey() instanceof Isolatable) {
                 if (entry.getValue() instanceof Isolatable) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/NullValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/NullValueSnapshot.java
@@ -16,9 +16,10 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
 import org.gradle.caching.internal.BuildCacheHasher;
 
-public class NullValueSnapshot implements ValueSnapshot {
+public class NullValueSnapshot implements ValueSnapshot, Isolatable<Object> {
     public static final NullValueSnapshot INSTANCE = new NullValueSnapshot();
 
     private NullValueSnapshot() {
@@ -35,5 +36,10 @@ public class NullValueSnapshot implements ValueSnapshot {
     @Override
     public void appendToHasher(BuildCacheHasher hasher) {
         hasher.putNull();
+    }
+
+    @Override
+    public Object isolate() {
+        return null;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/NullValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/NullValueSnapshot.java
@@ -34,6 +34,14 @@ public class NullValueSnapshot implements ValueSnapshot, Isolatable<Object> {
     }
 
     @Override
+    public ValueSnapshot isolatableSnapshot(Object value, ValueSnapshotter snapshotter) {
+        if (value == null) {
+            return this;
+        }
+        return snapshotter.isolatableSnapshot(value);
+    }
+
+    @Override
     public void appendToHasher(BuildCacheHasher hasher) {
         hasher.putNull();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SerializedValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SerializedValueSnapshot.java
@@ -61,12 +61,7 @@ public class SerializedValueSnapshot implements ValueSnapshot {
             }
 
             // Deserialize the old value and use the equals() implementation. This will be removed at some point
-            Object oldValue;
-            try {
-                oldValue = new ClassLoaderObjectInputStream(new ByteArrayInputStream(serializedValue), value.getClass().getClassLoader()).readObject();
-            } catch (Exception e) {
-                throw new UncheckedIOException(e);
-            }
+            Object oldValue = populateClass(value.getClass());
             if (oldValue.equals(value)) {
                 // Same value
                 return this;
@@ -96,6 +91,16 @@ public class SerializedValueSnapshot implements ValueSnapshot {
         }
         SerializedValueSnapshot other = (SerializedValueSnapshot) obj;
         return Objects.equal(implementationHash, other.implementationHash) && Arrays.equals(serializedValue, other.serializedValue);
+    }
+
+    protected  Object populateClass(Class<?> originalClass) {
+        Object populated;
+        try {
+            populated = new ClassLoaderObjectInputStream(new ByteArrayInputStream(serializedValue), originalClass.getClassLoader()).readObject();
+        } catch (Exception e) {
+            throw new UncheckedIOException(e);
+        }
+        return populated;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SerializedValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SerializedValueSnapshot.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.changedetection.state;
 import com.google.common.base.Objects;
 import com.google.common.hash.HashCode;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
 import org.gradle.caching.internal.BuildCacheHasher;
 import org.gradle.internal.io.ClassLoaderObjectInputStream;
 
@@ -48,27 +49,45 @@ public class SerializedValueSnapshot implements ValueSnapshot {
     @Override
     public ValueSnapshot snapshot(Object value, ValueSnapshotter snapshotter) {
         ValueSnapshot snapshot = snapshotter.snapshot(value);
+        if (hasSameSerializedValue(value, snapshot)) {
+            return this;
+        }
+        return snapshot;
+    }
 
+    @Override
+    public ValueSnapshot isolatableSnapshot(Object value, ValueSnapshotter snapshotter) {
+        ValueSnapshot snapshot = snapshotter.isolatableSnapshot(value);
+        if (hasSameSerializedValue(value, snapshot)) {
+            if (this instanceof Isolatable) {
+                return this;
+            } else {
+                return snapshotter.wrap(value, this);
+            }
+        }
+        return snapshot;
+    }
+
+    private boolean hasSameSerializedValue(Object value, ValueSnapshot snapshot) {
         if (snapshot instanceof SerializedValueSnapshot) {
             SerializedValueSnapshot newSnapshot = (SerializedValueSnapshot) snapshot;
             if (!Objects.equal(implementationHash, newSnapshot.implementationHash)) {
                 // Different implementation - assume value has changed
-                return newSnapshot;
+                return false;
             }
             if (Arrays.equals(serializedValue, newSnapshot.serializedValue)) {
                 // Same serialized content - value has not changed
-                return this;
+                return true;
             }
 
             // Deserialize the old value and use the equals() implementation. This will be removed at some point
             Object oldValue = populateClass(value.getClass());
             if (oldValue.equals(value)) {
                 // Same value
-                return this;
+                return true;
             }
         }
-
-        return snapshot;
+        return false;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SetValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SetValueSnapshot.java
@@ -17,9 +17,14 @@
 package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
+import org.gradle.api.internal.changedetection.state.isolation.IsolationException;
 import org.gradle.caching.internal.BuildCacheHasher;
 
-public class SetValueSnapshot implements ValueSnapshot {
+import java.util.HashSet;
+import java.util.Set;
+
+public class SetValueSnapshot implements ValueSnapshot, Isolatable<Set> {
     private final ImmutableSet<ValueSnapshot> elements;
 
     public SetValueSnapshot(ImmutableSet<ValueSnapshot> elements) {
@@ -66,5 +71,18 @@ public class SetValueSnapshot implements ValueSnapshot {
     @Override
     public int hashCode() {
         return elements.hashCode();
+    }
+
+    @Override
+    public Set isolate() {
+        Set set = new HashSet();
+        for (ValueSnapshot snapshot : elements) {
+            if (snapshot instanceof Isolatable) {
+                set.add(((Isolatable) snapshot).isolate());
+            } else {
+                throw new IsolationException("Attempted to isolate an object which is not Isolatable.");
+            }
+        }
+        return set;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SetValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SetValueSnapshot.java
@@ -47,13 +47,29 @@ public class SetValueSnapshot implements ValueSnapshot, Isolatable<Set> {
     @Override
     public ValueSnapshot snapshot(Object value, ValueSnapshotter snapshotter) {
         ValueSnapshot newSnapshot = snapshotter.snapshot(value);
+        if (isEqualSetValueSnapshot(newSnapshot)) {
+            return this;
+        }
+        return newSnapshot;
+    }
+
+    @Override
+    public ValueSnapshot isolatableSnapshot(Object value, ValueSnapshotter snapshotter) {
+        ValueSnapshot newSnapshot = snapshotter.isolatableSnapshot(value);
+        if (isEqualSetValueSnapshot(newSnapshot)) {
+            return this;
+        }
+        return newSnapshot;
+    }
+
+    private boolean isEqualSetValueSnapshot(ValueSnapshot newSnapshot) {
         if (newSnapshot instanceof SetValueSnapshot) {
             SetValueSnapshot other = (SetValueSnapshot) newSnapshot;
             if (elements.equals(other.elements)) {
-                return this;
+                return true;
             }
         }
-        return newSnapshot;
+        return false;
     }
 
     @Override
@@ -80,7 +96,7 @@ public class SetValueSnapshot implements ValueSnapshot, Isolatable<Set> {
             if (snapshot instanceof Isolatable) {
                 set.add(((Isolatable) snapshot).isolate());
             } else {
-                throw new IsolationException("Attempted to isolate an object which is not Isolatable.");
+                throw new IsolationException(snapshot);
             }
         }
         return set;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SetValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SetValueSnapshot.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
 import org.gradle.api.internal.changedetection.state.isolation.IsolationException;
 import org.gradle.caching.internal.BuildCacheHasher;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class SetValueSnapshot implements ValueSnapshot, Isolatable<Set> {
@@ -90,8 +90,9 @@ public class SetValueSnapshot implements ValueSnapshot, Isolatable<Set> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Set isolate() {
-        Set set = new HashSet();
+        Set set = new LinkedHashSet();
         for (ValueSnapshot snapshot : elements) {
             if (snapshot instanceof Isolatable) {
                 set.add(((Isolatable) snapshot).isolate());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ValueSnapshot.java
@@ -24,4 +24,10 @@ public interface ValueSnapshot extends Snapshot {
      * Takes a snapshot of the given value, using this as a candidate snapshot. If the value is the same as the value represented by this snapshot, this snapshot _must_ be returned.
      */
     ValueSnapshot snapshot(Object value, ValueSnapshotter snapshotter);
+
+    /**
+     * Creates an {@link org.gradle.api.internal.changedetection.state.isolation.Isolatable} {@link Snapshot} of the value. If the value is the same as the value represented by this
+     * snapshot, this snapshot _must_ be returned.
+     */
+    ValueSnapshot isolatableSnapshot(Object value, ValueSnapshotter snapshotter);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ValueSnapshotStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ValueSnapshotStrategy.java
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state.isolation;
+package org.gradle.api.internal.changedetection.state;
 
 /**
- * Represents a problem while attempting to isolate an instance.
+ * Encapsulates a strategy for making {@link ValueSnapshot}s
  */
-public class IsolationException extends RuntimeException {
-    private static final String MSG_FORMAT="Could not isolate value: [%s] of type: [%s]";
+public class ValueSnapshotStrategy {
+    protected final ValueSnapshotter snapshotter;
 
-    public IsolationException(String msg) {
-        super(msg);
+    public ValueSnapshotStrategy(ValueSnapshotter snapshotter) {
+        this.snapshotter = snapshotter;
     }
 
-    public IsolationException(Object value) {
-        super(String.format(MSG_FORMAT, value, value.getClass()));
+    public ValueSnapshot snapshot(Object value) {
+        return snapshotter.snapshot(value);
+    }
+
+    public ValueSnapshot snapshot(Object value, ValueSnapshot candidate) {
+        return snapshotter.snapshot(value, candidate);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ValueSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ValueSnapshotter.java
@@ -22,6 +22,7 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
 import org.gradle.api.internal.changedetection.state.isolation.IsolatableEnumValueSnapshot;
 import org.gradle.api.internal.changedetection.state.isolation.IsolatableSerializedValueSnapshot;
+import org.gradle.api.internal.changedetection.state.isolation.IsolatableValueSnapshotStrategy;
 import org.gradle.api.internal.changedetection.state.isolation.IsolationException;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 
@@ -47,15 +48,24 @@ public class ValueSnapshotter {
      * @throws UncheckedIOException On failure to snapshot the value.
      */
     public ValueSnapshot snapshot(Object value) throws UncheckedIOException {
-        ValueSnapshot possible = internalSnapshot(value);
+        return processValue(value, new ValueSnapshotStrategy(this));
+    }
+
+    /**
+     * Create an {@link Isolatable} {@link Snapshot} of a value.
+     *
+     * @throws UncheckedIOException On failure to snapshot the value.
+     */
+    public ValueSnapshot isolatableSnapshot(Object value) throws UncheckedIOException {
+        ValueSnapshot possible = processValue(value, new IsolatableValueSnapshotStrategy(this));
         if (possible instanceof Isolatable) {
             return possible;
         } else {
             return wrap(value, possible);
         }
     }
-    
-    private ValueSnapshot internalSnapshot(Object value) throws UncheckedIOException {
+
+    private ValueSnapshot processValue(Object value, ValueSnapshotStrategy strategy) {
         if (value == null) {
             return NullValueSnapshot.INSTANCE;
         }
@@ -73,7 +83,7 @@ public class ValueSnapshotter {
             ValueSnapshot[] elements = new ValueSnapshot[list.size()];
             for (int i = 0; i < list.size(); i++) {
                 Object element = list.get(i);
-                elements[i] = snapshot(element);
+                elements[i] = strategy.snapshot(element);
             }
             return new ListValueSnapshot(elements);
         }
@@ -99,7 +109,7 @@ public class ValueSnapshotter {
             Set<?> set = (Set<?>) value;
             ImmutableSet.Builder<ValueSnapshot> builder = ImmutableSet.builder();
             for (Object element : set) {
-                builder.add(snapshot(element));
+                builder.add(strategy.snapshot(element));
             }
             return new SetValueSnapshot(builder.build());
         }
@@ -107,7 +117,7 @@ public class ValueSnapshotter {
             Map<?, ?> map = (Map<?, ?>) value;
             ImmutableMap.Builder<ValueSnapshot, ValueSnapshot> builder = new ImmutableMap.Builder<ValueSnapshot, ValueSnapshot>();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
-                builder.put(snapshot(entry.getKey()), snapshot(entry.getValue()));
+                builder.put(strategy.snapshot(entry.getKey()), strategy.snapshot(entry.getValue()));
             }
             return new MapValueSnapshot(builder.build());
         }
@@ -119,7 +129,7 @@ public class ValueSnapshotter {
             ValueSnapshot[] elements = new ValueSnapshot[length];
             for (int i = 0; i < length; i++) {
                 Object element = Array.get(value, i);
-                elements[i] = snapshot(element);
+                elements[i] = strategy.snapshot(element);
             }
             return new ArrayValueSnapshot(elements);
         }
@@ -142,7 +152,7 @@ public class ValueSnapshotter {
         return new SerializedValueSnapshot(classLoaderHasher.getClassLoaderHash(value.getClass().getClassLoader()), outputStream.toByteArray());
     }
 
-    private ValueSnapshot wrap(Object value, ValueSnapshot possible) {
+    ValueSnapshot wrap(Object value, ValueSnapshot possible) {
         if (possible instanceof EnumValueSnapshot) {
             return new IsolatableEnumValueSnapshot((Enum) value);
         }
@@ -150,7 +160,7 @@ public class ValueSnapshotter {
             SerializedValueSnapshot original = (SerializedValueSnapshot) possible;
             return new IsolatableSerializedValueSnapshot(original.getImplementationHash(), original.getValue(), value.getClass());
         }
-        throw new IsolationException(String.format("Could not isolate value: [%s] of type: [%s]", value, value.getClass()));
+        throw new IsolationException(value);
     }
 
     /**
@@ -158,5 +168,13 @@ public class ValueSnapshotter {
      */
     public ValueSnapshot snapshot(Object value, ValueSnapshot candidate) {
         return candidate.snapshot(value, this);
+    }
+
+    /**
+     * Creates an {@link Isolatable} {@link Snapshot} of the given value, given a candidate snapshot. If the value is
+     * the same as the value provided by the candidate snapshot, the candidate _must_ be returned.
+     */
+    public ValueSnapshot isolatableSnapshot(Object value, ValueSnapshot candidate) {
+        return candidate.isolatableSnapshot(value, this);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/Isolatable.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/Isolatable.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.api.internal.changedetection.state.isolation;
 
 /**
  * Isolatable objects can return an isolated instance of the given type T from which this object was created.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/IsolatableEnumValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/IsolatableEnumValueSnapshot.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state.isolation;
+
+import org.gradle.api.internal.changedetection.state.EnumValueSnapshot;
+
+/**
+ * Isolates an Enum value and is a snapshot for that value.
+ */
+public class IsolatableEnumValueSnapshot extends EnumValueSnapshot implements Isolatable<Enum> {
+    private final Enum<?> value;
+
+    public IsolatableEnumValueSnapshot(Enum<?> value) {
+        super(value);
+        this.value = value;
+    }
+
+    @Override
+    public Enum isolate() {
+        return value;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/IsolatableSerializedValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/IsolatableSerializedValueSnapshot.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state.isolation;
+
+import com.google.common.hash.HashCode;
+import org.gradle.api.internal.changedetection.state.SerializedValueSnapshot;
+
+/**
+ * Isolates a Serialized value and is a snapshot for that value.
+ */
+public class IsolatableSerializedValueSnapshot extends SerializedValueSnapshot implements Isolatable<Object> {
+    private final Class<?> originalClass;
+
+    public IsolatableSerializedValueSnapshot(HashCode implementationHash, byte[] serializedValue, Class<?> originalClass) {
+        super(implementationHash, serializedValue);
+        this.originalClass = originalClass;
+    }
+
+    @Override
+    public Object isolate() {
+        return populateClass(originalClass);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/IsolatableValueSnapshotStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/IsolatableValueSnapshotStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state.isolation;
+
+import org.gradle.api.internal.changedetection.state.ValueSnapshot;
+import org.gradle.api.internal.changedetection.state.ValueSnapshotStrategy;
+import org.gradle.api.internal.changedetection.state.ValueSnapshotter;
+
+/**
+ * A strategy for creating {@link ValueSnapshot}s which ensures that they are {@link Isolatable}.
+ */
+public class IsolatableValueSnapshotStrategy extends ValueSnapshotStrategy {
+    public IsolatableValueSnapshotStrategy(ValueSnapshotter snapshotter) {
+        super(snapshotter);
+    }
+
+    @Override
+    public ValueSnapshot snapshot(Object value) {
+        return snapshotter.isolatableSnapshot(value);
+    }
+
+    @Override
+    public ValueSnapshot snapshot(Object value, ValueSnapshot candidate) {
+        return snapshotter.isolatableSnapshot(value, candidate);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/IsolationException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/isolation/IsolationException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.api.internal.changedetection.state.isolation;
 
 /**
  * Represents a problem while attempting to isolate an instance.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/IsolationTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/IsolationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state
 
+import org.gradle.api.internal.changedetection.state.isolation.Isolatable
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import spock.lang.Specification
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/IsolationTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/IsolationTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state
+
+import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
+import spock.lang.Specification
+
+/**
+ * Tests that Isolation is implemented for various types of Snapshots.
+ */
+class IsolationTest extends Specification {
+    def snapshotter = new ValueSnapshotter(Stub(ClassLoaderHierarchyHasher))
+
+    def "can isolate Strings"() {
+        given:
+        def original = "Original String"
+        def snapshot = snapshotter.snapshot(original)
+
+        expect:
+        snapshot instanceof Isolatable<String>
+        (snapshot as Isolatable<String>).isolate() == original
+    }
+
+    def "can isolate an array of scalars"() {
+        given:
+        def original = ["Hello", "GoodBye"] as String[]
+        def snapshot = snapshotter.snapshot(original)
+
+        expect:
+        snapshot instanceof Isolatable<Object[]>
+        def isolated = (snapshot as Isolatable<Object[]>).isolate()
+        isolated == original
+        !isolated.is(original)
+    }
+
+    def "can isolate an array of an array of scalars"() {
+        given:
+        def original = [["Hello", "GoodBye"], ["Up", "Down"], ["Left", "Right"]] as String[][]
+        def snapshot = snapshotter.snapshot(original)
+
+        expect:
+        snapshot instanceof Isolatable<Object[]>
+        def isolated = (snapshot as Isolatable<Object[]>).isolate()
+        isolated == original
+        !isolated.is(original)
+    }
+
+    def "can isolate a List"() {
+        given:
+        def original = ["Hello", "GoodBye"]
+        def snapshot = snapshotter.snapshot(original)
+
+        expect:
+        snapshot instanceof Isolatable<List>
+        def isolated = (snapshot as Isolatable<List>).isolate()
+        isolated == original
+        !isolated.is(original)
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationTest.groovy
@@ -171,20 +171,20 @@ public class CountRecorder extends ArtifactTransform {
         then:
         outputContains("variants: [{artifactType=firstCount}, {artifactType=firstCount}]")
         file("build/libs1").assertHasDescendants("test-1.3.jar.txt", "test2-2.3.jar.txt")
-        file("build/libs1/test-1.3.jar.txt").text == "0\n1\n2\n3\n4\n"
-        file("build/libs1/test2-2.3.jar.txt").text == "0\n1\n2\n3\n4\n"
+        file("build/libs1/test-1.3.jar.txt").readLines() == ["0", "1", "2", "3", "4"]
+        file("build/libs1/test2-2.3.jar.txt").readLines() == ["0", "1", "2", "3", "4"]
 
         and:
         outputContains("variants: [{artifactType=secondCount}, {artifactType=secondCount}]")
         file("build/libs2").assertHasDescendants("test-1.3.jar.txt", "test2-2.3.jar.txt")
-        file("build/libs2/test-1.3.jar.txt").text == "1\n2\n3\n4\n5\n"
-        file("build/libs2/test2-2.3.jar.txt").text == "1\n2\n3\n4\n5\n"
+        file("build/libs2/test-1.3.jar.txt").readLines() == ["1", "2", "3", "4", "5"]
+        file("build/libs2/test2-2.3.jar.txt").readLines() == ["1", "2", "3", "4", "5"]
 
         and:
         outputContains("variants: [{artifactType=thirdCount}, {artifactType=thirdCount}]")
         file("build/libs3").assertHasDescendants("test-1.3.jar.txt", "test2-2.3.jar.txt")
-        file("build/libs3/test-1.3.jar.txt").text == "2\n3\n4\n5\n6\n"
-        file("build/libs3/test2-2.3.jar.txt").text == "2\n3\n4\n5\n6\n"
+        file("build/libs3/test-1.3.jar.txt").readLines() == ["2", "3", "4", "5", "6"]
+        file("build/libs3/test2-2.3.jar.txt").readLines() == ["2", "3", "4", "5", "6"]
 
         and:
         output.count("Transforming") == 6

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationTest.groovy
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.transform
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+
+/**
+ * Ensures that artifact transform parameters are isolated from one another and the surrounding project state.
+ */
+class ArtifactTransformIsolationTest extends AbstractHttpDependencyResolutionTest {
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+
+        buildFile << """
+
+def artifactType = Attribute.of('artifactType', String)
+
+class Counter implements Serializable {    
+    private int count = 0;
+
+    public int increment() {
+        return ++count;
+    }
+
+    public int getCount() {
+        return count;
+    }
+}
+
+public class CountRecorder extends ArtifactTransform {
+    private final Counter counter;
+    
+    @javax.inject.Inject
+    public CountRecorder(Counter counter) {
+        this.counter = counter
+        println "Creating CountRecorder"
+    }
+    
+    List<File> transform(File input) {
+        assert outputDirectory.directory && outputDirectory.list().length == 0
+        def output = new File(outputDirectory, input.name + ".txt")
+        println "Transforming \${input.name} to \${output.name}"
+        output.withWriter { out ->
+            out.println String.valueOf(counter.getCount())
+            for (int i = 0; i < 4; i++) {
+                out.println String.valueOf(counter.increment())
+            }
+            out.close()
+        }
+        return [output]
+    }
+}
+"""
+    }
+
+    def "serialized mutable class is isolated during artifact transformation"() {
+        def m1 = mavenRepo.module("test", "test", "1.3").publish()
+        def m2 = mavenRepo.module("test", "test2", "2.3").publish()
+
+        given:
+        buildFile << """
+            def counter = new Counter()
+
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            
+            configurations {
+                compile
+            }
+            
+            dependencies {
+                compile 'test:test:1.3'
+                compile 'test:test2:2.3'
+            }
+            
+            dependencies {
+                registerTransform {
+                    from.attribute(artifactType, 'jar')
+                    to.attribute(artifactType, 'firstCount')
+                    artifactTransform(CountRecorder) { params(counter) }
+                }
+                counter.increment()
+                registerTransform {
+                    from.attribute(artifactType, 'jar')
+                    to.attribute(artifactType, 'secondCount')
+                    artifactTransform(CountRecorder) { params(counter) }
+                }
+                counter.increment()
+                registerTransform {
+                    from.attribute(artifactType, 'jar')
+                    to.attribute(artifactType, 'thirdCount')
+                    artifactTransform(CountRecorder) { params(counter) }
+                }
+            }
+
+            task resolveFirst(type: Copy) {
+                def first = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(artifactType, 'firstCount') }
+                }.artifacts
+                from first.artifactFiles
+                into "\${buildDir}/libs1"
+                
+                doLast {
+                    println "files: " + first.collect { it.file.name }
+                    println "ids: " + first.collect { it.id }
+                    println "components: " + first.collect { it.id.componentIdentifier }
+                    println "variants: " + first.collect { it.variant.attributes }
+                }
+            }
+            
+            task increment {
+                doFirst {
+                    // Just to show that incrementing the counter doesn't matter.
+                    counter.increment()
+                }
+            }
+
+            task resolveSecond(type: Copy) {
+                def second = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(artifactType, 'secondCount') }
+                }.artifacts
+                from second.artifactFiles
+                into "\${buildDir}/libs2"
+                
+                doLast {
+                    println "files: " + second.collect { it.file.name }
+                    println "ids: " + second.collect { it.id }
+                    println "components: " + second.collect { it.id.componentIdentifier }
+                    println "variants: " + second.collect { it.variant.attributes }
+                }
+            }
+
+            task resolveThird(type: Copy) {
+                def third = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(artifactType, 'thirdCount') }
+                }.artifacts
+                from third.artifactFiles
+                into "\${buildDir}/libs3"
+                
+                doLast {
+                    println "files: " + third.collect { it.file.name }
+                    println "ids: " + third.collect { it.id }
+                    println "components: " + third.collect { it.id.componentIdentifier }
+                    println "variants: " + third.collect { it.variant.attributes }
+                }
+            }
+            
+            task resolve dependsOn 'resolveFirst', 'increment', 'resolveSecond', 'resolveThird'
+        """
+
+        when:
+        run 'resolve'
+
+        then:
+        outputContains("variants: [{artifactType=firstCount}, {artifactType=firstCount}]")
+        file("build/libs1").assertHasDescendants("test-1.3.jar.txt", "test2-2.3.jar.txt")
+        file("build/libs1/test-1.3.jar.txt").text == "0\n1\n2\n3\n4\n"
+        file("build/libs1/test2-2.3.jar.txt").text == "0\n1\n2\n3\n4\n"
+
+        and:
+        outputContains("variants: [{artifactType=secondCount}, {artifactType=secondCount}]")
+        file("build/libs2").assertHasDescendants("test-1.3.jar.txt", "test2-2.3.jar.txt")
+        file("build/libs2/test-1.3.jar.txt").text == "1\n2\n3\n4\n5\n"
+        file("build/libs2/test2-2.3.jar.txt").text == "1\n2\n3\n4\n5\n"
+
+        and:
+        outputContains("variants: [{artifactType=thirdCount}, {artifactType=thirdCount}]")
+        file("build/libs3").assertHasDescendants("test-1.3.jar.txt", "test2-2.3.jar.txt")
+        file("build/libs3/test-1.3.jar.txt").text == "2\n3\n4\n5\n6\n"
+        file("build/libs3/test2-2.3.jar.txt").text == "2\n3\n4\n5\n6\n"
+
+        and:
+        output.count("Transforming") == 6
+        output.count("Transforming test-1.3.jar to test-1.3.jar.txt") == 3
+        output.count("Transforming test2-2.3.jar to test2-2.3.jar.txt") == 3
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformBackedTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformBackedTransformer.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
+import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.util.BiFunction;
 
@@ -26,10 +27,10 @@ import java.util.List;
 
 class ArtifactTransformBackedTransformer implements BiFunction<List<File>, File, File> {
     private final Class<? extends ArtifactTransform> implementationClass;
-    private final Object[] parameters;
     private final Instantiator instantiator;
+    private final Isolatable<Object[]> parameters;
 
-    ArtifactTransformBackedTransformer(Class<? extends ArtifactTransform> implementationClass, Object[] parameters, Instantiator instantiator) {
+    ArtifactTransformBackedTransformer(Class<? extends ArtifactTransform> implementationClass, Isolatable<Object[]> parameters, Instantiator instantiator) {
         this.implementationClass = implementationClass;
         this.parameters = parameters;
         this.instantiator = instantiator;
@@ -37,7 +38,7 @@ class ArtifactTransformBackedTransformer implements BiFunction<List<File>, File,
 
     @Override
     public List<File> apply(File file, File outputDir) {
-        ArtifactTransform artifactTransform = instantiator.newInstance(implementationClass, parameters);
+        ArtifactTransform artifactTransform = instantiator.newInstance(implementationClass, parameters.isolate());
         artifactTransform.setOutputDirectory(outputDir);
         List<File> outputs = artifactTransform.transform(file);
         if (outputs == null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistration.java
@@ -27,7 +27,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.changedetection.state.ArrayValueSnapshot;
 import org.gradle.api.internal.changedetection.state.ValueSnapshot;
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter;
-import org.gradle.api.internal.changedetection.state.IsolationException;
+import org.gradle.api.internal.changedetection.state.isolation.IsolationException;
 import org.gradle.caching.internal.DefaultBuildCacheHasher;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.reflect.Instantiator;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistration.java
@@ -73,7 +73,7 @@ class DefaultVariantTransformRegistration implements VariantTransformRegistry.Re
         }
         ArrayValueSnapshot paramsSnapshot = (ArrayValueSnapshot) snapshot;
 
-        this.transformer = new ArtifactTransformBackedTransformer(implementation, paramsSnapshot.isolate(), instantiator);
+        this.transformer = new ArtifactTransformBackedTransformer(implementation, paramsSnapshot, instantiator);
     }
 
     public AttributeContainerInternal getFrom() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistration.java
@@ -59,7 +59,7 @@ class DefaultVariantTransformRegistration implements VariantTransformRegistry.Re
         // TODO - should snapshot later?
         ValueSnapshot snapshot;
         try {
-            snapshot = valueSnapshotter.snapshot(params);
+            snapshot = valueSnapshotter.isolatableSnapshot(params);
         } catch (Exception e) {
             throw new VariantTransformConfigurationException(String.format("Could not snapshot configuration values for transform %s: %s", ModelType.of(implementation).getDisplayName(), Arrays.asList(params)), e);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistration.java
@@ -24,8 +24,10 @@ import org.gradle.api.artifacts.transform.VariantTransformConfigurationException
 import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.changedetection.state.ArrayValueSnapshot;
 import org.gradle.api.internal.changedetection.state.ValueSnapshot;
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter;
+import org.gradle.api.internal.changedetection.state.IsolationException;
 import org.gradle.caching.internal.DefaultBuildCacheHasher;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.reflect.Instantiator;
@@ -55,7 +57,6 @@ class DefaultVariantTransformRegistration implements VariantTransformRegistry.Re
         hasher.putHash(classLoaderHierarchyHasher.getClassLoaderHash(implementation.getClassLoader()));
 
         // TODO - should snapshot later?
-        // TODO - should make params immutable
         ValueSnapshot snapshot;
         try {
             snapshot = valueSnapshotter.snapshot(params);
@@ -66,7 +67,13 @@ class DefaultVariantTransformRegistration implements VariantTransformRegistry.Re
         snapshot.appendToHasher(hasher);
         inputsHash = hasher.hash();
 
-        this.transformer = new ArtifactTransformBackedTransformer(implementation, params, instantiator);
+        // Isolate Parameters
+        if (!(snapshot instanceof ArrayValueSnapshot)) {
+            throw new IsolationException("Snapshotting the ActionConfiguration's params didn't create an ArrayValueSnapshot.");
+        }
+        ArrayValueSnapshot paramsSnapshot = (ArrayValueSnapshot) snapshot;
+
+        this.transformer = new ArtifactTransformBackedTransformer(implementation, paramsSnapshot.isolate(), instantiator);
     }
 
     public AttributeContainerInternal getFrom() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -22,7 +22,9 @@ import org.gradle.api.artifacts.transform.ArtifactTransformException
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
+import org.gradle.api.internal.changedetection.state.ArrayValueSnapshot
 import org.gradle.api.internal.changedetection.state.StringValueSnapshot
+import org.gradle.api.internal.changedetection.state.ValueSnapshot
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.internal.reflect.ObjectInstantiationException
@@ -50,6 +52,9 @@ class DefaultVariantTransformRegistryTest extends Specification {
     def registry = new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, transformedFileCache, valueSnapshotter, classLoaderHierarchyHasher)
 
     def "creates registration without configuration"() {
+        given:
+        def valueSnapshotArray = [] as ValueSnapshot[]
+
         when:
         registry.registerTransform {
             it.from.attribute(TEST_ATTRIBUTE, "FROM")
@@ -58,7 +63,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot([] as Object[]) >> new StringValueSnapshot("inputs")
+        1 * valueSnapshotter.snapshot([] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
         1 * classLoaderHierarchyHasher.getClassLoaderHash(TestArtifactTransform.classLoader) >> HashCode.fromInt(123)
 
         and:
@@ -82,6 +87,9 @@ class DefaultVariantTransformRegistryTest extends Specification {
     }
 
     def "creates registration with configuration"() {
+        given:
+        def valueSnapshotArray = [new StringValueSnapshot("EXTRA_1"), new StringValueSnapshot("EXTRA_2")] as ValueSnapshot[]
+
         when:
         registry.registerTransform {
             it.from.attribute(TEST_ATTRIBUTE, "FROM")
@@ -92,7 +100,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot(["EXTRA_1", "EXTRA_2"] as Object[]) >> new StringValueSnapshot("inputs")
+        1 * valueSnapshotter.snapshot(["EXTRA_1", "EXTRA_2"] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray);
         1 * classLoaderHierarchyHasher.getClassLoaderHash(TestArtifactTransform.classLoader) >> HashCode.fromInt(123)
 
         and:
@@ -119,6 +127,9 @@ class DefaultVariantTransformRegistryTest extends Specification {
     }
 
     def "fails when artifactTransform cannot be instantiated"() {
+        given:
+        def valueSnapshotArray = [] as ValueSnapshot[]
+
         when:
         registry.registerTransform {
             it.from.attribute(TEST_ATTRIBUTE, "FROM")
@@ -127,7 +138,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot([] as Object[]) >> new StringValueSnapshot("inputs")
+        1 * valueSnapshotter.snapshot([] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
         1 * classLoaderHierarchyHasher.getClassLoaderHash(AbstractArtifactTransform.classLoader) >> HashCode.fromInt(123)
 
         and:
@@ -148,6 +159,11 @@ class DefaultVariantTransformRegistryTest extends Specification {
     }
 
     def "fails when incorrect number of artifactTransform parameters supplied for registration"() {
+        given:
+        def valueSnapshotArray = [new StringValueSnapshot("EXTRA_1"),
+                                  new StringValueSnapshot("EXTRA_2"),
+                                  new StringValueSnapshot("EXTRA_3")] as ValueSnapshot[]
+
         when:
         registry.registerTransform {
             it.from.attribute(TEST_ATTRIBUTE, "FROM")
@@ -159,7 +175,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot(["EXTRA_1", "EXTRA_2", "EXTRA_3"] as Object[]) >> new StringValueSnapshot("inputs")
+        1 * valueSnapshotter.snapshot(["EXTRA_1", "EXTRA_2", "EXTRA_3"] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
         1 * classLoaderHierarchyHasher.getClassLoaderHash(TestArtifactTransformWithParams.classLoader) >> HashCode.fromInt(123)
 
         and:
@@ -182,6 +198,9 @@ class DefaultVariantTransformRegistryTest extends Specification {
     }
 
     def "fails when artifactTransform throws exception"() {
+        given:
+        def valueSnapshotArray = [] as ValueSnapshot[]
+
         when:
         registry.registerTransform {
             it.from.attribute(TEST_ATTRIBUTE, "FROM")
@@ -190,7 +209,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot([] as Object[]) >> new StringValueSnapshot("inputs")
+        1 * valueSnapshotter.snapshot([] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
         1 * classLoaderHierarchyHasher.getClassLoaderHash(BrokenTransform.classLoader) >> HashCode.fromInt(123)
 
         and:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -63,7 +63,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot([] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
+        1 * valueSnapshotter.isolatableSnapshot([] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
         1 * classLoaderHierarchyHasher.getClassLoaderHash(TestArtifactTransform.classLoader) >> HashCode.fromInt(123)
 
         and:
@@ -100,7 +100,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot(["EXTRA_1", "EXTRA_2"] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray);
+        1 * valueSnapshotter.isolatableSnapshot(["EXTRA_1", "EXTRA_2"] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray);
         1 * classLoaderHierarchyHasher.getClassLoaderHash(TestArtifactTransform.classLoader) >> HashCode.fromInt(123)
 
         and:
@@ -138,7 +138,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot([] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
+        1 * valueSnapshotter.isolatableSnapshot([] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
         1 * classLoaderHierarchyHasher.getClassLoaderHash(AbstractArtifactTransform.classLoader) >> HashCode.fromInt(123)
 
         and:
@@ -175,7 +175,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot(["EXTRA_1", "EXTRA_2", "EXTRA_3"] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
+        1 * valueSnapshotter.isolatableSnapshot(["EXTRA_1", "EXTRA_2", "EXTRA_3"] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
         1 * classLoaderHierarchyHasher.getClassLoaderHash(TestArtifactTransformWithParams.classLoader) >> HashCode.fromInt(123)
 
         and:
@@ -209,7 +209,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        1 * valueSnapshotter.snapshot([] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
+        1 * valueSnapshotter.isolatableSnapshot([] as Object[]) >> new ArrayValueSnapshot(valueSnapshotArray)
         1 * classLoaderHierarchyHasher.getClassLoaderHash(BrokenTransform.classLoader) >> HashCode.fromInt(123)
 
         and:


### PR DESCRIPTION
Add `Isolatable<T>` abstraction

This change adds the interface and several implementations to allow `SnapshotValue` objects to be isolatable as long as they are running in the same JVM in which they were created.

This change goes on further to integration the usage of this new interface into the artifact transform code which to show how it can make it possible to run several of those transforms in parallel.