### PR TITLE
Fix issue with more worker daemons being started than max workers

### DIFF
--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
@@ -54,6 +54,7 @@ abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegration
 
     String getTaskTypeUsingWorker() {
         withParameterClassInBuildSrc()
+        withFileHelperClassInBuildSrc()
 
         return """
             import javax.inject.Inject
@@ -97,9 +98,7 @@ abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegration
             import java.io.File;
             import java.util.List;
             import org.gradle.other.Foo;
-            import java.io.PrintWriter;
-            import java.io.BufferedWriter;
-            import java.io.FileWriter;
+            import org.gradle.test.FileHelper;
             import java.util.UUID;
             import javax.inject.Inject;
 
@@ -117,22 +116,9 @@ abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegration
                 }
 
                 public void run() {
-                    outputDir.mkdirs();
-
                     for (String name : files) {
-                        PrintWriter out = null;
-                        try {
-                            File outputFile = new File(outputDir, name);
-                            outputFile.createNewFile();
-                            out = new PrintWriter(new BufferedWriter(new FileWriter(outputFile)));
-                            out.print(id);
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        } finally {
-                            if (out != null) {
-                                out.close();
-                            }
-                        }
+                        File outputFile = new File(outputDir, name);
+                        FileHelper.write(id, outputFile);
                     }
                 }
             }
@@ -146,6 +132,12 @@ abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegration
             import java.io.Serializable;
 
             public class Foo implements Serializable { }
+        """
+    }
+
+    void withFileHelperClassInBuildSrc() {
+        file("buildSrc/src/main/java/org/gradle/test/FileHelper.java") << """
+            $fileHelperClass
         """
     }
 
@@ -177,6 +169,9 @@ abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegration
         builder.sourceFile("org/gradle/other/Foo.java") << """
             $parameterClass
         """
+        builder.sourceFile("org/gradle/test/FileHelper.java") << """
+            $fileHelperClass
+        """
         builder.buildJar(runnableJar)
 
         addImportToBuildScript("org.gradle.test.TestRunnable")
@@ -189,6 +184,35 @@ abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegration
             import java.io.Serializable;
 
             public class Foo implements Serializable { }
+        """
+    }
+
+    String getFileHelperClass() {
+        return """
+            package org.gradle.test;
+            
+            import java.io.File;
+            import java.io.PrintWriter;
+            import java.io.BufferedWriter;
+            import java.io.FileWriter;
+            
+            public class FileHelper {
+                static void write(String id, File outputFile) {
+                    PrintWriter out = null;
+                    try {
+                        outputFile.getParentFile().mkdirs();
+                        outputFile.createNewFile();
+                        out = new PrintWriter(new BufferedWriter(new FileWriter(outputFile)));
+                        out.print(id);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        if (out != null) {
+                            out.close();
+                        }
+                    }
+                }
+            }
         """
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
@@ -64,6 +64,7 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(workerProtocolImplementation.class, options).execute(spec)
 
         then:
+        1 * workerOperation.startChild() >> completion
         1 * clientsManager.reserveIdleClient(options) >> null
 
         then:
@@ -71,7 +72,6 @@ class WorkerDaemonFactoryTest extends Specification {
         1 * clientsManager.reserveNewClient(workerProtocolImplementation.class, _, options) >> client
 
         then:
-        1 * workerOperation.startChild() >> completion
         1 * buildOperationExecutor.call(_) >> { args -> args[0].call() }
         1 * client.execute(spec)
 
@@ -84,10 +84,10 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(workerProtocolImplementation.class, options).execute(spec)
 
         then:
+        1 * workerOperation.startChild() >> completion
         1 * clientsManager.reserveIdleClient(options) >> client
 
         then:
-        1 * workerOperation.startChild() >> completion
         1 * buildOperationExecutor.call(_) >> { args -> args[0].call() }
         1 * client.execute(spec)
 
@@ -100,10 +100,10 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(workerProtocolImplementation.class, options).execute(spec)
 
         then:
+        1 * workerOperation.startChild() >> completion
         1 * clientsManager.reserveIdleClient(options) >> client
 
         then:
-        1 * workerOperation.startChild() >> completion
         1 * buildOperationExecutor.call(_) >> { args -> args[0].call() }
         1 * client.execute(spec) >> { throw new RuntimeException("Boo!") }
 
@@ -133,8 +133,8 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(workerProtocolImplementation.class, options).execute(spec)
 
         then:
-        1 * clientsManager.reserveIdleClient(options) >> client
         1 * workerOperation.startChild() >> completion
+        1 * clientsManager.reserveIdleClient(options) >> client
         1 * buildOperationExecutor.call(_)
         1 * completion.leaseFinish()
     }
@@ -144,8 +144,8 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(workerProtocolImplementation.class, options).execute(spec)
 
         then:
-        1 * clientsManager.reserveIdleClient(options) >> client
         1 * workerOperation.startChild() >> completion
+        1 * clientsManager.reserveIdleClient(options) >> client
         1 * buildOperationExecutor.call(_) >> { args -> args[0].call() }
         1 * client.execute(spec) >> { throw new RuntimeException("Boo!") }
 


### PR DESCRIPTION
Fixes an issue where a single task can end up starting more worker daemons than max workers rather than reusing existing workers.