### PR TITLE
Fix synchronization in `HttpClientHelper`

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsIntegrationTest.groovy
@@ -29,6 +29,8 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
         server.start()
     }
 
+    String getAuthConfig() { '' }
+
     @Unroll
     def "downloads artifacts in parallel from a Maven repo - #expression"() {
         def m1 = mavenRepo.module('test', 'test1', '1.0').publish()
@@ -38,7 +40,10 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
 
         buildFile << """
             repositories {
-                maven { url = uri('$server.uri') }
+                maven { 
+                    url = uri('$server.uri')
+                    $authConfig
+                }
             }
             configurations { compile }
             dependencies {
@@ -88,7 +93,10 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
 
         buildFile << """
             repositories {
-                ivy { url = uri('$server.uri') }
+                ivy { 
+                    url = uri('$server.uri')
+                    $authConfig
+                }
             }
             configurations { compile }
             dependencies {
@@ -130,7 +138,10 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
 
         buildFile << """
             repositories {
-                maven { url = uri('$server.uri') }
+                maven { 
+                    url = uri('$server.uri')
+                    $authConfig
+                }
             }
             configurations { compile }
             dependencies {
@@ -186,7 +197,10 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
 
         buildFile << """
             repositories {
-                ivy { url = uri('$server.uri') }
+                ivy { 
+                    url = uri('$server.uri')
+                    $authConfig
+                }
             }
             
             configurations { compile }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsOnAuthenticatedRepoIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsOnAuthenticatedRepoIntegrationTest.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+class ParallelDownloadsOnAuthenticatedRepoIntegrationTest extends ParallelDownloadsIntegrationTest {
+    private final static String USERNAME = 'username'
+    private final static String PASSWORD = 'password'
+
+    String getAuthConfig() {
+        """
+        credentials {
+            username = '$USERNAME'
+            password = '$PASSWORD'
+        }
+
+        authentication {
+            auth(BasicAuthentication)
+        }
+        """
+    }
+
+    def setup() {
+        server.withBasicAuthentication(USERNAME, PASSWORD)
+    }
+}

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpConnectorFactory.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpConnectorFactory.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.transport.http;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.authentication.Authentication;
 import org.gradle.authentication.http.BasicAuthentication;
 import org.gradle.authentication.http.DigestAuthentication;
@@ -26,10 +26,16 @@ import org.gradle.internal.resource.connector.ResourceConnectorSpecification;
 import org.gradle.internal.resource.transfer.DefaultExternalResourceConnector;
 import org.gradle.internal.resource.transfer.ExternalResourceConnector;
 
-import java.util.HashSet;
 import java.util.Set;
 
 public class HttpConnectorFactory implements ResourceConnectorFactory {
+    private final static Set<String> SUPPORTED_PROTOCOLS = ImmutableSet.of("http", "https");
+    private final static Set<Class<? extends Authentication>> SUPPORTED_AUTHENTICATION = ImmutableSet.of(
+        BasicAuthentication.class,
+        DigestAuthentication.class,
+        AllSchemesAuthentication.class
+    );
+
     private SslContextFactory sslContextFactory;
 
     public HttpConnectorFactory(SslContextFactory sslContextFactory) {
@@ -38,16 +44,12 @@ public class HttpConnectorFactory implements ResourceConnectorFactory {
 
     @Override
     public Set<String> getSupportedProtocols() {
-        return Sets.newHashSet("http", "https");
+        return SUPPORTED_PROTOCOLS;
     }
 
     @Override
     public Set<Class<? extends Authentication>> getSupportedAuthentication() {
-        Set<Class<? extends Authentication>> supported = new HashSet<Class<? extends Authentication>>();
-        supported.add(BasicAuthentication.class);
-        supported.add(DigestAuthentication.class);
-        supported.add(AllSchemesAuthentication.class);
-        return supported;
+        return SUPPORTED_AUTHENTICATION;
     }
 
     @Override


### PR DESCRIPTION
This commit fixes the synchronization in `HttpClientHelper` which prevented parallel downloads from happening in case
of an authenticated repository. To fix it, the helper now maintains a map of thread to http context, as recommended
by the HttpClient team. We don't use the JDK thread-local map because we need to clear the contexts once we close
the helper, in order to avoid leaking memory.

### Context

Parallel downloads worked well only in the case of un-authenticated repositories. With this change, all repositories will benefit from parallel downloads (metadata and artifacts).

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
