### PR TITLE
Review items from project locking PR

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
@@ -21,6 +21,7 @@ import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseService;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.concurrent.Executor;
@@ -155,7 +156,7 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
         }
 
         private void runBatch(final T firstOperation) {
-            workerLeases.withLocks(parentWorkerLease.createChild()).execute(new Runnable() {
+            workerLeases.withLocks(Collections.singleton(parentWorkerLease.createChild()), new Runnable() {
                 @Override
                 public void run() {
                     T operation = firstOperation;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
@@ -123,7 +123,8 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
             return unlockedResources != null && !unlockedResources.isEmpty();
         }
 
-        void releaseLocks() {
+        @Override
+        public void releaseLocks() {
             if (lockedResources != null) {
                 rollback = true;
                 try {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
@@ -22,7 +22,6 @@ import org.gradle.api.Transformer;
 import org.gradle.internal.UncheckedException;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -141,7 +140,7 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
     /**
      * Attempts an atomic, blocking lock on the provided resource locks.
      */
-    public static Transformer<ResourceLockState.Disposition, ResourceLockState> lock(Collection<? extends ResourceLock> resourceLocks) {
+    public static Transformer<ResourceLockState.Disposition, ResourceLockState> lock(Iterable<? extends ResourceLock> resourceLocks) {
         return new AcquireLocks(resourceLocks, true);
     }
 
@@ -155,7 +154,7 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
     /**
      * Attempts an atomic, non-blocking lock on the provided resource locks.
      */
-    public static Transformer<ResourceLockState.Disposition, ResourceLockState> tryLock(Collection<? extends ResourceLock> resourceLocks) {
+    public static Transformer<ResourceLockState.Disposition, ResourceLockState> tryLock(Iterable<? extends ResourceLock> resourceLocks) {
         return new AcquireLocks(resourceLocks, false);
     }
 
@@ -169,7 +168,7 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
     /**
      * Unlocks the provided resource locks.
      */
-    public static Transformer<ResourceLockState.Disposition, ResourceLockState> unlock(Collection<? extends ResourceLock> resourceLocks) {
+    public static Transformer<ResourceLockState.Disposition, ResourceLockState> unlock(Iterable<? extends ResourceLock> resourceLocks) {
         return new ReleaseLocks(resourceLocks);
     }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ProjectLeaseRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ProjectLeaseRegistry.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.resources;
 
+import java.util.concurrent.Callable;
+
 public interface ProjectLeaseRegistry {
     /**
      * Get a lock for the specified project.
@@ -27,12 +29,18 @@ public interface ProjectLeaseRegistry {
     ResourceLock getProjectLock(String gradlePath, String projectPath);
 
     /**
+     * Releases all project locks held by the current thread and executes the {@link Callable}.  Upon completion of the
+     * {@link Callable}, if a lock was held at the time the method was called, then it will be reacquired.  If no locks were held at the
+     * time the method was called, then no attempt will be made to reacquire a lock on completion.  While blocking to reacquire the project
+     * lock, all worker leases held by the thread will be released and reacquired once the project lock is obtained.
+     */
+    <T> T withoutProjectLock(Callable<T> action);
+
+    /**
      * Releases all project locks held by the current thread and executes the {@link Runnable}.  Upon completion of the
      * {@link Runnable}, if a lock was held at the time the method was called, then it will be reacquired.  If no locks were held at the
      * time the method was called, then no attempt will be made to reacquire a lock on completion.  While blocking to reacquire the project
      * lock, all worker leases held by the thread will be released and reacquired once the project lock is obtained.
-     *
-     * @param runnable
      */
-    void withoutProjectLock(Runnable runnable);
+    void withoutProjectLock(Runnable action);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockState.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockState.java
@@ -37,4 +37,9 @@ public interface ResourceLockState {
      * @param resourceLock
      */
     void registerUnlocked(ResourceLock resourceLock);
+
+    /**
+     * Release any locks that have been acquired during the transform.
+     */
+    void releaseLocks();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -69,7 +69,7 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService {
     public WorkerLease getCurrentWorkerLease() {
         Collection<? extends ResourceLock> operations = workerLeaseLockRegistry.getResourceLocksByCurrentThread();
         if (operations.isEmpty()) {
-            throw new IllegalStateException("No worker lease associated with the current thread");
+            throw new NoAvailableWorkerLeaseException("No worker lease associated with the current thread");
         }
         return (DefaultWorkerLease) operations.toArray()[operations.size() - 1];
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/NoAvailableWorkerLeaseException.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/NoAvailableWorkerLeaseException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.work;
+
+public class NoAvailableWorkerLeaseException extends RuntimeException {
+    public NoAvailableWorkerLeaseException(String message) {
+        super(message);
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseService.java
@@ -20,7 +20,7 @@ import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLock;
 
-import java.util.concurrent.Executor;
+import java.util.concurrent.Callable;
 
 public interface WorkerLeaseService extends WorkerLeaseRegistry, ProjectLeaseRegistry, Stoppable {
     /**
@@ -29,17 +29,28 @@ public interface WorkerLeaseService extends WorkerLeaseRegistry, ProjectLeaseReg
     int getMaxWorkerCount();
 
     /**
-     * Returns an {@link Executor} that will run a given {@link Runnable} while the specified locks are being held, releasing
-     * the locks upon completion.  {@link Executor#execute(Runnable)} will run the provided {@link Runnable} immediately and
-     * synchronously.  Blocks until the specified locks can be obtained.
+     * Runs a given {@link Callable} while the specified locks are being held, releasing
+     * the locks upon completion.  Blocks until the specified locks can be obtained.
      */
-    Executor withLocks(ResourceLock... locks);
+    <T> T withLocks(Iterable<? extends ResourceLock> locks, Callable<T> action);
 
     /**
-     * Returns an {@link Executor} that will run a given {@link Runnable} while the specified locks are released and then
-     * reacquire the locks upon completion.  If the locks cannot be immediately reacquired, the current worker lease will be released
-     * the method will block until the locks are reacquired.  {@link Executor#execute(Runnable)} will run the provided {@link Runnable}
-     * immediately and synchronously.
+     * Runs a given {@link Runnable} while the specified locks are being held, releasing
+     * the locks upon completion.  Blocks until the specified locks can be obtained.
      */
-    Executor withoutLocks(ResourceLock... locks);
+    void withLocks(Iterable<? extends ResourceLock> locks, Runnable action);
+
+    /**
+     * Runs a given {@link Callable} while the specified locks are released and then reacquire the locks
+     * upon completion.  If the locks cannot be immediately reacquired, the current worker lease will be released
+     * and the method will block until the locks are reacquired.
+     */
+    <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> action);
+
+    /**
+     * Runs a given {@link Runnable} while the specified locks are released and then reacquire the locks
+     * upon completion.  If the locks cannot be immediately reacquired, the current worker lease will be released
+     * and the method will block until the locks are reacquired.
+     */
+    void withoutLocks(Iterable<? extends ResourceLock> locks, Runnable action);
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
@@ -40,7 +40,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
         assert !lockIsHeld(projectLock)
 
         when:
-        workerLeaseService.withLocks(projectLock).execute {
+        workerLeaseService.withLocks([projectLock]) {
             assert lockIsHeld(projectLock)
         }
 
@@ -59,7 +59,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
                     started.countDown()
                     thread.blockUntil.releaseAll
                     def projectLock = workerLeaseService.getProjectLock("root", ":project")
-                    workerLeaseService.withLocks(projectLock).execute {
+                    workerLeaseService.withLocks([projectLock]) {
                         assert lockIsHeld(projectLock)
                     }
                 }
@@ -115,7 +115,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
             threadCount.times { i ->
                 start {
                     def projectLock = workerLeaseService.getProjectLock("root", ":project${i}")
-                    workerLeaseService.withLocks(projectLock).execute {
+                    workerLeaseService.withLocks([projectLock]) {
                         started.countDown()
                         thread.blockUntil.releaseAll
                         assert lockIsHeld(projectLock)
@@ -143,7 +143,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
                     started.countDown()
                     thread.blockUntil.releaseAll
                     def projectLock = projectLockService.getProjectLock("root", ":project${i}")
-                    workerLeaseService.withLocks(projectLock).execute {
+                    workerLeaseService.withLocks([projectLock]) {
                         assert testLock.tryLock()
                         try {
                             assert lockIsHeld(projectLock)
@@ -177,7 +177,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
                     thread.blockUntil.releaseAll
                     def buildIndex = i % buildCount
                     def projectLock = projectLockService.getProjectLock("build${buildIndex}", ":project${i}")
-                    workerLeaseService.withLocks(projectLock).execute {
+                    workerLeaseService.withLocks([projectLock]) {
                         assert testLock[buildIndex].tryLock()
                         try {
                             assert lockIsHeld(projectLock)
@@ -203,7 +203,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
         assert !lockIsHeld(projectLock)
 
         when:
-        workerLeaseService.withLocks(projectLock).execute {
+        workerLeaseService.withLocks([projectLock]) {
             assert lockIsHeld(projectLock)
             workerLeaseService.withoutProjectLock() {
                 assert !lockIsHeld(projectLock)
@@ -226,7 +226,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
         assert !lockIsHeld(projectLock)
 
         when:
-        workerLeaseService.withLocks(projectLock, otherProjectLock).execute {
+        workerLeaseService.withLocks([projectLock, otherProjectLock]) {
             assert lockIsHeld(projectLock)
             assert lockIsHeld(otherProjectLock)
             workerLeaseService.withoutProjectLock {
@@ -263,7 +263,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
         async {
             start {
                 def workerLease = workerLeaseService.getWorkerLease()
-                workerLeaseService.withLocks(projectLock, workerLease).execute {
+                workerLeaseService.withLocks([projectLock, workerLease]) {
                     workerLeaseService.withoutProjectLock {
                         thread.blockUntil.projectLocked
                     }
@@ -271,7 +271,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
                 }
             }
 
-            workerLeaseService.withLocks(projectLock).execute {
+            workerLeaseService.withLocks([projectLock]) {
                 instant.projectLocked
                 start {
                     def workerLease = workerLeaseService.getWorkerLease()

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
@@ -21,24 +21,26 @@ import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.TestTrackedResourceLock
 import spock.lang.Specification
 
+import java.util.concurrent.Callable
+
 
 class DefaultWorkerLeaseServiceTest extends Specification {
     def coordinationService = new DefaultResourceLockCoordinationService()
     def workerLeaseService = new DefaultWorkerLeaseService(coordinationService, true, 1)
 
-    def "can use withLock to execute an action with resources locked"() {
+    def "can use withLocks to execute a runnable with resources locked"() {
         boolean executed = false
         def lock1 = resourceLock("lock1", false)
         def lock2 = resourceLock("lock1", false)
 
         when:
-        workerLeaseService.withLocks(lock1, lock2).execute {
+        workerLeaseService.withLocks([lock1, lock2], runnable {
             assert lock1.lockedState
             assert lock2.lockedState
             assert lock1.doIsLockedByCurrentThread()
             assert lock2.doIsLockedByCurrentThread()
             executed = true
-        }
+        })
 
         then:
         executed
@@ -48,22 +50,44 @@ class DefaultWorkerLeaseServiceTest extends Specification {
         !lock2.lockedState
     }
 
-    def "can use withoutProjectLock to execute an action with locks temporarily released"() {
+    def "can use withLocks to execute a callable with resources locked"() {
         boolean executed = false
         def lock1 = resourceLock("lock1", false)
-        def lock2 = resourceLock("lock1", false)
+        def lock2 = resourceLock("lock2", false)
 
         when:
-        workerLeaseService.withLocks(lock1, lock2).execute {
+        executed = workerLeaseService.withLocks([lock1, lock2], callable {
             assert lock1.lockedState
             assert lock2.lockedState
-            workerLeaseService.withoutLocks(lock1, lock2).execute {
+            assert lock1.doIsLockedByCurrentThread()
+            assert lock2.doIsLockedByCurrentThread()
+            return true
+        })
+
+        then:
+        executed
+
+        and:
+        !lock1.lockedState
+        !lock2.lockedState
+    }
+
+    def "can use withoutLocks to execute a runnable with locks temporarily released"() {
+        boolean executed = false
+        def lock1 = resourceLock("lock1", false)
+        def lock2 = resourceLock("lock2", false)
+
+        when:
+        workerLeaseService.withLocks([lock1, lock2]) {
+            assert lock1.lockedState
+            assert lock2.lockedState
+            workerLeaseService.withoutLocks([lock1, lock2], runnable {
                 assert !lock1.lockedState
                 assert !lock2.lockedState
                 assert !lock1.doIsLockedByCurrentThread()
                 assert !lock2.doIsLockedByCurrentThread()
                 executed = true
-            }
+            })
             assert lock1.lockedState
             assert lock2.lockedState
         }
@@ -76,18 +100,46 @@ class DefaultWorkerLeaseServiceTest extends Specification {
         !lock2.lockedState
     }
 
-    def "throws an exception from withoutProjectLock when locks are not currently held"() {
+    def "can use withoutLocks to execute a callable with locks temporarily released"() {
         boolean executed = false
         def lock1 = resourceLock("lock1", false)
-        def lock2 = resourceLock("lock1", false)
+        def lock2 = resourceLock("lock2", false)
 
         when:
-        workerLeaseService.withLocks(lock1).execute {
+        workerLeaseService.withLocks([lock1, lock2]) {
+            assert lock1.lockedState
+            assert lock2.lockedState
+            executed = workerLeaseService.withoutLocks([lock1, lock2], callable {
+                assert !lock1.lockedState
+                assert !lock2.lockedState
+                assert !lock1.doIsLockedByCurrentThread()
+                assert !lock2.doIsLockedByCurrentThread()
+                return true
+            })
+            assert lock1.lockedState
+            assert lock2.lockedState
+        }
+
+        then:
+        executed
+
+        and:
+        !lock1.lockedState
+        !lock2.lockedState
+    }
+
+    def "throws an exception from withoutLocks when locks are not currently held"() {
+        boolean executed = false
+        def lock1 = resourceLock("lock1", false)
+        def lock2 = resourceLock("lock2", false)
+
+        when:
+        workerLeaseService.withLocks([lock1]) {
             assert lock1.lockedState
             assert !lock2.lockedState
-            workerLeaseService.withoutLocks(lock1, lock2).execute {
+            workerLeaseService.withoutLocks([lock1, lock2], runnable {
                 executed = true
-            }
+            })
             assert lock1.lockedState
             assert !lock2.lockedState
         }
@@ -107,5 +159,23 @@ class DefaultWorkerLeaseServiceTest extends Specification {
 
     TestTrackedResourceLock resourceLock(String displayName) {
         return resourceLock(displayName, false)
+    }
+
+    Runnable runnable(Closure closure) {
+        return new Runnable() {
+            @Override
+            void run() {
+                closure.run()
+            }
+        }
+    }
+
+    Callable callable(Closure closure) {
+        return new Callable() {
+            @Override
+            Object call() throws Exception {
+                return closure.call()
+            }
+        }
     }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
@@ -211,7 +211,7 @@ class DefaultWorkerLeaseServiceWorkerLeaseTest extends ConcurrentSpec {
         registry.currentWorkerLease
 
         then:
-        IllegalStateException e = thrown()
+        NoAvailableWorkerLeaseException e = thrown()
         e.message == 'No worker lease associated with the current thread'
 
         when:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -127,7 +127,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
                 }
 
                 try {
-                    asyncWorkTracker.waitForCompletion(currentOperation);
+                    asyncWorkTracker.waitForCompletion(currentOperation, true);
                 } catch (Throwable t) {
                     List<Throwable> failures = Lists.newArrayList();
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -37,6 +37,7 @@ import org.gradle.internal.progress.BuildOperationDescriptor;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 import org.gradle.internal.work.WorkerLeaseService;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -113,7 +114,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
         // TODO:pm Move this to RunAsBuildOperationBuildActionRunner when BuildOperationWorkerRegistry scope is changed
         final AtomicReference<BuildResult> buildResult = new AtomicReference<BuildResult>();
         WorkerLeaseService workerLeaseService = buildServices.get(WorkerLeaseService.class);
-        workerLeaseService.withLocks(workerLeaseService.getWorkerLease()).execute(new Runnable() {
+        workerLeaseService.withLocks(Collections.singleton(workerLeaseService.getWorkerLease()), new Runnable() {
             @Override
             public void run() {
                 Throwable failure = null;

--- a/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkTracker.java
@@ -38,6 +38,7 @@ public interface AsyncWorkTracker {
      * thrown.
      *
      * @param operation - The build operation whose asynchronous work should be completed
+     * @param releaseLocks - Whether or not project locks should be released while waiting on work
      */
-    void waitForCompletion(BuildOperationState operation);
+    void waitForCompletion(BuildOperationState operation, boolean releaseLocks);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
@@ -76,7 +76,8 @@ public class DefaultAsyncWorkTracker implements AsyncWorkTracker {
                 });
                 // only release the project lock if we have to wait for items to finish
                 if (releaseLocks && workInProgress) {
-                    projectLeaseRegistry.withoutProjectLock(new Runnable() {
+                    projectLeaseRegistry.withoutProjectLock(
+                        new Runnable() {
                         @Override
                         public void run() {
                             waitForItemsAndGatherFailures(workItems);

--- a/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
@@ -55,7 +55,7 @@ public class DefaultAsyncWorkTracker implements AsyncWorkTracker {
     }
 
     @Override
-    public void waitForCompletion(BuildOperationState operation) {
+    public void waitForCompletion(BuildOperationState operation, boolean releaseLocks) {
         final List<AsyncWorkCompletion> workItems;
         lock.lock();
         try {
@@ -75,7 +75,7 @@ public class DefaultAsyncWorkTracker implements AsyncWorkTracker {
                     }
                 });
                 // only release the project lock if we have to wait for items to finish
-                if (workInProgress) {
+                if (releaseLocks && workInProgress) {
                     projectLeaseRegistry.withoutProjectLock(new Runnable() {
                         @Override
                         public void run() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecutorTest.groovy
@@ -112,7 +112,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action1.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_)
+        1 * asyncWorkTracker.waitForCompletion(_, true)
         then:
         1 * buildOperationExecutor.run(_ as RunnableBuildOperation) >> { args -> args[0].run(Stub(BuildOperationContext)) }
         then:
@@ -126,7 +126,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action2.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_)
+        1 * asyncWorkTracker.waitForCompletion(_, true)
         then:
         1 * buildOperationExecutor.run(_ as RunnableBuildOperation) >> { args -> args[0].run(Stub(BuildOperationContext)) }
         then:
@@ -168,7 +168,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action1.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_)
+        1 * asyncWorkTracker.waitForCompletion(_, true)
         then:
         1 * buildOperationExecutor.run(_ as RunnableBuildOperation) >> { args -> args[0].run(Stub(BuildOperationContext)) }
         then:
@@ -200,7 +200,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action1.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_)
+        1 * asyncWorkTracker.waitForCompletion(_, true)
         then:
         1 * buildOperationExecutor.run(_ as RunnableBuildOperation) >> { args -> args[0].run(Stub(BuildOperationContext)) }
         then:
@@ -242,7 +242,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action1.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_)
+        1 * asyncWorkTracker.waitForCompletion(_, true)
         then:
         1 * buildOperationExecutor.run(_ as RunnableBuildOperation) >> { args -> args[0].run(Stub(BuildOperationContext)) }
         then:
@@ -278,7 +278,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action1.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_)
+        1 * asyncWorkTracker.waitForCompletion(_, true)
         then:
         1 * buildOperationExecutor.run(_ as RunnableBuildOperation) >> { args -> args[0].run(Stub(BuildOperationContext)) }
         then:
@@ -292,7 +292,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action2.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_)
+        1 * asyncWorkTracker.waitForCompletion(_, true)
         then:
         1 * buildOperationExecutor.run(_ as RunnableBuildOperation) >> { args -> args[0].run(Stub(BuildOperationContext)) }
         then:
@@ -327,7 +327,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action1.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_) >> {
+        1 * asyncWorkTracker.waitForCompletion(_, true) >> {
             throw new DefaultMultiCauseException("mock failures", new RuntimeException("failure 1"), new RuntimeException("failure 2"))
         }
         then:
@@ -372,7 +372,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action1.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_) >> {
+        1 * asyncWorkTracker.waitForCompletion(_, true) >> {
             throw new DefaultMultiCauseException("mock failures", new RuntimeException("failure 1"), new RuntimeException("failure 2"))
         }
         then:
@@ -416,7 +416,7 @@ class ExecuteActionsTaskExecutorTest extends Specification {
         then:
         1 * action1.contextualise(null)
         then:
-        1 * asyncWorkTracker.waitForCompletion(_) >> {
+        1 * asyncWorkTracker.waitForCompletion(_, true) >> {
             throw new DefaultMultiCauseException("mock failures", failure)
         }
         then:

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.work
+
+import org.gradle.internal.resources.ResourceLock
+import org.gradle.internal.work.WorkerLeaseRegistry
+import org.gradle.internal.work.WorkerLeaseService
+
+import java.util.concurrent.Executor
+
+
+class TestWorkerLeaseService implements WorkerLeaseService {
+    @Override
+    ResourceLock getProjectLock(String gradlePath, String projectPath) {
+        return null
+    }
+
+    @Override
+    void stop() {
+    }
+
+    @Override
+    int getMaxWorkerCount() {
+        return 0
+    }
+
+    @Override
+    WorkerLeaseRegistry.WorkerLease getCurrentWorkerLease() {
+        return workerLease()
+    }
+
+    @Override
+    void withoutProjectLock(Runnable runnable) {
+        runnable.run()
+    }
+
+    @Override
+    Executor withLocks(ResourceLock... locks) {
+        return new Executor() {
+            @Override
+            void execute(Runnable command) {
+                command.run()
+            }
+        }
+    }
+
+    @Override
+    WorkerLeaseRegistry.WorkerLease getWorkerLease() {
+        return workerLease()
+    }
+
+    @Override
+    Executor withoutLocks(ResourceLock... locks) {
+        return new Executor() {
+            @Override
+            void execute(Runnable command) {
+                command.run()
+            }
+        }
+    }
+
+    private WorkerLeaseRegistry.WorkerLease workerLease() {
+        return new WorkerLeaseRegistry.WorkerLease() {
+            @Override
+            WorkerLeaseRegistry.WorkerLease createChild() {
+                return null
+            }
+
+            @Override
+            WorkerLeaseRegistry.WorkerLeaseCompletion startChild() {
+                return null
+            }
+
+            @Override
+            boolean isLocked() {
+                return false
+            }
+
+            @Override
+            boolean isLockedByCurrentThread() {
+                return false
+            }
+
+            @Override
+            boolean tryLock() {
+                return false
+            }
+
+            @Override
+            void unlock() {
+
+            }
+
+            @Override
+            String getDisplayName() {
+                return null
+            }
+        }
+    }
+}

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
@@ -20,7 +20,7 @@ import org.gradle.internal.resources.ResourceLock
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.work.WorkerLeaseService
 
-import java.util.concurrent.Executor
+import java.util.concurrent.Callable
 
 
 class TestWorkerLeaseService implements WorkerLeaseService {
@@ -49,13 +49,8 @@ class TestWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
-    Executor withLocks(ResourceLock... locks) {
-        return new Executor() {
-            @Override
-            void execute(Runnable command) {
-                command.run()
-            }
-        }
+    def <T> T withoutProjectLock(Callable<T> action) {
+        return action.call()
     }
 
     @Override
@@ -64,13 +59,23 @@ class TestWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
-    Executor withoutLocks(ResourceLock... locks) {
-        return new Executor() {
-            @Override
-            void execute(Runnable command) {
-                command.run()
-            }
-        }
+    def <T> T withLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
+        return action.call()
+    }
+
+    @Override
+    void withLocks(Iterable<? extends ResourceLock> locks, Runnable action) {
+        action.run()
+    }
+
+    @Override
+    def <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
+        return action.call()
+    }
+
+    @Override
+    void withoutLocks(Iterable<? extends ResourceLock> locks, Runnable action) {
+        action.run()
     }
 
     private WorkerLeaseRegistry.WorkerLease workerLease() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.nativeplatform.toolchain.internal
 import org.gradle.api.Action
 import org.gradle.api.internal.file.BaseDirFileResolver
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.GradleThread
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -34,8 +35,6 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import java.util.concurrent.Executor
 
 abstract class NativeCompilerTest extends Specification {
     @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
@@ -53,23 +52,12 @@ abstract class NativeCompilerTest extends Specification {
 
     protected CommandLineToolInvocationWorker commandLineTool = Mock(CommandLineToolInvocationWorker)
 
-    WorkerLeaseService workerLeaseService = Stub(WorkerLeaseService)
+    WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     private BuildOperationListener buildOperationListener = Mock(BuildOperationListener)
     private TimeProvider timeProvider = Mock(TimeProvider)
     protected BuildOperationExecutor buildOperationExecutor = new DefaultBuildOperationExecutor(buildOperationListener, timeProvider, new NoOpProgressLoggerFactory(),
         new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), 1)
-
-    def setup() {
-        _ * workerLeaseService.withLocks(_) >> { args ->
-            new Executor() {
-                @Override
-                void execute(Runnable runnable) {
-                    runnable.run()
-                }
-            }
-        }
-    }
 
     def "arguments include source file"() {
         given:

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.testing.junit.report
 import org.gradle.api.internal.tasks.testing.BuildableTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.AggregateTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
+import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
@@ -33,8 +34,6 @@ import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import java.util.concurrent.Executor
-
 class DefaultTestReportTest extends Specification {
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
@@ -43,24 +42,13 @@ class DefaultTestReportTest extends Specification {
     final TestFile reportDir = tmpDir.file('report')
     final TestFile indexFile = reportDir.file('index.html')
     final TestResultsProvider testResultProvider = Mock()
-    final WorkerLeaseService workerLeaseService = Stub(WorkerLeaseService)
+    final WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     def reportWithMaxThreads(int numThreads) {
         buildOperationExecutor = new DefaultBuildOperationExecutor(
             Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), numThreads)
         return new DefaultTestReport(buildOperationExecutor)
-    }
-
-    def setup() {
-        _ * workerLeaseService.withLocks(_) >> { args ->
-            new Executor() {
-                @Override
-                void execute(Runnable runnable) {
-                    runnable.run()
-                }
-            }
-        }
     }
 
     def generatesReportWhenThereAreNoTestResults() {

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.Action
+import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
@@ -31,15 +32,13 @@ import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import java.util.concurrent.Executor
-
 class Binary2JUnitXmlReportGeneratorSpec extends Specification {
 
     @Rule private TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
     private resultsProvider = Mock(TestResultsProvider)
     BuildOperationExecutor buildOperationExecutor
     Binary2JUnitXmlReportGenerator generator
-    final WorkerLeaseService workerLeaseService = Stub(WorkerLeaseService)
+    final WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     def generatorWithMaxThreads(int numThreads) {
         buildOperationExecutor = new DefaultBuildOperationExecutor(
@@ -48,17 +47,6 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
         Binary2JUnitXmlReportGenerator reportGenerator = new Binary2JUnitXmlReportGenerator(temp.testDirectory, resultsProvider, TestOutputAssociation.WITH_SUITE, buildOperationExecutor, "localhost")
         reportGenerator.xmlWriter = Mock(JUnitXmlResultWriter)
         return reportGenerator
-    }
-
-    def setup() {
-        _ * workerLeaseService.withLocks(_) >> { args ->
-            new Executor() {
-                @Override
-                void execute(Runnable runnable) {
-                    runnable.run()
-                }
-            }
-        }
     }
 
     @Unroll

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -250,7 +250,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         fails 'runInWorker'
 
         then:
-        failure.assertHasCause 'No worker lease associated with the current thread'
+        failure.assertHasCause 'An attempt was made to submit work from a thread not managed by Gradle.  Work may only be submitted from a Gradle-managed thread.'
 
         where:
         isolationMode << ISOLATION_MODES

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -305,7 +305,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
     }
 
     @Unroll
-    def "user can take responsibility for failing work items in #isolationMode (using: #waitMethod)"() {
+    def "user can take responsibility for failing work items in #isolationMode"() {
         given:
         buildFile << """
             import java.util.concurrent.ExecutionException
@@ -342,13 +342,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         output.contains("A failure occurred while executing work item 2")
 
         where:
-        waitMethod                       | isolationMode
-        'result.get()'                   | 'IsolationMode.NONE'
-        'result.get()'                   | 'IsolationMode.PROCESS'
-        'result.get()'                   | 'IsolationMode.CLASSLOADER'
-        'workerExecutor.await([result])' | 'IsolationMode.NONE'
-        'workerExecutor.await([result])' | 'IsolationMode.PROCESS'
-        'workerExecutor.await([result])' | 'IsolationMode.CLASSLOADER'
+        isolationMode << ISOLATION_MODES
     }
 
     def "max workers is honored by parallel work"() {
@@ -478,7 +472,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         succeeds("allTasks")
     }
 
-    def "can start another task when the user is waiting on async work"() {
+    def "does not start another task when the user is waiting on async work"() {
         given:
         buildFile << """
             task firstTask(type: MultipleWorkItemTask) {
@@ -498,15 +492,50 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             }
         """
 
-        blockingHttpServer.expectConcurrent("task1-1", "task2")
+        blockingHttpServer.expectConcurrent("task1-1")
         blockingHttpServer.expectConcurrent("task1-2")
+        blockingHttpServer.expectConcurrent("task2")
 
         expect:
         args("--max-workers=3")
         succeeds("allTasks")
     }
 
-    def "can start another task in a different project when the user is waiting on async work"() {
+    def "does not start another task in a different project when the user is waiting on async work"() {
+        given:
+        settingsFile << """
+            include ':childProject'
+        """
+        buildFile << """
+            task firstTask(type: MultipleWorkItemTask) {
+                doLast { 
+                    submitWorkItem("task1-1") 
+                    workerExecutor.await()
+                    ${blockingHttpServer.callFromBuild("task1-2")}
+                }
+            }
+            
+            project(':childProject') {
+                task secondTask(type: MultipleWorkItemTask) {
+                    doLast { ${blockingHttpServer.callFromBuild("task2")} }
+                }
+            }
+            
+            task allTasks {
+                dependsOn firstTask, project(':childProject').secondTask
+            }
+        """
+
+        blockingHttpServer.expectConcurrent("task1-1")
+        blockingHttpServer.expectConcurrent("task1-2")
+        blockingHttpServer.expectConcurrent("task2")
+
+        expect:
+        args("--max-workers=3")
+        succeeds("allTasks")
+    }
+
+    def "can start another task in a different project when the user is waiting on async work with --parallel"() {
         given:
         settingsFile << """
             include ':childProject'
@@ -535,7 +564,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         blockingHttpServer.expectConcurrent("task1-2")
 
         expect:
-        args("--max-workers=3")
+        args("--max-workers=3", "--parallel")
         succeeds("allTasks")
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -145,7 +145,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
     public void await() throws WorkerExecutionException {
         BuildOperationState currentOperation = buildOperationExecutor.getCurrentOperation();
         try {
-            asyncWorkTracker.waitForCompletion(currentOperation);
+            asyncWorkTracker.waitForCompletion(currentOperation, false);
         } catch (DefaultMultiCauseException e) {
             throw workerExecutionException(e.getCauses());
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -33,6 +33,7 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.progress.BuildOperationState;
 import org.gradle.internal.work.AsyncWorkCompletion;
 import org.gradle.internal.work.AsyncWorkTracker;
+import org.gradle.internal.work.NoAvailableWorkerLeaseException;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.process.JavaForkOptions;
@@ -87,7 +88,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
     }
 
     private void submit(final ActionExecutionSpec spec, final File workingDir, final IsolationMode isolationMode, final DaemonForkOptions daemonForkOptions) {
-        final WorkerLease currentWorkerWorkerLease = workerLeaseRegistry.getCurrentWorkerLease();
+        final WorkerLease currentWorkerWorkerLease = getCurrentWorkerLease();
         final BuildOperationState currentBuildOperation = buildOperationExecutor.getCurrentOperation();
         ListenableFuture<DefaultWorkResult> workerDaemonResult = executor.submit(new Callable<DefaultWorkResult>() {
             @Override
@@ -102,6 +103,14 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
             }
         });
         registerAsyncWork(spec.getDisplayName(), workerDaemonResult);
+    }
+
+    private WorkerLease getCurrentWorkerLease() {
+        try {
+            return workerLeaseRegistry.getCurrentWorkerLease();
+        } catch (NoAvailableWorkerLeaseException e) {
+            throw new IllegalStateException("An attempt was made to submit work from a thread not managed by Gradle.  Work may only be submitted from a Gradle-managed thread.", e);
+        }
     }
 
     private WorkerFactory getWorkerFactory(IsolationMode isolationMode) {

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -81,7 +81,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         workerExecutor.await()
 
         then:
-        1 * asyncWorkerTracker.waitForCompletion(_)
+        1 * asyncWorkerTracker.waitForCompletion(_, false)
     }
 
     def "all errors are thrown when waiting on multiple results"() {
@@ -89,7 +89,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         workerExecutor.await()
 
         then:
-        1 * asyncWorkerTracker.waitForCompletion(_) >> {
+        1 * asyncWorkerTracker.waitForCompletion(_, false) >> {
             throw new DefaultMultiCauseException(null, new RuntimeException(), new RuntimeException())
         }
 


### PR DESCRIPTION
This PR addresses a few minor deferred changes from the previous review of the project locking PR:

- Don't release the project lock when the user waits on work - only in between task actions (when there is async WIP). [comment](https://github.com/gradle/gradle/pull/1627#discussion_r111050017)
- Refactor the setup [here](https://github.com/gradle/gradle/blob/33c5b140421fc5b09943430d789d15016927d189/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy#L51-L51) into a test fixture. [comment](https://github.com/gradle/gradle/pull/1627#discussion_r111050637)
- Refactor [this](https://github.com/gradle/gradle/blob/d60b527ff902fd0710f64972ad25f7ed02c289bc/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r25/TaskProgressCrossVersionSpec.groovy#L259-L259) to not use `Thread.sleep()` [comment](https://github.com/gradle/gradle/pull/1627#discussion_r111050745)
- Improve the error message when an unmanaged thread tries to submit work such that it is more clear that the problem is that we are running in an unmanaged thread. [comment](https://github.com/gradle/gradle/pull/1627#discussion_r111051315)
- Add some coverage for when a task has multiple task actions and submits async work in parallel with another task. [comment](https://github.com/gradle/gradle/pull/1627#discussion_r111051802)
- Don't use `Executor` for the lock convenience methods in `WorkerLeaseService`.  [comment](https://github.com/gradle/gradle/pull/1627#discussion_r111055679)
- Add a `reset()` method onto `ResourceLockState` so we can roll back changes without relying on the mechanisms in `withStateLock()`. [comment](https://github.com/gradle/gradle/pull/1627#discussion_r111056781)