### PR TITLE
Refine the concept of 'enable' on a Build Cache Configuration Connector.

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
@@ -47,7 +47,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
         !result.disabled
         !result.localDisabled
-        result.remoteDisabled
+        !result.remoteDisabled
 
         result.local.className == 'org.gradle.caching.local.DirectoryBuildCache'
         result.local.config.location == cacheDir.absoluteFile.toString()
@@ -91,7 +91,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
         !result.disabled
         !result.localDisabled
-        result.remoteDisabled
+        !result.remoteDisabled
 
         result.local.className == 'CustomBuildCache'
         result.local.config.directory == directory

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServiceProvider.java
@@ -98,8 +98,8 @@ public class BuildCacheServiceProvider {
 
                 context.setResult(new FinalizeBuildCacheConfigurationDetails.Result(
                     false,
-                    !localEnabled,
-                    !remoteEnabled,
+                    local != null && !local.isEnabled(),
+                    remote != null && (!remote.isEnabled() || startParameter.isOffline()),
                     localDescribedService == null ? null : localDescribedService.description,
                     remoteDescribedService == null ? null : remoteDescribedService.description
                 ));


### PR DESCRIPTION
We want to capture that a connector is present on the DSL, but it's effectively disabled for whatever reason.

Related to this issue: gradle/task-output-cache#438