### PR TITLE
Make HP sampling interval configurable

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/testing/PerformanceTest.java
+++ b/buildSrc/src/main/groovy/org/gradle/testing/PerformanceTest.java
@@ -111,4 +111,9 @@ public class PerformanceTest extends DistributionTest {
             systemProperty("org.gradle.performance.honestprofiler", artifactsDirectory.getAbsolutePath());
         }
     }
+
+    @Option(option = "sampling-interval", description = "How many ms to wait between two samples when profiling")
+    public void setSamplingInterval(String samplingInterval) {
+        systemProperty("org.gradle.performance.samplinginterval", samplingInterval);
+    }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/HonestProfilerCollector.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/HonestProfilerCollector.groovy
@@ -31,12 +31,13 @@ class HonestProfilerCollector implements DataCollector {
     // if set, this system property must point to the directory where log files will be copied
     // and flame graphs generated
     public static final String HONESTPROFILER_KEY = "org.gradle.performance.honestprofiler"
+    public static final String SAMPLING_INTERVAL_KEY = "org.gradle.performance.samplinginterval"
 
     boolean enabled = System.getProperty(HONESTPROFILER_KEY) != null
     int honestProfilerPort = AvailablePortFinder.getNextAvailable(18080)
     String honestProfilerHost = '127.0.0.1'
     int maxFrames = 1024
-    int interval = 7
+    int interval = Integer.getInteger(SAMPLING_INTERVAL_KEY, 7)
     boolean initiallyStopped = true
     boolean autoStartStop = true
     private File logFile


### PR DESCRIPTION
This will help analyze short-running scenarios like `gradle help`, where the default sampling rate was too low.

Here's a build using the new option: https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Branches_Performance_AdHocPerformanceScenarioLinux&branch_Gradle_Branches_Performance=so-sampling-interval&tab=buildTypeStatusDiv