### PR TITLE
Avoid single quotes to be escaped for concatenated offline link value

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -279,6 +279,26 @@ Joe!""")
         result.assertOutputContains("-J-Dpublic.api=com.sample.tools.VisibilityPublic")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/2235")
+    def "can pass offline links"() {
+        buildFile << """
+            apply plugin: 'java'
+            
+            javadoc {
+                options {
+                    linksOffline 'https://docs.oracle.com/javase/8/docs/api/', 'gradle/javadocs/jdk'
+                    linksOffline 'http://javadox.com/org.jetbrains/annotations/15.0/', 'gradle/javadocs/jetbrains-annotations'
+                }
+            }
+        """
+        writeSourceFile()
+        file('gradle/javadocs/jdk/package-list') << ''
+        file('gradle/javadocs/jetbrains-annotations/package-list') << ''
+
+        expect:
+        succeeds("javadoc")
+    }
+
     private TestFile writeSourceFile() {
         file("src/main/java/Foo.java") << "public class Foo {}"
     }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/JavadocOfflineLink.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/JavadocOfflineLink.java
@@ -58,8 +58,4 @@ public class JavadocOfflineLink implements Serializable {
     public int hashCode() {
         return Objects.hashCode(extDocUrl, packagelistLoc);
     }
-
-    public String toString() {
-        return extDocUrl + "' '" + packagelistLoc;
-    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/LinksOfflineJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/LinksOfflineJavadocOptionFileOption.java
@@ -31,9 +31,17 @@ public class LinksOfflineJavadocOptionFileOption extends AbstractJavadocOptionFi
     public void write(JavadocOptionFileWriterContext writerContext) throws IOException {
         if (value != null && !value.isEmpty()) {
             for (final JavadocOfflineLink offlineLink : value) {
-                writerContext.writeValueOption(option, offlineLink.toString());
+                writeOfflineLink(writerContext, offlineLink);
             }
         }
+    }
+
+    private void writeOfflineLink(JavadocOptionFileWriterContext writerContext, JavadocOfflineLink offlineLink) throws IOException {
+        writerContext.writeOptionHeader(option);
+        writerContext.writeValue(offlineLink.getExtDocUrl());
+        writerContext.write(" ");
+        writerContext.writeValue(offlineLink.getPackagelistLoc());
+        writerContext.newLine();
     }
 
     @Override

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/LinksOfflineJavadocOptionFileOptionTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/LinksOfflineJavadocOptionFileOptionTest.java
@@ -54,7 +54,11 @@ public class LinksOfflineJavadocOptionFileOptionTest {
         linksOfflineOption.getValue().add(new JavadocOfflineLink(extDocUrl, packageListLoc));
 
         context.checking(new Expectations() {{
-            oneOf(writerContextMock).writeValueOption(optionName, extDocUrl + "' '" + packageListLoc);
+            oneOf(writerContextMock).writeOptionHeader(optionName);
+            oneOf(writerContextMock).writeValue(extDocUrl);
+            oneOf(writerContextMock).write(" ");
+            oneOf(writerContextMock).writeValue(packageListLoc);
+            oneOf(writerContextMock).newLine();
         }});
 
         linksOfflineOption.write(writerContextMock);


### PR DESCRIPTION
### Context

See issue https://github.com/gradle/gradle/issues/2235. The problem was that the rendered value on `javadoc.options` would should up as 
`-linkoffline 'https://docs.oracle.com/javase/8/docs/api/\' \'gradle/javadocs/jdk'` 
instead of 
`-linkoffline 'https://docs.oracle.com/javase/8/docs/api/' 'gradle/javadocs/jdk'`. `JavadocOptionFileWriterContext` escapes single quotes now by default to account for String that can contain single quotes e.g. in headers or footers. Here no escaping is needed.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
