### PR TITLE
Prevent spurious gradle-wrapper.jar changes

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -161,6 +161,7 @@ public class Wrapper extends DefaultTask {
 
     private void addBuildReceipt(ZipOutputStream zipOutputStream) throws IOException {
         ZipEntry buildReceipt = new ZipEntry("build-receipt.properties");
+        buildReceipt.setTime(GUtil.CONSTANT_TIME_FOR_ZIP_ENTRIES);
         zipOutputStream.putNextEntry(buildReceipt);
         String contents = "versionNumber=" + GradleVersion.current().getVersion();
         zipOutputStream.write(contents.getBytes(StandardCharsets.ISO_8859_1));


### PR DESCRIPTION
Without this patch `$ ./gradlew wrapper` changes `gradle-wrapper.jar` whenever the timestamp changes.

### Context

I ran into this both when updating `gradlew`, and when attempting to verify the `gradle-wrapper.jar` committed by someone else. I ran `./gradlew wrapper --gradle-version 3.5` repeatedly and git would sometimes report a `gradle-wrapper.jar` modification. It turned out that this depended on the timestamp used for `build-receipt.properties`. (In my testing it has minute-level resolution.) 

This uses the constant timestamp already used for all other entries in the jar for `build-receipt.properties`.

I manually tested running the resulting Gradle version on separate minutes and the jars it built were byte-for-byte (with `cmp`) identical. I can't think of a way to test this behavior that isn't mocking different timestamps, at which point the jars would necessarily differ.

I haven't found any tests that depend on `build-receipt.properties` having a real timestamp.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [X] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
