### PR TITLE
Add some basic functional tests asserting task output grouping

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractConsoleFunctionalSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractConsoleFunctionalSpec.groovy
@@ -46,6 +46,24 @@ class AbstractConsoleFunctionalSpec extends AbstractIntegrationSpec {
         return styledString
     }
 
+    /**
+     * Grabs the grouped output of a task
+     * @param taskName a fully qualified task name e.g. :project:task1
+     * @return
+     */
+    protected String taskOutputFrom(String taskName) {
+        // Starting with >, including the task name, and going till the first new line
+        def taskHeader = "> Task $taskName[^\\n]*\n"
+        // Start of the next task
+        def taskFooter = "\n\n[^\\n]*> Task"
+        // End of the build, or the build failure message
+        def buildFooter = "\n\n\n[^\\n]*(BUILD SUCCESSFUL|BUILD FAILED|FAILURE:)"
+        //Find all output between the header and footer
+        def matcher = result.output =~ /(?msU)\$taskHeader(.*?)(\$taskFooter|\$buildFooter)/
+
+        return matcher[0][1]
+    }
+
     def setup() {
         executer.requireGradleDistribution().withRichConsole()
     }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/BasicGroupedTaskLoggingFunctionalSpec.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/BasicGroupedTaskLoggingFunctionalSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging
+
+import org.gradle.integtests.fixtures.AbstractConsoleFunctionalSpec
+
+class BasicGroupedTaskLoggingFunctionalSpec extends AbstractConsoleFunctionalSpec {
+
+    def "Parallel tasks logs are still grouped by task"() {
+        given:
+        settingsFile << "include '1', '2', '3'"
+
+        buildFile << """
+            subprojects {
+                task log { doFirst { logger.quiet "Output from " + project.name } }
+            }
+        """
+
+        when:
+        // run in quiet mode just to make it easier to see
+        executer.withArgument('--parallel')
+        succeeds('log')
+
+        then:
+        taskOutputFrom(':1:log') == "Output from 1"
+        taskOutputFrom(':2:log') == "Output from 2"
+        taskOutputFrom(':3:log') == "Output from 3"
+    }
+
+    def "Logs at execution time are grouped"() {
+        given:
+        buildFile << """task log { 
+                        logger.quiet 'Logged during configuration'
+                        doFirst { 
+                            logger.quiet 'First line of text' 
+                            logger.quiet 'Second line of text' 
+                        } 
+                    }"""
+        when:
+        succeeds('log')
+
+        then:
+        taskOutputFrom(':log') == "First line of text\nSecond line of text"
+    }
+
+    def "Failure is grouped"() {
+        given:
+        buildFile << """task log { 
+                        logger.quiet 'Logged during configuration'
+                        doFirst { 
+                            logger.quiet 'First line of text' 
+                            logger.quiet '' 
+                            logger.quiet '' 
+                            logger.quiet 'Last line of text' 
+                            assert false
+                        } 
+                    }"""
+        when:
+        executer.withStackTraceChecksDisabled()
+        fails('log')
+
+        then:
+        taskOutputFrom(':log') == "First line of text\n\n\nLast line of text"
+    }
+}


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Another iteration of making it easier to write functional tests that assert output in the rich console.

### Contributor Checklist
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches&branch_Gradle_Branches=wl-log-grouping-spec)
