### PR TITLE
Avoid removing the stack trace portion on standard output when executed in rich console mode

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -950,24 +950,16 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
             @Override
             public void execute(ExecutionResult executionResult) {
-                String normalizedOutput = executionResult.getNormalizedOutput();
-                // Rich console output contains standard output and error
-                normalizedOutput = useRichConsole ? removeStackTraceAfterExpectedException(executionResult, normalizedOutput) : normalizedOutput;
-                validate(normalizedOutput, "Standard output");
+                validate(executionResult.getNormalizedOutput(), "Standard output");
                 String error = executionResult.getError();
-                error = removeStackTraceAfterExpectedException(executionResult, error);
-                validate(error, "Standard error");
-            }
-
-            private String removeStackTraceAfterExpectedException(ExecutionResult executionResult, String text) {
                 if (executionResult instanceof ExecutionFailure) {
                     // Axe everything after the expected exception
-                    int pos = text.indexOf("* Exception is:\n");
+                    int pos = error.indexOf("* Exception is:\n");
                     if (pos >= 0) {
-                        text = text.substring(0, pos);
+                        error = error.substring(0, pos);
                     }
                 }
-                return text;
+                validate(error, "Standard error");
             }
 
             private void validate(String output, String displayName) {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/BasicGroupedTaskLoggingFunctionalSpec.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/BasicGroupedTaskLoggingFunctionalSpec.groovy
@@ -95,6 +95,8 @@ class BasicGroupedTaskLoggingFunctionalSpec extends AbstractConsoleFunctionalSpe
     }
 
     def "grouped output is displayed for failed tasks"() {
+        executer.withStackTraceChecksDisabled()
+
         given:
         buildFile << """
             task log {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleJvmTestLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleJvmTestLoggingFunctionalTest.groovy
@@ -30,6 +30,8 @@ class ConsoleJvmTestLoggingFunctionalTest extends AbstractConsoleFunctionalSpec 
     }
 
     def "can group failed test log event with task by default"() {
+        executer.withStackTraceChecksDisabled()
+
         given:
         file(JAVA_TEST_FILE_PATH) << javaTestClass {
             'throw new RuntimeException("expected");'
@@ -102,6 +104,8 @@ class ConsoleJvmTestLoggingFunctionalTest extends AbstractConsoleFunctionalSpec 
     }
 
     def "can group multiple test log events with task"() {
+        executer.withStackTraceChecksDisabled()
+
         given:
         buildFile << testLoggingEvents(TestLogEvent.STARTED.testLoggingIdentifier, TestLogEvent.FAILED.testLoggingIdentifier)
         buildFile << testLoggingStandardStream()


### PR DESCRIPTION
Reverts remove the stack trace portion on standard output when executed in rich console mode.

Failed on daemon builds. Needs further investigation.
