### PR TITLE
Make logging faster

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -224,7 +224,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
             new BuildStatusRenderer(
                 new WorkInProgressRenderer(
                         new BuildLogLevelFilterRenderer(
-                            new GroupingProgressLogEventGenerator(new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), timeProvider)),
+                            new GroupingProgressLogEventGenerator(new StyledTextOutputBackedRenderer(console.getBuildOutputArea()))),
                     console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
                 console.getStatusBar(), console, consoleMetaData, timeProvider),
             timeProvider);

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Subject
 class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
     private final OutputEventListener downstreamListener = Mock(OutputEventListener)
     def timeProvider = new MockTimeProvider()
-    @Subject listener = new GroupingProgressLogEventGenerator(downstreamListener, timeProvider)
+    @Subject listener = new GroupingProgressLogEventGenerator(downstreamListener)
 
     def "forwards logs with no group"() {
         given:
@@ -92,11 +92,6 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
         then: 1 * downstreamListener.onOutput({ it.toString() == "[null] [category] " })
         then: 1 * downstreamListener.onOutput(endBuildEvent)
         then: 0 * _
-
-        and:
-        listener.buildOpIdHierarchy.isEmpty()
-        listener.operationsInProgress.isEmpty()
-        listener.progressToBuildOpIdMap.isEmpty()
     }
 
     def "handles multiple simultaneous operations"() {


### PR DESCRIPTION
These changes are aimed to mitigate the recent regressions caused by producing more progress log events. One of them optimizes the client side rendering, the other optimizes how we buffer messages to the client. See the individual commits for more details.