### PR TITLE
Expand BuildOperationFinishedNotification interface with a details object.

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationFinishedNotification.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationFinishedNotification.java
@@ -47,4 +47,9 @@ public interface BuildOperationFinishedNotification {
      */
     Throwable getNotificationOperationFailure();
 
+    /**
+     * A structured object providing details about the operation that was performed.
+     */
+    Object getNotificationOperationDetails();
+
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/BuildOperationNotificationBridge.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/BuildOperationNotificationBridge.java
@@ -107,7 +107,7 @@ public class BuildOperationNotificationBridge implements Stoppable {
                 return;
             }
 
-            Finished notification = new Finished(buildOperation.getId(), finishEvent.getResult(), finishEvent.getFailure());
+            Finished notification = new Finished(buildOperation.getId(), finishEvent.getResult(), finishEvent.getFailure(), buildOperation.getDetails());
             try {
                 listener.finished(notification);
             } catch (Exception e) {
@@ -153,11 +153,13 @@ public class BuildOperationNotificationBridge implements Stoppable {
         private final Object id;
         private final Object result;
         private final Throwable failure;
+        private final Object details;
 
-        private Finished(Object id, Object result, Throwable failure) {
+        private Finished(Object id, Object result, Throwable failure, Object details) {
             this.id = id;
             this.result = result;
             this.failure = failure;
+            this.details = details;
         }
 
         @Override
@@ -176,8 +178,17 @@ public class BuildOperationNotificationBridge implements Stoppable {
         }
 
         @Override
+        public Object getNotificationOperationDetails() {
+            return details;
+        }
+
+        @Override
         public String toString() {
-            return "BuildOperationFinishedNotification{id=" + id + ", result=" + result + '}';
+            return "Finished{"
+                + "id=" + id
+                + ", result=" + result
+                + ", details=" + details
+                + '}';
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/BuildOperationNotificationBridgeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/BuildOperationNotificationBridgeTest.groovy
@@ -67,7 +67,6 @@ class BuildOperationNotificationBridgeTest extends Specification {
         def d1 = BuildOperationDescriptor.displayName("a").details([:] as BuildOperationDetails).build(1, null)
         def d2 = BuildOperationDescriptor.displayName("a").build(2, null)
         def d3 = BuildOperationDescriptor.displayName("a").details([:] as BuildOperationDetails).build(3, null)
-        def d4 = BuildOperationDescriptor.displayName("a").details([:] as BuildOperationDetails).build(4, null)
         def e1 = new Exception()
 
         when:
@@ -97,6 +96,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
             assert n.notificationOperationId == d1.id
             assert n.notificationOperationResult == 10
             assert n.notificationOperationFailure == null
+            assert n.notificationOperationDetails.is(d1.details)
         }
 
         // operation with no details
@@ -131,6 +131,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
             assert n.notificationOperationId == d3.id
             assert n.notificationOperationResult == null
             assert n.notificationOperationFailure == null
+            assert n.notificationOperationDetails.is(d3.details)
         }
 
 
@@ -152,6 +153,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
             assert n.notificationOperationId == d3.id
             assert n.notificationOperationResult == null
             assert n.notificationOperationFailure == e1
+            assert n.notificationOperationDetails.is(d3.details)
         }
     }
 


### PR DESCRIPTION
Small improvement to https://github.com/gradle/gradle/pull/1961