### PR TITLE
Exclude non-jar files when starting findbugs (Fix 1094,1745)

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsSpecBuilder.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsSpecBuilder.java
@@ -190,10 +190,16 @@ public class FindBugsSpecBuilder {
         if (has(classpath)) {
             args.add("-auxclasspath");
 
-            // Filter unexisting files as FindBugs can't handle them.
+            // Filter files FindBugs can't handle
+            // See edu.umd.cs.findbugs.classfile.impl.ClassFactory.createFilesystemCodeBase
             args.add(classpath.filter(new Spec<File>() {
                 public boolean isSatisfiedBy(File element) {
-                    return element.exists();
+                    if (element.isDirectory()) {
+                        return true;
+                    } else if (element.isFile()) {
+                        return element.getName().endsWith(".class") || element.getName().endsWith(".jar");
+                    }
+                    return false;
                 }
             }).getAsPath());
         }


### PR DESCRIPTION
### Context

It has been reported in #1094 #1745 and [old forum](https://discuss.gradle.org/t/findbugs-plugin-issue-throwing-zipexception/2010) that Findbugs will throw exception when non-jar files exist in classpath. The reason is that [FindBugsSpecBuilder](https://github.com/gradle/gradle/blob/master/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsSpecBuilder.java#L196) doesn't filter files in classpath but [Findbugs](https://github.com/findbugsproject/findbugs/blob/master/findbugs/src/java/edu/umd/cs/findbugs/classfile/impl/ClassFactory.java#L105) can only recognize `class` files and `jar` files.

This fix adds filter to `FindBugsSpecBuilder` and provides unit test/integration test.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`
