### PR TITLE
--tests filters never override filters defined in build script

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -62,6 +62,10 @@ Previous versions of Gradle would select the `runtimeElements` when both project
 
 This change makes the selection behaviour consistent so that the `runtimeElements` configuration is selected regardless of whether the consuming project uses the Java plugin or not. This is also consistent with the selection when the consuming project is using one of the Android plugins.
 
+### Filters defined via command line option --tests never override filters from build script
+
+The `--tests` filters are now always applied on top of the filtering defined in build scripts. In previous Gradle versions, filters defined through `filter.includeTestsMatching` or `filter.includePatterns` were overridden, while other filters were not. The [Test filtering](userguide/java_plugin.html#test_filtering) documentation was adjusted to reflect the new behavior.
+
 ## External contributions
 
 We would like to thank the following community members for making contributions to this release of Gradle.
@@ -73,6 +77,7 @@ We would like to thank the following community members for making contributions 
  - [Jörn Huxhorn](https://github.com/huxi) - Replace uses of `Stack` with `ArrayDeque` (#771)
  - [Björn Kautler](https://github.com/Vampire) - Fix WTP component version (#2076)
  - [Bo Zhang](https://github.com/blindpirate) - Add support for 'console' output type of CodeNarc plugin (#2170)
+ - [Bo Zhang](https://github.com/blindpirate) - Contributions to consistent --tests option handling (#2172)
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 

--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -784,7 +784,7 @@ Test filtering feature has following characteristic:
 
 * Fully qualified class name or fully qualified method name is supported, e.g. “org.gradle.SomeTest”, “org.gradle.SomeTest.someMethod”
 * Wildcard '*' is supported for matching any characters
-* Command line option “--tests” is provided to conveniently set the test filter. Especially useful for the classic 'single test method execution' use case. When the command line option is used, the inclusion filters declared in the build script are ignored. It is possible to supply multiple “--tests” options and tests matching any of those patterns will be included.
+* Command line option “--tests” is provided to conveniently extend the test filter for an individual Gradle execution. This is especially useful for the classic 'single test method execution' use case. When the command line option is used, the inclusions declared in the build script are still honored. That is, the command line filters are always applied on top of the filter definition in the build script. It is possible to supply multiple “--tests” options and tests matching any of those patterns will be included.
 * Gradle tries to filter the tests given the limitations of the test framework API. Some advanced, synthetic tests may not be fully compatible with filtering. However, the vast majority of tests and use cases should be handled neatly.
 * Test filtering supersedes the file-based test selection. The latter may be completely replaced in future. We will grow the test filtering API and add more kinds of filters.
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -214,6 +214,48 @@ class TestTest extends AbstractConventionTaskTest {
         test.getExcludes() == toLinkedSet(TEST_PATTERN_1, TEST_PATTERN_2, TEST_PATTERN_3)
     }
 
+    def "--tests is combined with includes and excludes"() {
+        given:
+        test.include(TEST_PATTERN_1)
+        test.exclude(TEST_PATTERN_1)
+
+        when:
+        test.setTestNameIncludePatterns([TEST_PATTERN_2])
+
+        then:
+        test.includes == [ TEST_PATTERN_1 ] as Set
+        test.excludes == [ TEST_PATTERN_1 ] as Set
+        test.filter.commandLineIncludePatterns == [ TEST_PATTERN_2] as Set
+    }
+
+    def "--tests is combined with filter.includeTestsMatching"() {
+        given:
+        test.filter.includeTestsMatching(TEST_PATTERN_1)
+
+        when:
+        test.setTestNameIncludePatterns([TEST_PATTERN_2])
+
+        then:
+        test.includes.empty
+        test.excludes.empty
+        test.filter.includePatterns == [TEST_PATTERN_1] as Set
+        test.filter.commandLineIncludePatterns == [ TEST_PATTERN_2] as Set
+    }
+
+    def "--tests is combined with filter.includePatterns"() {
+        given:
+        test.filter.includePatterns = [ TEST_PATTERN_1 ]
+
+        when:
+        test.setTestNameIncludePatterns([TEST_PATTERN_2])
+
+        then:
+        test.includes.empty
+        test.excludes.empty
+        test.filter.includePatterns == [TEST_PATTERN_1] as Set
+        test.filter.commandLineIncludePatterns == [ TEST_PATTERN_2] as Set
+    }
+
     private void assertIsDirectoryTree(FileTree classFiles, Set<String> includes, Set<String> excludes) {
         assert classFiles instanceof CompositeFileTree
         def files = (CompositeFileTree) classFiles

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
@@ -20,12 +20,14 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.testing.TestFilter;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 public class DefaultTestFilter implements TestFilter {
 
     private Set<String> testNames = new HashSet<String>();
+    private Set<String> commandLineTestNames = new HashSet<String>();
     private boolean failOnNoMatching = true;
 
     private void validateName(String name) {
@@ -74,6 +76,20 @@ public class DefaultTestFilter implements TestFilter {
             validateName(name);
         }
         this.testNames = Sets.newHashSet(testNamePatterns);
+        return this;
+    }
+
+    @Input
+    public Set<String> getCommandLineIncludePatterns() {
+        return commandLineTestNames;
+    }
+
+    public TestFilter setCommandLineIncludePatterns(Collection<String> testNamePatterns) {
+        for (String name : testNamePatterns) {
+            validateName(name);
+        }
+        this.commandLineTestNames.clear();
+        this.commandLineTestNames.addAll(testNamePatterns);
         return this;
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -25,13 +25,21 @@ import java.util.regex.Pattern;
 
 public class TestSelectionMatcher {
 
-    private final List<Pattern> includePatterns;
+    private final List<Pattern> buildScriptIncludePatterns;
+    private final List<Pattern> commandLineIncludePatterns;
 
-    public TestSelectionMatcher(Collection<String> includedTests) {
-        includePatterns = new ArrayList<Pattern>(includedTests.size());
+    public TestSelectionMatcher(Collection<String> includedTests, Collection<String> includedTestsCommandLine) {
+        buildScriptIncludePatterns = preparePatternList(includedTests);
+        commandLineIncludePatterns = preparePatternList(includedTestsCommandLine);
+    }
+
+    private List<Pattern> preparePatternList(Collection<String> includedTests) {
+        List<Pattern> buildScriptIncludePatterns;
+        buildScriptIncludePatterns = new ArrayList<Pattern>(includedTests.size());
         for (String includedTest : includedTests) {
-            includePatterns.add(preparePattern(includedTest));
+            buildScriptIncludePatterns.add(preparePattern(includedTest));
         }
+        return buildScriptIncludePatterns;
     }
 
     private Pattern preparePattern(String input) {
@@ -51,6 +59,14 @@ public class TestSelectionMatcher {
     }
 
     public boolean matchesTest(String className, String methodName) {
+        return matchesPattern(buildScriptIncludePatterns, className, methodName)
+            && matchesPattern(commandLineIncludePatterns, className, methodName);
+    }
+
+    private boolean matchesPattern(List<Pattern> includePatterns, String className, String methodName) {
+        if (includePatterns.isEmpty()) {
+            return true;
+        }
         String fullName = className + "." + methodName;
         for (Pattern pattern : includePatterns) {
             if (methodName != null && pattern.matcher(fullName).matches()) {

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -21,7 +21,8 @@ import spock.lang.Specification
 class TestSelectionMatcherTest extends Specification {
 
     def "knows if test matches class"() {
-        expect: new TestSelectionMatcher(input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
 
         where:
         input                    | className                 | methodName            | match
@@ -52,7 +53,8 @@ class TestSelectionMatcherTest extends Specification {
     }
 
     def "knows if test matches"() {
-        expect: new TestSelectionMatcher(input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
 
         where:
         input                    | className                 | methodName            | match
@@ -77,7 +79,8 @@ class TestSelectionMatcherTest extends Specification {
     }
 
     def "matches any of input"() {
-        expect: new TestSelectionMatcher(input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
 
         where:
         input                               | className                 | methodName            | match
@@ -103,7 +106,8 @@ class TestSelectionMatcherTest extends Specification {
     }
 
     def "regexp chars are handled"() {
-        expect: new TestSelectionMatcher(input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
 
         where:
         input                               | className                 | methodName            | match
@@ -114,7 +118,8 @@ class TestSelectionMatcherTest extends Specification {
     }
 
     def "handles null test method"() {
-        expect: new TestSelectionMatcher(input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
 
         where:
         input                               | className                 | methodName            | match
@@ -125,5 +130,14 @@ class TestSelectionMatcherTest extends Specification {
         ["FooTest"]                         | "OtherTest"               | null                  | false
         ["FooTest.test"]                    | "FooTest"                 | null                  | false
         ["FooTest.null"]                    | "FooTest"                 | null                  | false
+    }
+
+    def "script includes and command line includes both have to match"() {
+        expect: new TestSelectionMatcher(input, inputCommandLine).matchesTest(className, methodName) == match
+
+        where:
+        input               | inputCommandLine | className  | methodName | match
+        ["FooTest", "Bar" ] | []               | "FooTest"  | "whatever" | true
+        ["FooTest"]         | ["Bar"]          | "FooTest"  | "whatever" | false
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
@@ -22,11 +22,13 @@ public class JUnitSpec implements Serializable {
     private final Set<String> includeCategories;
     private final Set<String> excludeCategories;
     private final Set<String> includedTests;
+    private final Set<String> includedTestsCommandLine;
 
-    public JUnitSpec(Set<String> includeCategories, Set<String> excludeCategories, Set<String> includedTests) {
+    public JUnitSpec(Set<String> includeCategories, Set<String> excludeCategories, Set<String> includedTests, Set<String> includedTestsCommandLine) {
         this.includeCategories = includeCategories;
         this.excludeCategories = excludeCategories;
         this.includedTests = includedTests;
+        this.includedTestsCommandLine = includedTestsCommandLine;
     }
 
     public Set<String> getIncludeCategories() {
@@ -43,5 +45,9 @@ public class JUnitSpec implements Serializable {
 
     public Set<String> getIncludedTests() {
         return includedTests;
+    }
+
+    public Set<String> getIncludedTestsCommandLine() {
+        return includedTestsCommandLine;
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecuter.java
@@ -85,8 +85,8 @@ public class JUnitTestClassExecuter {
         Request request = Request.aClass(testClass);
         Runner runner = request.getRunner();
 
-        if (!options.getIncludedTests().isEmpty()) {
-            TestSelectionMatcher matcher = new TestSelectionMatcher(options.getIncludedTests());
+        if (!options.getIncludedTests().isEmpty() || !options.getIncludedTestsCommandLine().isEmpty()) {
+            TestSelectionMatcher matcher = new TestSelectionMatcher(options.getIncludedTests(), options.getIncludedTestsCommandLine());
 
             // For test suites (including suite-like custom Runners), if the test suite class
             // matches the filter, run the entire suite instead of filtering away its contents.

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -45,7 +45,7 @@ public class JUnitTestFramework implements TestFramework {
 
     @Override
     public WorkerTestClassProcessorFactory getProcessorFactory() {
-        return new TestClassProcessorFactoryImpl(new JUnitSpec(options.getIncludeCategories(), options.getExcludeCategories(), filter.getIncludePatterns()));
+        return new TestClassProcessorFactoryImpl(new JUnitSpec(options.getIncludeCategories(), options.getExcludeCategories(), filter.getIncludePatterns(), filter.getCommandLineIncludePatterns()));
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
@@ -34,6 +34,7 @@ public class TestNGSpec implements Serializable {
     private final Set<String> excludeGroups;
     private final Set<String> listeners;
     private final Set<String> includedTests;
+    private final Set<String> includedTestsCommandLine;
     private final String configFailurePolicy;
     private final boolean preserveOrder;
     private final boolean groupByInstances;
@@ -48,6 +49,7 @@ public class TestNGSpec implements Serializable {
         this.excludeGroups = options.getExcludeGroups();
         this.listeners = options.getListeners();
         this.includedTests = filter.getIncludePatterns();
+        this.includedTestsCommandLine = filter.getCommandLineIncludePatterns();
         this.configFailurePolicy = options.getConfigFailurePolicy();
         this.preserveOrder = options.getPreserveOrder();
         this.groupByInstances = options.getGroupByInstances();
@@ -87,6 +89,10 @@ public class TestNGSpec implements Serializable {
 
     public Set<String> getIncludedTests() {
         return includedTests;
+    }
+
+    public Set<String> getIncludedTestsCommandLine() {
+        return includedTestsCommandLine;
     }
 
     public String getConfigFailurePolicy() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -116,8 +116,8 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
             }
         }
 
-        if (!options.getIncludedTests().isEmpty()) {
-            testNg.addListener(new SelectedTestsFilter(options.getIncludedTests()));
+        if (!options.getIncludedTests().isEmpty() || !options.getIncludedTestsCommandLine().isEmpty()) {
+            testNg.addListener(new SelectedTestsFilter(options.getIncludedTests(), options.getIncludedTestsCommandLine()));
         }
 
         if (!suiteFiles.isEmpty()) {
@@ -149,8 +149,8 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
 
         private final TestSelectionMatcher matcher;
 
-        public SelectedTestsFilter(Set<String> includedTests) {
-            matcher = new TestSelectionMatcher(includedTests);
+        public SelectedTestsFilter(Set<String> includedTests, Set<String> includedTestsCommandLine) {
+            matcher = new TestSelectionMatcher(includedTests, includedTestsCommandLine);
         }
 
         @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -622,8 +622,8 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
         TestEventLogger eventLogger = new TestEventLogger(getTextOutputFactory(), currentLevel, levelLogging, exceptionFormatter);
         addTestListener(eventLogger);
         addTestOutputListener(eventLogger);
-        if (getFilter().isFailOnNoMatchingTests() && !getFilter().getIncludePatterns().isEmpty()) {
-            addTestListener(new NoMatchingTestsReporter("No tests found for given includes: " + getFilter().getIncludePatterns()));
+        if (getFilter().isFailOnNoMatchingTests() && (!getFilter().getIncludePatterns().isEmpty() || !filter.getCommandLineIncludePatterns().isEmpty())) {
+            addTestListener(new NoMatchingTestsReporter(createNoMatchingTestErrorMessage()));
         }
 
         File binaryResultsDir = getBinResultsDir();
@@ -701,6 +701,23 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
         if (testCountLogger.hadFailures()) {
             handleTestFailures();
         }
+    }
+
+    private String createNoMatchingTestErrorMessage() {
+        String msg = "No tests found for given includes: ";
+        if (!getIncludes().isEmpty()) {
+            msg += getIncludes() + "(include rules) ";
+        }
+        if (!getExcludes().isEmpty()) {
+            msg += getExcludes() + "(exclude rules) ";
+        }
+        if (!filter.getIncludePatterns().isEmpty()) {
+            msg += filter.getIncludePatterns() + "(filter.includeTestsMatching) ";
+        }
+        if (!filter.getCommandLineIncludePatterns().isEmpty()) {
+            msg += filter.getCommandLineIncludePatterns() + "(--tests filter) ";
+        }
+        return msg;
     }
 
     /**
@@ -898,7 +915,7 @@ public class Test extends ConventionTask implements JavaForkOptions, PatternFilt
     @Option(option = "tests", description = "Sets test class or method name to be included, '*' is supported.")
     @Incubating
     public Test setTestNameIncludePatterns(List<String> testNamePattern) {
-        filter.setIncludePatterns(testNamePattern.toArray(new String[]{}));
+        filter.setCommandLineIncludePatterns(testNamePattern);
         return this;
     }
 

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
@@ -34,7 +34,7 @@ class JUnitTestClassProcessorTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
 
     def processor = Mock(TestResultProcessor)
-    def spec = new JUnitSpec([] as Set, [] as Set, [] as Set)
+    def spec = new JUnitSpec([] as Set, [] as Set, [] as Set, [] as Set)
 
     @Subject classProcessor = withSpec(spec)
 
@@ -221,7 +221,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes specific method"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithSeveralMethods.name + ".pass"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithSeveralMethods.name + ".pass"] as Set, [] as Set))
 
         when: process(ATestClassWithSeveralMethods)
 
@@ -234,7 +234,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     def "executes multiple specific methods"() {
         classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithSeveralMethods.name + ".pass",
-                ATestClassWithSeveralMethods.name + ".pass2"] as Set))
+                ATestClassWithSeveralMethods.name + ".pass2"] as Set, [] as Set))
 
         when: process(ATestClassWithSeveralMethods)
 
@@ -246,7 +246,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes methods from multiple classes by pattern"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*Methods.*Slowly*"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*Methods.*Slowly*"] as Set, [] as Set))
 
         when: process(ATestClassWithSeveralMethods, ATestClassWithSlowMethods, ATestClass)
 
@@ -261,7 +261,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes all tests for class with test runner that is not filterable when any test description matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithRunner.name + ".ok"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithRunner.name + ".ok"] as Set, [] as Set))
 
         when: process(ATestClassWithRunner)
 
@@ -276,7 +276,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "does not execute class with test runner that is not filterable when no test description matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithRunner.name + ".ignoreme"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithRunner.name + ".ignoreme"] as Set, [] as Set))
 
         when: process(ATestClassWithRunner)
 
@@ -286,7 +286,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes no methods when method name does not match"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["does not exist"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["does not exist"] as Set, [] as Set))
 
         when: process(ATestClassWithSeveralMethods)
 
@@ -296,7 +296,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes all tests within a JUnit 3 suite when the suite class name matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestClassWithSuiteMethod"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestClassWithSuiteMethod"] as Set, [] as Set))
 
         //Run tests in ATestClassWithSuiteMethod only
         when: process(ATestClassWithSuiteMethod, ATestSuite)
@@ -313,7 +313,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes all tests within a suite when the suite class name matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestSuite"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestSuite"] as Set, [] as Set))
 
         //Run tests in ATestSuite only
         when: process(ATestClassWithSuiteMethod, ATestSuite)
@@ -332,7 +332,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes all tests within a custom runner suite class name matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ACustomSuite"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ACustomSuite"] as Set, [] as Set))
 
         //Run tests in ATestSuite only
         when: process(ATestClassWithSuiteMethod, ACustomSuite)
@@ -351,7 +351,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "attempting to filter methods on a suite does NOT work"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestSuite.ok*"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestSuite.ok*"] as Set, [] as Set))
 
         //Doesn't run any tests
         when: process(ATestClassWithSuiteMethod, ATestSuite)
@@ -365,7 +365,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "has no errors when dealing with an empty suite"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AnEmptyTestSuite"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AnEmptyTestSuite"] as Set, [] as Set))
 
         //Run tests in AnEmptyTestSuite (e.g. no tests)
         when: process(AnEmptyTestSuite)
@@ -377,7 +377,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be run with a class-level filter"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest"] as Set, [] as Set))
 
         when: process(AParameterizedTest)
 
@@ -397,7 +397,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be filtered by method name"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.helpfulTest*"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.helpfulTest*"] as Set, [] as Set))
 
         when: process(AParameterizedTest)
 
@@ -413,7 +413,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be filtered by iteration only."() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.*[1]"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.*[1]"] as Set, [] as Set))
 
         when: process(AParameterizedTest)
 
@@ -429,7 +429,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be filtered by full method name"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.helpfulTest[1]"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.helpfulTest[1]"] as Set, [] as Set))
 
         when: process(AParameterizedTest)
 
@@ -443,7 +443,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be empty"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AnEmptyParameterizedTest"] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AnEmptyParameterizedTest"] as Set, [] as Set))
 
         when: process(AnEmptyParameterizedTest)
 


### PR DESCRIPTION
This is a follow up/alternative to #2172. As discussed here (https://github.com/gradle/gradle/issues/1571#issuecomment-309057188), instead of making `--tests` override more things than before, we make sure that `--tests` never overrides any filters defined in the build scripts. Thus, also reaching a consistent behavior as fix for #1571. 

This PR also improves the [error message for the _not test matches_ case](https://github.com/gradle/gradle/issues/1571#issuecomment-309057188).
 

This PR includes adjustment to the [test filtering documentation](https://github.com/gradle/gradle/blob/2043a96ac11d588b19143f2d680eb977464db655/subprojects/docs/src/docs/userguide/javaPlugin.adoc#test-filtering), which is part of the _Java plugin_ user guide. It now states:
> Command line option “--tests” is provided to conveniently extend the test filter for an individual Gradle execution. This is especially useful for the classic 'single test method execution' use case. When the command line option is used, the inclusions declared in the build script are still honored. That is, the command line filters are always applied on top of the filter definition in the build script. It is possible to supply multiple “--tests” options and tests matching any of those patterns will be included.