### PR TITLE
Let --tests option override test.include and test.exclude

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/util/PatternSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/util/PatternSet.java
@@ -102,17 +102,14 @@ public class PatternSet implements AntBuilderAware, PatternFilterable {
     }
 
     public PatternSet copyFrom(PatternFilterable sourcePattern) {
-        return doCopyFrom((PatternSet) sourcePattern);
-    }
-
-    protected PatternSet doCopyFrom(PatternSet from) {
         includes.clear();
         excludes.clear();
         includeSpecs.clear();
         excludeSpecs.clear();
-        caseSensitive = from.caseSensitive;
 
-        if (from instanceof IntersectionPatternSet) {
+        if (sourcePattern instanceof IntersectionPatternSet) {
+            PatternSet from = (PatternSet) sourcePattern;
+            caseSensitive = from.caseSensitive;
             PatternSet other = ((IntersectionPatternSet) from).other;
             PatternSet otherCopy = new PatternSet(other).copyFrom(other);
             PatternSet intersectCopy = new IntersectionPatternSet(otherCopy);
@@ -121,7 +118,9 @@ public class PatternSet implements AntBuilderAware, PatternFilterable {
             intersectCopy.includeSpecs.addAll(from.includeSpecs);
             intersectCopy.excludeSpecs.addAll(from.excludeSpecs);
             includeSpecs.add(intersectCopy.getAsSpec());
-        } else {
+        } else if (sourcePattern instanceof PatternSet) {
+            PatternSet from = (PatternSet) sourcePattern;
+            caseSensitive = from.caseSensitive;
             includes.addAll(from.includes);
             excludes.addAll(from.excludes);
             includeSpecs.addAll(from.includeSpecs);

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -57,6 +57,12 @@ Previous versions of Gradle would select the `runtimeElements` when both project
 
 This change makes the selection behaviour consistent so that the `runtimeElements` configuration is selected regardless of whether the consuming project uses the Java plugin or not. This is also consistent with the selection when the consuming project is using one of the Android plugins.
 
+### Changes to setTestNameIncludePatterns() of Test task
+
+`setTestNameIncludePatterns` method of `Test` task is designed to be used in command line, therefore it will override configurations of `include`/`exclude` in `build.gradle` according to [Test filtering](userguide/java_plugin.html#test_filtering).
+
+However, in previous versions of Gradle, this overriding mechanism is not implemented. Now, if `setTestNameIncludePatterns` is invoked directly, it will disable `include`/`exclude` defined in `build.gradle`. If you're affected by this change, use `filter.setIncludePatterns` instead.
+
 ## External contributions
 
 We would like to thank the following community members for making contributions to this release of Gradle.

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -214,6 +214,22 @@ class TestTest extends AbstractConventionTaskTest {
         test.getExcludes() == toLinkedSet(TEST_PATTERN_1, TEST_PATTERN_2, TEST_PATTERN_3)
     }
 
+    def "disable includes and excludes when --tests specified"() {
+        given:
+        test.include(TEST_PATTERN_1)
+        test.exclude(TEST_PATTERN_1)
+
+        when:
+        test.setTestNameIncludePatterns([TEST_PATTERN_2])
+        test.include(TEST_PATTERN_3)
+        test.exclude(TEST_PATTERN_3)
+
+        then:
+        test.includes.empty
+        test.excludes.empty
+        test.filter.includePatterns == [TEST_PATTERN_2] as Set
+    }
+
     private void assertIsDirectoryTree(FileTree classFiles, Set<String> includes, Set<String> excludes) {
         assert classFiles instanceof CompositeFileTree
         def files = (CompositeFileTree) classFiles

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -231,6 +231,32 @@ class TestTaskIntegrationTest extends AbstractIntegrationSpec {
         result.assertOutputContains("The setTestClassesDir(File) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the setTestClassesDirs(FileCollection) method instead.")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/1571")
+    def "option --tests override include and exclude filters"() {
+        given:
+        buildFile << '''
+        apply plugin: 'java'
+        repositories { jcenter() }
+        dependencies { testCompile 'junit:junit:4.12' }
+
+        test {
+            include '*ATest*'
+            exclude '*BTest*'
+        }
+        '''
+
+        when:
+        file('src/test/java/ATest.java') << testClass('ATest')
+        file('src/test/java/BTest.java') << testClass('BTest')
+        file('src/test/java/CTest.java') << testClass('CTest')
+
+        then:
+        succeeds('test', '--tests', '*BTest*', '--tests', '*CTest*', '--info')
+        !output.contains('ATest >')
+        output.contains('BTest >')
+        output.contains('CTest >')
+    }
+
     private static String standaloneTestClass() {
         return testClass('MyTest')
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -231,32 +231,6 @@ class TestTaskIntegrationTest extends AbstractIntegrationSpec {
         result.assertOutputContains("The setTestClassesDir(File) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the setTestClassesDirs(FileCollection) method instead.")
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/1571")
-    def "option --tests override include and exclude filters"() {
-        given:
-        buildFile << '''
-        apply plugin: 'java'
-        repositories { jcenter() }
-        dependencies { testCompile 'junit:junit:4.12' }
-
-        test {
-            include '*ATest*'
-            exclude '*BTest*'
-        }
-        '''
-
-        when:
-        file('src/test/java/ATest.java') << testClass('ATest')
-        file('src/test/java/BTest.java') << testClass('BTest')
-        file('src/test/java/CTest.java') << testClass('CTest')
-
-        then:
-        succeeds('test', '--tests', '*BTest*', '--tests', '*CTest*', '--info')
-        !output.contains('ATest >')
-        output.contains('BTest >')
-        output.contains('CTest >')
-    }
-
     private static String standaloneTestClass() {
         return testClass('MyTest')
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -102,6 +102,7 @@ import org.gradle.util.SingleMessageLogger;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -898,6 +899,7 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
     @Option(option = "tests", description = "Sets test class or method name to be included, '*' is supported.")
     @Incubating
     public Test setTestNameIncludePatterns(List<String> testNamePattern) {
+        patternSet = new ReadOnlyEmptyPatternSet();
         filter.setIncludePatterns(testNamePattern.toArray(new String[]{}));
         return this;
     }
@@ -1409,6 +1411,68 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
             getLogger().warn(message);
         } else {
             throw new GradleException(message);
+        }
+    }
+
+    private static class ReadOnlyEmptyPatternSet implements PatternFilterable {
+        @Override
+        public Set<String> getIncludes() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<String> getExcludes() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public PatternFilterable setIncludes(Iterable<String> includes) {
+            return this;
+        }
+
+        @Override
+        public PatternFilterable setExcludes(Iterable<String> excludes) {
+            return this;
+        }
+
+        @Override
+        public PatternFilterable include(String... includes) {
+            return this;
+        }
+
+        @Override
+        public PatternFilterable include(Iterable<String> includes) {
+            return this;
+        }
+
+        @Override
+        public PatternFilterable include(Spec<FileTreeElement> includeSpec) {
+            return this;
+        }
+
+        @Override
+        public PatternFilterable include(Closure includeSpec) {
+            return this;
+        }
+
+        @Override
+        public PatternFilterable exclude(String... excludes) {
+            return this;
+        }
+
+        @Override
+        public PatternFilterable exclude(Iterable<String> excludes) {
+            return this;
+        }
+
+        @Override
+        public PatternFilterable exclude(Spec<FileTreeElement> excludeSpec) {
+            return this;
+        }
+
+        @Override
+        public PatternFilterable exclude(Closure excludeSpec) {
+            return this;
         }
     }
 }


### PR DESCRIPTION
### Context

As stated in #1571 , Although it is documented that when the command line option is used, 
the inclusion filters declared in the build script are ignored.This feature
 is not implemented actually. When --tests arguments are
set, Test's patternSet will be set to an "empty read-only set" so that
 include/exclude defined in build are disabled. This fix causes an extra
 problem that PatternSet.copyFrom throws a ClassCastException because it
 assumes copyFrom always receives a PatternSet. Therefore,
 PatternSet.copyFrom is slightly refined.

An unit test and an integration test have been provided.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

