### PR TITLE
Remove lifecycle log level from command line options

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
@@ -241,12 +241,6 @@ public class DefaultCommandLineConverterTest extends CommandLineConverterTestSup
     }
 
     @Test
-    public void withLifecycleLoggingOptions() {
-        expectedLogLevel = LogLevel.LIFECYCLE;
-        checkConversion("-l");
-    }
-
-    @Test
     public void withWarnLoggingOptions() {
         expectedLogLevel = LogLevel.WARN;
         checkConversion("-w");

--- a/subprojects/docs/src/docs/userguide/commandLine.xml
+++ b/subprojects/docs/src/docs/userguide/commandLine.xml
@@ -137,14 +137,6 @@
             </listitem>
         </varlistentry>
         <varlistentry>
-            <term>
-                <option>-l</option>, <option>--lifecycle</option>
-            </term>
-            <listitem>
-                <para>Set log level to lifecycle. See <xref linkend="logging"/></para>
-            </listitem>
-        </varlistentry>
-        <varlistentry>
             <term><option>-m</option>, <option>--dry-run</option>
             </term>
             <listitem>

--- a/subprojects/docs/src/docs/userguide/logging.xml
+++ b/subprojects/docs/src/docs/userguide/logging.xml
@@ -92,12 +92,6 @@
             </tr>
             <tr>
                 <td>
-                    <literal>-l</literal> or <literal>--lifecycle</literal>
-                </td>
-                <td>LIFECYCLE and higher</td>
-            </tr>
-            <tr>
-                <td>
                     <literal>-i</literal> or <literal>--info</literal>
                 </td>
                 <td>INFO and higher</td>

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -50,7 +50,7 @@ public class DaemonGradleExecuter extends ForkingGradleExecuter {
     protected List<String> getAllArgs() {
         List<String> args = new ArrayList<String>(super.getAllArgs());
         if(!isQuiet() && isAllowExtraLogging()) {
-            if (!containsAny(args, asList("-i", "--info", "-d", "--debug", "-w", "--warn", "-l", "--lifecycle", "-q", "--quiet"))) {
+            if (!containsAny(args, asList("-i", "--info", "-d", "--debug", "-w", "--warn", "-q", "--quiet"))) {
                 args.add(0, "-i");
             }
         }

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
@@ -36,7 +36,6 @@ class BuildLogLevelMixInTest extends Specification {
         args                     | logLevel
         ['-i']                   | LogLevel.INFO
         ['-q']                   | LogLevel.QUIET
-        ['-l']                   | LogLevel.LIFECYCLE
         ['-w']                   | LogLevel.WARN
         ['foo', '--info', 'bar'] | LogLevel.INFO
         ['-i', 'foo', 'bar']     | LogLevel.INFO

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/JavaUtilLoggingSystemIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/JavaUtilLoggingSystemIntegrationTest.groovy
@@ -88,32 +88,6 @@ class JavaUtilLoggingSystemIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @NotYetImplemented
-    def 'JUL logger.isLoggable corresponds to gradle log level for --lifecycle'() {
-        given:
-        buildFile << """
-            task isLoggable() {
-                doLast {
-                    def logger = Logger.getLogger('some-logger')
-
-                    assert logger.isLoggable(Level.SEVERE)
-                    assert logger.isLoggable(Level.WARNING)
-                    assert !logger.isLoggable(Level.INFO)
-                    assert !logger.isLoggable(Level.CONFIG)
-                    assert !logger.isLoggable(Level.FINE)
-                    assert !logger.isLoggable(Level.FINER)
-                    assert !logger.isLoggable(Level.FINEST)
-                }
-            }
-        """
-
-        when:
-        executer.withArgument("--lifecycle")
-
-        then:
-        succeeds('isLoggable')
-    }
-
-    @NotYetImplemented
     def 'JUL logger.isLoggable corresponds to gradle log level for --info'() {
         given:
         buildFile << """

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
@@ -41,8 +41,6 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
     public static final String WARN_LONG = "warn";
     public static final String INFO = "i";
     public static final String INFO_LONG = "info";
-    public static final String LIFECYCLE = "l";
-    public static final String LIFECYCLE_LONG = "lifecycle";
     public static final String QUIET = "q";
     public static final String QUIET_LONG = "quiet";
     public static final String CONSOLE = "console";
@@ -55,7 +53,6 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
 
     public LoggingCommandLineConverter() {
         logLevelMap.put(QUIET, LogLevel.QUIET);
-        logLevelMap.put(LIFECYCLE, LogLevel.LIFECYCLE);
         logLevelMap.put(WARN, LogLevel.WARN);
         logLevelMap.put(INFO, LogLevel.INFO);
         logLevelMap.put(DEBUG, LogLevel.DEBUG);
@@ -94,9 +91,8 @@ public class LoggingCommandLineConverter extends AbstractCommandLineConverter<Lo
         parser.option(DEBUG, DEBUG_LONG).hasDescription("Log in debug mode (includes normal stacktrace).");
         parser.option(QUIET, QUIET_LONG).hasDescription("Log errors only.");
         parser.option(INFO, INFO_LONG).hasDescription("Set log level to info.");
-        parser.option(LIFECYCLE, LIFECYCLE_LONG).hasDescription("Set log level to lifecycle.");
         parser.option(WARN, WARN_LONG).hasDescription("Set log level to warn.");
-        parser.allowOneOf(DEBUG, QUIET, INFO, LIFECYCLE, WARN);
+        parser.allowOneOf(DEBUG, QUIET, INFO, WARN);
 
         parser.option(CONSOLE).hasArgument().hasDescription("Specifies which type of console output to generate. Values are 'plain', 'auto' (default) or 'rich'.");
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
@@ -47,14 +47,6 @@ class LoggingCommandLineConverterTest extends Specification {
         checkConversion(['--info'])
     }
 
-    def convertsLifecycleLevel() {
-        expectedConfig.logLevel = LogLevel.LIFECYCLE
-
-        expect:
-        checkConversion(['-l'])
-        checkConversion(['--lifecycle'])
-    }
-
     def convertsQuietLevel() {
         expectedConfig.logLevel = LogLevel.QUIET
 
@@ -120,7 +112,7 @@ class LoggingCommandLineConverterTest extends Specification {
 
     def providesLogLevelOptions() {
         expect:
-        converter.logLevelOptions == ['d', 'q', 'i', 'l', 'w'] as Set
+        converter.logLevelOptions == ['d', 'q', 'i', 'w'] as Set
         converter.logLevels == [LogLevel.DEBUG, LogLevel.INFO, LogLevel.LIFECYCLE, LogLevel.QUIET, LogLevel.WARN] as Set
     }
 


### PR DESCRIPTION
### Context

The default log level has been reverted to `LIFECYCLE`. Therefore, there's no more need to be able to set the log level to `LIFECYCLE` from the command line as it is the default value.

The original change had been made here: https://github.com/gradle/gradle/pull/1921

Kind of related question: Should we disallow `-Dorg.gradle.logging.level=lifecycle`?

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
