### PR TITLE
Reduce object allocations during dependency resolution

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
@@ -15,15 +15,15 @@
  */
 package org.gradle.api.internal.artifacts;
 
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 
 public interface ComponentMetadataProcessor {
     ComponentMetadataProcessor NO_OP = new ComponentMetadataProcessor() {
         @Override
-        public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata) {
+        public MutableModuleComponentResolveMetadata processMetadata(MutableModuleComponentResolveMetadata metadata) {
             return metadata;
         }
     };
 
-    ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata);
+    MutableModuleComponentResolveMetadata processMetadata(MutableModuleComponentResolveMetadata metadata);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionSelector.java
@@ -64,7 +64,7 @@ public class DefaultModuleVersionSelector implements ModuleVersionSelector {
 
     @Override
     public String toString() {
-        return String.format("%s:%s:%s", group, name, version);
+        return group + ":" + name + ":" + version;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -71,7 +71,7 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
             }
 
             if (result.getState() == BuildableModuleComponentMetaDataResolveResult.State.Resolved) {
-                result.setMetadata(metadataProcessor.processMetadata(result.getMetaData()));
+                result.setMetadata(metadataProcessor.processMetadata(result.getMetaData().asMutable()).asImmutable());
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetaData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetaData.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.internal.artifacts.ivyservice.dynamicversions.DefaultResolvedModuleVersion;
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.util.BuildCommencedTimeProvider;
 
@@ -27,9 +27,9 @@ class DefaultCachedMetaData implements ModuleMetaDataCache.CachedMetaData {
     private final ModuleSource moduleSource;
     private final BigInteger descriptorHash;
     private final long ageMillis;
-    private final ModuleComponentResolveMetadata metaData;
+    private final MutableModuleComponentResolveMetadata metaData;
 
-    public DefaultCachedMetaData(ModuleMetadataCacheEntry entry, ModuleComponentResolveMetadata metaData, BuildCommencedTimeProvider timeProvider) {
+    public DefaultCachedMetaData(ModuleMetadataCacheEntry entry, MutableModuleComponentResolveMetadata metaData, BuildCommencedTimeProvider timeProvider) {
         this.moduleSource = entry.moduleSource;
         this.descriptorHash = entry.moduleDescriptorHash;
         this.ageMillis = timeProvider.getCurrentTime() - entry.createTimestamp;
@@ -48,7 +48,7 @@ class DefaultCachedMetaData implements ModuleMetaDataCache.CachedMetaData {
         return isMissing() ? null : new DefaultResolvedModuleVersion(getMetaData().getId());
     }
 
-    public ModuleComponentResolveMetadata getMetaData() {
+    public MutableModuleComponentResolveMetadata getMetaData() {
         return metaData;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetaDataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetaDataCache.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 
 import java.math.BigInteger;
@@ -33,7 +34,7 @@ public interface ModuleMetaDataCache {
     interface CachedMetaData {
         ResolvedModuleVersion getModuleVersion();
 
-        ModuleComponentResolveMetadata getMetaData();
+        MutableModuleComponentResolveMetadata getMetaData();
 
         long getAgeMillis();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCacheEntry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCacheEntry.java
@@ -51,9 +51,9 @@ class ModuleMetadataCacheEntry {
         return type == TYPE_MISSING;
     }
 
-    protected ModuleComponentResolveMetadata configure(MutableModuleComponentResolveMetadata input) {
+    protected MutableModuleComponentResolveMetadata configure(MutableModuleComponentResolveMetadata input) {
         input.setChanging(isChanging);
         input.setSource(moduleSource);
-        return input.asImmutable();
+        return input;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -67,14 +67,14 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final List<? extends DependencyMetadata> dependencies;
     private final List<Exclude> excludes;
 
-    protected AbstractModuleComponentResolveMetadata(MutableModuleComponentResolveMetadata metadata) {
+    protected AbstractModuleComponentResolveMetadata(MutableModuleComponentResolveMetadata metadata, @Nullable ModuleSource source) {
         this.descriptor = metadata.getDescriptor();
         this.componentIdentifier = metadata.getComponentId();
         this.moduleVersionIdentifier = metadata.getId();
         changing = metadata.isChanging();
         status = metadata.getStatus();
         statusScheme = metadata.getStatusScheme();
-        moduleSource = metadata.getSource();
+        moduleSource = source == null ? metadata.getSource() : source;
         configurationDefinitions = metadata.getConfigurationDefinitions();
         dependencies = metadata.getDependencies();
         excludes = descriptor.getExcludes();
@@ -367,13 +367,14 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
 
         private boolean include(DependencyMetadata dependency) {
             Set<String> hierarchy = getHierarchy();
-            for (String moduleConfiguration : dependency.getModuleConfigurations()) {
+            Set<String> moduleConfigurations = dependency.getModuleConfigurations();
+            for (String moduleConfiguration : moduleConfigurations) {
                 if (moduleConfiguration.equals("%") || hierarchy.contains(moduleConfiguration)) {
                     return true;
                 }
                 if (moduleConfiguration.equals("*")) {
                     boolean include = true;
-                    for (String conf2 : dependency.getModuleConfigurations()) {
+                    for (String conf2 : moduleConfigurations) {
                         if (conf2.startsWith("!") && conf2.substring(1).equals(getName())) {
                             include = false;
                             break;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.component.external.model;
 
+import org.gradle.api.Nullable;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
 import org.gradle.internal.component.model.ModuleSource;
 
@@ -22,7 +23,11 @@ import java.util.Map;
 
 public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentResolveMetadata implements IvyModuleResolveMetadata {
     DefaultIvyModuleResolveMetadata(MutableIvyModuleResolveMetadata metadata) {
-        super(metadata);
+        super(metadata, null);
+    }
+
+    DefaultIvyModuleResolveMetadata(MutableIvyModuleResolveMetadata metadata, @Nullable ModuleSource source) {
+        super(metadata, source);
     }
 
     private DefaultIvyModuleResolveMetadata(DefaultIvyModuleResolveMetadata metadata, ModuleSource source) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -30,7 +30,11 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     private final String snapshotTimestamp;
 
     DefaultMavenModuleResolveMetadata(MutableMavenModuleResolveMetadata metadata) {
-        super(metadata);
+        this(metadata, null);
+    }
+
+    DefaultMavenModuleResolveMetadata(MutableMavenModuleResolveMetadata metadata, @Nullable ModuleSource source) {
+        super(metadata, source);
         packaging = metadata.getPackaging();
         relocated = metadata.isRelocated();
         snapshotTimestamp = metadata.getSnapshotTimestamp();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadata.java
@@ -26,6 +26,7 @@ import org.gradle.internal.component.external.descriptor.ModuleDescriptorState;
 import org.gradle.internal.component.external.descriptor.MutableModuleDescriptorState;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.ModuleSource;
 
 import java.util.Collection;
 import java.util.Map;
@@ -60,5 +61,10 @@ public class DefaultMutableIvyModuleResolveMetadata extends AbstractMutableModul
     @Override
     public IvyModuleResolveMetadata asImmutable() {
         return new DefaultIvyModuleResolveMetadata(this);
+    }
+
+    @Override
+    public ModuleComponentResolveMetadata asImmutableWithSource(ModuleSource source) {
+        return new DefaultIvyModuleResolveMetadata(this, source);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
@@ -25,6 +25,7 @@ import org.gradle.internal.component.external.descriptor.ModuleDescriptorState;
 import org.gradle.internal.component.external.descriptor.MutableModuleDescriptorState;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.ModuleSource;
 
 import java.util.Collection;
 import java.util.Set;
@@ -64,6 +65,11 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
     @Override
     public MavenModuleResolveMetadata asImmutable() {
         return new DefaultMavenModuleResolveMetadata(this);
+    }
+
+    @Override
+    public ModuleComponentResolveMetadata asImmutableWithSource(ModuleSource source) {
+        return new DefaultMavenModuleResolveMetadata(this, source);
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -43,6 +43,11 @@ public interface MutableModuleComponentResolveMetadata {
     ModuleComponentResolveMetadata asImmutable();
 
     /**
+     * Creates an immutable copy of this meta-data.
+     */
+    ModuleComponentResolveMetadata asImmutableWithSource(ModuleSource source);
+
+    /**
      * Sets the component id and legacy module version id
      */
     void setComponentId(ModuleComponentIdentifier componentId);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -53,7 +53,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
     def ruleAction = Stub(RuleAction)
 
     def "does nothing when no rules registered"() {
-        def metadata = ivyMetadata().asImmutable()
+        def metadata = ivyMetadata()
 
         expect:
         mockedHandler.processMetadata(metadata).is(metadata)
@@ -202,7 +202,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         metadata.statusScheme = ["alpha", "beta"]
 
         when:
-        handler.processMetadata(metadata.asImmutable())
+        handler.processMetadata(metadata)
 
         then:
         ModuleVersionResolveException e = thrown()
@@ -217,7 +217,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         handler.all { throw failure }
 
         and:
-        handler.processMetadata(metadata.asImmutable())
+        handler.processMetadata(metadata)
 
         then:
         InvalidUserCodeException e = thrown()
@@ -235,7 +235,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         handler.all { ComponentMetadataDetails cmd, IvyModuleDescriptor imd -> closuresCalled << 3 }
 
         and:
-        handler.processMetadata(metadata.asImmutable())
+        handler.processMetadata(metadata)
 
         then:
         closuresCalled.sort() == [ 1, 2, 3 ]
@@ -249,7 +249,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.processMetadata(metadata.asImmutable())
+        handler.processMetadata(metadata)
 
         then:
         noExceptionThrown()
@@ -277,7 +277,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.processMetadata(metadata.asImmutable())
+        handler.processMetadata(metadata)
 
         then:
         noExceptionThrown()
@@ -306,7 +306,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.processMetadata(metadata.asImmutable())
+        handler.processMetadata(metadata)
 
         then:
         noExceptionThrown()
@@ -322,7 +322,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.processMetadata(metadata.asImmutable())
+        handler.processMetadata(metadata)
 
         then:
         !invoked
@@ -369,7 +369,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.processMetadata(metadata.asImmutable())
+        handler.processMetadata(metadata)
 
         then:
         noExceptionThrown()


### PR DESCRIPTION
### Context
As part of verifying my parallel resolution changes, I found some opportunities to reduce object allocations and GC pressure.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
