### PR TITLE
Implement exponential backoff for cross-process file locking

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -344,7 +344,6 @@ public class DefaultFileLockManager implements FileLockManager {
                 }
                 //TODO SF we should inform on the progress/status bar that we're waiting
                 Thread.sleep(backoff(++i));
-                i++;
             } while (!timer.hasExpired());
             return null;
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractDependencyResolutionTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractDependencyResolutionTest.groovy
@@ -15,6 +15,7 @@
  */
 
 package org.gradle.integtests.fixtures
+
 import org.gradle.test.fixtures.ivy.IvyFileRepository
 import org.gradle.test.fixtures.maven.MavenFileRepository
 


### PR DESCRIPTION
### Context

Cache locking uses a fixed delay between attempts to acquire the lock (200ms). Change it to a smaller delay, but use exponential backoff to mitigate.
