### PR TITLE
Support for functionally testing rich console output

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractConsoleFunctionalSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractConsoleFunctionalSpec.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+/**
+ * A base class for testing the console in rich mode. Executes with a Gradle distribution and {@code "--console=rich"} command line option.
+ * <p>
+ * <b>Note:</b> The console output contains formatting characters.
+ */
+class AbstractConsoleFunctionalSpec extends AbstractIntegrationSpec {
+
+    def setup() {
+        executer.requireGradleDistribution().withRichConsole()
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -947,13 +947,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
             int expectedDeprecationWarnings = AbstractGradleExecuter.this.expectedDeprecationWarnings;
             boolean expectStackTraces = !AbstractGradleExecuter.this.stackTraceChecksOn;
             boolean checkDeprecations = AbstractGradleExecuter.this.checkDeprecations;
-            boolean useRichConsole = AbstractGradleExecuter.this.useRichConsole;
 
             @Override
             public void execute(ExecutionResult executionResult) {
-                if (!useRichConsole) {
-                    validate(executionResult.getNormalizedOutput(), "Standard output");
-                }
+                validate(executionResult.getNormalizedOutput(), "Standard output");
                 String error = executionResult.getError();
                 if (executionResult instanceof ExecutionFailure) {
                     // Axe everything after the expected exception

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -124,6 +124,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private boolean useOnlyRequestedJvmOpts;
     private boolean requiresGradleDistribution;
     private boolean useOwnUserHomeServices;
+    private boolean useRichConsole;
 
     private int expectedDeprecationWarnings;
     private boolean eagerClassLoaderCreationChecksOn = true;
@@ -201,6 +202,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         interactive = false;
         checkDeprecations = true;
         durationMeasurement = null;
+        useRichConsole = false;
         return this;
     }
 
@@ -334,6 +336,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
         if (durationMeasurement != null) {
             executer.withDurationMeasurement(durationMeasurement);
+        }
+
+        if (useRichConsole) {
+            executer.withRichConsole();
         }
 
         return executer;
@@ -656,6 +662,12 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return this;
     }
 
+    @Override
+    public GradleExecuter withRichConsole() {
+        useRichConsole = true;
+        return this;
+    }
+
     /**
      * Performs cleanup at completion of the test.
      */
@@ -771,6 +783,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         if (getGradleUserHomeDir() != null) {
             allArgs.add("--gradle-user-home");
             allArgs.add(getGradleUserHomeDir().getAbsolutePath());
+        }
+
+        if (useRichConsole) {
+            allArgs.add("--console=rich");
         }
 
         allArgs.addAll(args);
@@ -931,10 +947,13 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
             int expectedDeprecationWarnings = AbstractGradleExecuter.this.expectedDeprecationWarnings;
             boolean expectStackTraces = !AbstractGradleExecuter.this.stackTraceChecksOn;
             boolean checkDeprecations = AbstractGradleExecuter.this.checkDeprecations;
+            boolean useRichConsole = AbstractGradleExecuter.this.useRichConsole;
 
             @Override
             public void execute(ExecutionResult executionResult) {
-                validate(executionResult.getNormalizedOutput(), "Standard output");
+                if (!useRichConsole) {
+                    validate(executionResult.getNormalizedOutput(), "Standard output");
+                }
                 String error = executionResult.getError();
                 if (executionResult instanceof ExecutionFailure) {
                     // Axe everything after the expected exception

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -18,6 +18,7 @@ package org.gradle.integtests.fixtures.executer;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.integtests.fixtures.AbstractConsoleFunctionalSpec;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.test.fixtures.file.TestFile;
@@ -407,4 +408,11 @@ public interface GradleExecuter extends Stoppable {
      * </p>
      */
     GradleExecuter withOwnUserHomeServices();
+
+    /**
+     * Executes the build with {@code "--console=rich"} argument.
+     *
+     * @see AbstractConsoleFunctionalSpec
+     */
+    GradleExecuter withRichConsole();
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
@@ -18,10 +18,17 @@ package org.gradle.internal.logging
 
 import org.gradle.integtests.fixtures.AbstractConsoleFunctionalSpec
 
+import static org.gradle.util.TextUtil.normaliseFileSeparators
+
 class ConsoleTaskGroupingFunctionalTest extends AbstractConsoleFunctionalSpec {
+
+    private static final String JAVA_SRC_DIR_PATH = 'src/main/java'
 
     def "compiler warnings emitted from compilation task are grouped"() {
         given:
+        def javaSourceFile = file("$JAVA_SRC_DIR_PATH/MyClass.java")
+        def normalizedJavaSourceFilePath = normaliseFileSeparators(javaSourceFile.absolutePath)
+
         buildFile << """
             apply plugin: 'java'
 
@@ -30,12 +37,12 @@ class ConsoleTaskGroupingFunctionalTest extends AbstractConsoleFunctionalSpec {
             }
         """
 
-        file('src/main/java/Legacy.java') << """
+        file("$JAVA_SRC_DIR_PATH/Legacy.java") << """
             @Deprecated
             public class Legacy { }
         """
 
-        file('src/main/java/MyClass.java') << """
+        file("$JAVA_SRC_DIR_PATH/MyClass.java") << """
             public class MyClass {
                 public void instantiateDeprecatedClass() {
                     new Legacy();
@@ -48,7 +55,7 @@ class ConsoleTaskGroupingFunctionalTest extends AbstractConsoleFunctionalSpec {
 
         then:
         result.output.contains("""> Task :compileJava\u001B[m\u001B[0K
-$testDirectory/src/main/java/MyClass.java:4: warning: [deprecation] Legacy in unnamed package has been deprecated
+$normalizedJavaSourceFilePath:4: warning: [deprecation] Legacy in unnamed package has been deprecated
                     new Legacy();
                         ^
 1 warning""")

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
@@ -31,6 +31,7 @@ class ConsoleTaskGroupingFunctionalTest extends AbstractConsoleFunctionalSpec {
     def "compiler warnings emitted from compilation task are grouped"() {
         given:
         def javaSourceFile = file("$JAVA_SRC_DIR_PATH/MyClass.java")
+        def normalizedJavaSourceFilePath = normaliseFileSeparators(javaSourceFile.absolutePath)
 
         buildFile << """
             apply plugin: 'java'
@@ -57,10 +58,9 @@ class ConsoleTaskGroupingFunctionalTest extends AbstractConsoleFunctionalSpec {
         succeeds('compileJava')
 
         then:
-        normaliseFileSeparators(result.output).contains("""> Task :compileJava\u001B[m\u001B[0K
-$javaSourceFile:4: warning: [deprecation] Legacy in unnamed package has been deprecated
-                    new Legacy();
-                        ^
-1 warning""")
+        def matcher = result.output =~ /(?ms)(> Task :compileJava.*?1 warning)/
+        matcher.find()
+        def expectedOutput = matcher[0][1]
+        normaliseFileSeparators(expectedOutput).contains("${normalizedJavaSourceFilePath}:4: warning: [deprecation] Legacy in unnamed package has been deprecated")
     }
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
@@ -24,6 +24,10 @@ class ConsoleTaskGroupingFunctionalTest extends AbstractConsoleFunctionalSpec {
 
     private static final String JAVA_SRC_DIR_PATH = 'src/main/java'
 
+    def setup() {
+        executer.expectDeprecationWarning()
+    }
+
     def "compiler warnings emitted from compilation task are grouped"() {
         given:
         def javaSourceFile = file("$JAVA_SRC_DIR_PATH/MyClass.java")

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
@@ -27,7 +27,6 @@ class ConsoleTaskGroupingFunctionalTest extends AbstractConsoleFunctionalSpec {
     def "compiler warnings emitted from compilation task are grouped"() {
         given:
         def javaSourceFile = file("$JAVA_SRC_DIR_PATH/MyClass.java")
-        def normalizedJavaSourceFilePath = normaliseFileSeparators(javaSourceFile.absolutePath)
 
         buildFile << """
             apply plugin: 'java'
@@ -54,8 +53,8 @@ class ConsoleTaskGroupingFunctionalTest extends AbstractConsoleFunctionalSpec {
         succeeds('compileJava')
 
         then:
-        result.output.contains("""> Task :compileJava\u001B[m\u001B[0K
-$normalizedJavaSourceFilePath:4: warning: [deprecation] Legacy in unnamed package has been deprecated
+        normaliseFileSeparators(result.output).contains("""> Task :compileJava\u001B[m\u001B[0K
+$javaSourceFile:4: warning: [deprecation] Legacy in unnamed package has been deprecated
                     new Legacy();
                         ^
 1 warning""")

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleTaskGroupingFunctionalTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging
+
+import org.gradle.integtests.fixtures.AbstractConsoleFunctionalSpec
+
+class ConsoleTaskGroupingFunctionalTest extends AbstractConsoleFunctionalSpec {
+
+    def "compiler warnings emitted from compilation task are grouped"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+
+            compileJava {
+                options.compilerArgs = ['-Xlint:all']
+            }
+        """
+
+        file('src/main/java/Legacy.java') << """
+            @Deprecated
+            public class Legacy { }
+        """
+
+        file('src/main/java/MyClass.java') << """
+            public class MyClass {
+                public void instantiateDeprecatedClass() {
+                    new Legacy();
+                }
+            }
+        """
+
+        when:
+        succeeds('compileJava')
+
+        then:
+        result.output.contains("""> Task :compileJava\u001B[m\u001B[0K
+$testDirectory/src/main/java/MyClass.java:4: warning: [deprecation] Legacy in unnamed package has been deprecated
+                    new Legacy();
+                        ^
+1 warning""")
+    }
+}


### PR DESCRIPTION
### Context

We need to stronger functional test support for rich console output.

This is how a sample output would look like (ignore the ? marks assuming they are control characters):

```
[1A[1m<-------------> 0% INITIALIZING [0s][m[36D[1B[1A[1m<-------------> 0% CONFIGURING [1s][m[0K[35D[1B[1A[1m<-------------> 0% EXECUTING [2s][m[0K[33D[1B[1A[1m> Task :compileJava[m[0K
/Users/bmuschko/dev/projects/gradle/build/tmp/test files/ConsoleTaskGroupingIntegrationTest/compiler_warnings_are_grouped/z9yxc/src/main/java/MyClass.java:4: warning: [deprecation] Legacy in unnamed package has been deprecated
                    new Legacy();
                        ^
1 warning


BUILD SUCCESSFUL in 2s
1 actionable task: 1 executed
[2K
```

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
