### PR TITLE
Show stale output cleanup message on info level

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/cleanup/BuildOperationBuildOutputDeleterDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/cleanup/BuildOperationBuildOutputDeleterDecorator.java
@@ -18,9 +18,10 @@ package org.gradle.internal.cleanup;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.progress.BuildOperationDescriptor;
-import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.util.GUtil;
 
 import java.io.File;
 
@@ -45,7 +46,8 @@ public class BuildOperationBuildOutputDeleterDecorator implements BuildOutputDel
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                return BuildOperationDescriptor.displayName("Clean stale outputs for " + gradle.getIdentityPath().getName());
+                String rootProjectIdentifier = GUtil.elvis(gradle.getIdentityPath().getName(), "root build");
+                return BuildOperationDescriptor.displayName("Clean stale outputs for " + rootProjectIdentifier).progressDisplayName("cleanup stale outputs for " + rootProjectIdentifier);
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/cleanup/DefaultBuildOutputDeleter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/cleanup/DefaultBuildOutputDeleter.java
@@ -19,7 +19,6 @@ package org.gradle.internal.cleanup;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import org.gradle.api.UncheckedIOException;
-import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.delete.Deleter;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -29,14 +28,11 @@ import java.io.File;
 import java.util.Collection;
 
 public class DefaultBuildOutputDeleter implements BuildOutputDeleter {
-    public static final String STALE_OUTPUT_MESSAGE = "Gradle is removing stale outputs from a previous version of Gradle, for more information about stale outputs see";
+    public static final String STALE_OUTPUT_MESSAGE = "Gradle is removing stale outputs from a previous version of Gradle.";
     private final Logger logger = Logging.getLogger(DefaultBuildOutputDeleter.class);
-
-    private final DocumentationRegistry documentationRegistry;
     private final Deleter deleter;
 
-    public DefaultBuildOutputDeleter(DocumentationRegistry documentationRegistry, Deleter deleter) {
-        this.documentationRegistry = documentationRegistry;
+    public DefaultBuildOutputDeleter(Deleter deleter) {
         this.deleter = deleter;
     }
 
@@ -50,7 +46,7 @@ public class DefaultBuildOutputDeleter implements BuildOutputDeleter {
         });
 
         if (!roots.isEmpty()) {
-            logger.warn(STALE_OUTPUT_MESSAGE + " {}.", documentationRegistry.getDocumentationFor("more_about_tasks", "sec:stale_task_outputs"));
+            logger.info(STALE_OUTPUT_MESSAGE);
             for (File output : roots) {
                 deleteOutput(output);
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.service.scopes;
 
 import org.gradle.api.Action;
-import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
@@ -190,8 +189,8 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         return new DefaultBuildOutputCleanupRegistry(fileResolver);
     }
 
-    protected BuildOutputDeleter createBuildOutputDeleter(BuildOperationExecutor buildOperationExecutor, GradleInternal gradle, FileResolver fileResolver, FileLookup lookup, DocumentationRegistry documentationRegistry) {
-        return new BuildOperationBuildOutputDeleterDecorator(gradle, buildOperationExecutor, new DefaultBuildOutputDeleter(documentationRegistry, new Deleter(fileResolver, lookup.getFileSystem())));
+    protected BuildOutputDeleter createBuildOutputDeleter(BuildOperationExecutor buildOperationExecutor, GradleInternal gradle, FileResolver fileResolver, FileLookup lookup) {
+        return new BuildOperationBuildOutputDeleterDecorator(gradle, buildOperationExecutor, new DefaultBuildOutputDeleter(new Deleter(fileResolver, lookup.getFileSystem())));
     }
 
     protected BuildOutputCleanupCache createBuildOutputCleanupCache(CacheRepository cacheRepository, GradleInternal gradle, BuildOutputDeleter buildOutputDeleter, BuildOutputCleanupRegistry buildOutputCleanupRegistry) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/cleanup/DefaultBuildOutputDeleterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/cleanup/DefaultBuildOutputDeleterTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.cleanup
 
-import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.file.delete.Deleter
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -28,7 +27,7 @@ class DefaultBuildOutputDeleterTest extends Specification {
     final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 
     def deleter = Mock(Deleter)
-    def buildOutputDeleter = new DefaultBuildOutputDeleter(Stub(DocumentationRegistry), deleter)
+    def buildOutputDeleter = new DefaultBuildOutputDeleter(deleter)
 
     def "skips deletion operation if no directory or file is provided"() {
         when:

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
@@ -41,6 +41,12 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
         mostRecentFinalReleaseExecuter.cleanup()
     }
 
+    def setup() {
+        executer.beforeExecute {
+            executer.withArgument('--info')
+        }
+    }
+
     @Issue("GRADLE-1501")
     @Unroll
     def "production sources files are removed in a single project build for #description"() {


### PR DESCRIPTION
With the now reduced console logging it makes much more sense to not have the cleanup message at all in the lifecycle log.