### PR TITLE
Issue #2212: When two BOM's declare the same dependency with conflicting versions the first BOM wins

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyManagementImportOrderTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyManagementImportOrderTest.groovy
@@ -20,9 +20,11 @@ dependencies {
 	}
 }
 task verifyUndertowVersion {
-	def fileNames = configurations.test.files.collect { it.name }
-	assert fileNames.contains('undertow-servlet-1.4.11.Final.jar')
-	assert !fileNames.contains('undertow-servlet-1.2.9.Final.jar')
+	doLast {	
+		def fileNames = configurations.test.files.collect { it.name }
+		assert fileNames.contains('undertow-servlet-1.4.11.Final.jar')
+		assert !fileNames.contains('undertow-servlet-1.2.9.Final.jar')
+	}
 }
 		'''
 		
@@ -147,10 +149,12 @@ dependencies {
 	test 'group:level1:1'
 }
 task verifyVersion {
-	def fileNames = configurations.test.files.collect { it.name }
-	assert fileNames.contains('level1-1.jar')
-	assert fileNames.contains('level2-1.jar')
-	assert !fileNames.contains('level2-2.jar')
+	doLast {
+		def fileNames = configurations.test.files.collect { it.name }
+		assert fileNames.contains('level1-1.jar')
+		assert fileNames.contains('level2-1.jar')
+		assert !fileNames.contains('level2-2.jar')
+	}
 }
 		'''
 		

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyManagementImportOrderTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyManagementImportOrderTest.groovy
@@ -1,0 +1,162 @@
+package org.gradle.integtests.resolve.maven;
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+public class MavenDependencyManagementImportOrderTest extends AbstractIntegrationSpec {
+	@Issue("https://github.com/gradle/gradle/issues/2212")
+	def "Verify that gradle resolves org.wildfly.swarm:undertow the same as maven"() {
+		when:
+		buildFile.text = '''
+repositories {
+	mavenCentral()
+}
+configurations {
+	test
+}
+dependencies {
+	test('org.wildfly.swarm:undertow:2017.5.0') {
+		exclude module: 'javax.el-impl'
+	}
+}
+task verifyUndertowVersion {
+	def fileNames = configurations.test.files.collect { it.name }
+	assert fileNames.contains('undertow-servlet-1.4.11.Final.jar')
+	assert !fileNames.contains('undertow-servlet-1.2.9.Final.jar')
+}
+		'''
+		
+		then:
+		succeeds 'verifyUndertowVersion'
+	}
+	
+	@Issue("https://github.com/gradle/gradle/issues/2212")
+	def "Verify that if multiple boms declare the same dependency, the first bom wins"() {
+		file("mavenRoot/group/level1/1/level1-1.pom").text = '''\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>group</groupId>
+  <artifactId>level1</artifactId>
+  <version>1</version>
+  <packaging>jar</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>group</groupId>
+        <artifactId>bom1</artifactId>
+        <version>1</version>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>group</groupId>
+        <artifactId>bom2</artifactId>
+        <version>1</version>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>group</groupId>
+      <artifactId>level2</artifactId>
+    </dependency>
+  </dependencies>
+</project>'''
+
+		file("mavenRoot/group/level1/1/level1-1.jar").text = 'foo'
+		
+		file("mavenRoot/group/bom1/1/bom1-1.pom").text = '''\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>group</groupId>
+  <artifactId>bom1</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>group</groupId>
+        <artifactId>level2</artifactId>
+        <version>1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>'''
+
+		file("mavenRoot/group/bom2/1/bom2-1.pom").text = '''\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>group</groupId>
+  <artifactId>bom2</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>group</groupId>
+        <artifactId>level2</artifactId>
+        <version>2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>'''
+
+		file("mavenRoot/group/level2/1/level2-1.pom").text = '''\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>group</groupId>
+  <artifactId>level2</artifactId>
+  <version>1</version>
+  <packaging>jar</packaging>
+</project>'''
+
+		file("mavenRoot/group/level2/1/level2-1.jar").text = 'foo'
+
+		file("mavenRoot/group/level2/2/level2-2.pom").text = '''\
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>group</groupId>
+  <artifactId>level2</artifactId>
+  <version>1</version>
+  <packaging>jar</packaging>
+</project>'''
+
+		file("mavenRoot/group/level2/2/level2-2.jar").text = 'foo'
+
+		when:
+		buildFile.text = '''
+repositories {
+	maven {
+		url uri(file('mavenRoot'))
+	}
+}
+configurations {
+	test
+}
+dependencies {
+	test 'group:level1:1'
+}
+task verifyVersion {
+	def fileNames = configurations.test.files.collect { it.name }
+	assert fileNames.contains('level1-1.jar')
+	assert fileNames.contains('level2-1.jar')
+	assert !fileNames.contains('level2-2.jar')
+}
+		'''
+		
+		then:
+		succeeds 'verifyVersion'
+	}
+	
+	
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -170,10 +170,13 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
         for(PomDependencyMgt currentDependencyMgt : currentDependencyMgts) {
             if(isDependencyImportScoped(currentDependencyMgt)) {
                 PomReader importDescr = parseImportedPom(parseContext, currentDependencyMgt);
-                importedDependencyMgts.putAll(importDescr.getDependencyMgt());
+                for (Map.Entry<MavenDependencyKey, PomDependencyMgt> entry : importDescr.getDependencyMgt().entrySet()) {
+                    if (!importedDependencyMgts.containsKey(entry.getKey())) {
+                        importedDependencyMgts.put(entry.getKey(), entry.getValue());
+                    }
+                }
             }
         }
-
         return importedDependencyMgts;
     }
 


### PR DESCRIPTION
### Context
Added test case for @oehme changes [here](https://github.com/gradle/gradle/commit/9e385a0adaaeb3daf086e4e3c61cfc4720a5a4f4)
Issue [here](https://github.com/gradle/gradle/issues/2212)
Forum post [here](https://discuss.gradle.org/t/strange-problem-of-gradle-compare-with-maven/22807/10)


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
