### PR TITLE
Instantiate progress operation children sets lazily

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ProgressOperation.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ProgressOperation.java
@@ -29,7 +29,7 @@ public class ProgressOperation {
     private final String category;
     private final OperationIdentifier operationId;
     private ProgressOperation parent;
-    private final Set<ProgressOperation> children = new HashSet<ProgressOperation>();
+    private Set<ProgressOperation> children;
 
     public ProgressOperation(String shortDescription, String status, String category, OperationIdentifier operationId, ProgressOperation parent) {
         this.shortDescription = shortDescription;
@@ -65,7 +65,21 @@ public class ProgressOperation {
         return parent;
     }
 
-    public Set<ProgressOperation> getChildren() {
-        return children;
+    public boolean addChild(ProgressOperation operation) {
+        if (children == null) {
+            children = new HashSet<ProgressOperation>();
+        }
+        return children.add(operation);
+    }
+
+    public boolean removeChild(ProgressOperation operation) {
+        if (children == null) {
+            throw new IllegalStateException(String.format("Cannot remove child operation [%s] from operation with no children [%s]", operation.getMessage(), getMessage()));
+        }
+        return children.remove(operation);
+    }
+
+    public boolean hasChildren() {
+        return children != null && !children.isEmpty();
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ProgressOperations.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ProgressOperations.java
@@ -32,7 +32,7 @@ public class ProgressOperations {
         }
         ProgressOperation operation = new ProgressOperation(description, status, category, operationId, parent);
         if (parent != null) {
-            parent.getChildren().add(operation);
+            parent.addChild(operation);
         }
         operationsById.put(operationId, operation);
         return operation;
@@ -53,7 +53,7 @@ public class ProgressOperations {
             throw new IllegalStateException("Received complete event for an unknown operation (id: " + operationId + ")");
         }
         if (op.getParent() != null) {
-            op.getParent().getChildren().remove(op);
+            op.getParent().removeChild(op);
         }
         return op;
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/WorkInProgressRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/WorkInProgressRenderer.java
@@ -127,8 +127,7 @@ public class WorkInProgressRenderer extends BatchOutputEventListener {
     }
 
     private void attach(ProgressOperation operation) {
-        // Skip attach if a children is already present
-        if (!operation.getChildren().isEmpty() || !isRenderable(operation)) {
+        if (operation.hasChildren() || !isRenderable(operation)) {
             return;
         }
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ProgressOperationTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ProgressOperationTest.groovy
@@ -43,4 +43,22 @@ class ProgressOperationTest extends Specification {
         expect:
         progressOperation.getMessage() == null
     }
+
+    def "allows children to be managed"() {
+        given:
+        ProgressOperation progressOperation = new ProgressOperation("SHORT_DESCRIPTION", "STATUS", "CATEGORY", new OperationIdentifier(1), null)
+        def mockOperation = Mock(ProgressOperation)
+
+        when:
+        progressOperation.addChild(mockOperation)
+
+        then:
+        progressOperation.hasChildren()
+
+        when:
+        progressOperation.removeChild(mockOperation)
+
+        then:
+        !progressOperation.hasChildren()
+    }
 }


### PR DESCRIPTION
This should incrementally improve performance by avoiding creation
of HashSets when they're never used.

### Context
Found this small optimization while running perf tests

### Contributor Checklist
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches&branch_Gradle_Branches=ew-lazy-sets-in-progress-operations)
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
