### PR TITLE
Annotate non public APIs used by the build scan plugin.

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/exceptions/MultiCauseException.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/exceptions/MultiCauseException.java
@@ -15,8 +15,11 @@
  */
 package org.gradle.internal.exceptions;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 import java.util.List;
 
+@UsedByScanPlugin
 public interface MultiCauseException {
     List<? extends Throwable> getCauses();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.os;
 
 import org.gradle.api.Nullable;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -85,6 +86,7 @@ public abstract class OperatingSystem {
         return osVersion;
     }
 
+    @UsedByScanPlugin
     public boolean isWindows() {
         return false;
     }
@@ -111,6 +113,7 @@ public abstract class OperatingSystem {
 
     public abstract String getStaticLibraryName(String libraryName);
 
+    @UsedByScanPlugin
     public abstract String getFamilyName();
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/BuildOperationListener.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/BuildOperationListener.java
@@ -15,14 +15,11 @@
  */
 package org.gradle.internal.progress;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * A listener that is notified as build operations are executed via a {@link org.gradle.internal.operations.BuildOperationExecutor}.
  *
  * @since 3.5
  */
-@UsedByScanPlugin
 public interface BuildOperationListener {
 
     void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/BuildOperationListener.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/BuildOperationListener.java
@@ -15,11 +15,14 @@
  */
 package org.gradle.internal.progress;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 /**
  * A listener that is notified as build operations are executed via a {@link org.gradle.internal.operations.BuildOperationExecutor}.
  *
  * @since 3.5
  */
+@UsedByScanPlugin
 public interface BuildOperationListener {
 
     void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/OperationFinishEvent.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/OperationFinishEvent.java
@@ -19,7 +19,7 @@ package org.gradle.internal.progress;
 import org.gradle.api.Nullable;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
-@UsedByScanPlugin
+@UsedByScanPlugin("Used via InternalTaskExecutionListener")
 public final class OperationFinishEvent {
     private final long startTime;
     private final long endTime;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/OperationFinishEvent.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/OperationFinishEvent.java
@@ -17,7 +17,9 @@
 package org.gradle.internal.progress;
 
 import org.gradle.api.Nullable;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public final class OperationFinishEvent {
     private final long startTime;
     private final long endTime;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/OperationStartEvent.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/OperationStartEvent.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.progress;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+@UsedByScanPlugin
 public final class OperationStartEvent {
     private final long startTime;
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/progress/OperationStartEvent.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/progress/OperationStartEvent.java
@@ -18,7 +18,7 @@ package org.gradle.internal.progress;
 
 import org.gradle.internal.scan.UsedByScanPlugin;
 
-@UsedByScanPlugin
+@UsedByScanPlugin("Used via InternalTaskExecutionListener")
 public final class OperationStartEvent {
     private final long startTime;
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceLookupException.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceLookupException.java
@@ -16,9 +16,12 @@
 
 package org.gradle.internal.service;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 /**
  * Thrown when there is some failure locating a service.
  */
+@UsedByScanPlugin
 public class ServiceLookupException extends RuntimeException {
     public ServiceLookupException(String message) {
         super(message);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistry.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.service;
 
 import org.gradle.internal.Factory;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -33,6 +34,7 @@ public interface ServiceRegistry {
      * @throws UnknownServiceException When there is no service of the given type available.
      * @throws ServiceLookupException On failure to lookup the specified service.
      */
+    @UsedByScanPlugin
     <T> T get(Class<T> serviceType) throws UnknownServiceException, ServiceLookupException;
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/UnknownServiceException.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/UnknownServiceException.java
@@ -15,8 +15,11 @@
  */
 package org.gradle.internal.service;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 import java.lang.reflect.Type;
 
+@UsedByScanPlugin
 public class UnknownServiceException extends IllegalArgumentException {
     private final Type type;
 

--- a/subprojects/core/src/main/java/org/gradle/api/execution/internal/InternalTaskExecutionListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/execution/internal/InternalTaskExecutionListener.java
@@ -19,10 +19,12 @@ package org.gradle.api.execution.internal;
 import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.OperationFinishEvent;
 import org.gradle.internal.progress.OperationStartEvent;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Used by build scans to collect some task details, and will be retired. Use {@link BuildOperationListener} instead.
  */
+@UsedByScanPlugin
 public interface InternalTaskExecutionListener {
     void beforeExecute(TaskOperationInternal taskOperation, OperationStartEvent startEvent);
     void afterExecute(TaskOperationInternal taskOperation, OperationFinishEvent result);

--- a/subprojects/core/src/main/java/org/gradle/api/execution/internal/TaskOperationInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/execution/internal/TaskOperationInternal.java
@@ -17,7 +17,9 @@
 package org.gradle.api.execution.internal;
 
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public final class TaskOperationInternal {
     private final TaskInternal task;
     private final Object id;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.execution.TaskGraphExecuter;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.util.Path;
@@ -80,6 +81,7 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
      */
     BuildListener getBuildListenerBroadcaster();
 
+    @UsedByScanPlugin
     ServiceRegistry getServices();
 
     ServiceRegistryFactory getServiceRegistryFactory();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -35,6 +35,7 @@ import java.util.Collection;
  * An internal interface for Gradle that exposed objects and concepts that are not intended for public
  * consumption.
  */
+@UsedByScanPlugin
 public interface GradleInternal extends Gradle, PluginAwareInternal {
     /**
      * {@inheritDoc}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputCachingState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputCachingState.java
@@ -18,7 +18,9 @@ package org.gradle.api.internal;
 
 import org.gradle.api.Nullable;
 import org.gradle.api.internal.tasks.TaskOutputCachingDisabledReasonCategory;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public interface TaskOutputCachingState {
     /**
      * Check if caching is enabled for the task outputs.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -33,6 +33,7 @@ import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.metaobject.DynamicObject;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.model.internal.registry.ModelRegistry;
@@ -75,6 +76,7 @@ public interface ProjectInternal extends Project, ProjectIdentifier, FileOperati
 
     FileResolver getFileResolver();
 
+    @UsedByScanPlugin
     ServiceRegistry getServices();
 
     ServiceRegistryFactory getServiceRegistryFactory();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -40,6 +40,7 @@ import org.gradle.model.internal.registry.ModelRegistry;
 import org.gradle.model.internal.registry.ModelRegistryScope;
 import org.gradle.util.Path;
 
+@UsedByScanPlugin
 public interface ProjectInternal extends Project, ProjectIdentifier, FileOperations, ProcessOperations, DomainObjectContext, DependencyMetaDataProvider, ModelRegistryScope, PluginAwareInternal {
 
     // These constants are defined here and not with the rest of their kind in HelpTasksPlugin because they are referenced

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -30,7 +30,6 @@ import java.util.Map;
  *
  * @since 4.0
  */
-@UsedByScanPlugin
 public final class SnapshotTaskInputsBuildOperationType implements BuildOperationType<SnapshotTaskInputsBuildOperationType.Details, SnapshotTaskInputsBuildOperationType.Result> {
 
     @UsedByScanPlugin

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputCachingDisabledReasonCategory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputCachingDisabledReasonCategory.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+@UsedByScanPlugin
 public enum TaskOutputCachingDisabledReasonCategory {
     UNKNOWN,
     BUILD_CACHE_DISABLED,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -79,6 +79,7 @@ public class TaskStateInternal implements TaskState {
         this.taskOutputCaching = taskOutputCaching;
     }
 
+    @UsedByScanPlugin
     public TaskOutputCachingState getTaskOutputCaching() {
         return taskOutputCaching;
     }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/ScriptCompilationException.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/ScriptCompilationException.java
@@ -16,10 +16,12 @@
 package org.gradle.groovy.scripts;
 
 import org.gradle.api.GradleScriptException;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * A {@code ScriptCompilationException} is thrown when a script cannot be compiled.
  */
+@UsedByScanPlugin
 public class ScriptCompilationException extends GradleScriptException {
     private final ScriptSource scriptSource;
     private final Integer lineNumber;

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/ScriptSource.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/ScriptSource.java
@@ -16,12 +16,14 @@
 package org.gradle.groovy.scripts;
 
 import org.gradle.internal.resource.TextResource;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.io.Serializable;
 
 /**
  * The source for the text of a script, with some meta-info about the script.
  */
+@UsedByScanPlugin
 public interface ScriptSource extends Serializable {
     /**
      * Returns the name to use for the compiled class for this script. Never returns null.

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildRequestMetaData.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildRequestMetaData.java
@@ -15,11 +15,13 @@
  */
 package org.gradle.initialization;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.util.Clock;
 
 /**
  * A bunch of information about the request which launched a build.
  */
+@UsedByScanPlugin
 public interface BuildRequestMetaData {
     /**
      * Returns the meta-data about the client used to launch this build.

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayout.java
@@ -16,9 +16,11 @@
 package org.gradle.initialization.layout;
 
 import org.gradle.initialization.SettingsLocation;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.io.File;
 
+@UsedByScanPlugin
 public class BuildLayout extends SettingsLocation {
     private final File rootDirectory;
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
@@ -16,12 +16,14 @@
 package org.gradle.initialization.layout;
 
 import org.gradle.StartParameter;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.io.File;
 
 /**
  * Configuration which affects the (static) layout of a build.
  */
+@UsedByScanPlugin
 public class BuildLayoutConfiguration {
     private File currentDir;
     private boolean searchUpwards;

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -18,9 +18,11 @@ package org.gradle.initialization.layout;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.resources.MissingResourceException;
 import org.gradle.internal.FileUtils;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.io.File;
 
+@UsedByScanPlugin
 public class BuildLayoutFactory {
     /**
      * Determines the layout of the build, given a current directory and some other configuration.

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionLogger.java
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.TaskState;
 import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.progress.LoggerProvider;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,6 +31,7 @@ import java.util.Map;
 /**
  * A listener which logs the execution of tasks.
  */
+@UsedByScanPlugin
 public class TaskExecutionLogger implements TaskExecutionListener {
 
     private final Map<Task, ProgressLogger> currentTasks = new HashMap<Task, ProgressLogger>();

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionLogger.java
@@ -31,7 +31,7 @@ import java.util.Map;
 /**
  * A listener which logs the execution of tasks.
  */
-@UsedByScanPlugin
+@UsedByScanPlugin("Used to filter out ProgressStartEvent with this category")
 public class TaskExecutionLogger implements TaskExecutionListener {
 
     private final Map<Task, ProgressLogger> currentTasks = new HashMap<Task, ProgressLogger>();

--- a/subprojects/core/src/main/java/org/gradle/internal/environment/GradleBuildEnvironment.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/environment/GradleBuildEnvironment.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.environment;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+@UsedByScanPlugin
 public interface GradleBuildEnvironment {
 
     boolean isLongLivingProcess();

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/LocationAwareException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/LocationAwareException.java
@@ -20,6 +20,7 @@ import org.gradle.api.GradleException;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.util.TreeVisitor;
 
 import java.util.ArrayList;
@@ -28,6 +29,7 @@ import java.util.List;
 /**
  * A {@code LocationAwareException} is an exception which can be annotated with a location in a script.
  */
+@UsedByScanPlugin
 public class LocationAwareException extends GradleException implements FailureResolutionAware {
     private final String sourceDisplayName;
     private final Integer lineNumber;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
@@ -19,6 +19,7 @@ package org.gradle.internal.logging;
 import org.gradle.api.logging.LoggingOutput;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.internal.logging.events.OutputEventListener;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.io.OutputStream;
 
@@ -62,10 +63,12 @@ public interface LoggingOutputInternal extends LoggingOutput {
     /**
      * Adds the given listener as a logging destination.
      */
+    @UsedByScanPlugin
     void addOutputEventListener(OutputEventListener listener);
 
     /**
      * Adds the given listener.
      */
+    @UsedByScanPlugin
     void removeOutputEventListener(OutputEventListener listener);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/CategorisedOutputEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/CategorisedOutputEvent.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.logging.events;
 
 import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 public class CategorisedOutputEvent extends OutputEvent {
     private final String category;
@@ -37,6 +38,7 @@ public class CategorisedOutputEvent extends OutputEvent {
         return logLevel;
     }
 
+    @UsedByScanPlugin
     public String getCategory() {
         return category;
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/LogEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/LogEvent.java
@@ -19,7 +19,9 @@ package org.gradle.internal.logging.events;
 import org.gradle.api.Nullable;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public class LogEvent extends RenderableOutputEvent {
     private final String message;
     private final Throwable throwable;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/OutputEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/OutputEvent.java
@@ -18,10 +18,12 @@ package org.gradle.internal.logging.events;
 
 import org.gradle.api.Nullable;
 import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Represents some event which may generate output. All implementations are immutable.
  */
+@UsedByScanPlugin
 public abstract class OutputEvent {
     /**
      * Returns the log level for this event.

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/OutputEventListener.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/OutputEventListener.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.logging.events;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+@UsedByScanPlugin
 public interface OutputEventListener {
     void onOutput(OutputEvent event);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressStartEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/ProgressStartEvent.java
@@ -19,7 +19,9 @@ package org.gradle.internal.logging.events;
 import org.gradle.api.Nullable;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.progress.BuildOperationCategory;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public class ProgressStartEvent extends CategorisedOutputEvent {
     private final OperationIdentifier progressOperationId;
     private final OperationIdentifier parentProgressOperationId;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/StyledTextOutputEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/StyledTextOutputEvent.java
@@ -19,12 +19,14 @@ package org.gradle.internal.logging.events;
 import org.gradle.api.Nullable;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@UsedByScanPlugin
 public class StyledTextOutputEvent extends RenderableOutputEvent {
     private final List<Span> spans;
 
@@ -70,6 +72,7 @@ public class StyledTextOutputEvent extends RenderableOutputEvent {
         }
     }
 
+    @UsedByScanPlugin
     public static class Span implements Serializable {
         private final String text;
         private final StyledTextOutput.Style style;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/StyledTextOutput.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/StyledTextOutput.java
@@ -16,11 +16,15 @@
 
 package org.gradle.internal.logging.text;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 /**
  * Provides streaming of styled text, that is, a stream of text with inline styling information. Implementations are not
  * required to be thread-safe.
  */
+@UsedByScanPlugin
 public interface StyledTextOutput extends Appendable {
+    @UsedByScanPlugin
     enum Style {
         /**
          * Regular text.

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/StyledTextOutputFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/StyledTextOutputFactory.java
@@ -17,7 +17,9 @@
 package org.gradle.internal.logging.text;
 
 import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public interface StyledTextOutputFactory {
     /**
      * Creates a {@code StyledTextOutput} with the given category and the standard output log level.

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderException.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/PlaceholderException.java
@@ -18,10 +18,12 @@ package org.gradle.internal.serialize;
 
 import org.gradle.api.Nullable;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * A {@code PlaceholderException} is used when an exception cannot be serialized or deserialized.
  */
+@UsedByScanPlugin
 public class PlaceholderException extends RuntimeException {
     private final String exceptionClassName;
     private final Throwable getMessageException;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestCompleteEvent.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestCompleteEvent.java
@@ -18,7 +18,9 @@ package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.Nullable;
 import org.gradle.api.tasks.testing.TestResult;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public class TestCompleteEvent {
     private final long endTime;
     private final TestResult.ResultType resultType;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
@@ -18,7 +18,9 @@ package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.Nullable;
 import org.gradle.api.tasks.testing.TestDescriptor;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public interface TestDescriptorInternal extends TestDescriptor {
     @Nullable
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestStartEvent.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestStartEvent.java
@@ -17,7 +17,9 @@
 package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.Nullable;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public class TestStartEvent {
     private final long startTime;
     private final Object parentId;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestListenerInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestListenerInternal.java
@@ -21,7 +21,9 @@ import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.internal.tasks.testing.TestStartEvent;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestResult;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
+@UsedByScanPlugin
 public interface TestListenerInternal {
     void started(TestDescriptorInternal testDescriptor, TestStartEvent startEvent);
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationResult.java
@@ -17,6 +17,7 @@
 package org.gradle.tooling.events;
 
 import org.gradle.api.Incubating;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Describes the result of running an operation.
@@ -24,6 +25,7 @@ import org.gradle.api.Incubating;
  * @since 2.4
  */
 @Incubating
+@UsedByScanPlugin
 public interface OperationResult {
 
     /**


### PR DESCRIPTION
The scan plugin relies on several internal BT APIs. This is not always clear to anyone working on the BT code, which means that the build scan plugin can unknowingly be broken. We want to make this dependency clear.