### PR TITLE
Log task path for task output caching problems

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
@@ -61,6 +61,7 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends AbstractIntegrat
         executer.withFullDeprecationStackTraceDisabled()
         withBuildCache().succeeds "customTask"
         then:
+        output.contains "Could not pack cache results for task ':customTask'"
         output ==~ /(?s).*org\.gradle\.api\.GradleException: Could not pack property 'outputFile': ${errorPattern}.*/ ||
             output ==~ /(?s).*org\.gradle\.caching\.BuildCacheException: Unable to store entry at .*: ${errorPattern}.*/
     }


### PR DESCRIPTION
Previously we only logged the offending task property name when packing/unpacking failed. Now we also log the path of the task.