### PR TITLE
Adds a check for null values in signing properties

### DIFF
--- a/subprojects/docs/src/docs/userguide/signingPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/signingPlugin.xml
@@ -88,6 +88,9 @@ gradle.taskGraph.whenReady { taskGraph ->
     }
 }
         </programlisting>
+        <para>
+          Note that the presence of a null value for any these three properties will cause an exception.
+        </para>
         <section id="sec:subkeys">
             <title>Using OpenPGP subkeys</title>
             <para>

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactory.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactory.java
@@ -81,8 +81,16 @@ public class PgpSignatoryFactory {
         for (String property : PROPERTIES) {
             String qualifiedProperty = (String)getQualifiedPropertyName(prefix, property);
             if (project.hasProperty(qualifiedProperty)) {
-                values.add(
-                    project.property(qualifiedProperty));
+                Object prop = project.property(qualifiedProperty);
+                if(prop != null){
+                    values.add(prop);
+                } else {
+                    if(required){
+                        throw new InvalidUserDataException("property \'" + qualifiedProperty + "\' was null. A valid value is needed for signing");
+                    } else {
+                        return null;
+                    }
+                }
             } else {
                 if (required) {
                     throw new InvalidUserDataException("property \'" + qualifiedProperty + "\' could not be found on project and is needed for signing");

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactory.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactory.java
@@ -80,30 +80,35 @@ public class PgpSignatoryFactory {
         ArrayList<Object> values = new ArrayList<Object>();
         for (String property : PROPERTIES) {
             String qualifiedProperty = (String)getQualifiedPropertyName(prefix, property);
-            if (project.hasProperty(qualifiedProperty)) {
-                Object prop = project.property(qualifiedProperty);
-                if(prop != null){
-                    values.add(prop);
-                } else {
-                    if(required){
-                        throw new InvalidUserDataException("property \'" + qualifiedProperty + "\' was null. A valid value is needed for signing");
-                    } else {
-                        return null;
-                    }
-                }
-            } else {
-                if (required) {
-                    throw new InvalidUserDataException("property \'" + qualifiedProperty + "\' could not be found on project and is needed for signing");
-                } else {
-                    return null;
-                }
+            Object prop = getPropertySafely(project, qualifiedProperty, required);
+            if(prop == null) {
+                return null;
             }
+            values.add(prop);
         }
 
         String keyId = values.get(0).toString();
         File keyRing = project.file(values.get(1).toString());
         String password = values.get(2).toString();
         return createSignatory(name, keyId, keyRing, password);
+    }
+
+    private Object getPropertySafely(Project project, String qualifiedProperty, boolean required) {
+        if (project.hasProperty(qualifiedProperty)) {
+            Object prop = project.property(qualifiedProperty);
+            if(prop != null){
+                return prop;
+            } else {
+                if(required){
+                    throw new InvalidUserDataException("property \'" + qualifiedProperty + "\' was null. A valid value is needed for signing");
+                }
+            }
+        } else {
+            if (required) {
+                throw new InvalidUserDataException("property \'" + qualifiedProperty + "\' could not be found on project and is needed for signing");
+            }
+        }
+        return null;
     }
 
     protected Object getQualifiedPropertyName(final String propertyPrefix, final String name) {

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactorySpec.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactorySpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.signing.signatory.pgp
+
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.*
+
+class PgpSignatoryFactorySpec extends Specification {
+
+    //https://github.com/gradle/gradle/issues/2267
+    protected Project aProjectWithNullProperties(){
+        def project = new ProjectBuilder().build()
+        project.ext.'signing.keyId' = null
+        project.ext.'signing.password' = null
+        project.ext.'signing.secretKeyRingFile' = null
+        project
+    }
+
+    def "null properties do not throw an NPE"() {
+        setup:
+            def factory = new PgpSignatoryFactory()
+            def project = aProjectWithNullProperties()
+        when:
+            factory.createSignatory(project, true)
+        then:
+            //notThrown NullPointerException // does not allow the real exception through
+            Exception ex = thrown()
+            ex.class != NullPointerException
+    }
+    def "null properties throw a nice exception"() {
+        setup:
+            def factory = new PgpSignatoryFactory()
+            def project = aProjectWithNullProperties()
+        when:
+            factory.createSignatory(project, true)
+        then:
+            thrown InvalidUserDataException
+    }
+
+
+}

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
@@ -21,9 +21,9 @@ import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.*
 
+@Issue("https://github.com/gradle/gradle/issues/2267")
 class PgpSignatoryFactoryTest extends Specification {
 
-    //https://github.com/gradle/gradle/issues/2267
     protected Project aProjectWithNullProperties(){
         def project = new ProjectBuilder().build()
         project.ext.'signing.keyId' = null

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
@@ -50,7 +50,9 @@ class PgpSignatoryFactoryTest extends Specification {
         when:
             factory.createSignatory(project, true)
         then:
-            thrown InvalidUserDataException
+            Exception ex = thrown()
+            ex.message.matches 'property .* was null\\. A valid value is needed for signing'
+            //thrown InvalidUserDataException // This is implied by the message contents check.
     }
 
 

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
@@ -43,7 +43,7 @@ class PgpSignatoryFactoryTest extends Specification {
             Exception ex = thrown()
             ex.class != NullPointerException
     }
-    def "null properties throw a nice exception"() {
+    def "null properties throw a descriptive exception"() {
         setup:
             def factory = new PgpSignatoryFactory()
             def project = aProjectWithNullProperties()

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.*
 @Issue("https://github.com/gradle/gradle/issues/2267")
 class PgpSignatoryFactoryTest extends Specification {
 
-    protected Project aProjectWithNullProperties(){
+    static Project aProjectWithNullProperties(){
         def project = new ProjectBuilder().build()
         project.ext.'signing.keyId' = null
         project.ext.'signing.password' = null

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/signatory/pgp/PgpSignatoryFactoryTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.*
 
-class PgpSignatoryFactorySpec extends Specification {
+class PgpSignatoryFactoryTest extends Specification {
 
     //https://github.com/gradle/gradle/issues/2267
     protected Project aProjectWithNullProperties(){


### PR DESCRIPTION
If a property such as `signing.keyId` was set to a null value, perhaps by setting it to the return of `System.getenv('KEY_ID')` when `KEY_ID` is unset, the PgpSignatoryFactory would throw an NPE when reading those properties while constructing the PgpSignatory.

This change adds a null check that also bypasses signatory creation when `required` is false.

Fixes #2267