### PR TITLE
Trim whitespace at the end of task groups

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -71,7 +71,7 @@ public class GroupedOutputFixture {
         while (matcher.find()) {
             String taskName = matcher.group(1);
             String taskOutput = matcher.group(2);
-            taskOutput = taskOutput.replace(ERASE_TO_END_OF_LINE, "");
+            taskOutput = taskOutput.replace(ERASE_TO_END_OF_LINE, "").trim();
             if (tasks.containsKey(taskName)) {
                 tasks.get(taskName).addOutput(taskOutput);
             } else {

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
@@ -74,27 +74,25 @@ Second incremental output
     def "parses tasks with progress bar interference"() {
         given:
         def consoleOutput = """
- [1A [1m<-------------> 0% INITIALIZING [1s] [m [36D [1B
- [1A [1m<-------------> 0% CONFIGURING [5s] [m [0K [35D [1B
- [1A [1m<-------------> 0% CONFIGURING [6s] [m [35D [1B
- [1A [1m<=============> 100% CONFIGURING [6s] [m [37D [1B
- [1A [1m<=============> 100% CONFIGURING [7s] [m [37D [1B
- [1A [1m<-------------> 0% EXECUTING [7s] [m [0K [33D [1B
- [1A [1m> Task :1:log [m [0K
+\u001B[1A [1m<-------------> 0% INITIALIZING [1s] [m [36D [1B
+\u001B[1A [1m<-------------> 0% CONFIGURING [5s] [m [0K [35D [1B
+\u001B[1A [1m<=============> 100% CONFIGURING [7s] [m [37D [1B
+\u001B[1A [1m<-------------> 0% EXECUTING [7s] [m [0K [33D [1B
+\u001B[1A [1m> Task :1:log [m [0K
 Output from 1
 
- [0K
- [1A [1m<====---------> 33% EXECUTING [7s] [m [34D [1B
- [1A [1m> Task :2:log [m [0K
+\u001B[0K
+\u001B[1A [1m<====---------> 33% EXECUTING [7s] [m [34D [1B
+\u001B[1A [1m> Task :2:log\u001B[m [0K
 Output from 2
 
- [1m> Task :3:log [m
+\u001B[1m> Task :3:log\u001B[m
 Output from 3
 
 
- [32;1mBUILD SUCCESSFUL [0;39m in 8s
+\u001B[32;1mBUILD SUCCESSFUL\u001B[0;39m in 8s
 3 actionable tasks: 3 executed
- [2K
+\u001B[2K
 """
         when:
         GroupedOutputFixture groupedOutput = new GroupedOutputFixture(consoleOutput)
@@ -105,12 +103,11 @@ Output from 3
         groupedOutput.task(':2:log').output == 'Output from 2'
     }
 
-
     def "handles task outputs with erase to end of line chars"() {
         given:
         def consoleOutput = """
- [2A [1m<-------------> 0% EXECUTING [3s] [m [33D [1B [1m> :log [m [6D [1B
- [2A [1m> Task :log [m [0K
+\u001B[2A [1m<-------------> 0% EXECUTING [3s] [m [33D [1B [1m> :log [m [6D [1B
+\u001B[2A [1m> Task :log [m [0K
 First line of text\u001B[0K
 
 
@@ -118,7 +115,7 @@ First line of text\u001B[0K
 Last line of text
 
 
- [31mFAILURE:  [39m [31mBuild failed with an exception. [39m
+\u001B[31mFAILURE:  [39m [31mBuild failed with an exception. [39m
 """
         when:
         GroupedOutputFixture groupedOutput = new GroupedOutputFixture(consoleOutput)
@@ -127,4 +124,24 @@ Last line of text
         groupedOutput.task(':log').output == 'First line of text\n\n\n\nLast line of text'
     }
 
+    def "handles erase directly before progress bar right before end of build"() {
+        given:
+        def consoleOutput = """
+\u001B[1m> Task :1:log\u001B[m\u001B[0K
+Output from 1
+
+
+\u001B[0K
+\u001B[0K
+\u001B[2A\u001B[1m<=============> 100% EXECUTING [5s]\u001B[m\u001B[35D\u001B[1B\u001B[90m> IDLE\u001B[39m\u001B[6D\u001B[1B
+\u001B[2A\u001B[32;1mBUILD SUCCESSFUL\u001B[0;39m in 5s\u001B[0K
+3 actionable tasks: 3 executed [0K
+\u001B[2K
+"""
+        when:
+        GroupedOutputFixture groupedOutput = new GroupedOutputFixture(consoleOutput)
+
+        then:
+        groupedOutput.task(':1:log').output == "Output from 1"
+    }
 }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Fixes some flakiness in the grouped logging tests due to trailing newline characters.  

[Failed CI Build](https://builds.gradle.org/viewLog.html?buildId=3010261&buildTypeId=Gradle_Release_CoveragePhase_WindowsCoverage_WindowsJava17DaemonIntegrationTes_7)

### Contributor Checklist
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches&branch_Gradle_Branches=wl-trim-grouped-output)
