### PR TITLE
Stop using `getPackages` for Java 9

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -53,7 +53,7 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
             Method method = ClassLoader.class.getMethod("getDefinedPackages");
             systemPackages = (Package[]) method.invoke(EXT_CLASS_LOADER);
         } catch (NoSuchMethodException e) {
-            // Ignore
+            // We must not be on Java 9 where the getDefinedPackages() method exists. Fall back to getPackages()
             JavaMethod<ClassLoader, Package[]> method = JavaReflectionUtil.method(ClassLoader.class, Package[].class, "getPackages");
             systemPackages = method.invoke(EXT_CLASS_LOADER);
         } catch (Exception e) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -22,7 +22,6 @@ import org.gradle.internal.reflect.JavaReflectionUtil;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.lang.NoSuchMethodException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;


### PR DESCRIPTION
In Java 9, some of the uses of reflection we have in our codebase
are not acceptable anymore. There is also a public method on
ClassLoader which doesn't require us to use reflection to access
it.

This change just starts trying to use the Java 9 method if it is
there and falls back to using reflection on the older protected
method if the Java 9 version is not found.