### PR TITLE
Expose the task object in SnapshotTaskInputsOperationDetails

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 
 class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec {
 
-    private static final String BUILD_OPERATION = 'Compute task input hashes and build cache key'
+    private static final String BUILD_OPERATION = "Snapshot task inputs for :customTask"
 
     @Rule
     BuildOperationsFixture buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
@@ -36,10 +36,10 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         succeeds('customTask')
 
         then:
-        def result = buildOperationResult()
+        def result = buildOperations.operation(BUILD_OPERATION).result
 
         then:
-        result.containsKey("buildCacheKey")
+        result.buildCacheKey != null
         result.inputHashes.keySet() == ['input1', 'input2'] as Set
         result.outputPropertyNames == ['outputFile1', 'outputFile2']
     }
@@ -78,10 +78,6 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
                 input2 = '$input2'
             }
         """
-    }
-
-    Map<String, ?> buildOperationResult() {
-        buildOperations.operation(SnapshotTaskInputsOperationDetails).result
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationDetails.java
@@ -17,7 +17,9 @@
 package org.gradle.api.internal.tasks;
 
 import org.gradle.api.Nullable;
+import org.gradle.api.Task;
 import org.gradle.internal.progress.BuildOperationDetails;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.util.List;
 import java.util.SortedMap;
@@ -28,20 +30,19 @@ import java.util.SortedSet;
  *
  * This operation is executed only when the build cache is enabled.
  *
- * This class is intentionally internal and consumed by the build scan plugin.
- *
  * @since 4.0
  */
+@UsedByScanPlugin
 public final class SnapshotTaskInputsOperationDetails implements BuildOperationDetails<SnapshotTaskInputsOperationDetails.Result> {
 
-    private final String taskPath;
+    private final Task task;
 
-    public SnapshotTaskInputsOperationDetails(String taskPath) {
-        this.taskPath = taskPath;
+    public SnapshotTaskInputsOperationDetails(Task task) {
+        this.task = task;
     }
 
-    public String getTaskPath() {
-        return taskPath;
+    public Task getTask() {
+        return task;
     }
 
     public interface Result {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuter.java
@@ -92,7 +92,7 @@ public class ResolveBuildCacheKeyExecuter implements TaskExecuter {
             public BuildOperationDescriptor.Builder description() {
                 return BuildOperationDescriptor
                     .displayName("Snapshot task inputs for " + task.getIdentityPath())
-                    .details(new SnapshotTaskInputsOperationDetails(task.getPath()));
+                    .details(new SnapshotTaskInputsOperationDetails(task));
             }
         });
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuterTest.groovy
@@ -50,7 +50,6 @@ class ResolveBuildCacheKeyExecuterTest extends Specification {
         executer.execute(task, taskState, taskContext)
 
         then:
-        1 * task.getPath() >> ":foo"
         1 * task.getIdentityPath() >> Path.path(":foo")
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
         1 * taskArtifactState.calculateCacheKey() >> cacheKey
@@ -82,7 +81,6 @@ class ResolveBuildCacheKeyExecuterTest extends Specification {
         executer.execute(task, taskState, taskContext)
 
         then:
-        1 * task.getPath() >> ":foo"
         1 * task.getIdentityPath() >> Path.path(":foo")
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
         1 * taskArtifactState.calculateCacheKey() >> {
@@ -100,7 +98,6 @@ class ResolveBuildCacheKeyExecuterTest extends Specification {
         executer.execute(task, taskState, taskContext)
 
         then:
-        1 * task.getPath() >> ":foo"
         1 * task.getIdentityPath() >> Path.path(":foo")
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
         1 * taskArtifactState.calculateCacheKey() >> DefaultTaskOutputCachingBuildCacheKeyBuilder.NO_CACHE_KEY

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
@@ -17,6 +17,8 @@
 package org.gradle.integtests.fixtures
 
 import groovy.json.JsonSlurper
+import org.gradle.api.execution.internal.TaskOperationDetails
+import org.gradle.api.internal.tasks.SnapshotTaskInputsOperationDetails
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.fixtures.executer.InitScriptExecuterFixture
 import org.gradle.internal.progress.BuildOperationDescriptor
@@ -48,6 +50,7 @@ class BuildOperationsFixture extends InitScriptExecuterFixture {
             import ${OperationFinishEvent.name}
 
             def operations = [:]
+            def unserializable = [$TaskOperationDetails.name, $SnapshotTaskInputsOperationDetails.name]
             def operationListener = new BuildOperationListener() {
                 
                 void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
@@ -58,7 +61,7 @@ class BuildOperationsFixture extends InitScriptExecuterFixture {
                         name: buildOperation.name,
                         startTime: startEvent.startTime
                     ]
-                    if (buildOperation.details != null && buildOperation.details.class != org.gradle.api.execution.internal.TaskOperationDetails) {
+                    if (buildOperation.details != null && !unserializable.contains(buildOperation.details.class)) {
                         operations[buildOperation.id].putAll(
                             detailsType: buildOperation.details.class.name,
                             details: buildOperation.details


### PR DESCRIPTION
Needed for build scans.