### PR TITLE
Fix 'BUILD FAILED' message not displaying at warn or quiet log levels

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildResultLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildResultLogger.java
@@ -41,12 +41,12 @@ public class BuildResultLogger extends BuildAdapter {
     }
 
     public void buildFinished(BuildResult result) {
-        boolean failed = result.getFailure() != null;
+        boolean buildSucceeded = result.getFailure() == null;
 
-        StyledTextOutput textOutput = textOutputFactory.create(BuildResultLogger.class, failed ? LogLevel.ERROR : LogLevel.LIFECYCLE);
+        StyledTextOutput textOutput = textOutputFactory.create(BuildResultLogger.class, buildSucceeded ? LogLevel.LIFECYCLE : LogLevel.ERROR);
         textOutput.println();
         String action = result.getAction().toUpperCase();
-        if (result.getFailure() == null) {
+        if (buildSucceeded) {
             textOutput.withStyle(SuccessHeader).text(action + " SUCCESSFUL");
         } else {
             textOutput.withStyle(FailureHeader).text(action + " FAILED");

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildResultLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildResultLogger.java
@@ -41,7 +41,9 @@ public class BuildResultLogger extends BuildAdapter {
     }
 
     public void buildFinished(BuildResult result) {
-        StyledTextOutput textOutput = textOutputFactory.create(BuildResultLogger.class, LogLevel.LIFECYCLE);
+        boolean failed = result.getFailure() != null;
+
+        StyledTextOutput textOutput = textOutputFactory.create(BuildResultLogger.class, failed ? LogLevel.ERROR : LogLevel.LIFECYCLE);
         textOutput.println();
         String action = result.getAction().toUpperCase();
         if (result.getFailure() == null) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
@@ -49,6 +49,6 @@ class BuildResultLoggerTest extends Specification {
         then:
         1 * clock.getElapsedMillis() >> { 10L }
         1 * durationFormatter.format(10L) >> { "10s" }
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}\n{failureheader}ACTION FAILED{normal} in 10s\n"
+        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{ERROR}\n{failureheader}ACTION FAILED{normal} in 10s\n"
     }
 }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
If a build is being run at `WARN` or at `QUIET` log level, there is no build status message printed at the end.  This is a bit weird in all cases, but especially a problem if the build failed.


### Contributor Checklist
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches&branch_Gradle_Branches=wl-log-failure-as-error)
