### PR TITLE
Provide enable information on Finalize Build Cache Configuration Build Operation

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
@@ -44,6 +44,10 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
         then:
         def result = result()
+
+        !result.localDisabled
+        result.remoteDisabled
+
         result.local.className == 'org.gradle.caching.local.DirectoryBuildCache'
         result.local.config.location == cacheDir.absoluteFile.toString()
         result.local.type == 'directory'
@@ -83,6 +87,10 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
         then:
         def result = result()
+
+        !result.localDisabled
+        result.remoteDisabled
+
         result.local.className == 'CustomBuildCache'
         result.local.config.directory == directory
         result.local.type == type
@@ -125,8 +133,34 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         then:
         def result = result()
 
+        result.localDisabled
+        result.remoteDisabled
+
         result.local == null
         result.remote == null
+    }
+
+    def "local build cache configuration is not exposed when disabled"() {
+        given:
+        def cacheDir = temporaryFolder.file("cache-dir").createDir()
+        settingsFile << """
+            buildCache {
+                local(DirectoryBuildCache) {
+                    enabled = false
+                    directory = '${cacheDir.absoluteFile.toURI().toString()}'
+                    push = true 
+                }
+            }
+        """
+        executer.withBuildCacheEnabled()
+
+        when:
+        succeeds("help")
+
+        then:
+        def result = result()
+        result.localDisabled
+        result.local == null
     }
 
     Map<String, ?> result() {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/FinalizeBuildCacheConfigurationDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/FinalizeBuildCacheConfigurationDetails.java
@@ -79,13 +79,27 @@ public final class FinalizeBuildCacheConfigurationDetails implements BuildOperat
 
         }
 
+        private final boolean localDisabled;
+
         private final BuildCacheDescription local;
+
+        private final boolean remoteDisabled;
 
         private final BuildCacheDescription remote;
 
-        public Result(@Nullable BuildCacheDescription local, @Nullable BuildCacheDescription remote) {
+        public Result(boolean localDisabled, boolean remoteDisabled, @Nullable BuildCacheDescription local, @Nullable BuildCacheDescription remote) {
+            this.localDisabled = localDisabled;
+            this.remoteDisabled = remoteDisabled;
             this.local = local;
             this.remote = remote;
+        }
+
+        public boolean isLocalDisabled() {
+            return localDisabled;
+        }
+
+        public boolean isRemoteDisabled() {
+            return remoteDisabled;
         }
 
         @Nullable // if not enabled


### PR DESCRIPTION
This information is required on the Build Scan Plugin. The implementation respects the fact that Build Cache Service instances need to be _not_ instantiated when the configuration disable them somehow.