### PR TITLE
Document new unexpected behavior due to logging changes

### DIFF
--- a/subprojects/docs/src/docs/userguide/commandLine.xml
+++ b/subprojects/docs/src/docs/userguide/commandLine.xml
@@ -140,7 +140,7 @@
             <term><option>-m</option>, <option>--dry-run</option>
             </term>
             <listitem>
-                <para>Runs the build with all task actions disabled. See <xref linkend="sec:dry_run"/>.
+                <para>Runs the build with all task actions disabled. In order to see which tasks would have been run, you must also include <option>--console=plain</option> or run with a logging level at INFO or higher. See <xref linkend="sec:dry_run"/>.
                 </para>
             </listitem>
         </varlistentry>

--- a/subprojects/docs/src/docs/userguide/commandLineTutorial.xml
+++ b/subprojects/docs/src/docs/userguide/commandLineTutorial.xml
@@ -271,8 +271,8 @@
     <section id="sec:dry_run">
         <title>Dry Run</title>
         <para>Sometimes you are interested in which tasks are executed in which order for a given set of tasks specified on the
-            command line, but you don't want the tasks to be executed. You can use the <option>-m</option> option for this.
-            For example, if you run “<userinput>gradle -m clean compile</userinput>”, you'll see all the tasks that would be
+            command line, but you don't want the tasks to be executed. You can use the <option>-m</option> option in combination with <option>--console=plain</option> for this.
+            For example, if you run “<userinput>gradle -m clean compile --console=plain</userinput>”, you'll see all the tasks that would be
             executed as part of the <literal>clean</literal> and <literal>compile</literal> tasks.
             This is complementary to the <option>tasks</option> task, which shows you the tasks which are available for
             execution.


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
With the new logging framework, by default, tasks with no generated logs do not show up in the console.  A side-effect of this is the following:  
```console
$ gradle build --dry-run

BUILD SUCCESSFUL in 1s
$
```
The output from previous versions of Gradle can still be captured via `--console=plain`:
```console
$ gradle build --dry-run --console plain
:compileJava SKIPPED
:processResources SKIPPED
:classes SKIPPED
:jar SKIPPED
:startScripts SKIPPED
:distTar SKIPPED
:distZip SKIPPED
:assemble SKIPPED
:compileTestJava SKIPPED
:processTestResources SKIPPED
:testClasses SKIPPED
:test SKIPPED
:check SKIPPED
:build SKIPPED

BUILD SUCCESSFUL in 1s
$
```

### Contributor Checklist
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes

### Gradle Core Team Checklist
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
