### PR TITLE
Add simple warn functionality to SingleMessageLogger

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -34,6 +34,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public class SingleMessageLogger {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeprecationLogger.class);
     private static final Set<String> FEATURES = Collections.synchronizedSet(new HashSet<String>());
+    private static final Set<String> WARNINGS = Collections.synchronizedSet(new HashSet<String>());
 
     private static final ThreadLocal<Boolean> ENABLED = new ThreadLocal<Boolean>() {
         @Override
@@ -67,6 +68,7 @@ public class SingleMessageLogger {
 
     public static void reset() {
         FEATURES.clear();
+        WARNINGS.clear();
         LOCK.lock();
         try {
             handler = new LoggingDeprecatedFeatureHandler();
@@ -244,6 +246,15 @@ public class SingleMessageLogger {
                 message = message + "\n" + additionalWarning;
             }
             LOGGER.warn(message);
+        }
+    }
+
+    public static void warn(String warning) {
+        // Since WARNINGS is a synchronized set, we can be sure that each
+        // warning will only be logged once (i.e. The first time it is added to
+        // the set.)
+        if (WARNINGS.add(warning)) {
+            LOGGER.warn(warning);
         }
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/util/SingleMessageLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/util/SingleMessageLoggerTest.groovy
@@ -53,6 +53,29 @@ class SingleMessageLoggerTest extends ConcurrentSpec {
         events[1].message.startsWith('nag')
     }
 
+    def "logs generic warnings once until reset"() {
+        given:
+        def message = "Watch out!"
+
+        when:
+        SingleMessageLogger.warn(message)
+        SingleMessageLogger.warn(message)
+
+        then:
+        def events = outputEventListener.events
+        events.size() == 1
+        events[0].message == message
+
+        when:
+        SingleMessageLogger.reset()
+        SingleMessageLogger.warn(message)
+
+        then:
+        events.size() == 2
+        events[0].message == message
+        events[1].message == message
+    }
+
     def "does not log warning while disabled with factory"() {
         given:
         Factory<String> factory = Mock(Factory)


### PR DESCRIPTION
Currently, there are many places in the codebase which solve the "only
long this message one time" problem in an ad hoc manner. This will
allow those cases to consolidate on a single mechanism.