### PR TITLE
Worker daemons set working directory only during execution

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
@@ -68,7 +68,7 @@ abstract class AbstractWorkerProcessIntegrationSpec extends Specification {
     final ClassPathRegistry classPathRegistry = new DefaultClassPathRegistry(new DefaultClassPathProvider(moduleRegistry), new WorkerProcessClassPathProvider(cacheRepository))
     final JavaExecHandleFactory execHandleFactory = TestFiles.javaExecHandleFactory(tmpDir.testDirectory)
     final OutputEventListener outputEventListener = new TestOutputEventListener()
-    DefaultWorkerProcessFactory workerFactory = new DefaultWorkerProcessFactory(LogLevel.DEBUG, server, classPathRegistry, new LongIdGenerator(), null, new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
+    DefaultWorkerProcessFactory workerFactory = new DefaultWorkerProcessFactory(LogLevel.DEBUG, server, classPathRegistry, new LongIdGenerator(), tmpDir.file("gradleUserHome"), new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
 
     def cleanup() {
         services.close()

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/MultiRequestWorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/MultiRequestWorkerProcessIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.process.internal
 
+import org.gradle.internal.reflect.ObjectInstantiationException
 import org.gradle.process.internal.worker.WorkerControl
 import org.gradle.process.internal.worker.WorkerProcessException
 import org.gradle.test.fixtures.ConcurrentTestUtil
@@ -147,7 +148,7 @@ class CustomTestWorker implements TestProtocol {
         then:
         def e = thrown(WorkerProcessException)
         e.message == 'Failed to run broken worker'
-        e.cause instanceof InstantiationException
+        e.cause instanceof ObjectInstantiationException
 
         cleanup:
         worker?.stop()

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/SingleRequestWorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/SingleRequestWorkerProcessIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.process.internal
 
+import org.gradle.internal.reflect.ObjectInstantiationException
 import org.gradle.process.internal.worker.WorkerProcessException
 import org.gradle.util.TextUtil
 import spock.lang.Ignore
@@ -134,7 +135,7 @@ class CustomTestWorker implements TestProtocol {
         then:
         def e = thrown(WorkerProcessException)
         e.message == 'Failed to run broken worker'
-        e.cause instanceof InstantiationException
+        e.cause instanceof ObjectInstantiationException
     }
 
     def "propagates failure to start worker process"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
@@ -96,7 +96,7 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
         String expectedLogStatement = "[[INFO] [org.gradle.process.internal.LogSerializableLogAction] info log statement]"
 
         when:
-        workerFactory = new DefaultWorkerProcessFactory(LogLevel.LIFECYCLE, server, classPathRegistry, new LongIdGenerator(), null, new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
+        workerFactory = new DefaultWorkerProcessFactory(LogLevel.LIFECYCLE, server, classPathRegistry, new LongIdGenerator(), tmpDir.file("gradleUserHome"), new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
         and:
         execute(worker(loggingProcess))
 
@@ -104,7 +104,7 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
         !outputEventListener.toString().contains(TextUtil.toPlatformLineSeparators(expectedLogStatement))
 
         when:
-        workerFactory = new DefaultWorkerProcessFactory(LogLevel.INFO, server, classPathRegistry, new LongIdGenerator(), null, new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
+        workerFactory = new DefaultWorkerProcessFactory(LogLevel.INFO, server, classPathRegistry, new LongIdGenerator(), tmpDir.file("gradleUserHome"), new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
         and:
         execute(worker(loggingProcess))
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessFactory.java
@@ -52,7 +52,7 @@ public class DefaultWorkerProcessFactory implements WorkerProcessFactory {
         this.gradleUserHomeDir = gradleUserHomeDir;
         this.execHandleFactory = execHandleFactory;
         this.outputEventListener = outputEventListener;
-        this.workerImplementationFactory = new ApplicationClassesInSystemClassLoaderWorkerImplementationFactory(classPathRegistry, temporaryFileProvider, jvmVersionDetector);
+        this.workerImplementationFactory = new ApplicationClassesInSystemClassLoaderWorkerImplementationFactory(classPathRegistry, temporaryFileProvider, jvmVersionDetector, gradleUserHomeDir);
         this.memoryManager = memoryManager;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerProcessContext.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerProcessContext.java
@@ -17,6 +17,7 @@
 package org.gradle.process.internal.worker;
 
 import org.gradle.internal.remote.ObjectConnection;
+import org.gradle.internal.service.ServiceRegistry;
 
 public interface WorkerProcessContext {
     /**
@@ -35,4 +36,6 @@ public interface WorkerProcessContext {
     ObjectConnection getServerConnection();
 
     ClassLoader getApplicationClassLoader();
+
+    ServiceRegistry getServiceRegistry();
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ActionExecutionWorker.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ActionExecutionWorker.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal.worker.child;
 import org.gradle.api.Action;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.remote.ObjectConnection;
+import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.process.internal.worker.WorkerProcessContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +49,7 @@ public class ActionExecutionWorker implements Action<WorkerContext>, Serializabl
 
     public void execute(final WorkerContext workerContext) {
         final ObjectConnection clientConnection = workerContext.getServerConnection();
+        final ServiceRegistry serviceRegistry = workerContext.getServiceRegistry();
         LOGGER.debug("Starting {}.", displayName);
         WorkerProcessContext context = new WorkerProcessContext() {
             public ObjectConnection getServerConnection() {
@@ -64,6 +66,11 @@ public class ActionExecutionWorker implements Action<WorkerContext>, Serializabl
 
             public String getDisplayName() {
                 return displayName;
+            }
+
+            @Override
+            public ServiceRegistry getServiceRegistry() {
+                return serviceRegistry;
             }
         };
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
@@ -71,11 +71,13 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
     private final ClassPathRegistry classPathRegistry;
     private final TemporaryFileProvider temporaryFileProvider;
     private final JvmVersionDetector jvmVersionDetector;
+    private final File gradleUserHomeDir;
 
-    public ApplicationClassesInSystemClassLoaderWorkerImplementationFactory(ClassPathRegistry classPathRegistry, TemporaryFileProvider temporaryFileProvider, JvmVersionDetector jvmVersionDetector) {
+    public ApplicationClassesInSystemClassLoaderWorkerImplementationFactory(ClassPathRegistry classPathRegistry, TemporaryFileProvider temporaryFileProvider, JvmVersionDetector jvmVersionDetector, File gradleUserHomeDir) {
         this.classPathRegistry = classPathRegistry;
         this.temporaryFileProvider = temporaryFileProvider;
         this.jvmVersionDetector = jvmVersionDetector;
+        this.gradleUserHomeDir = gradleUserHomeDir;
     }
 
     @Override
@@ -131,10 +133,11 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory im
             OutputStreamBackedEncoder encoder = new OutputStreamBackedEncoder(outstr);
             encoder.writeSmallInt(logLevel.ordinal());
             encoder.writeBoolean(publishProcessInfo);
+            encoder.writeString(gradleUserHomeDir.getAbsolutePath());
             new MultiChoiceAddressSerializer().write(encoder, (MultiChoiceAddress) serverAddress);
 
             // Serialize the worker, this is consumed by SystemApplicationClassLoaderWorker
-            ActionExecutionWorker worker = new ActionExecutionWorker(processBuilder.getWorker(), workerId, displayName, processBuilder.getGradleUserHomeDir());
+            ActionExecutionWorker worker = new ActionExecutionWorker(processBuilder.getWorker(), workerId, displayName, gradleUserHomeDir);
             byte[] serializedWorker = GUtil.serialize(worker);
             encoder.writeBinary(serializedWorker);
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/DefaultWorkerDirectoryProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/DefaultWorkerDirectoryProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.workers.internal;
+package org.gradle.process.internal.worker.child;
 
 import org.gradle.initialization.GradleUserHomeDirProvider;
 
@@ -28,7 +28,7 @@ public class DefaultWorkerDirectoryProvider implements WorkerDirectoryProvider {
     }
 
     @Override
-    public File getDefaultWorkerDirectory() {
+    public File getIdleWorkingDirectory() {
         File defaultWorkerDirectory = new File(gradleUserHomeDir, "workers");
         if (!defaultWorkerDirectory.exists() && !defaultWorkerDirectory.mkdirs()) {
             throw new IllegalStateException("Unable to create default worker directory at " + defaultWorkerDirectory.getAbsolutePath());

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -18,6 +18,7 @@ package org.gradle.process.internal.worker.child;
 
 import org.gradle.api.Action;
 import org.gradle.api.logging.LogLevel;
+import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.DefaultListenerManager;
@@ -47,6 +48,7 @@ import org.gradle.process.internal.worker.WorkerJvmMemoryInfoSerializer;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
+import java.io.File;
 import java.io.ObjectInputStream;
 import java.util.concurrent.Callable;
 
@@ -81,10 +83,14 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
         // Read whether process info should be published
         boolean shouldPublishJvmMemoryInfo = decoder.readBoolean();
 
+        // Read path to Gradle user home
+        String gradleUserHomeDirPath = decoder.readString();
+        File gradleUserHomeDir = new File(gradleUserHomeDirPath);
+
         // Read server address and start connecting
         MultiChoiceAddress serverAddress = new MultiChoiceAddressSerializer().read(decoder);
         MessagingServices messagingServices = new MessagingServices();
-        WorkerServices workerServices = new WorkerServices(messagingServices);
+        final WorkerServices workerServices = new WorkerServices(messagingServices, gradleUserHomeDir);
 
         ObjectConnection connection = null;
         WorkerLogEventListener workerLogEventListener = null;
@@ -116,6 +122,11 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
                 @Override
                 public ObjectConnection getServerConnection() {
                     return serverConnection;
+                }
+
+                @Override
+                public ServiceRegistry getServiceRegistry() {
+                    return workerServices;
                 }
             });
         } finally {
@@ -158,8 +169,18 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
     }
 
     private static class WorkerServices extends DefaultServiceRegistry {
-        public WorkerServices(ServiceRegistry parent) {
+        public WorkerServices(ServiceRegistry parent, final File gradleUserHomeDir) {
             super(parent);
+            addProvider(new Object() {
+                GradleUserHomeDirProvider createGradleUserHomeDirProvider() {
+                    return new GradleUserHomeDirProvider() {
+                        @Override
+                        public File getGradleUserHomeDirectory() {
+                            return gradleUserHomeDir;
+                        }
+                    };
+                }
+            });
         }
 
         ListenerManager createListenerManager() {
@@ -176,6 +197,10 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
 
         MemoryManager createMemoryManager(OsMemoryInfo osMemoryInfo, JvmMemoryInfo jvmMemoryInfo, ListenerManager listenerManager, ExecutorFactory executorFactory) {
             return new DefaultMemoryManager(osMemoryInfo, jvmMemoryInfo, listenerManager, executorFactory);
+        }
+
+        WorkerDirectoryProvider createWorkerDirectoryProvider(GradleUserHomeDirProvider gradleUserHomeDirProvider) {
+            return new DefaultWorkerDirectoryProvider(gradleUserHomeDirProvider);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerContext.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerContext.java
@@ -17,8 +17,10 @@
 package org.gradle.process.internal.worker.child;
 
 import org.gradle.internal.remote.ObjectConnection;
+import org.gradle.internal.service.ServiceRegistry;
 
 public interface WorkerContext {
     ClassLoader getApplicationClassLoader();
     ObjectConnection getServerConnection();
+    ServiceRegistry getServiceRegistry();
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerDirectoryProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerDirectoryProvider.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package org.gradle.workers.internal;
+package org.gradle.process.internal.worker.child;
 
 import java.io.File;
 
 public interface WorkerDirectoryProvider {
     /**
-     * Returns a File object representing the default working directory for providers.
+     * Returns a File object representing the idle working directory for workers.
      */
-    File getDefaultWorkerDirectory();
+    File getIdleWorkingDirectory();
 }

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -22,6 +22,7 @@ import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.workers.internal.ActionExecutionSpec;
 import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.workers.internal.DefaultWorkResult;
+import org.gradle.workers.internal.SimpleActionExecutionSpec;
 import org.gradle.workers.internal.Worker;
 import org.gradle.workers.internal.WorkerDaemonServer;
 import org.gradle.workers.internal.WorkerFactory;
@@ -50,7 +51,7 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
     public WorkResult execute(T spec) {
         DaemonForkOptions daemonForkOptions = toDaemonOptions(spec);
         Worker<ActionExecutionSpec> worker = workerFactory.getWorker(getServerImplementation(), daemonForkOptions);
-        DefaultWorkResult result = worker.execute(new ActionExecutionSpec(CompilerRunnable.class, "compiler daemon", executionWorkingDir, new Object[] {delegate, spec}));
+        DefaultWorkResult result = worker.execute(new SimpleActionExecutionSpec(CompilerRunnable.class, "compiler daemon", executionWorkingDir, new Object[] {delegate, spec}));
         if (result.isSuccess()) {
             return result;
         } else {

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -17,8 +17,11 @@ package org.gradle.api.internal.tasks.compile.daemon;
 
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.nativeintegration.ProcessEnvironment;
+import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
+import org.gradle.process.internal.worker.child.WorkerDirectoryProvider;
 import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.workers.internal.DefaultWorkResult;
 import org.gradle.workers.internal.WorkSpec;
@@ -26,15 +29,16 @@ import org.gradle.workers.internal.Worker;
 import org.gradle.workers.internal.WorkerFactory;
 import org.gradle.workers.internal.WorkerProtocol;
 
+import javax.inject.Inject;
 import java.io.File;
 
 public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements Compiler<T> {
     private final Compiler<T> delegate;
     private final WorkerFactory workerFactory;
-    private final File daemonWorkingDir;
+    private final File executionWorkingDir;
 
-    public AbstractDaemonCompiler(File daemonWorkingDir, Compiler<T> delegate, WorkerFactory workerFactory) {
-        this.daemonWorkingDir = daemonWorkingDir;
+    public AbstractDaemonCompiler(File executionWorkingDir, Compiler<T> delegate, WorkerFactory workerFactory) {
+        this.executionWorkingDir = executionWorkingDir;
         this.delegate = delegate;
         this.workerFactory = workerFactory;
     }
@@ -46,8 +50,8 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
     @Override
     public WorkResult execute(T spec) {
         DaemonForkOptions daemonForkOptions = toDaemonOptions(spec);
-        Worker<WorkerCompileSpec<?>> worker = workerFactory.getWorker(CompilerDaemonServer.class, daemonWorkingDir, daemonForkOptions);
-        DefaultWorkResult result = worker.execute(new WorkerCompileSpec<T>(delegate, spec));
+        Worker<WorkerCompileSpec<?>> worker = workerFactory.getWorker(CompilerDaemonServer.class, daemonForkOptions);
+        DefaultWorkResult result = worker.execute(new WorkerCompileSpec<T>(delegate, spec, executionWorkingDir));
         if (result.isSuccess()) {
             return result;
         }
@@ -59,10 +63,12 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
     private static class WorkerCompileSpec<T extends CompileSpec> implements WorkSpec {
         private final Compiler<T> compiler;
         private final T spec;
+        private final File executionWorkingDir;
 
-        WorkerCompileSpec(Compiler<T> compiler, T spec) {
+        private WorkerCompileSpec(Compiler<T> compiler, T spec, File executionWorkingDir) {
             this.compiler = compiler;
             this.spec = spec;
+            this.executionWorkingDir = executionWorkingDir;
         }
 
         @Override
@@ -73,15 +79,30 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
         public DefaultWorkResult compile() {
             return new DefaultWorkResult(compiler.execute(spec).getDidWork(), null);
         }
+
+        public File getExecutionWorkingDir() {
+            return executionWorkingDir;
+        }
     }
 
     public static class CompilerDaemonServer implements WorkerProtocol<WorkerCompileSpec<?>> {
+        private final WorkerDirectoryProvider workerDirectoryProvider;
+
+        @Inject
+        CompilerDaemonServer(WorkerDirectoryProvider workerDirectoryProvider) {
+            this.workerDirectoryProvider = workerDirectoryProvider;
+        }
+
         @Override
         public DefaultWorkResult execute(WorkerCompileSpec<?> spec) {
+            ProcessEnvironment processEnvironment = NativeServices.getInstance().get(ProcessEnvironment.class);
             try {
+                processEnvironment.maybeSetProcessDir(spec.getExecutionWorkingDir());
                 return spec.compile();
             } catch (Throwable t) {
                 return new DefaultWorkResult(true, t);
+            } finally {
+                processEnvironment.maybeSetProcessDir(workerDirectoryProvider.getIdleWorkingDirectory());
             }
         }
     }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/AbstractProcessEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/AbstractProcessEnvironment.java
@@ -88,10 +88,6 @@ public abstract class AbstractProcessEnvironment implements ProcessEnvironment {
 
     @Override
     public void setProcessDir(File processDir) throws NativeIntegrationException {
-        if (!processDir.exists()) {
-            return;
-        }
-
         setNativeProcessDir(processDir);
         System.setProperty("user.dir", processDir.getAbsolutePath());
     }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
+    def "sets the working directory to the project directory by default during worker execution"() {
+        withRunnableClassInBuildScript()
+        buildFile << """
+            import org.gradle.workers.IsolationMode
+
+            $runnableThatPrintsWorkingDirectory
+
+            task runInWorker(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+                runnableClass = WorkingDirRunnable.class
+            }
+        """
+
+        when:
+        args("--info")
+        succeeds("runInWorker")
+
+        then:
+        output.contains("Starting process 'Gradle Worker Daemon 1'. Working directory: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+
+        and:
+        output.contains("Execution working dir: " + testDirectory.getAbsolutePath())
+
+        and:
+        output.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+    }
+
+    def "sets the working directory to the specified directory during worker execution"() {
+        withRunnableClassInBuildScript()
+        buildFile << """
+            import org.gradle.workers.IsolationMode
+
+            $runnableThatPrintsWorkingDirectory
+
+            task runInWorker(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+                runnableClass = WorkingDirRunnable.class
+                additionalForkOptions = { it.workingDir = project.file("workerDir") }
+            }
+        """
+        testDirectory.file("workerDir").createDir()
+
+        when:
+        args("--info")
+        succeeds("runInWorker")
+
+        then:
+        output.contains("Starting process 'Gradle Worker Daemon 1'. Working directory: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+
+        and:
+        output.contains("Execution working dir: " + testDirectory.file("workerDir").getAbsolutePath())
+
+        and:
+        output.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+    }
+
+    def getRunnableThatPrintsWorkingDirectory() {
+        return """
+            class WorkingDirRunnable extends TestRunnable {
+                @Inject
+                public WorkingDirRunnable(List<String> files, File outputDir, Foo foo) {
+                    super(files, outputDir, foo);
+                    Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            printWorkingDirectory("Shutdown")
+                        }
+                    }));
+                }
+                
+                public void run() {
+                    super.run()
+                    printWorkingDirectory("Execution")
+                }
+                
+                void printWorkingDirectory(String phase) {
+                    println phase + " working dir: " + System.getProperty("user.dir")
+                }
+            }
+        """
+    }
+}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.workers.internal
 
-import groovy.transform.NotYetImplemented
 import org.gradle.internal.jvm.Jvm
 import org.gradle.workers.IsolationMode
 import spock.lang.Unroll
@@ -101,7 +100,6 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         failureHasCause("Failed to run Gradle Worker Daemon")
     }
 
-    @NotYetImplemented
     def "produces a sensible error if the specified working directory cannot be used"() {
         executer.withStackTraceChecksDisabled()
         withRunnableClassInBuildSrc()

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.workers.internal
 
+import groovy.transform.NotYetImplemented
 import org.gradle.internal.jvm.Jvm
 import org.gradle.workers.IsolationMode
 import spock.lang.Unroll
@@ -98,6 +99,30 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
         and:
         failureHasCause("Failed to run Gradle Worker Daemon")
+    }
+
+    @NotYetImplemented
+    def "produces a sensible error if the specified working directory cannot be used"() {
+        executer.withStackTraceChecksDisabled()
+        withRunnableClassInBuildSrc()
+
+        buildFile << """
+            task runInDaemon(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+                additionalForkOptions = {
+                    it.workingDir = project.file("doesNotExist")
+                }
+            }
+        """.stripIndent()
+
+        when:
+        fails("runInDaemon")
+
+        then:
+        failureHasCause("Could not set process working directory to '" + file('doesNotExist').absolutePath + "'")
+
+        and:
+        failureHasCause("A failure occurred while executing org.gradle.test.TestRunnable")
     }
 
     @Unroll

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
@@ -21,6 +21,7 @@ import org.gradle.internal.io.ClassLoaderObjectInputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -31,11 +32,15 @@ import java.io.ObjectOutputStream;
 public class ActionExecutionSpec implements WorkSpec {
     private final String displayName;
     private final Class<? extends Runnable> implementationClass;
+    private final File defaultDir;
+    private final File workingDir;
     private final byte[] params;
 
-    ActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, Object[] params) {
+    ActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, File defaultDir, File workingDir, Object[] params) {
         this.implementationClass = implementationClass;
         this.displayName = displayName;
+        this.defaultDir = defaultDir;
+        this.workingDir = workingDir;
         this.params = serialize(params);
     }
 
@@ -46,6 +51,14 @@ public class ActionExecutionSpec implements WorkSpec {
     @Override
     public String getDisplayName() {
         return displayName;
+    }
+
+    public File getDefaultDir() {
+        return defaultDir;
+    }
+
+    public File getWorkingDir() {
+        return workingDir;
     }
 
     public Object[] getParams(ClassLoader classLoader) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
@@ -35,7 +35,7 @@ public class ActionExecutionSpec implements WorkSpec {
     private final File executionWorkingDir;
     private final byte[] params;
 
-    ActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, File executionWorkingDir, Object[] params) {
+    public ActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, File executionWorkingDir, Object[] params) {
         this.implementationClass = implementationClass;
         this.displayName = displayName;
         this.executionWorkingDir = executionWorkingDir;

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
@@ -16,76 +16,15 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.internal.exceptions.Contextual;
-import org.gradle.internal.io.ClassLoaderObjectInputStream;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 
-/**
- * Represents a {@link WorkSpec} that contains constructor parameters.
- */
-public class ActionExecutionSpec implements WorkSpec {
-    private final String displayName;
-    private final Class<? extends Runnable> implementationClass;
-    private final File executionWorkingDir;
-    private final byte[] params;
-
-    public ActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, File executionWorkingDir, Object[] params) {
-        this.implementationClass = implementationClass;
-        this.displayName = displayName;
-        this.executionWorkingDir = executionWorkingDir;
-        this.params = serialize(params);
-    }
-
-    public Class<? extends Runnable> getImplementationClass() {
-        return implementationClass;
-    }
+public interface ActionExecutionSpec extends WorkSpec {
+    Class<? extends Runnable> getImplementationClass();
 
     @Override
-    public String getDisplayName() {
-        return displayName;
-    }
+    String getDisplayName();
 
-    public File getExecutionWorkingDir() {
-        return executionWorkingDir;
-    }
+    File getExecutionWorkingDir();
 
-    public Object[] getParams(ClassLoader classLoader) {
-        return deserialize(classLoader);
-    }
-
-    private byte[] serialize(Object[] params) {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        try {
-            ObjectOutputStream oos = new ObjectOutputStream(bos);
-            oos.writeObject(params);
-        } catch (IOException e) {
-            throw new ParameterSerializationException("Could not serialize parameters", e);
-        }
-        return bos.toByteArray();
-    }
-
-    private Object[] deserialize(ClassLoader classLoader) {
-        ByteArrayInputStream bis = new ByteArrayInputStream(params);
-        try {
-            ObjectInputStream ois = new ClassLoaderObjectInputStream(bis, classLoader);
-            return (Object[])ois.readObject();
-        } catch (IOException e) {
-            throw new ParameterSerializationException("Could not deserialize parameters", e);
-        } catch (ClassNotFoundException e) {
-            throw new ParameterSerializationException("Could not deserialize parameters", e);
-        }
-    }
-
-    @Contextual
-    static class ParameterSerializationException extends RuntimeException {
-        ParameterSerializationException(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
+    Object[] getParams(ClassLoader classLoader);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
@@ -32,15 +32,13 @@ import java.io.ObjectOutputStream;
 public class ActionExecutionSpec implements WorkSpec {
     private final String displayName;
     private final Class<? extends Runnable> implementationClass;
-    private final File defaultDir;
-    private final File workingDir;
+    private final File executionWorkingDir;
     private final byte[] params;
 
-    ActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, File defaultDir, File workingDir, Object[] params) {
+    ActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, File executionWorkingDir, Object[] params) {
         this.implementationClass = implementationClass;
         this.displayName = displayName;
-        this.defaultDir = defaultDir;
-        this.workingDir = workingDir;
+        this.executionWorkingDir = executionWorkingDir;
         this.params = serialize(params);
     }
 
@@ -53,12 +51,8 @@ public class ActionExecutionSpec implements WorkSpec {
         return displayName;
     }
 
-    public File getDefaultDir() {
-        return defaultDir;
-    }
-
-    public File getWorkingDir() {
-        return workingDir;
+    public File getExecutionWorkingDir() {
+        return executionWorkingDir;
     }
 
     public Object[] getParams(ClassLoader classLoader) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerDirectoryProvider.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerDirectoryProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import org.gradle.initialization.GradleUserHomeDirProvider;
+
+import java.io.File;
+
+public class DefaultWorkerDirectoryProvider implements WorkerDirectoryProvider {
+    private final File gradleUserHomeDir;
+
+    public DefaultWorkerDirectoryProvider(GradleUserHomeDirProvider gradleUserHomeDirProvider) {
+        this.gradleUserHomeDir = gradleUserHomeDirProvider.getGradleUserHomeDirectory();
+    }
+
+    @Override
+    public File getDefaultWorkerDirectory() {
+        File defaultWorkerDirectory = new File(gradleUserHomeDir, "workers");
+        if (!defaultWorkerDirectory.exists() && !defaultWorkerDirectory.mkdirs()) {
+            throw new IllegalStateException("Unable to create default worker directory at " + defaultWorkerDirectory.getAbsolutePath());
+        }
+        return defaultWorkerDirectory;
+    }
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -81,7 +81,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         // Serialize parameters in this thread prior to starting work in a separate thread
         ActionExecutionSpec spec;
         try {
-            spec = new ActionExecutionSpec(actionClass, description, configuration.getForkOptions().getWorkingDir(), configuration.getParams());
+            spec = new SerializingActionExecutionSpec(actionClass, description, configuration.getForkOptions().getWorkingDir(), configuration.getParams());
         } catch (Throwable t) {
             throw new WorkExecutionException(description, t);
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -37,7 +37,6 @@ import org.gradle.internal.work.NoAvailableWorkerLeaseException;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.process.JavaForkOptions;
-import org.gradle.process.internal.worker.child.WorkerDirectoryProvider;
 import org.gradle.util.CollectionUtils;
 import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkerConfiguration;
@@ -59,11 +58,10 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
     private final WorkerLeaseRegistry workerLeaseRegistry;
     private final BuildOperationExecutor buildOperationExecutor;
     private final AsyncWorkTracker asyncWorkTracker;
-    private final WorkerDirectoryProvider workerDirectoryProvider;
 
     public DefaultWorkerExecutor(WorkerFactory daemonWorkerFactory, WorkerFactory isolatedClassloaderWorkerFactory, WorkerFactory noIsolationWorkerFactory,
                                  FileResolver fileResolver, ExecutorFactory executorFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor,
-                                 AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider) {
+                                 AsyncWorkTracker asyncWorkTracker) {
         this.daemonWorkerFactory = daemonWorkerFactory;
         this.isolatedClassloaderWorkerFactory = isolatedClassloaderWorkerFactory;
         this.noIsolationWorkerFactory = noIsolationWorkerFactory;
@@ -72,7 +70,6 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         this.workerLeaseRegistry = workerLeaseRegistry;
         this.buildOperationExecutor = buildOperationExecutor;
         this.asyncWorkTracker = asyncWorkTracker;
-        this.workerDirectoryProvider = workerDirectoryProvider;
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
@@ -43,7 +43,6 @@ import org.gradle.util.GUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -64,7 +63,7 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
     }
 
     @Override
-    public <T extends WorkSpec> Worker<T> getWorker(final Class<? extends WorkerProtocol<T>> workerImplementationClass, File workingDir, final DaemonForkOptions forkOptions) {
+    public <T extends WorkSpec> Worker<T> getWorker(final Class<? extends WorkerProtocol<T>> workerImplementationClass, final DaemonForkOptions forkOptions) {
         return new Worker<T>() {
             @Override
             public DefaultWorkResult execute(T spec) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
@@ -40,6 +40,7 @@ import org.gradle.internal.serialize.ExceptionReplacingObjectOutputStream;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.util.GUtil;
+import org.gradle.workers.IsolationMode;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -90,6 +91,11 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
                 }
             }
         };
+    }
+
+    @Override
+    public IsolationMode getIsolationMode() {
+        return IsolationMode.CLASSLOADER;
     }
 
     private <T extends WorkSpec> DefaultWorkResult executeInWorkerClassLoader(Class<? extends WorkerProtocol<T>> workerImplementationClass, T spec, DaemonForkOptions forkOptions) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -24,8 +24,6 @@ import org.gradle.internal.progress.BuildOperationState;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 
-import java.io.File;
-
 public class NoIsolationWorkerFactory implements WorkerFactory {
     private final WorkerLeaseRegistry workerLeaseRegistry;
     private final BuildOperationExecutor buildOperationExecutor;
@@ -36,7 +34,7 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
     }
 
     @Override
-    public <T extends WorkSpec> Worker<T> getWorker(final Class<? extends WorkerProtocol<T>> workerImplementationClass, File workingDir, final DaemonForkOptions forkOptions) {
+    public <T extends WorkSpec> Worker<T> getWorker(final Class<? extends WorkerProtocol<T>> workerImplementationClass, final DaemonForkOptions forkOptions) {
         return new Worker<T>() {
             @Override
             public DefaultWorkResult execute(T spec) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -23,6 +23,7 @@ import org.gradle.internal.progress.BuildOperationDescriptor;
 import org.gradle.internal.progress.BuildOperationState;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.work.WorkerLeaseRegistry;
+import org.gradle.workers.IsolationMode;
 
 public class NoIsolationWorkerFactory implements WorkerFactory {
     private final WorkerLeaseRegistry workerLeaseRegistry;
@@ -62,5 +63,10 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
                 }
             }
         };
+    }
+
+    @Override
+    public IsolationMode getIsolationMode() {
+        return IsolationMode.NONE;
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/SerializingActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/SerializingActionExecutionSpec.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import org.gradle.internal.exceptions.Contextual;
+import org.gradle.internal.io.ClassLoaderObjectInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Represents a {@link WorkSpec} that contains constructor parameters.
+ */
+public class SerializingActionExecutionSpec implements ActionExecutionSpec {
+    private final String displayName;
+    private final Class<? extends Runnable> implementationClass;
+    private final File executionWorkingDir;
+    private final byte[] params;
+
+    public SerializingActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, File executionWorkingDir, Object[] params) {
+        this.implementationClass = implementationClass;
+        this.displayName = displayName;
+        this.executionWorkingDir = executionWorkingDir;
+        this.params = serialize(params);
+    }
+
+    @Override
+    public Class<? extends Runnable> getImplementationClass() {
+        return implementationClass;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public File getExecutionWorkingDir() {
+        return executionWorkingDir;
+    }
+
+    @Override
+    public Object[] getParams(ClassLoader classLoader) {
+        return deserialize(classLoader);
+    }
+
+    private byte[] serialize(Object[] params) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
+            oos.writeObject(params);
+        } catch (IOException e) {
+            throw new ParameterSerializationException("Could not serialize parameters", e);
+        }
+        return bos.toByteArray();
+    }
+
+    private Object[] deserialize(ClassLoader classLoader) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(params);
+        try {
+            ObjectInputStream ois = new ClassLoaderObjectInputStream(bis, classLoader);
+            return (Object[])ois.readObject();
+        } catch (IOException e) {
+            throw new ParameterSerializationException("Could not deserialize parameters", e);
+        } catch (ClassNotFoundException e) {
+            throw new ParameterSerializationException("Could not deserialize parameters", e);
+        }
+    }
+
+    @Contextual
+    static class ParameterSerializationException extends RuntimeException {
+        ParameterSerializationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import java.io.File;
+
+public class SimpleActionExecutionSpec implements ActionExecutionSpec {
+    private final Class<? extends Runnable> implementationClass;
+    private final String displayName;
+    private final File executionWorkingDir;
+    private final Object[] params;
+
+    public SimpleActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, File executionWorkingDir, Object[] params) {
+        this.implementationClass = implementationClass;
+        this.displayName = displayName;
+        this.executionWorkingDir = executionWorkingDir;
+        this.params = params;
+    }
+
+    @Override
+    public Class<? extends Runnable> getImplementationClass() {
+        return implementationClass;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public File getExecutionWorkingDir() {
+        return executionWorkingDir;
+    }
+
+    @Override
+    public Object[] getParams(ClassLoader classLoader) {
+        return params;
+    }
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
@@ -24,8 +24,7 @@ import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.process.internal.health.memory.MemoryManager;
 import org.gradle.process.internal.health.memory.TotalPhysicalMemoryProvider;
-
-import java.io.File;
+import org.gradle.process.internal.worker.child.WorkerDirectoryProvider;
 
 /**
  * Controls the lifecycle of the worker daemon and provides access to it.
@@ -37,23 +36,25 @@ public class WorkerDaemonFactory implements WorkerFactory, Stoppable {
     private final WorkerDaemonExpiration workerDaemonExpiration;
     private final WorkerLeaseRegistry workerLeaseRegistry;
     private final BuildOperationExecutor buildOperationExecutor;
+    private final WorkerDirectoryProvider workerDirectoryProvider;
 
-    public WorkerDaemonFactory(WorkerDaemonClientsManager clientsManager, MemoryManager memoryManager, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
+    public WorkerDaemonFactory(WorkerDaemonClientsManager clientsManager, MemoryManager memoryManager, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, WorkerDirectoryProvider workerDirectoryProvider) {
         this.clientsManager = clientsManager;
         this.memoryManager = memoryManager;
         this.workerDaemonExpiration = new WorkerDaemonExpiration(clientsManager, getTotalPhysicalMemory());
         memoryManager.addMemoryHolder(workerDaemonExpiration);
         this.workerLeaseRegistry = workerLeaseRegistry;
         this.buildOperationExecutor = buildOperationExecutor;
+        this.workerDirectoryProvider = workerDirectoryProvider;
     }
 
     @Override
-    public <T extends WorkSpec> Worker<T> getWorker(final Class<? extends WorkerProtocol<T>> workerImplementationClass, final File workingDir, final DaemonForkOptions forkOptions) {
+    public <T extends WorkSpec> Worker<T> getWorker(final Class<? extends WorkerProtocol<T>> workerImplementationClass, final DaemonForkOptions forkOptions) {
         return new Worker<T>() {
             public DefaultWorkResult execute(T spec, WorkerLease parentWorkerWorkerLease, BuildOperationState parentBuildOperation) {
                 WorkerDaemonClient<T> client = clientsManager.reserveIdleClient(forkOptions);
                 if (client == null) {
-                    client = clientsManager.reserveNewClient(workerImplementationClass, workingDir, forkOptions);
+                    client = clientsManager.reserveNewClient(workerImplementationClass, workerDirectoryProvider.getIdleWorkingDirectory(), forkOptions);
                 }
                 try {
                     return client.execute(spec, parentWorkerWorkerLease, parentBuildOperation);

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
@@ -25,6 +25,7 @@ import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.process.internal.health.memory.MemoryManager;
 import org.gradle.process.internal.health.memory.TotalPhysicalMemoryProvider;
 import org.gradle.process.internal.worker.child.WorkerDirectoryProvider;
+import org.gradle.workers.IsolationMode;
 
 /**
  * Controls the lifecycle of the worker daemon and provides access to it.
@@ -68,6 +69,11 @@ public class WorkerDaemonFactory implements WorkerFactory, Stoppable {
                 return execute(spec, workerLeaseRegistry.getCurrentWorkerLease(), buildOperationExecutor.getCurrentOperation());
             }
         };
+    }
+
+    @Override
+    public IsolationMode getIsolationMode() {
+        return IsolationMode.PROCESS;
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -18,18 +18,28 @@ package org.gradle.workers.internal;
 
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.process.internal.worker.child.WorkerDirectoryProvider;
+
+import javax.inject.Inject;
 
 public class WorkerDaemonServer extends WorkerServer {
+    private final WorkerDirectoryProvider workerDirectoryProvider;
+
+    @Inject
+    WorkerDaemonServer(WorkerDirectoryProvider workerDirectoryProvider) {
+        this.workerDirectoryProvider = workerDirectoryProvider;
+    }
+
     @Override
     public DefaultWorkResult execute(ActionExecutionSpec spec) {
         ProcessEnvironment processEnvironment = NativeServices.getInstance().get(ProcessEnvironment.class);
         try {
-            processEnvironment.maybeSetProcessDir(spec.getWorkingDir());
+            processEnvironment.maybeSetProcessDir(spec.getExecutionWorkingDir());
             return super.execute(spec);
         } catch (Throwable t) {
             return new DefaultWorkResult(true, t);
         } finally {
-            processEnvironment.maybeSetProcessDir(spec.getDefaultDir());
+            processEnvironment.maybeSetProcessDir(workerDirectoryProvider.getIdleWorkingDirectory());
         }
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDirectoryProvider.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDirectoryProvider.java
@@ -18,6 +18,9 @@ package org.gradle.workers.internal;
 
 import java.io.File;
 
-public interface WorkerFactory {
-    <T extends WorkSpec> Worker<T> getWorker(Class<? extends WorkerProtocol<T>> workerImplementationClass, File workingDir, DaemonForkOptions forkOptions);
+public interface WorkerDirectoryProvider {
+    /**
+     * Returns a File object representing the default working directory for providers.
+     */
+    File getDefaultWorkerDirectory();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerFactory.java
@@ -16,8 +16,6 @@
 
 package org.gradle.workers.internal;
 
-import java.io.File;
-
 public interface WorkerFactory {
-    <T extends WorkSpec> Worker<T> getWorker(Class<? extends WorkerProtocol<T>> workerImplementationClass, File workingDir, DaemonForkOptions forkOptions);
+    <T extends WorkSpec> Worker<T> getWorker(Class<? extends WorkerProtocol<T>> workerImplementationClass, DaemonForkOptions forkOptions);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerFactory.java
@@ -16,6 +16,10 @@
 
 package org.gradle.workers.internal;
 
+import org.gradle.workers.IsolationMode;
+
 public interface WorkerFactory {
     <T extends WorkSpec> Worker<T> getWorker(Class<? extends WorkerProtocol<T>> workerImplementationClass, DaemonForkOptions forkOptions);
+
+    IsolationMode getIsolationMode();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -18,6 +18,7 @@ package org.gradle.workers.internal;
 
 import org.gradle.StartParameter;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -39,7 +40,8 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
     private static class BuildSessionScopeServices {
         WorkerDaemonClientsManager createWorkerDaemonClientsManager(WorkerProcessFactory workerFactory,
                                                                     StartParameter startParameter,
-                                                                    BuildOperationExecutor buildOperationExecutor) {
+                                                                    BuildOperationExecutor buildOperationExecutor,
+                                                                    WorkerDirectoryProvider workerDirectoryProvider) {
             return new WorkerDaemonClientsManager(new WorkerDaemonStarter(workerFactory, startParameter, buildOperationExecutor));
         }
 
@@ -47,8 +49,8 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
             return new WorkerDaemonFactory(workerDaemonClientsManager, memoryManager, workerLeaseRegistry, buildOperationExecutor);
         }
 
-        WorkerExecutor createWorkerExecutor(Instantiator instantiator, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, NoIsolationWorkerFactory noIsolationWorkerFactory, FileResolver fileResolver, ExecutorFactory executorFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker) {
-            return instantiator.newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker);
+        WorkerExecutor createWorkerExecutor(Instantiator instantiator, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, NoIsolationWorkerFactory noIsolationWorkerFactory, FileResolver fileResolver, ExecutorFactory executorFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider) {
+            return instantiator.newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider);
         }
 
         IsolatedClassloaderWorkerFactory createIsolatedClassloaderWorkerFactory(ClassLoaderFactory classLoaderFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
@@ -57,6 +59,10 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
 
         NoIsolationWorkerFactory createNoIsolationWorkerFactory(WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
             return new NoIsolationWorkerFactory(workerLeaseRegistry, buildOperationExecutor);
+        }
+
+        WorkerDirectoryProvider createWorkerDirectoryProvider(GradleUserHomeDirProvider gradleUserHomeDirProvider) {
+            return new DefaultWorkerDirectoryProvider(gradleUserHomeDirProvider);
         }
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -29,6 +29,8 @@ import org.gradle.internal.work.AsyncWorkTracker;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.process.internal.health.memory.MemoryManager;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
+import org.gradle.process.internal.worker.child.DefaultWorkerDirectoryProvider;
+import org.gradle.process.internal.worker.child.WorkerDirectoryProvider;
 import org.gradle.workers.WorkerExecutor;
 
 public class WorkersServices extends AbstractPluginServiceRegistry {
@@ -40,13 +42,12 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
     private static class BuildSessionScopeServices {
         WorkerDaemonClientsManager createWorkerDaemonClientsManager(WorkerProcessFactory workerFactory,
                                                                     StartParameter startParameter,
-                                                                    BuildOperationExecutor buildOperationExecutor,
-                                                                    WorkerDirectoryProvider workerDirectoryProvider) {
+                                                                    BuildOperationExecutor buildOperationExecutor) {
             return new WorkerDaemonClientsManager(new WorkerDaemonStarter(workerFactory, startParameter, buildOperationExecutor));
         }
 
-        WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, MemoryManager memoryManager, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
-            return new WorkerDaemonFactory(workerDaemonClientsManager, memoryManager, workerLeaseRegistry, buildOperationExecutor);
+        WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, MemoryManager memoryManager, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, WorkerDirectoryProvider workerDirectoryProvider) {
+            return new WorkerDaemonFactory(workerDaemonClientsManager, memoryManager, workerLeaseRegistry, buildOperationExecutor, workerDirectoryProvider);
         }
 
         WorkerExecutor createWorkerExecutor(Instantiator instantiator, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, NoIsolationWorkerFactory noIsolationWorkerFactory, FileResolver fileResolver, ExecutorFactory executorFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -50,8 +50,8 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
             return new WorkerDaemonFactory(workerDaemonClientsManager, memoryManager, workerLeaseRegistry, buildOperationExecutor, workerDirectoryProvider);
         }
 
-        WorkerExecutor createWorkerExecutor(Instantiator instantiator, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, NoIsolationWorkerFactory noIsolationWorkerFactory, FileResolver fileResolver, ExecutorFactory executorFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider) {
-            return instantiator.newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider);
+        WorkerExecutor createWorkerExecutor(Instantiator instantiator, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, NoIsolationWorkerFactory noIsolationWorkerFactory, FileResolver fileResolver, ExecutorFactory executorFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker) {
+            return instantiator.newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker);
         }
 
         IsolatedClassloaderWorkerFactory createIsolatedClassloaderWorkerFactory(ClassLoaderFactory classLoaderFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -40,6 +40,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def buildOperationWorkerRegistry = Mock(WorkerLeaseRegistry)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkerTracker = Mock(AsyncWorkTracker)
+    def workerDirectoryProvider = Mock(WorkerDirectoryProvider)
     def fileResolver = Mock(FileResolver)
     def stoppableExecutor = Mock(ManagedExecutor)
     ListenableFutureTask task
@@ -49,7 +50,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         _ * fileResolver.resolveLater(_) >> fileFactory()
         _ * fileResolver.resolve(_) >> { files -> files[0] }
         _ * workerExecutorFactory.create(_ as String) >> stoppableExecutor
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, fileResolver, workerExecutorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, fileResolver, workerExecutorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider)
     }
 
     @Unroll

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
-import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.util.UsesNativeServices
 import org.gradle.workers.IsolationMode
@@ -41,7 +40,6 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def buildOperationWorkerRegistry = Mock(WorkerLeaseRegistry)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkerTracker = Mock(AsyncWorkTracker)
-    def workerDirectoryProvider = Mock(WorkerDirectoryProvider)
     def fileResolver = Mock(FileResolver)
     def stoppableExecutor = Mock(ManagedExecutor)
     ListenableFutureTask task
@@ -51,7 +49,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         _ * fileResolver.resolveLater(_) >> fileFactory()
         _ * fileResolver.resolve(_) >> { files -> files[0] }
         _ * workerExecutorFactory.create(_ as String) >> stoppableExecutor
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, fileResolver, workerExecutorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, fileResolver, workerExecutorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker)
     }
 
     @Unroll

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
+import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.util.UsesNativeServices
 import org.gradle.workers.IsolationMode

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -43,6 +43,7 @@ class DefaultWorkerExecutorTest extends Specification {
     def buildOperationWorkerRegistry = Mock(WorkerLeaseRegistry)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkTracker = Mock(AsyncWorkTracker)
+    def workerDirectoryProvider = Mock(WorkerDirectoryProvider)
     def fileResolver = Mock(FileResolver)
     def factory = Mock(Factory)
     def runnable = Mock(Runnable)
@@ -55,7 +56,7 @@ class DefaultWorkerExecutorTest extends Specification {
         _ * fileResolver.resolveLater(_) >> factory
         _ * fileResolver.resolve(_) >> { files -> files[0] }
         _ * executorFactory.create(_ as String) >> executor
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider)
     }
 
     def "worker configuration fork property defaults to AUTO"() {

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
+import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.util.RedirectStdOutAndErr
 import org.gradle.util.UsesNativeServices
 import org.gradle.workers.IsolationMode
@@ -144,7 +145,7 @@ class DefaultWorkerExecutorTest extends Specification {
         task.run()
 
         then:
-        1 * workerDaemonFactory.getWorker(_, _, _) >> worker
+        1 * workerDaemonFactory.getWorker(_, _) >> worker
         1 * worker.execute(_, _, _) >> { spec, workOperation, buildOperation ->
             assert spec.implementationClass == TestRunnable
             return new DefaultWorkResult(true, null)
@@ -166,7 +167,7 @@ class DefaultWorkerExecutorTest extends Specification {
         task.run()
 
         then:
-        1 * inProcessWorkerFactory.getWorker(_, _, _) >> worker
+        1 * inProcessWorkerFactory.getWorker(_, _) >> worker
         1 * worker.execute(_, _, _) >> { spec, workOperation, buildOperation ->
             assert spec.implementationClass == TestRunnable
             return new DefaultWorkResult(true, null)
@@ -188,7 +189,7 @@ class DefaultWorkerExecutorTest extends Specification {
         task.run()
 
         then:
-        1 * noIsolationWorkerFactory.getWorker(_, _, _) >> worker
+        1 * noIsolationWorkerFactory.getWorker(_, _) >> worker
         1 * worker.execute(_, _, _) >> { spec, workOperation, buildOperation ->
             assert spec.implementationClass == TestRunnable
             return new DefaultWorkResult(true, null)

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
-import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.util.RedirectStdOutAndErr
 import org.gradle.util.UsesNativeServices
 import org.gradle.workers.IsolationMode
@@ -44,7 +43,6 @@ class DefaultWorkerExecutorTest extends Specification {
     def buildOperationWorkerRegistry = Mock(WorkerLeaseRegistry)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkTracker = Mock(AsyncWorkTracker)
-    def workerDirectoryProvider = Mock(WorkerDirectoryProvider)
     def fileResolver = Mock(FileResolver)
     def factory = Mock(Factory)
     def runnable = Mock(Runnable)
@@ -57,7 +55,7 @@ class DefaultWorkerExecutorTest extends Specification {
         _ * fileResolver.resolveLater(_) >> factory
         _ * fileResolver.resolve(_) >> { files -> files[0] }
         _ * executorFactory.create(_ as String) >> executor
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker)
     }
 
     def "worker configuration fork property defaults to AUTO"() {


### PR DESCRIPTION
This is preparatory work for pulling `WorkerDaemonFactory` up to gradle user home scope.  This allows worker daemons to use a project-agnostic "idle" working directory and only switch to the configured working directory while work execution is in progress (switching back to the "idle" working directory when a work item completes).