### PR TITLE
Expose the 'enable' property for the whole build cache, not only connectors.

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
@@ -45,6 +45,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         then:
         def result = result()
 
+        !result.disabled
         !result.localDisabled
         result.remoteDisabled
 
@@ -88,6 +89,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         then:
         def result = result()
 
+        !result.disabled
         !result.localDisabled
         result.remoteDisabled
 
@@ -133,6 +135,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         then:
         def result = result()
 
+        result.disabled
         result.localDisabled
         result.remoteDisabled
 
@@ -159,7 +162,10 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
         then:
         def result = result()
+
+        !result.disabled
         result.localDisabled
+
         result.local == null
     }
 

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServiceProvider.java
@@ -68,7 +68,7 @@ public class BuildCacheServiceProvider {
             @Override
             public BuildCacheService call(BuildOperationContext context) {
                 if (!startParameter.isBuildCacheEnabled()) {
-                    context.setResult(new FinalizeBuildCacheConfigurationDetails.Result(true, true, null, null));
+                    context.setResult(FinalizeBuildCacheConfigurationDetails.Result.buildCacheConfigurationDisabled());
                     return new NoOpBuildCacheService();
                 }
 
@@ -96,6 +96,7 @@ public class BuildCacheServiceProvider {
                     : null;
 
                 context.setResult(new FinalizeBuildCacheConfigurationDetails.Result(
+                    false,
                     !localEnabled,
                     !remoteEnabled,
                     localDescribedService == null ? null : localDescribedService.description,

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/FinalizeBuildCacheConfigurationDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/FinalizeBuildCacheConfigurationDetails.java
@@ -79,6 +79,8 @@ public final class FinalizeBuildCacheConfigurationDetails implements BuildOperat
 
         }
 
+        private final boolean disabled;
+
         private final boolean localDisabled;
 
         private final BuildCacheDescription local;
@@ -87,11 +89,20 @@ public final class FinalizeBuildCacheConfigurationDetails implements BuildOperat
 
         private final BuildCacheDescription remote;
 
-        public Result(boolean localDisabled, boolean remoteDisabled, @Nullable BuildCacheDescription local, @Nullable BuildCacheDescription remote) {
+        public Result(boolean disabled, boolean localDisabled, boolean remoteDisabled, @Nullable BuildCacheDescription local, @Nullable BuildCacheDescription remote) {
+            this.disabled = disabled;
             this.localDisabled = localDisabled;
             this.remoteDisabled = remoteDisabled;
             this.local = local;
             this.remote = remote;
+        }
+
+        public static Result buildCacheConfigurationDisabled() {
+            return new FinalizeBuildCacheConfigurationDetails.Result(true, true, true, null, null);
+        }
+
+        public boolean isDisabled() {
+            return disabled;
         }
 
         public boolean isLocalDisabled() {


### PR DESCRIPTION
So the build scan plugin is able to expose these scenarios:

- The `--build-scan` flag has not been provided, so the whole build scan is not enabled.
- The `--build-scan` flag has been provided, but the connectors are disabled through the DSL or through `--offline` in the case of Remote Connectors.