### PR TITLE
Set default log level back to LIFECYCLE

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -308,17 +308,4 @@ public class GradleVersion implements Comparable<GradleVersion> {
             return 0;
         }
     }
-
-    public boolean isSameOrNewer(String otherVersion) {
-        return isVersion(otherVersion) || this.compareTo(GradleVersion.version(otherVersion)) > 0;
-    }
-
-    public boolean isSameOrOlder(String otherVersion) {
-        return isVersion(otherVersion) || this.compareTo(GradleVersion.version(otherVersion)) <= 0;
-    }
-
-    public boolean isVersion(String otherVersionString) {
-        GradleVersion otherVersion = GradleVersion.version(otherVersionString);
-        return this.compareTo(otherVersion) == 0 || (this.isSnapshot() && this.getBaseVersion().equals(otherVersion.getBaseVersion()));
-    }
 }

--- a/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/CompareGradleBuilds.java
+++ b/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/CompareGradleBuilds.java
@@ -283,7 +283,7 @@ public class CompareGradleBuilds extends DefaultTask implements VerificationTask
         } else {
             String message = String.format("The build outcomes were not found to be identical. See the report at: %s", reportUrl);
             if (getIgnoreFailures()) {
-                getLogger().lifecycle(message);
+                getLogger().warn(message);
             } else {
                 throw new GradleException(message);
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
@@ -96,7 +96,7 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
         String expectedLogStatement = "[[INFO] [org.gradle.process.internal.LogSerializableLogAction] info log statement]"
 
         when:
-        workerFactory = new DefaultWorkerProcessFactory(LogLevel.WARN, server, classPathRegistry, new LongIdGenerator(), null, new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
+        workerFactory = new DefaultWorkerProcessFactory(LogLevel.LIFECYCLE, server, classPathRegistry, new LongIdGenerator(), null, new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
         and:
         execute(worker(loggingProcess))
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildResultLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildResultLogger.java
@@ -41,7 +41,7 @@ public class BuildResultLogger extends BuildAdapter {
     }
 
     public void buildFinished(BuildResult result) {
-        StyledTextOutput textOutput = textOutputFactory.create(BuildResultLogger.class, LogLevel.WARN);
+        StyledTextOutput textOutput = textOutputFactory.create(BuildResultLogger.class, LogLevel.LIFECYCLE);
         textOutput.println();
         String action = result.getAction().toUpperCase();
         if (result.getFailure() == null) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionStatisticsReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionStatisticsReporter.java
@@ -33,7 +33,7 @@ public class TaskExecutionStatisticsReporter implements TaskExecutionStatisticsL
         if (total > 0) {
             final long avoidedPercentage = Math.round(statistics.getAvoidedTasksCount() * 100.0 / total);
             final String pluralizedTasks = total > 1 ? "tasks" : "task";
-            StyledTextOutput textOutput = textOutputFactory.create(BuildResultLogger.class, LogLevel.WARN);
+            StyledTextOutput textOutput = textOutputFactory.create(BuildResultLogger.class, LogLevel.LIFECYCLE);
             textOutput.formatln("%d actionable %s: %d executed, %d avoided (%d%%)", total, pluralizedTasks, statistics.getExecutedTasksCount(), statistics.getAvoidedTasksCount(), avoidedPercentage);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
@@ -58,7 +58,7 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
     private final Set<File> applicationClasspath = new LinkedHashSet<File>();
     private final MemoryManager memoryManager;
     private Action<? super WorkerProcessContext> action;
-    private LogLevel logLevel = LogLevel.WARN;
+    private LogLevel logLevel = LogLevel.LIFECYCLE;
     private String baseName = "Gradle Worker";
     private File gradleUserHomeDir;
     private int connectTimeoutSeconds;

--- a/subprojects/core/src/main/java/org/gradle/profile/ReportGeneratingProfileListener.java
+++ b/subprojects/core/src/main/java/org/gradle/profile/ReportGeneratingProfileListener.java
@@ -48,7 +48,7 @@ public class ReportGeneratingProfileListener extends BuildAdapter implements Pro
     }
 
     private void renderReportUrl(File reportFile) {
-        StyledTextOutput textOutput = textOutputFactory.create(ReportGeneratingProfileListener.class, LogLevel.WARN);
+        StyledTextOutput textOutput = textOutputFactory.create(ReportGeneratingProfileListener.class, LogLevel.LIFECYCLE);
         textOutput.println();
         String reportUrl = new ConsoleRenderer().asClickableFileUrl(reportFile);
         textOutput.formatln("See the profiling report at: %s", reportUrl);

--- a/subprojects/core/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -106,7 +106,7 @@ class StartParameterTest extends Specification {
         parameter.buildFile == null
         parameter.settingsFile == null
 
-        parameter.logLevel == LogLevel.WARN
+        parameter.logLevel == LogLevel.LIFECYCLE
         parameter.consoleOutput == ConsoleOutput.Auto
         parameter.taskNames.empty
         parameter.taskRequests.empty

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
@@ -49,7 +49,7 @@ public class CommandLineConverterTestSupport {
     protected boolean expectedSearchUpwards = true;
     protected boolean expectedDryRun;
     protected ShowStacktrace expectedShowStackTrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
-    protected LogLevel expectedLogLevel = LogLevel.WARN;
+    protected LogLevel expectedLogLevel = LogLevel.LIFECYCLE;
     protected ConsoleOutput expectedConsoleOutput = ConsoleOutput.Auto;
     protected StartParameter actualStartParameter;
     protected boolean expectedProfile;

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
@@ -39,7 +39,7 @@ class BuildResultLoggerTest extends Specification {
         then:
         1 * clock.getElapsedMillis() >> { 10L }
         1 * durationFormatter.format(10L) >> { "10s" }
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{WARN}\n{success}ACTION SUCCESSFUL{normal} in 10s\n"
+        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}\n{success}ACTION SUCCESSFUL{normal} in 10s\n"
     }
 
     def "logs build failure with total time"() {
@@ -49,6 +49,6 @@ class BuildResultLoggerTest extends Specification {
         then:
         1 * clock.getElapsedMillis() >> { 10L }
         1 * durationFormatter.format(10L) >> { "10s" }
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{WARN}\n{failure}ACTION FAILED{normal} in 10s\n"
+        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}\n{failure}ACTION FAILED{normal} in 10s\n"
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
@@ -50,7 +50,7 @@ class TaskExecutionStatisticsReporterTest extends Specification {
         reporter.buildFinished(new TaskExecutionStatistics(1, 0))
 
         then:
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{WARN}1 actionable task: 1 executed, 0 avoided (0%)\n"
+        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}1 actionable task: 1 executed, 0 avoided (0%)\n"
     }
 
     def "reports statistics with rounded percentages"() {
@@ -58,6 +58,6 @@ class TaskExecutionStatisticsReporterTest extends Specification {
         reporter.buildFinished(new TaskExecutionStatistics(2, 1))
 
         then:
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{WARN}3 actionable tasks: 2 executed, 1 avoided (33%)\n"
+        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}3 actionable tasks: 2 executed, 1 avoided (33%)\n"
     }
 }

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -48,7 +48,6 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
             inDirectory(contentsDir)
             usingExecutable('gradlew')
             withTasks('binZip')
-            withLifecycleLoggingDisabled()
         }.run()
 
         then:

--- a/subprojects/docs/src/docs/userguide/logging.xml
+++ b/subprojects/docs/src/docs/userguide/logging.xml
@@ -19,8 +19,7 @@
         by this. On the other hand you need relevant information for figuring out if things have gone wrong. Gradle
         defines 6 log levels, as shown in <xref linkend="logLevels"/>. There are two Gradle-specific log levels, in
         addition to the ones you might normally see. Those levels are <emphasis>QUIET</emphasis> and
-        <emphasis>LIFECYCLE</emphasis>. The latter is used to report build progress. The default log level is set
-        to <emphasis>WARN</emphasis> to emphasize important log output.
+        <emphasis>LIFECYCLE</emphasis>. The latter is the default, and is used to report build progress.
     </para>
     <table id="logLevels">
         <title>Log levels</title>

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
@@ -58,7 +58,6 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
         result = runWithMostRecentFinalRelease(JAR_TASK_NAME)
 
         then:
-        javaProject.assertBuildTasksExecuted(result)
         javaProject.assertDoesNotHaveCleanupMessage(result)
         javaProject.mainClassFile.assertIsFile()
         javaProject.redundantClassFile.assertIsFile()
@@ -69,7 +68,6 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
         succeeds JAR_TASK_NAME
 
         then:
-        javaProject.assertBuildTasksExecuted(result)
         javaProject.assertHasCleanupMessage(result)
         javaProject.mainClassFile.assertIsFile()
         javaProject.redundantClassFile.assertDoesNotExist()
@@ -195,7 +193,6 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         javaProjects.each { javaProject ->
-            javaProject.assertBuildTasksExecuted(result)
             javaProject.assertDoesNotHaveCleanupMessage(result)
             javaProject.mainClassFile.assertIsFile()
             javaProject.redundantClassFile.assertIsFile()
@@ -210,7 +207,6 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         javaProjects.each { javaProject ->
-            javaProject.assertBuildTasksExecuted(result)
             javaProject.assertHasCleanupMessage(result)
             javaProject.mainClassFile.assertIsFile()
             javaProject.redundantClassFile.assertDoesNotExist()
@@ -222,7 +218,6 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         javaProjects.each { javaProject ->
-            javaProject.assertBuildTasksSkipped(result)
             javaProject.assertDoesNotHaveCleanupMessage(result)
         }
 
@@ -255,7 +250,6 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         javaProjects.each { javaProject ->
-            javaProject.assertBuildTasksExecuted(result)
             javaProject.assertDoesNotHaveCleanupMessage(result)
             javaProject.mainClassFile.assertIsFile()
             javaProject.redundantClassFile.assertIsFile()
@@ -359,7 +353,6 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
         result = runWithMostRecentFinalRelease(taskPath)
 
         then:
-        result.executedTasks.containsAll(taskPath, ':copy1', ':copy2')
         targetFile1.assertIsFile()
         targetFile2.assertIsFile()
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -101,7 +101,6 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private boolean allowExtraLogging = true;
     private File workingDir;
     private boolean quiet;
-    private boolean lifecycle = true;
     private boolean taskList;
     private boolean dependencyList;
     private boolean searchUpwards;
@@ -182,7 +181,6 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         buildScript = null;
         settingsFile = null;
         quiet = false;
-        lifecycle = true;
         taskList = false;
         dependencyList = false;
         searchUpwards = false;
@@ -268,9 +266,6 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         executer.usingExecutable(executable);
         if (quiet) {
             executer.withQuietLogging();
-        }
-        if (!lifecycle) {
-            executer.withLifecycleLoggingDisabled();
         }
         if (taskList) {
             executer.withTaskList();
@@ -543,11 +538,6 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return this;
     }
 
-    public GradleExecuter withLifecycleLoggingDisabled() {
-        lifecycle = false;
-        return this;
-    }
-
     public GradleExecuter withTaskList() {
         taskList = true;
         return this;
@@ -785,25 +775,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
         allArgs.addAll(args);
         allArgs.addAll(tasks);
-        prependLifecycleLogLevel(allArgs);
         return allArgs;
-    }
-
-    /**
-     * Adds LIFECYCLE log level to build execution arguments with the goal of being able to capture most output for testing.
-     * The log level is only added for Gradle versions supporting the command line option (>= 4.0). For earlier versions it is
-     * assumed to automatically log on LIFECYCLE level as it was the default.
-     * <p>
-     * <b>Note:</b> Build executions can override the log level by providing their own argument for this executor.
-     * The Log level command line options is evaluated with "last one wins" strategy.
-     * Setting the log level to LIFECYCLE level by default can also be disabled with the method {@link #withLifecycleLoggingDisabled()}.
-     *
-     * @param args Arguments
-     */
-    private void prependLifecycleLogLevel(List<String> args) {
-        if (lifecycle && gradleVersion.isSameOrNewer("4.0")) {
-            args.add(0, "-l");
-        }
     }
 
     /**
@@ -1034,15 +1006,6 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
     public boolean isAllowExtraLogging() {
         return allowExtraLogging;
-    }
-
-    public GradleExecuter useDefaultLogLevel() {
-        this.lifecycle = true;
-        return this;
-    }
-
-    public boolean isDefaultLogLevel() {
-        return lifecycle;
     }
 
     public boolean isRequiresGradleDistribution() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -59,7 +59,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
 
     public boolean worksWith(Jvm jvm) {
         // Milestone 4 was broken on the IBM jvm
-        if (jvm.isIbmJvm() && version.isVersion("1.0-milestone-4")) {
+        if (jvm.isIbmJvm() && isVersion("1.0-milestone-4")) {
             return false;
         }
 
@@ -73,17 +73,17 @@ public class DefaultGradleDistribution implements GradleDistribution {
 
     private boolean worksWith(JavaVersion javaVersion) {
         // 0.9-rc-1 was broken for Java 5
-        if (version.isVersion("0.9-rc-1") && javaVersion == JavaVersion.VERSION_1_5) {
+        if (isVersion("0.9-rc-1") && javaVersion == JavaVersion.VERSION_1_5) {
             return false;
         }
 
         // 1.x works on Java 5 - 8
-        if (version.isSameOrOlder("1.12")) {
+        if (isSameOrOlder("1.12")) {
             return javaVersion.compareTo(JavaVersion.VERSION_1_5) >= 0 && javaVersion.compareTo(JavaVersion.VERSION_1_8) <= 0;
         }
 
         // 2.x and 3.0-milestone-1 work on Java 6 - 8
-        if (version.isSameOrOlder("3.0-milestone-1")) {
+        if (isSameOrOlder("3.0-milestone-1")) {
             return javaVersion.compareTo(JavaVersion.VERSION_1_6) >= 0 && javaVersion.compareTo(JavaVersion.VERSION_1_8) <= 0;
         }
 
@@ -94,7 +94,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
     public boolean worksWith(OperatingSystem os) {
         // 1.0-milestone-5 was broken where jna was not available
         //noinspection SimplifiableIfStatement
-        if (version.isVersion("1.0-milestone-5")) {
+        if (isVersion("1.0-milestone-5")) {
             return os.isWindows() || os.isMacOsX() || os.isLinux();
         } else {
             return true;
@@ -102,15 +102,15 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public boolean isDaemonIdleTimeoutConfigurable() {
-        return version.isSameOrNewer("1.0-milestone-7");
+        return isSameOrNewer("1.0-milestone-7");
     }
 
     public boolean isOpenApiSupported() {
-        return version.isSameOrNewer("0.9-rc-1") && !version.isSameOrNewer("2.0-rc-1");
+        return isSameOrNewer("0.9-rc-1") && !isSameOrNewer("2.0-rc-1");
     }
 
     public boolean isToolingApiSupported() {
-        return version.isSameOrNewer("1.0-milestone-3");
+        return isSameOrNewer("1.0-milestone-3");
     }
 
     @Override
@@ -120,62 +120,62 @@ public class DefaultGradleDistribution implements GradleDistribution {
 
     public boolean isToolingApiNonAsciiOutputSupported() {
         if (OperatingSystem.current().isWindows()) {
-            return !version.isVersion("1.0-milestone-7") && !version.isVersion("1.0-milestone-8") && !version.isVersion("1.0-milestone-8a");
+            return !isVersion("1.0-milestone-7") && !isVersion("1.0-milestone-8") && !isVersion("1.0-milestone-8a");
         }
         return true;
     }
 
     public boolean isToolingApiDaemonBaseDirSupported() {
-        return version.isSameOrNewer("2.2-rc-1");
+        return isSameOrNewer("2.2-rc-1");
     }
 
     @Override
     public boolean isToolingApiEventsInEmbeddedModeSupported() {
-        return version.isSameOrNewer("2.6-rc-1");
+        return isSameOrNewer("2.6-rc-1");
     }
 
     @Override
     public boolean isToolingApiLocksBuildActionClasses() {
-        return version.isSameOrOlder("3.0");
+        return isSameOrOlder("3.0");
     }
 
     @Override
     public boolean isToolingApiLoggingInEmbeddedModeSupported() {
-        return version.isSameOrNewer("2.9-rc-1");
+        return isSameOrNewer("2.9-rc-1");
     }
 
     public VersionNumber getArtifactCacheLayoutVersion() {
-        if (version.isSameOrNewer("3.2-rc-1")) {
+        if (isSameOrNewer("3.2-rc-1")) {
             return VersionNumber.parse("2.23");
-        } else if (version.isSameOrNewer("3.1-rc-1")) {
+        } else if (isSameOrNewer("3.1-rc-1")) {
             return VersionNumber.parse("2.21");
-        } else if (version.isSameOrNewer("3.0-milestone-1")) {
+        } else if (isSameOrNewer("3.0-milestone-1")) {
             return VersionNumber.parse("2.17");
-        } else if (version.isSameOrNewer("2.8-rc-1")) {
+        } else if (isSameOrNewer("2.8-rc-1")) {
             return VersionNumber.parse("2.16");
-        } else if (version.isSameOrNewer("2.4-rc-1")) {
+        } else if (isSameOrNewer("2.4-rc-1")) {
             return VersionNumber.parse("2.15");
-        } else if (version.isSameOrNewer("2.2-rc-1")) {
+        } else if (isSameOrNewer("2.2-rc-1")) {
             return VersionNumber.parse("2.14");
-        } else if (version.isSameOrNewer("2.1-rc-3")) {
+        } else if (isSameOrNewer("2.1-rc-3")) {
             return VersionNumber.parse("2.13");
-        } else if (version.isSameOrNewer("2.0-rc-1")) {
+        } else if (isSameOrNewer("2.0-rc-1")) {
             return VersionNumber.parse("2.12");
-        } else if (version.isSameOrNewer("1.12-rc-1")) {
+        } else if (isSameOrNewer("1.12-rc-1")) {
             return VersionNumber.parse("2.6");
-        } else if (version.isSameOrNewer("1.11-rc-1")) {
+        } else if (isSameOrNewer("1.11-rc-1")) {
             return VersionNumber.parse("2.2");
-        } else if (version.isSameOrNewer("1.9-rc-2")) {
+        } else if (isSameOrNewer("1.9-rc-2")) {
             return VersionNumber.parse("2.1");
-        } else if (version.isSameOrNewer("1.9-rc-1")) {
+        } else if (isSameOrNewer("1.9-rc-1")) {
             return VersionNumber.parse("1.31");
-        } else if (version.isSameOrNewer("1.7-rc-1")) {
+        } else if (isSameOrNewer("1.7-rc-1")) {
             return VersionNumber.parse("0.26");
-        } else if (version.isSameOrNewer("1.6-rc-1")) {
+        } else if (isSameOrNewer("1.6-rc-1")) {
             return VersionNumber.parse("0.24");
-        } else if (version.isSameOrNewer("1.4-rc-1")) {
+        } else if (isSameOrNewer("1.4-rc-1")) {
             return VersionNumber.parse("0.23");
-        } else if (version.isSameOrNewer("1.3")) {
+        } else if (isSameOrNewer("1.3")) {
             return VersionNumber.parse("0.15");
         } else {
             return VersionNumber.parse("0.1");
@@ -183,15 +183,15 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public boolean wrapperCanExecute(GradleVersion version) {
-        if (version.equals(GradleVersion.version("0.8")) || version.isVersion("0.8")) {
+        if (version.equals(GradleVersion.version("0.8")) || isVersion("0.8")) {
             // There was a breaking change after 0.8
             return false;
         }
-        if (version.isVersion("0.9.1")) {
+        if (isVersion("0.9.1")) {
             // 0.9.1 couldn't handle anything with a timestamp whose timezone was behind GMT
             return version.getVersion().matches(".*+\\d{4}");
         }
-        if (version.isSameOrNewer("0.9.2") && version.isSameOrOlder("1.0-milestone-2")) {
+        if (isSameOrNewer("0.9.2") && isSameOrOlder("1.0-milestone-2")) {
             // These versions couldn't handle milestone patches
             if (version.getVersion().matches("1.0-milestone-\\d+[a-z]-.+")) {
                 return false;
@@ -201,15 +201,27 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public boolean isWrapperSupportsGradleUserHomeCommandLineOption() {
-        return version.isSameOrNewer("1.7");
+        return isSameOrNewer("1.7");
     }
 
     public boolean isSupportsSpacesInGradleAndJavaOpts() {
-        return version.isSameOrNewer("1.0-milestone-5");
+        return isSameOrNewer("1.0-milestone-5");
     }
 
     public boolean isFullySupportsIvyRepository() {
-        return version.isSameOrNewer("1.0-milestone-7");
+        return isSameOrNewer("1.0-milestone-7");
     }
 
+    protected boolean isSameOrNewer(String otherVersion) {
+        return isVersion(otherVersion) || version.compareTo(GradleVersion.version(otherVersion)) > 0;
+    }
+
+    protected boolean isSameOrOlder(String otherVersion) {
+        return isVersion(otherVersion) || version.compareTo(GradleVersion.version(otherVersion)) <= 0;
+    }
+
+    protected boolean isVersion(String otherVersionString) {
+        GradleVersion otherVersion = GradleVersion.version(otherVersionString);
+        return version.compareTo(otherVersion) == 0 || (version.isSnapshot() && version.getBaseVersion().equals(otherVersion.getBaseVersion()));
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -212,8 +212,4 @@ public class DefaultGradleDistribution implements GradleDistribution {
         return version.isSameOrNewer("1.0-milestone-7");
     }
 
-    public boolean isLifecycleLogLevelFlagSupported() {
-        return version.isSameOrNewer("4.0");
-    }
-
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
@@ -125,9 +125,4 @@ public interface GradleDistribution {
      * Returns true if the wrapper for this version honours the --gradle-user-home command-line option.
      */
     boolean isWrapperSupportsGradleUserHomeCommandLineOption();
-
-    /**
-     * Returns true if the lifecycle log level flag is supported by this distribution.
-     */
-    boolean isLifecycleLogLevelFlagSupported();
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -55,8 +55,6 @@ public interface GradleExecuter extends Stoppable {
 
     GradleExecuter withQuietLogging();
 
-    GradleExecuter withLifecycleLoggingDisabled();
-
     /**
      * Sets the additional command-line arguments to use when executing the build. Defaults to an empty list.
      */
@@ -127,8 +125,6 @@ public interface GradleExecuter extends Stoppable {
 
     /**
      * Executes the requested build, asserting that the build succeeds. Resets the configuration of this executer.
-     * <p>
-     * Uses the log level {@code LIFECYCLE} by default. The log level can be overridden by providing a different log level as argument for executor.
      *
      * @return The result.
      */
@@ -136,8 +132,6 @@ public interface GradleExecuter extends Stoppable {
 
     /**
      * Executes the requested build, asserting that the build fails. Resets the configuration of this executer.
-     * <p>
-     * Uses the log level {@code LIFECYCLE} by default. The log level can be overridden by providing a different log level as argument for executor.
      *
      * @return The result.
      */
@@ -145,8 +139,6 @@ public interface GradleExecuter extends Stoppable {
 
     /**
      * Starts executing the build asynchronously.
-     * <p>
-     * Uses the log level {@code LIFECYCLE} by default. The log level can be overridden by providing a different log level as argument for executor.
      *
      * @return the handle, never null.
      */

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/CommandLineIntegrationLoggingSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/CommandLineIntegrationLoggingSpec.groovy
@@ -39,7 +39,7 @@ class CommandLineIntegrationLoggingSpec extends AbstractIntegrationSpec {
             }
         """
         expect:
-        executer.withArguments(flags).withLifecycleLoggingDisabled()
+        executer.withArguments(flags)
         succeeds("assertLogging")
         outputContains(message)
 
@@ -70,7 +70,7 @@ class CommandLineIntegrationLoggingSpec extends AbstractIntegrationSpec {
             }
         """
         expect:
-        executer.withCommandLineGradleOpts(flags).requireDaemon().requireIsolatedDaemons().withLifecycleLoggingDisabled()
+        executer.withCommandLineGradleOpts(flags).requireDaemon().requireIsolatedDaemons()
         succeeds("assertLogging")
         outputContains(message)
 
@@ -101,7 +101,7 @@ class CommandLineIntegrationLoggingSpec extends AbstractIntegrationSpec {
             }
         """
         expect:
-        executer.withArguments(flags).withCommandLineGradleOpts(options).requireDaemon().requireIsolatedDaemons().withLifecycleLoggingDisabled()
+        executer.withArguments(flags).withCommandLineGradleOpts(options).requireDaemon().requireIsolatedDaemons()
         succeeds("assertLogging")
         outputContains(message)
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
@@ -56,16 +56,16 @@ class BuildLogLevelMixInTest extends Specification {
         ['-q']                  | false   | LogLevel.QUIET
         ['-q']                  | true    | LogLevel.QUIET
         ['noLogLevelArguments'] | true    | LogLevel.DEBUG
-        null                    | false   | LogLevel.WARN
+        null                    | false   | LogLevel.LIFECYCLE
         null                    | true    | LogLevel.DEBUG
     }
 
-    def "default log level is warn"() {
+    def "default log level is lifecycle"() {
         when:
         parameters.getArguments() >> ['no log level arguments']
         parameters.getVerboseLogging() >> false
 
         then:
-        mixin.getBuildLogLevel() == LogLevel.WARN
+        mixin.getBuildLogLevel() == LogLevel.LIFECYCLE
     }
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/LoggingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/LoggingIntegrationTest.groovy
@@ -158,11 +158,6 @@ class LoggingIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void warnLogging() {
-        checkOutput(this.&run, logOutput.warn)
-    }
-
-    @Test
     public void lifecycleLogging() {
         checkOutput(this.&run, logOutput.lifecycle)
     }
@@ -370,14 +365,8 @@ class LogOutput {
             errorMessages: [errorMessages],
             allMessages: allOuts
     )
-    final LogLevel warn = new LogLevel(
-            args: [],
-            infoMessages: [quietMessages, warningMessages],
-            errorMessages: [errorMessages],
-            allMessages: allOuts
-    )
     final LogLevel lifecycle = new LogLevel(
-            args: ['-l'],
+            args: [],
             infoMessages: [quietMessages, warningMessages, lifecycleMessages],
             errorMessages: [errorMessages],
             allMessages: allOuts

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
@@ -24,7 +24,7 @@ import org.gradle.api.logging.LogLevel;
 public interface LoggingConfiguration {
     /**
      * Returns the minimum logging level to use. All log messages with a lower log level are ignored.
-     * Defaults to {@link LogLevel#WARN}.
+     * Defaults to {@link LogLevel#LIFECYCLE}.
      */
     LogLevel getLogLevel();
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
@@ -26,7 +26,7 @@ import org.gradle.api.logging.configuration.ShowStacktrace;
 import java.io.Serializable;
 
 public class DefaultLoggingConfiguration implements Serializable, LoggingConfiguration {
-    private LogLevel logLevel = LogLevel.WARN;
+    private LogLevel logLevel = LogLevel.LIFECYCLE;
     private ShowStacktrace showStacktrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private ConsoleOutput consoleOutput = ConsoleOutput.Auto;
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/config/LoggingSystemAdapter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/config/LoggingSystemAdapter.java
@@ -24,7 +24,7 @@ import org.gradle.api.logging.LogLevel;
 public class LoggingSystemAdapter implements LoggingSourceSystem {
     private final LoggingConfigurer configurer;
     private boolean enabled;
-    private LogLevel logLevel = LogLevel.WARN;
+    private LogLevel logLevel = LogLevel.LIFECYCLE;
 
     public LoggingSystemAdapter(LoggingConfigurer configurer) {
         this.configurer = configurer;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
@@ -58,7 +58,7 @@ public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
      *     <li>Replaces System.out and System.err with implementations that route output through the logging system as per {@link LoggingManagerInternal#captureSystemSources()}.</li>
      *     <li>Configures slf4j, log4j and java util logging to route log messages through the logging system.</li>
      *     <li>Routes logging output to the original System.out and System.err as per {@link LoggingManagerInternal#attachSystemOutAndErr()}.</li>
-     *     <li>Sets log level to {@link org.gradle.api.logging.LogLevel#WARN}.</li>
+     *     <li>Sets log level to {@link org.gradle.api.logging.LogLevel#LIFECYCLE}.</li>
      * </ul>
      *
      * <p>Does nothing until started.</p>
@@ -78,7 +78,7 @@ public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
      *
      * <ul>
      *     <li>Configures slf4j and log4j to route log messages through the logging system.</li>
-     *     <li>Sets log level to {@link org.gradle.api.logging.LogLevel#WARN}.</li>
+     *     <li>Sets log level to {@link org.gradle.api.logging.LogLevel#LIFECYCLE}.</li>
      * </ul>
      *
      * <p>Does not:</p>
@@ -99,7 +99,7 @@ public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
      * Creates a set of logging services to set up a new logging scope that does nothing by default. The methods on {@link LoggingManagerInternal} can be used to configure the
      * logging services do useful things.
      *
-     * <p>Sets log level to {@link org.gradle.api.logging.LogLevel#WARN}.</p>
+     * <p>Sets log level to {@link org.gradle.api.logging.LogLevel#LIFECYCLE}.</p>
      */
     public static LoggingServiceRegistry newNestedLogging() {
         return new NestedLogging();

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/config/LoggingSystemAdapterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/config/LoggingSystemAdapterTest.groovy
@@ -28,7 +28,7 @@ class LoggingSystemAdapterTest extends Specification {
         loggingSystem.startCapture()
 
         then:
-        1 * loggingConfigurer.configure(LogLevel.WARN)
+        1 * loggingConfigurer.configure(LogLevel.LIFECYCLE)
         0 * loggingConfigurer._
     }
 
@@ -72,7 +72,7 @@ class LoggingSystemAdapterTest extends Specification {
         loggingSystem.restore(snapshot)
 
         then:
-        1 * loggingConfigurer.configure(LogLevel.WARN)
+        1 * loggingConfigurer.configure(LogLevel.LIFECYCLE)
         0 * loggingConfigurer._
     }
 
@@ -93,7 +93,7 @@ class LoggingSystemAdapterTest extends Specification {
         loggingSystem.restore(snapshot1)
 
         then:
-        1 * loggingConfigurer.configure(LogLevel.WARN)
+        1 * loggingConfigurer.configure(LogLevel.LIFECYCLE)
         0 * loggingConfigurer._
 
         when:

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegationTest.groovy
@@ -83,7 +83,6 @@ class GradleRunnerMiscEndUserIntegationTest extends BaseTestKitEndUserIntegratio
         """
 
         then:
-        executer.withArguments('-w')
         fails 'build'
         failure.output.contains "Could not find a Gradle installation to use based on the location of the GradleRunner class: $testKitJar.canonicalPath. Please specify a Gradle runtime to use via GradleRunner.withGradleVersion() or similar."
     }
@@ -115,7 +114,6 @@ class GradleRunnerMiscEndUserIntegationTest extends BaseTestKitEndUserIntegratio
         }
 
         then:
-        executer.withArguments('-w')
         succeeds 'test'
 
         testClassNames.each { testClassName ->

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/ToolingApiGradleExecutor.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/ToolingApiGradleExecutor.java
@@ -51,7 +51,6 @@ import org.gradle.wrapper.GradleUserHomeLookup;
 import java.io.File;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -114,7 +113,7 @@ public class ToolingApiGradleExecutor implements GradleExecutor {
 
             launcher.addProgressListener(new TaskExecutionProgressListener(tasks), OperationType.TASK);
 
-            launcher.withArguments(prepareArguments(targetGradleVersion, parameters.getBuildArgs()).toArray(new String[0]));
+            launcher.withArguments(parameters.getBuildArgs().toArray(new String[0]));
             launcher.setJvmArguments(parameters.getJvmArgs().toArray(new String[0]));
 
             if (!parameters.getInjectedClassPath().isEmpty()) {
@@ -156,16 +155,6 @@ public class ToolingApiGradleExecutor implements GradleExecutor {
         }
 
         return new GradleExecutionResult(new BuildOperationParameters(targetGradleVersion, parameters.isEmbedded()), outputBuffer.readAsString(), tasks);
-    }
-
-    private List<String> prepareArguments(GradleVersion targetGradleVersion, List<String> userProvidedBuildArgs) {
-        if (targetGradleVersion.isSameOrNewer("4.0")) {
-            List<String> modifiedBuildArgs = new ArrayList<String>(userProvidedBuildArgs);
-            modifiedBuildArgs.add(0, "-l");
-            return Collections.unmodifiableList(modifiedBuildArgs);
-        }
-
-        return userProvidedBuildArgs;
     }
 
     private GradleVersion determineTargetGradleVersion(ProjectConnection connection) {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainer.java
@@ -41,9 +41,6 @@ public class DefaultTestLoggingContainer implements TestLoggingContainer {
         setEvents(EnumSet.of(TestLogEvent.FAILED));
         setExceptionFormat(TestExceptionFormat.SHORT);
 
-        getLifecycle().setEvents(EnumSet.of(TestLogEvent.FAILED));
-        getLifecycle().setExceptionFormat(TestExceptionFormat.SHORT);
-
         getInfo().setEvents(EnumSet.of(TestLogEvent.FAILED, TestLogEvent.SKIPPED, TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR));
         getInfo().setStackTraceFilters(EnumSet.of(TestStackTraceFilter.TRUNCATE));
 
@@ -274,6 +271,6 @@ public class DefaultTestLoggingContainer implements TestLoggingContainer {
     }
 
     private TestLogging getDefaultTestLogging() {
-        return getWarn();
+        return getLifecycle();
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLoggingContainer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLoggingContainer.java
@@ -22,14 +22,14 @@ import org.gradle.api.logging.LogLevel;
 /**
  * Container for all test logging related options. Different options
  * can be set for each log level. Options that are set directly (without
- * specifying a log level) apply to log level WARN. Example:
+ * specifying a log level) apply to log level LIFECYCLE. Example:
  *
  * <pre autoTested=''>
  * apply plugin: 'java'
  *
  * test {
  *     testLogging {
- *         // set options for log level WARN
+ *         // set options for log level LIFECYCLE
  *         events "failed"
  *         exceptionFormat "short"
  *

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainerTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/DefaultTestLoggingContainerTest.groovy
@@ -47,7 +47,7 @@ class DefaultTestLoggingContainerTest extends Specification {
         def logging = container.get(LogLevel.WARN)
 
         expect:
-        assertDefaultSettings(logging)
+        hasUnchangedDefaults(logging)
     }
 
     def "sets defaults for level LIFECYCLE"() {
@@ -83,8 +83,8 @@ class DefaultTestLoggingContainerTest extends Specification {
         logging.stackTraceFilters == [] as Set
     }
 
-    def "implicitly configures level WARN"() {
-        def logging = container.get(LogLevel.WARN)
+    def "implicitly configures level LIFECYCLE"() {
+        def logging = container.get(LogLevel.LIFECYCLE)
         assert logging.showExceptions
 
         when:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
@@ -199,16 +199,9 @@ test {
         !result.output.contains('output from foo')
 
         when: "run with lifecycle"
-        result = executer.withArguments('-l').withTasks('cleanTest', 'test').run()
-
-        then:
-        !result.output.contains('output from foo')
-
-        when: "run with warn"
-        result = executer.withArguments('-w').withTasks('cleanTest', 'test').run()
+        result = executer.noExtraLogging().withTasks('cleanTest', 'test').run()
 
         then:
         result.output.contains('output from foo')
-        result.output.contains('error from foo')
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -412,11 +412,8 @@ class TestingIntegrationTest extends AbstractIntegrationSpec {
                 testCompile 'junit:junit:4.12'
             }
             test {
-                
                 testLogging {
-                    lifecycle {
-                        events "passed", "skipped", "failed"
-                    }
+                    events "passed", "skipped", "failed"
                 }
             }
         """

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
@@ -300,7 +300,7 @@ project.description = text
             file("build$idx/build.gradle") << """
 System.out.println 'this is stdout: $idx'
 System.err.println 'this is stderr: $idx'
-logger.warn 'this is warn: $idx'
+logger.lifecycle 'this is lifecycle: $idx'
 """
         }
 
@@ -318,9 +318,9 @@ logger.warn 'this is warn: $idx'
                     assert operation.standardError.contains("this is stderr: $idx")
                     assert operation.standardError.count("this is stderr") == 1
 
-                    assert operation.standardOutput.contains("this is warn: $idx")
-                    assert operation.standardOutput.count("this is warn") == 1
-                    assert operation.standardError.count("this is warn") == 0
+                    assert operation.standardOutput.contains("this is lifecycle: $idx")
+                    assert operation.standardOutput.count("this is lifecycle") == 1
+                    assert operation.standardError.count("this is lifecycle") == 0
                 }
             }
         }
@@ -335,7 +335,7 @@ logger.warn 'this is warn: $idx'
             file("build$idx/build.gradle") << """
 System.out.println 'this is stdout: $idx'
 System.err.println 'this is stderr: $idx'
-logger.warn 'this is warn: $idx'
+logger.lifecycle 'this is lifecycle: $idx'
 """
         }
 
@@ -353,9 +353,9 @@ logger.warn 'this is warn: $idx'
                     assert operation.standardError.contains("this is stderr: $idx")
                     assert operation.standardError.count("this is stderr") == 1
 
-                    assert operation.standardOutput.contains("this is warn: $idx")
-                    assert operation.standardOutput.count("this is warn") == 1
-                    assert operation.standardError.count("this is warn") == 0
+                    assert operation.standardOutput.contains("this is lifecycle: $idx")
+                    assert operation.standardOutput.count("this is lifecycle") == 1
+                    assert operation.standardError.count("this is lifecycle") == 0
                 }
             }
         }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiModelCrossVersionSpec.groovy
@@ -31,7 +31,7 @@ System.err.println 'this is stderr'
         progress.pop()
 
         then:
-        progress.size() >= 1
+        progress.size() >= 2
         progress.every { it }
     }
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r112/BuildInvocationsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r112/BuildInvocationsCrossVersionSpec.groovy
@@ -91,7 +91,6 @@ project(':b:c') {
             connection.action(new FetchTaskSelectorsBuildAction('b')).run() }
         TaskSelector selector = projectSelectors.taskSelectors.find { it -> it.name == 't1'}
         def result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(selector)
         }
 
@@ -108,7 +107,6 @@ project(':b:c') {
             it.name == 't1'
         }
         def result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(selector)
         }
 
@@ -124,7 +122,6 @@ project(':b:c') {
         TaskSelector selectorT1 = model.taskSelectors.find {  it.name == 't1' }
         TaskSelector selectorT2 = model.taskSelectors.find { it.name == 't2' }
         def result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(selectorT1, selectorT2)
         }
         then:
@@ -132,7 +129,6 @@ project(':b:c') {
 
         when:
         result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(selectorT2, selectorT1)
         }
         then:
@@ -193,7 +189,6 @@ project(':b:c') {
         }
         Launchable task = tasks.find { it -> it.name == 't2'}
         def result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(task)
         }
 
@@ -210,7 +205,6 @@ project(':b:c') {
             it.name == 't1'
         }
         def result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(task)
         }
 
@@ -227,7 +221,6 @@ project(':b:c') {
         GradleTask taskBT2 = model.findByPath(':b').tasks.find { it.name == 't2' }
         GradleTask taskBCT1 = model.findByPath(':b:c').tasks.find { it.name == 't1' }
         def result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(taskT1, taskBT2, taskBCT1)
         }
 
@@ -236,7 +229,6 @@ project(':b:c') {
 
         when:
         result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(taskBCT1, taskBT2, taskT1)
         }
         then:
@@ -256,7 +248,6 @@ project(':b:c') {
         TaskSelector selectorBT1 = bSelectors.taskSelectors.find { it.name == 't1' }
         TaskSelector selectorBT3 = bSelectors.taskSelectors.find { it.name == 't3' }
         def result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(selectorBT1, selectorBT3, taskT1)
         }
         then:
@@ -276,7 +267,6 @@ project(':b:c') {
         TaskSelector selectorT1 = rootSelectors.taskSelectors.find { it.name == 't1' }
         TaskSelector selectorT2 = rootSelectors.taskSelectors.find { it.name == 't2' }
         def result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(taskT1, selectorT1, selectorT2, taskBT2)
         }
         then:
@@ -316,7 +306,6 @@ project(':b:c') {
         TaskSelector selectorBT1 = bSelectors.taskSelectors.find { it.name == 't1' }
         TaskSelector selectorBT3 = bSelectors.taskSelectors.find { it.name == 't3' }
         def result = withBuild { BuildLauncher it ->
-            enableLifecycleLogging(it)
             it.forLaunchables(selectorBT1, selectorBT3, selectorT1)
         }
         then:

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r112/UserHomeDirCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r112/UserHomeDirCrossVersionSpec.groovy
@@ -37,7 +37,7 @@ class UserHomeDirCrossVersionSpec extends ToolingApiSpecification {
             connector.useGradleUserHomeDir(userHomeDir)
         }
         toolingApi.withConnection { connection ->
-            BuildLauncher build = newBuildWithLifecycleLogging(connection)
+            BuildLauncher build = connection.newBuild()
             build.forTasks("gradleBuild");
             build.standardOutput = baos
             build.run()

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r15/CombiningCommandLineArgumentsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r15/CombiningCommandLineArgumentsCrossVersionSpec.groovy
@@ -42,7 +42,7 @@ class CombiningCommandLineArgumentsCrossVersionSpec extends ToolingApiSpecificat
     //the test was added to validate the behavior that was questioned on forums
     def "supports gradle.properties and changed build file"() {
         file('gradle.properties') << "systemProp.foo=bar"
-        file('buildX.gradle') << "logger.quiet('sys property: ' + System.properties['foo'])"
+        file('buildX.gradle') << "logger.lifecycle('sys property: ' + System.properties['foo'])"
 
         when:
         def out = withBuild { it.withArguments('-b', 'buildX.gradle') }.standardOutput

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r23/StandardStreamsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r23/StandardStreamsCrossVersionSpec.groovy
@@ -47,7 +47,7 @@ task log {
 
         when:
         withConnection { ProjectConnection connection ->
-            def build = newBuildWithLifecycleLogging(connection)
+            def build = connection.newBuild()
             build.forTasks("log")
             build.run()
         }
@@ -78,7 +78,7 @@ task log {
         def output = new TestOutputStream()
         def error = new TestOutputStream()
         withConnection { ProjectConnection connection ->
-            def build = newBuildWithLifecycleLogging(connection)
+            def build = connection.newBuild()
             build.standardOutput = output
             build.standardError = error
             build.forTasks("log")
@@ -109,7 +109,7 @@ task log {
         when:
         def output = new TestOutputStream()
         withConnection { ProjectConnection connection ->
-            def build = newBuildWithLifecycleLogging(connection)
+            def build = connection.newBuild()
             build.standardOutput = output
             build.colorOutput = true
             build.forTasks("log")
@@ -136,7 +136,7 @@ task log {
         when:
         def output = new TestOutputStream()
         withConnection { ProjectConnection connection ->
-            def build = newBuildWithLifecycleLogging(connection)
+            def build = connection.newBuild()
             build.standardOutput = output
             build.colorOutput = true
             build.forTasks("log")
@@ -161,7 +161,7 @@ task log {
 
         when:
         withConnection { ProjectConnection connection ->
-            def build = newBuildWithLifecycleLogging(connection)
+            def build = connection.newBuild()
             build.colorOutput = true
             build.forTasks("log")
             build.run()

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
@@ -36,13 +36,7 @@ class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
         println "Building plugin with $gradleDist"
         def pluginDir = file("plugin")
         def pluginJar = pluginDir.file("plugin.jar")
-        def executor = new ForkingGradleExecuter(gradleDist, temporaryFolder)
-
-        if (!gradleDist.isLifecycleLogLevelFlagSupported()) {
-            executor.withLifecycleLoggingDisabled()
-        }
-
-        def builder = new GradleBackedArtifactBuilder(executor, pluginDir)
+        def builder = new GradleBackedArtifactBuilder(new ForkingGradleExecuter(gradleDist, temporaryFolder), pluginDir)
         builder.sourceFile("com/example/MyTask.java") << """
             package com.example;
             

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -30,7 +30,6 @@ import org.gradle.test.fixtures.file.TestDistributionDirectoryProvider
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testing.internal.util.RetryRule
-import org.gradle.tooling.BuildLauncher
 import org.gradle.tooling.GradleConnectionException
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
@@ -40,6 +39,7 @@ import org.junit.Rule
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import spock.lang.Specification
+
 /**
  * A spec that executes tests against all compatible versions of tooling API consumer and testDirectoryProvider, including the current Gradle version under test.
  *
@@ -154,7 +154,7 @@ abstract class ToolingApiSpecification extends Specification {
 
     public ConfigurableOperation withBuild(Closure cl = {}) {
         withConnection {
-            def build = newBuildWithLifecycleLogging(it)
+            def build = it.newBuild()
             cl(build)
             def out = new ConfigurableOperation(build)
             build.run()
@@ -242,20 +242,5 @@ abstract class ToolingApiSpecification extends Specification {
 
     protected static GradleVersion getTargetVersion() {
         GradleVersion.version(targetDist.version.baseVersion.version)
-    }
-
-    /**
-     * Creates a new build launcher. Initializes with lifecycle log level argument if support by target version.
-     */
-    protected BuildLauncher newBuildWithLifecycleLogging(ProjectConnection connection) {
-        BuildLauncher build = connection.newBuild()
-        enableLifecycleLogging(build)
-        build
-    }
-
-    protected void enableLifecycleLogging(BuildLauncher build) {
-        if (targetDist.isLifecycleLogLevelFlagSupported()) {
-            build.withArguments('-l')
-        }
     }
 }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
@@ -134,13 +134,7 @@ task hello {
     }
 
     void checkWrapperWorksWith(GradleExecuter executer, GradleDistribution executionVersion) {
-        executer.usingExecutable('gradlew').withTasks('hello')
-
-        if (!executionVersion.isLifecycleLogLevelFlagSupported()) {
-            executer.withLifecycleLoggingDisabled()
-        }
-
-        def result = executer.run()
+        def result = executer.usingExecutable('gradlew').withTasks('hello').run()
 
         assert result.output.contains("hello from $executionVersion.version.version")
         assert result.output.contains("using distribution at ${executer.gradleUserHomeDir.file("wrapper/dists")}")


### PR DESCRIPTION
### Context

Revert back the default log level to `LIFECYCLE`. It turned out that we needed a different approach for showing less logs.

You can find the initial PR that switched from `LIFECYCLE` to `WARN` here: https://github.com/gradle/gradle/pull/1952

Stage 4 build passed on CI: https://builds.gradle.org/viewLog.html?buildId=2917756&tab=buildResultsDiv&buildTypeId=Gradle_Branches_Checkpoints_Stage4FullCoverage

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
