### PR TITLE
Runtime fixes to support running on Jigsaw

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
@@ -57,7 +57,7 @@ public abstract class ClassLoaderUtils {
         JavaMethod<ClassLoader, T> method;
         try {
             method = JavaReflectionUtil.method(ClassLoader.class, clazz, firstChoice, params);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             // We must not be on Java 9 where the getDefinedPackages() method exists. Fall back to getPackages()
             method = JavaReflectionUtil.method(ClassLoader.class, clazz, fallback, params);
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -49,12 +49,8 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
     static {
         EXT_CLASS_LOADER = ClassLoaderUtils.getPlatformClassLoader();
         Package[] systemPackages;
+        JavaMethod<ClassLoader, Package[]> method = ClassLoaderUtils.getPackagesMethod();
         try {
-            Method method = ClassLoader.class.getMethod("getDefinedPackages");
-            systemPackages = (Package[]) method.invoke(EXT_CLASS_LOADER);
-        } catch (NoSuchMethodException e) {
-            // We must not be on Java 9 where the getDefinedPackages() method exists. Fall back to getPackages()
-            JavaMethod<ClassLoader, Package[]> method = JavaReflectionUtil.method(ClassLoader.class, Package[].class, "getPackages");
             systemPackages = method.invoke(EXT_CLASS_LOADER);
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
@@ -299,23 +295,23 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
             }
             Spec other = (Spec) obj;
             return other.packageNames.equals(packageNames)
-                    && other.packagePrefixes.equals(packagePrefixes)
-                    && other.resourceNames.equals(resourceNames)
-                    && other.resourcePrefixes.equals(resourcePrefixes)
-                    && other.classNames.equals(classNames)
-                    && other.disallowedClassNames.equals(disallowedClassNames)
-                    && other.disallowedPackagePrefixes.equals(disallowedPackagePrefixes);
+                && other.packagePrefixes.equals(packagePrefixes)
+                && other.resourceNames.equals(resourceNames)
+                && other.resourcePrefixes.equals(resourcePrefixes)
+                && other.classNames.equals(classNames)
+                && other.disallowedClassNames.equals(disallowedClassNames)
+                && other.disallowedPackagePrefixes.equals(disallowedPackagePrefixes);
         }
 
         @Override
         public int hashCode() {
             return packageNames.hashCode()
-                    ^ packagePrefixes.hashCode()
-                    ^ resourceNames.hashCode()
-                    ^ resourcePrefixes.hashCode()
-                    ^ classNames.hashCode()
-                    ^ disallowedClassNames.hashCode()
-                    ^ disallowedPackagePrefixes.hashCode();
+                ^ packagePrefixes.hashCode()
+                ^ resourceNames.hashCode()
+                ^ resourcePrefixes.hashCode()
+                ^ classNames.hashCode()
+                ^ disallowedClassNames.hashCode()
+                ^ disallowedPackagePrefixes.hashCode();
         }
 
         Set<String> getPackageNames() {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -18,10 +18,8 @@ package org.gradle.internal.classloader;
 
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.reflect.JavaMethod;
-import org.gradle.internal.reflect.JavaReflectionUtil;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
@@ -17,7 +17,6 @@ package org.gradle.internal.classloader;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.internal.reflect.JavaMethod;
-import org.gradle.internal.reflect.JavaReflectionUtil;
 
 import java.io.IOException;
 import java.net.URL;
@@ -38,8 +37,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class MultiParentClassLoader extends ClassLoader implements ClassLoaderHierarchy {
 
-    private static final JavaMethod<ClassLoader, Package[]> GET_PACKAGES_METHOD = JavaReflectionUtil.method(ClassLoader.class, Package[].class, "getPackages");
-    private static final JavaMethod<ClassLoader, Package> GET_PACKAGE_METHOD = JavaReflectionUtil.method(ClassLoader.class, Package.class, "getPackage", String.class);
+    private static final JavaMethod<ClassLoader, Package[]> GET_PACKAGES_METHOD = ClassLoaderUtils.getPackagesMethod();
+    private static final JavaMethod<ClassLoader, Package> GET_PACKAGE_METHOD =  ClassLoaderUtils.getPackageMethod();
 
     private final List<ClassLoader> parents;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/PackageListGenerator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/PackageListGenerator.java
@@ -63,7 +63,8 @@ public class PackageListGenerator extends DefaultTask {
         "org/apache/log4j",
         "org/apache/xerces",
         "org/w3c/dom",
-        "org/xml/sax");
+        "org/xml/sax",
+        "sun/misc");
 
     private File outputFile;
     private FileCollection classpath;

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGenerator.java
@@ -16,14 +16,12 @@
 
 package org.gradle.model.internal.asm;
 
-import org.gradle.internal.Cast;
-import org.gradle.internal.reflect.JavaMethod;
-import org.gradle.internal.reflect.JavaReflectionUtil;
+import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
 
 public class AsmClassGenerator {
-    private static final JavaMethod<ClassLoader, ?> DEFINE_CLASS_METHOD = JavaReflectionUtil.method(ClassLoader.class, Class.class, "defineClass", String.class, byte[].class, Integer.TYPE, Integer.TYPE);
+
     private final ClassWriter visitor;
     private final String generatedTypeName;
     private final Type generatedType;
@@ -57,7 +55,6 @@ public class AsmClassGenerator {
     }
 
     public <T> Class<T> define(ClassLoader targetClassLoader) {
-        byte[] generatedByteCode = visitor.toByteArray();
-        return Cast.uncheckedCast(DEFINE_CLASS_METHOD.invoke(targetClassLoader, generatedTypeName, generatedByteCode, 0, generatedByteCode.length));
+       return ClassLoaderUtils.define(targetClassLoader, generatedTypeName, visitor.toByteArray());
     }
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/PackageListGeneratorIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/PackageListGeneratorIntegrationTest.groovy
@@ -36,7 +36,9 @@ class PackageListGeneratorIntegrationTest extends AbstractIntegrationSpec {
         "org/apache/log4j",
         "org/apache/xerces",
         "org/w3c/dom",
-        "org/xml/sax"]
+        "org/xml/sax",
+        "sun/misc"
+    ]
 
     def "generates a curated list of package prefixes from directories"() {
         given:

--- a/subprojects/tooling-api/tooling-api.gradle
+++ b/subprojects/tooling-api/tooling-api.gradle
@@ -53,7 +53,7 @@ task shadedJarWithoutVersion(type: ShadedJar) {
     classesDir = file("$outputDir/classes")
     jarFile = file("$outputDir/gradle-tooling-api-shaded-${baseVersion}.jar")
     keepPackages = ["org.gradle.tooling"]
-    unshadedPackages = ["org.gradle", "org.slf4j"]
+    unshadedPackages = ["org.gradle", "org.slf4j", "sun.misc"]
     ignorePackages = ["org.gradle.tooling.provider.model"]
     shadowPackage = "org.gradle.internal.impldep"
 }


### PR DESCRIPTION
### Context

This pull request contains 2 changes that make it possible to run Gradle on JDK 9 (jigsaw, build 171), with `--no-daemon`.

Daemon is still unsupported at this point.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
