### PR TITLE
Fix Wtp Component File Version

### DIFF
--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiWtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiWtpComponent.xml
@@ -1,4 +1,4 @@
-<project-modules id="moduleCoreId" project-version="2.0">
+<project-modules id="moduleCoreId" project-version="1.5.0">
 	<wb-module deploy-name="api">
 		<wb-resource deploy-path="/" source-path="src/main/java"/>
 		<wb-resource deploy-path="/" source-path="src/main/resources"/>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonWtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonWtpComponent.xml
@@ -1,4 +1,4 @@
-<project-modules id="moduleCoreId" project-version="2.0">
+<project-modules id="moduleCoreId" project-version="1.5.0">
 	<wb-module deploy-name="common">
 		<wb-resource deploy-path="/" source-path="src/main/java"/>
 		<wb-resource deploy-path="/" source-path="src/main/resources"/>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6WtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6WtpComponent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project-modules id="moduleCoreId" project-version="2.0">
+<project-modules id="moduleCoreId" project-version="1.5.0">
 	<wb-module deploy-name="webAppJava6">
 		<property name="context-root" value="webAppJava6"/>
 		<wb-resource deploy-path="/WEB-INF/classes" source-path="src/main/java"/>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsWtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsWtpComponent.xml
@@ -1,4 +1,4 @@
-<project-modules id="moduleCoreId" project-version="2.0">
+<project-modules id="moduleCoreId" project-version="1.5.0">
 	<wb-module deploy-name="webAppWithVars">
 		<property name="context-root" value="webAppWithVars"/>
 		<wb-resource deploy-path="/WEB-INF/classes" source-path="src/main/java"/>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceWtpComponent.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceWtpComponent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project-modules id="moduleCoreId" project-version="2.0">
+<project-modules id="moduleCoreId" project-version="1.5.0">
 	<wb-module deploy-name="webservice">
 		<property name="context-root" value="webservice"/>
 		<wb-resource deploy-path="/WEB-INF/classes" source-path="src/main/java"/>

--- a/subprojects/ide/src/main/resources/org/gradle/plugins/ide/eclipse/model/defaultWtpComponent.xml
+++ b/subprojects/ide/src/main/resources/org/gradle/plugins/ide/eclipse/model/defaultWtpComponent.xml
@@ -1,3 +1,3 @@
-<project-modules id="moduleCoreId" project-version="2.0">
+<project-modules id="moduleCoreId" project-version="1.5.0">
     <wb-module/>
 </project-modules>


### PR DESCRIPTION
The wtp component file that was generated out of nowhere (no file already present before running the task) generated a version of 2.0.
Current Eclipse Neon (seen this behavior also in Kepler) has a version of 1.5.0 if Eclipse generates this file.
Having 2.0 in this file triggers the bug (or behavior) described in https://bugs.eclipse.org/bugs/show_bug.cgi?id=416346.

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] (n/a) [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] (n/a) Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] (n/a) Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes