### PR TITLE
Always print task name when there's an exception during execution

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ArchiveIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ArchiveIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.test.fixtures.archive.TarTestFixture
 import org.gradle.test.fixtures.file.TestFile
-import org.hamcrest.Matchers
 import spock.lang.Issue
 
 import static org.hamcrest.Matchers.equalTo
@@ -280,7 +279,7 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
         def failure = runAndFail('copy')
 
         then:
-        failure.assertThatDescription(Matchers.startsWith("Unable to expand TAR"))
+        failure.assertHasCause("Unable to expand TAR")
     }
 
     def cannotCreateAnEmptyZip() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
@@ -81,7 +81,8 @@ class CachedTaskIntegrationTest extends AbstractIntegrationSpec implements Direc
         corruptMetadata({ metadata -> metadata.text = "corrupt" })
         withBuildCache().fails("cacheable")
         then:
-        failure.assertHasCause("Cached result format error, corrupted origin metadata.")
+        failure.assertHasCause("Could not load entry")
+        errorOutput.contains("Cached result format error, corrupted origin metadata.")
 
         when:
         file("build").deleteDir()
@@ -89,7 +90,8 @@ class CachedTaskIntegrationTest extends AbstractIntegrationSpec implements Direc
         corruptMetadata({ metadata -> metadata.delete() })
         withBuildCache().fails("cacheable")
         then:
-        failure.assertHasCause("Cached result format error, no origin metadata was found.")
+        failure.assertHasCause("Could not load entry")
+        errorOutput.contains("Cached result format error, no origin metadata was found.")
     }
 
     def corruptMetadata(Closure corrupter) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -40,7 +40,7 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when: fails "foo"
-        then: failure.assertHasDescription("Unable to store input properties for task ':foo'. Property 'b' with value 'xxx' cannot be serialized.")
+        then: failure.assertHasCause("Unable to store input properties for task ':foo'. Property 'b' with value 'xxx' cannot be serialized.")
     }
 
     def "deals gracefully with not serializable contents of GStrings"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -133,7 +133,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
                 Object value = prepareValue(entry.getValue());
                 actualProperties.put(propertyName, value);
             } catch (Exception ex) {
-                throw new InvalidUserDataException(String.format("Error while evaluating property '%s' of %s", propertyName, task), ex);
+                throw new InvalidUserDataException(String.format("Error while evaluating property '%s': %s", propertyName, ex.getMessage()), ex);
             }
         }
         return actualProperties;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CatchExceptionTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CatchExceptionTaskExecuter.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskStateInternal;
+import org.gradle.api.tasks.TaskExecutionException;
 
 public class CatchExceptionTaskExecuter implements TaskExecuter {
     private final TaskExecuter delegate;
@@ -32,8 +33,10 @@ public class CatchExceptionTaskExecuter implements TaskExecuter {
     public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
         try {
             delegate.execute(task, state, context);
-        } catch (RuntimeException e) {
+        } catch (TaskExecutionException e) {
             state.setOutcome(e);
+        } catch (RuntimeException e) {
+            state.setOutcome(new TaskExecutionException(task, e));
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuter.java
@@ -22,7 +22,6 @@ import org.gradle.api.internal.changedetection.TaskArtifactStateRepository;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskStateInternal;
-import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey;
 
 public class VerifyNoInputChangesTaskExecuter implements TaskExecuter {
@@ -42,10 +41,10 @@ public class VerifyNoInputChangesTaskExecuter implements TaskExecuter {
         if (beforeExecution.isValid()) {
             TaskOutputCachingBuildCacheKey afterExecution = repository.getStateFor(task).calculateCacheKey();
             if (!afterExecution.isValid()) {
-                throw new TaskExecutionException(task, new GradleException("The build cache key became invalid after the task has been executed!"));
+                throw new GradleException("The build cache key became invalid after the task has been executed!");
             }
             if (!beforeExecution.getHashCode().equals(afterExecution.getHashCode())) {
-                throw new TaskExecutionException(task, new GradleException("The inputs for the task changed during the execution! Check if you have a `doFirst` changing the inputs."));
+                throw new GradleException("The inputs for the task changed during the execution! Check if you have a `doFirst` changing the inputs.");
             }
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/CatchExceptionTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/CatchExceptionTaskExecuterTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskExecutionContext
 import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
+import org.gradle.api.tasks.TaskExecutionException
 import spock.lang.Specification
 
 class CatchExceptionTaskExecuterTest extends Specification {
@@ -43,7 +44,24 @@ class CatchExceptionTaskExecuterTest extends Specification {
         !state.failure
     }
 
-    def 'should throw exception of delegate and set the outcome to failure'() {
+    def 'should throw task execution exception of delegate and set the outcome to failure'() {
+        given:
+        def failure = new TaskExecutionException(task, new RuntimeException("Failure"))
+
+        when:
+        executer.execute(task, state, context)
+
+        then:
+        1 * delegate.execute(task, state, context) >> {
+            throw failure
+        }
+        0 * _
+
+        state.outcome == TaskExecutionOutcome.EXECUTED
+        state.failure.is(failure)
+    }
+
+    def 'should rethrow general exception of delegate as task execution exception and set the outcome to failure'() {
         given:
         def failure = new RuntimeException("Failure")
 
@@ -57,6 +75,8 @@ class CatchExceptionTaskExecuterTest extends Specification {
         0 * _
 
         state.outcome == TaskExecutionOutcome.EXECUTED
-        state.failure.is(failure)
+        state.failure instanceof TaskExecutionException
+        state.failure.task == task
+        state.failure.cause.is(failure)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuterTest.groovy
@@ -16,13 +16,13 @@
 
 package org.gradle.api.internal.tasks.execution
 
+import org.gradle.api.GradleException
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.changedetection.TaskArtifactState
 import org.gradle.api.internal.changedetection.TaskArtifactStateRepository
 import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskExecutionContext
 import org.gradle.api.internal.tasks.TaskStateInternal
-import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.caching.internal.tasks.BuildCacheKeyInputs
 import org.gradle.caching.internal.tasks.DefaultTaskOutputCachingBuildCacheKeyBuilder
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey
@@ -80,9 +80,8 @@ class VerifyNoInputChangesTaskExecuterTest extends Specification {
         1 * after.calculateCacheKey() >> cacheKey(hashKeyAfter)
         0 * _
 
-        TaskExecutionException e = thrown(TaskExecutionException)
-        e.task == task
-        e.cause.message == "The inputs for the task changed during the execution! Check if you have a `doFirst` changing the inputs."
+        def e = thrown GradleException
+        e.message == "The inputs for the task changed during the execution! Check if you have a `doFirst` changing the inputs."
     }
 
     def 'exception if cache key became invalid'() {
@@ -99,9 +98,8 @@ class VerifyNoInputChangesTaskExecuterTest extends Specification {
         1 * after.calculateCacheKey() >> invalidCacheKey()
         0 * _
 
-        TaskExecutionException e = thrown(TaskExecutionException)
-        e.task == task
-        e.cause.message == "The build cache key became invalid after the task has been executed!"
+        def e = thrown GradleException
+        e.message == "The build cache key became invalid after the task has been executed!"
     }
 
     private static TaskOutputCachingBuildCacheKey cacheKey(String hash) {

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/jshint/JsHint.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/jshint/JsHint.java
@@ -28,7 +28,6 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.plugins.javascript.jshint.internal.JsHintProtocol;
 import org.gradle.plugins.javascript.jshint.internal.JsHintResult;
 import org.gradle.plugins.javascript.jshint.internal.JsHintSpec;
@@ -179,7 +178,7 @@ public class JsHint extends SourceTask {
         }
 
         if (anyErrors) {
-            throw new TaskExecutionException(this, new GradleException("JsHint detected errors"));
+            throw new GradleException("JsHint detected errors");
         }
     }
 }


### PR DESCRIPTION
Previously we didn't print the name of the task in some cases.