### PR TITLE
Skip environment manipulation for Java 9

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -53,7 +53,7 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
             Method method = ClassLoader.class.getMethod("getDefinedPackages");
             systemPackages = (Package[]) method.invoke(EXT_CLASS_LOADER);
         } catch (NoSuchMethodException e) {
-            // Ignore
+            // We must not be on Java 9 where the getDefinedPackages() method exists. Fall back to getPackages()
             JavaMethod<ClassLoader, Package[]> method = JavaReflectionUtil.method(ClassLoader.class, Package[].class, "getPackages");
             systemPackages = method.invoke(EXT_CLASS_LOADER);
         } catch (Exception e) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -22,7 +22,6 @@ import org.gradle.internal.reflect.JavaReflectionUtil;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.lang.NoSuchMethodException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/ReflectiveEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/ReflectiveEnvironment.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.nativeintegration;
 
+import org.gradle.api.JavaVersion;
 import org.gradle.internal.os.OperatingSystem;
 
 import java.lang.reflect.Field;
@@ -27,6 +28,9 @@ import java.util.Map;
 public class ReflectiveEnvironment {
 
     public void unsetenv(String name) {
+        if (JavaVersion.current().isJava9Compatible()) {
+            return;
+        }
         Map<String, String> map = getEnv();
         map.remove(name);
         if (OperatingSystem.current().isWindows()) {
@@ -36,6 +40,9 @@ public class ReflectiveEnvironment {
     }
 
     public void setenv(String name, String value) {
+        if (JavaVersion.current().isJava9Compatible()) {
+            return;
+        }
         Map<String, String> map = getEnv();
         map.put(name, value);
         if (OperatingSystem.current().isWindows()) {

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/NativePlatformBackedProcessEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/NativePlatformBackedProcessEnvironment.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.nativeintegration.processenvironment;
 
 import net.rubygrapefruit.platform.Process;
+import org.gradle.api.JavaVersion;
 
 import java.io.File;
 
@@ -28,12 +29,16 @@ public class NativePlatformBackedProcessEnvironment extends AbstractProcessEnvir
 
     @Override
     protected void removeNativeEnvironmentVariable(String name) {
-        process.setEnvironmentVariable(name, null);
+        if (!JavaVersion.current().isJava9Compatible()) {
+            process.setEnvironmentVariable(name, null);
+        }
     }
 
     @Override
     protected void setNativeEnvironmentVariable(String name, String value) {
-        process.setEnvironmentVariable(name, value);
+        if (!JavaVersion.current().isJava9Compatible()) {
+            process.setEnvironmentVariable(name, value);
+        }
     }
 
     @Override


### PR DESCRIPTION
The underlying implementation attempts to modify an unmodifiable map
that is locked down in Java 9.