### PR TITLE
Make progress event serialization more compact

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
@@ -32,7 +32,6 @@ import org.gradle.internal.logging.serializer.ProgressStartEventSerializer;
 import org.gradle.internal.logging.serializer.SpanSerializer;
 import org.gradle.internal.logging.serializer.StyledTextOutputEventSerializer;
 import org.gradle.internal.logging.text.StyledTextOutput;
-import org.gradle.internal.progress.BuildOperationCategory;
 import org.gradle.internal.serialize.BaseSerializerFactory;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.DefaultSerializer;
@@ -46,7 +45,6 @@ public class DaemonMessageSerializer {
         BaseSerializerFactory factory = new BaseSerializerFactory();
         Serializer<LogLevel> logLevelSerializer = factory.getSerializerFor(LogLevel.class);
         Serializer<Throwable> throwableSerializer = factory.getSerializerFor(Throwable.class);
-        Serializer<BuildOperationCategory> buildOperationCategorySerializer = factory.getSerializerFor(BuildOperationCategory.class);
         DefaultSerializerRegistry registry = new DefaultSerializerRegistry();
 
         registry.register(BuildEvent.class, new BuildEventSerializer());
@@ -59,7 +57,7 @@ public class DaemonMessageSerializer {
         // Output events
         registry.register(LogEvent.class, new LogEventSerializer(logLevelSerializer, throwableSerializer));
         registry.register(StyledTextOutputEvent.class, new StyledTextOutputEventSerializer(logLevelSerializer, new ListSerializer<StyledTextOutputEvent.Span>(new SpanSerializer(factory.getSerializerFor(StyledTextOutput.Style.class)))));
-        registry.register(ProgressStartEvent.class, new ProgressStartEventSerializer(buildOperationCategorySerializer));
+        registry.register(ProgressStartEvent.class, new ProgressStartEventSerializer());
         registry.register(ProgressCompleteEvent.class, new ProgressCompleteEventSerializer());
         registry.register(ProgressEvent.class, new ProgressEventSerializer());
         registry.register(LogLevelChangeEvent.class, new LogLevelChangeEventSerializer(logLevelSerializer));

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressStartEventSerializerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/serializer/ProgressStartEventSerializerTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.internal.logging.serializer
 import org.gradle.internal.logging.events.OperationIdentifier
 import org.gradle.internal.logging.events.ProgressStartEvent
 import org.gradle.internal.progress.BuildOperationCategory
-import org.gradle.internal.serialize.BaseSerializerFactory
-import org.gradle.internal.serialize.Serializer
 import spock.lang.Subject
 
 @Subject(ProgressStartEventSerializer)
@@ -32,14 +30,12 @@ class ProgressStartEventSerializerTest extends LogSerializerSpec {
     ProgressStartEventSerializer serializer
 
     def setup() {
-        BaseSerializerFactory serializerFactory = new BaseSerializerFactory()
-        Serializer<BuildOperationCategory> buildOperationCategorySerializer = serializerFactory.getSerializerFor(BuildOperationCategory.class)
-        serializer = new ProgressStartEventSerializer(buildOperationCategorySerializer)
+        serializer = new ProgressStartEventSerializer()
     }
 
-    def "can serialize ProgressStartEvent messages"() {
+    def "can serialize ProgressStartEvent messages"(BuildOperationCategory category) {
         given:
-        def event = new ProgressStartEvent(OPERATION_ID, new OperationIdentifier(5678L), TIMESTAMP, CATEGORY, DESCRIPTION, "short", "header", "status", new OperationIdentifier(42L), new OperationIdentifier(43L), BuildOperationCategory.TASK)
+        def event = new ProgressStartEvent(OPERATION_ID, new OperationIdentifier(5678L), TIMESTAMP, CATEGORY, DESCRIPTION, "short", "header", "status", new OperationIdentifier(42L), new OperationIdentifier(43L), category)
 
         when:
         def result = serialize(event, serializer)
@@ -56,7 +52,10 @@ class ProgressStartEventSerializerTest extends LogSerializerSpec {
         result.status == "status"
         result.buildOperationId == new OperationIdentifier(42L)
         result.parentBuildOperationId == new OperationIdentifier(43L)
-        result.buildOperationCategory == BuildOperationCategory.TASK
+        result.buildOperationCategory == category
+
+        where:
+        category << BuildOperationCategory.values()
     }
 
     def "can serialize ProgressStartEvent messages with empty fields"() {


### PR DESCRIPTION
Use a single byte to indicate nullness of all optional fields instead of writing one byte for each of them. Also encode the category in that byte.

This shaves off another ~30ms on the ABI change scenario.