### PR TITLE
Fix PatchExternalModules to run only on relevant changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -314,13 +314,10 @@ dependencies {
 import org.gradle.modules.PatchExternalModules
 
 task patchExternalModules(type: PatchExternalModules) {
-    // Include any dependency jars that are not available in the core runtime
-    externalModulesRuntime = configurations.externalModulesRuntime
-    coreRuntime = configurations.coreRuntime
-    externalModules = configurations.externalModules
+    allModules = configurations.externalModulesRuntime
+    coreModules = configurations.coreRuntime
+    modulesToPatch = configurations.externalModules
     destination = patchedExternalModulesDir
-
-    dependsOn configurations.externalModules
 }
 
 task verifyIsProductionBuildEnvironment {

--- a/buildSrc/src/main/groovy/org/gradle/modules/PatchExternalModules.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/modules/PatchExternalModules.groovy
@@ -20,48 +20,70 @@ import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec
+import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 @CompileStatic
 class PatchExternalModules extends DefaultTask {
 
     @Internal
-    Configuration externalModules
+    Configuration modulesToPatch
 
     @Input
-    Set<String> getExternalModuleNames() {
-        externalModules.dependencies*.name as Set
+    Set<String> getNamesOfModulesToPatch() {
+        modulesToPatch.dependencies*.name as Set
+    }
+
+    @Internal
+    Configuration allModules
+
+    @Input
+    Set<String> getFileNamesOfAllModules() {
+        allModules.incoming.artifacts*.file*.name as Set
+    }
+
+    @Internal
+    Configuration coreModules
+
+    @Input
+    Set<String> getFileNamesOfCoreModules() {
+        coreModules.incoming.artifacts*.file*.name as Set
     }
 
     @Classpath
-    Configuration externalModulesRuntime
-
-    @Classpath
-    Configuration coreRuntime
+    FileCollection getExternalModules() {
+        allModules - coreModules
+    }
 
     @OutputDirectory
     File destination
 
     PatchExternalModules() {
         description = 'Patches the classpath manifests of external modules such as gradle-script-kotlin to match the Gradle runtime configuration.'
+        dependsOn { modulesToPatch }
     }
 
     @TaskAction
     void patch() {
         ((ProjectInternal) project).sync { CopySpec copySpec ->
-            copySpec.from(externalModulesRuntime - coreRuntime)
+            copySpec.from(externalModules)
             copySpec.into(destination)
         }
 
         def rootProject = project.rootProject as ProjectInternal
 
-        new ClasspathManifestPatcher(rootProject, temporaryDir, externalModulesRuntime, externalModuleNames)
+        new ClasspathManifestPatcher(rootProject, temporaryDir, allModules, namesOfModulesToPatch)
                 .writePatchedFilesTo(destination)
 
         // TODO: Should this be configurable?
-        new ExcludeEntryPatcher(rootProject, temporaryDir, externalModulesRuntime, "kotlin-compiler-embeddable")
+        new ExcludeEntryPatcher(rootProject, temporaryDir, allModules, "kotlin-compiler-embeddable")
                 .exclude("META-INF/services/java.nio.charset.spi.CharsetProvider")
                 .exclude("net/rubygrapefruit/platform/**")
                 .writePatchedFilesTo(destination)


### PR DESCRIPTION
This task is only supposed to run when an external module changes,
since that is the only kind of module it touches. However, the inputs
of the task were set up such that it would also be triggered by any
change to a core module. This made `gradle install` after a simple
one-line change take unnecessarily long.