### PR TITLE
Simplify finding the previous execution of a task

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1220,4 +1220,34 @@ task generate(type: TransformerTask) {
         then:
         failure.assertHasDescription("A deadlock was detected while resolving the task outputs for :foobar.  This can be caused, for instance, by a task output causing dependency resolution.")
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/2180")
+    def "fileTrees can be used as output files"() {
+        given:
+        buildScript """
+            task myTask {
+                inputs.file file('input.txt')
+                outputs.files fileTree(dir: 'build', include: 'output.txt')
+                doLast {
+                    file('build').mkdirs()
+                    file('build/output.txt').text = new File('input.txt').text
+                }
+            }
+        """.stripIndent()
+
+        file('input.txt').text = 'input file'
+
+        when:
+        succeeds 'myTask'
+
+        then:
+        nonSkippedTasks.contains(':myTask')
+
+        when:
+        succeeds('myTask')
+
+        then:
+        skippedTasks.contains(':myTask')
+    }
+
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
@@ -570,8 +570,8 @@ class DefaultTaskArtifactStateRepositoryTest extends AbstractProjectBuilderSpec 
         when:
         TestFile outputDir2 = temporaryFolder.createDir("output-dir-2")
         TestFile outputDirFile2 = outputDir2.file("output-file-2")
-        TaskInternal task1 = builder.withOutputFiles(dir: [outputDir]).createsFiles(outputDirFile).task()
-        TaskInternal task2 = builder.withOutputFiles(dir: [outputDir2]).createsFiles(outputDirFile2).task()
+        TaskInternal task1 = builder.withOutputFiles(dir: [outputDir]).createsFiles(outputDirFile).withPath('task1').task()
+        TaskInternal task2 = builder.withOutputFiles(dir: [outputDir2]).createsFiles(outputDirFile2).withPath('task2').task()
 
         execute(task1, task2)
 
@@ -597,26 +597,6 @@ class DefaultTaskArtifactStateRepositoryTest extends AbstractProjectBuilderSpec 
 
         then:
         repository.getStateFor(task).originBuildInvocationId == buildScopeId.id
-    }
-
-    def "has no origin build ID if outputs are not usable"() {
-        when:
-        execute(task)
-
-        then:
-        def state1 = repository.getStateFor(task)
-        state1.originBuildInvocationId == buildScopeId.id
-        state1.isUpToDate([])
-
-        when:
-        def changedOutputsTask = builder.withOutputFiles(temporaryFolder.createDir("output-dir-2")).task()
-
-        then:
-
-        task.path == changedOutputsTask.path
-        def state2 = repository.getStateFor(changedOutputsTask)
-        state2.originBuildInvocationId == null
-        !state2.isUpToDate([])
     }
 
     private void outOfDate(TaskInternal task) {


### PR DESCRIPTION
For up-to-date checks we use the previous execution of the task instead of trying to match the output paths and use the best matching task from history.
Modifying declared outputs dynamically should be discouraged and simplifying this code while fixing #2180 in the process seems to be worth removing this optimization.