### PR TITLE
Avoid notifying lock waiters when we roll back locks

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/AbstractTrackedResourceLock.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/AbstractTrackedResourceLock.java
@@ -60,7 +60,7 @@ public abstract class AbstractTrackedResourceLock implements ResourceLock {
             releaseLock();
             LOGGER.debug("{}: released lock on {}", Thread.currentThread().getName(), displayName);
             unlockAction.execute(this);
-            coordinationService.notifyStateChange();
+            coordinationService.getCurrent().registerUnlocked(this);
         }
     }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockCoordinationService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockCoordinationService.java
@@ -43,9 +43,4 @@ public interface ResourceLockCoordinationService {
      * @return true if the lock state changes finished successfully, otherwise false.
      */
     boolean withStateLock(Transformer<ResourceLockState.Disposition, ResourceLockState> stateLockAction);
-
-    /**
-     * Notify the coordinator that the resource lock state has changed in some way.
-     */
-    void notifyStateChange();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockState.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockState.java
@@ -29,4 +29,12 @@ public interface ResourceLockState {
      * @param resourceLock
      */
     void registerLocked(ResourceLock resourceLock);
+
+    /**
+     * Registers a resource lock that has been unlocked during the transform so that the coordination service can
+     * notify threads waiting on a lock.
+     *
+     * @param resourceLock
+     */
+    void registerUnlocked(ResourceLock resourceLock);
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/DefaultResourceLockCoordinationServiceTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/DefaultResourceLockCoordinationServiceTest.groovy
@@ -92,7 +92,13 @@ class DefaultResourceLockCoordinationServiceTest extends ConcurrentSpec {
             }
 
             lock2.lockedState = false
-            coordinationService.notifyStateChange()
+            coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
+                @Override
+                ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {
+                    resourceLockState.registerUnlocked(lock2)
+                    return FINISHED
+                }
+            })
 
             thread.blockUntil.executed2
         }


### PR DESCRIPTION
This changes the lock coordination service so that when it rolls back locks we aren't notifying lock waiters to retry their locks.  In other words, we only notify waiters when we actually transition a lock from a locked state to an unlocked state.