### PR TITLE
Exclude Path in BuildDependenciesOnlyFileCollectionResolveContext.add

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.internal.file.PathToFileResolver;
 
+import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
 import static org.gradle.util.GUtil.uncheckedCall;
@@ -73,7 +74,7 @@ public class BuildDependenciesOnlyFileCollectionResolveContext implements FileCo
             if (callableResult != null) {
                 add(callableResult);
             }
-        } else if (element instanceof Iterable) {
+        } else if (element instanceof Iterable && !(element instanceof Path)) {
             Iterable<?> iterable = (Iterable) element;
             for (Object value : iterable) {
                 add(value);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContextTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContextTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.TaskOutputs
 import spock.lang.Specification
 
+import java.nio.file.Path
 import java.util.concurrent.Callable
 
 class BuildDependenciesOnlyFileCollectionResolveContextTest extends Specification {
@@ -147,6 +148,7 @@ class BuildDependenciesOnlyFileCollectionResolveContextTest extends Specificatio
         context.add('a')
         context.add(Stub(TaskDependency))
         context.add(Stub(Runnable))
+        context.add(Stub(Path))
 
         then:
         0 * taskContext._


### PR DESCRIPTION
### Context

This fix #1973 , the reason is that Path.iterator() returns Path itself, resulting in calling [BuildDependenciesOnlyFileCollectionResolveContext.add](https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java#L52) infinitely.

Please let me know if this fix is inappropriate or there's something I haven't taken into consideration.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`
