### PR TITLE
Add more inputs for integration tests

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/build/DefaultJavaInstallation.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/DefaultJavaInstallation.groovy
@@ -1,0 +1,11 @@
+package org.gradle.build
+
+import org.gradle.api.JavaVersion
+import org.gradle.jvm.toolchain.internal.LocalJavaInstallation
+
+class DefaultJavaInstallation implements LocalJavaInstallation {
+    JavaVersion javaVersion
+    File javaHome
+    String displayName
+    String name
+}

--- a/gradle/compile.gradle
+++ b/gradle/compile.gradle
@@ -9,6 +9,7 @@ if (!hasProperty('java7Home')) {
 }
 
 ext.jvmForCompilation = Jvm.current()
+ext.javaVendor = System.getProperty("java.vendor", "unknown")
 
 tasks.withType(AbstractCompile) {
     options.fork = true // Always fork compilation
@@ -36,9 +37,15 @@ tasks.withType(JavaCompile) {
     // while compiling.
     options.compilerArgs = ['-Xlint:-options', '-Xlint:-path']
     options.incremental = true
+    inputs.property('javaVendor') {
+        java7Home ? 'Oracle Corporation' : javaVendor
+    }
 }
 tasks.withType(GroovyCompile) {
     options.encoding = 'utf-8'
     options.compilerArgs = ['-Xlint:-options', '-Xlint:-path']
     groovyOptions.encoding = 'utf-8'
+    inputs.property('javaVendor') {
+        javaVendor
+    }
 }

--- a/gradle/compile.gradle
+++ b/gradle/compile.gradle
@@ -1,4 +1,6 @@
 import org.gradle.internal.jvm.Jvm
+import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
+import org.gradle.jvm.toolchain.internal.LocalJavaInstallation
 
 if (!hasProperty('java7Home')) {
     // We allow the system property and the project property so that it is
@@ -8,8 +10,13 @@ if (!hasProperty('java7Home')) {
     ext.java7Home = System.getProperty('java7.home')
 }
 
+def javaInstallationProbe = gradle.services.get(JavaInstallationProbe)
+
 ext.jvmForCompilation = Jvm.current()
-ext.javaVendor = System.getProperty("java.vendor", "unknown")
+ext.currentJavaInstallation = new DefaultJavaInstallation()
+ext.javaInstallationForCompilation = new DefaultJavaInstallation()
+javaInstallationProbe.current(currentJavaInstallation)
+javaInstallationProbe.current(javaInstallationForCompilation)
 
 tasks.withType(AbstractCompile) {
     options.fork = true // Always fork compilation
@@ -17,6 +24,7 @@ tasks.withType(AbstractCompile) {
 
 if (java7Home) {
     jvmForCompilation = Jvm.forHome(file(java7Home))
+    javaInstallationProbe.checkJdk(file(java7Home)).configure(javaInstallationForCompilation)
     tasks.withType(AbstractCompile) {
         options.with {
             fork = true
@@ -37,15 +45,22 @@ tasks.withType(JavaCompile) {
     // while compiling.
     options.compilerArgs = ['-Xlint:-options', '-Xlint:-path']
     options.incremental = true
-    inputs.property('javaVendor') {
-        java7Home ? 'Oracle Corporation' : javaVendor
+    inputs.property('javaInstallation') {
+        javaInstallationForCompilation.displayName
     }
 }
 tasks.withType(GroovyCompile) {
     options.encoding = 'utf-8'
     options.compilerArgs = ['-Xlint:-options', '-Xlint:-path']
     groovyOptions.encoding = 'utf-8'
-    inputs.property('javaVendor') {
-        javaVendor
+    inputs.property('javaInstallation') {
+        currentJavaInstallation.displayName
     }
+}
+
+class DefaultJavaInstallation implements LocalJavaInstallation {
+    JavaVersion javaVersion
+    File javaHome
+    String displayName
+    String name
 }

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -47,6 +47,9 @@ testTasks.all { task ->
         // enable class unloading
         task.jvmArgs '-XX:+UseConcMarkSweepGC', '-XX:+CMSClassUnloadingEnabled'
     }
+    task.inputs.property('javaVendor') {
+        javaVendor
+    }
     doFirst {
         if (isCiServer) {
             println "maxParallelForks for '$task.path' is $task.maxParallelForks"

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -47,8 +47,8 @@ testTasks.all { task ->
         // enable class unloading
         task.jvmArgs '-XX:+UseConcMarkSweepGC', '-XX:+CMSClassUnloadingEnabled'
     }
-    task.inputs.property('javaVendor') {
-        javaVendor
+    task.inputs.property('javaInstallation') {
+        currentJavaInstallation.displayName
     }
     doFirst {
         if (isCiServer) {


### PR DESCRIPTION
In the coverage phase we use different Java vendors.
Therefore, we need to track the vendor if we want to use the build cache.
