### PR TITLE
Fix conditional logic bug

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -155,7 +155,7 @@ public class JavaCompilerArgumentsBuilder {
         }
 
         FileCollection sourcepath = compileOptions.getSourcepath();
-        if (!noEmptySourcePath || sourcepath != null && sourcepath.isEmpty()) {
+        if (!noEmptySourcePath || sourcepath != null && !sourcepath.isEmpty()) {
             args.add("-sourcepath");
             args.add(sourcepath == null ? "" : sourcepath.getAsPath());
         }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -319,6 +319,7 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
 
         expect:
         builder.build() == ["-g", "-sourcepath", fc.asPath, "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
+        builder.noEmptySourcePath().build() == ["-g", "-sourcepath", fc.asPath, "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
     }
 
     String defaultEmptySourcePathRefFolder() {


### PR DESCRIPTION
The idea of the if statement in the code is that we should only be
setting the `-sourcepath` argument when there is sourcepath specified
in the `compileOptions`,
(i.e. `sourcepath != null && !sourcepath.isEmpty()`) or when we are
okay setting an explicitly empty `-sourcepath`
argument (i.e. `!noEmptySourcePath`)

Before this change, if a user called `noEmptySourcepath()` then we
would not be setting the sourcepath even if it was not empty.
