### PR TITLE
Relax the test assertion and avoid sleep usage

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/BasicGroupedTaskLoggingFunctionalSpec.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/BasicGroupedTaskLoggingFunctionalSpec.groovy
@@ -119,7 +119,7 @@ class BasicGroupedTaskLoggingFunctionalSpec extends AbstractConsoleFunctionalSpe
         fails('log')
 
         then:
-        result.groupedOutput.task(':log').output == "First line of text\n\n\nLast line of text"
+        result.groupedOutput.task(':log').output =~ /First line of text\n{3,}Last line of text/
     }
 
     @IgnoreIf({ !GradleContextualExecuter.parallel })


### PR DESCRIPTION
### Context
Related this [CI failure](https://builds.gradle.org/viewLog.html?buildId=3123404&buildTypeId=Gradle_Release_CommitPhase_LinuxCommit_LinuxCommitJava18_7LinuxCommitJava18) and this [Slack discussion](https://gradle.slack.com/archives/C03A0MT6S/p1496670232626754).

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Branches_Checkpoints&branch_Gradle_Branches_Checkpoints=dl-fix-flaky-console-test)
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
