### PR TITLE
Hotfix deadlock in parallel test execution

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/actor/internal/DefaultActorFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/actor/internal/DefaultActorFactory.java
@@ -135,7 +135,7 @@ public class DefaultActorFactory implements ActorFactory, Stoppable {
             dispatch = new AsyncDispatch<MethodInvocation>(executor,
                     new FailureHandlingDispatch<MethodInvocation>(
                             new ReflectionDispatch(targetObject),
-                            failureHandler));
+                            failureHandler), Integer.MAX_VALUE);
         }
 
         public <T> T getProxy(Class<T> type) {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
@@ -16,15 +16,13 @@
 package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Timeout
 import spock.lang.Unroll
 
 @Timeout(240)
-@IgnoreIf({ GradleContextualExecuter.isParallel() })
 class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
 
     @Rule
@@ -52,7 +50,7 @@ class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
         println "Test-count: $testCount"
 
         and:
-        withJUnitTests(testCount)
+        withBlockingJUnitTests(testCount)
         buildFile << """
             test {
                 maxParallelForks = $maxParallelForks
@@ -103,7 +101,32 @@ class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
         2              | 3          | 2                | 1
     }
 
-    private void withJUnitTests(int testCount) {
+    def "can handle parallel tests together with parallel project execution"() {
+        given:
+        settingsFile << """
+            include 'a'
+            include 'b'
+        """
+        ["a", "b"].collect { file(it) }.each { TestFile build ->
+            build.file("build.gradle") << """
+                plugins { id "java" }
+                repositories { jcenter() }
+                dependencies {
+                    testCompile localGroovy()
+                    testCompile "junit:junit:4.12"
+                }
+                test.maxParallelForks = 2
+            """
+            withNonBlockingJUnitTests(build, 200)
+        }
+        when:
+        def gradle = executer.withArguments("--parallel", "--max-workers=2").withTasks('test').start()
+
+        then:
+        gradle.waitForFinish()
+    }
+
+    private void withBlockingJUnitTests(int testCount) {
         testIndices(testCount).each { idx ->
             file("src/test/java/pkg/SomeTest_${idx}.java") << """
                 package pkg;
@@ -112,6 +135,20 @@ class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
                     @Test
                     public void test_$idx() {
                         ${blockingServer.callFromBuild("test_$idx")}
+                    }
+                }
+            """.stripIndent()
+        }
+    }
+
+    private void withNonBlockingJUnitTests(TestFile projectDir, int testCount) {
+        testIndices(testCount).each { idx ->
+            projectDir.file("src/test/java/pkg/SomeTest_${idx}.java") << """
+                package pkg;
+                import org.junit.Test;
+                public class SomeTest_$idx {
+                    @Test
+                    public void test_$idx() {
                     }
                 }
             """.stripIndent()


### PR DESCRIPTION
For each test task we create `maxParallelForks` actors
which receive test classes in a round-robin fashion. These
actors then acquire a worker lease and send the tests to the
actual test process for execution. The problem is that these
actors have a limited queue, so if one of them fails to acquire
a worker lease, then the whole test task comes to a halt, because
the actor blocks the round-robin loop. This can then deadlock
the whole build if the number of Test tasks is >= max-workers.

This hotfix for Gradle 4.0 just raises the queue size of the actors,
so they won't block the round-robin loop for any realistically-sized project.
The real fix would be to acquire a worker lease *before* we create a new
actor. This will be a follup-up change for 4.1.