### PR TITLE
Fix issue 2077 - StringIndexOutOfBoundsException on Windows

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
@@ -185,6 +185,8 @@ public abstract class AbstractLineChoppingStyledTextOutput extends AbstractStyle
                 context.next(2);
                 context.reset();
                 context.setState(START_LINE_STATE);
+            } else if (context.isCurrentCharEquals('\r')) {
+                context.next();
             } else {
                 context.seenCharsFromEol = 0;
                 context.next(2);

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.logging.text
 import org.gradle.internal.SystemProperties
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -145,6 +146,19 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         then:
         result.toString() == "[a][---][a][---][a]"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/2077")
+    def "can append consecutive return character on Windows"() {
+        System.setProperty("line.separator", "\r\n")
+        def output = output()
+
+        when:
+        output.text('\r')
+        output.text("\r\na")
+
+        then:
+        result.toString() == "[\r]{eol}{start}[a]"
     }
 
     def "can split eol across style changes"() {


### PR DESCRIPTION
### Context

As reported in #2077 , when consecutive \r characters are appended on Windows, a StringIndexOutOfBoundsException will be thrown. The reason is this scenario is not considered and tested.

For example, this test will fail:

```
        System.setProperty("line.separator", "\r\n")
        def output = output()

        when:
        output.text('\r')
        output.text("\r\na")
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

