### PR TITLE
Introduce descriptive types to refer to task input and output files and directories

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
@@ -19,7 +19,6 @@ package org.gradle.internal.reflect;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Cast;
-import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.util.CollectionUtils;
 
@@ -321,10 +320,6 @@ public class JavaReflectionUtil {
         }
     }
 
-    public static <T> Factory<T> factory(final Instantiator instantiator, final Class<? extends T> type, final Object... args) {
-        return new InstantiatingFactory<T>(instantiator, type, args);
-    }
-
     public static boolean hasDefaultToString(Object object) {
         try {
             return object.getClass().getMethod("toString").getDeclaringClass() == Object.class;
@@ -338,7 +333,7 @@ public class JavaReflectionUtil {
         private final Method method;
         private final Class<F> returnType;
 
-        public GetterMethodBackedPropertyAccessor(String property, Class<F> returnType, Method method) {
+        GetterMethodBackedPropertyAccessor(String property, Class<F> returnType, Method method) {
             this.property = property;
             this.method = method;
             this.returnType = returnType;
@@ -373,7 +368,7 @@ public class JavaReflectionUtil {
         private final Field field;
         private final Class<F> fieldType;
 
-        public FieldBackedPropertyAccessor(String property, Class<F> fieldType, Field field) {
+        FieldBackedPropertyAccessor(String property, Class<F> fieldType, Field field) {
             this.property = property;
             this.field = field;
             this.fieldType = fieldType;
@@ -403,7 +398,7 @@ public class JavaReflectionUtil {
         private final String property;
         private final Method method;
 
-        public MethodBackedPropertyMutator(String property, Method method) {
+        MethodBackedPropertyMutator(String property, Method method) {
             this.property = property;
             this.method = method;
         }
@@ -436,7 +431,7 @@ public class JavaReflectionUtil {
         private final String name;
         private final Field field;
 
-        public FieldBackedPropertyMutator(String name, Field field) {
+        FieldBackedPropertyMutator(String name, Field field) {
             this.name = name;
             this.field = field;
         }
@@ -460,22 +455,6 @@ public class JavaReflectionUtil {
             } catch (IllegalAccessException e) {
                 throw UncheckedException.throwAsUncheckedException(e);
             }
-        }
-    }
-
-    private static class InstantiatingFactory<T> implements Factory<T> {
-        private final Instantiator instantiator;
-        private final Class<? extends T> type;
-        private final Object[] args;
-
-        public InstantiatingFactory(Instantiator instantiator, Class<? extends T> type, Object... args) {
-            this.instantiator = instantiator;
-            this.type = type;
-            this.args = args;
-        }
-
-        public T create() {
-            return instantiator.newInstance(type, args);
         }
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTest.groovy
@@ -268,15 +268,6 @@ class JavaReflectionUtilTest extends Specification {
         }
     }
 
-    def "new instance"() {
-        def instantiator = DirectInstantiator.INSTANCE
-
-        expect:
-        factory(instantiator, Thing).create().name == null
-        factory(instantiator, Thing, "foo").create().name == "foo"
-        !factory(instantiator, Thing).create().is(factory(instantiator, Thing).create())
-    }
-
     def "default toString methods"() {
         expect:
         hasDefaultToString(clazz)

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/javascript/GoogleClosureCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/javascript/GoogleClosureCompiler.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.internal.file.RelativeFile;
 import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
-import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.JavaMethod;
@@ -84,8 +83,7 @@ public class GoogleClosureCompiler implements Compiler<JavaScriptCompileSpec>, S
         Object sourceFile = fromFileJavaMethod.invokeStatic(javascriptFile.getFile());
 
         // Construct a new CompilerOptions class
-        Factory<?> compilerOptionsFactory = JavaReflectionUtil.factory(DirectInstantiator.INSTANCE, compilerOptionsClass);
-        Object compilerOptions = compilerOptionsFactory.create();
+        Object compilerOptions = DirectInstantiator.INSTANCE.newInstance(compilerOptionsClass);
 
         // Get the CompilationLevel.SIMPLE_OPTIMIZATIONS class and set it on the CompilerOptions class
         @SuppressWarnings({ "rawtypes", "unchecked" }) Enum simpleLevel = Enum.valueOf(compilationLevelClass, "SIMPLE_OPTIMIZATIONS");
@@ -93,8 +91,7 @@ public class GoogleClosureCompiler implements Compiler<JavaScriptCompileSpec>, S
         setOptionsForCompilationLevelMethod.invoke(simpleLevel, compilerOptions);
 
         // Construct a new Compiler class
-        Factory<?> compilerFactory = JavaReflectionUtil.factory(DirectInstantiator.INSTANCE, compilerClass, getDummyPrintStream());
-        Object compiler = compilerFactory.create();
+        Object compiler = DirectInstantiator.INSTANCE.newInstance(compilerClass, getDummyPrintStream());
 
         // Compile the javascript file with the options we've created
         JavaMethod<Object, Object> compileMethod = JavaReflectionUtil.method(compilerClass, Object.class, "compile", sourceFileClass, sourceFileClass, compilerOptionsClass);


### PR DESCRIPTION
A solution for #2290 and #2305, introducing various APIs to define and reference lazily calculated directory and file locations, and use these to define and wire together task input and output files and directories.