### PR TITLE
Convert some wordy daemon logs to DEBUG from INFO

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -136,7 +136,7 @@ public class DefaultDaemonStarter implements DaemonStarter {
     }
 
     private DaemonStartupInfo startProcess(List<String> args, File workingDir, InputStream stdInput) {
-        LOGGER.info("Starting daemon process: workingDir = {}, daemonArgs: {}", workingDir, args);
+        LOGGER.debug("Starting daemon process: workingDir = {}, daemonArgs: {}", workingDir, args);
         Timer clock = Timers.startTimer();
         try {
             GFileUtils.mkdirs(workingDir);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ExecuteBuild.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ExecuteBuild.java
@@ -51,7 +51,7 @@ public class ExecuteBuild extends BuildCommandOnly {
 
     protected void doBuild(final DaemonCommandExecution execution, Build build) {
         LOGGER.debug(DaemonMessages.STARTED_BUILD);
-        LOGGER.info("Executing build with daemon context: {}", execution.getDaemonContext());
+        LOGGER.debug("Executing build with daemon context: {}", execution.getDaemonContext());
         runningStats.buildStarted();
         try {
             BuildCancellationToken cancellationToken = execution.getDaemonStateControl().getCancellationToken();


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Feel free to reject this if we think we still need this information at the `INFO` level.  They were some of the more egregious logs that stood out to me when running builds.

### Contributor Checklist
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
