### PR TITLE
Add support for 'console' output type of CodeNarc plugin (Fix 1481)

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcPluginIntegrationTest.groovy
@@ -203,6 +203,21 @@ class CodeNarcPluginIntegrationTest extends WellBehavedPluginTest {
         'toolVersion'  | "codenarc { toolVersion '0.17' } "
     }
 
+    def "output should be printed in stdout if console type is specified"() {
+        when:
+        buildFile << '''
+            codenarc {
+                configFile == file('config/codenarc/codenarc.xml')
+                reportFormat = 'console' 
+            }
+        '''
+        file('src/main/groovy/a/A.groovy') << 'package a;class A{}'
+
+        then:
+        succeeds('check')
+        output.contains('CodeNarc Report')
+        output.contains('CodeNarc completed: (p1=0; p2=0; p3=0)')
+    }
 
     private void writeBuildFile() {
         file("build.gradle") << """

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcInvoker.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcInvoker.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.plugins.quality.internal
 
 import org.gradle.api.GradleException
 import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.project.ant.AntLoggingAdapter
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.plugins.quality.CodeNarc
 import org.gradle.api.reporting.SingleFileReport
@@ -49,12 +50,12 @@ abstract class CodeNarcInvoker {
                     reports.enabled.each { SingleFileReport r ->
                         // See http://codenarc.sourceforge.net/codenarc-TextReportWriter.html
                         if (r.name == 'console') {
-                            setLifecycleLogLevel(ant,'INFO')
+                            setLifecycleLogLevel(ant, 'INFO')
                             report(type: 'text') {
                                 option(name: 'writeToStandardOut', value: true)
                             }
                         } else {
-                            setLifecycleLogLevel(ant,null)
+                            setLifecycleLogLevel(ant, null)
                             report(type: r.name) {
                                 option(name: 'outputFile', value: r.destination)
                             }
@@ -85,7 +86,7 @@ abstract class CodeNarcInvoker {
     static void setLifecycleLogLevel(Object ant, String lifecycleLogLevel) {
         ant?.builder?.project?.buildListeners?.each {
             // We cannot use instanceof or getClass()==AntLoggingAdapter since they're in different class loaders
-            if (it.class.simpleName == 'AntLoggingAdapter') {
+            if (it.class.name == AntLoggingAdapter.name) {
                 it.lifecycleLogLevel = lifecycleLogLevel
             }
         }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcReportsImpl.java
@@ -30,6 +30,7 @@ public class CodeNarcReportsImpl extends TaskReportContainer<SingleFileReport> i
         add(TaskGeneratedSingleFileReport.class, "xml", task);
         add(TaskGeneratedSingleFileReport.class, "html", task);
         add(TaskGeneratedSingleFileReport.class, "text", task);
+        add(TaskGeneratedSingleFileReport.class, "console", task);
     }
 
     public SingleFileReport getXml() {

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodenarcTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodenarcTest.groovy
@@ -30,4 +30,9 @@ class CodenarcTest extends Specification {
         codenarc.configFile == project.file("config/file.txt")
         codenarc.config.inputFiles.singleFile == project.file("config/file.txt")
     }
+
+    def "has html/xml/text/console"() {
+        expect:
+        codenarc.reports.names == ['console', 'html', 'text', 'xml'] as Set
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ant/AntLoggingAdapter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ant/AntLoggingAdapter.java
@@ -88,6 +88,10 @@ public class AntLoggingAdapter implements BuildLogger {
         }
     }
 
+    public void setLifecycleLogLevel(String lifecycleLogLevel) {
+        setLifecycleLogLevel(lifecycleLogLevel == null ? null : AntMessagePriority.valueOf(lifecycleLogLevel));
+    }
+
     public void setLifecycleLogLevel(AntMessagePriority lifecycleLogLevel) {
         this.lifecycleLogLevel = lifecycleLogLevel;
     }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -10,6 +10,10 @@ Add-->
 
 Gradle's [continuous build feature](userguide/continuous_build.html) now works with [composite builds](userguide/composite_builds.html). Gradle will automatically detect changes to any input from any build and rebuild the appropriate pieces.
 
+### CodeNarc plugin supports report format 'console'
+
+CodeNarc plugin supports outputting report to console now. In some scenarios this is convenient for user.
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.


### PR DESCRIPTION
### Context

See #1481 and [discussion in old forum](https://discuss.gradle.org/t/codenarc-reportformat-console-still-hides-the-output-from-the-console/11971/2). 

Although it is documented that CodeNarc plugin supports 'console' output type, that type is never implemented. This commit add 'console' TaskGeneratedSingleFile to CodeNarcReportsImpl, and adjust the options with which Ant codenarc task is called. To redirect Ant output to Gradle standard output in 'console' type, the lifecycleLogLevel of AntLogAdapter is changed to INFO.

Then, a unit test and an integration test are provided.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`
