### PR TITLE
Log progress headers when not associated with a build operation

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
@@ -32,6 +32,7 @@ import org.gradle.internal.logging.events.RenderableOutputEvent;
 import org.gradle.internal.logging.events.StyledTextOutputEvent;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.progress.BuildOperationCategory;
+import org.gradle.util.GUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -76,15 +77,22 @@ public class GroupingProgressLogEventGenerator extends BatchOutputEventListener 
 
     private void onStart(ProgressStartEvent startEvent) {
         Object buildOpId = startEvent.getBuildOperationId();
+        boolean isGrouped = isGroupedOperation(startEvent.getBuildOperationCategory());
         if (buildOpId != null) {
             buildOpIdHierarchy.put(buildOpId, startEvent.getParentBuildOperationId());
             progressToBuildOpIdMap.put(startEvent.getProgressOperationId(), buildOpId);
 
             // Create a new group for tasks or configure project
-            if (isGroupedOperation(startEvent.getBuildOperationCategory())) {
+            if (isGrouped) {
                 String header = startEvent.getLoggingHeader() != null ? startEvent.getLoggingHeader() : startEvent.getDescription();
                 operationsInProgress.put(buildOpId, new OperationGroup(startEvent.getCategory(), header, startEvent.getTimestamp(), startEvent.getBuildOperationId()));
             }
+        }
+
+        // Preserve logging of headers for progress operations started outside of the build operation executor as was done in Gradle 3.x
+        // Basically, if we see an operation with a logging header and it's not grouped, just log it
+        if (GUtil.isTrue(startEvent.getLoggingHeader()) && (buildOpId == null || !isGrouped)) {
+            onUngroupedOutput(new LogEvent(startEvent.getTimestamp(), startEvent.getCategory(), startEvent.getLogLevel(), startEvent.getLoggingHeader(), null, startEvent.getBuildOperationId()));
         }
     }
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
@@ -42,6 +42,17 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
         and: 0 * _
     }
 
+    def "renders ungrouped logging headers"() {
+        given:
+        def header = "Download http://repo.somewhere.com/foo.jar"
+        def downloadEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), tenAm, CATEGORY, "Download description", null, header, null, null, null, BuildOperationCategory.UNCATEGORIZED)
+
+        when: listener.onOutput(downloadEvent)
+
+        then: 1 * downstreamListener.onOutput({ it.getMessage() == header })
+        and: 0 * _
+    }
+
     def "forwards a group of logs for a task"() {
         given:
         def taskStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), tenAm, CATEGORY, "Execute :foo", ":foo", null, null, new OperationIdentifier(2L), null, BuildOperationCategory.TASK)

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsLoggingIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsLoggingIntegrationTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.devel.impldeps
+
+import org.gradle.util.GradleVersion
+
+class GradleImplDepsLoggingIntegrationTest extends BaseGradleImplDepsIntegrationTest {
+    def setup() {
+        requireOwnGradleUserHomeDir()
+    }
+
+    def "Generating shaded JARs is logged with console #console"() {
+        given:
+        executer.withArgument("--console=$console")
+        buildFile << """
+            configurations {
+                gradleImplDeps
+            }
+
+            dependencies {
+                gradleImplDeps gradleApi(), gradleTestKit()
+            }
+
+            task resolveDependencies {
+                doLast {
+                    configurations.gradleImplDeps.resolve()
+                }
+            }
+        """
+
+        when:
+        succeeds('resolveDependencies')
+
+        then:
+        def gradleVersion = GradleVersion.current().version
+        output.contains("Generating JAR file 'gradle-api-${gradleVersion}.jar'")
+        output.contains("Generating JAR file 'gradle-test-kit-${gradleVersion}.jar'")
+
+        where:
+        console  | placeholder
+        "plain"  | _
+        "rich"   | _
+    }
+}


### PR DESCRIPTION
### Context
Brings back the logs, but not the progress display for downloading files, generating shaded JARs, and other things we log in Gradle 3.x.

### Contributor Checklist
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
