### PR TITLE
Introduce a `quickFeedbackCrossVersionIntegTest` build type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ buildTypes {
         tasks "crossVersionIntegTest"
         projectProperties useIncomingDistributions: true
     }
-    quickFeedbackCrossVersionIntegTest {
+    quickFeedbackCrossVersionTest {
         tasks "quickFeedbackCrossVersionIntegTest"
         projectProperties useIncomingDistributions: true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,10 @@ buildTypes {
         tasks "crossVersionIntegTest"
         projectProperties useIncomingDistributions: true
     }
+    quickFeedbackCrossVersionIntegTest {
+        tasks "quickFeedbackCrossVersionIntegTest"
+        projectProperties useIncomingDistributions: true
+    }
 
     // Used to build production distros and smoke test them
     packageBuild {

--- a/gradle/integTest.gradle
+++ b/gradle/integTest.gradle
@@ -64,6 +64,10 @@ task crossVersionIntegTest {
     description "Runs the cross version tests against all Gradle versions"
 }
 
+task quickFeedbackCrossVersionIntegTest {
+    description "Runs the cross version tests against a subset of selected Gradle versions for quick feedback"
+}
+
 releasedVersions.testedVersions.each { targetVersion ->
     tasks.create("gradle${targetVersion}IntegTest", IntegrationTest).configure {
         crossVersionIntegTest.dependsOn it
@@ -71,6 +75,12 @@ releasedVersions.testedVersions.each { targetVersion ->
         systemProperties['org.gradle.integtest.versions'] = targetVersion
         systemProperties['org.gradle.integtest.executer'] = 'forking'
         include '**/*CrossVersion*'
+    }
+}
+
+releasedVersions.getTestedVersions(true).each { targetVersion ->
+    tasks.getByName("gradle${targetVersion}IntegTest").configure {
+        quickFeedbackCrossVersionIntegTest.dependsOn it
     }
 }
 


### PR DESCRIPTION
This build type is similar to `crossVersionIntegTest`, but only runs a subset of the released Gradle versions.
This is done so that we can use it in "commit" builds, for faster feedback, while still running the whole
test suite in a later stage, executed less often (because less likely to fail).

The current selection process is to select the first and last released versions for each major release of
Gradle. There's an option to ban specific versions of Gradle from this list, in which case the selection
process is the same, but without considering the banned versions.

With this changes, as of today, the list of versions are:

- quick cross-version checks: 4.0-rc-1, 3.0, 3.5, 2.0, 2.14.1, 1.0, 1.12
- all cross-version checks: 4.0-rc-1, 3.5, 3.4.1, 3.4, 3.3, 3.2.1, 3.2, 3.1, 3.0, 2.14.1, 2.14, 2.13, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2.1, 2.2, 2.1, 2.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0

See gradle/ci-health#111
