### PR TITLE
Add the action types to the SnapshotTaskInputsBuildOperationType.Result

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -66,6 +66,9 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
         // Order corresponds to task action order
         List<String> getActionClassLoaderHashes();
 
+        // Order corresponds to task action order
+        List<String> getActionTypes();
+
         SortedMap<String, String> getInputHashes();
 
         SortedSet<String> getOutputPropertyNames();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuter.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.execution;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
@@ -162,6 +163,11 @@ public class ResolveBuildCacheKeyExecuter implements TaskExecuter {
                     return input.toString();
                 }
             });
+        }
+
+        @Override
+        public List<String> getActionTypes() {
+            return ImmutableList.copyOf(key.getInputs().getActionsTypes());
         }
 
         @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuterTest.groovy
@@ -152,6 +152,12 @@ class ResolveBuildCacheKeyExecuterTest extends Specification {
         adapter.actionClassLoaderHashes == ["ee", "dd"]
 
         when:
+        inputs.actionsTypes >> ["foo", "bar"]
+
+        then:
+        adapter.actionTypes == ["foo", "bar"]
+
+        when:
         inputs.outputPropertyNames >> ["2", "1"].toSet()
 
         then:


### PR DESCRIPTION
After https://github.com/gradle/gradle/pull/2037, this PR is about exposing this new data in the BuildOperation that encapsulates the cache key computation (for the build scan plugin to consume)