### PR TITLE
Fix Invalid cookie header messages

### DIFF
--- a/subprojects/resources-http/resources-http.gradle
+++ b/subprojects/resources-http/resources-http.gradle
@@ -31,6 +31,7 @@ dependencies {
 }
 
 useTestFixtures()
+useTestFixtures(project: ':logging')
 useClassycle()
 // Cannot use strict compile because JDK 7 doesn't recognize
 // @SuppressWarnings("deprecation"), used in org.gradle.internal.resource.transport.http.HttpClientHelper.AutoClosedHttpResponse

--- a/subprojects/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/CookieHeaderTest.groovy
+++ b/subprojects/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/CookieHeaderTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.internal.logging.CollectingTestOutputEventListener
+import org.gradle.internal.logging.ConfigureLogging
+import org.gradle.test.fixtures.server.http.HttpServer
+import org.gradle.testing.internal.util.Specification
+import org.junit.Rule
+import spock.lang.Unroll
+
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Unroll
+class CookieHeaderTest extends Specification {
+
+    @Rule
+    HttpServer httpServer = new HttpServer()
+    CollectingTestOutputEventListener listener = new CollectingTestOutputEventListener()
+    @Rule
+    ConfigureLogging logging = new ConfigureLogging(listener, LogLevel.WARN)
+    SslContextFactory sslContextFactory = new DefaultSslContextFactory()
+    HttpSettings settings = new DefaultHttpSettings([], sslContextFactory)
+    HttpClientHelper client = new HttpClientHelper(settings)
+
+    def "cookie header with attributes #attributes can be parsed"() {
+        httpServer.start()
+        httpServer.expect("/cookie", ['GET'],
+            new RespondWithCookieAction("some; ${attributes}"))
+        when:
+        client.performGet("${httpServer.address}/cookie", false)
+
+        then:
+        listener.events*.message.every { assert !it.contains('Invalid cookie header:') }
+
+        where:
+        attributes << [
+                'Max-Age=31536000; Expires=Sun, 24 Jun 2018 16:26:36 GMT;',
+                'Max-Age=31536000; Expires=Sun Jun 24 16:26:36 2018;',
+                'Max-Age=31536000; Expires=Sun, 24-Jun-18 16:26:36 GMT;',
+                'Max-Age=31536000; Expires=Sun, 24-Jun-18 16:26:36 GMT-08:00;',
+        ]
+    }
+
+}
+
+class RespondWithCookieAction extends HttpServer.ActionSupport {
+    private final String cookie
+
+    RespondWithCookieAction(String cookie) {
+        super("Return cookie header ${cookie}")
+        this.cookie = cookie
+    }
+
+    @Override
+    void handle(HttpServletRequest request, HttpServletResponse response) {
+        response.addCookie(new Cookie("cookie_name", cookie))
+        String message = "Cookie sent"
+        response.setContentLength(message.bytes.length)
+        response.setContentType("text/html")
+        response.setCharacterEncoding("utf8")
+        response.outputStream.bytes = message.bytes
+    }
+}

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
@@ -29,12 +29,17 @@ import org.apache.http.auth.NTCredentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.client.utils.DateUtils;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.util.PublicSuffixMatcher;
+import org.apache.http.conn.util.PublicSuffixMatcherLoader;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.auth.BasicSchemeFactory;
 import org.apache.http.impl.auth.DigestSchemeFactory;
@@ -43,6 +48,10 @@ import org.apache.http.impl.auth.SPNegoSchemeFactory;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.apache.http.impl.cookie.DefaultCookieSpecProvider;
+import org.apache.http.impl.cookie.IgnoreSpecProvider;
+import org.apache.http.impl.cookie.NetscapeDraftSpecProvider;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpCoreContext;
 import org.gradle.api.credentials.PasswordCredentials;
@@ -82,6 +91,7 @@ public class HttpClientConfigurer {
         configureCredentials(builder, credentialsProvider, httpSettings.getAuthenticationSettings());
         configureProxy(builder, credentialsProvider, httpSettings);
         configureUserAgent(builder);
+        configureCookieSpecRegistry(builder);
         builder.setDefaultCredentialsProvider(credentialsProvider);
         builder.setMaxConnTotal(MAX_HTTP_CONNECTIONS);
         builder.setMaxConnPerRoute(MAX_HTTP_CONNECTIONS);
@@ -157,6 +167,32 @@ public class HttpClientConfigurer {
 
     public void configureUserAgent(HttpClientBuilder builder) {
         builder.setUserAgent(UriTextResource.getUserAgentString());
+    }
+
+    private void configureCookieSpecRegistry(HttpClientBuilder builder) {
+        PublicSuffixMatcher publicSuffixMatcher = PublicSuffixMatcherLoader.getDefault();
+        builder.setPublicSuffixMatcher(publicSuffixMatcher);
+        // Add more data patterns to the default configuration to work around https://github.com/gradle/gradle/issues/1596
+        final CookieSpecProvider defaultProvider = new DefaultCookieSpecProvider(DefaultCookieSpecProvider.CompatibilityLevel.DEFAULT, publicSuffixMatcher, new String[]{
+            "EEE, dd-MMM-yy HH:mm:ss z", // Netscape expires pattern
+            DateUtils.PATTERN_RFC1036,
+            DateUtils.PATTERN_ASCTIME,
+            DateUtils.PATTERN_RFC1123
+        }, false);
+        final CookieSpecProvider laxStandardProvider = new RFC6265CookieSpecProvider(
+            RFC6265CookieSpecProvider.CompatibilityLevel.RELAXED, publicSuffixMatcher);
+        final CookieSpecProvider strictStandardProvider = new RFC6265CookieSpecProvider(
+            RFC6265CookieSpecProvider.CompatibilityLevel.STRICT, publicSuffixMatcher);
+        builder.setDefaultCookieSpecRegistry(RegistryBuilder.<CookieSpecProvider>create()
+            .register(CookieSpecs.DEFAULT, defaultProvider)
+            .register("best-match", defaultProvider)
+            .register("compatibility", defaultProvider)
+            .register(CookieSpecs.STANDARD, laxStandardProvider)
+            .register(CookieSpecs.STANDARD_STRICT, strictStandardProvider)
+            .register(CookieSpecs.NETSCAPE, new NetscapeDraftSpecProvider())
+            .register(CookieSpecs.IGNORE_COOKIES, new IgnoreSpecProvider())
+            .build()
+        );
     }
 
     private PasswordCredentials getPasswordCredentials(Authentication authentication) {


### PR DESCRIPTION
When downloading from some repositories like the oracle maven repository
httpclient is not able to parse the expires attribute in the set cookie
header.
This looks like using the `standard` cookie spec instead of the default
one fixes the problem. It is also necessary to upgrade httpclient to
the latest version to make this work for
https://issues.apache.org/jira/browse/HTTPCLIENT-1077.

This would fix #1596.