### PR TITLE
Remove redundant extends from compile for apiElements

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -393,7 +393,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         apiElementsConfiguration.setCanBeResolved(false);
         apiElementsConfiguration.setCanBeConsumed(true);
         apiElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
-        apiElementsConfiguration.extendsFrom(compileConfiguration, runtimeConfiguration);
+        apiElementsConfiguration.extendsFrom(runtimeConfiguration);
 
         Configuration runtimeElementsConfiguration = configurations.maybeCreate(RUNTIME_ELEMENTS_CONFIGURATION_NAME);
         runtimeElementsConfiguration.setVisible(false);

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -120,7 +120,7 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         !apiElements.visible
-        apiElements.extendsFrom == [api, compile, runtime] as Set
+        apiElements.extendsFrom == [api, runtime] as Set
         apiElements.canBeConsumed
         !apiElements.canBeResolved
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -175,7 +175,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         !apiElements.visible
-        apiElements.extendsFrom == [compile, runtime] as Set
+        apiElements.extendsFrom == [runtime] as Set
         apiElements.canBeConsumed
         !apiElements.canBeResolved
 


### PR DESCRIPTION
This is just a minor cleanup. Runtime already extends compile, so
apiElements only needs to extend from runtime to get them both.