### PR TITLE
Add org.gradle.logging.level to release notes

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -280,7 +280,7 @@ Ivy plugin repositories now support the same API for patterns and layouts that I
 The Java version used by Groovy compilation influences the compiled Groovy and Java classes for the `GroovyCompile` task.
 Gradle now tracks changes to this version and recompiles whenever necessary.
 
-### Choose a log level via Gradle property
+### Configure log level using Gradle properties
 
 Gradle now allows you to specify the log level as a Gradle property, allowing a default log level to be set for a project, a machine, etc.  See the [user guide](userguide/build_environment.html#sec:gradle_configuration_properties) for more information.
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -275,10 +275,14 @@ This will take advantage of performance optimizations in the latest [Zinc](https
 
 Ivy plugin repositories now support the same API for patterns and layouts that Ivy artifact repositories support.
 
-## Track Java version for Groovy compilation
+### Track Java version for Groovy compilation
 
 The Java version used by Groovy compilation influences the compiled Groovy and Java classes for the `GroovyCompile` task.
 Gradle now tracks changes to this version and recompiles whenever necessary.
+
+### Choose a log level via Gradle property
+
+Gradle now allows you to specify the log level as a Gradle property, allowing a default log level to be set for a project, a machine, etc.  See the [user guide](userguide/build_environment.html#sec:gradle_configuration_properties) for more information.
 
 <!--
 ### Example new and noteworthy

--- a/subprojects/docs/src/docs/userguide/buildEnvironment.xml
+++ b/subprojects/docs/src/docs/userguide/buildEnvironment.xml
@@ -80,7 +80,7 @@
             </varlistentry>
             <varlistentry>
                 <term><literal>org.gradle.logging.level</literal></term>
-                    <listitem><para>When set to quiet, warn, lifecycle, info, or debug, Gradle will use this logging level.  This property is case insensitive.
+                    <listitem><para>When set to quiet, warn, lifecycle, info, or debug, Gradle will use this log level.  The values are not case sensitive.
                         See <xref linkend="sec:choosing_a_log_level"/>.</para>
                     </listitem>
             </varlistentry>

--- a/subprojects/docs/src/docs/userguide/logging.xml
+++ b/subprojects/docs/src/docs/userguide/logging.xml
@@ -63,7 +63,7 @@
     <section id="sec:choosing_a_log_level">
         <title>Choosing a log level</title>
         <para>You can use the command line switches shown in <xref linkend='logLevelCommandLineOptions'/> to choose
-            different log levels. You can also set the log level using <xref linkend="sec:gradle_configuration_properties"/>. In <xref linkend='stacktraces'/> you find the command line switches which affect
+            different log levels. You can also configure the log level using gradle.properties, see <xref linkend="sec:gradle_configuration_properties"/>. In <xref linkend='stacktraces'/> you find the command line switches which affect
             stacktrace logging.
         </para>
         <table id='logLevelCommandLineOptions'>


### PR DESCRIPTION
Add #1919 to release notes.

### Contributor Checklist
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes

### Gradle Core Team Checklist
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
