### PR TITLE
Handle null Throwable stack trace to avoid NullPointerException

### DIFF
--- a/subprojects/messaging/src/integTest/groovy/org/gradle/internal/serialize/ExceptionPlaceholderIntegrationTest.groovy
+++ b/subprojects/messaging/src/integTest/groovy/org/gradle/internal/serialize/ExceptionPlaceholderIntegrationTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+class ExceptionPlaceholderIntegrationTest extends AbstractIntegrationSpec {
+
+    @Issue("https://github.com/gradle/gradle/issues/1618")
+    def "internal exception should not be thrown"() {
+        given:
+        buildFile << '''
+            apply plugin: 'java'
+
+            repositories {
+                jcenter()
+            }
+
+            dependencies {
+                testCompile 'junit:junit:4.12'
+                testCompile 'org.mockito:mockito-core:2.3.7'
+            }
+        '''
+
+        file('src/test/java/example/Issue1618Test.java') << '''
+        package example;
+
+        import org.junit.Test;
+
+        import static org.mockito.Mockito.doThrow;
+        import static org.mockito.Mockito.mock;
+
+        public class Issue1618Test {
+
+            public static class Bugger {
+                public void run() {
+                }
+            }
+
+            @Test(expected = RuntimeException.class)
+            public void thisTestShouldBeMarkedAsFailed() {
+                RuntimeException mockedException = mock(RuntimeException.class);
+                Bugger bugger = mock(Bugger.class);
+                doThrow(mockedException).when(bugger).run();
+                bugger.run();
+            }
+        }
+        '''
+
+        expect:
+        succeeds('test')
+    }
+}

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
@@ -45,7 +45,7 @@ class ExceptionPlaceholder implements Serializable {
         type = throwable.getClass().getName();
 
         try {
-            stackTrace = throwable.getStackTrace();
+            stackTrace = throwable.getStackTrace() == null ? new StackTraceElement[0] : throwable.getStackTrace();
         } catch (Throwable ignored) {
 // TODO:ADAM - switch the logging back on. Need to make sending messages from daemon to client async wrt log event generation
 //                LOGGER.debug("Ignoring failure to extract throwable stack trace.", ignored);

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/MessageTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/MessageTest.groovy
@@ -259,6 +259,18 @@ class MessageTest extends Specification {
         e2.message == 'broken toString()'
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/1618")
+    def "transports mock exception with null cause"() {
+        def exceptionWithNullCause = Mock(Exception)
+        exceptionWithNullCause.stackTrace >> null
+
+        when:
+        def transported = transport(exceptionWithNullCause)
+
+        then:
+        transported.stackTrace == [] as StackTraceElement[]
+    }
+
     @Issue("GRADLE-1996")
     def "can transport exception that implements writeReplace()"() {
         def original = new WriteReplaceException("original")


### PR DESCRIPTION
### Context

See #1618 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`