### PR TITLE
Fixes #2259

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
@@ -125,7 +125,7 @@ public class DefaultFileCollectionResolveContext implements ResolvableFileCollec
                 if (callableResult != null) {
                     queue.add(0, callableResult);
                 }
-            } else if (element instanceof Iterable) {
+            } else if (element instanceof Iterable && !(element instanceof java.nio.file.Path)) {
                 Iterable<?> iterable = (Iterable) element;
                 GUtil.addToCollection(queue.subList(0, 0), iterable);
             } else if (element instanceof Object[]) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionTest.java
@@ -35,6 +35,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -352,4 +354,25 @@ public class DefaultConfigurableFileCollectionTest {
         assertThat(collection.getAsFileTree().matching(TestUtil.TEST_CLOSURE).getBuildDependencies().getDependencies(null), equalTo((Set) toSet(task)));
     }
 
+    @Test(timeout = 5000)
+    public void resolveNioPath() {
+        final Path dir = Paths.get("testdir");
+
+        final Path srcFile1 = Paths.get("1");
+        final Path srcFile2 = Paths.get("2");
+        final File resolvedFile1 = dir.resolve(srcFile1).toFile();
+        final File resolvedFile2 = dir.resolve(srcFile2).toFile();
+
+        DefaultConfigurableFileCollection collection = new DefaultConfigurableFileCollection(resolverMock, taskResolverStub, srcFile1, srcFile2);
+
+        context.checking(new Expectations() {{
+            oneOf(resolverMock).resolve(srcFile1);
+            will(returnValue(resolvedFile1));
+            oneOf(resolverMock).resolve(srcFile2);
+            will(returnValue(resolvedFile2));
+        }});
+
+        assertThat(collection.getFrom(), equalTo(toLinkedSet((Object) srcFile1, srcFile2)));
+        assertThat(collection.getFiles(), equalTo(toLinkedSet(resolvedFile1, resolvedFile2)));
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContextTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContextTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.TaskOutputs
 import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
 
+import java.nio.file.Paths
 import java.util.concurrent.Callable
 
 @UsesNativeServices
@@ -377,6 +378,19 @@ class DefaultFileCollectionResolveContextTest extends Specification {
         result[0] instanceof ListBackedFileSet
         result[0].files as List == [file]
         1 * resolver.resolve('a') >> file
+    }
+
+    def resolveNioPath() {
+        File file = file('a')
+
+        when:
+        context.add(Paths.get('a'))
+        def result = context.resolveAsMinimalFileCollections()
+
+        then:
+        result.size() == 1
+        result[0] instanceof ListBackedFileSet
+        result[0].files as List == [file]
     }
 
     def canPushContextWhichUsesADifferentFileResolverToConvertToFileCollections() {


### PR DESCRIPTION
Fixes Issue #2259: "Project.files enters into an infinite loop when passing a nio Path instance".

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [X] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

