### PR TITLE
Add --failed command-line option to Test

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.testing.Test.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.testing.Test.xml
@@ -186,6 +186,9 @@
             <tr>
                 <td>options</td>
             </tr>
+            <tr>
+                <td>filterForFailed</td>
+            </tr>
         </table>
     </section>
 </section>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -23,6 +23,12 @@ codenarc {
 
 The Gradle command line client now starts up ~200ms faster, speeding up every build.
 
+### Filtering Java test execution based on test failures
+
+When executing `Test` tasks, you can now pass the [`--failed` command-line option](userguide/java_plugin.html#test_filtering). This option will filter test execution to only the test classes that failed in the last execution.
+
+If there are no previous results, the previous results cannot be read or no tests failed in the last execution, all tests will be executed instead.
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -784,7 +784,8 @@ Test filtering feature has following characteristic:
 
 * Fully qualified class name or fully qualified method name is supported, e.g. “org.gradle.SomeTest”, “org.gradle.SomeTest.someMethod”
 * Wildcard '*' is supported for matching any characters
-* Command line option “--tests” is provided to conveniently set the test filter. Especially useful for the classic 'single test method execution' use case. When the command line option is used, the inclusion filters declared in the build script are ignored. It is possible to supply multiple “--tests” options and tests matching any of those patterns will be included.
+* Command line option `--tests` is provided to conveniently set the test filter. Especially useful for the classic 'single test method execution' use case. When the command line option is used, the inclusion filters declared in the build script are ignored. It is possible to supply multiple `--tests` options and tests matching any of those patterns will be included.
+* Command line option `--failed` is provided to set the test filter based on the results of the last execution. If there are no previous results, the previous results cannot be read or no tests failed in the last execution, no filters are applied and all tests will be executed.  This command-line option will replace any existing filters.
 * Gradle tries to filter the tests given the limitations of the test framework API. Some advanced, synthetic tests may not be fully compatible with filtering. However, the vast majority of tests and use cases should be handled neatly.
 * Test filtering supersedes the file-based test selection. The latter may be completely replaced in future. We will grow the test filtering API and add more kinds of filters.
 
@@ -800,6 +801,7 @@ For more details and examples please see the api:org.gradle.api.tasks.testing.Te
 
 Some examples of using the command line option:
 
+* `gradle test --failed`
 * `gradle test --tests org.gradle.SomeTest.someSpecificFeature`
 * `gradle test --tests \*SomeTest.someSpecificFeature`
 * `gradle test --tests \*SomeSpecificTest`

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/FailedTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/FailedTestIntegrationTest.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
+@Requires(TestPrecondition.ONLINE)
+class FailedTestIntegrationTest extends AbstractIntegrationSpec {
+    public static final String RUN_FAILING_TEST = "Test failingTest(org.gradle.FailingTest)"
+    public static final String RUN_PASSING_TEST = "Test passingTest(org.gradle.PassingTest)"
+    def failingTest = file("src/test/java/org/gradle/FailingTest.java")
+
+    def setup() {
+        buildFile << """
+            apply plugin: 'java'
+            repositories { jcenter() }
+            dependencies { testCompile 'junit:junit:4.12' }
+            
+            task validate() {
+                doLast {
+                    def expectedFilters = project.findProperty("expectedFilters") 
+                    if (expectedFilters) {
+                        assert test.filter.includePatterns == project.expectedFilters.split(",") as Set
+                    } else {
+                        assert test.filter.includePatterns.isEmpty()
+                    }
+                }
+            }
+
+            test {
+                dependsOn validate
+                beforeTest { logger.lifecycle(it.toString()) }
+            }
+        """.stripIndent()
+
+        failingTest << """
+            package org.gradle;
+            
+            import org.junit.Test;
+            import org.junit.Assert;
+            
+            public class FailingTest {
+                @Test
+                public void failingTest() {
+                    Assert.assertTrue(false);
+                }
+            }
+        """
+        file("src/test/java/org/gradle/PassingTest.java") << """
+            package org.gradle;
+            
+            import org.junit.Test;
+            import org.junit.Assert;
+            
+            public class PassingTest {
+                @Test
+                public void passingTest() {
+                    Assert.assertTrue(true);
+                }
+            }
+        """
+    }
+
+    def "--failed runs failed tests only"() {
+        when:
+        fails("test")
+        then:
+        result.assertOutputContains(RUN_FAILING_TEST)
+        result.assertOutputContains(RUN_PASSING_TEST)
+
+        when:
+        fails("test", "--failed", "-PexpectedFilters=org.gradle.FailingTest")
+        then:
+        result.assertOutputContains(RUN_FAILING_TEST)
+        !result.output.contains(RUN_PASSING_TEST)
+
+        when:
+        makeFailingTestPass()
+        and:
+        succeeds("test", "--failed", "-PexpectedFilters=org.gradle.FailingTest")
+        then:
+        result.assertOutputContains(RUN_FAILING_TEST)
+        !result.output.contains(RUN_PASSING_TEST)
+
+        when:
+        succeeds("test")
+        then:
+        result.assertOutputContains(RUN_FAILING_TEST)
+        result.assertOutputContains(RUN_PASSING_TEST)
+    }
+
+    def "--failed when there were no previous failures runs all tests"() {
+        when:
+        makeFailingTestPass()
+        and:
+        succeeds("test", "--failed")
+        then:
+        result.assertOutputContains("No tests failed previously, running all tests.")
+        result.assertOutputContains(RUN_FAILING_TEST)
+        result.assertOutputContains(RUN_PASSING_TEST)
+    }
+
+    def "--failed when there is a problem reading previous results runs all tests"() {
+        when:
+        makeFailingTestPass()
+        and:
+        succeeds("test")
+        then:
+        result.assertOutputContains(RUN_FAILING_TEST)
+        result.assertOutputContains(RUN_PASSING_TEST)
+
+        when:
+        file("build/test-results/test/binary/results.bin").text = "corrupted"
+        and:
+        succeeds("test", "--failed")
+        then:
+        result.assertOutputContains("No tests failed previously, running all tests.")
+        result.assertOutputContains(RUN_FAILING_TEST)
+        result.assertOutputContains(RUN_PASSING_TEST)
+    }
+
+    void makeFailingTestPass() {
+        failingTest.text = failingTest.text.replace("false", "true")
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.tasks.testing;
 
+import com.google.common.collect.Lists;
 import groovy.lang.Closure;
+import org.apache.commons.io.IOUtils;
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
@@ -42,6 +44,7 @@ import org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework;
 import org.gradle.api.internal.tasks.testing.junit.report.DefaultTestReport;
 import org.gradle.api.internal.tasks.testing.junit.report.TestReporter;
 import org.gradle.api.internal.tasks.testing.junit.result.Binary2JUnitXmlReportGenerator;
+import org.gradle.api.internal.tasks.testing.junit.result.BinaryResultBackedTestResultsProvider;
 import org.gradle.api.internal.tasks.testing.junit.result.InMemoryTestResultsProvider;
 import org.gradle.api.internal.tasks.testing.junit.result.TestClassResult;
 import org.gradle.api.internal.tasks.testing.junit.result.TestOutputAssociation;
@@ -612,6 +615,44 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
     @Override
     public Test copyTo(JavaForkOptions target) {
         forkOptions.copyTo(target);
+        return this;
+    }
+
+    /**
+     * Filters tests to be executed based on which tests failed in the previous execution.
+     * <p>
+     * If there are no previous results, the previous results cannot be read or no tests failed in
+     * the last execution, no filters are applied and all tests will be executed.
+     * <p>
+     * This option will replace any existing filters.
+     *
+     * @since 4.1
+     */
+    @Option(option = "failed", description = "Filter tests based on tests that failed previously.")
+    public Test filterForFailed(boolean failed) {
+        if (failed) {
+            TestResultsProvider resultsProvider = null;
+            try {
+                resultsProvider = new BinaryResultBackedTestResultsProvider(getBinResultsDir());
+                final List<String> failedTestClasses = Lists.newArrayList();
+                resultsProvider.visitClasses(new Action<TestClassResult>() {
+                    @Override
+                    public void execute(TestClassResult testClassResult) {
+                        if (testClassResult.getFailuresCount() > 0) {
+                            failedTestClasses.add(testClassResult.getClassName());
+                        }
+                    }
+                });
+                if (!failedTestClasses.isEmpty()) {
+                    return setTestNameIncludePatterns(failedTestClasses);
+                }
+            } catch (Exception e) {
+                getLogger().debug("cannot find previously failed tests", e);
+            } finally {
+                IOUtils.closeQuietly(resultsProvider);
+            }
+            getLogger().warn("No tests failed previously, running all tests.");
+        }
         return this;
     }
 


### PR DESCRIPTION
- When specified, we inspect the previous execution and filter by any
  test classes that failed.
- If the previous test execution results do not exist or cannot be read,
  no filter is applied and we run all tests.

demo: https://asciinema.org/a/alielycyjjkst2niborcey95w