### PR TITLE
Replace disabled for enabled on Build Cache Configuration Build Operation

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheConfigurationBuildOperationIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheConfigurationBuildOperationIntegrationTest.groovy
@@ -73,8 +73,8 @@ class HttpBuildCacheConfigurationBuildOperationIntegrationTest extends AbstractI
         then:
         def result = result()
 
-        !result.remoteDisabled
-        result.localDisabled
+        result.remoteEnabled
+        !result.localEnabled
 
         result.remote.className == 'org.gradle.caching.http.HttpBuildCache'
         result.remote.config.url == url
@@ -138,7 +138,7 @@ class HttpBuildCacheConfigurationBuildOperationIntegrationTest extends AbstractI
         succeeds("help")
 
         then:
-        result().remoteDisabled
+        !result().remoteEnabled
     }
 
     def "remote build cache configuration details is not exposed when disabled"() {
@@ -160,7 +160,29 @@ class HttpBuildCacheConfigurationBuildOperationIntegrationTest extends AbstractI
 
         then:
         def result = result()
-        result.remoteDisabled
+        !result.remoteEnabled
+        result.remote == null
+    }
+
+    def "remote build cache configuration details is not exposed when not defined"() {
+        given:
+        settingsFile << """
+            buildCache {  
+                local(DirectoryBuildCache) {
+                    enabled = false 
+                    directory = 'directory'
+                    push = false 
+                }
+            }
+        """
+        executer.withBuildCacheEnabled()
+
+        when:
+        succeeds("help")
+
+        then:
+        def result = result()
+        !result.remoteEnabled
         result.remote == null
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
@@ -45,9 +45,9 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         then:
         def result = result()
 
-        !result.disabled
-        !result.localDisabled
-        !result.remoteDisabled
+        result.enabled
+        result.localEnabled
+        !result.remoteEnabled
 
         result.local.className == 'org.gradle.caching.local.DirectoryBuildCache'
         result.local.config.location == cacheDir.absoluteFile.toString()
@@ -89,9 +89,9 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         then:
         def result = result()
 
-        !result.disabled
-        !result.localDisabled
-        !result.remoteDisabled
+        result.enabled
+        result.localEnabled
+        !result.remoteEnabled
 
         result.local.className == 'CustomBuildCache'
         result.local.config.directory == directory
@@ -135,9 +135,9 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         then:
         def result = result()
 
-        result.disabled
-        result.localDisabled
-        result.remoteDisabled
+        !result.enabled
+        !result.localEnabled
+        !result.remoteEnabled
 
         result.local == null
         result.remote == null
@@ -163,8 +163,8 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         then:
         def result = result()
 
-        !result.disabled
-        result.localDisabled
+        result.enabled
+        !result.localEnabled
 
         result.local == null
     }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServiceProvider.java
@@ -97,9 +97,9 @@ public class BuildCacheServiceProvider {
                     : null;
 
                 context.setResult(new FinalizeBuildCacheConfigurationDetails.Result(
-                    false,
-                    local != null && !local.isEnabled(),
-                    remote != null && (!remote.isEnabled() || startParameter.isOffline()),
+                    true,
+                    local != null && local.isEnabled(),
+                    remote != null && remote.isEnabled() && !startParameter.isOffline(),
                     localDescribedService == null ? null : localDescribedService.description,
                     remoteDescribedService == null ? null : remoteDescribedService.description
                 ));

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/FinalizeBuildCacheConfigurationDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/FinalizeBuildCacheConfigurationDetails.java
@@ -79,38 +79,38 @@ public final class FinalizeBuildCacheConfigurationDetails implements BuildOperat
 
         }
 
-        private final boolean disabled;
+        private final boolean enabled;
 
-        private final boolean localDisabled;
+        private final boolean localEnabled;
 
         private final BuildCacheDescription local;
 
-        private final boolean remoteDisabled;
+        private final boolean remoteEnabled;
 
         private final BuildCacheDescription remote;
 
-        public Result(boolean disabled, boolean localDisabled, boolean remoteDisabled, @Nullable BuildCacheDescription local, @Nullable BuildCacheDescription remote) {
-            this.disabled = disabled;
-            this.localDisabled = localDisabled;
-            this.remoteDisabled = remoteDisabled;
+        public Result(boolean enabled, boolean localEnabled, boolean remoteEnabled, @Nullable BuildCacheDescription local, @Nullable BuildCacheDescription remote) {
+            this.enabled = enabled;
+            this.localEnabled = localEnabled;
+            this.remoteEnabled = remoteEnabled;
             this.local = local;
             this.remote = remote;
         }
 
         public static Result buildCacheConfigurationDisabled() {
-            return new FinalizeBuildCacheConfigurationDetails.Result(true, true, true, null, null);
+            return new FinalizeBuildCacheConfigurationDetails.Result(false, false, false, null, null);
         }
 
-        public boolean isDisabled() {
-            return disabled;
+        public boolean isEnabled() {
+            return enabled;
         }
 
-        public boolean isLocalDisabled() {
-            return localDisabled;
+        public boolean isLocalEnabled() {
+            return localEnabled;
         }
 
-        public boolean isRemoteDisabled() {
-            return remoteDisabled;
+        public boolean isRemoteEnabled() {
+            return remoteEnabled;
         }
 
         @Nullable // if not enabled


### PR DESCRIPTION
We were using disabled as an optimization for the build scan plugin, but it makes the code harder to understand as the DSL refers to enable.

Related to https://github.com/gradle/task-output-cache/issues/438