### PR TITLE
Optimize serialization of empty logging operation ids

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class DefaultBuildOperationExecutor implements BuildOperationExecutor, Stoppable {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultBuildOperationExecutor.class);
     private static final String LINE_SEPARATOR = SystemProperties.getInstance().getLineSeparator();
+    private static final long ROOT_BUILD_OPERATION_ID_VALUE = 1L;
 
     private final BuildOperationListener listener;
     private final TimeProvider timeProvider;
@@ -63,7 +64,7 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
     private final BuildOperationQueueFactory buildOperationQueueFactory;
     private final StoppableExecutor fixedSizePool;
 
-    private final AtomicLong nextId = new AtomicLong();
+    private final AtomicLong nextId = new AtomicLong(ROOT_BUILD_OPERATION_ID_VALUE);
     private final ThreadLocal<DefaultBuildOperationState> currentOperation = new ThreadLocal<DefaultBuildOperationState>();
 
     public DefaultBuildOperationExecutor(BuildOperationListener listener, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory,
@@ -250,7 +251,8 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
      */
     protected void createRunningRootOperation(String displayName) {
         assert currentOperation.get() == null;
-        DefaultBuildOperationState operation = new DefaultBuildOperationState(BuildOperationDescriptor.displayName(displayName).build(new OperationIdentifier(0), null), timeProvider.getCurrentTime());
+        OperationIdentifier rootBuildOpId = new OperationIdentifier(ROOT_BUILD_OPERATION_ID_VALUE);
+        DefaultBuildOperationState operation = new DefaultBuildOperationState(BuildOperationDescriptor.displayName(displayName).build(rootBuildOpId, null), timeProvider.getCurrentTime());
         operation.setRunning(true);
         currentOperation.set(operation);
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
@@ -45,7 +45,7 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
         return new BuildOperationState() {
             @Override
             public Object getId() {
-                return new OperationIdentifier(0);
+                return new OperationIdentifier(1L);
             }
 
             @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/OperationIdentifier.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/OperationIdentifier.java
@@ -16,12 +16,15 @@
 
 package org.gradle.internal.logging.events;
 
+import com.google.common.base.Preconditions;
+
 import java.io.Serializable;
 
 public class OperationIdentifier implements Serializable {
     private final long id;
 
     public OperationIdentifier(long id) {
+        Preconditions.checkArgument(id != 0, "Operation ID value must be non-zero");
         this.id = id;
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/ProgressLoggerFactory.java
@@ -22,7 +22,7 @@ import org.gradle.internal.progress.BuildOperationDescriptor;
  * Thread-safe, however the progress logger instances created are not.
  */
 public interface ProgressLoggerFactory {
-    long ROOT_PROGRESS_OPERATION_ID = -1;
+    long ROOT_PROGRESS_OPERATION_ID = 1;
 
     /**
      * Creates a new long-running operation which has not been started.

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/events/OperationIdentifierTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/events/OperationIdentifierTest.groovy
@@ -1,0 +1,21 @@
+package org.gradle.internal.logging.events
+
+import spock.lang.Specification
+
+class OperationIdentifierTest extends Specification {
+    def "allows instantiation with non-zero values"() {
+        expect:
+        new OperationIdentifier(-1).getId() == -1
+        new OperationIdentifier(1).getId() == 1
+        new OperationIdentifier(Long.MAX_VALUE).getId() == Long.MAX_VALUE
+        new OperationIdentifier(Long.MIN_VALUE).getId() == Long.MIN_VALUE
+    }
+
+    def "disallows instantiation with a value of 0"() {
+        when:
+        new OperationIdentifier(0)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}


### PR DESCRIPTION
This reserves 0 as a special operation id value and changes all
construction of OperationIdentifiers to avoid a 0 value. This
allows for compact serialization of progress and build operation
ids because we can serialize a 0 value and deserialize as empty.

### Context
This further addresses any remaining performance regressions from logging changes in 4.0

### Contributor Checklist
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
