### PR TITLE
Account for multiple lines in the progress bar

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -37,7 +37,11 @@ public class GroupedOutputFixture {
 
     private final static String BUILD_STATUS_FOOTER = "\\n[^\\n]*?BUILD SUCCESSFUL";
     private final static String BUILD_FAILED_FOOTER = "\\n[^\\n]*?FAILURE:";
-    private final static String PROGRESS_BAR = ".?\\[0K.*?";
+
+    /**
+     * Start of a new line, the control character, and must have <--------> or <=========>
+     */
+    private final static String PROGRESS_BAR = "^\u001B\\[[^\\n]*?\\[1m(<[-=]+>.*?)\\[m.*?$";
     private final static String END_OF_TASK_OUTPUT = TASK_HEADER + "|" + BUILD_STATUS_FOOTER + "|" + BUILD_FAILED_FOOTER + "|" + PROGRESS_BAR;
 
 
@@ -50,8 +54,6 @@ public class GroupedOutputFixture {
         // Capture all output, lazily up until two new lines and an END_OF_TASK designation
         precompiledPattern += "(.*?(?=\\n\\n(?:[^\\n]*?" + END_OF_TASK_OUTPUT + ")))";
         TASK_OUTPUT_PATTERN = Pattern.compile(precompiledPattern);
-        //TODO: Remove once stable
-        System.err.println(precompiledPattern);
     }
 
     /**
@@ -67,11 +69,11 @@ public class GroupedOutputFixture {
 
     private void parse(String output) {
         tasks = new HashedMap();
-        Matcher matcher = TASK_OUTPUT_PATTERN.matcher(output);
+        Matcher matcher = TASK_OUTPUT_PATTERN.matcher(output.replace(ERASE_TO_END_OF_LINE, ""));
         while (matcher.find()) {
             String taskName = matcher.group(1);
             String taskOutput = matcher.group(2);
-            taskOutput = taskOutput.replace(ERASE_TO_END_OF_LINE, "").trim();
+            taskOutput = taskOutput.trim();
             if (tasks.containsKey(taskName)) {
                 tasks.get(taskName).addOutput(taskOutput);
             } else {

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
@@ -144,4 +144,33 @@ Output from 1
         then:
         groupedOutput.task(':1:log').output == "Output from 1"
     }
+
+    def "handles multiple lines of progress bar"() {
+        given:
+        def consoleOutput = """
+\u001B[4A\u001B[1m<-------------> 0% EXECUTING [3s] [m [0K [33D [1B [1m> :1:log [m [8D [1B [1m> :2:log [m [8D [1B [1m> :3:log [m [8D [1B
+\u001B[4A\u001B[0K
+\u001B[1m> Task :1:log\u001B[m\u001B[0K
+Output from 1\u001B[0K
+\u001B[0K
+\u001B[1m> Task :2:log\u001B[m
+Output from 2
+
+\u001B[1m> Task :3:log\u001B[m
+Output from 3
+
+
+\u001B[32;1mBUILD SUCCESSFUL\u001B[0;39m in 3s
+3 actionable tasks: 3 executed
+\u001B[2K
+"""
+        when:
+        GroupedOutputFixture groupedOutput = new GroupedOutputFixture(consoleOutput)
+
+        then:
+        groupedOutput.taskCount == 3
+        groupedOutput.task(':1:log').output == "Output from 1"
+        groupedOutput.task(':2:log').output == "Output from 2"
+        groupedOutput.task(':3:log').output == "Output from 3"
+    }
 }


### PR DESCRIPTION
### Context
When tests are run in parallel there are multiple lines in the progress bar, as a result when messages are logged, there are line erasures sent on multiple lines of output.  This accounts for that case.

### Contributor Checklist
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches&branch_Gradle_Branches=wl-fix-flaky-test)
