### PR TITLE
Make testing faster

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IndexedNormalizedFileSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IndexedNormalizedFileSnapshot.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.changedetection.state;
 public class IndexedNormalizedFileSnapshot extends AbstractNormalizedFileSnapshot {
     private final String absolutePath;
     private final int index;
+    private String normalizedPath;
 
     public IndexedNormalizedFileSnapshot(String absolutePath, int index, FileContentSnapshot snapshot) {
         super(snapshot);
@@ -28,7 +29,10 @@ public class IndexedNormalizedFileSnapshot extends AbstractNormalizedFileSnapsho
 
     @Override
     public String getNormalizedPath() {
-        return absolutePath.substring(index);
+        if (normalizedPath == null) {
+            normalizedPath = absolutePath.substring(index);
+        }
+        return normalizedPath;
     }
 
     public String getAbsolutePath() {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/btree/BTreePersistentIndexedCache.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/btree/BTreePersistentIndexedCache.java
@@ -282,7 +282,7 @@ public class BTreePersistentIndexedCache<K, V> {
     }
 
     private class IndexRoot {
-        private BlockPointer rootPos = new BlockPointer();
+        private BlockPointer rootPos = BlockPointer.start();
         private HeaderBlock owner;
 
         private IndexRoot(HeaderBlock owner) {
@@ -325,7 +325,7 @@ public class BTreePersistentIndexedCache<K, V> {
 
         @Override
         protected void read(DataInputStream instr) throws Exception {
-            index.rootPos = new BlockPointer(instr.readLong());
+            index.rootPos = BlockPointer.pos(instr.readLong());
 
             short actualChildIndexEntries = instr.readShort();
             if (actualChildIndexEntries != maxChildIndexEntries) {
@@ -346,7 +346,7 @@ public class BTreePersistentIndexedCache<K, V> {
 
     private class IndexBlock extends BlockPayload {
         private final List<IndexEntry> entries = new ArrayList<IndexEntry>();
-        private BlockPointer tailPos = new BlockPointer();
+        private BlockPointer tailPos = BlockPointer.start();
         // Transient fields
         private IndexBlock parent;
         private int parentEntryIndex;
@@ -368,11 +368,11 @@ public class BTreePersistentIndexedCache<K, V> {
             for (int i = 0; i < count; i++) {
                 IndexEntry entry = new IndexEntry();
                 entry.hashCode = instr.readLong();
-                entry.dataBlock = new BlockPointer(instr.readLong());
-                entry.childIndexBlock = new BlockPointer(instr.readLong());
+                entry.dataBlock = BlockPointer.pos(instr.readLong());
+                entry.childIndexBlock = BlockPointer.pos(instr.readLong());
                 entries.add(entry);
             }
-            tailPos = new BlockPointer(instr.readLong());
+            tailPos = BlockPointer.pos(instr.readLong());
         }
 
         public void write(DataOutputStream outstr) throws IOException {
@@ -394,7 +394,7 @@ public class BTreePersistentIndexedCache<K, V> {
                 assert tailPos.isNull();
                 entry = new IndexEntry();
                 entry.hashCode = hashCode;
-                entry.childIndexBlock = new BlockPointer();
+                entry.childIndexBlock = BlockPointer.start();
                 index = -index - 1;
                 entries.add(index, entry);
             }
@@ -419,7 +419,7 @@ public class BTreePersistentIndexedCache<K, V> {
                 siblingEntries.clear();
                 sibling.tailPos = tailPos;
                 tailPos = splitEntry.childIndexBlock;
-                splitEntry.childIndexBlock = new BlockPointer();
+                splitEntry.childIndexBlock = BlockPointer.start();
                 parent.add(this, splitEntry, sibling);
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/btree/Block.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/btree/Block.java
@@ -48,7 +48,7 @@ public abstract class Block {
     }
 
     public BlockPointer getNextPos() {
-        return new BlockPointer(getPos().getPos() + getSize());
+        return BlockPointer.pos(getPos().getPos() + getSize());
     }
 
     public abstract boolean hasPos();

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/btree/BlockPointer.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/btree/BlockPointer.java
@@ -15,14 +15,29 @@
  */
 package org.gradle.cache.internal.btree;
 
-public class BlockPointer implements Comparable<BlockPointer> {
-    private final long pos;
+import com.google.common.primitives.Longs;
 
-    public BlockPointer() {
-        pos = -1;
+public class BlockPointer implements Comparable<BlockPointer> {
+
+    private static final BlockPointer NULL = new BlockPointer(-1);
+
+    public static BlockPointer start() {
+        return NULL;
     }
 
-    public BlockPointer(long pos) {
+    public static BlockPointer pos(long pos) {
+        if (pos < -1) {
+            throw new IllegalArgumentException("pos must be >= -1");
+        }
+        if (pos == -1) {
+            return NULL;
+        }
+        return new BlockPointer(pos);
+    }
+
+    private final long pos;
+
+    private BlockPointer(long pos) {
         this.pos = pos;
     }
 
@@ -41,9 +56,6 @@ public class BlockPointer implements Comparable<BlockPointer> {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
-            return true;
-        }
         if (obj == null || obj.getClass() != getClass()) {
             return false;
         }
@@ -53,16 +65,10 @@ public class BlockPointer implements Comparable<BlockPointer> {
 
     @Override
     public int hashCode() {
-        return (int) pos;
+        return Longs.hashCode(pos);
     }
 
     public int compareTo(BlockPointer o) {
-        if (pos > o.pos) {
-            return 1;
-        }
-        if (pos < o.pos) {
-            return -1;
-        }
-        return 0;
+        return Longs.compare(pos, o.pos);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/btree/FileBackedBlockStore.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/btree/FileBackedBlockStore.java
@@ -91,7 +91,7 @@ public class FileBackedBlockStore implements BlockStore {
     }
 
     public <T extends BlockPayload> T readFirst(Class<T> payloadType) {
-        return read(new BlockPointer(0), payloadType);
+        return read(BlockPointer.pos(0), payloadType);
     }
 
     public <T extends BlockPayload> T read(BlockPointer pos, Class<T> payloadType) {
@@ -151,7 +151,7 @@ public class FileBackedBlockStore implements BlockStore {
         @Override
         public BlockPointer getPos() {
             if (pos == null) {
-                pos = new BlockPointer(alloc(getSize()));
+                pos = BlockPointer.pos(alloc(getSize()));
             }
             return pos;
         }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/btree/FreeListBlockStore.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/btree/FreeListBlockStore.java
@@ -122,7 +122,7 @@ public class FreeListBlockStore implements BlockStore {
     public class FreeListBlock extends BlockPayload {
         private List<FreeListEntry> entries = new ArrayList<FreeListEntry>();
         private int largestInNextBlock;
-        private BlockPointer nextBlock = new BlockPointer();
+        private BlockPointer nextBlock = BlockPointer.start();
         // Transient fields
         private FreeListBlock prev;
         private FreeListBlock next;
@@ -140,11 +140,11 @@ public class FreeListBlockStore implements BlockStore {
 
         @Override
         protected void read(DataInputStream inputStream) throws Exception {
-            nextBlock = new BlockPointer(inputStream.readLong());
+            nextBlock = BlockPointer.pos(inputStream.readLong());
             largestInNextBlock = inputStream.readInt();
             int count = inputStream.readInt();
             for (int i = 0; i < count; i++) {
-                BlockPointer pos = new BlockPointer(inputStream.readLong());
+                BlockPointer pos = BlockPointer.pos(inputStream.readLong());
                 int size = inputStream.readInt();
                 entries.add(new FreeListEntry(pos, size));
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/xml/SimpleMarkupWriter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/xml/SimpleMarkupWriter.java
@@ -20,7 +20,8 @@ import org.gradle.internal.SystemProperties;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * <p>A streaming markup writer. Encodes characters and CDATA. Provides only basic state validation, and some simple indentation.</p>
@@ -37,7 +38,7 @@ public class SimpleMarkupWriter extends Writer {
     }
 
     private final Writer output;
-    private final LinkedList<String> elements = new LinkedList<String>();
+    private final Deque<String> elements = new ArrayDeque<String>();
     private Context context = Context.Outside;
     private int squareBrackets;
     private final String indent;

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.performance.fixture.InvocationSpec
 import org.gradle.performance.fixture.MavenInvocationSpec
 import org.gradle.performance.measure.MeasuredOperation
 import org.gradle.performance.mutator.ApplyNonAbiChangeToJavaSourceFileMutator
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.MEDIUM_JAVA_MULTI_PROJECT
@@ -36,7 +35,6 @@ import static org.gradle.performance.generator.JavaTestProject.MEDIUM_MONOLITHIC
  * Performance tests aimed at comparing the performance of Gradle for compiling and executing test suites, making
  * sure we are always faster than Maven.
  */
-@Ignore
 class JavaTestGradleVsMavenPerformanceTest extends AbstractGradleVsMavenPerformanceTest {
 
     @Unroll

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/BinaryResultBackedTestResultsProvider.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/BinaryResultBackedTestResultsProvider.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Writer;
 
 public class BinaryResultBackedTestResultsProvider extends TestOutputStoreBackedResultsProvider {
@@ -81,9 +80,5 @@ public class BinaryResultBackedTestResultsProvider extends TestOutputStoreBacked
     @Override
     public void visitClasses(final Action<? super TestClassResult> visitor) {
         resultSerializer.read(visitor);
-    }
-
-    @Override
-    public void close() throws IOException {
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/InMemoryTestResultsProvider.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/InMemoryTestResultsProvider.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.testing.junit.result;
 import org.gradle.api.Action;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 
-import java.io.IOException;
 import java.io.Writer;
 
 public class InMemoryTestResultsProvider extends TestOutputStoreBackedResultsProvider {
@@ -82,9 +81,5 @@ public class InMemoryTestResultsProvider extends TestOutputStoreBackedResultsPro
     @Override
     public boolean isHasResults() {
         return results.iterator().hasNext();
-    }
-
-    @Override
-    public void close() throws IOException {
     }
 }


### PR DESCRIPTION
While analyzing the `cleanTest test` performance scenario, I found a couple of low-hanging memory bottlenecks. Fixing these reduced memory spikes from ~850MB to ~750MB. According to several ad-hoc performance tests, this should be enough to fix that particular performance test.