### PR TITLE
Fix incremental compiler not detecting change of order of jars on classpath

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/RecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/RecompilationSpecProvider.java
@@ -27,9 +27,12 @@ import org.gradle.api.internal.tasks.compile.incremental.jar.PreviousCompilation
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.api.tasks.incremental.InputFileDetails;
+import org.gradle.internal.util.Alignment;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.gradle.internal.FileUtils.hasExtension;
 
@@ -63,18 +66,30 @@ public class RecompilationSpecProvider {
     }
 
     private void processJarChanges(Map<File, JarSnapshot> previousCompilationJarSnapshots, JarClasspathSnapshot currentJarSnapshots, JarChangeProcessor jarChangeProcessor, RecompilationSpec spec) {
-        for (Map.Entry<File, JarSnapshot> entry : previousCompilationJarSnapshots.entrySet()) {
-            File key = entry.getKey();
-            JarSnapshot value = entry.getValue();
-            JarSnapshot snapshot = currentJarSnapshots.getSnapshot(key);
-            if (snapshot == null || !snapshot.getHash().equals(value.getHash())) {
-                ChangeType changeType = snapshot==null ? ChangeType.REMOVED : ChangeType.MODIFIED;
-                jarChangeProcessor.processChange(new FileChange(key.getAbsolutePath(), changeType, "jar"), spec);
-            }
-        }
-        for (File file : currentJarSnapshots.getJars()) {
-            if (!previousCompilationJarSnapshots.containsKey(file)) {
-                jarChangeProcessor.processChange(new FileChange(file.getAbsolutePath(), ChangeType.ADDED, "jar"), spec);
+        Set<File> previousCompilationJars = previousCompilationJarSnapshots.keySet();
+        Set<File> currentCompilationJars = currentJarSnapshots.getJars();
+        List<Alignment<File>> alignment = Alignment.align(currentCompilationJars.toArray(new File[0]), previousCompilationJars.toArray(new File[0]));
+        for (Alignment<File> fileAlignment : alignment) {
+            switch (fileAlignment.getKind()) {
+                case added:
+                    jarChangeProcessor.processChange(new FileChange(fileAlignment.getCurrentValue().getAbsolutePath(), ChangeType.ADDED, "jar"), spec);
+                    break;
+                case removed:
+                    jarChangeProcessor.processChange(new FileChange(fileAlignment.getPreviousValue().getAbsolutePath(), ChangeType.REMOVED, "jar"), spec);
+                    break;
+                case transformed:
+                    // If we detect a transformation in the classpath, we need to recompile, because we could typically be facing the case where
+                    // 2 jars are reversed in the order of classpath elements, and one class that was shadowing the other is now visible
+                    spec.setFullRebuildCause("Classpath has been changed", null);
+                    return;
+                case identical:
+                    File key = fileAlignment.getPreviousValue();
+                    JarSnapshot previousSnapshot = previousCompilationJarSnapshots.get(key);
+                    JarSnapshot snapshot = currentJarSnapshots.getSnapshot(key);
+                    if (!snapshot.getHash().equals(previousSnapshot.getHash())) {
+                        jarChangeProcessor.processChange(new FileChange(key.getAbsolutePath(), ChangeType.MODIFIED, "jar"), spec);
+                    }
+                    break;
             }
         }
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarClasspathSnapshot.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarClasspathSnapshot.java
@@ -20,15 +20,15 @@ import org.gradle.api.Action;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.Set;
 
 public class JarClasspathSnapshot {
 
-    private final Map<File, JarSnapshot> jarSnapshots;
+    private final LinkedHashMap<File, JarSnapshot> jarSnapshots;
     private final JarClasspathSnapshotData data;
 
-    public JarClasspathSnapshot(Map<File, JarSnapshot> jarSnapshots, JarClasspathSnapshotData data) {
+    public JarClasspathSnapshot(LinkedHashMap<File, JarSnapshot> jarSnapshots, JarClasspathSnapshotData data) {
         this.jarSnapshots = jarSnapshots;
         this.data = data;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarClasspathSnapshotFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarClasspathSnapshotFactory.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import com.google.common.hash.HashCode;
 
 import java.io.File;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -33,7 +34,7 @@ public class JarClasspathSnapshotFactory {
     }
 
     JarClasspathSnapshot createSnapshot(Iterable<JarArchive> jarArchives) {
-        Map<File, JarSnapshot> jarSnapshots = Maps.newHashMap();
+        LinkedHashMap<File, JarSnapshot> jarSnapshots = Maps.newLinkedHashMap();
         Map<File, HashCode> jarHashes = Maps.newHashMap();
         Set<String> allClasses = Sets.newHashSet();
         Set<String> duplicateClasses = Sets.newHashSet();

--- a/subprojects/language-java/src/main/java/org/gradle/internal/util/Alignment.java
+++ b/subprojects/language-java/src/main/java/org/gradle/internal/util/Alignment.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.util;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+public class Alignment<T> {
+    private final T previousValue;
+    private final T currentValue;
+    private final Kind kind;
+
+    private Alignment(T previous, T current) {
+        this.previousValue = previous;
+        this.currentValue = current;
+        this.kind = kindOf(previous, current);
+    }
+
+    public T getPreviousValue() {
+        return previousValue;
+    }
+
+    public T getCurrentValue() {
+        return currentValue;
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    private static <T> Kind kindOf(T previous, T current) {
+        if (previous == current) {
+            return Kind.identical;
+        }
+        if (previous == null) {
+            return Kind.added;
+        }
+        if (current == null) {
+            return Kind.removed;
+        }
+        if (current.equals(previous)) {
+            return Kind.identical;
+        }
+        return Kind.transformed;
+    }
+
+    @Override
+    public String toString() {
+        switch (kind) {
+            case added:
+                return "+" + currentValue;
+            case removed:
+                return "-" + previousValue;
+            case transformed:
+                return previousValue + " -> " + currentValue;
+            case identical:
+                return previousValue.toString();
+        }
+        throw new IllegalStateException();
+    }
+
+    /**
+     * Implements the Wagner-Fischer algorithm (https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm) to align 2 sequences of elements.
+     * @param current a sequence of elements
+     * @param previous the sequence to align to
+     * @param <T> the type of the elements of the sequence
+     * @return a list of alignments, telling if an element was added, removed, identical, or mutated
+     */
+    public static <T> List<Alignment<T>> align(T[] current, T[] previous) {
+        int currentLen = current.length;
+        int previousLen = previous.length;
+        int[][] costs = new int[currentLen + 1][previousLen + 1];
+        for (int j = 0; j <= previousLen; j++) {
+            costs[0][j] = j;
+        }
+        for (int i = 1; i <= currentLen; i++) {
+            costs[i][0] = i;
+            for (int j = 1; j <= previousLen; j++) {
+                costs[i][j] = Math.min(Math.min(costs[i - 1][j], costs[i][j - 1]) + 1, current[i - 1].equals(previous[j - 1]) ? costs[i - 1][j - 1] : costs[i - 1][j - 1] + 1);
+            }
+        }
+
+        List<Alignment<T>> result = Lists.newLinkedList();
+        for (int i = currentLen, j = previousLen; i > 0 || j > 0;) {
+            int cost = costs[i][j];
+            if (i > 0 && j > 0 && cost == (current[i - 1].equals(previous[j - 1]) ? costs[i - 1][j - 1] : costs[i - 1][j - 1] + 1)) {
+                T a = current[--i];
+                T b = previous[--j];
+                if (a.equals(b)) {
+                    result.add(0, new Alignment<T>(b, a));
+                } else {
+                    result.add(0, new Alignment<T>(b, a));
+                }
+            } else if (i > 0 && cost == 1 + costs[i - 1][j]) {
+                result.add(0, new Alignment<T>(null, current[--i]));
+            } else if (j > 0 && cost == 1 + costs[i][j - 1]) {
+                result.add(0, new Alignment<T>(previous[--j], null));
+            } else {
+                throw new IllegalStateException("Unexpected cost matrix");
+            }
+        }
+        return result;
+    }
+
+    public enum Kind {
+        added,
+        removed,
+        transformed,
+        identical
+    }
+
+}

--- a/subprojects/language-java/src/test/groovy/org/gradle/internal/util/AlignmentTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/internal/util/AlignmentTest.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.util
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.gradle.internal.util.Alignment.Kind.identical
+
+@Unroll
+class AlignmentTest extends Specification {
+    def "sequences #left and #right are identical"() {
+        given:
+        def alignment = align(left, right)
+
+        expect:
+        alignment.every { it.kind == identical }
+
+        where:
+        left  | right
+        ''    | ''
+        'A'   | 'A'
+        'B'   | 'B'
+        'AB'  | 'AB'
+        'ABC' | 'ABC'
+        'CAB' | 'CAB'
+    }
+
+    def "detects insertion #current and #previous"() {
+        given:
+        def alignment = align(current, previous)
+
+        expect:
+        isAligned(alignment, expectedAlignment)
+
+        where:
+        current | previous | expectedAlignment
+        'A'     | ''       | ['+A']
+        'AA'    | 'A'      | ['+A', 'A']
+        'BA'    | 'B'      | ['B', '+A']
+        'AB'    | 'A'      | ['A', '+B']
+        'ABC'   | 'AC'     | ['A', '+B', 'C']
+        'CAB'   | 'AB'     | ['+C', 'A', 'B']
+    }
+
+    def "detects removal #current and #previous"() {
+        given:
+        def alignment = align(current, previous)
+
+        expect:
+        isAligned(alignment, expectedAlignment)
+
+        where:
+        current | previous | expectedAlignment
+        ''      | 'A'      | ['-A']
+        ''      | 'AB'     | ['-A', '-B']
+        'A'     | 'AA'     | ['-A', 'A']
+        'A'     | 'BA'     | ['-B', 'A']
+        'A'     | 'AB'     | ['A', '-B']
+        'AC'    | 'ABC'    | ['A', '-B', 'C']
+        'AB'    | 'CAB'    | ['-C', 'A', 'B']
+    }
+
+    def "detects reorder #current and #previous"() {
+        given:
+        def alignment = align(current, previous)
+
+        expect:
+        isAligned(alignment, expectedAlignment)
+
+        where:
+        current | previous | expectedAlignment
+        'AB'    | 'BA'     | ['B -> A', 'A -> B']
+        'ABC'   | 'BAC'    | ['B -> A', 'A -> B', 'C']
+        'ABC'   | 'CBA'    | ['C -> A', 'B', 'A -> C']
+    }
+
+    def "detects mix of addition, removals and mutations #current and #previous"() {
+        given:
+        def alignment = align(current, previous)
+
+        expect:
+        isAligned(alignment, expectedAlignment)
+
+        where:
+        current | previous | expectedAlignment
+        'AB'    | 'CD'     | ['C -> A', 'D -> B']
+        'AB'    | 'XADY'   | ['-X', 'A', '-D', 'Y -> B']
+        'EABC'  | 'ABCD'   | ['+E', 'A', 'B', 'C', '-D']
+        'ABC'   | 'BA'     | ['+A', 'B', 'A -> C']
+        'EABC'  | 'ACBD'   | ['A -> E', 'C -> A', 'B', 'D -> C']
+    }
+
+    private static <T> void isAligned(List<Alignment<T>> result, List<?> expectation) {
+        if (expectation.size() != result.size()) {
+            throw new AssertionError("Unexpected alignment. Expected $expectation, was: $result")
+        }
+        for (int i = 0; i < expectation.size(); i++) {
+            def expected = expectation[i]
+            def actual = result[i].toString()
+            assert actual == expected: """Unexpected alignment. Expected $expectation, was: $result
+At index $i, found $actual. Expected $expected"""
+        }
+    }
+
+    private static List<Alignment<Character>> align(String a, String b) {
+        Alignment.align(a as Character[], b as Character[])
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompileAvoidanceIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompileAvoidanceIntegrationSpec.groovy
@@ -1053,8 +1053,8 @@ public class ToolImpl {
                // beginning of a list, when the collection is ordered. It has been agreed not to fix it now, but
                // rather change the incremental compiler not to rely on this incorrect information
                
-               implementation 'net.jcip:jcip-annotations:1.0'
-               implementation 'org.slf4j:slf4j-api:1.7.10'
+               $config 'net.jcip:jcip-annotations:1.0'
+               $config 'org.slf4j:slf4j-api:1.7.10'
             }
         """
         file("src/main/java/Client.java") << """import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -1073,6 +1073,65 @@ public class ToolImpl {
         noExceptionThrown()
 
         when: "Apache Commons is removed from classpath"
+        fails ':compileJava'
+
+        then:
+        failure.assertHasCause('Compilation failed; see the compiler error output for details.')
+
+        where:
+        config << ['api', 'implementation', 'compile']
+    }
+
+    @Unroll
+    def "detects changes in compile classpath order with #config"() {
+        given:
+        ['a', 'b'].each {
+            // Same class is defined in both project `a` and `b` but with a different ABI
+            // so one shadows the other depending on the order on classpath
+            file("$it/src/main/java/A.java") << """
+                public class A {
+                    public static String m_$it() { return "ok"; }
+                }
+            """
+        }
+        buildFile << """
+            apply plugin: 'java-library'
+               
+            repositories {
+               jcenter()
+            }
+            
+            dependencies {
+               switch (project.getProperty('order') as int) {
+                  case 0:
+                    $config 'org.apache.commons:commons-lang3:3.5'
+                    $config project(':a')
+                    $config project(':b')
+                    break
+                  case 1:
+                    $config 'org.apache.commons:commons-lang3:3.5'
+                    $config project(':b')
+                    $config project(':a')
+               }
+            }
+        """
+        file("src/main/java/Client.java") << """import org.apache.commons.lang3.exception.ExceptionUtils;
+            public class Client {
+                public void doSomething() {
+                    ExceptionUtils.rethrow(new RuntimeException(A.m_a()));
+                }
+            }
+        """
+
+        when:
+        executer.withArgument('-Porder=0')
+        succeeds ':compileJava'
+
+        then:
+        noExceptionThrown()
+
+        when: "Order is changed"
+        executer.withArgument('-Porder=1')
         fails ':compileJava'
 
         then:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalJavaCompileAvoidanceAgainstJarIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalJavaCompileAvoidanceAgainstJarIntegrationSpec.groovy
@@ -16,62 +16,10 @@
 
 package org.gradle.java.compile
 
-import spock.lang.Issue
-import spock.lang.Unroll
-
 class IncrementalJavaCompileAvoidanceAgainstJarIntegrationSpec extends AbstractJavaCompileAvoidanceAgainstJarIntegrationSpec {
     def setup() {
         useJar()
         useIncrementalCompile()
     }
 
-    @Unroll
-    @Issue("gradle/gradle#1913")
-    def "detects changes in compile classpath with #config change"() {
-        given:
-        buildFile << """
-            apply plugin: 'java-library'
-               
-            repositories {
-               jcenter()
-            }
-            
-            dependencies {
-               if (project.hasProperty('useCommons')) {
-                  $config 'org.apache.commons:commons-lang3:3.5'
-               }
-               
-               // There MUST be at least 3 dependencies, in that specific order, for the bug to show up.
-               // The reason is that `IncrementalTaskInputs` reports wrong information about deletions at the
-               // beginning of a list, when the collection is ordered. It has been agreed not to fix it now, but
-               // rather change the incremental compiler not to rely on this incorrect information
-               
-               implementation 'net.jcip:jcip-annotations:1.0'
-               implementation 'org.slf4j:slf4j-api:1.7.10'
-            }
-        """
-        file("src/main/java/Client.java") << """import org.apache.commons.lang3.exception.ExceptionUtils;
-            public class Client {
-                public void doSomething() {
-                    ExceptionUtils.rethrow(new RuntimeException("ok"));
-                }
-            }
-        """
-
-        when:
-        executer.withArgument('-PuseCommons')
-        succeeds ':compileJava'
-
-        then:
-        noExceptionThrown()
-
-        when: "Apache Commons is removed from classpath"
-        fails ':compileJava'
-
-        then:
-        failure.assertHasCause('Compilation failed; see the compiler error output for details.')
-
-        where:
-        config << ['api', 'implementation', 'compile']
-    }
 }


### PR DESCRIPTION
This pull request fixes a bug with the incremental compiler, which didn't detect when the order of 2 jars was exchanged on classpath. The consequence of this is that we didn't recompile, even if we should. As an illustration, imagine `foo.jar` and `bar.jar` both providing the same `A` class, but with a different binary interface:

```
public class A {
   void inModuleFoo() {...}
}
```
and
```
public class A {
   void inModuleBar() { ... }
}
```
if a consumer uses the version from `foo`, then `foo` must be found first on classpath. The bug was that if compilation passed, but then we reordered the classpath, we didn't recompile, because neither `foo.jar` nor `bar.jar` had changed.

To fix this, this PR implements an adapted version of the [Wagner-Fischer algorithm](https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm), which is implemented in a generic form. I think it could be used to solve #1931 too, but I didn't want to go that route for the `release` branch.

The PR also pushes a test up the hierarchy to make sure it applied on all combinations of incremental, non incremental, classes directory and jars cases.
