### PR TITLE
Shutdown the executors eagerly

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -46,7 +46,7 @@ public class GroupedOutputFixture {
     private final static String END_OF_TASK_OUTPUT = TASK_HEADER + "|" + BUILD_STATUS_FOOTER + "|" + BUILD_FAILED_FOOTER;
 
     private final static String PROGRESS_BAR_PATTERN = "<[-=]*> \\d+% (INITIALIZ|CONFIGUR|EXECUT)ING \\[((\\d+h )? \\d+m )?\\d+s\\]";
-    private final static String WORK_IN_PROGRESS_PATTERN = "\u001b\\[\\d+m> (IDLE|[:a-z][\\w\\s\\d:]+)\u001b\\[\\d*m";
+    private final static String WORK_IN_PROGRESS_PATTERN = "\u001b\\[\\d+m> (IDLE|[:a-z][\\w\\s\\d:>/\\\\\\.]+)\u001b\\[\\d*m";
     private final static String DOWN_MOVEMENT_WITH_NEW_LINE_PATTERN = "\u001b\\[\\d+B\\n";
 
     private final static String WORK_IN_PROGRESS_AREA_PATTERN = PROGRESS_BAR_PATTERN + "|" + WORK_IN_PROGRESS_PATTERN + "|" + DOWN_MOVEMENT_WITH_NEW_LINE_PATTERN;

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
@@ -304,4 +304,27 @@ Before\u001B[0K
         then:
         groupedOutput.task(':log').output == 'Before\nAfter'
     }
+
+    def "handles complex work-in-progress items"() {
+        given:
+        def consoleOutput = """
+\u001B[1m> Task :buildSrc:helloWorld\u001B[m
+Hello world
+
+
+\u001B[2A\u001B[1m<-------------> 0% CONFIGURING [0s]\u001B[m\u001B[35D\u001B[1B\u001B[1m> root project > Compiling /Users/daniel/gradle/gradle/build/tmp/test files/ConsoleBuildSrcFunctionalTest/can_group_task_outp..._buildSrc/pco71/build.gradle into local compilation cache\u001B[m\u001B[185D\u001B[1B\u001B[2A\u001B[0K
+\u001B[1m> Task :byeWorld\u001B[m\u001B[0K
+Bye world
+
+
+\u001B[32;1mBUILD SUCCESSFUL\u001B[0;39m in 0s
+1 actionable task: 1 executed
+\u001B[2K"""
+
+        when:
+        GroupedOutputFixture groupedOutput = new GroupedOutputFixture(consoleOutput)
+
+        then:
+        groupedOutput.task(':buildSrc:helloWorld').output == 'Hello world'
+    }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildStatusRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildStatusRenderer.java
@@ -162,6 +162,6 @@ public class BuildStatusRenderer extends BatchOutputEventListener {
         if (future != null && !future.isCancelled()) {
             future.cancel(false);
         }
-        executor.shutdown();
+        executor.shutdownNow();
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
@@ -88,7 +88,7 @@ public class GroupingProgressLogEventGenerator extends BatchOutputEventListener 
             if (future != null && !future.isCancelled()) {
                 future.cancel(false);
             }
-            executor.shutdown();
+            executor.shutdownNow();
             onEnd((EndOutputEvent) event);
         } else if (!(event instanceof ProgressEvent)) {
             listener.onOutput(event);

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
@@ -257,5 +257,6 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
         listener.onOutput([end] as ArrayList<OutputEvent>)
 
         then: 1 * future.cancel(false)
+        then: 1 * executor.shutdownNow()
     }
 }


### PR DESCRIPTION
### Context
See [Slack discussion](https://gradle.slack.com/archives/C03A0MT6S/p1495708080658498) and [performance report](https://builds.gradle.org/repository/download/Gradle_Release_Performance_PerformanceTestCoordinatorLinux/3049298:id/results/performance/build/performance-tests/report/index.html). 

See adhoc performance test result for [`libA0:buildDependentsLibA0 on nativeDependents`](https://builds.gradle.org/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=3050355&_focus=1851) and [`libA0.dependentComponents on nativeDependents`](https://builds.gradle.org/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=3051224&_focus=1756)

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches_Checkpoints&branch_Gradle_Branches_Checkpoints=dl%2Fregression-release)
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
