### PR TITLE
Do not resolve classes dirs as a file tree

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AbstractFindBugsPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AbstractFindBugsPluginIntegrationTest.groovy
@@ -510,6 +510,27 @@ abstract class AbstractFindBugsPluginIntegrationTest extends AbstractIntegration
         result.assertTaskNotSkipped(":findbugsMain")
     }
 
+    def "does not fail if resources are generated into classes"() {
+        given:
+        goodCode()
+        buildFile << """
+            compileJava {
+                doLast {
+                    def manifest = new File(destinationDir, "META-INF/MANIFEST.MF")
+                    manifest.parentFile.mkdirs()
+                    manifest.text = "manifest"
+                    def properties = new File(destinationDir, "com/example/service.properties")
+                    properties.parentFile.mkdirs()
+                    properties.text = "someProp=value"
+                }
+            } 
+        """
+        when:
+        succeeds("check")
+        then:
+        !result.error.contains("Wrong magic bytes")
+    }
+
     private static boolean containsXmlMessages(File xmlReportFile) {
         new XmlSlurper().parseText(xmlReportFile.text).BugInstance.children().collect { it.name() }.containsAll(['ShortMessage', 'LongMessage'])
     }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
@@ -329,6 +329,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     protected FileCollection getCandidateClassFiles() {
+        // We need to resolve the classes into a set of files so @SkipWhenEmpty will work
+        // Otherwise, a collection of empty directories is not seen as "empty" 
         return getClasses().getAsFileTree();
     }
 

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
@@ -50,6 +50,7 @@ import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
+import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
@@ -328,12 +329,26 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
     @SkipWhenEmpty
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
+    public FileCollection getCandidateClasses() {
+        return getClasses().getAsFileTree().matching(new Action<PatternFilterable>() {
+            @Override
+            public void execute(PatternFilterable patternFilterable) {
+                patternFilterable.include("**/*.class");
+            }
+        });
+    }
+
+    /**
+     * The class directories to be analyzed.
+     */
+    @Internal
     public FileCollection getClasses() {
         return classes;
     }
 
+
     /**
-     * The classes to be analyzed.
+     * The class directories to be analyzed.
      */
     public void setClasses(FileCollection classes) {
         this.classes = classes;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
@@ -50,7 +50,6 @@ import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
-import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
@@ -329,13 +328,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
     @SkipWhenEmpty
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
-    public FileCollection getCandidateClasses() {
-        return getClasses().getAsFileTree().matching(new Action<PatternFilterable>() {
-            @Override
-            public void execute(PatternFilterable patternFilterable) {
-                patternFilterable.include("**/*.class");
-            }
-        });
+    protected FileCollection getCandidateClassFiles() {
+        return getClasses().getAsFileTree();
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
@@ -186,7 +186,7 @@ public class FindBugsPlugin extends AbstractCodeQualityPlugin<FindBugs> {
         taskMapping.map("classes", new Callable<FileCollection>() {
             @Override
             public FileCollection call() {
-                return sourceSet.getOutput().getClassesDirs().getAsFileTree();
+                return sourceSet.getOutput().getClassesDirs();
             }
         });
         taskMapping.map("classpath", new Callable<FileCollection>() {

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/FindBugsPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/FindBugsPluginTest.groovy
@@ -84,7 +84,7 @@ class FindBugsPluginTest extends AbstractProjectBuilderSpec {
             description == "Run FindBugs analysis for ${sourceSet.name} classes"
             source as List == sourceSet.allJava as List
             findbugsClasspath == project.configurations.findbugs
-            classes.empty // no classes to analyze
+            candidateClasses.empty // no classes to analyze
             reports.xml.destination == project.file("build/reports/findbugs/${sourceSet.name}.xml")
             !ignoreFailures
             effort == null

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/FindBugsPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/FindBugsPluginTest.groovy
@@ -84,7 +84,7 @@ class FindBugsPluginTest extends AbstractProjectBuilderSpec {
             description == "Run FindBugs analysis for ${sourceSet.name} classes"
             source as List == sourceSet.allJava as List
             findbugsClasspath == project.configurations.findbugs
-            candidateClasses.empty // no classes to analyze
+            candidateClassFiles.empty // no classes to analyze
             reports.xml.destination == project.file("build/reports/findbugs/${sourceSet.name}.xml")
             !ignoreFailures
             effort == null

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.FindBugs.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.FindBugs.xml
@@ -10,7 +10,7 @@
             </thead>
             <tr>
                 <td>classes</td>
-                <td><literal><replaceable>sourceSet</replaceable>.output</literal></td>
+                <td><literal><replaceable>sourceSet</replaceable>.output.classesDirs</literal></td>
             </tr>
             <tr>
                 <td>classpath</td>


### PR DESCRIPTION
This causes us to include resources in a way that causes FindBugs to
produce an annoying error message

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
