### PR TITLE
Decouple Play and Twirl versions

### DIFF
--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/PlayTwirlAdapterV22X.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/PlayTwirlAdapterV22X.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.internal.twirl;
+
+import org.gradle.language.twirl.TwirlImports;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+class PlayTwirlAdapterV22X implements VersionedPlayTwirlAdapter {
+
+    // Based on https://github.com/playframework/playframework/blob/2.2.6/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
+    private static final List<String> DEFAULT_JAVA_IMPORTS = Collections.unmodifiableList(Arrays.asList(
+            "play.api.templates._",
+            "play.api.templates.PlayMagic._",
+            "models._",
+            "controllers._",
+            "java.lang._",
+            "java.util._",
+            "scala.collection.JavaConversions._",
+            "scala.collection.JavaConverters._",
+            "play.api.i18n._",
+            "play.core.j.PlayMagicForJava._",
+            "play.mvc._",
+            "play.data._",
+            "play.api.data.Field",
+            "play.mvc.Http.Context.Implicit._"));
+
+    private static final List<String> DEFAULT_SCALA_IMPORTS = Collections.unmodifiableList(Arrays.asList(
+            "play.api.templates._",
+            "play.api.templates.PlayMagic._",
+            "models._",
+            "controllers._",
+            "play.api.i18n._",
+            "play.api.mvc._",
+            "play.api.data._"));
+
+    @Override
+    public List<String> getDefaultImports(TwirlImports language) {
+        return language == TwirlImports.JAVA ? DEFAULT_JAVA_IMPORTS : DEFAULT_SCALA_IMPORTS;
+    }
+}

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/PlayTwirlAdapterV23X.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/PlayTwirlAdapterV23X.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.internal.twirl;
+
+import org.gradle.language.twirl.TwirlImports;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+class PlayTwirlAdapterV23X implements VersionedPlayTwirlAdapter {
+
+    // Based on https://github.com/playframework/playframework/blob/2.4.0/framework/src/build-link/src/main/java/play/TemplateImports.java
+    private static List<String> defaultTemplateImports = Collections.unmodifiableList(
+        Arrays.asList(
+            "models._",
+            "controllers._",
+            "play.api.i18n._",
+            "play.api.templates.PlayMagic._"
+        ));
+
+    private static final List<String> DEFAULT_JAVA_IMPORTS;
+    private static final List<String> DEFAULT_SCALA_IMPORTS;
+    static {
+        List<String> javaImports = new ArrayList<String>();
+        javaImports.addAll(defaultTemplateImports);
+        javaImports.add("java.lang._");
+        javaImports.add("java.util._");
+        javaImports.add("scala.collection.JavaConversions._");
+        javaImports.add("scala.collection.JavaConverters._");
+        javaImports.add("play.core.j.PlayMagicForJava._");
+        javaImports.add("play.mvc._");
+        javaImports.add("play.data._");
+        javaImports.add("play.api.data.Field");
+        javaImports.add("play.mvc.Http.Context.Implicit._");
+        DEFAULT_JAVA_IMPORTS = Collections.unmodifiableList(javaImports);
+
+        List<String> scalaImports = new ArrayList<String>();
+        scalaImports.addAll(defaultTemplateImports);
+        scalaImports.add("play.api.mvc._");
+        scalaImports.add("play.api.data._");
+        DEFAULT_SCALA_IMPORTS = Collections.unmodifiableList(scalaImports);
+    }
+
+    @Override
+    public List<String> getDefaultImports(TwirlImports language) {
+        return language == TwirlImports.JAVA ? DEFAULT_JAVA_IMPORTS : DEFAULT_SCALA_IMPORTS;
+    }
+}

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/PlayTwirlAdapterV26X.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/PlayTwirlAdapterV26X.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.internal.twirl;
+
+import org.gradle.language.twirl.TwirlImports;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+class PlayTwirlAdapterV26X implements VersionedPlayTwirlAdapter {
+
+    // Based on https://github.com/playframework/playframework/blob/2.6.0/framework/src/build-link/src/main/java/play/TemplateImports.java
+    private static List<String> defaultTemplateImports = Collections.unmodifiableList(
+        Arrays.asList(
+            "models._",
+            "controllers._",
+            "play.api.i18n._",
+            "play.api.templates.PlayMagic._"
+        ));
+
+    private static final List<String> DEFAULT_JAVA_IMPORTS;
+    private static final List<String> DEFAULT_SCALA_IMPORTS;
+    static {
+        List<String> minimalJavaImports = new ArrayList<String>();
+        minimalJavaImports.addAll(defaultTemplateImports);
+        minimalJavaImports.add("java.lang._");
+        minimalJavaImports.add("java.util._");
+        minimalJavaImports.add("scala.collection.JavaConverters._");
+        minimalJavaImports.add("play.core.j.PlayMagicForJava._");
+        minimalJavaImports.add("play.mvc._");
+        minimalJavaImports.add("play.api.data.Field");
+        minimalJavaImports.add("play.mvc.Http.Context.Implicit._");
+
+        List<String> defaultJavaImports = new ArrayList<String>();
+        defaultJavaImports.addAll(minimalJavaImports);
+        defaultJavaImports.add("play.data._");
+        defaultJavaImports.add("play.core.j.PlayFormsMagicForJava._");
+        DEFAULT_JAVA_IMPORTS = Collections.unmodifiableList(defaultJavaImports);
+
+        List<String> scalaImports = new ArrayList<String>();
+        scalaImports.addAll(defaultTemplateImports);
+        scalaImports.add("play.api.mvc._");
+        scalaImports.add("play.api.data._");
+        DEFAULT_SCALA_IMPORTS = Collections.unmodifiableList(scalaImports);
+    }
+
+    @Override
+    public List<String> getDefaultImports(TwirlImports language) {
+        return language == TwirlImports.JAVA ? DEFAULT_JAVA_IMPORTS : DEFAULT_SCALA_IMPORTS;
+    }
+}

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompilerAdapterV13X.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompilerAdapterV13X.java
@@ -35,55 +35,27 @@ class TwirlCompilerAdapterV13X extends TwirlCompilerAdapterV10X {
 
     private static final Iterable<String> SHARED_PACKAGES = Arrays.asList("play.twirl.compiler", "scala.io", "scala.util.parsing.input", "scala.collection");
 
-    // Default imports are based on:
-    // https://github.com/playframework/playframework/blob/2.6.0/framework/src/build-link/src/main/java/play/TemplateImports.java
-    private final static List<String> DEFAULT_JAVA_TEMPLATE_IMPORTS;
-    private final static List<String> DEFAULT_SCALA_TEMPLATE_IMPORTS;
-
-    private final static List<String> DEFAULT_TEMPLATE_IMPORTS = Collections.unmodifiableList(
+    // Also available via play.japi.twirl.compiler.TwirlCompiler.DEFAULT_IMPORTS but we would have to grab it via reflection
+    private static final List<String> DEFAULT_TEMPLATE_IMPORTS = Collections.unmodifiableList(
         Arrays.asList(
-            "models._",
-            "controllers._",
-            "play.api.i18n._",
-            "play.api.templates.PlayMagic._",
-            // Based on https://github.com/playframework/twirl/blob/1.3.13/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L156
-            "_root_.play.twirl.api.TwirlFeatureImports._",
-            "_root_.play.twirl.api.TwirlHelperImports._",
-            "_root_.play.twirl.api.Html",
-            "_root_.play.twirl.api.JavaScript",
-            "_root_.play.twirl.api.Txt",
-            "_root_.play.twirl.api.Xml"
+            // Based on https://github.com/playframework/twirl/blob/1.3.13/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L156    
+            "_root_.play.twirl.api.TwirlFeatureImports._", 
+            "_root_.play.twirl.api.TwirlHelperImports._",  
+            "_root_.play.twirl.api.Html",  
+            "_root_.play.twirl.api.JavaScript",    
+            "_root_.play.twirl.api.Txt",   
+            "_root_.play.twirl.api.Xml"    
         ));
 
-    static {
-        List<String> defaultJavaImports = new ArrayList<String>();
-        defaultJavaImports.addAll(DEFAULT_TEMPLATE_IMPORTS);
-        defaultJavaImports.add("java.lang._");
-        defaultJavaImports.add("java.util._");
-        defaultJavaImports.add("scala.collection.JavaConverters._");
-        defaultJavaImports.add("play.core.j.PlayMagicForJava._");
-        defaultJavaImports.add("play.mvc._");
-        defaultJavaImports.add("play.libs.F");
-        defaultJavaImports.add("play.api.data.Field");
-        defaultJavaImports.add("play.mvc.Http.Context.Implicit._");
-        defaultJavaImports.add("play.data._");
-        defaultJavaImports.add("play.core.j.PlayFormsMagicForJava._");
-        DEFAULT_JAVA_TEMPLATE_IMPORTS = Collections.unmodifiableList(defaultJavaImports);
-
-        List<String> scalaImports = new ArrayList<String>();
-        scalaImports.addAll(DEFAULT_TEMPLATE_IMPORTS);
-        scalaImports.add("play.api.mvc._");
-        scalaImports.add("play.api.data._");
-        DEFAULT_SCALA_TEMPLATE_IMPORTS = Collections.unmodifiableList(scalaImports);
-    }
-
-    public TwirlCompilerAdapterV13X(String twirlVersion, String scalaVersion) {
-        super(twirlVersion, scalaVersion);
+    public TwirlCompilerAdapterV13X(String twirlVersion, String scalaVersion, VersionedPlayTwirlAdapter playTwirlAdapter) {
+        super(twirlVersion, scalaVersion, playTwirlAdapter);
     }
 
     @Override
     public ScalaMethod getCompileMethod(ClassLoader cl) throws ClassNotFoundException {
-        // https://github.com/playframework/twirl/blob/1.3.12/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L167
+        // We could do this in Java, which would be easier. However, Twirl only has a Java interface in version 1.3+
+        // If we used Java here then Gradle's TwirlCompiler would need to support both ScalaMethod for Twirl 1.0-1.2 and Java's Method for Twirl 1.3+
+        // Method definition: https://github.com/playframework/twirl/blob/1.3.12/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L167
         return ScalaReflectionUtil.scalaMethod(
             cl,
             "play.twirl.compiler.TwirlCompiler",
@@ -100,13 +72,15 @@ class TwirlCompilerAdapterV13X extends TwirlCompilerAdapterV10X {
     }
 
     @Override
-    public Object[] createCompileParameters(ClassLoader cl, final File file, File sourceDirectory, File destinationDirectory, TwirlImports defaultImports, TwirlTemplateFormat templateFormat, List<String> additionalImports) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+    public Object[] createCompileParameters(ClassLoader cl, File file, File sourceDirectory, File destinationDirectory, TwirlImports defaultPlayImports, TwirlTemplateFormat templateFormat, List<String> additionalImports) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        final List<String> defaultImports = new ArrayList<String>(DEFAULT_TEMPLATE_IMPORTS);
+        defaultImports.addAll(playTwirlAdapter.getDefaultImports(defaultPlayImports));
         return new Object[]{
             file,
             sourceDirectory,
             destinationDirectory,
             templateFormat.getFormatType(),
-            toScalaSeq(CollectionUtils.flattenCollections(getDefaultImports(defaultImports), additionalImports, templateFormat.getTemplateImports()), cl),
+            toScalaSeq(CollectionUtils.flattenCollections(defaultImports, additionalImports, templateFormat.getTemplateImports()), cl),
             toScalaSeq(Collections.emptyList(), cl),
             ScalaCodecMapper.create(cl, "UTF-8"),
             isInclusiveDots(),
@@ -118,18 +92,14 @@ class TwirlCompilerAdapterV13X extends TwirlCompilerAdapterV10X {
         return method.invoke(list);
     }
 
-    private boolean isInclusiveDots() {
-        return false;
-    }
-
-    @Override
-    public Iterable<String> getClassLoaderPackages() {
-        return SHARED_PACKAGES;
+    @Override  
+    public Iterable<String> getClassLoaderPackages() { 
+        return SHARED_PACKAGES;    
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<String> getDependencyNotation() {
+    public List<String> getDependencyNotation() { 
         if (scalaVersion.startsWith("2.12")) {
             // We need scala.util.parsing.input.Positional
             return (List<String>) CollectionUtils.flattenCollections(super.getDependencyNotation(), "org.scala-lang.modules:scala-parser-combinators_2.12:1.0.6");
@@ -138,13 +108,4 @@ class TwirlCompilerAdapterV13X extends TwirlCompilerAdapterV10X {
         }
     }
 
-    @Override
-    protected Collection<String> getDefaultScalaImports() {
-        return DEFAULT_SCALA_TEMPLATE_IMPORTS;
-    }
-
-    @Override
-    protected Collection<String> getDefaultJavaImports() {
-        return DEFAULT_JAVA_TEMPLATE_IMPORTS;
-    }
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompilerAdapterV22X.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompilerAdapterV22X.java
@@ -32,38 +32,14 @@ import java.util.List;
 class TwirlCompilerAdapterV22X extends VersionedTwirlCompilerAdapter {
     private static final Iterable<String> SHARED_PACKAGES = Collections.singleton("play.templates");
 
-    // Based on https://github.com/playframework/playframework/blob/2.2.6/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
-    private static final Collection<String> DEFAULT_JAVA_IMPORTS = Arrays.asList(
-        "play.api.templates._",
-        "play.api.templates.PlayMagic._",
-        "models._",
-        "controllers._",
-        "java.lang._",
-        "java.util._",
-        "scala.collection.JavaConversions._",
-        "scala.collection.JavaConverters._",
-        "play.api.i18n._",
-        "play.core.j.PlayMagicForJava._",
-        "play.mvc._",
-        "play.data._",
-        "play.api.data.Field",
-        "play.mvc.Http.Context.Implicit._");
-
-    private static final Collection<String> DEFAULT_SCALA_IMPORTS = Arrays.asList(
-        "play.api.templates._",
-        "play.api.templates.PlayMagic._",
-        "models._",
-        "controllers._",
-        "play.api.i18n._",
-        "play.api.mvc._",
-        "play.api.data._");
-
     private final String twirlVersion;
     private final String scalaVersion;
+    private final VersionedPlayTwirlAdapter playTwirlAdapter;
 
-    public TwirlCompilerAdapterV22X(String twirlVersion, String scalaVersion) {
+    public TwirlCompilerAdapterV22X(String twirlVersion, String scalaVersion, VersionedPlayTwirlAdapter playTwirlAdapter) {
         this.twirlVersion = twirlVersion;
         this.scalaVersion = scalaVersion;
+        this.playTwirlAdapter = playTwirlAdapter;
     }
 
     @Override
@@ -82,12 +58,7 @@ class TwirlCompilerAdapterV22X extends VersionedTwirlCompilerAdapter {
 
     @Override
     public Object[] createCompileParameters(ClassLoader cl, File file, File sourceDirectory, File destinationDirectory, TwirlImports defaultImports, TwirlTemplateFormat templateFormat, List<String> additionalImports) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        final Collection<String> defaultTwirlImports;
-        if (defaultImports == TwirlImports.JAVA) {
-            defaultTwirlImports = DEFAULT_JAVA_IMPORTS;
-        } else {
-            defaultTwirlImports = DEFAULT_SCALA_IMPORTS;
-        }
+        final Collection<String> defaultTwirlImports = playTwirlAdapter.getDefaultImports(defaultImports);
         return new Object[] {
                 file,
                 sourceDirectory,

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompilerFactory.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompilerFactory.java
@@ -28,25 +28,36 @@ public class TwirlCompilerFactory {
     public static VersionedTwirlCompilerAdapter createAdapter(PlayPlatform playPlatform) {
         String playVersion = playPlatform.getPlayVersion();
         String scalaCompatibilityVersion = playPlatform.getScalaPlatform().getScalaCompatibilityVersion();
+        VersionedPlayTwirlAdapter playTwirlAdapter = createPlayTwirlAdapter(playPlatform);
         switch (PlayMajorVersion.forPlatform(playPlatform)) {
             case PLAY_2_2_X:
-                return new TwirlCompilerAdapterV22X("2.2.6", scalaCompatibilityVersion);
+                return new TwirlCompilerAdapterV22X("2.2.6", scalaCompatibilityVersion, playTwirlAdapter);
             case PLAY_2_3_X:
-                return new TwirlCompilerAdapterV10X("1.0.4", scalaCompatibilityVersion);
+                return new TwirlCompilerAdapterV10X("1.0.4", scalaCompatibilityVersion, playTwirlAdapter);
             case PLAY_2_4_X:
             case PLAY_2_5_X:
-                return new TwirlCompilerAdapterV10X("1.1.1", scalaCompatibilityVersion);
+                return new TwirlCompilerAdapterV10X("1.1.1", scalaCompatibilityVersion, playTwirlAdapter);
             case PLAY_2_6_X:
-                // TODO: create a TwirlJavaCompiler for Twirl 1.3.x that uses the Java compiler interface
-                // Rename TwirlCompiler to TwirlScalaCompiler
-                // Waiting for https://github.com/playframework/twirl/pull/136
-                // and https://github.com/gradle/gradle/pull/2062
-                // We don't want to use the legacy TwirlScalaCompiler for Twirl 3.0 because the interface is more
-                // complicated and it would be really frustrating to deal with typed parameters via reflection,
-                // to create Scala Seqs in Java, etc.
-                return new TwirlCompilerAdapterV13X("1.3.13", scalaCompatibilityVersion);
+                return new TwirlCompilerAdapterV13X("1.3.13", scalaCompatibilityVersion, playTwirlAdapter);
             default:
                 throw new RuntimeException("Could not create Twirl compile spec for Play version: " + playVersion);
         }
     }
+
+    public static VersionedPlayTwirlAdapter createPlayTwirlAdapter(PlayPlatform playPlatform) {
+        String playVersion = playPlatform.getPlayVersion();
+        switch (PlayMajorVersion.forPlatform(playPlatform)) {
+            case PLAY_2_2_X:
+                return new PlayTwirlAdapterV22X();
+            case PLAY_2_3_X:
+            case PLAY_2_4_X:
+            case PLAY_2_5_X:
+                return new PlayTwirlAdapterV23X();
+            case PLAY_2_6_X:
+                return new PlayTwirlAdapterV26X();
+            default:
+                throw new RuntimeException("Could not create Twirl adapter spec for Play version: " + playVersion);
+        }
+    }
+
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/VersionedPlayTwirlAdapter.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/VersionedPlayTwirlAdapter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.internal.twirl;
+
+import org.gradle.language.twirl.TwirlImports;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Returns template info for a specifc Play version.
+ */
+public interface VersionedPlayTwirlAdapter extends Serializable {
+
+    List<String> getDefaultImports(TwirlImports language);
+
+}


### PR DESCRIPTION
### Context

This change fixes support for Play 2.6 which is currently using the Play 2.3 import list.

This also theoretically makes it so that you can use varying versions of Twirl with a given version of Play, which is something that makes upgrades between Play versions easier, allows for pulling in bug fixes for Twirl separately, and is something supported by the SBT plugin.

This changes the imports to a List from which the concatenated string version is then constructed. This change is necessary because Twirl 1.3 expects a List. (Well maybe not strictly necessary as I could explode the concatenated string version into a List, but that wouldn't be as clean)

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [X] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [N/A] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [N/A] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew :platformPlay:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
