### PR TITLE
Implement a content hash for remapped build scripts

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/CrossBuildScriptCachingIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/CrossBuildScriptCachingIntegrationSpec.groovy
@@ -170,11 +170,7 @@ class CrossBuildScriptCachingIntegrationSpec extends AbstractIntegrationSpec {
         run 'help'
 
         when:
-        root {
-            module1 {
-                'build.gradle'(this.simpleBuild('different contents'))
-            }
-        }
+        file('module1/build.gradle').text = simpleBuild('different contents')
         run 'help'
 
         then:
@@ -520,6 +516,65 @@ task fastTask { }
         hasCachedScripts(commonHash, settingsHash, coreHash, initHash)
         getCompileClasspath(commonHash, 'cp_dsl').length == 1
         getCompileClasspath(commonHash, 'dsl').length == 1
+    }
+
+    def "remapped classes have content hash"() {
+        root {
+            'build.gradle'('''
+
+                void assertContentHash(Object o, Set<String> seen) {
+                    assert (o instanceof org.gradle.scripts.WithContentHash)
+                    // need to get through reflection to bypass the Groovy MOP on closures, which would cause calling the method on the owner instead of the closure itself
+                    def contentHash = o.class.getMethod('getContentHash').invoke(o)
+                    assert contentHash
+                    println "Content hash for ${o.class} = ${contentHash.asHexString()}"
+                    if (!seen.add(contentHash.asHexString())) {
+                       throw new AssertionError("Expected a unique hash, but found duplicate: ${o.contentHash.asHexString()} in $seen")
+                    }
+                }
+                
+                Set<String> seen = []
+    
+                assertContentHash(this, seen)
+            
+                task one {
+                    doLast {
+                        { ->
+                            assertContentHash(owner, seen) // hack to get a handle on the parent closure
+                        }()
+                    }
+                }
+                
+                task two {
+                    def v
+                    v = { assertContentHash(v, seen) }
+                    doFirst(v)
+                }
+                
+                task three {
+                    doLast(new Action() {
+                        void execute(Object o) {
+                            assertContentHash(this, seen)
+                        }
+                    })
+                }
+                
+                task four {
+                    doLast {
+                        def a = new A()
+                        assertContentHash(a, seen)
+                    }
+                }
+                
+                class A {}
+            ''')
+        }
+
+        when:
+        run 'one', 'two', 'three', 'four'
+
+        then:
+        noExceptionThrown()
     }
 
     def "same applied script is compiled once for different projects with different classpath"() {

--- a/subprojects/core/src/main/java/org/gradle/scripts/WithContentHash.java
+++ b/subprojects/core/src/main/java/org/gradle/scripts/WithContentHash.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.scripts;
+
+import org.gradle.internal.hash.HashValue;
+
+/**
+ * This interface is implemented by remapped build scripts.
+ */
+public interface WithContentHash {
+    HashValue getContentHash();
+}


### PR DESCRIPTION
This commit adds a `getContentHash` method on classes which have been rewritten by our remapping build script compiler. This
content hash gives access to a hash of the original class, before it has been remapped. The hash is provided as a lazy `HashValue`.
The value of the hash is stored into the class as a static field, in hex format (to simplify the implementation) and is returned
lazily as a `HashValue`, but the generated `HashValue` is not cached (so subsequent calls to `getContentHash` are going to return
a new `HashValue`). This means that if you don't look at the hash value, there's no overhead to adding the content hash, but there
is at reading it.

See https://github.com/gradle/task-output-cache/issues/644
