### PR TITLE
Identify target of plugins/scripts in build operation notifications

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListenerRegistrar.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListenerRegistrar.java
@@ -20,6 +20,10 @@ import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Mechanism by which the scan plugin registers for notifications.
+ * <p>
+ * One instance of this exists per build tree.
+ * Only one listener may register.
+ * Subsequent attempts yield exceptions.
  *
  * @since 4.0
  */

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationStartedNotification.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationStartedNotification.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.operations.notify;
 
+import org.gradle.api.Nullable;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -36,26 +37,28 @@ public interface BuildOperationStartedNotification {
     Object getNotificationOperationId();
 
     /**
+     * The ID of the parent of this notification.
+     *
+     * Note: this is the ID of the nearest parent operation that also resulted in a notification.
+     * As notifications are not sent for all operations, this may be a different value to the
+     * parent operation ID.
+     *
+     * Null if the operation has no parent.
+     */
+    @Nullable
+    Object getNotificationOperationParentId();
+
+    /**
      * A structured object providing details about the operation to be performed.
      */
     Object getNotificationOperationDetails();
 
     /*
-        NOTES:
-
-        Parent operation IDs and timestamps are conspicuously absent here.
-
-        The build scan plugin does not currently need parent IDs.
-        Before we add it here, we need to define the semantics of details-less operations
-        and this interface. Specifically, what is to happen if a parent operation is details-less
-        but the child operation has details.
+        Timestamps are conspicuously absent here.
 
         Timestamps are missing because the build scan plugin has different timestamp requirements.
         Specifically, it goes to some effort to provide monotonic timestamps (and the observed value) if different,
         and deterministic ordering of events that yield the same timestamp value (e.g. two clock reads quicker than the clock granularity).
-
-        These are both things to be worked out.
-        When we do, they will be added to this interface in some form.
      */
 
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -38,7 +38,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         succeeds('customTask')
 
         then:
-        def result = operations.operation(SnapshotTaskInputsBuildOperationType).result
+        def result = operations.first(SnapshotTaskInputsBuildOperationType).result
 
         then:
         result.buildCacheKey != null
@@ -65,7 +65,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         succeeds('noOutputs', "--build-cache")
 
         then:
-        def result = operations.operation(SnapshotTaskInputsBuildOperationType).result
+        def result = operations.first(SnapshotTaskInputsBuildOperationType).result
         result.containsKey("buildCacheKey") && result.buildCacheKey == null
         result.containsKey("classLoaderHash") && result.classLoaderHash == null
         result.containsKey("actionClassLoaderHashes") && result.actionClassLoaderHashes == null
@@ -85,7 +85,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         succeeds('noInputs', "--build-cache")
 
         then:
-        def result = operations.operation(SnapshotTaskInputsBuildOperationType).result
+        def result = operations.first(SnapshotTaskInputsBuildOperationType).result
         result.buildCacheKey != null
         result.classLoaderHash != null
         result.actionClassLoaderHashes != null
@@ -121,7 +121,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         succeeds('customTask', '--build-cache')
 
         then:
-        def result = operations.operation(SnapshotTaskInputsBuildOperationType).result
+        def result = operations.first(SnapshotTaskInputsBuildOperationType).result
         result.containsKey("buildCacheKey") && result.buildCacheKey == null
         result.containsKey("classLoaderHash") && result.classLoaderHash == null
         result.actionClassLoaderHashes.last() == null
@@ -147,7 +147,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         succeeds('customTask', '--build-cache')
 
         then:
-        def result = operations.operation(SnapshotTaskInputsBuildOperationType).result
+        def result = operations.first(SnapshotTaskInputsBuildOperationType).result
         result.containsKey("buildCacheKey") && result.buildCacheKey == null
         result.containsKey("classLoaderHash") && result.classLoaderHash != null
         result.actionClassLoaderHashes.last() == null

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ApplyScriptPluginBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ApplyScriptPluginBuildOperationIntegrationTest.groovy
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configuration
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.test.fixtures.server.http.HttpServer
+import org.junit.Rule
+
+import static org.gradle.util.TextUtil.normaliseFileSeparators
+
+class ApplyScriptPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
+
+    def operations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    def "captures gradle script events"() {
+        given:
+        def otherScript2 = file("script2.gradle") << ""
+        def otherScript1 = file("script1.gradle") << """
+            apply from: "${normaliseFileSeparators(otherScript2.absolutePath)}"
+        """
+        def initScript = file("init.gradle") << """
+            apply from: "${normaliseFileSeparators(otherScript1.absolutePath)}"
+        """
+
+        when:
+        succeeds "help", "-I", initScript.absolutePath
+
+        then:
+        def ops = operations.all(ApplyScriptPluginBuildOperationType) {
+            it.details.targetType == "gradle" && it.details.buildPath == ":"
+        }
+        ops.size() == 3
+
+        ops[0].details.file == initScript.absolutePath
+        ops[1].details.file == otherScript1.absolutePath
+        ops[2].details.file == otherScript2.absolutePath
+
+        operations.search(ops[0], ApplyScriptPluginBuildOperationType).size() == 2
+        operations.search(ops[1], ApplyScriptPluginBuildOperationType).size() == 1
+        operations.search(ops[2], ApplyScriptPluginBuildOperationType).size() == 0
+    }
+
+    def "captures settings script events"() {
+        given:
+        def otherScript2 = file("script2.gradle") << ""
+        def otherScript1 = file("script1.gradle") << """
+            apply from: "${normaliseFileSeparators(otherScript2.absolutePath)}"
+        """
+        settingsFile << """
+            apply from: "${normaliseFileSeparators(otherScript1.absolutePath)}"
+        """
+
+        when:
+        succeeds "help"
+
+        then:
+        def ops = operations.all(ApplyScriptPluginBuildOperationType) {
+            it.details.targetType == "settings" && it.details.buildPath == ":"
+        }
+        ops.size() == 3
+
+        ops[0].details.file == settingsFile.absolutePath
+        ops[1].details.file == otherScript1.absolutePath
+        ops[2].details.file == otherScript2.absolutePath
+
+        operations.search(ops[0], ApplyScriptPluginBuildOperationType).size() == 2
+        operations.search(ops[1], ApplyScriptPluginBuildOperationType).size() == 1
+        operations.search(ops[2], ApplyScriptPluginBuildOperationType).size() == 0
+    }
+
+    def "captures project script events"() {
+        given:
+        def otherScript2 = file("script2.gradle") << ""
+        def otherScript1 = file("script1.gradle") << """
+            apply from: "${normaliseFileSeparators(otherScript2.absolutePath)}"
+        """
+        buildFile << """
+            apply from: "${normaliseFileSeparators(otherScript1.absolutePath)}"
+        """
+
+        when:
+        succeeds "help"
+
+        then:
+        def ops = operations.all(ApplyScriptPluginBuildOperationType) {
+            it.details.targetType == "project" &&
+                it.details.buildPath == ":" &&
+                it.details.targetPath == ":"
+        }
+        ops.size() == 3
+
+        ops[0].details.file == buildFile.absolutePath
+        ops[1].details.file == otherScript1.absolutePath
+        ops[2].details.file == otherScript2.absolutePath
+
+        operations.search(ops[0], ApplyScriptPluginBuildOperationType).size() == 2
+        operations.search(ops[1], ApplyScriptPluginBuildOperationType).size() == 1
+        operations.search(ops[2], ApplyScriptPluginBuildOperationType).size() == 0
+    }
+
+    def "captures for arbitrary targets"() {
+        given:
+        def script = file("script.gradle") << ""
+        buildScript """
+            apply from: "${normaliseFileSeparators(script.absolutePath)}", to: new Object() {}
+        """
+
+        when:
+        succeeds "help"
+
+        then:
+        def op = operations.only(ApplyScriptPluginBuildOperationType) {
+            it.details.targetType == null
+        }
+
+        op.details.file == script.absolutePath
+        op.details.targetPath == null
+        op.details.buildPath == null
+    }
+
+    @Rule
+    HttpServer httpServer = new HttpServer()
+
+    def "captures for http scripts"() {
+        given:
+        println testDirectory.absolutePath
+        httpServer.start()
+        def script = file("script.gradle") << ""
+        httpServer.allowGetOrHead("/script.gradle", script)
+        buildScript """
+            apply from: "${httpServer.uri}/script.gradle"
+        """
+
+        when:
+        succeeds "help"
+
+        then:
+        def op = operations.only(ApplyScriptPluginBuildOperationType) {
+            it.details.targetType == "project" &&
+            it.details.uri != null
+        }
+
+        op.details.file == null
+        op.details.uri == "${httpServer.uri}/script.gradle"
+        op.details.targetPath == ":"
+        op.details.buildPath == ":"
+    }
+
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -84,7 +84,7 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
     }
 
     private BuildOperationRecord operation() {
-        buildOperations.operation(CalculateTaskGraphBuildOperationType)
+        buildOperations.first(CalculateTaskGraphBuildOperationType)
     }
 
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -27,11 +27,11 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         """
             def listener = new $BuildOperationNotificationListener.name() {
                 void started($BuildOperationStartedNotification.name notification) {
-                    println "STARTED: \${notification.details.class.interfaces.first().name} - \${${JsonOutput.name}.toJson(notification.details)}"   
+                    println "STARTED: \${notification.details.class.interfaces.first().name} - \${${JsonOutput.name}.toJson(notification.details)} - \$notification.notificationOperationId - \$notification.notificationOperationParentId"   
                 }
 
                 void finished($BuildOperationFinishedNotification.name notification) {
-                    println "FINISHED: \${notification.result?.class?.interfaces?.first()?.name} - \${${JsonOutput.name}.toJson(notification.result)}"
+                    println "FINISHED: \${notification.result?.class?.interfaces?.first()?.name} - \${${JsonOutput.name}.toJson(notification.result)} - \$notification.notificationOperationId"
                 }
             }
             def registrar = services.get($BuildOperationNotificationListenerRegistrar.name)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -20,6 +20,7 @@ import org.gradle.api.Nullable;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.execution.TaskGraphExecuter;
@@ -33,7 +34,7 @@ import java.util.Collection;
  * An internal interface for Gradle that exposed objects and concepts that are not intended for public
  * consumption.
  */
-public interface GradleInternal extends Gradle {
+public interface GradleInternal extends Gradle, PluginAwareInternal {
     /**
      * {@inheritDoc}
      */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/SettingsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/SettingsInternal.java
@@ -17,18 +17,19 @@
 package org.gradle.api.internal;
 
 import org.gradle.StartParameter;
+import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.initialization.ProjectDescriptor;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.initialization.DefaultProjectDescriptor;
-import org.gradle.api.initialization.IncludedBuild;
 
 import java.io.File;
 import java.util.Map;
 
-public interface SettingsInternal extends Settings {
+public interface SettingsInternal extends Settings, PluginAwareInternal {
     /**
      * Returns the scope containing classes that should be visible to all settings scripts and build scripts invoked by this build.
      */
@@ -50,4 +51,7 @@ public interface SettingsInternal extends Settings {
     void setDefaultProject(ProjectDescriptor defaultProject);
 
     Map<File, IncludedBuild> getIncludedBuilds();
+
+    @Override
+    GradleInternal getGradle();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ApplyPluginBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ApplyPluginBuildOperationType.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.plugins;
 import org.gradle.api.Nullable;
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.UsedByScanPlugin;
-import org.gradle.plugin.use.PluginId;
 
 /**
  * Details about a plugin being applied.
@@ -31,30 +30,33 @@ public final class ApplyPluginBuildOperationType implements BuildOperationType<A
     @UsedByScanPlugin
     public interface Details {
 
+        /**
+         * The fully qualified plugin ID, if known.
+         */
         @Nullable
         String getPluginId();
 
+        /**
+         * The fully qualified class name of the Plugin implementation.
+         */
         String getClassName();
 
-    }
+        /**
+         * The target of the plugin.
+         * One of "gradle", "settings", "project" or null.
+         */
+        String getTargetType();
 
-    static class DetailsImpl implements Details {
-        private PluginId pluginId;
-        private String className;
-
-        DetailsImpl(@Nullable PluginId pluginId, String className) {
-            this.pluginId = pluginId;
-            this.className = className;
-        }
-
+        /**
+         * If the target is a project, its path.
+         */
         @Nullable
-        public String getPluginId() {
-            return pluginId.getId();
-        }
+        String getTargetPath();
 
-        public String getClassName() {
-            return className;
-        }
+        /**
+         * The build path of the target.
+         */
+        String getBuildPath();
     }
 
     private ApplyPluginBuildOperationType() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
@@ -18,15 +18,21 @@ package org.gradle.api.internal.plugins;
 
 import org.gradle.api.Nullable;
 import org.gradle.api.Plugin;
+import org.gradle.configuration.ConfigurationTargetIdentifier;
 
 import static org.gradle.internal.Cast.uncheckedCast;
 
-public class ImperativeOnlyPluginTarget<T> implements PluginTarget {
+public class ImperativeOnlyPluginTarget<T extends PluginAwareInternal> implements PluginTarget {
 
     private final T target;
 
     public ImperativeOnlyPluginTarget(T target) {
         this.target = target;
+    }
+
+    @Override
+    public ConfigurationTargetIdentifier getConfigurationTargetIdentifier() {
+        return target.getConfigurationTargetIdentifier();
     }
 
     public void applyImperative(@Nullable String pluginId, Plugin<?> plugin) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginTarget.java
@@ -18,10 +18,13 @@ package org.gradle.api.internal.plugins;
 
 import org.gradle.api.Nullable;
 import org.gradle.api.Plugin;
+import org.gradle.configuration.ConfigurationTargetIdentifier;
 
 public interface PluginTarget {
 
     // Implementations should not wrap exceptions, this is done in DefaultObjectConfigurationAction
+
+    ConfigurationTargetIdentifier getConfigurationTargetIdentifier();
 
     void applyImperative(@Nullable String pluginId, Plugin<?> plugin);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/RuleBasedPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/RuleBasedPluginTarget.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.plugins;
 
 import org.gradle.api.Nullable;
 import org.gradle.api.Plugin;
+import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.model.RuleSource;
 import org.gradle.model.internal.inspect.ExtractedRuleSource;
 import org.gradle.model.internal.inspect.ModelRuleExtractor;
@@ -37,6 +38,11 @@ public class RuleBasedPluginTarget<T extends ModelRegistryScope & PluginAwareInt
         this.ruleInspector = ruleInspector;
         this.ruleDetector = ruleDetector;
         this.imperativeTarget = new ImperativeOnlyPluginTarget<T>(target);
+    }
+
+    @Override
+    public ConfigurationTargetIdentifier getConfigurationTargetIdentifier() {
+        return imperativeTarget.getConfigurationTargetIdentifier();
     }
 
     public void applyImperative(@Nullable String pluginId, Plugin<?> plugin) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/AbstractPluginAware.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/AbstractPluginAware.java
@@ -22,8 +22,10 @@ import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;
 import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.plugins.ObjectConfigurationAction;
 import org.gradle.api.plugins.PluginContainer;
+import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.util.ConfigureUtil;
 
+import javax.inject.Inject;
 import java.util.Map;
 
 public abstract class AbstractPluginAware implements PluginAwareInternal {
@@ -46,6 +48,11 @@ public abstract class AbstractPluginAware implements PluginAwareInternal {
 
     public PluginContainer getPlugins() {
         return getPluginManager().getPluginContainer();
+    }
+
+    @Inject
+    public ConfigurationTargetIdentifier getConfigurationTargetIdentifier() {
+        throw new UnsupportedOperationException();
     }
 
     abstract protected DefaultObjectConfigurationAction createObjectConfigurationAction();

--- a/subprojects/core/src/main/java/org/gradle/configuration/ApplyScriptPluginBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/ApplyScriptPluginBuildOperationType.java
@@ -20,8 +20,6 @@ import org.gradle.api.Nullable;
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
-import java.io.File;
-
 /**
  * Details about a script plugin being applied.
  *
@@ -33,33 +31,40 @@ public final class ApplyScriptPluginBuildOperationType implements BuildOperation
     public interface Details {
 
         /**
-         * The absolute path to the file.
+         * The absolute path to the script file.
+         * Null if was not a script file.
+         * Null if uri != null.
          */
         @Nullable
         String getFile();
 
-        String getDisplayName();
-
-    }
-
-    public static class DetailsImpl implements Details {
-
-        private File file;
-        private String displayName;
-
-        public DetailsImpl(@Nullable File file, String displayName) {
-            this.file = file;
-            this.displayName = displayName;
-        }
-
+        /**
+         * The URI of the script.
+         * Null if was not applied as URI.
+         * Null if file != null.
+         */
         @Nullable
-        public String getFile() {
-            return file.getAbsolutePath();
-        }
+        String getUri();
 
-        public String getDisplayName() {
-            return displayName;
-        }
+        /**
+         * The target of the script.
+         * One of "gradle", "settings", "project" or null.
+         * If null, the target is an arbitrary object.
+         */
+        @Nullable
+        String getTargetType();
+
+        /**
+         * If the target is a project, its path.
+         */
+        @Nullable
+        String getTargetPath();
+
+        /**
+         * The build path, if the target is a known type (i.e. targetType != null)
+         */
+        @Nullable
+        String getBuildPath();
 
     }
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/ConfigurationTargetIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/ConfigurationTargetIdentifier.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configuration;
+
+import org.gradle.api.Nullable;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.plugins.PluginAwareInternal;
+import org.gradle.api.internal.project.ProjectInternal;
+
+/**
+ * Uniquely identifies the target of some configuration.
+ *
+ * This is primarily used to support
+ * {@code ApplyScriptPluginBuildOperationType.Details} and {@code ApplyPluginBuildOperationType.Details}.
+ */
+public abstract class ConfigurationTargetIdentifier {
+
+    private ConfigurationTargetIdentifier() {
+    }
+
+    public enum Type {
+        GRADLE,
+        SETTINGS,
+        PROJECT;
+
+        public final String label = name().toLowerCase();
+    }
+
+    abstract public Type getTargetType();
+
+    /**
+     * If type == project, that project's path (not identity path).
+     * Else, null.
+     */
+    @Nullable
+    abstract public String getTargetPath();
+
+    abstract public String getBuildPath();
+
+    /**
+     * Returns null if the thing is of an unknown type.
+     * This can happen with {@code apply(from: "foo", to: someTask)},
+     * where “to” can be absolutely anything.
+     */
+    @Nullable
+    public static ConfigurationTargetIdentifier of(Object any) {
+        if (any instanceof PluginAwareInternal) {
+            return ((PluginAwareInternal) any).getConfigurationTargetIdentifier();
+        } else {
+            return null;
+        }
+    }
+
+    public static ConfigurationTargetIdentifier of(final ProjectInternal project) {
+        return new ConfigurationTargetIdentifier() {
+            @Override
+            public Type getTargetType() {
+                return Type.PROJECT;
+            }
+
+            @Nullable
+            @Override
+            public String getTargetPath() {
+                return project.getProjectPath().getPath();
+            }
+
+            @Override
+            public String getBuildPath() {
+                return project.getGradle().getIdentityPath().getPath();
+            }
+        };
+    }
+
+    public static ConfigurationTargetIdentifier of(final SettingsInternal settings) {
+        return new ConfigurationTargetIdentifier() {
+            @Override
+            public Type getTargetType() {
+                return Type.SETTINGS;
+            }
+
+            @Nullable
+            @Override
+            public String getTargetPath() {
+                return null;
+            }
+
+            @Override
+            public String getBuildPath() {
+                return settings.getGradle().getIdentityPath().getPath();
+            }
+        };
+    }
+
+    public static ConfigurationTargetIdentifier of(final GradleInternal gradle) {
+        return new ConfigurationTargetIdentifier() {
+            @Override
+            public Type getTargetType() {
+                return Type.GRADLE;
+            }
+
+            @Nullable
+            @Override
+            public String getTargetPath() {
+                return null;
+            }
+
+            @Override
+            public String getBuildPath() {
+                return gradle.getIdentityPath().getPath();
+            }
+        };
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationBridge.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationBridge.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.operations.notify;
 
 import org.gradle.api.execution.internal.ExecuteTaskBuildOperationDetails;
-import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.progress.BuildOperationDescriptor;
 import org.gradle.internal.progress.BuildOperationListener;
@@ -27,17 +26,14 @@ import org.gradle.internal.progress.OperationStartEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 class BuildOperationNotificationBridge implements BuildOperationNotificationListenerRegistrar, Stoppable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BuildOperationNotificationBridge.class);
 
-    private final List<Listener> listeners = new CopyOnWriteArrayList<Listener>();
-
+    private Listener operationListener;
     private final BuildOperationListenerManager buildOperationListenerManager;
 
     BuildOperationNotificationBridge(BuildOperationListenerManager buildOperationListenerManager) {
@@ -46,14 +42,19 @@ class BuildOperationNotificationBridge implements BuildOperationNotificationList
 
     @Override
     public void registerBuildScopeListener(BuildOperationNotificationListener notificationListener) {
-        Listener listener = new Listener(notificationListener, buildOperationListenerManager);
-        listeners.add(listener);
-        buildOperationListenerManager.addListener(listener);
+        if (operationListener == null) {
+            operationListener = new Listener(notificationListener);
+            buildOperationListenerManager.addListener(operationListener);
+        } else {
+            throw new IllegalStateException("listener is already registered");
+        }
     }
 
     @Override
     public void stop() {
-        CompositeStoppable.stoppable(listeners).stop();
+        if (operationListener != null) {
+            buildOperationListenerManager.removeListener(operationListener);
+        }
     }
 
     /*
@@ -64,17 +65,15 @@ class BuildOperationNotificationBridge implements BuildOperationNotificationList
         OperationStartEvent. This will happen later.
      */
 
-    private static class Listener implements BuildOperationListener, Stoppable {
+    private static class Listener implements BuildOperationListener {
 
-        private final BuildOperationNotificationListener listener;
-        private final BuildOperationListenerManager buildOperationListenerManager;
+        private final BuildOperationNotificationListener notificationListener;
 
         private final Map<Object, Object> parents = new ConcurrentHashMap<Object, Object>();
         private final Map<Object, Object> active = new ConcurrentHashMap<Object, Object>();
 
-        private Listener(BuildOperationNotificationListener listener, BuildOperationListenerManager buildOperationListenerManager) {
-            this.listener = listener;
-            this.buildOperationListenerManager = buildOperationListenerManager;
+        private Listener(BuildOperationNotificationListener notificationListener) {
+            this.notificationListener = notificationListener;
         }
 
         @Override
@@ -100,7 +99,7 @@ class BuildOperationNotificationBridge implements BuildOperationNotificationList
 
             Started notification = new Started(id, parentId, buildOperation.getDetails());
             try {
-                listener.started(notification);
+                notificationListener.started(notification);
             } catch (Exception e) {
                 LOGGER.debug("Build operation notification listener threw an error on " + notification, e);
             }
@@ -116,16 +115,10 @@ class BuildOperationNotificationBridge implements BuildOperationNotificationList
 
             Finished notification = new Finished(id, buildOperation.getDetails(), finishEvent.getResult(), finishEvent.getFailure());
             try {
-                listener.finished(notification);
+                notificationListener.finished(notification);
             } catch (Exception e) {
                 LOGGER.debug("Build operation notification listener threw an error on " + notification, e);
             }
-        }
-
-        @Override
-        public void stop() {
-            buildOperationListenerManager.removeListener(this);
-            active.clear();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.operations.trace;
 
 import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.LinkedHashMap;
@@ -32,9 +31,9 @@ public final class BuildOperationRecord {
     public final long startTime;
     public final long endTime;
     public final Map<String, ?> details;
-    public final String detailsClassName;
+    private final String detailsClassName;
     public final Map<String, ?> result;
-    public final String resultClassName;
+    private final String resultClassName;
     public final String failure;
 
     public final List<BuildOperationRecord> children;
@@ -57,38 +56,12 @@ public final class BuildOperationRecord {
         this.displayName = displayName;
         this.startTime = startTime;
         this.endTime = endTime;
-        this.details = details;
+        this.details = details == null ? null : new StrictMap<String, Object>(details);
         this.detailsClassName = detailsClassName;
-        this.result = result;
+        this.result = result == null ? null : new StrictMap<String, Object>(result);
         this.resultClassName = resultClassName;
         this.failure = failure;
         this.children = children;
-    }
-
-    BuildOperationRecord(Map<String, ?> serialized) {
-        this.id = serialized.get("id");
-        this.parentId = serialized.get("parentId");
-        this.displayName = (String) serialized.get("displayName");
-        this.startTime = (Long) serialized.get("startTime");
-        this.endTime = (Long) serialized.get("endTime");
-
-        this.detailsClassName = (String) serialized.get("detailsClassName");
-        @SuppressWarnings("unchecked") Map<String, ?> detailsMap = (Map<String, ?>) serialized.get("details");
-        this.details = detailsMap;
-
-        this.resultClassName = (String) serialized.get("resultClassName");
-        @SuppressWarnings("unchecked") Map<String, ?> resultMap = (Map<String, ?>) serialized.get("result");
-        this.result = resultMap;
-
-        this.failure = (String) serialized.get("failure");
-
-        @SuppressWarnings("unchecked") List<Map<String, ?>> children = (List<Map<String, ?>>) serialized.get("children");
-        this.children = ImmutableList.copyOf(Lists.transform(children, new Function<Map<String, ?>, BuildOperationRecord>() {
-            @Override
-            public BuildOperationRecord apply(Map<String, ?> input) {
-                return new BuildOperationRecord(input);
-            }
-        }));
     }
 
     Map<String, ?> toSerializable() {

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/StrictMap.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/StrictMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,24 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.plugins;
+package org.gradle.internal.operations.trace;
 
-import org.gradle.api.plugins.PluginAware;
-import org.gradle.configuration.ConfigurationTargetIdentifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
-public interface PluginAwareInternal extends PluginAware {
-    PluginManagerInternal getPluginManager();
+class StrictMap<K, V> extends HashMap<K, V> {
 
-    ConfigurationTargetIdentifier getConfigurationTargetIdentifier();
+    public StrictMap(Map<? extends K, ? extends V> m) {
+        super(m);
+    }
+
+    @Override
+    public V get(Object key) {
+        if (!containsKey(key)) {
+            throw new NoSuchElementException("No entry with key: " + key + " (keys: " + keySet() +  ")");
+        }
+
+        return super.get(key);
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.options.OptionReader;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.cache.CacheRepository;
+import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.execution.BuildConfigurationAction;
 import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.execution.BuildExecuter;
@@ -177,7 +178,7 @@ public class GradleScopeServices extends DefaultServiceRegistry {
     }
 
     PluginManagerInternal createPluginManager(Instantiator instantiator, GradleInternal gradleInternal, PluginRegistry pluginRegistry, InstantiatorFactory instantiatorFactory, BuildOperationExecutor buildOperationExecutor) {
-        PluginTarget target = new ImperativeOnlyPluginTarget<Gradle>(gradleInternal);
+        PluginTarget target = new ImperativeOnlyPluginTarget<GradleInternal>(gradleInternal);
         return instantiator.newInstance(DefaultPluginManager.class, pluginRegistry, instantiatorFactory.inject(this), target, buildOperationExecutor);
     }
 
@@ -195,6 +196,10 @@ public class GradleScopeServices extends DefaultServiceRegistry {
 
     protected BuildOutputCleanupCache createBuildOutputCleanupCache(CacheRepository cacheRepository, GradleInternal gradle, BuildOutputDeleter buildOutputDeleter, BuildOutputCleanupRegistry buildOutputCleanupRegistry) {
         return new DefaultBuildOutputCleanupCache(cacheRepository, gradle, buildOutputDeleter, buildOutputCleanupRegistry);
+    }
+
+    protected ConfigurationTargetIdentifier createConfigurationTargetIdentifier(GradleInternal gradle) {
+        return ConfigurationTargetIdentifier.of(gradle);
     }
 
     // Note: This would be better housed in a scope that encapsulated the tree of Gradle objects.

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -57,6 +57,7 @@ import org.gradle.api.resources.normalization.internal.DefaultResourceNormalizat
 import org.gradle.api.resources.normalization.internal.DefaultRuntimeClasspathNormalization;
 import org.gradle.api.resources.normalization.internal.RuntimeClasspathNormalizationInternal;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.project.DefaultProjectConfigurationActionContainer;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.initialization.ProjectAccessListener;
@@ -158,7 +159,11 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
     }
 
     protected PluginManagerInternal createPluginManager(Instantiator instantiator, InstantiatorFactory instantiatorFactory, BuildOperationExecutor buildOperationExecutor) {
-        PluginTarget target = new RuleBasedPluginTarget<ProjectInternal>(project, get(ModelRuleExtractor.class), get(ModelRuleSourceDetector.class));
+        PluginTarget target = new RuleBasedPluginTarget<ProjectInternal>(
+            project,
+            get(ModelRuleExtractor.class),
+            get(ModelRuleSourceDetector.class)
+        );
         return instantiator.newInstance(DefaultPluginManager.class, get(PluginRegistry.class), instantiatorFactory.inject(this), target, buildOperationExecutor);
     }
 
@@ -194,9 +199,9 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
 
     protected ScriptHandler createScriptHandler() {
         ScriptHandlerFactory factory = new DefaultScriptHandlerFactory(
-                get(DependencyManagementServices.class),
-                get(FileResolver.class),
-                get(DependencyMetaDataProvider.class));
+            get(DependencyManagementServices.class),
+            get(FileResolver.class),
+            get(DependencyMetaDataProvider.class));
         return factory.create(project.getBuildScriptSource(), project.getClassLoaderScope(), project);
     }
 
@@ -233,4 +238,9 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
     protected ResourceNormalizationHandler createResourceNormalizationHandler(Instantiator instantiator, RuntimeClasspathNormalizationInternal runtimeClasspathNormalizationStrategy) {
         return instantiator.newInstance(DefaultResourceNormalizationHandler.class, runtimeClasspathNormalizationStrategy);
     }
+
+    protected ConfigurationTargetIdentifier createConfigurationTargetIdentifier() {
+        return ConfigurationTargetIdentifier.of(project);
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
@@ -23,10 +23,11 @@ import org.gradle.api.internal.file.BaseDirFileResolver;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.plugins.DefaultPluginManager;
 import org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget;
-import org.gradle.api.internal.plugins.PluginTarget;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.plugins.PluginRegistry;
+import org.gradle.api.internal.plugins.PluginTarget;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.initialization.DefaultProjectDescriptorRegistry;
 import org.gradle.initialization.ProjectDescriptorRegistry;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
@@ -69,4 +70,9 @@ public class SettingsScopeServices extends DefaultServiceRegistry {
     protected ProjectDescriptorRegistry createProjectDescriptorRegistry() {
         return new DefaultProjectDescriptorRegistry();
     }
+
+    protected ConfigurationTargetIdentifier createConfigurationTargetIdentifier() {
+        return ConfigurationTargetIdentifier.of(settings);
+    }
+
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
@@ -146,6 +146,7 @@ class DefaultPluginManagerTest extends Specification {
 
         then:
         1 * target.applyRules(null, rulesClass)
+        1 * target.getConfigurationTargetIdentifier()
         1 * action.execute(_)
         0 * target._
         0 * action._
@@ -273,6 +274,7 @@ class DefaultPluginManagerTest extends Specification {
         manager.apply(hybridClass)
 
         then:
+        1 * target.getConfigurationTargetIdentifier()
         1 * target.applyImperativeRulesHybrid(null, { hybridClass.isInstance(it) })
         0 * target._
         1 * action.execute(_)
@@ -355,6 +357,7 @@ class DefaultPluginManagerTest extends Specification {
         manager.pluginContainer.apply(imperativeClass)
 
         then:
+        1 * target.getConfigurationTargetIdentifier()
         1 * target.applyImperative(null, { imperativeClass.isInstance(it) })
         0 * target._
 
@@ -378,6 +381,7 @@ class DefaultPluginManagerTest extends Specification {
         manager.apply(imperativeClass)
 
         then:
+        1 * target.getConfigurationTargetIdentifier()
         1 * target.applyImperative(null, { imperativeClass.isInstance(it) })
         0 * target._
         1 * action.execute(_)
@@ -523,6 +527,7 @@ class DefaultPluginManagerTest extends Specification {
         manager.apply(imperativeClass)
 
         then:
+        1 * target.getConfigurationTargetIdentifier()
         1 * target.applyImperative("bar", { imperativeClass.isInstance(it) })
         0 * target._
         1 * action.execute(_)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -53,11 +53,11 @@ import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.project.ant.AntLoggingAdapter
 import org.gradle.api.internal.project.taskfactory.ITaskFactory
 import org.gradle.api.internal.tasks.TaskContainerInternal
-import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.resources.normalization.ResourceNormalizationHandler
+import org.gradle.configuration.ConfigurationTargetIdentifier
 import org.gradle.configuration.ScriptPluginFactory
 import org.gradle.configuration.project.ProjectConfigurationActionContainer
 import org.gradle.configuration.project.ProjectEvaluator
@@ -128,7 +128,8 @@ class DefaultProjectTest {
     ComponentMetadataHandler moduleHandlerMock = context.mock(ComponentMetadataHandler)
     ScriptHandler scriptHandlerMock = context.mock(ScriptHandler)
     DependencyMetaDataProvider dependencyMetaDataProviderMock = context.mock(DependencyMetaDataProvider)
-    Gradle build = context.mock(GradleInternal)
+    GradleInternal build = context.mock(GradleInternal)
+    ConfigurationTargetIdentifier configurationTargetIdentifier = context.mock(ConfigurationTargetIdentifier)
     FileOperations fileOperationsMock = context.mock(FileOperations)
     ProviderFactory propertyStateFactoryMock = context.mock(ProviderFactory)
     ProcessOperations processOperationsMock = context.mock(ProcessOperations)
@@ -182,6 +183,7 @@ class DefaultProjectTest {
             allowing(serviceRegistryMock).get(ArtifactHandler); will(returnValue(context.mock(ArtifactHandler)))
             allowing(serviceRegistryMock).get(DependencyHandler); will(returnValue(dependencyHandlerMock))
             allowing(serviceRegistryMock).get((Type) ComponentMetadataHandler); will(returnValue(moduleHandlerMock))
+            allowing(serviceRegistryMock).get((Type) ConfigurationTargetIdentifier); will(returnValue(configurationTargetIdentifier))
             allowing(serviceRegistryMock).get((Type) SoftwareComponentContainer); will(returnValue(softwareComponentsMock))
             allowing(serviceRegistryMock).get((Type) ResourceNormalizationHandler); will(returnValue(resourceNormalizationHandler))
             allowing(serviceRegistryMock).get(ProjectEvaluator); will(returnValue(projectEvaluator))

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/BuildOperationScriptPluginTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/BuildOperationScriptPluginTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.configuration
 
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.resource.ResourceLocation
 import org.gradle.internal.resource.TextResource
 import spock.lang.Specification
 
@@ -28,6 +29,7 @@ class BuildOperationScriptPluginTest extends Specification {
         def buildOperationExecutor = new TestBuildOperationExecutor()
         def scriptSource = Mock(ScriptSource)
         def scriptSourceResource = Mock(TextResource)
+        def scriptSourceResourceLocation = Mock(ResourceLocation)
         def decoratedScriptPlugin = Mock(ScriptPlugin)
         def buildOperationScriptPlugin = new BuildOperationScriptPlugin(decoratedScriptPlugin, buildOperationExecutor)
         def target = "Test Target"
@@ -37,6 +39,7 @@ class BuildOperationScriptPluginTest extends Specification {
 
         then:
         2 * scriptSource.getResource() >> scriptSourceResource
+        1 * scriptSourceResource.getLocation() >> scriptSourceResourceLocation
         1 * scriptSourceResource.isContentCached() >> true
         1 * scriptSourceResource.getHasEmptyContent() >> false
         2 * decoratedScriptPlugin.getSource() >> scriptSource
@@ -54,6 +57,7 @@ class BuildOperationScriptPluginTest extends Specification {
         def buildOperationExecutor = new TestBuildOperationExecutor()
         def scriptSource = Mock(ScriptSource)
         def scriptSourceResource = Mock(TextResource)
+        def scriptSourceResourceLocation = Mock(ResourceLocation)
         def decoratedScriptPlugin = Mock(ScriptPlugin)
         def scriptFile = Mock(File)
         def buildOperationScriptPlugin = new BuildOperationScriptPlugin(decoratedScriptPlugin, buildOperationExecutor)
@@ -64,9 +68,10 @@ class BuildOperationScriptPluginTest extends Specification {
 
         then:
         2 * scriptSource.getResource() >> scriptSourceResource
+        1 * scriptSourceResource.getLocation() >> scriptSourceResourceLocation
         1 * scriptSourceResource.isContentCached() >> true
         1 * scriptSourceResource.getHasEmptyContent() >> false
-        1 * scriptSourceResource.getFile() >> scriptFile
+        1 * scriptSourceResourceLocation.getFile() >> scriptFile
         1 * scriptFile.getName() >> "build.gradle"
         2 * decoratedScriptPlugin.getSource() >> scriptSource
         0 * scriptSource.getDisplayName() >> "test.source"

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationBridgeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationBridgeTest.groovy
@@ -54,6 +54,15 @@ class BuildOperationNotificationBridgeTest extends Specification {
         }
     }
 
+    def "does not allow duplicate registration"() {
+        when:
+        register(listener)
+        register(listener)
+
+        then:
+        thrown IllegalStateException
+    }
+
     def "forwards operations with details"() {
         given:
         def d1 = d(1, null, 1)
@@ -231,7 +240,9 @@ class BuildOperationNotificationBridgeTest extends Specification {
     }
 
     void register(BuildOperationNotificationListener listener) {
-        bridge = new BuildOperationNotificationBridge(listenerManager)
+        if (bridge == null) {
+            bridge = new BuildOperationNotificationBridge(listenerManager)
+        }
         bridge.registerBuildScopeListener(listener)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationBridgeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationBridgeTest.groovy
@@ -16,28 +16,25 @@
 
 package org.gradle.internal.operations.notify
 
+import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.progress.BuildOperationDescriptor
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.BuildOperationListenerManager
+import org.gradle.internal.progress.DefaultBuildOperationListenerManager
 import org.gradle.internal.progress.OperationFinishEvent
 import org.gradle.testing.internal.util.Specification
 
 class BuildOperationNotificationBridgeTest extends Specification {
 
-    def listenerManager = Mock(BuildOperationListenerManager)
-    def bridge = new BuildOperationNotificationBridge(listenerManager)
+    def rawListenerManager = new DefaultListenerManager()
+    def listenerManager = new DefaultBuildOperationListenerManager(rawListenerManager)
+    BuildOperationNotificationBridge bridge
+    def broadcast = rawListenerManager.getBroadcaster(BuildOperationListener)
     def listener = Mock(BuildOperationNotificationListener)
-
-    def "adapts listener"() {
-        when:
-        register(listener)
-
-        then:
-        1 * listenerManager.addListener(_)
-    }
 
     def "removes listener when stopped"() {
         given:
+        listenerManager = Mock(BuildOperationListenerManager)
         def buildOperationListener
 
         when:
@@ -59,23 +56,15 @@ class BuildOperationNotificationBridgeTest extends Specification {
 
     def "forwards operations with details"() {
         given:
-        BuildOperationListener buildOperationListener
-        def d1 = BuildOperationDescriptor.displayName("a").details(1).build(1, null)
-        def d2 = BuildOperationDescriptor.displayName("a").build(2, null)
-        def d3 = BuildOperationDescriptor.displayName("a").details(1).build(3, null)
+        def d1 = d(1, null, 1)
+        def d2 = d(2, null, null)
+        def d3 = d(3, null, 3)
         def e1 = new Exception()
-
-        when:
         register(listener)
-
-        then:
-        1 * listenerManager.addListener(_) >> {
-            buildOperationListener = it[0]
-        }
 
         // operation with details and non null result
         when:
-        buildOperationListener.started(d1, null)
+        broadcast.started(d1, null)
 
         then:
         1 * listener.started(_) >> { BuildOperationStartedNotification n ->
@@ -84,7 +73,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
         }
 
         when:
-        buildOperationListener.finished(d1, new OperationFinishEvent(-1, -1, null, 10))
+        broadcast.finished(d1, new OperationFinishEvent(-1, -1, null, 10))
 
         then:
         1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
@@ -96,20 +85,20 @@ class BuildOperationNotificationBridgeTest extends Specification {
 
         // operation with no details
         when:
-        buildOperationListener.started(d2, null)
+        broadcast.started(d2, null)
 
         then:
         0 * listener.started(_)
 
         when:
-        buildOperationListener.finished(d2, new OperationFinishEvent(-1, -1, null, 10))
+        broadcast.finished(d2, new OperationFinishEvent(-1, -1, null, 10))
 
         then:
         0 * listener.finished(_)
 
         // operation with details and null result
         when:
-        buildOperationListener.started(d3, null)
+        broadcast.started(d3, null)
 
         then:
         1 * listener.started(_) >> { BuildOperationStartedNotification n ->
@@ -118,7 +107,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
         }
 
         when:
-        buildOperationListener.finished(d3, new OperationFinishEvent(-1, -1, null, null))
+        broadcast.finished(d3, new OperationFinishEvent(-1, -1, null, null))
 
         then:
         1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
@@ -130,7 +119,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
 
         // operation with details and failure
         when:
-        buildOperationListener.started(d3, null)
+        broadcast.started(d3, null)
 
         then:
         1 * listener.started(_) >> { BuildOperationStartedNotification n ->
@@ -139,7 +128,7 @@ class BuildOperationNotificationBridgeTest extends Specification {
         }
 
         when:
-        buildOperationListener.finished(d3, new OperationFinishEvent(-1, -1, e1, null))
+        broadcast.finished(d3, new OperationFinishEvent(-1, -1, e1, null))
 
         then:
         1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
@@ -150,7 +139,99 @@ class BuildOperationNotificationBridgeTest extends Specification {
         }
     }
 
+    BuildOperationDescriptor d(Long id, Long parentId, Long details) {
+        BuildOperationDescriptor.displayName(id.toString()).details(details).build(id, parentId)
+    }
+
+    def "parentId is of last parent that a notification was sent for"() {
+        given:
+        register(listener)
+        def d1 = d(1, null, 1)
+        def d2 = d(2, 1, null)
+        def d3 = d(3, 2, 3)
+        def d4 = d(4, 2, 4)
+        def d5 = d(5, 4, 5)
+        def d6 = d(6, 5, null)
+        def d7 = d(7, 6, 7)
+
+        when:
+        broadcast.started(d1, null)
+        broadcast.started(d2, null)
+
+        broadcast.started(d3, null)
+        broadcast.finished(d3, new OperationFinishEvent(-1, -1, null, null))
+
+        broadcast.started(d4, null)
+        broadcast.started(d5, null)
+        broadcast.started(d6, null)
+        broadcast.started(d7, null)
+
+        broadcast.finished(d7, new OperationFinishEvent(-1, -1, null, null))
+        broadcast.finished(d6, new OperationFinishEvent(-1, -1, null, null))
+        broadcast.finished(d5, new OperationFinishEvent(-1, -1, null, null))
+        broadcast.finished(d4, new OperationFinishEvent(-1, -1, null, null))
+
+        broadcast.finished(d2, new OperationFinishEvent(-1, -1, null, null))
+        broadcast.finished(d1, new OperationFinishEvent(-1, -1, null, null))
+
+        then:
+        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
+            assert n.notificationOperationId == d1.id
+        }
+
+        then:
+        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
+            assert n.notificationOperationId == d3.id
+            assert n.notificationOperationParentId == d1.id
+        }
+
+        then:
+        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
+            assert n.notificationOperationId == d3.id
+        }
+
+        then:
+        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
+            assert n.notificationOperationId == d4.id
+            assert n.notificationOperationParentId == d1.id
+        }
+
+        then:
+        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
+            assert n.notificationOperationId == d5.id
+            assert n.notificationOperationParentId == d4.id
+        }
+
+        then:
+        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
+            assert n.notificationOperationId == d7.id
+            assert n.notificationOperationParentId == d5.id
+        }
+
+        then:
+        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
+            assert n.notificationOperationId == d7.id
+        }
+
+        then:
+        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
+            assert n.notificationOperationId == d5.id
+        }
+
+        then:
+        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
+            assert n.notificationOperationId == d4.id
+        }
+
+        then:
+        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
+            assert n.notificationOperationId == d1.id
+        }
+
+    }
+
     void register(BuildOperationNotificationListener listener) {
+        bridge = new BuildOperationNotificationBridge(listenerManager)
         bridge.registerBuildScopeListener(listener)
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
@@ -60,7 +60,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         then:
         def actualFileLength = m.pom.file.bytes.length
-        def buildOp = buildOperations.operation(ExternalResourceDownloadBuildOperationType)
+        def buildOp = buildOperations.first(ExternalResourceDownloadBuildOperationType)
         buildOp.details.contentType == 'null'
         buildOp.details.contentLength == chunked ? -1 : actualFileLength
         URI.create(buildOp.details.location).path == m.pomPath

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/JUnit4GroovyMockery.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/JUnit4GroovyMockery.java
@@ -18,6 +18,7 @@ package org.gradle.util;
 
 
 import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.codehaus.groovy.runtime.InvokerInvocationException;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -107,7 +108,7 @@ public class JUnit4GroovyMockery extends JUnit4Mockery {
         }
     }
 
-    public void checking(Closure c) {
+    public void checking(@DelegatesTo(type = "org.gradle.util.JUnit4GroovyMockery.ClosureExpectations") Closure c) {
         ClosureExpectations expectations = new ClosureExpectations();
         expectations.closureInit(c, expectations);
         super.checking(expectations);


### PR DESCRIPTION
One of the upcoming features in build scans is some insight into what happens at configuration time, in particular where the hotspots are and some indication of what might be causing them. Gradle 4.0 already emits three build operations to scans for this: configure-build, apply-script and apply-plugin. This change adds information to the `apply-script` and `apply-plugin` notifications, to include identifying information about what that application target is. 

Without this, it is not possible to determine what the application target is. The parent configure-project operation does not indicate this. It only indicates when a project is being formally evaluated, which only happens once per project and is not triggered for configuration injection.

CI: https://builds.gradle.org/project.html?projectId=Gradle_Branches&branch_Gradle_Branches_Checkpoints=ld%2Fbuild-ops%2Fplugins