### PR TITLE
Add compilationClasspath property to CodeNarc task which allows to configure classpath used by CodeNarc enhanced rules when compiling analysed classes.

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcCompilationClasspathIntegrationSpec.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcCompilationClasspathIntegrationSpec.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.quality
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.Matchers.startsWith
+
+class CodeNarcCompilationClasspathIntegrationSpec extends AbstractIntegrationSpec {
+
+    private final static String CONFIG_FILE_PATH = 'config/codenarc/rulesets.groovy'
+
+    def "compilation classpath can be specified for a CodeNarc task"() {
+        given:
+        buildFileWithCodeNarcAndCompilationClasspath('0.27.0')
+        cloneWithoutCloneableRuleEnabled()
+        codeViolatingCloneWithoutCloneableRule()
+
+        expect:
+        fails("codenarcMain")
+        failure.assertThatCause(startsWith("CodeNarc rule violations were found"))
+    }
+
+    def "an informative error is shown when a compilation classpath is specified on a CodeNarc task when using an incompatible CodeNarc version"() {
+        given:
+        buildFileWithCodeNarcAndCompilationClasspath('0.26.0')
+        cloneWithoutCloneableRuleEnabled()
+        codeViolatingCloneWithoutCloneableRule()
+
+        expect:
+        fails("codenarcMain")
+        failure.assertThatCause(equalTo("The compilationClasspath property of CodeNarc task can only be non-empty when using CodeNarc 0.27.0 or newer."))
+    }
+
+    private void buildFileWithCodeNarcAndCompilationClasspath(String codeNarcVersion) {
+        buildFile << """
+            apply plugin: "codenarc"
+            apply plugin: "groovy"
+
+            repositories {
+                mavenCentral()
+            }
+
+            codenarc {
+                toolVersion = '$codeNarcVersion'
+                codenarc.configFile = file('$CONFIG_FILE_PATH') 
+            }
+            
+            dependencies {
+                compile localGroovy()
+            }
+            
+            codenarcMain {
+                compilationClasspath = configurations.compile
+            }
+        """
+    }
+
+    private void cloneWithoutCloneableRuleEnabled() {
+        file(CONFIG_FILE_PATH) << '''
+            ruleset {
+                CloneWithoutCloneable
+            }
+        '''
+    }
+
+    private codeViolatingCloneWithoutCloneableRule() {
+        file('src/main/groovy/ViolatingClass.groovy') << '''
+            class ViolatingClass extends Tuple {
+                ViolatingClass clone() {}
+            }
+        '''
+    }
+}

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarc.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarc.java
@@ -21,6 +21,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.ClosureBackedAction;
+import org.gradle.api.internal.file.collections.SimpleFileCollection;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.plugins.quality.internal.CodeNarcInvoker;
 import org.gradle.api.plugins.quality.internal.CodeNarcReportsImpl;
@@ -29,6 +30,7 @@ import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.PathSensitive;
@@ -49,6 +51,8 @@ public class CodeNarc extends SourceTask implements VerificationTask, Reporting<
 
     private FileCollection codenarcClasspath;
 
+    private FileCollection compilationClasspath;
+
     private TextResource config;
 
     private int maxPriority1Violations;
@@ -63,6 +67,7 @@ public class CodeNarc extends SourceTask implements VerificationTask, Reporting<
 
     public CodeNarc() {
         reports = getInstantiator().newInstance(CodeNarcReportsImpl.class, this);
+        compilationClasspath = new SimpleFileCollection();
     }
 
     /**
@@ -132,6 +137,22 @@ public class CodeNarc extends SourceTask implements VerificationTask, Reporting<
      */
     public void setCodenarcClasspath(FileCollection codenarcClasspath) {
         this.codenarcClasspath = codenarcClasspath;
+    }
+
+    /**
+     * The class path to be used by CodeNarc when compiling classes during analysis.
+     */
+    @InputFiles
+    @PathSensitive(PathSensitivity.ABSOLUTE)
+    public FileCollection getCompilationClasspath() {
+        return compilationClasspath;
+    }
+
+    /**
+     * The class path to be used by CodeNarc when compiling classes during analysis.
+     */
+    public void setCompilationClasspath(FileCollection compilationClasspath) {
+        this.compilationClasspath = compilationClasspath;
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcInvoker.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcInvoker.groovy
@@ -33,6 +33,7 @@ abstract class CodeNarcInvoker {
         def codenarcClasspath = codenarcTask.codenarcClasspath
         def antBuilder = codenarcTask.antBuilder
         def classpath = new DefaultClassPath(codenarcClasspath)
+        def compilationClasspath = codenarcTask.compilationClasspath
         def configFile = codenarcTask.configFile
         def maxPriority1Violations = codenarcTask.maxPriority1Violations
         def maxPriority2Violations = codenarcTask.maxPriority2Violations
@@ -63,6 +64,10 @@ abstract class CodeNarcInvoker {
                     }
 
                     source.addToAntBuilder(ant, 'fileset', FileCollection.AntType.FileSet)
+
+                    if (!compilationClasspath.empty) {
+                        compilationClasspath.addToAntBuilder(ant, 'classpath')
+                    }
                 }
             } catch (Exception e) {
                 if (e.message.matches('Exceeded maximum number of priority \\d* violations.*')) {
@@ -76,6 +81,10 @@ abstract class CodeNarcInvoker {
                         logger.warn(message)
                         return
                     }
+                    throw new GradleException(message, e)
+                }
+                if (e.message == /codenarc doesn't support the nested "classpath" element./) {
+                    def message = "The compilationClasspath property of CodeNarc task can only be non-empty when using CodeNarc 0.27.0 or newer."
                     throw new GradleException(message, e)
                 }
                 throw e

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.CodeNarc.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.CodeNarc.xml
@@ -41,6 +41,10 @@
                 <td><literal>project.configurations.codenarc</literal></td>
             </tr>
             <tr>
+                <td>compilationClasspath</td>
+                <td>empty file collection</td>
+            </tr>
+            <tr>
                 <td>reports</td>
                 <td></td>
             </tr>


### PR DESCRIPTION
### Context

CodeNarc has had a concept of [enhanced classpath rules](http://codenarc.sourceforge.net/codenarc-enhanced-classpath-rules.html) for a while now. Some time ago I discovered that unfortunately [it's impossible to use them because there is no way of specifying the classpath to be used for compilation](https://sourceforge.net/p/codenarc/mailman/message/35699609/). I have then [contributed a way to specify the compilation classpath using CodeNarc's ant task](https://github.com/CodeNarc/CodeNarc/pull/192).

This pull request further extends the ability to specify compilation classpath when running CodeNarc to Gradle's CodeNarc task.

A possible next step and an improvement would be to configure the compilation classpath of each CodeNarc task on a convention basis to point at the compile configuration associated with the analysed source set. I've not done this as part of this PR as there are some issues that need to be decided on (i.e. how to do it without breaking compatibility with pre 0.27.0 versions of CodeNarc) and I believe that this PR is a good first step and provides value to users as is.

I'm looking forward to a review and will happily apply any necessary changes afterwards.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
