### PR TITLE
Console summary with cache hits

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -131,12 +131,8 @@ public class TaskStateInternal implements TaskState {
         return outcome == TaskExecutionOutcome.FROM_CACHE;
     }
 
-    public boolean isAvoided() {
-        return actionable && getUpToDate();
-    }
-
-    public boolean isActionsWereExecuted() {
-        return actionable && outcome == TaskExecutionOutcome.EXECUTED;
+    public boolean isActionable() {
+        return actionable;
     }
 
     public void setActionable(boolean actionable) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatistics.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatistics.java
@@ -15,25 +15,35 @@
  */
 package org.gradle.api.internal.tasks.execution.statistics;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class TaskExecutionStatistics {
-    private final int avoidedTasksCount;
     private final int executedTasksCount;
+    private final int fromCacheTaskCount;
+    private final int upToDateTaskCount;
 
-    public TaskExecutionStatistics(int executedTasksCount, int avoidedTasksCount) {
-        Preconditions.checkArgument(avoidedTasksCount >= 0, "numAvoidedTasks must be non-negative");
-        Preconditions.checkArgument(executedTasksCount >= 0, "numExecutedTasks must be non-negative");
-
-        this.avoidedTasksCount = avoidedTasksCount;
+    public TaskExecutionStatistics(int executedTasksCount, int fromCacheTaskCount, int upToDateTaskCount) {
+        checkArgument(executedTasksCount >= 0, "executedTasksCount must be non-negative");
+        checkArgument(fromCacheTaskCount >= 0, "fromCacheTaskCount must be non-negative");
+        checkArgument(upToDateTaskCount >= 0, "upToDateTaskCount must be non-negative");
         this.executedTasksCount = executedTasksCount;
-    }
-
-    public int getAvoidedTasksCount() {
-        return avoidedTasksCount;
+        this.fromCacheTaskCount = fromCacheTaskCount;
+        this.upToDateTaskCount = upToDateTaskCount;
     }
 
     public int getExecutedTasksCount() {
         return executedTasksCount;
+    }
+
+    public int getFromCacheTaskCount() {
+        return fromCacheTaskCount;
+    }
+
+    public int getUpToDateTaskCount() {
+        return upToDateTaskCount;
+    }
+
+    public int getTotalTaskCount() {
+        return executedTasksCount + fromCacheTaskCount + upToDateTaskCount;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionStatisticsReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionStatisticsReporter.java
@@ -28,13 +28,27 @@ public class TaskExecutionStatisticsReporter implements TaskExecutionStatisticsL
         this.textOutputFactory = textOutputFactory;
     }
 
-    public void buildFinished(final TaskExecutionStatistics statistics) {
-        final int total = statistics.getAvoidedTasksCount() + statistics.getExecutedTasksCount();
+    public void buildFinished(TaskExecutionStatistics statistics) {
+        int total = statistics.getTotalTaskCount();
         if (total > 0) {
-            final long avoidedPercentage = Math.round(statistics.getAvoidedTasksCount() * 100.0 / total);
-            final String pluralizedTasks = total > 1 ? "tasks" : "task";
+            String pluralizedTasks = total > 1 ? "tasks" : "task";
             StyledTextOutput textOutput = textOutputFactory.create(BuildResultLogger.class, LogLevel.LIFECYCLE);
-            textOutput.formatln("%d actionable %s: %d executed, %d avoided (%d%%)", total, pluralizedTasks, statistics.getExecutedTasksCount(), statistics.getAvoidedTasksCount(), avoidedPercentage);
+            textOutput.format("%d actionable %s:", total, pluralizedTasks);
+            boolean printedDetail = formatDetail(textOutput, statistics.getExecutedTasksCount(), "executed", false);
+            printedDetail = formatDetail(textOutput, statistics.getFromCacheTaskCount(), "from cache", printedDetail);
+            formatDetail(textOutput, statistics.getUpToDateTaskCount(), "up-to-date", printedDetail);
+            textOutput.println();
         }
+    }
+
+    private static boolean formatDetail(StyledTextOutput textOutput, int count, String title, boolean alreadyPrintedDetail) {
+        if (count == 0) {
+            return alreadyPrintedDetail;
+        }
+        if (alreadyPrintedDetail) {
+            textOutput.format(",");
+        }
+        textOutput.format(" %d %s", count, title);
+        return true;
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskStateInternalTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskStateInternalTest.groovy
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
-
-
 package org.gradle.api.internal.tasks
 
 import org.gradle.api.GradleException
@@ -39,7 +35,7 @@ class TaskStateInternalTest {
         assertThat(state.getSkipMessage(), nullValue())
         assertFalse(state.upToDate)
         assertFalse(state.taskOutputCaching.enabled)
-        assertFalse(state.actionsWereExecuted)
+        assertTrue(state.actionable)
     }
 
     @Test

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecutorTest.groovy
@@ -87,7 +87,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         state.outcome == TaskExecutionOutcome.UP_TO_DATE
         !state.didWork
         !state.executing
-        !state.actionsWereExecuted
+        state.actionable
     }
 
     def executesEachActionInOrder() {
@@ -139,7 +139,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         state.didWork
         state.outcome == TaskExecutionOutcome.EXECUTED
         !state.failure
-        state.actionsWereExecuted
+        state.actionable
     }
 
     def executeDoesOperateOnNewActionListInstance() {
@@ -211,7 +211,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         !state.executing
         state.didWork
         state.outcome == TaskExecutionOutcome.EXECUTED
-        state.actionsWereExecuted
+        state.actionable
 
         TaskExecutionException wrappedFailure = (TaskExecutionException) state.failure
         wrappedFailure instanceof TaskExecutionException
@@ -304,7 +304,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         state.outcome == TaskExecutionOutcome.EXECUTED
         !state.executing
         !state.failure
-        state.actionsWereExecuted
+        state.actionable
 
         noMoreInteractions()
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatisticsEventAdapterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatisticsEventAdapterTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.execution.statistics
 import org.gradle.BuildResult
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.invocation.Gradle
 import spock.lang.Specification
@@ -33,7 +34,7 @@ class TaskExecutionStatisticsEventAdapterTest extends Specification {
     def project = Stub(Project) { getGradle() >> gradle }
     def result = Stub(BuildResult) { getGradle() >> gradle }
     def task = Stub(Task) { getProject() >> project }
-    def taskState = Stub(TaskStateInternal) { isAvoided() >> true }
+    def taskState = Stub(TaskStateInternal) { getOutcome() >> TaskExecutionOutcome.UP_TO_DATE }
 
     def "delegates to reporter when building root project"() {
         given:


### PR DESCRIPTION
Display end of build summary like this:

```text
XX actionable tasks: YY executed, ZZ from cache, WW up-to-date
```
[CI Status](https://builds.gradle.org/project.html?projectId=Gradle_Branches&branch_Gradle_Branches=lp%2Fconsole-summary-with-cache-hits)
