### PR TITLE
Track task action types

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskActionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskActionIntegrationTest.groovy
@@ -16,13 +16,11 @@
 
 package org.gradle.api.tasks
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 
 class CachedTaskActionIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
-    @NotYetImplemented
     def "ad hoc tasks with different actions don't share results"() {
         file("input.txt").text = "data"
         buildFile << """
@@ -91,7 +89,6 @@ class CachedTaskActionIntegrationTest extends AbstractIntegrationSpec implements
         skippedTasks as List == [":taskB"]
     }
 
-    @NotYetImplemented
     def "built-in tasks with different actions don't share results"() {
         file("src/main/java/Main.java").text = "public class Main {}"
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
-import com.google.common.collect.Sets;
 import groovy.lang.Closure;
 import groovy.lang.MissingPropertyException;
 import groovy.util.ObservableList;
@@ -216,15 +215,6 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
             actions = new ArrayList<ContextAwareTaskAction>();
         }
         return actions;
-    }
-
-    @Override
-    public Set<ClassLoader> getActionClassLoaders() {
-        Set<ClassLoader> actionLoaders = Sets.newLinkedHashSet();
-        for (ContextAwareTaskAction action : getTaskActions()) {
-            actionLoaders.add(action.getClassLoader());
-        }
-        return actionLoaders;
     }
 
     @Override
@@ -693,6 +683,11 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         public ClassLoader getClassLoader() {
             return closure.getClass().getClassLoader();
         }
+
+        @Override
+        public Class<?> getActionType() {
+            return closure.getClass();
+        }
     }
 
     private static class TaskActionWrapper implements ContextAwareTaskAction {
@@ -724,6 +719,15 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
                 return ((ClassLoaderAwareTaskAction) action).getClassLoader();
             } else {
                 return action.getClass().getClassLoader();
+            }
+        }
+
+        @Override
+        public Class<?> getActionType() {
+            if (action instanceof ClassLoaderAwareTaskAction) {
+                return ((ClassLoaderAwareTaskAction) action).getActionType();
+            } else {
+                return action.getClass();
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -31,7 +31,6 @@ import org.gradle.util.Path;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 public interface TaskInternal extends Task, Configurable<Task> {
 
@@ -42,9 +41,6 @@ public interface TaskInternal extends Task, Configurable<Task> {
      */
     @Internal
     List<ContextAwareTaskAction> getTaskActions();
-
-    @Internal
-    Set<ClassLoader> getActionClassLoaders();
 
     @Internal
     Spec<? super TaskInternal> getOnlyIf();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/TaskUpToDateState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/TaskUpToDateState.java
@@ -49,7 +49,7 @@ public class TaskUpToDateState {
         ResourceNormalizationStrategy resourceNormalizationStrategy = ((ResourceNormalizationHandlerInternal) task.getProject().getNormalization()).buildFinalStrategy();
 
         TaskStateChanges noHistoryState = new NoHistoryTaskStateChanges(lastExecution);
-        TaskStateChanges taskTypeState = new TaskTypeTaskStateChanges(lastExecution, thisExecution, task.getPath(), task.getClass(), task.getActionClassLoaders(), classLoaderHierarchyHasher);
+        TaskStateChanges taskTypeState = new TaskTypeTaskStateChanges(lastExecution, thisExecution, task.getPath(), task.getClass(), task.getTaskActions(), classLoaderHierarchyHasher);
         TaskStateChanges inputPropertiesState = new InputPropertiesTaskStateChanges(lastExecution, thisExecution, task, valueSnapshotter);
 
         // Capture outputs state

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
@@ -251,6 +251,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
             setTaskClass(taskExecutionSnapshot.getTaskClass());
             setTaskClassLoaderHash(taskExecutionSnapshot.getTaskClassLoaderHash());
             setTaskActionsClassLoaderHashes(taskExecutionSnapshot.getTaskActionsClassLoaderHashes());
+            setTaskActionsTypes(taskExecutionSnapshot.getTaskActionsTypes());
             setInputProperties(taskExecutionSnapshot.getInputProperties());
             setOutputPropertyNamesForCacheKey(taskExecutionSnapshot.getCacheableOutputProperties());
             setDeclaredOutputFilePaths(taskExecutionSnapshot.getDeclaredOutputFilePaths());
@@ -322,6 +323,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
                 getDeclaredOutputFilePaths(),
                 getTaskClassLoaderHash(),
                 getTaskActionsClassLoaderHashes(),
+                getTaskActionsTypes(),
                 getInputProperties(),
                 inputFilesSnapshotIds,
                 discoveredFilesSnapshotId,
@@ -362,6 +364,13 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
                 }
                 List<HashCode> taskActionsClassLoaderHashes = Collections.unmodifiableList(mutableTaskActionsClassLoaderHashes);
 
+                int taskActionsTypeCount = decoder.readSmallInt();
+                ImmutableList.Builder<String> taskActionsTypesBuilder = ImmutableList.builder();
+                for (int j = 0; j < taskActionsTypeCount; j++) {
+                    taskActionsTypesBuilder.add(decoder.readString());
+                }
+                ImmutableList<String> taskActionsTypes = taskActionsTypesBuilder.build();
+
                 int cacheableOutputPropertiesCount = decoder.readSmallInt();
                 ImmutableSortedSet.Builder<String> cacheableOutputPropertiesBuilder = ImmutableSortedSet.naturalOrder();
                 for (int j = 0; j < cacheableOutputPropertiesCount; j++) {
@@ -385,6 +394,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
                     declaredOutputFilePaths,
                     taskClassLoaderHash,
                     taskActionsClassLoaderHashes,
+                    taskActionsTypes,
                     inputProperties,
                     inputFilesSnapshotIds,
                     discoveredFilesSnapshotId,
@@ -413,6 +423,10 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
                         encoder.writeBoolean(true);
                         encoder.writeBinary(actionsClassLoaderHash.asBytes());
                     }
+                }
+                encoder.writeSmallInt(execution.getTaskActionsTypes().size());
+                for (String taskActionType : execution.getTaskActionsTypes()) {
+                    encoder.writeString(taskActionType);
                 }
                 encoder.writeSmallInt(execution.getCacheableOutputProperties().size());
                 for (String outputFile : execution.getCacheableOutputProperties()) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecution.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.changedetection.state;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -32,6 +33,7 @@ public abstract class TaskExecution {
     private String taskClass;
     private HashCode taskClassLoaderHash;
     private List<HashCode> taskActionsClassLoaderHashes;
+    private ImmutableList<String> taskActionsTypes;
     private ImmutableSortedMap<String, ValueSnapshot> inputProperties;
     private Iterable<String> outputPropertyNamesForCacheKey;
     private ImmutableSet<String> declaredOutputFilePaths;
@@ -94,6 +96,14 @@ public abstract class TaskExecution {
 
     public void setTaskActionsClassLoaderHashes(List<HashCode> taskActionsClassLoaderHashes) {
         this.taskActionsClassLoaderHashes = taskActionsClassLoaderHashes;
+    }
+
+    public ImmutableList<String> getTaskActionsTypes() {
+        return taskActionsTypes;
+    }
+
+    public void setTaskActionsTypes(ImmutableList<String> taskActionsTypes) {
+        this.taskActionsTypes = taskActionsTypes;
     }
 
     public ImmutableSortedMap<String, ValueSnapshot> getInputProperties() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecutionSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecutionSnapshot.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -32,6 +33,7 @@ public class TaskExecutionSnapshot {
     private final String taskClass;
     private final HashCode taskClassLoaderHash;
     private final List<HashCode> taskActionsClassLoaderHashes;
+    private final ImmutableList<String> taskActionsTypes;
     private final ImmutableSortedMap<String, ValueSnapshot> inputProperties;
     private final ImmutableSortedSet<String> cacheableOutputProperties;
     private final ImmutableSet<String> declaredOutputFilePaths;
@@ -39,13 +41,14 @@ public class TaskExecutionSnapshot {
     private final ImmutableSortedMap<String, Long> outputFilesSnapshotIds;
     private final Long discoveredFilesSnapshotId;
 
-    public TaskExecutionSnapshot(UniqueId buildId, String taskClass, ImmutableSortedSet<String> cacheableOutputProperties, ImmutableSet<String> declaredOutputFilePaths, HashCode taskClassLoaderHash, List<HashCode> taskActionsClassLoaderHashes, ImmutableSortedMap<String, ValueSnapshot> inputProperties, ImmutableSortedMap<String, Long> inputFilesSnapshotIds, Long discoveredFilesSnapshotId, ImmutableSortedMap<String, Long> outputFilesSnapshotIds) {
+    public TaskExecutionSnapshot(UniqueId buildId, String taskClass, ImmutableSortedSet<String> cacheableOutputProperties, ImmutableSet<String> declaredOutputFilePaths, HashCode taskClassLoaderHash, List<HashCode> taskActionsClassLoaderHashes, ImmutableList<String> taskActionsTypes, ImmutableSortedMap<String, ValueSnapshot> inputProperties, ImmutableSortedMap<String, Long> inputFilesSnapshotIds, Long discoveredFilesSnapshotId, ImmutableSortedMap<String, Long> outputFilesSnapshotIds) {
         this.buildId = buildId;
         this.taskClass = taskClass;
         this.cacheableOutputProperties = cacheableOutputProperties;
         this.declaredOutputFilePaths = declaredOutputFilePaths;
         this.taskClassLoaderHash = taskClassLoaderHash;
         this.taskActionsClassLoaderHashes = taskActionsClassLoaderHashes;
+        this.taskActionsTypes = taskActionsTypes;
         this.inputProperties = inputProperties;
         this.inputFilesSnapshotIds = inputFilesSnapshotIds;
         this.discoveredFilesSnapshotId = discoveredFilesSnapshotId;
@@ -82,6 +85,10 @@ public class TaskExecutionSnapshot {
 
     public List<HashCode> getTaskActionsClassLoaderHashes() {
         return taskActionsClassLoaderHashes;
+    }
+
+    public ImmutableList<String> getTaskActionsTypes() {
+        return taskActionsTypes;
     }
 
     public String getTaskClass() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
@@ -68,12 +68,12 @@ public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
         Set<String> methods = new HashSet<String>();
         for (Class current = type; current != null; current = current.getSuperclass()) {
             for (Method method : current.getDeclaredMethods()) {
-                attachTaskAction(method, taskClassInfo, methods);
+                attachTaskAction(type, method, taskClassInfo, methods);
             }
         }
     }
 
-    private void attachTaskAction(final Method method, TaskClassInfo taskClassInfo, Collection<String> processedMethods) {
+    private void attachTaskAction(Class<? extends Task> type, final Method method, TaskClassInfo taskClassInfo, Collection<String> processedMethods) {
         if (method.getAnnotation(TaskAction.class) == null) {
             return;
         }
@@ -102,26 +102,28 @@ public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
         if (processedMethods.contains(method.getName())) {
             return;
         }
-        taskClassInfo.getTaskActions().add(createActionFactory(method, parameterTypes));
+        taskClassInfo.getTaskActions().add(createActionFactory(type, method, parameterTypes));
         processedMethods.add(method.getName());
     }
 
-    private Factory<Action<Task>> createActionFactory(final Method method, final Class<?>[] parameterTypes) {
+    private Factory<Action<Task>> createActionFactory(final Class<? extends Task> type, final Method method, final Class<?>[] parameterTypes) {
         return new Factory<Action<Task>>() {
             public Action<Task> create() {
                 if (parameterTypes.length == 1) {
-                    return new IncrementalTaskAction(method);
+                    return new IncrementalTaskAction(type, method);
                 } else {
-                    return new StandardTaskAction(method);
+                    return new StandardTaskAction(type, method);
                 }
             }
         };
     }
 
     private static class StandardTaskAction implements ClassLoaderAwareTaskAction {
+        private final Class<? extends Task> type;
         private final Method method;
 
-        public StandardTaskAction(Method method) {
+        public StandardTaskAction(Class<? extends Task> type, Method method) {
+            this.type = type;
             this.method = method;
         }
 
@@ -143,14 +145,19 @@ public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
         public ClassLoader getClassLoader() {
             return method.getDeclaringClass().getClassLoader();
         }
+
+        @Override
+        public Class<?> getActionType() {
+            return type;
+        }
     }
 
     private static class IncrementalTaskAction extends StandardTaskAction implements ContextAwareTaskAction {
 
         private TaskArtifactState taskArtifactState;
 
-        public IncrementalTaskAction(Method method) {
-            super(method);
+        public IncrementalTaskAction(Class<? extends Task> type, Method method) {
+            super(type, method);
         }
 
         public void contextualise(TaskExecutionContext context) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ClassLoaderAwareTaskAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ClassLoaderAwareTaskAction.java
@@ -25,4 +25,6 @@ public interface ClassLoaderAwareTaskAction extends Action<Task> {
      * of the implementing class, or the classloader of some delegate action.
      */
     ClassLoader getClassLoader();
+
+    Class<?> getActionType();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskMutator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskMutator.java
@@ -83,25 +83,7 @@ public class TaskMutator {
     }
 
     public ContextAwareTaskAction leftShift(final ContextAwareTaskAction action) {
-        return new ContextAwareTaskAction() {
-            public void execute(Task task) {
-                executingleftShiftAction = true;
-                try {
-                    action.execute(task);
-                } finally {
-                    executingleftShiftAction = false;
-                }
-            }
-
-            public void contextualise(TaskExecutionContext context) {
-                action.contextualise(context);
-            }
-
-            @Override
-            public ClassLoader getClassLoader() {
-                return action.getClassLoader();
-            }
-        };
+        return new LeftShiftTaskAction(action);
     }
 
     private String format(String method) {
@@ -109,5 +91,36 @@ public class TaskMutator {
             return String.format("Cannot call %s on %s after task has started execution. Check the configuration of %s as you may have misused '<<' at task declaration.", method, task, task);
         }
         return String.format("Cannot call %s on %s after task has started execution.", method, task);
+    }
+
+    private class LeftShiftTaskAction implements ContextAwareTaskAction {
+        private final ContextAwareTaskAction action;
+
+        public LeftShiftTaskAction(ContextAwareTaskAction action) {
+            this.action = action;
+        }
+
+        public void execute(Task task) {
+            executingleftShiftAction = true;
+            try {
+                action.execute(task);
+            } finally {
+                executingleftShiftAction = false;
+            }
+        }
+
+        public void contextualise(TaskExecutionContext context) {
+            action.contextualise(context);
+        }
+
+        @Override
+        public ClassLoader getClassLoader() {
+            return action.getClassLoader();
+        }
+
+        @Override
+        public Class<?> getActionType() {
+            return action.getActionType();
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/BuildCacheKeyInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/BuildCacheKeyInputs.java
@@ -32,14 +32,16 @@ public class BuildCacheKeyInputs {
     private final String taskClass;
     private final HashCode classLoaderHash;
     private final List<HashCode> actionClassLoaderHashes;
+    private final List<String> actionsTypes;
     private final ImmutableSortedMap<String, HashCode> inputHashes;
     private final ImmutableSortedSet<String> outputPropertyNames;
 
-    public BuildCacheKeyInputs(String taskClass, HashCode classLoaderHash, List<HashCode> actionClassLoaderHashes, ImmutableSortedMap<String, HashCode> inputHashes, ImmutableSortedSet<String> outputPropertyNames) {
+    public BuildCacheKeyInputs(String taskClass, HashCode classLoaderHash, List<HashCode> actionClassLoaderHashes, List<String> actionsTypes, ImmutableSortedMap<String, HashCode> inputHashes, ImmutableSortedSet<String> outputPropertyNames) {
         this.taskClass = taskClass;
         this.inputHashes = inputHashes;
         this.classLoaderHash = classLoaderHash;
         this.actionClassLoaderHashes = actionClassLoaderHashes;
+        this.actionsTypes = actionsTypes;
         this.outputPropertyNames = outputPropertyNames;
     }
 
@@ -60,6 +62,10 @@ public class BuildCacheKeyInputs {
         return actionClassLoaderHashes;
     }
 
+    public List<String> getActionsTypes() {
+        return actionsTypes;
+    }
+
     public Set<String> getOutputPropertyNames() {
         return outputPropertyNames;
     }
@@ -69,6 +75,8 @@ public class BuildCacheKeyInputs {
         return "BuildCacheKeyInputs{"
             + "classLoaderHash=" + classLoaderHash
             + ", actionsClassLoaderHash=" + actionClassLoaderHashes
+            + ", actionsTypes=" + actionsTypes
+            + ", actionsHash=" + actionClassLoaderHashes
             + ", inputHashes=" + inputHashes
             + ", outputPropertyNames=" + outputPropertyNames
             + '}';

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/DefaultTaskOutputCachingBuildCacheKeyBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/DefaultTaskOutputCachingBuildCacheKeyBuilder.java
@@ -37,6 +37,7 @@ public class DefaultTaskOutputCachingBuildCacheKeyBuilder {
     private String taskClass;
     private HashCode classLoaderHash;
     private List<HashCode> actionsClassLoaderHashes;
+    private List<String> actionsTypes;
     private final ImmutableSortedMap.Builder<String, HashCode> inputHashes = ImmutableSortedMap.naturalOrder();
     private final ImmutableSortedSet.Builder<String> outputPropertyNames = ImmutableSortedSet.naturalOrder();
 
@@ -67,6 +68,15 @@ public class DefaultTaskOutputCachingBuildCacheKeyBuilder {
         return this;
     }
 
+    public DefaultTaskOutputCachingBuildCacheKeyBuilder appendActionsTypes(List<String> actionsTypes) {
+        this.actionsTypes = actionsTypes;
+        for (String actionsType : actionsTypes) {
+            hasher.putString(actionsType);
+            log("actionsType", actionsType);
+        }
+        return this;
+    }
+
     public DefaultTaskOutputCachingBuildCacheKeyBuilder appendInputPropertyHash(String propertyName, HashCode hashCode) {
         hasher.putString(propertyName);
         hasher.putBytes(hashCode.asBytes());
@@ -87,7 +97,7 @@ public class DefaultTaskOutputCachingBuildCacheKeyBuilder {
     }
 
     public TaskOutputCachingBuildCacheKey build() {
-        BuildCacheKeyInputs inputs = new BuildCacheKeyInputs(taskClass, classLoaderHash, actionsClassLoaderHashes, inputHashes.build(), outputPropertyNames.build());
+        BuildCacheKeyInputs inputs = new BuildCacheKeyInputs(taskClass, classLoaderHash, actionsClassLoaderHashes, actionsTypes, inputHashes.build(), outputPropertyNames.build());
         if (classLoaderHash == null || actionsClassLoaderHashes.contains(null)) {
             return new DefaultTaskOutputCachingBuildCacheKey(null, inputs);
         }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskCacheKeyCalculator.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskCacheKeyCalculator.java
@@ -33,10 +33,12 @@ public class TaskCacheKeyCalculator {
         DefaultTaskOutputCachingBuildCacheKeyBuilder builder = new DefaultTaskOutputCachingBuildCacheKeyBuilder();
         HashCode taskClassLoaderHash = execution.getTaskClassLoaderHash();
         List<HashCode> taskActionsClassLoaderHashes = execution.getTaskActionsClassLoaderHashes();
+        List<String> taskActionsTypes = execution.getTaskActionsTypes();
 
         builder.appendTaskClass(execution.getTaskClass());
         builder.appendClassloaderHash(taskClassLoaderHash);
         builder.appendActionsClassloaderHashes(taskActionsClassLoaderHashes);
+        builder.appendActionsTypes(taskActionsTypes);
 
         SortedMap<String, ValueSnapshot> inputProperties = execution.getInputProperties();
         for (Map.Entry<String, ValueSnapshot> entry : inputProperties.entrySet()) {


### PR DESCRIPTION
Previously we haven't been tracking the types of additional task actions, and thus we could confuse tasks with different actions. This could have lead to loading results for tasks that weren't actually produced by the same actions.

**Example**

```groovy
someTask {
    if (System.getenv("CI")) {
        doLast {
            // Do something on CI
        }
    } else {
        doLast {
            // Do something else locally
        }
    }
}
```

The classloaders of the two actions are the same, and therefore the results produced by on CI would be interchangeable with results produced locally.