### PR TITLE
Reuse worker daemons across builds

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
@@ -35,8 +35,11 @@ import org.gradle.internal.id.LongIdGenerator
 import org.gradle.internal.installation.CurrentGradleInstallation
 import org.gradle.internal.jvm.inspection.CachingJvmVersionDetector
 import org.gradle.internal.jvm.inspection.DefaultJvmVersionDetector
+import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.logging.TestOutputEventListener
 import org.gradle.internal.logging.events.OutputEventListener
+import org.gradle.internal.logging.services.DefaultLoggingManagerFactory
+import org.gradle.internal.logging.services.LoggingServiceRegistry
 import org.gradle.internal.remote.MessagingServer
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistryBuilder
@@ -68,7 +71,7 @@ abstract class AbstractWorkerProcessIntegrationSpec extends Specification {
     final ClassPathRegistry classPathRegistry = new DefaultClassPathRegistry(new DefaultClassPathProvider(moduleRegistry), new WorkerProcessClassPathProvider(cacheRepository))
     final JavaExecHandleFactory execHandleFactory = TestFiles.javaExecHandleFactory(tmpDir.testDirectory)
     final OutputEventListener outputEventListener = new TestOutputEventListener()
-    DefaultWorkerProcessFactory workerFactory = new DefaultWorkerProcessFactory(LogLevel.DEBUG, server, classPathRegistry, new LongIdGenerator(), tmpDir.file("gradleUserHome"), new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
+    DefaultWorkerProcessFactory workerFactory = new DefaultWorkerProcessFactory(loggingManager(LogLevel.DEBUG), server, classPathRegistry, new LongIdGenerator(), tmpDir.file("gradleUserHome"), new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
 
     def cleanup() {
         services.close()
@@ -113,5 +116,11 @@ abstract class AbstractWorkerProcessIntegrationSpec extends Specification {
                 throw ex
             }
         }
+    }
+
+    static LoggingManagerInternal loggingManager(LogLevel logLevel) {
+        def loggingManager = LoggingServiceRegistry.newEmbeddableLogging().get(DefaultLoggingManagerFactory).create()
+        loggingManager.setLevelInternal(logLevel)
+        return loggingManager
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
@@ -96,7 +96,7 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
         String expectedLogStatement = "[[INFO] [org.gradle.process.internal.LogSerializableLogAction] info log statement]"
 
         when:
-        workerFactory = new DefaultWorkerProcessFactory(LogLevel.LIFECYCLE, server, classPathRegistry, new LongIdGenerator(), tmpDir.file("gradleUserHome"), new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
+        workerFactory = new DefaultWorkerProcessFactory(loggingManager(LogLevel.LIFECYCLE), server, classPathRegistry, new LongIdGenerator(), tmpDir.file("gradleUserHome"), new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
         and:
         execute(worker(loggingProcess))
 
@@ -104,7 +104,7 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
         !outputEventListener.toString().contains(TextUtil.toPlatformLineSeparators(expectedLogStatement))
 
         when:
-        workerFactory = new DefaultWorkerProcessFactory(LogLevel.INFO, server, classPathRegistry, new LongIdGenerator(), tmpDir.file("gradleUserHome"), new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
+        workerFactory = new DefaultWorkerProcessFactory(loggingManager(LogLevel.INFO), server, classPathRegistry, new LongIdGenerator(), tmpDir.file("gradleUserHome"), new TmpDirTemporaryFileProvider(), execHandleFactory, new CachingJvmVersionDetector(new DefaultJvmVersionDetector(execHandleFactory)), outputEventListener, Stub(MemoryManager))
         and:
         execute(worker(loggingProcess))
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -19,9 +19,6 @@ package org.gradle.internal.service.scopes;
 import com.google.common.hash.HashCode;
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
-import org.gradle.api.internal.ClassPathRegistry;
-import org.gradle.api.internal.DefaultClassPathProvider;
-import org.gradle.api.internal.DefaultClassPathRegistry;
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.cache.DefaultGeneratedGradleJarCache;
@@ -42,8 +39,6 @@ import org.gradle.api.internal.changedetection.state.GenericFileCollectionSnapsh
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory;
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
 import org.gradle.api.internal.changedetection.state.TaskHistoryStore;
-import org.gradle.api.internal.classpath.ModuleRegistry;
-import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.hash.DefaultFileHasher;
 import org.gradle.api.internal.hash.FileHasher;
@@ -56,17 +51,14 @@ import org.gradle.cache.internal.CacheScopeMapping;
 import org.gradle.cache.internal.VersionStrategy;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
 import org.gradle.deployment.internal.DeploymentRegistry;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.concurrent.ParallelExecutionManager;
 import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.id.LongIdGenerator;
-import org.gradle.internal.jvm.inspection.JvmVersionDetector;
-import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -76,7 +68,6 @@ import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.BuildOperationListenerManager;
 import org.gradle.internal.progress.DefaultBuildOperationExecutor;
 import org.gradle.internal.progress.DefaultBuildOperationListenerManager;
-import org.gradle.internal.remote.MessagingServer;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
@@ -94,11 +85,6 @@ import org.gradle.internal.work.DefaultAsyncWorkTracker;
 import org.gradle.internal.work.DefaultWorkerLeaseService;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.plugin.use.internal.InjectedPluginClasspath;
-import org.gradle.process.internal.JavaExecHandleFactory;
-import org.gradle.process.internal.health.memory.MemoryManager;
-import org.gradle.process.internal.worker.DefaultWorkerProcessFactory;
-import org.gradle.process.internal.worker.WorkerProcessFactory;
-import org.gradle.process.internal.worker.child.WorkerProcessClassPathProvider;
 import org.gradle.util.GradleVersion;
 
 import java.io.File;
@@ -147,7 +133,6 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         TimeProvider timeProvider,
         ProgressLoggerFactory progressLoggerFactory,
         WorkerLeaseService workerLeaseService,
-        StartParameter startParameter,
         ExecutorFactory executorFactory,
         ResourceLockCoordinationService resourceLockCoordinationService,
         ParallelExecutionManager parallelExecutionManager,
@@ -161,34 +146,6 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
             resourceLockCoordinationService,
             parallelExecutionManager
         );
-    }
-
-    WorkerProcessFactory createWorkerProcessFactory(StartParameter startParameter, MessagingServer messagingServer, ClassPathRegistry classPathRegistry,
-                                                    TemporaryFileProvider temporaryFileProvider, JavaExecHandleFactory execHandleFactory, JvmVersionDetector jvmVersionDetector,
-                                                    MemoryManager memoryManager) {
-        return new DefaultWorkerProcessFactory(
-            startParameter.getLogLevel(),
-            messagingServer,
-            classPathRegistry,
-            new LongIdGenerator(),
-            startParameter.getGradleUserHomeDir(),
-            temporaryFileProvider,
-            execHandleFactory,
-            jvmVersionDetector,
-            get(OutputEventListener.class),
-            memoryManager
-        );
-    }
-
-    ClassPathRegistry createClassPathRegistry() {
-        return new DefaultClassPathRegistry(
-            new DefaultClassPathProvider(get(ModuleRegistry.class)),
-            get(WorkerProcessClassPathProvider.class)
-        );
-    }
-
-    WorkerProcessClassPathProvider createWorkerProcessClassPathProvider(CacheRepository cacheRepository) {
-        return new WorkerProcessClassPathProvider(cacheRepository);
     }
 
     GeneratedGradleJarCache createGeneratedGradleJarCache(CacheRepository cacheRepository) {
@@ -266,5 +223,4 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
     protected WorkspaceScopeId createWorkspaceScopeId(PersistentScopeIdLoader persistentScopeIdLoader) {
         return persistentScopeIdLoader.getWorkspace();
     }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -76,6 +76,7 @@ import org.gradle.internal.filewatch.DefaultFileWatcherFactory;
 import org.gradle.internal.filewatch.FileWatcherFactory;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.installation.GradleRuntimeShadedJarDetector;
+import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.progress.BuildOperationListenerManager;
@@ -333,5 +334,9 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
 
     PatternSpecFactory createPatternSpecFactory() {
         return new CachingPatternSpecFactory();
+    }
+
+    LoggingManagerInternal createLoggingManager(Factory<LoggingManagerInternal> loggingManagerFactory) {
+        return loggingManagerFactory.create();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -17,6 +17,9 @@
 package org.gradle.internal.service.scopes;
 
 import com.google.common.hash.HashCode;
+import org.gradle.api.internal.ClassPathRegistry;
+import org.gradle.api.internal.DefaultClassPathProvider;
+import org.gradle.api.internal.DefaultClassPathRegistry;
 import org.gradle.api.internal.cache.CrossBuildInMemoryCacheFactory;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.CachingFileHasher;
@@ -34,6 +37,8 @@ import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFacto
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
 import org.gradle.api.internal.changedetection.state.TaskHistoryStore;
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter;
+import org.gradle.api.internal.classpath.ModuleRegistry;
+import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.hash.DefaultFileHasher;
 import org.gradle.api.internal.hash.FileHasher;
@@ -58,10 +63,20 @@ import org.gradle.internal.classpath.CachedJarFileStore;
 import org.gradle.internal.classpath.DefaultCachedClasspathTransformer;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.JarCache;
+import org.gradle.internal.id.LongIdGenerator;
+import org.gradle.internal.jvm.inspection.JvmVersionDetector;
+import org.gradle.internal.logging.LoggingManagerInternal;
+import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+import org.gradle.internal.remote.MessagingServer;
 import org.gradle.internal.serialize.HashCodeSerializer;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.process.internal.JavaExecHandleFactory;
+import org.gradle.process.internal.health.memory.MemoryManager;
+import org.gradle.process.internal.worker.DefaultWorkerProcessFactory;
+import org.gradle.process.internal.worker.WorkerProcessFactory;
+import org.gradle.process.internal.worker.child.WorkerProcessClassPathProvider;
 
 import java.util.List;
 
@@ -144,5 +159,33 @@ public class GradleUserHomeScopeServices {
 
     CachedClasspathTransformer createCachedClasspathTransformer(CacheRepository cacheRepository, FileHasher fileHasher, List<CachedJarFileStore> fileStores) {
         return new DefaultCachedClasspathTransformer(cacheRepository, new JarCache(fileHasher), fileStores);
+    }
+
+    WorkerProcessFactory createWorkerProcessFactory(LoggingManagerInternal loggingManagerInternal, MessagingServer messagingServer, ClassPathRegistry classPathRegistry,
+                                                    TemporaryFileProvider temporaryFileProvider, JavaExecHandleFactory execHandleFactory, JvmVersionDetector jvmVersionDetector,
+                                                    MemoryManager memoryManager, GradleUserHomeDirProvider gradleUserHomeDirProvider, OutputEventListener outputEventListener) {
+        return new DefaultWorkerProcessFactory(
+            loggingManagerInternal,
+            messagingServer,
+            classPathRegistry,
+            new LongIdGenerator(),
+            gradleUserHomeDirProvider.getGradleUserHomeDirectory(),
+            temporaryFileProvider,
+            execHandleFactory,
+            jvmVersionDetector,
+            outputEventListener,
+            memoryManager
+        );
+    }
+
+    ClassPathRegistry createClassPathRegistry(ModuleRegistry moduleRegistry, WorkerProcessClassPathProvider workerProcessClassPathProvider) {
+        return new DefaultClassPathRegistry(
+            new DefaultClassPathProvider(moduleRegistry),
+            workerProcessClassPathProvider
+        );
+    }
+
+    WorkerProcessClassPathProvider createWorkerProcessClassPathProvider(CacheRepository cacheRepository) {
+        return new WorkerProcessClassPathProvider(cacheRepository);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessFactory.java
@@ -19,7 +19,7 @@ package org.gradle.process.internal.worker;
 import org.gradle.api.Action;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.file.TemporaryFileProvider;
-import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.LoggingManager;
 import org.gradle.internal.classloader.ClasspathUtil;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
@@ -33,7 +33,7 @@ import java.io.File;
 
 public class DefaultWorkerProcessFactory implements WorkerProcessFactory {
 
-    private final LogLevel workerLogLevel;
+    private final LoggingManager loggingManager;
     private final MessagingServer server;
     private final IdGenerator<?> idGenerator;
     private final File gradleUserHomeDir;
@@ -43,10 +43,10 @@ public class DefaultWorkerProcessFactory implements WorkerProcessFactory {
     private final MemoryManager memoryManager;
     private int connectTimeoutSeconds = 120;
 
-    public DefaultWorkerProcessFactory(LogLevel workerLogLevel, MessagingServer server, ClassPathRegistry classPathRegistry, IdGenerator<?> idGenerator,
+    public DefaultWorkerProcessFactory(LoggingManager loggingManager, MessagingServer server, ClassPathRegistry classPathRegistry, IdGenerator<?> idGenerator,
                                        File gradleUserHomeDir, TemporaryFileProvider temporaryFileProvider, JavaExecHandleFactory execHandleFactory,
                                        JvmVersionDetector jvmVersionDetector, OutputEventListener outputEventListener, MemoryManager memoryManager) {
-        this.workerLogLevel = workerLogLevel;
+        this.loggingManager = loggingManager;
         this.server = server;
         this.idGenerator = idGenerator;
         this.gradleUserHomeDir = gradleUserHomeDir;
@@ -80,7 +80,7 @@ public class DefaultWorkerProcessFactory implements WorkerProcessFactory {
 
     private DefaultWorkerProcessBuilder newWorkerProcessBuilder() {
         DefaultWorkerProcessBuilder builder = new DefaultWorkerProcessBuilder(execHandleFactory, server, idGenerator, workerImplementationFactory, outputEventListener, memoryManager);
-        builder.setLogLevel(workerLogLevel);
+        builder.setLogLevel(loggingManager.getLevel());
         builder.setGradleUserHomeDir(gradleUserHomeDir);
         builder.setConnectTimeoutSeconds(connectTimeoutSeconds);
         return builder;

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
@@ -17,9 +17,11 @@ package org.gradle.testfixtures.internal;
 
 import org.gradle.cache.internal.CacheFactory;
 import org.gradle.cache.internal.FileLockManager;
+import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ParallelExecutionManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory;
@@ -42,6 +44,10 @@ public class TestGlobalScopeServices extends GlobalScopeServices {
 
     BuildOperationExecutor createBuildOperationExecutor(ListenerManager listenerManager, TimeProvider timeProvider, WorkerLeaseService workerLeaseService, ProgressLoggerFactory progressLoggerFactory, ExecutorFactory executorFactory, ResourceLockCoordinationService resourceLockCoordinationService, ParallelExecutionManager parallelExecutionManager) {
         return new ProjectBuilderBuildOperationExecutor(listenerManager.getBroadcaster(BuildOperationListener.class), timeProvider, progressLoggerFactory, new DefaultBuildOperationQueueFactory(workerLeaseService), executorFactory, resourceLockCoordinationService, parallelExecutionManager);
+    }
+
+    LoggingManagerInternal createLoggingManager(Factory<LoggingManagerInternal> loggingManagerFactory) {
+        return loggingManagerFactory.create();
     }
 
     private static class ProjectBuilderBuildOperationExecutor extends DefaultBuildOperationExecutor {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildSessionScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildSessionScopeServicesTest.groovy
@@ -17,11 +17,9 @@
 package org.gradle.internal.service.scopes
 
 import org.gradle.StartParameter
-import org.gradle.api.internal.ClassPathRegistry
 import org.gradle.api.internal.classpath.DefaultModuleRegistry
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.internal.CacheFactory
 import org.gradle.cache.internal.DefaultCacheRepository
@@ -32,22 +30,15 @@ import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ParallelExecutionManager
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.installation.CurrentGradleInstallation
-import org.gradle.internal.jvm.inspection.JvmVersionDetector
 import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
-import org.gradle.internal.remote.MessagingServer
 import org.gradle.internal.resources.ProjectLeaseRegistry
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.time.TimeProvider
 import org.gradle.internal.work.DefaultWorkerLeaseService
 import org.gradle.internal.work.WorkerLeaseRegistry
-import org.gradle.process.internal.JavaExecHandleFactory
-import org.gradle.process.internal.health.memory.MemoryManager
-import org.gradle.process.internal.worker.DefaultWorkerProcessFactory
-import org.gradle.process.internal.worker.WorkerProcessFactory
-import org.gradle.process.internal.worker.child.WorkerProcessClassPathProvider
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -106,36 +97,5 @@ class BuildSessionScopeServicesTest extends Specification {
         expect:
         registry.get(BuildOperationExecutor) instanceof DefaultBuildOperationExecutor
         registry.get(BuildOperationExecutor) == registry.get(BuildOperationExecutor)
-    }
-
-    def "provides a WorkerProcessBuilder factory"() {
-        setup:
-        expectParentServiceLocated(MessagingServer)
-        expectParentServiceLocated(TemporaryFileProvider)
-        expectParentServiceLocated(JavaExecHandleFactory)
-        expectParentServiceLocated(JvmVersionDetector)
-        expectParentServiceLocated(MemoryManager)
-
-        expect:
-        registry.get(WorkerProcessFactory) instanceof DefaultWorkerProcessFactory
-        registry.get(WorkerProcessFactory) == registry.get(WorkerProcessFactory)
-    }
-
-    def "provides a ClassPathRegistry"() {
-        expect:
-        registry.get(ClassPathRegistry) instanceof ClassPathRegistry
-        registry.get(ClassPathRegistry) == registry.get(ClassPathRegistry)
-    }
-
-    def "provides a WorkerProcessClassPathProvider"() {
-        expect:
-        registry.get(WorkerProcessClassPathProvider) instanceof WorkerProcessClassPathProvider
-        registry.get(WorkerProcessClassPathProvider) == registry.get(WorkerProcessClassPathProvider)
-    }
-
-    private <T> T expectParentServiceLocated(Class<T> type) {
-        T t = Mock(type)
-        parent.get(type) >> t
-        t
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.scopes
+
+import org.gradle.StartParameter
+import org.gradle.api.internal.ClassPathRegistry
+import org.gradle.api.internal.cache.CrossBuildInMemoryCacheFactory
+import org.gradle.api.internal.cache.StringInterner
+import org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache
+import org.gradle.api.internal.changedetection.state.FileSystemMirror
+import org.gradle.api.internal.changedetection.state.FileSystemSnapshotter
+import org.gradle.api.internal.changedetection.state.GlobalScopeFileTimeStampInspector
+import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory
+import org.gradle.api.internal.changedetection.state.ValueSnapshotter
+import org.gradle.api.internal.classpath.ModuleRegistry
+import org.gradle.api.internal.file.TemporaryFileProvider
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.internal.hash.FileHasher
+import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache
+import org.gradle.cache.PersistentCache
+import org.gradle.cache.internal.CacheDecorator
+import org.gradle.cache.internal.CacheFactory
+import org.gradle.groovy.scripts.internal.CrossBuildInMemoryCachingScriptClassCache
+import org.gradle.initialization.ClassLoaderRegistry
+import org.gradle.initialization.GradleUserHomeDirProvider
+import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
+import org.gradle.internal.classloader.HashingClassLoaderFactory
+import org.gradle.internal.classpath.CachedClasspathTransformer
+import org.gradle.internal.concurrent.ExecutorFactory
+import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfiguration
+import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.jvm.inspection.JvmVersionDetector
+import org.gradle.internal.logging.LoggingManagerInternal
+import org.gradle.internal.logging.events.OutputEventListener
+import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.internal.remote.MessagingServer
+import org.gradle.internal.service.ServiceRegistry
+import org.gradle.internal.service.ServiceRegistryBuilder
+import org.gradle.internal.time.TimeProvider
+import org.gradle.process.internal.JavaExecHandleFactory
+import org.gradle.process.internal.health.memory.MemoryManager
+import org.gradle.process.internal.worker.WorkerProcessFactory
+import org.gradle.process.internal.worker.child.WorkerProcessClassPathProvider
+import spock.lang.Specification
+import spock.lang.Unroll
+
+
+class GradleUserHomeScopeServicesTest extends Specification {
+    ServiceRegistry parent = Stub(ServiceRegistry)
+    ServiceRegistry registry
+
+    def setup() {
+        parent.hasService(_) >> true
+        parent.getAll(PluginServiceRegistry) >> []
+        registry =  ServiceRegistryBuilder.builder()
+            .parent(parent)
+            .provider(new Object() {
+                GradleUserHomeDirProvider createGradleUserHomeDirProvider() {
+                    return new GradleUserHomeDirProvider() {
+                        @Override
+                        public File getGradleUserHomeDirectory() {
+                            return new File("")
+                        }
+                    }
+                }
+            })
+            .provider(new GradleUserHomeScopeServices(parent))
+            .build()
+    }
+
+    @Unroll
+    def "provides a #serviceType.simpleName"() {
+        given:
+        expectParentServiceLocated(ListenerManager) {
+            _ * it.createChild() >> Mock(ListenerManager)
+        }
+        expectParentServiceLocated(ParallelExecutionManager) {
+            _ * it.getParallelismConfiguration() >> Mock(ParallelismConfiguration)
+        }
+        expectParentServiceLocated(InMemoryCacheDecoratorFactory) {
+            _ * it.decorator(_, _) >> Mock(CacheDecorator)
+        }
+        expectParentServiceLocated(CacheFactory) {
+            _ * it.open(_, _, _, _, _, _, _, _) >> Mock(PersistentCache) { _ * getBaseDir() >> Mock(File) }
+        }
+        expectParentServiceLocated(LoggingManagerInternal)
+        expectParentServiceLocated(TimeProvider)
+        expectParentServiceLocated(ProgressLoggerFactory)
+        expectParentServiceLocated(StartParameter)
+        expectParentServiceLocated(ExecutorFactory)
+        expectParentServiceLocated(ModuleRegistry)
+        expectParentServiceLocated(MessagingServer)
+        expectParentServiceLocated(TemporaryFileProvider)
+        expectParentServiceLocated(JavaExecHandleFactory)
+        expectParentServiceLocated(JvmVersionDetector)
+        expectParentServiceLocated(MemoryManager)
+        expectParentServiceLocated(OutputEventListener)
+        expectParentServiceLocated(StringInterner)
+        expectParentServiceLocated(FileSystem)
+        expectParentServiceLocated(CrossBuildInMemoryCacheFactory)
+        expectParentServiceLocated(ClassLoaderRegistry)
+        expectParentServiceLocated(DirectoryFileTreeFactory)
+
+        expect:
+        findsAndCachesService(serviceType)
+
+        where:
+        serviceType << [
+            ListenerManager,
+            CrossBuildFileHashCache,
+            GlobalScopeFileTimeStampInspector,
+            FileHasher,
+            CrossBuildInMemoryCachingScriptClassCache,
+            ValueSnapshotter,
+            ClassLoaderHierarchyHasher,
+            FileSystemMirror,
+            FileSystemSnapshotter,
+            HashingClassLoaderFactory,
+            ClassLoaderCache,
+            CachedClasspathTransformer,
+            WorkerProcessFactory,
+            ClassPathRegistry,
+            WorkerProcessClassPathProvider
+        ]
+    }
+
+    boolean findsAndCachesService(Class<?> serviceType) {
+        assert serviceType.isAssignableFrom(registry.get(serviceType).class) : "${registry.get(serviceType).class.name} is not an instance of ${serviceType.simpleName}"
+        assert registry.get(serviceType) == registry.get(serviceType)
+        true
+    }
+
+    private <T> T expectParentServiceLocated(Class<T> type) {
+        T t = Mock(type)
+        parent.get(type) >> t
+        return t
+    }
+
+    private <T> T expectParentServiceLocated(Class<T> type, Closure closure) {
+        T t = expectParentServiceLocated(type)
+        t.with closure
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
@@ -61,6 +61,12 @@ class TestNGExecutionResult implements TestExecutionResult {
         return new TestNgTestClassExecutionResult(testClass, findTestClass(testClass))
     }
 
+    @Override
+    TestClassExecutionResult testClassStartsWith(String testClass) {
+        def matching = findTestClassStartsWith(testClass)
+        return new TestNgTestClassExecutionResult(matching.key, matching.value)
+    }
+
     private void parseResults() {
         resultsXml = new XmlSlurper().parse(xmlReportFile().assertIsFile())
     }
@@ -75,6 +81,15 @@ class TestNGExecutionResult implements TestExecutionResult {
             throw new AssertionError("Could not find test class ${testClass}. Found ${testClasses.keySet()}")
         }
         testClasses[testClass]
+    }
+
+    private def findTestClassStartsWith(String testClass) {
+        def testClasses = findTestClasses()
+        def matching = testClasses.find { it.key.startsWith(testClass) }
+        if (!matching) {
+            throw new AssertionError("Could not find test class matching ${testClass}. Found ${testClasses.keySet()}")
+        }
+        matching
     }
 
     private def findTestClasses() {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
@@ -46,6 +46,10 @@ class DefaultTestExecutionResult implements TestExecutionResult {
         new DefaultTestClassExecutionResult(results.collect {it.testClass(testClass)});
     }
 
+    TestClassExecutionResult testClassStartsWith(String testClass) {
+        new DefaultTestClassExecutionResult(results.collect { it.testClassStartsWith(testClass) })
+    }
+
     private class DefaultTestClassExecutionResult implements TestClassExecutionResult {
         def testClassResults
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -50,7 +50,11 @@ class HtmlTestExecutionResult implements TestExecutionResult {
     }
 
     TestClassExecutionResult testClass(String testClass) {
-        return new HtmlTestClassExecutionResult(new File(htmlReportDirectory, "classes/${FileUtils.toSafeFileName(testClass)}.html"));
+        return new HtmlTestClassExecutionResult(new File(htmlReportDirectory, "classes/${FileUtils.toSafeFileName(testClass)}.html"))
+    }
+
+    TestClassExecutionResult testClassStartsWith(String testClass) {
+        return new HtmlTestClassExecutionResult(new File(htmlReportDirectory, "classes").listFiles().find { it.name.startsWith(FileUtils.toSafeFileName(testClass)) })
     }
 
     private static class HtmlTestClassExecutionResult implements TestClassExecutionResult {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitXmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitXmlTestExecutionResult.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.fixtures
 import org.gradle.test.fixtures.file.TestFile
 
 import static org.hamcrest.Matchers.*
+import static org.hamcrest.core.StringStartsWith.startsWith
 import static org.junit.Assert.assertThat
 
 class JUnitXmlTestExecutionResult implements TestExecutionResult {
@@ -54,12 +55,26 @@ class JUnitXmlTestExecutionResult implements TestExecutionResult {
         return new JUnitTestClassExecutionResult(findTestClass(testClass), testClass, outputAssociation)
     }
 
+    TestClassExecutionResult testClassStartsWith(String testClass) {
+        def matching = findTestClassStartsWith(testClass)
+        return new JUnitTestClassExecutionResult(matching[1], matching[0], outputAssociation)
+    }
+
     private def findTestClass(String testClass) {
         def classes = findClasses()
         assertThat(classes.keySet(), hasItem(testClass))
         def classFile = classes.get(testClass)
         assertThat(classFile, notNullValue())
         return new XmlSlurper().parse(classFile)
+    }
+
+    private def findTestClassStartsWith(String testClass) {
+        def classes = findClasses()
+        assertThat(classes.keySet(), hasItem(startsWith(testClass)))
+        def classEntry = classes.find { it.key.startsWith(testClass) }
+        def classFile = classEntry.value
+        assertThat(classFile, notNullValue())
+        return [classEntry.key, new XmlSlurper().parse(classFile)]
     }
 
     private def findClasses() {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestExecutionResult.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestExecutionResult.java
@@ -26,4 +26,9 @@ public interface TestExecutionResult {
      * Returns the result for the given test class.
      */
     TestClassExecutionResult testClass(String testClass);
+
+    /**
+     * Returns the result for the first test class whose name starts with the given string.
+     */
+    TestClassExecutionResult testClassStartsWith(String testClass);
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
@@ -21,12 +21,14 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.classpath.DefaultClassPath;
+import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.remote.Address;
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder;
+import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
 import org.gradle.launcher.bootstrap.EntryPoint;
 import org.gradle.launcher.bootstrap.ExecutionListener;
 import org.gradle.launcher.daemon.configuration.DaemonServerConfiguration;
@@ -127,6 +129,8 @@ public class DaemonMain extends EntryPoint {
             daemon.stopOnExpiration(expirationStrategy, parameters.getPeriodicCheckIntervalMs());
         } finally {
             daemon.stop();
+            // TODO: Stop all daemon services
+            CompositeStoppable.stoppable(daemonServices.get(GradleUserHomeScopeServiceRegistry.class)).stop();
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -18,7 +18,6 @@ package org.gradle.tooling.internal.provider;
 
 import org.gradle.api.execution.internal.TaskInputsListener;
 import org.gradle.initialization.GradleLauncherFactory;
-import org.gradle.internal.Factory;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ParallelExecutionManager;
@@ -65,7 +64,7 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                           TaskInputsListener inputsListener,
                                           StyledTextOutputFactory styledTextOutputFactory,
                                           ExecutorFactory executorFactory,
-                                          Factory<LoggingManagerInternal> loggingManagerFactory,
+                                          LoggingManagerInternal loggingManager,
                                           GradleUserHomeScopeServiceRegistry userHomeServiceRegistry,
                                           ParallelExecutionManager parallelExecutionManager) {
             return new SetupLoggingActionExecuter(
@@ -89,7 +88,7 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                     userHomeServiceRegistry)),
                         parallelExecutionManager)),
                     styledTextOutputFactory),
-                loggingManagerFactory.create(), parallelExecutionManager);
+                loggingManager, parallelExecutionManager);
         }
 
         ExecuteBuildActionRunner createExecuteBuildActionRunner() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -70,7 +70,7 @@ class BuildActionsFactoryTest extends Specification {
         _ * loggingServices.getAll(BuildActionRunner) >> []
         _ * loggingServices.get(StyledTextOutputFactory) >> Mock(StyledTextOutputFactory)
         _ * loggingServices.get(FileSystem) >> Mock(FileSystem)
-        _ * loggingServices.getFactory(LoggingManagerInternal) >> Mock(Factory)
+        _ * loggingServices.getFactory(LoggingManagerInternal) >> Mock(Factory) { _ * create() >> Mock(LoggingManagerInternal) }
         _ * loggingServices.getAll(PluginServiceRegistry) >> []
         _ * loggingServices.hasService(_) >> true
         _ * loggingServices.getAll(_) >> []

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -28,6 +28,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.gradle.util.Matchers.containsLine
+import static org.gradle.util.Matchers.matchesRegexp
 import static org.hamcrest.Matchers.*
 import static org.junit.Assert.assertThat
 
@@ -365,8 +366,8 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
         assert containsLine(result.getOutput(), "START [Gradle Test Run :test] [Gradle Test Run :test]")
         assert containsLine(result.getOutput(), "FINISH [Gradle Test Run :test] [Gradle Test Run :test] [FAILURE] [4]")
 
-        assert containsLine(result.getOutput(), "START [Gradle Test Executor 1] [Gradle Test Executor 1]")
-        assert containsLine(result.getOutput(), "FINISH [Gradle Test Executor 1] [Gradle Test Executor 1] [FAILURE] [4]")
+        assert containsLine(result.getOutput(), matchesRegexp("START \\[Gradle Test Executor \\d+\\] \\[Gradle Test Executor \\d+\\]"))
+        assert containsLine(result.getOutput(), matchesRegexp("FINISH \\[Gradle Test Executor \\d+\\] \\[Gradle Test Executor \\d+\\] \\[FAILURE\\] \\[4\\]"))
 
         assert containsLine(result.getOutput(), "START [Test class SomeOtherTest] [SomeOtherTest]")
         assert containsLine(result.getOutput(), "FINISH [Test class SomeOtherTest] [SomeOtherTest] [SUCCESS] [1]")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -122,8 +122,8 @@ class TestNGIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.output.contains "START [Gradle Test Run :test] [Gradle Test Run :test]\n"
         result.output.contains "FINISH [Gradle Test Run :test] [Gradle Test Run :test]\n"
-        result.output.contains "START [Gradle Test Executor 1] [Gradle Test Executor 1]\n"
-        result.output.contains "FINISH [Gradle Test Executor 1] [Gradle Test Executor 1]\n"
+        result.output.readLines().find { it.matches "START \\[Gradle Test Executor \\d+] \\[Gradle Test Executor \\d+]" }
+        result.output.readLines().find { it.matches "FINISH \\[Gradle Test Executor \\d+] \\[Gradle Test Executor \\d+]" }
         result.output.contains "START [Test suite 'Gradle suite'] [Gradle suite]\n"
         result.output.contains "FINISH [Test suite 'Gradle suite'] [Gradle suite]\n"
         result.output.contains "START [Test suite 'Gradle test'] [Gradle test]\n"

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
@@ -89,11 +89,14 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
         when: run "test"
 
         then:
-        result.output.contains """Gradle Test Executor 1 -> static out
-Gradle Test Executor 1 -> static err
-Gradle Test Executor 1 -> constructor out
-Gradle Test Executor 1 -> constructor err
-Test suite 'The Foo Test' -> beforeTest out
+        containsLinesThatMatch(result.output,
+            "Gradle Test Executor \\d+ -> static out",
+            "Gradle Test Executor \\d+ -> static err",
+            "Gradle Test Executor \\d+ -> constructor out",
+            "Gradle Test Executor \\d+ -> constructor err"
+        )
+
+        result.output.contains """Test suite 'The Foo Test' -> beforeTest out
 Test suite 'The Foo Test' -> beforeTest err
 Test suite 'The Foo Test' -> beforeClass out
 Test suite 'The Foo Test' -> beforeClass err
@@ -131,11 +134,14 @@ Test suite 'The Foo Test' -> afterTest err
         when: run "test"
 
         then:
-        result.output.contains """Gradle Test Executor 1 -> static out
-Gradle Test Executor 1 -> static err
-Gradle Test Executor 1 -> constructor out
-Gradle Test Executor 1 -> constructor err
-Test suite 'Gradle test' -> beforeTest out
+        containsLinesThatMatch(result.output,
+            "Gradle Test Executor \\d+ -> static out",
+            "Gradle Test Executor \\d+ -> static err",
+            "Gradle Test Executor \\d+ -> constructor out",
+            "Gradle Test Executor \\d+ -> constructor err"
+        )
+
+        result.output.contains """Test suite 'Gradle test' -> beforeTest out
 Test suite 'Gradle test' -> beforeTest err
 Test suite 'Gradle test' -> beforeClass out
 Test suite 'Gradle test' -> beforeClass err
@@ -168,5 +174,11 @@ Test suite 'Gradle test' -> afterTest err
         def classReport = htmlReport.testClass("FooTest")
         classReport.assertStdout(is("m1: \u03b1</html>\nm2 out\n"))
         classReport.assertStderr(is("m1 err\nm2 err\n"))
+    }
+
+    boolean containsLinesThatMatch(String text, String... regexes) {
+        return regexes.every { regex ->
+            text.readLines().find { it.matches regex }
+        }
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
@@ -87,7 +87,7 @@ class TestNGStaticLoggingIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.output.contains("Test method foo(FooTest) -> cool output from test")
         result.output.contains("Test method foo(FooTest) -> err output from test")
-        result.output.contains("Gradle Test Executor 1 -> cool output from initializer")
+        result.output.readLines().find { it.matches "Gradle Test Executor \\d+ -> cool output from initializer" }
 
         def testResult = new JUnitXmlTestExecutionResult(testDirectory)
         testResult.testClass("FooTest").assertTestCaseStdout("foo", is("cool output from test\n"))

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
@@ -35,19 +35,19 @@ class TestNGSuiteInitialisationIntegrationTest extends AbstractIntegrationSpec {
             test.useTestNG()
         """
         file("src/test/java/FooTest.java") << """
-import org.testng.annotations.*;
-
-public class FooTest {
-    public FooTest() { throw new NullPointerException(); }
-    @Test public void foo() {}
-}
-"""
+            import org.testng.annotations.*;
+            
+            public class FooTest {
+                public FooTest() { throw new NullPointerException(); }
+                @Test public void foo() {}
+            }
+        """
 
         expect:
         fails("test")
 
         def result = new DefaultTestExecutionResult(testDirectory)
-        result.testClass("Gradle Test Executor 1").assertTestFailed("execution failure",
+        result.testClassStartsWith("Gradle Test Executor").assertTestFailed("execution failure",
                 startsWith("org.gradle.api.internal.tasks.testing.TestSuiteExecutionException"))
     }
 }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -176,11 +176,11 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         rootSuite.descriptor.methodName == null
         rootSuite.descriptor.parent == null
 
-        def workerSuite = events.operation("Gradle Test Executor 2")
+        def workerSuite = events.operationMatches("Gradle Test Executor \\d+")
         workerSuite.descriptor.jvmTestKind == JvmTestKind.SUITE
-        workerSuite.descriptor.name == 'Gradle Test Executor 2'
-        workerSuite.descriptor.displayName == 'Gradle Test Executor 2'
-        workerSuite.descriptor.suiteName == 'Gradle Test Executor 2'
+        workerSuite.descriptor.name.matches 'Gradle Test Executor \\d+'
+        workerSuite.descriptor.displayName.matches 'Gradle Test Executor \\d+'
+        workerSuite.descriptor.suiteName.matches 'Gradle Test Executor \\d+'
         workerSuite.descriptor.className == null
         workerSuite.descriptor.methodName == null
         workerSuite.descriptor.parent == rootSuite.descriptor
@@ -247,11 +247,11 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         rootSuite.result instanceof TestFailureResult
         rootSuite.result.failures.size() == 0
 
-        def workerSuite = events.operation("Gradle Test Executor 2")
+        def workerSuite = events.operationMatches("Gradle Test Executor \\d+")
         workerSuite.descriptor.jvmTestKind == JvmTestKind.SUITE
-        workerSuite.descriptor.name == 'Gradle Test Executor 2'
-        workerSuite.descriptor.displayName == 'Gradle Test Executor 2'
-        workerSuite.descriptor.suiteName == 'Gradle Test Executor 2'
+        workerSuite.descriptor.name.matches 'Gradle Test Executor \\d+'
+        workerSuite.descriptor.displayName.matches 'Gradle Test Executor \\d+'
+        workerSuite.descriptor.suiteName.matches 'Gradle Test Executor \\d+'
         workerSuite.descriptor.className == null
         workerSuite.descriptor.methodName == null
         workerSuite.descriptor.parent == rootSuite.descriptor

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
@@ -58,9 +58,10 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
         events.operation("Task :test").successful
         events.operation("Task :secondTest").successful
         events.operation("Gradle Test Run :test").successful
-        events.operation("Gradle Test Executor 1").successful
         events.operation("Gradle Test Run :secondTest").successful
-        events.operation("Gradle Test Executor 2").successful
+        def testExecutorEvents = events.operations.findAll { it.descriptor.displayName.matches "Gradle Test Executor \\d+" }
+        testExecutorEvents.size() == 2
+        testExecutorEvents.every { it.successful }
         events.tests.findAll { it.descriptor.displayName == "Test class example.MyTest" }.size() == 2
         events.tests.findAll { it.descriptor.displayName == "Test foo(example.MyTest)" }.size() == 2
         events.tests.findAll { it.descriptor.displayName == "Test foo2(example.MyTest)" }.size() == 2

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
@@ -254,6 +254,20 @@ class ProgressEvents implements ProgressListener {
     }
 
     /**
+     * Returns the first operation with a display name matching the given regex. Fails when an operation is not found.
+     *
+     * @param regex candidate display names (may be different depending on the Gradle version under test)
+     */
+    Operation operationMatches(String regex) {
+        assertHasZeroOrMoreTrees()
+        def operation = operations.find { it.descriptor.displayName.matches(regex) }
+        if (operation == null) {
+            throw new AssertionFailedError("No operation matching regex '${regex}' found in:\n${describeList(operations)}")
+        }
+        return operation
+    }
+
+    /**
      * Returns the operation with the given display name. Fails when there is not exactly one such operation.
      *
      * @param displayNames candidate display names (may be different depending on the Gradle version under test)

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractDaemonWorkerExecutorIntegrationSpec.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractDaemonWorkerExecutorIntegrationSpec.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
+import org.gradle.integtests.fixtures.daemon.DaemonsFixture
+
+
+abstract class AbstractDaemonWorkerExecutorIntegrationSpec extends AbstractWorkerExecutorIntegrationTest {
+    def setup() {
+        executer.requireDaemon()
+        executer.requireIsolatedDaemons()
+        executer.withWorkerDaemonsExpirationDisabled()
+    }
+
+    void stopDaemonsNow() {
+        result = executer.withArguments("--stop", "--info").run()
+    }
+
+    DaemonsFixture getDaemons() {
+        new DaemonLogsAnalyzer(executer.daemonBaseDir)
+    }
+
+    DaemonsFixture daemons(String gradleVersion) {
+        new DaemonLogsAnalyzer(executer.daemonBaseDir, gradleVersion)
+    }
+}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -16,6 +16,10 @@
 
 package org.gradle.workers.internal
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+
+import static org.gradle.util.TextUtil.normaliseFileSeparators
+
 class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     def "sets the working directory to the project directory by default during worker execution"() {
         withRunnableClassInBuildScript()
@@ -38,13 +42,13 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         gradle.waitForFinish()
 
         and:
-        gradle.standardOutput.readLines().find { it.matches "Starting process 'Gradle Worker Daemon \\d'. Working directory: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath() + ".*" }
+        gradle.standardOutput.readLines().find { normaliseFileSeparators(it).matches "Starting process 'Gradle Worker Daemon \\d+'. Working directory: " + normaliseFileSeparators(executer.gradleUserHomeDir.file("workers").getAbsolutePath()) + ".*" }
 
         and:
         gradle.standardOutput.contains("Execution working dir: " + testDirectory.getAbsolutePath())
 
         and:
-        gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        GradleContextualExecuter.daemon || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
     }
 
     def "sets the working directory to the specified directory during worker execution"() {
@@ -70,13 +74,13 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         gradle.waitForFinish()
 
         and:
-        gradle.standardOutput.readLines().find { it.matches "Starting process 'Gradle Worker Daemon \\d'. Working directory: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath() + ".*" }
+        gradle.standardOutput.readLines().find { normaliseFileSeparators(it).matches "Starting process 'Gradle Worker Daemon \\d+'. Working directory: " + normaliseFileSeparators(executer.gradleUserHomeDir.file("workers").getAbsolutePath()) + ".*" }
 
         and:
         gradle.standardOutput.contains("Execution working dir: " + testDirectory.file("workerDir").getAbsolutePath())
 
         and:
-        gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        GradleContextualExecuter.daemon || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
     }
 
     def getRunnableThatPrintsWorkingDirectory() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -32,16 +32,19 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
 
         when:
         args("--info")
-        succeeds("runInWorker")
+        def gradle = executer.withTasks("runInWorker").start()
 
         then:
-        output.contains("Starting process 'Gradle Worker Daemon 1'. Working directory: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        gradle.waitForFinish()
 
         and:
-        output.contains("Execution working dir: " + testDirectory.getAbsolutePath())
+        gradle.standardOutput.readLines().find { it.matches "Starting process 'Gradle Worker Daemon \\d'. Working directory: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath() + ".*" }
 
         and:
-        output.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        gradle.standardOutput.contains("Execution working dir: " + testDirectory.getAbsolutePath())
+
+        and:
+        gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
     }
 
     def "sets the working directory to the specified directory during worker execution"() {
@@ -61,16 +64,19 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
 
         when:
         args("--info")
-        succeeds("runInWorker")
+        def gradle = executer.withTasks("runInWorker").start()
 
         then:
-        output.contains("Starting process 'Gradle Worker Daemon 1'. Working directory: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        gradle.waitForFinish()
 
         and:
-        output.contains("Execution working dir: " + testDirectory.file("workerDir").getAbsolutePath())
+        gradle.standardOutput.readLines().find { it.matches "Starting process 'Gradle Worker Daemon \\d'. Working directory: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath() + ".*" }
 
         and:
-        output.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        gradle.standardOutput.contains("Execution working dir: " + testDirectory.file("workerDir").getAbsolutePath())
+
+        and:
+        gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
     }
 
     def getRunnableThatPrintsWorkingDirectory() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationSpec {
+    String logSnapshot = ""
+
+    def "worker daemons are reused across builds"() {
+        withRunnableClassInBuildScript()
+        buildFile << """
+            task runInWorker1(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+            }
+            
+            task runInWorker2(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+            }
+        """
+
+        when:
+        succeeds "runInWorker1"
+
+        and:
+        succeeds "runInWorker2"
+
+        then:
+        assertSameDaemonWasUsed("runInWorker1", "runInWorker2")
+    }
+
+    def "worker daemons can be restarted when daemon is stopped"() {
+        withRunnableClassInBuildScript()
+        buildFile << """
+            task runInWorker1(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+            }
+            
+            task runInWorker2(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+            }
+        """
+
+        when:
+        succeeds "runInWorker1"
+
+        then:
+        stopDaemonsNow()
+
+        when:
+        succeeds "runInWorker2"
+
+        then:
+        assertDifferentDaemonsWereUsed("runInWorker1", "runInWorker2")
+    }
+
+    def "worker daemons are stopped when daemon is stopped"() {
+        withRunnableClassInBuildScript()
+        buildFile << """
+            task runInWorker(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+            }
+        """
+
+        when:
+        args("--info")
+        succeeds "runInWorker"
+
+        then:
+        newSnapshot()
+        stopDaemonsNow()
+
+        and:
+        sinceSnapshot().contains("Stopped 1 worker daemon(s).")
+    }
+
+    def "worker daemons are not reused when classpath changes"() {
+        withRunnableClassInBuildScript()
+        buildFile << """
+            task runInWorker1(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+            }
+            
+            task runInWorker2(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+            }
+        """
+
+        when:
+        succeeds "runInWorker1"
+
+        then:
+        buildFile << """
+            task someNewTask
+        """
+
+        when:
+        succeeds "runInWorker2"
+
+        then:
+        assertDifferentDaemonsWereUsed("runInWorker1", "runInWorker2")
+
+        when:
+        file("buildSrc/src/main/java/NewClass.java") << "public class NewClass { }"
+
+        then:
+        succeeds "runInWorker1"
+
+        and:
+        assertDifferentDaemonsWereUsed("runInWorker1", "runInWorker2")
+    }
+
+    def "only compiler daemons are stopped with the build session"() {
+        withRunnableClassInBuildScript()
+        file('src/main/java').createDir()
+        file('src/main/java/Test.java') << "public class Test {}"
+        buildFile << """
+            apply plugin: "java"
+            
+            task runInWorker(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+            }
+            
+            tasks.withType(JavaCompile) {
+                options.fork = true
+            }
+        """
+
+        when:
+        args("--info")
+        succeeds "compileJava", "runInWorker"
+
+        then:
+        sinceSnapshot().count("Started Gradle worker daemon") == 2
+        sinceSnapshot().contains("Stopped 1 worker daemon(s).")
+        newSnapshot()
+
+        when:
+        stopDaemonsNow()
+
+        then:
+        sinceSnapshot().contains("Stopped 1 worker daemon(s).")
+    }
+
+    void newSnapshot() {
+        logSnapshot = daemons.daemon.log
+    }
+
+    String sinceSnapshot() {
+        return daemons.daemon.log - logSnapshot
+    }
+}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
@@ -22,16 +22,9 @@ class WorkerExecutorLoggingIntegrationTest extends AbstractWorkerExecutorIntegra
 
     @Unroll
     def "worker lifecycle is logged in #isolationMode"() {
-        def runnableJarName = "runnable.jar"
-        withRunnableClassInExternalJar(file(runnableJarName))
+        withRunnableClassInBuildSrc()
 
         buildFile << """
-            buildscript {
-                dependencies {
-                    classpath files("$runnableJarName")
-                }
-            }
-
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
             }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -247,7 +247,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         Iterable<File> daemonClasspath = classpathBuilder.build();
         Iterable<String> daemonSharedPackages = sharedPackagesBuilder.build();
 
-        return new DaemonForkOptions(forkOptions.getMinHeapSize(), forkOptions.getMaxHeapSize(), forkOptions.getAllJvmArgs(), daemonClasspath, daemonSharedPackages, KeepAliveMode.SESSION);
+        return new DaemonForkOptions(forkOptions.getMinHeapSize(), forkOptions.getMaxHeapSize(), forkOptions.getAllJvmArgs(), daemonClasspath, daemonSharedPackages, KeepAliveMode.DAEMON);
     }
 
     private static void addVisibilityFor(Class<?> visibleClass, ImmutableSet.Builder<File> classpathBuilder, ImmutableSet.Builder<String> sharedPackagesBuilder, boolean addToSharedPackages) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -17,13 +17,8 @@
 package org.gradle.workers.internal;
 
 import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.operations.BuildOperationContext;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.progress.BuildOperationState;
-import org.gradle.internal.operations.CallableBuildOperation;
-import org.gradle.internal.progress.BuildOperationDescriptor;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
-import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLeaseCompletion;
 import org.gradle.process.internal.health.memory.JvmMemoryStatus;
 import org.gradle.process.internal.worker.WorkerProcess;
 
@@ -31,42 +26,25 @@ class WorkerDaemonClient<T extends WorkSpec> implements Worker<T>, Stoppable {
     private final DaemonForkOptions forkOptions;
     private final WorkerDaemonProcess<T> workerDaemonProcess;
     private final WorkerProcess workerProcess;
-    private final BuildOperationExecutor buildOperationExecutor;
     private final KeepAliveMode keepAliveMode;
     private int uses;
 
-    public WorkerDaemonClient(DaemonForkOptions forkOptions, WorkerDaemonProcess<T> workerDaemonProcess, WorkerProcess workerProcess, BuildOperationExecutor buildOperationExecutor, KeepAliveMode keepAliveMode) {
+    public WorkerDaemonClient(DaemonForkOptions forkOptions, WorkerDaemonProcess<T> workerDaemonProcess, WorkerProcess workerProcess, KeepAliveMode keepAliveMode) {
         this.forkOptions = forkOptions;
         this.workerDaemonProcess = workerDaemonProcess;
         this.workerProcess = workerProcess;
-        this.buildOperationExecutor = buildOperationExecutor;
         this.keepAliveMode = keepAliveMode;
     }
 
     @Override
     public DefaultWorkResult execute(final T spec, WorkerLease parentWorkerWorkerLease, final BuildOperationState parentBuildOperation) {
-        WorkerLeaseCompletion workerLease = parentWorkerWorkerLease.startChild();
-        try {
-            return buildOperationExecutor.call(new CallableBuildOperation<DefaultWorkResult>() {
-                @Override
-                public DefaultWorkResult call(BuildOperationContext context) {
-                    uses++;
-                    return workerDaemonProcess.execute(spec);
-                }
-
-                @Override
-                public BuildOperationDescriptor.Builder description() {
-                    return BuildOperationDescriptor.displayName(spec.getDisplayName()).parent(parentBuildOperation);
-                }
-            });
-        } finally {
-            workerLease.leaseFinish();
-        }
+        return execute(spec);
     }
 
     @Override
     public DefaultWorkResult execute(T spec) {
-        throw new UnsupportedOperationException();
+        uses++;
+        return workerDaemonProcess.execute(spec);
     }
 
     public boolean isCompatibleWith(DaemonForkOptions required) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -16,6 +16,7 @@
 
 package org.gradle.workers.internal;
 
+import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.progress.BuildOperationState;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
@@ -26,14 +27,14 @@ class WorkerDaemonClient<T extends WorkSpec> implements Worker<T>, Stoppable {
     private final DaemonForkOptions forkOptions;
     private final WorkerDaemonProcess<T> workerDaemonProcess;
     private final WorkerProcess workerProcess;
-    private final KeepAliveMode keepAliveMode;
+    private final LogLevel logLevel;
     private int uses;
 
-    public WorkerDaemonClient(DaemonForkOptions forkOptions, WorkerDaemonProcess<T> workerDaemonProcess, WorkerProcess workerProcess, KeepAliveMode keepAliveMode) {
+    public WorkerDaemonClient(DaemonForkOptions forkOptions, WorkerDaemonProcess<T> workerDaemonProcess, WorkerProcess workerProcess, LogLevel logLevel) {
         this.forkOptions = forkOptions;
         this.workerDaemonProcess = workerDaemonProcess;
         this.workerProcess = workerProcess;
-        this.keepAliveMode = keepAliveMode;
+        this.logLevel = logLevel;
     }
 
     @Override
@@ -69,6 +70,10 @@ class WorkerDaemonClient<T extends WorkSpec> implements Worker<T>, Stoppable {
     }
 
     public KeepAliveMode getKeepAliveMode() {
-        return keepAliveMode;
+        return forkOptions.getKeepAliveMode();
+    }
+
+    public LogLevel getLogLevel() {
+        return logLevel;
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
@@ -17,12 +17,18 @@
 package org.gradle.workers.internal;
 
 import org.gradle.api.Transformer;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
 import org.gradle.initialization.SessionLifecycleListener;
 import org.gradle.internal.concurrent.CompositeStoppable;
+import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.logging.LoggingManagerInternal;
+import org.gradle.internal.logging.events.LogLevelChangeEvent;
+import org.gradle.internal.logging.events.OutputEvent;
+import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.util.CollectionUtils;
 
 import java.io.File;
@@ -31,9 +37,9 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
-public class WorkerDaemonClientsManager {
+public class WorkerDaemonClientsManager implements Stoppable {
 
-    private static final Logger LOGGER = Logging.getLogger(WorkerDaemonFactory.class);
+    private static final Logger LOGGER = Logging.getLogger(WorkerDaemonClientsManager.class);
 
     private final Object lock = new Object();
     private final List<WorkerDaemonClient> allClients = new ArrayList<WorkerDaemonClient>();
@@ -41,13 +47,20 @@ public class WorkerDaemonClientsManager {
 
     private final WorkerDaemonStarter workerDaemonStarter;
     private final ListenerManager listenerManager;
+    private final LoggingManagerInternal loggingManager;
     private final SessionLifecycleListener stopSessionScopeWorkers;
+    private final OutputEventListener logLevelChangeEventListener;
+    private LogLevel currentLogLevel;
 
-    public WorkerDaemonClientsManager(WorkerDaemonStarter workerDaemonStarter, ListenerManager listenerManager) {
+    public WorkerDaemonClientsManager(WorkerDaemonStarter workerDaemonStarter, ListenerManager listenerManager, LoggingManagerInternal loggingManager) {
         this.workerDaemonStarter = workerDaemonStarter;
         this.listenerManager = listenerManager;
+        this.loggingManager = loggingManager;
         this.stopSessionScopeWorkers = new StopSessionScopedWorkers();
         listenerManager.addListener(stopSessionScopeWorkers);
+        this.logLevelChangeEventListener = new LogLevelChangeEventListener();
+        loggingManager.addOutputEventListener(logLevelChangeEventListener);
+        this.currentLogLevel = loggingManager.getLevel();
     }
 
     // TODO - should supply and check for the same parameters as passed to reserveNewClient()
@@ -84,11 +97,14 @@ public class WorkerDaemonClientsManager {
         }
     }
 
+    @Override
     public void stop() {
         synchronized (lock) {
             stopWorkers(allClients);
             allClients.clear();
+            idleClients.clear();
             listenerManager.removeListener(stopSessionScopeWorkers);
+            loggingManager.removeOutputEventListener(logLevelChangeEventListener);
         }
     }
 
@@ -107,17 +123,19 @@ public class WorkerDaemonClientsManager {
             });
             List<WorkerDaemonClient> clientsToStop = selectionFunction.transform(new ArrayList<WorkerDaemonClient>(sortedClients));
             if (!clientsToStop.isEmpty()) {
-                idleClients.removeAll(clientsToStop);
-                allClients.removeAll(clientsToStop);
                 stopWorkers(clientsToStop);
             }
         }
     }
 
     private void stopWorkers(List<WorkerDaemonClient> clientsToStop) {
-        LOGGER.debug("Stopping {} worker daemon(s).", clientsToStop.size());
-        CompositeStoppable.stoppable(clientsToStop).stop();
-        LOGGER.info("Stopped {} worker daemon(s).", clientsToStop.size());
+        if (clientsToStop.size() > 0) {
+            LOGGER.debug("Stopping {} worker daemon(s).", clientsToStop.size());
+            CompositeStoppable.stoppable(clientsToStop).stop();
+            LOGGER.info("Stopped {} worker daemon(s).", clientsToStop.size());
+            idleClients.removeAll(clientsToStop);
+            allClients.removeAll(clientsToStop);
+        }
     }
 
     private class StopSessionScopedWorkers implements SessionLifecycleListener {
@@ -134,6 +152,23 @@ public class WorkerDaemonClientsManager {
                     }
                 });
                 stopWorkers(sessionScopedClients);
+            }
+        }
+    }
+
+    private class LogLevelChangeEventListener implements OutputEventListener {
+        @Override
+        public void onOutput(OutputEvent event) {
+            if (event instanceof LogLevelChangeEvent) {
+                LogLevelChangeEvent logLevelChangeEvent = (LogLevelChangeEvent) event;
+                if (currentLogLevel != logLevelChangeEvent.getNewLogLevel()) {
+                    // TODO: Send a message to workers to change their log level rather than stopping
+                    synchronized (lock) {
+                        LOGGER.info("Log level change has occurred.  Stopping all worker daemons.");
+                        stopWorkers(allClients);
+                        currentLogLevel = logLevelChangeEvent.getNewLogLevel();
+                    }
+                }
             }
         }
     }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
@@ -18,7 +18,10 @@ package org.gradle.workers.internal;
 
 import net.jcip.annotations.ThreadSafe;
 import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.CallableBuildOperation;
+import org.gradle.internal.progress.BuildOperationDescriptor;
 import org.gradle.internal.progress.BuildOperationState;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
@@ -52,13 +55,14 @@ public class WorkerDaemonFactory implements WorkerFactory, Stoppable {
     @Override
     public <T extends WorkSpec> Worker<T> getWorker(final Class<? extends WorkerProtocol<T>> workerImplementationClass, final DaemonForkOptions forkOptions) {
         return new Worker<T>() {
-            public DefaultWorkResult execute(T spec, WorkerLease parentWorkerWorkerLease, BuildOperationState parentBuildOperation) {
+            public DefaultWorkResult execute(final T spec, WorkerLease parentWorkerWorkerLease, final BuildOperationState parentBuildOperation) {
                 WorkerDaemonClient<T> client = clientsManager.reserveIdleClient(forkOptions);
                 if (client == null) {
                     client = clientsManager.reserveNewClient(workerImplementationClass, workerDirectoryProvider.getIdleWorkingDirectory(), forkOptions);
                 }
+
                 try {
-                    return client.execute(spec, parentWorkerWorkerLease, parentBuildOperation);
+                    return executeInClient(client, spec, parentWorkerWorkerLease, parentBuildOperation);
                 } finally {
                     clientsManager.release(client);
                 }
@@ -67,6 +71,25 @@ public class WorkerDaemonFactory implements WorkerFactory, Stoppable {
             @Override
             public DefaultWorkResult execute(T spec) {
                 return execute(spec, workerLeaseRegistry.getCurrentWorkerLease(), buildOperationExecutor.getCurrentOperation());
+            }
+
+            private DefaultWorkResult executeInClient(final WorkerDaemonClient<T> client, final T spec, WorkerLease parentWorkerWorkerLease, final BuildOperationState parentBuildOperation) {
+                WorkerLeaseRegistry.WorkerLeaseCompletion workerLease = parentWorkerWorkerLease.startChild();
+                try {
+                    return buildOperationExecutor.call(new CallableBuildOperation<DefaultWorkResult>() {
+                        @Override
+                        public DefaultWorkResult call(BuildOperationContext context) {
+                            return client.execute(spec);
+                        }
+
+                        @Override
+                        public BuildOperationDescriptor.Builder description() {
+                            return BuildOperationDescriptor.displayName(spec.getDisplayName()).parent(parentBuildOperation);
+                        }
+                    });
+                } finally {
+                    workerLease.leaseFinish();
+                }
             }
         };
     }
@@ -78,7 +101,6 @@ public class WorkerDaemonFactory implements WorkerFactory, Stoppable {
 
     @Override
     public void stop() {
-        clientsManager.stop();
         memoryManager.removeMemoryHolder(workerDaemonExpiration);
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
@@ -54,7 +54,7 @@ public class WorkerDaemonStarter {
         WorkerDaemonProcess workerDaemonProcess = builder.build();
         WorkerProcess workerProcess = workerDaemonProcess.start();
 
-        WorkerDaemonClient<T> client = new WorkerDaemonClient<T>(forkOptions, workerDaemonProcess, workerProcess, forkOptions.getKeepAliveMode());
+        WorkerDaemonClient<T> client = new WorkerDaemonClient<T>(forkOptions, workerDaemonProcess, workerProcess, loggingManager.getLevel());
 
         LOG.info("Started Gradle worker daemon ({}) with fork options {}.", clock.getElapsed(), forkOptions);
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.workers.internal
 
+import org.gradle.api.logging.LogLevel
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.progress.BuildOperationState
 import spock.lang.Specification
@@ -67,6 +68,6 @@ class WorkerDaemonClientTest extends Specification {
     WorkerDaemonClient client(WorkerDaemonProcess workerDaemonProcess) {
         def daemonForkOptions = Mock(DaemonForkOptions)
         def workerProcess = workerDaemonProcess.start()
-        return new WorkerDaemonClient(daemonForkOptions, workerDaemonProcess, workerProcess, KeepAliveMode.SESSION)
+        return new WorkerDaemonClient(daemonForkOptions, workerDaemonProcess, workerProcess, LogLevel.INFO)
     }
 }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientsManagerTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientsManagerTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Transformer
 import org.gradle.initialization.SessionLifecycleListener
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.util.ConcurrentSpecification
 import spock.lang.Subject
 
@@ -31,8 +32,9 @@ class WorkerDaemonClientsManagerTest extends ConcurrentSpecification {
     def starter = Stub(WorkerDaemonStarter)
     def serverImpl = Stub(WorkerProtocol)
     def listenerManager = Stub(ListenerManager)
+    def loggingManager = Stub(LoggingManagerInternal)
 
-    @Subject manager = new WorkerDaemonClientsManager(starter, listenerManager)
+    @Subject manager = new WorkerDaemonClientsManager(starter, listenerManager, loggingManager)
 
     def "does not reserve idle client when no clients"() {
         expect:
@@ -86,7 +88,7 @@ class WorkerDaemonClientsManagerTest extends ConcurrentSpecification {
 
     def "can stop session-scoped clients"() {
         listenerManager = new DefaultListenerManager()
-        manager = new WorkerDaemonClientsManager(starter, listenerManager)
+        manager = new WorkerDaemonClientsManager(starter, listenerManager, loggingManager)
         def client1 = Mock(WorkerDaemonClient)
         def client2 = Mock(WorkerDaemonClient)
         starter.startDaemon(serverImpl.class, workingDir, options) >>> [client1, client2]
@@ -105,7 +107,7 @@ class WorkerDaemonClientsManagerTest extends ConcurrentSpecification {
 
     def "Stopping session-scoped clients does not stop other clients"() {
         listenerManager = new DefaultListenerManager()
-        manager = new WorkerDaemonClientsManager(starter, listenerManager)
+        manager = new WorkerDaemonClientsManager(starter, listenerManager, loggingManager)
         def client1 = Mock(WorkerDaemonClient)
         def client2 = Mock(WorkerDaemonClient)
         starter.startDaemon(serverImpl.class, workingDir, options) >>> [client1, client2]

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonExpirationTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonExpirationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.jvm.Jvm
+import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.process.internal.health.memory.JvmMemoryStatus
 import org.gradle.process.internal.health.memory.MaximumHeapHelper
 import org.gradle.process.internal.health.memory.MemoryAmount
@@ -51,7 +52,7 @@ class WorkerDaemonExpirationTest extends Specification {
             }
         }
     }
-    def clientsManager = new WorkerDaemonClientsManager(daemonStarter, Mock(ListenerManager))
+    def clientsManager = new WorkerDaemonClientsManager(daemonStarter, Mock(ListenerManager), Mock(LoggingManagerInternal))
     def expiration = new WorkerDaemonExpiration(clientsManager, MemoryAmount.ofGigaBytes(OS_MEMORY_GB).bytes)
 
     def "expires least recently used idle worker daemon to free system memory when requested to release some memory"() {

--- a/subprojects/workers/workers.gradle
+++ b/subprojects/workers/workers.gradle
@@ -4,6 +4,8 @@ sourceCompatibility = javaVersion.java9Compatible ? 1.6 : 1.5
 dependencies {
     compile project(':core')
     compile libraries.jcip
+
+    integTestCompile project(':internalIntegTesting')
 }
 
 useTestFixtures(project: ":logging")


### PR DESCRIPTION
Pulls `WorkerDaemonClientsManager` and `WorkerProcessFactory` up to gradle user home scope and reuses worker daemons across builds.  