### PR TITLE
Remove unnecessary fields from progress events for performance

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ProgressLoggingFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ProgressLoggingFixture.groovy
@@ -53,7 +53,7 @@ class ProgressLoggingFixture extends InitScriptExecuterFixture {
                     } else if (event instanceof ProgressEvent) {
                         outputFile << "[\$event.status]\\n"
                     } else if (event instanceof ProgressCompleteEvent) {
-                        outputFile << "[END \$event.description]\\n"
+                        outputFile << "[END \$event.status]\\n"
                     }
                 }
            }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressCompleteEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressCompleteEvent.java
@@ -18,24 +18,19 @@ package org.gradle.internal.logging.events;
 
 import org.gradle.api.logging.LogLevel;
 
-public class ProgressCompleteEvent extends CategorisedOutputEvent {
+public class ProgressCompleteEvent extends OutputEvent {
+    private final long timestamp;
     private final String status;
-    private final String description;
     private OperationIdentifier progressOperationId;
 
-    public ProgressCompleteEvent(OperationIdentifier progressOperationId, long timestamp, String category, String description, String status) {
-        super(timestamp, category, LogLevel.LIFECYCLE);
+    public ProgressCompleteEvent(OperationIdentifier progressOperationId, long timestamp, String status) {
         this.progressOperationId = progressOperationId;
+        this.timestamp = timestamp;
         this.status = status;
-        this.description = description;
     }
 
     public String getStatus() {
         return status;
-    }
-
-    public String getDescription() {
-        return description;
     }
 
     @Override
@@ -45,5 +40,14 @@ public class ProgressCompleteEvent extends CategorisedOutputEvent {
 
     public OperationIdentifier getProgressOperationId() {
         return progressOperationId;
+    }
+
+    @Override
+    public LogLevel getLogLevel() {
+        return LogLevel.LIFECYCLE;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressEvent.java
@@ -18,12 +18,11 @@ package org.gradle.internal.logging.events;
 
 import org.gradle.api.logging.LogLevel;
 
-public class ProgressEvent extends CategorisedOutputEvent {
+public class ProgressEvent extends OutputEvent {
     private final String status;
     private final OperationIdentifier progressOperationId;
 
-    public ProgressEvent(OperationIdentifier progressOperationId, long timestamp, String category, String status) {
-        super(timestamp, category, LogLevel.LIFECYCLE);
+    public ProgressEvent(OperationIdentifier progressOperationId, String status) {
         this.progressOperationId = progressOperationId;
         this.status = status;
     }
@@ -39,5 +38,10 @@ public class ProgressEvent extends CategorisedOutputEvent {
 
     public OperationIdentifier getProgressOperationId() {
         return progressOperationId;
+    }
+
+    @Override
+    public LogLevel getLogLevel() {
+        return LogLevel.LIFECYCLE;
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
@@ -148,7 +148,7 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
 
         public void progress(String status) {
             assertRunning();
-            listener.progress(new ProgressEvent(progressOperationId, timeProvider.getCurrentTime(), category, toStatus(status)));
+            listener.progress(new ProgressEvent(progressOperationId, toStatus(status)));
         }
 
         public void completed() {
@@ -159,7 +159,7 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
             assertRunning();
             state = State.completed;
             current.set(parent);
-            listener.completed(new ProgressCompleteEvent(progressOperationId, timeProvider.getCurrentTime(), category, description, toStatus(status)));
+            listener.completed(new ProgressCompleteEvent(progressOperationId, timeProvider.getCurrentTime(), toStatus(status)));
         }
 
         private String toStatus(String status) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressCompleteEventSerializer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressCompleteEventSerializer.java
@@ -27,8 +27,6 @@ public class ProgressCompleteEventSerializer implements Serializer<ProgressCompl
     public void write(Encoder encoder, ProgressCompleteEvent event) throws Exception {
         encoder.writeSmallLong(event.getProgressOperationId().getId());
         encoder.writeLong(event.getTimestamp());
-        encoder.writeString(event.getCategory());
-        encoder.writeString(event.getDescription());
         encoder.writeString(event.getStatus());
     }
 
@@ -36,9 +34,7 @@ public class ProgressCompleteEventSerializer implements Serializer<ProgressCompl
     public ProgressCompleteEvent read(Decoder decoder) throws Exception {
         OperationIdentifier id = new OperationIdentifier(decoder.readSmallLong());
         long timestamp = decoder.readLong();
-        String category = decoder.readString();
-        String description = decoder.readString();
         String status = decoder.readString();
-        return new ProgressCompleteEvent(id, timestamp, category, description, status);
+        return new ProgressCompleteEvent(id, timestamp, status);
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressEventSerializer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/ProgressEventSerializer.java
@@ -26,17 +26,13 @@ public class ProgressEventSerializer implements Serializer<ProgressEvent> {
     @Override
     public void write(Encoder encoder, ProgressEvent event) throws Exception {
         encoder.writeSmallLong(event.getProgressOperationId().getId());
-        encoder.writeLong(event.getTimestamp());
-        encoder.writeString(event.getCategory());
         encoder.writeString(event.getStatus());
     }
 
     @Override
     public ProgressEvent read(Decoder decoder) throws Exception {
         OperationIdentifier id = new OperationIdentifier(decoder.readSmallLong());
-        long timestamp = decoder.readLong();
-        String category = decoder.readString();
         String status = decoder.readString();
-        return new ProgressEvent(id, timestamp, category, status);
+        return new ProgressEvent(id, status);
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/OutputSpecification.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/OutputSpecification.groovy
@@ -97,15 +97,15 @@ abstract class OutputSpecification extends Specification {
 
     ProgressEvent progress(String status) {
         long id = counter
-        return new ProgressEvent(new OperationIdentifier(id), tenAm, CATEGORY, status)
+        return new ProgressEvent(new OperationIdentifier(id), status)
     }
 
     ProgressCompleteEvent complete(String status) {
         long id = counter--
-        return new ProgressCompleteEvent(new OperationIdentifier(id), tenAm, CATEGORY, 'description', status)
+        return new ProgressCompleteEvent(new OperationIdentifier(id), tenAm, status)
     }
 
-    ProgressCompleteEvent complete(Long id, category='CATEGORY', description='DESCRIPTION', status='STATUS') {
-        new ProgressCompleteEvent(new OperationIdentifier(id), tenAm, category, description, status)
+    ProgressCompleteEvent complete(Long id, status='STATUS') {
+        new ProgressCompleteEvent(new OperationIdentifier(id), tenAm, status)
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleFunctionalTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleFunctionalTest.groovy
@@ -75,7 +75,7 @@ class ConsoleFunctionalTest extends Specification {
         when:
         currentTimeMs += 2000L;
         renderer.onOutput(completeEvent(2, BuildStatusRenderer.BUILD_PROGRESS_CATEGORY))
-        renderer.onOutput(progressEvent(1, BuildStatusRenderer.BUILD_PROGRESS_CATEGORY, '<=--> 33% CONFIGURING'))
+        renderer.onOutput(progressEvent(1, '<=--> 33% CONFIGURING'))
 
         then:
         ConcurrentTestUtil.poll(1) {
@@ -179,7 +179,7 @@ class ConsoleFunctionalTest extends Specification {
         }
 
         when:
-        renderer.onOutput(progressEvent(2, 'CATEGORY', '[35 / 50] :foo'))
+        renderer.onOutput(progressEvent(2, '[35 / 50] :foo'))
 
         then:
         ConcurrentTestUtil.poll(1) {
@@ -208,7 +208,7 @@ class ConsoleFunctionalTest extends Specification {
         ConcurrentTestUtil.poll(1) {
             assert progressArea.display == ['> :wat', '> :foo', '> :bar', '> :baz', '> :foz']
         }
-        progressArea.buildProgressLabelCount == metaData.rows / 2
+        progressArea.buildProgressLabelCount == (metaData.rows / 2).toInteger()
 
         when:
         renderer.onOutput(completeEvent(1, ':wat'))
@@ -217,7 +217,7 @@ class ConsoleFunctionalTest extends Specification {
         ConcurrentTestUtil.poll(1) {
             assert progressArea.display == ['> :nope', '> :foo', '> :bar', '> :baz', '> :foz']
         }
-        progressArea.buildProgressLabelCount == metaData.rows / 2
+        progressArea.buildProgressLabelCount == (metaData.rows / 2).toInteger()
     }
 
     def "progress display height scales when more work in progress are added"() {
@@ -271,9 +271,9 @@ class ConsoleFunctionalTest extends Specification {
     def "multiple events for same operation are coalesced and rendered once"() {
         when:
         renderer.onOutput(startEvent(1, ':wat'))
-        renderer.onOutput(progressEvent(1, 'CATEGORY', '[1 / 7] :wat'))
-        renderer.onOutput(progressEvent(1, 'CATEGORY', '[2 / 7] :wat'))
-        renderer.onOutput(progressEvent(1, 'CATEGORY', '[3 / 7] :wat'))
+        renderer.onOutput(progressEvent(1, '[1 / 7] :wat'))
+        renderer.onOutput(progressEvent(1, '[2 / 7] :wat'))
+        renderer.onOutput(progressEvent(1, '[3 / 7] :wat'))
 
         then:
         ConcurrentTestUtil.poll(1) {
@@ -283,7 +283,7 @@ class ConsoleFunctionalTest extends Specification {
 
     def "operation that finishes immediately is not rendered"() {
         when:
-        [startEvent(1, ':wat'), progressEvent(1, 'CATEGORY', ':wat'), completeEvent(1, 'CATEGORY', null, ':wat')].each {
+        [startEvent(1, ':wat'), progressEvent(1, ':wat'), completeEvent(1, ':wat')].each {
             renderer.onOutput(it)
         }
 
@@ -313,14 +313,13 @@ class ConsoleFunctionalTest extends Specification {
         new ProgressStartEvent(new OperationIdentifier(id), null, timeProvider.currentTime, null, null, null, null, status, null, null, BuildOperationType.UNCATEGORIZED)
     }
 
-    ProgressEvent progressEvent(Long id, category='CATEGORY', status='STATUS') {
-        long timestamp = timeProvider.currentTime
-        new ProgressEvent(new OperationIdentifier(id), timestamp, category, status)
+    ProgressEvent progressEvent(Long id, status='STATUS') {
+        new ProgressEvent(new OperationIdentifier(id), status)
     }
 
-    ProgressCompleteEvent completeEvent(Long id, category='CATEGORY', description='DESCRIPTION', status='STATUS') {
+    ProgressCompleteEvent completeEvent(Long id, status='STATUS') {
         long timestamp = timeProvider.currentTime
-        new ProgressCompleteEvent(new OperationIdentifier(id), timestamp, category, description, status)
+        new ProgressCompleteEvent(new OperationIdentifier(id), timestamp, status)
     }
 
     private ConsoleStub.TestableRedrawableLabel getStatusBar() {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/progress/DefaultProgressLoggerFactoryTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/progress/DefaultProgressLoggerFactoryTest.groovy
@@ -49,10 +49,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.progress('progress')
 
         then:
-        1 * timeProvider.getCurrentTime() >> 200L
         1 * progressListener.progress(!null) >> { ProgressEvent event ->
-            assert event.timestamp == 200L
-            assert event.category == 'logger'
             assert event.status == 'progress'
         }
 
@@ -63,14 +60,12 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         1 * timeProvider.getCurrentTime() >> 300L
         1 * progressListener.completed(!null) >> { ProgressCompleteEvent event ->
             assert event.timestamp == 300L
-            assert event.category == 'logger'
             assert event.status == 'completed'
         }
     }
 
     def "attaches current running operation as parent when operation is started"() {
         given:
-        def notStarted = factory.newOperation("category").setDescription("ignore-me")
         def completed = factory.newOperation("category").setDescription("ignore-me")
         def child = factory.newOperation("category").setDescription("child")
         def parent = factory.newOperation("category").setDescription("parent")

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressCompleteEventSerializerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressCompleteEventSerializerTest.groovy
@@ -22,7 +22,6 @@ import spock.lang.Subject
 @Subject(ProgressCompleteEventSerializer)
 class ProgressCompleteEventSerializerTest extends LogSerializerSpec {
     private static final long TIMESTAMP = 42L
-    private static final String DESCRIPTION = "description"
     private static final String CATEGORY = "category"
     private static final OperationIdentifier OPERATION_ID = new OperationIdentifier(1234L)
 
@@ -30,7 +29,7 @@ class ProgressCompleteEventSerializerTest extends LogSerializerSpec {
 
     def "can serialize ProgressCompleteEvent messages"() {
         given:
-        def event = new ProgressCompleteEvent(OPERATION_ID, TIMESTAMP, "category", DESCRIPTION, "status")
+        def event = new ProgressCompleteEvent(OPERATION_ID, TIMESTAMP, "status")
 
         when:
         def result = serialize(event, serializer)
@@ -39,13 +38,12 @@ class ProgressCompleteEventSerializerTest extends LogSerializerSpec {
         result instanceof ProgressCompleteEvent
         result.progressOperationId == OPERATION_ID
         result.timestamp == TIMESTAMP
-        result.category == CATEGORY
         result.status == "status"
     }
 
     def "can serialize ProgressCompleteEvent messages with empty fields"() {
         given:
-        def event = new ProgressCompleteEvent(OPERATION_ID, TIMESTAMP, "category", DESCRIPTION, "")
+        def event = new ProgressCompleteEvent(OPERATION_ID, TIMESTAMP, "")
 
         when:
         def result = serialize(event, serializer)
@@ -54,7 +52,6 @@ class ProgressCompleteEventSerializerTest extends LogSerializerSpec {
         result instanceof ProgressCompleteEvent
         result.progressOperationId == OPERATION_ID
         result.timestamp == TIMESTAMP
-        result.category == CATEGORY
         result.status == ""
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressEventSerializerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressEventSerializerTest.groovy
@@ -21,15 +21,13 @@ import spock.lang.Subject
 
 @Subject(ProgressEventSerializer)
 class ProgressEventSerializerTest extends LogSerializerSpec {
-    private static final long TIMESTAMP = 42L
-    private static final String CATEGORY = "category"
     private static final OperationIdentifier OPERATION_ID = new OperationIdentifier(1234L)
 
     ProgressEventSerializer serializer = new ProgressEventSerializer()
 
     def "can serialize ProgressEvent messages"() {
         given:
-        def event = new ProgressEvent(OPERATION_ID, TIMESTAMP, "category", "status")
+        def event = new ProgressEvent(OPERATION_ID, "status")
 
         when:
         def result = serialize(event, serializer)
@@ -37,14 +35,12 @@ class ProgressEventSerializerTest extends LogSerializerSpec {
         then:
         result instanceof ProgressEvent
         result.progressOperationId == OPERATION_ID
-        result.timestamp == TIMESTAMP
-        result.category == CATEGORY
         result.status == "status"
     }
 
     def "can serialize ProgressEvent messages with empty fields"() {
         given:
-        def event = new ProgressEvent(OPERATION_ID, TIMESTAMP, "category", "")
+        def event = new ProgressEvent(OPERATION_ID, "")
 
         when:
         def result = serialize(event, serializer)
@@ -52,8 +48,6 @@ class ProgressEventSerializerTest extends LogSerializerSpec {
         then:
         result instanceof ProgressEvent
         result.progressOperationId == OPERATION_ID
-        result.timestamp == TIMESTAMP
-        result.category == CATEGORY
         result.status == ""
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
@@ -51,7 +51,7 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
 
         then: 0 * _
 
-        when: listener.onOutput(new ProgressCompleteEvent(taskStartEvent.progressOperationId, tenAm, CATEGORY, 'Complete: :foo', null))
+        when: listener.onOutput(new ProgressCompleteEvent(taskStartEvent.progressOperationId, tenAm, null))
 
         then: 1 * downstreamListener.onOutput({ it.toString() == "[null] [category] <Header>> Execute :foo</Header><Normal>${GroupingProgressLogEventGenerator.EOL}</Normal>".toString() })
         then: 1 * downstreamListener.onOutput({ it.toString() == "[WARN] [category] Warning: some deprecation or something" })
@@ -64,8 +64,8 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
         def taskStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), tenAm, CATEGORY, "Execute :foo", ":foo", null, null, new OperationIdentifier(2L), null, BuildOperationType.TASK)
         def subtaskStartEvent = new ProgressStartEvent(new OperationIdentifier(-4L), new OperationIdentifier(-5L), tenAm, CATEGORY, ":foo subtask", "subtask", null, null, new OperationIdentifier(3L), taskStartEvent.buildOperationId, BuildOperationType.UNCATEGORIZED)
         def warningMessage = event('Child task log message', LogLevel.WARN, subtaskStartEvent.buildOperationId)
-        def subTaskCompleteEvent = new ProgressCompleteEvent(subtaskStartEvent.progressOperationId, tenAm, CATEGORY, 'Complete: subtask', 'subtask complete')
-        def taskCompleteEvent = new ProgressCompleteEvent(taskStartEvent.progressOperationId, tenAm, CATEGORY, 'Complete: :foo', 'UP-TO-DATE')
+        def subTaskCompleteEvent = new ProgressCompleteEvent(subtaskStartEvent.progressOperationId, tenAm, 'subtask complete')
+        def taskCompleteEvent = new ProgressCompleteEvent(taskStartEvent.progressOperationId, tenAm, 'UP-TO-DATE')
 
         when: listener.onOutput([taskStartEvent, subtaskStartEvent, warningMessage, subTaskCompleteEvent])
 
@@ -100,8 +100,8 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
         def taskBStartEvent = new ProgressStartEvent(new OperationIdentifier(-5L), new OperationIdentifier(-6L), tenAm, CATEGORY, "Execute :b", ":b", null, null, new OperationIdentifier(3L), null, BuildOperationType.TASK)
         def taskAOutput = event('message for task a', LogLevel.WARN, taskAStartEvent.buildOperationId)
         def taskBOutput = event('message for task b', LogLevel.WARN, taskBStartEvent.buildOperationId)
-        def taskBCompleteEvent = new ProgressCompleteEvent(taskBStartEvent.progressOperationId, tenAm, CATEGORY, 'Complete: :b', null)
-        def taskACompleteEvent = new ProgressCompleteEvent(taskAStartEvent.progressOperationId, tenAm, CATEGORY, 'Complete: :a', 'UP-TO-DATE')
+        def taskBCompleteEvent = new ProgressCompleteEvent(taskBStartEvent.progressOperationId, tenAm, null)
+        def taskACompleteEvent = new ProgressCompleteEvent(taskAStartEvent.progressOperationId, tenAm, 'UP-TO-DATE')
 
         when: listener.onOutput([taskAStartEvent, taskBStartEvent, taskAOutput, taskBOutput, taskBCompleteEvent, taskACompleteEvent])
 


### PR DESCRIPTION
This change removes the category from progress and progress
complete events. They are never used in logging because the
category from the start event is used for generated log messages.

Similarly, the timestamp is removed from progress events as it's
never used.

Finally, the description for progress complete events is never
used.

All of these reduce the serialization burden of a now much-larger
number of progress events, resulting in improved performance.

### Context
This is intended to improve results for the "[abi change on largeJavaMultiProject](https://builds.gradle.org/repository/download/Gradle_Release_Performance_PerformanceTestCoordinatorLinux/2944757:id/results/performance/build/performance-tests/report/tests/assemble-for-abi-change-on-largeJavaMultiProject.html)" performance scenario

[CI Build](https://builds.gradle.org/viewQueued.html?itemId=2950820&tab=queuedBuildOverviewTab)

### Contributor Checklist
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
