### PR TITLE
Clean up stack trace when run for functional console tests

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/BasicGroupedTaskLoggingFunctionalSpec.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/BasicGroupedTaskLoggingFunctionalSpec.groovy
@@ -95,8 +95,6 @@ class BasicGroupedTaskLoggingFunctionalSpec extends AbstractConsoleFunctionalSpe
     }
 
     def "grouped output is displayed for failed tasks"() {
-        executer.withStackTraceChecksDisabled()
-
         given:
         buildFile << """
             task log {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleJvmTestLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/ConsoleJvmTestLoggingFunctionalTest.groovy
@@ -30,8 +30,6 @@ class ConsoleJvmTestLoggingFunctionalTest extends AbstractConsoleFunctionalSpec 
     }
 
     def "can group failed test log event with task by default"() {
-        executer.withStackTraceChecksDisabled()
-
         given:
         file(JAVA_TEST_FILE_PATH) << javaTestClass {
             'throw new RuntimeException("expected");'
@@ -104,8 +102,6 @@ class ConsoleJvmTestLoggingFunctionalTest extends AbstractConsoleFunctionalSpec 
     }
 
     def "can group multiple test log events with task"() {
-        executer.withStackTraceChecksDisabled()
-
         given:
         buildFile << testLoggingEvents(TestLogEvent.STARTED.testLoggingIdentifier, TestLogEvent.FAILED.testLoggingIdentifier)
         buildFile << testLoggingStandardStream()


### PR DESCRIPTION
The check for useRichConsole doesn't evaluate properly when run with daemon. Instead check if the error is empty or null and whether the execution failed. That condition is a clear indicator that it ran with rich console.