### PR TITLE
Update documentation and deprecation warnings for split classes

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -346,7 +346,7 @@ To support additional features, you must use [Build Scan 1.7.4](https://plugins.
 
 ### Multiple class directories for a single source set
 
-In projects that use multiple JVM languages (Java and Scala, Groovy and other languages) in separate source directories (e.g., `src/main/groovy` and `src/main/java`), Gradle now uses separate output directories for each language. 
+In projects that use multiple JVM languages (Java and Scala, Groovy and other languages) in separate source directories (e.g., `src/main/groovy` and `src/main/java`), Gradle now uses separate output directories for each language.
 
 To return to the old behavior, explicitly set the classes directory:
 
@@ -355,21 +355,39 @@ To return to the old behavior, explicitly set the classes directory:
 
 Please be aware that this will interfere with the effectiveness of the build cache when using multiple JVM languages in the same source set. Gradle will disable caching for tasks when it detects that multiple tasks create outputs in the same location.
 
+### Detecting test classes for custom `Test` tasks
+
+Before Gradle 4.0, all test classes were compiled into a single output directory. As [described above](#multiple-class-directories-for-a-single-source-set), Gradle now uses separate classes directories for each language in a source set. 
+
+Builds that define custom `Test` tasks may not find the same test classes due to these changes if tests are written in languages other than Java. Deprecation warnings warn about this behavior.
+ 
+Instead of configuring a single path for `testClassesDir`, you must now configure a collection of paths with `testClassesDirs`.  A sample is provided in the `Test` [javadoc](javadoc/org/gradle/api/tasks/testing/Test.html#setTestClassesDirs(org.gradle.api.file.FileCollection)).
+
+This found all "integrationTest" classes before 4.0:
+
+    integrationTest.testClassesDir = sourceSets.integrationTest.output.classesDir
+
+This is required for 4.0 and going forward:
+
+    integrationTest.testClassesDirs = sourceSets.integrationTest.output.classesDirs
+
 ### Location of classes in the build directory
 
 The default location of classes when using the `java`, `groovy` or `scala` plugin has changed from:
 
-    Java: build/classes/main
-    Groovy: build/classes/main
-    Scala: build/classes/main
-    Generically: build/classes/${sourceSet.name}
+    Java, `src/main/java` -> build/classes/main
+    Groovy, `src/main/groovy` -> build/classes/main
+    Scala, `src/main/scala` -> build/classes/main
+    Generically, `src/main/${sourceDirectorySet.name}` -> build/classes/${sourceSet.name}
 
 to
 
-    Java: build/classes/java/main
-    Groovy: build/classes/groovy/main
-    Scala: build/classes/scala/main
-    Generically: build/classes/${sourceDirectorySet.name}/${sourceSet.name}
+    Java, `src/main/java` -> build/classes/java/main
+    Groovy, `src/main/groovy` -> build/classes/groovy/main
+    Scala, `src/main/scala` -> build/classes/scala/main
+    Generically, `src/main/${sourceDirectorySet.name}` -> build/classes/${sourceDirectorySet.name}/${sourceSet.name}
+
+Some compilers, like the Groovy and Scala compilers, support Java compilation as well.  Java files compiled by these tools will be written into the output directory of that language, not in the Java classes directory.
 
 Plugins, tasks or builds that used hardcoded paths may fail. You can access the specific output directory for a particular language via [`SourceDirectorySet#outputDir`](dsl/org.gradle.api.file.SourceDirectorySet.html#org.gradle.api.file.SourceDirectorySet:outputDir) or the collection of all of the output directories with [`SourceSetOutput#getClassesDirs()`](dsl/org.gradle.api.tasks.SourceSetOutput.html#org.gradle.api.tasks.SourceSetOutput:classesDirs).
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -359,7 +359,7 @@ Please be aware that this will interfere with the effectiveness of the build cac
 
 Before Gradle 4.0, all test classes were compiled into a single output directory. As [described above](#multiple-class-directories-for-a-single-source-set), Gradle now uses separate classes directories for each language in a source set. 
 
-Builds that define custom `Test` tasks may not find the same test classes due to these changes if tests are written in languages other than Java. Deprecation warnings warn about this behavior.
+Builds that define custom `Test` tasks may not find the same test classes due to these changes if tests are written in languages other than Java. Deprecation warnings warn about this behavior. *Test classes that were found in previous versions of Gradle may not run until the deprecation message is fixed.*
  
 Instead of configuring a single path for `testClassesDir`, you must now configure a collection of paths with `testClassesDirs`.  A sample is provided in the `Test` [javadoc](javadoc/org/gradle/api/tasks/testing/Test.html#setTestClassesDirs(org.gradle.api.file.FileCollection)).
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -61,6 +61,19 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec {
         then:
         file("build/classes/java/main").assertDoesNotExist()
         file("build/classes/main/Main.class").assertExists()
-        result.assertOutputContains("Using a single directory for all classes from a source set.")
+    }
+
+    def "emits deprecation message if something uses classesDir"() {
+        buildFile << """
+            apply plugin: 'java'
+            
+            def newPath = file("build/classes/java/main")
+            assert sourceSets.main.output.classesDir == newPath
+        """
+        when:
+        executer.expectDeprecationWarning()
+        succeeds("help")
+        then:
+        result.assertOutputContains("Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set.")
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
@@ -76,7 +76,7 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
         if (isLegacyLayout()) {
             return fileResolver.resolve(classesDir);
         }
-        SingleMessageLogger.nagUserOfDeprecatedBehaviour("Using a single directory for all classes from a source set");
+        SingleMessageLogger.nagUserOfDeprecatedBehaviour("Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set");
         Object firstClassesDir = CollectionUtils.findFirst(classesDirs.getFrom(), Specs.SATISFIES_ALL);
         if (firstClassesDir!=null) {
             return fileResolver.resolve(firstClassesDir);
@@ -91,7 +91,6 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
 
     @Override
     public void setClassesDir(Object classesDir) {
-        SingleMessageLogger.nagUserOfDeprecatedBehaviour("Using a single directory for all classes from a source set");
         this.classesDir = classesDir;
         this.classesDirs.setFrom(classesDir);
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks;
 
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.SourceDirectorySet;
 
 import java.io.File;
 import java.util.Map;
@@ -87,7 +88,7 @@ public interface SourceSetOutput extends FileCollection {
      * See example at {@link SourceSetOutput}
      *
      * @return The classes dir.
-     * @deprecated Use {@link #getClassesDirs()}
+     * @deprecated Use {@link #getClassesDirs()} or {@link SourceDirectorySet#getOutputDir()}
      */
     @Deprecated
     File getClassesDir();

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AutoTestedSampleTestingJvmIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AutoTestedSampleTestingJvmIntegrationTest.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import org.gradle.integtests.fixtures.AbstractAutoTestedSamplesTest
+import org.junit.Test
+
+class AutoTestedSampleTestingJvmIntegrationTest extends AbstractAutoTestedSamplesTest {
+    @Test
+    void runSamples() {
+        runSamplesFrom("subprojects/testing-jvm/src/main")
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -906,6 +906,7 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
      * Returns the root folder for the compiled test sources.
      *
      * @return All test class directories to be used.
+     * @deprecated Use {@link #getTestClassesDirs()}.
      */
     @Deprecated
     @Internal
@@ -921,6 +922,7 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
      * Sets the root folder for the compiled test sources.
      *
      * @param testClassesDir The root folder
+     * @deprecated Use {@link #setTestClassesDirs(FileCollection)}.
      */
     @Deprecated
     public void setTestClassesDir(File testClassesDir) {
@@ -941,6 +943,24 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
 
     /**
      * Sets the directories to scan for compiled test sources.
+     *
+     * Typically, this would be configured to use the output of a source set:
+     * <pre autoTested=''>
+     * apply plugin: 'java'
+     *
+     * sourceSets {
+     *    integrationTest {
+     *       compileClasspath += main.output
+     *       runtimeClasspath += main.output
+     *    }
+     * }
+     *
+     * task integrationTest(type: Test) {
+     *     // Runs tests from src/integrationTest
+     *     testClassesDirs = sourceSets.integrationTest.output.classesDirs
+     *     classpath = sourceSets.integrationTest.runtimeClasspath
+     * }
+     * </pre>
      *
      * @param testClassesDirs All test class directories to be used.
      * @since 4.0


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
