### PR TITLE
Stop testing with Java 9 until we fix Gradle

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -87,8 +87,8 @@ public class DefaultGradleDistribution implements GradleDistribution {
             return javaVersion.compareTo(JavaVersion.VERSION_1_6) >= 0 && javaVersion.compareTo(JavaVersion.VERSION_1_8) <= 0;
         }
 
-        // 3.x works on Java 7 - 9
-        return javaVersion.compareTo(JavaVersion.VERSION_1_7) >= 0 && javaVersion.compareTo(JavaVersion.VERSION_1_9) <= 0;
+        // 3.x works on Java 7 - 8
+        return javaVersion.compareTo(JavaVersion.VERSION_1_7) >= 0 && javaVersion.compareTo(JavaVersion.VERSION_1_8) <= 0;
     }
 
     public boolean worksWith(OperatingSystem os) {


### PR DESCRIPTION
This change removes our test coverage for Java 9 support. We are
currently broken with the latest ea releases of the Java 9 JVM, so we
shouldn't attempt to run our tests using Java 9.

We will reenable this when we have fixed the issues.

### Context
Developers who currently try to run many of our cross-version tests suites locally will run into issues if there is a Java 9 JVM installed on their system with which Gradle is incompatible. We need to fix Gradle to run on Java 9, and then reenable our support for the JVM in our cross-version tests.