### PR TITLE
Show fewer dots when downloading the wrapper

### DIFF
--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
@@ -21,8 +21,8 @@ import java.lang.reflect.Method;
 import java.net.*;
 
 public class Download implements IDownload {
-    private static final int PROGRESS_CHUNK = 20000;
-    private static final int BUFFER_SIZE = 10000;
+    private static final int PROGRESS_CHUNK = 1024 * 1024;
+    private static final int BUFFER_SIZE = 10 * 1024;
     private final Logger logger;
     private final String appName;
     private final String appVersion;


### PR DESCRIPTION
This would look a lot nicer than the 3367 dots we are currently printing:

<img width="1242" alt="wrapper" src="https://cloud.githubusercontent.com/assets/495366/25939810/643cf494-3634-11e7-81fc-fc6a68a315a1.png">

With this change we would be printing one dot per downloaded megabyte, 64 altogether for the currently nightly.