### PR TITLE
Allow worker daemons to have different keep alive modes

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.api.tasks.compile.GroovyForkOptions;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.workers.internal.DaemonForkOptions;
+import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerFactory;
 
 import java.io.File;
@@ -45,7 +46,7 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
 
     private DaemonForkOptions createJavaForkOptions(GroovyJavaJointCompileSpec spec) {
         ForkOptions options = spec.getCompileOptions().getForkOptions();
-        return new DaemonForkOptions(options.getMemoryInitialSize(), options.getMemoryMaximumSize(), options.getJvmArgs());
+        return new DaemonForkOptions(options.getMemoryInitialSize(), options.getMemoryMaximumSize(), options.getJvmArgs(), KeepAliveMode.SESSION);
     }
 
     private DaemonForkOptions createGroovyForkOptions(GroovyJavaJointCompileSpec spec) {
@@ -56,6 +57,6 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
         Collection<File> antFiles = classPathRegistry.getClassPath("ANT").getAsFiles();
         Iterable<File> groovyFiles = Iterables.concat(spec.getGroovyClasspath(), antFiles);
         return new DaemonForkOptions(options.getMemoryInitialSize(), options.getMemoryMaximumSize(),
-                options.getJvmArgs(), groovyFiles, SHARED_PACKAGES);
+                options.getJvmArgs(), groovyFiles, SHARED_PACKAGES, KeepAliveMode.SESSION);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler;
+import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
@@ -36,6 +37,6 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
         ForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         return new DaemonForkOptions(
                 forkOptions.getMemoryInitialSize(), forkOptions.getMemoryMaximumSize(), forkOptions.getJvmArgs(),
-                Collections.<File>emptyList(), SHARED_PACKAGES);
+                Collections.<File>emptyList(), SHARED_PACKAGES, KeepAliveMode.SESSION);
     }
 }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -33,6 +33,7 @@ package org.gradle.api.internal.tasks.scala;
  */
 
 import org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler;
+import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
@@ -59,13 +60,13 @@ public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends Ab
 
     private DaemonForkOptions createJavaForkOptions(T spec) {
         ForkOptions options = spec.getCompileOptions().getForkOptions();
-        return new DaemonForkOptions(options.getMemoryInitialSize(), options.getMemoryMaximumSize(), options.getJvmArgs());
+        return new DaemonForkOptions(options.getMemoryInitialSize(), options.getMemoryMaximumSize(), options.getJvmArgs(), KeepAliveMode.SESSION);
     }
 
     private DaemonForkOptions createScalaForkOptions(T spec) {
         ScalaForkOptions options = spec.getScalaCompileOptions().getForkOptions();
         return new DaemonForkOptions(options.getMemoryInitialSize(), options.getMemoryMaximumSize(),
-                options.getJvmArgs(), zincClasspath, SHARED_PACKAGES);
+                options.getJvmArgs(), zincClasspath, SHARED_PACKAGES, KeepAliveMode.SESSION);
     }
 }
 

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.compile.BaseForkOptions;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.play.internal.spec.PlayCompileSpec;
 import org.gradle.workers.internal.DaemonForkOptions;
+import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
 import java.io.File;
@@ -39,6 +40,6 @@ public class DaemonPlayCompiler<T extends PlayCompileSpec> extends AbstractDaemo
     @Override
     protected DaemonForkOptions toDaemonOptions(PlayCompileSpec spec) {
         BaseForkOptions forkOptions = spec.getForkOptions();
-        return new DaemonForkOptions(forkOptions.getMemoryInitialSize(), forkOptions.getMemoryMaximumSize(), Collections.<String>emptyList(), compilerClasspath, classLoaderPackages);
+        return new DaemonForkOptions(forkOptions.getMemoryInitialSize(), forkOptions.getMemoryMaximumSize(), Collections.<String>emptyList(), compilerClasspath, classLoaderPackages, KeepAliveMode.SESSION);
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -247,7 +247,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         Iterable<File> daemonClasspath = classpathBuilder.build();
         Iterable<String> daemonSharedPackages = sharedPackagesBuilder.build();
 
-        return new DaemonForkOptions(forkOptions.getMinHeapSize(), forkOptions.getMaxHeapSize(), forkOptions.getAllJvmArgs(), daemonClasspath, daemonSharedPackages);
+        return new DaemonForkOptions(forkOptions.getMinHeapSize(), forkOptions.getMaxHeapSize(), forkOptions.getAllJvmArgs(), daemonClasspath, daemonSharedPackages, KeepAliveMode.SESSION);
     }
 
     private static void addVisibilityFor(Class<?> visibleClass, ImmutableSet.Builder<File> classpathBuilder, ImmutableSet.Builder<String> sharedPackagesBuilder, boolean addToSharedPackages) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/KeepAliveMode.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/KeepAliveMode.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+public enum KeepAliveMode {
+    /**
+     * Keep alive until the end of the build session
+     */
+    SESSION,
+    /**
+     * Keep alive until the daemon stops
+     */
+    DAEMON
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -32,13 +32,15 @@ class WorkerDaemonClient<T extends WorkSpec> implements Worker<T>, Stoppable {
     private final WorkerDaemonProcess<T> workerDaemonProcess;
     private final WorkerProcess workerProcess;
     private final BuildOperationExecutor buildOperationExecutor;
+    private final KeepAliveMode keepAliveMode;
     private int uses;
 
-    public WorkerDaemonClient(DaemonForkOptions forkOptions, WorkerDaemonProcess<T> workerDaemonProcess, WorkerProcess workerProcess, BuildOperationExecutor buildOperationExecutor) {
+    public WorkerDaemonClient(DaemonForkOptions forkOptions, WorkerDaemonProcess<T> workerDaemonProcess, WorkerProcess workerProcess, BuildOperationExecutor buildOperationExecutor, KeepAliveMode keepAliveMode) {
         this.forkOptions = forkOptions;
         this.workerDaemonProcess = workerDaemonProcess;
         this.workerProcess = workerProcess;
         this.buildOperationExecutor = buildOperationExecutor;
+        this.keepAliveMode = keepAliveMode;
     }
 
     @Override
@@ -86,5 +88,9 @@ class WorkerDaemonClient<T extends WorkSpec> implements Worker<T>, Stoppable {
 
     public int getUses() {
         return uses;
+    }
+
+    public KeepAliveMode getKeepAliveMode() {
+        return keepAliveMode;
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
@@ -57,7 +57,7 @@ public class WorkerDaemonStarter {
         WorkerDaemonProcess workerDaemonProcess = builder.build();
         WorkerProcess workerProcess = workerDaemonProcess.start();
 
-        WorkerDaemonClient<T> client = new WorkerDaemonClient<T>(forkOptions, workerDaemonProcess, workerProcess, buildOperationExecutor);
+        WorkerDaemonClient<T> client = new WorkerDaemonClient<T>(forkOptions, workerDaemonProcess, workerProcess, buildOperationExecutor, forkOptions.getKeepAliveMode());
 
         LOG.info("Started Gradle worker daemon ({}) with fork options {}.", clock.getElapsed(), forkOptions);
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistration;
@@ -42,8 +43,9 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
     private static class BuildSessionScopeServices {
         WorkerDaemonClientsManager createWorkerDaemonClientsManager(WorkerProcessFactory workerFactory,
                                                                     StartParameter startParameter,
-                                                                    BuildOperationExecutor buildOperationExecutor) {
-            return new WorkerDaemonClientsManager(new WorkerDaemonStarter(workerFactory, startParameter, buildOperationExecutor));
+                                                                    BuildOperationExecutor buildOperationExecutor,
+                                                                    ListenerManager listenerManager) {
+            return new WorkerDaemonClientsManager(new WorkerDaemonStarter(workerFactory, startParameter, buildOperationExecutor), listenerManager);
         }
 
         WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, MemoryManager memoryManager, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, WorkerDirectoryProvider workerDirectoryProvider) {

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsMergeTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsMergeTest.groovy
@@ -20,9 +20,9 @@ import spock.lang.Specification
 
 class DaemonForkOptionsMergeTest extends Specification {
     DaemonForkOptions options1 = new DaemonForkOptions("200m", "1g", [" -Dfork=true ", "-Xdebug=false"],
-            [new File("lib/lib1.jar"), new File("lib/lib2.jar")], ["foo.bar", "baz.bar"])
+        [new File("lib/lib1.jar"), new File("lib/lib2.jar")], ["foo.bar", "baz.bar"], KeepAliveMode.SESSION)
     DaemonForkOptions options2 = new DaemonForkOptions("1g", "2000m", ["-XX:MaxHeapSize=300m", "-Dfork=true"],
-            [new File("lib/lib2.jar"), new File("lib/lib3.jar")], ["baz.bar", "other"])
+        [new File("lib/lib2.jar"), new File("lib/lib3.jar")], ["baz.bar", "other"], KeepAliveMode.SESSION)
     DaemonForkOptions merged = options1.mergeWith(options2)
 
     def "takes highest minHeapSize"() {
@@ -48,5 +48,16 @@ class DaemonForkOptionsMergeTest extends Specification {
     def "concatenates sharedPackages (retaining order, eliminating duplicates)"() {
         expect:
         merged.sharedPackages as List == ["foo.bar", "baz.bar", "other"]
+    }
+
+    def "throws an exception when merging options with different keepAlive modes"() {
+        options2 = new DaemonForkOptions("1g", "2000m", ["-XX:MaxHeapSize=300m", "-Dfork=true"],
+            [new File("lib/lib2.jar"), new File("lib/lib3.jar")], ["baz.bar", "other"], KeepAliveMode.DAEMON)
+
+        when:
+        options1.mergeWith(options2)
+
+        then:
+        thrown(IllegalArgumentException)
     }
 }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsTest.groovy
@@ -20,15 +20,15 @@ import spock.lang.Specification
 
 class DaemonForkOptionsTest extends Specification {
     def "is compatible with itself"() {
-        def settings = new DaemonForkOptions("128m", "1g", ["-server", "-esa"], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], ["foo.bar", "foo.baz"])
+        def settings = new DaemonForkOptions("128m", "1g", ["-server", "-esa"], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], ["foo.bar", "foo.baz"], KeepAliveMode.SESSION)
 
         expect:
         settings.isCompatibleWith(settings)
     }
 
     def "is compatible with same settings"() {
-        def settings1 = new DaemonForkOptions("128m", "1g", ["-server", "-esa"], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], ["foo.bar", "foo.baz"])
-        def settings2 = new DaemonForkOptions("128m", "1g", ["-server", "-esa"], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], ["foo.bar", "foo.baz"])
+        def settings1 = new DaemonForkOptions("128m", "1g", ["-server", "-esa"], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], ["foo.bar", "foo.baz"], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions("128m", "1g", ["-server", "-esa"], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], ["foo.bar", "foo.baz"], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
@@ -36,120 +36,136 @@ class DaemonForkOptionsTest extends Specification {
 
 
     def "is compatible with different representation of same memory requirements"() {
-        def settings1 = new DaemonForkOptions("1024m", "2g", [])
-        def settings2 = new DaemonForkOptions("1g", "2048m", [])
+        def settings1 = new DaemonForkOptions("1024m", "2g", [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions("1g", "2048m", [], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "is compatible with lower memory requirements"() {
-        def settings1 = new DaemonForkOptions("128m", "1g", [])
-        def settings2 = new DaemonForkOptions("64m", "512m", [])
+        def settings1 = new DaemonForkOptions("128m", "1g", [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions("64m", "512m", [], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "is not compatible with higher memory requirements"() {
-        def settings1 = new DaemonForkOptions("128m", "1g", [])
-        def settings2 = new DaemonForkOptions("256m", "512m", [])
+        def settings1 = new DaemonForkOptions("128m", "1g", [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions("256m", "512m", [], KeepAliveMode.SESSION)
 
         expect:
         !settings1.isCompatibleWith(settings2)
     }
 
     def "is compatible with same set of JVM args"() {
-        def settings1 = new DaemonForkOptions(null, null, ["-server", "-esa"])
-        def settings2 = new DaemonForkOptions(null, null, ["-esa", "-server"])
+        def settings1 = new DaemonForkOptions(null, null, ["-server", "-esa"], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, ["-esa", "-server"], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "is compatible with subset of JVM args"() {
-        def settings1 = new DaemonForkOptions(null, null, ["-server", "-esa"])
-        def settings2 = new DaemonForkOptions(null, null, ["-server"])
+        def settings1 = new DaemonForkOptions(null, null, ["-server", "-esa"], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, ["-server"], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "is not compatible with different set of JVM args"() {
-        def settings1 = new DaemonForkOptions(null, null, ["-server", "-esa"])
-        def settings2 = new DaemonForkOptions(null, null, ["-client", "-esa"])
+        def settings1 = new DaemonForkOptions(null, null, ["-server", "-esa"], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, ["-client", "-esa"], KeepAliveMode.SESSION)
 
         expect:
         !settings1.isCompatibleWith(settings2)
     }
 
     def "is compatible with same class path"() {
-        def settings1 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], [])
-        def settings2 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], [])
+        def settings1 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], [], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "is compatible with subset of class path"() {
-        def settings1 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], [])
-        def settings2 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar")], [])
+        def settings1 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar")], [], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "is not compatible with different class path"() {
-        def settings1 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], [])
-        def settings2 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib3.jar")], [])
+        def settings1 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib2.jar")], [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, [], [new File("lib/lib1.jar"), new File("lib/lib3.jar")], [], KeepAliveMode.SESSION)
 
         expect:
         !settings1.isCompatibleWith(settings2)
     }
 
     def "is compatible with same set of shared packages"() {
-        def settings1 = new DaemonForkOptions(null, null, [], [], ["foo.bar", "foo.baz"])
-        def settings2 = new DaemonForkOptions(null, null, [], [], ["foo.bar", "foo.baz"])
+        def settings1 = new DaemonForkOptions(null, null, [], [], ["foo.bar", "foo.baz"], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, [], [], ["foo.bar", "foo.baz"], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "is compatible with subset of shared packages"() {
-        def settings1 = new DaemonForkOptions(null, null, [], [], ["foo.bar", "foo.baz"])
-        def settings2 = new DaemonForkOptions(null, null, [], [], ["foo.baz"])
+        def settings1 = new DaemonForkOptions(null, null, [], [], ["foo.bar", "foo.baz"], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, [], [], ["foo.baz"], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "is not compatible with different set of shared packages"() {
-        def settings1 = new DaemonForkOptions(null, null, [], [], ["foo.bar", "foo.baz"])
-        def settings2 = new DaemonForkOptions(null, null, [], [], ["foo.pic", "foo.baz"])
+        def settings1 = new DaemonForkOptions(null, null, [], [], ["foo.bar", "foo.baz"], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, [], [], ["foo.pic", "foo.baz"], KeepAliveMode.SESSION)
+
+        expect:
+        !settings1.isCompatibleWith(settings2)
+    }
+
+    def "is compatible with same keep alive modes"() {
+        def settings1 = new DaemonForkOptions(null, null, [], [], [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, [], [], [], KeepAliveMode.SESSION)
+
+        expect:
+        settings1.isCompatibleWith(settings2)
+    }
+
+    def "is not compatible with different keep alive modes"() {
+        def settings1 = new DaemonForkOptions(null, null, [], [], [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, [], [], [], KeepAliveMode.DAEMON)
 
         expect:
         !settings1.isCompatibleWith(settings2)
     }
 
     def "string values are trimmed"() {
-        def settings1 = new DaemonForkOptions("128m ", "1g", [" -server", "-esa"])
-        def settings2 = new DaemonForkOptions("128m", " 1g", ["-server", "-esa "])
+        def settings1 = new DaemonForkOptions("128m ", "1g", [" -server", "-esa"], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions("128m", " 1g", ["-server", "-esa "], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "capitalization of memory options is irrelevant"() {
-        def settings1 = new DaemonForkOptions("128M", "1g", [])
-        def settings2 = new DaemonForkOptions("128m", "1G", [])
+        def settings1 = new DaemonForkOptions("128M", "1g", [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions("128m", "1G", [], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)
     }
 
     def "capitalization of JVM args is relevant"() {
-        def settings1 = new DaemonForkOptions("128M", "1g", ["-Server", "-esa"])
-        def settings2 = new DaemonForkOptions("128M", "1g", ["-server", "-esa"])
+        def settings1 = new DaemonForkOptions("128M", "1g", ["-Server", "-esa"], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions("128M", "1g", ["-server", "-esa"], KeepAliveMode.SESSION)
 
         expect:
         !settings1.isCompatibleWith(settings2)
@@ -157,7 +173,7 @@ class DaemonForkOptionsTest extends Specification {
 
     def "unspecified class path and shared packages default to empty list"() {
         when:
-        def options = new DaemonForkOptions("128m", "1g", ["-server", "-esa"])
+        def options = new DaemonForkOptions("128m", "1g", ["-server", "-esa"], KeepAliveMode.SESSION)
 
         then:
         options.classpath == []
@@ -165,9 +181,9 @@ class DaemonForkOptionsTest extends Specification {
     }
 
     def "unspecified memory options are only compatible with unspecified memory options"() {
-        def settings1 = new DaemonForkOptions(null, null, [])
-        def settings2 = new DaemonForkOptions(null, null, [])
-        def settings3 = new DaemonForkOptions("8m", "64m", [])
+        def settings1 = new DaemonForkOptions(null, null, [], KeepAliveMode.SESSION)
+        def settings2 = new DaemonForkOptions(null, null, [], KeepAliveMode.SESSION)
+        def settings3 = new DaemonForkOptions("8m", "64m", [], KeepAliveMode.SESSION)
 
         expect:
         settings1.isCompatibleWith(settings2)

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
@@ -111,6 +111,6 @@ class WorkerDaemonClientTest extends Specification {
     WorkerDaemonClient client(WorkerDaemonProcess workerDaemonProcess) {
         def daemonForkOptions = Mock(DaemonForkOptions)
         def workerProcess = workerDaemonProcess.start()
-        return new WorkerDaemonClient(daemonForkOptions, workerDaemonProcess, workerProcess, buildOperationExecutor)
+        return new WorkerDaemonClient(daemonForkOptions, workerDaemonProcess, workerProcess, buildOperationExecutor, KeepAliveMode.SESSION)
     }
 }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonExpirationTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonExpirationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.workers.internal
 
+import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.jvm.Jvm
 import org.gradle.process.internal.health.memory.JvmMemoryStatus
 import org.gradle.process.internal.health.memory.MaximumHeapHelper
@@ -26,10 +27,10 @@ class WorkerDaemonExpirationTest extends Specification {
     static final int OS_MEMORY_GB = 6
 
     def workingDir = new File("some-dir")
-    def defaultOptions = new DaemonForkOptions(null, null, ['default-options'])
-    def oneGbOptions = new DaemonForkOptions('1g', '1g', ['one-gb-options'])
-    def twoGbOptions = new DaemonForkOptions('2g', '2g', ['two-gb-options'])
-    def threeGbOptions = new DaemonForkOptions('3g', '3g', ['three-gb-options'])
+    def defaultOptions = new DaemonForkOptions(null, null, ['default-options'], KeepAliveMode.SESSION)
+    def oneGbOptions = new DaemonForkOptions('1g', '1g', ['one-gb-options'], KeepAliveMode.SESSION)
+    def twoGbOptions = new DaemonForkOptions('2g', '2g', ['two-gb-options'], KeepAliveMode.SESSION)
+    def threeGbOptions = new DaemonForkOptions('3g', '3g', ['three-gb-options'], KeepAliveMode.SESSION)
     def reportsMemoryUsage = true
     def daemonStarter = Mock(WorkerDaemonStarter) {
         startDaemon(_, _, _) >> { Class<? extends WorkerProtocol> impl, File workDir, DaemonForkOptions forkOptions ->
@@ -50,7 +51,7 @@ class WorkerDaemonExpirationTest extends Specification {
             }
         }
     }
-    def clientsManager = new WorkerDaemonClientsManager(daemonStarter)
+    def clientsManager = new WorkerDaemonClientsManager(daemonStarter, Mock(ListenerManager))
     def expiration = new WorkerDaemonExpiration(clientsManager, MemoryAmount.ofGigaBytes(OS_MEMORY_GB).bytes)
 
     def "expires least recently used idle worker daemon to free system memory when requested to release some memory"() {


### PR DESCRIPTION
This is an internal only feature that allows us to stop certain worker daemons with the build session and (eventually) others with the daemon.  At the moment, there is no functional change - all daemons will continue to be stopped with the build session, but this is pre-work for pulling some of the worker services up to gradle user home scope and reusing daemons across build sessions.
