### PR TITLE
Deprecate incubating sourcepath from ComileOptions

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -148,10 +148,9 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
                             // When annotation processing isn't required, it's better to add the Groovy stubs as part of the source path.
                             // This allows compilations to complete faster, because only the Groovy stubs that are needed by the java source are compiled.
                             FileCollection sourcepath = new SimpleFileCollection(stubDir);
-                            if (spec.getCompileOptions().getSourcepath() != null) {
-                                sourcepath = spec.getCompileOptions().getSourcepath().plus(sourcepath);
-                            }
-                            spec.getCompileOptions().setSourcepath(sourcepath);
+                            List<String> args = spec.getCompileOptions().getCompilerArgs();
+                            args.add("-sourcepath");
+                            args.add(sourcepath.getAsPath());
                         }
 
                         spec.setSource(spec.getSource().filter(new Spec<File>() {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpec.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpec.java
@@ -43,4 +43,9 @@ public class DefaultGroovyJavaJointCompileSpec extends DefaultJavaCompileSpec im
     public void setGroovyClasspath(List<File> groovyClasspath) {
         this.groovyClasspath = groovyClasspath;
     }
+
+    @Override
+    public boolean respectsSourcepath() {
+        return true;
+    }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -70,7 +70,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         // This makes sure the test above is correct AND you can get back javac's default behavior if needed
         when:
         buildFile << "project(':b').compileJava { options.sourcepath = classpath }"
-        run("compileJava")
+        executer.noDeprecationChecks().withTasks("compileJava").run()
         then:
         file("b/build/classes/java/main/Bar.class").exists()
         file("b/build/classes/java/main/Foo.class").exists()

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
@@ -43,4 +43,9 @@ public class DefaultJavaCompileSpec extends DefaultJvmLanguageCompileSpec implem
     public void setAnnotationProcessorPath(List<File> annotationProcessorPath) {
         this.annotationProcessorPath = annotationProcessorPath;
     }
+
+    @Override
+    public boolean respectsSourcepath() {
+        return false;
+    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
@@ -33,4 +33,20 @@ public interface JavaCompileSpec extends JvmLanguageCompileSpec {
     List<File> getAnnotationProcessorPath();
 
     void setAnnotationProcessorPath(List<File> path);
+
+    /**
+     * Whether or not the {@link javax.tools.JavaCompiler} should allow the following two things.
+     * <ul>
+     *     <li>Specifying a <code>-sourcepath</code> command line argument.</li>
+     *     <li>Find implicit sources on the sourcepath.</li>
+     * </ul>
+     * <p>
+     * If this is false for a spec and an empty <code>-sourcepath</code> argument to the compiler,
+     * and silently remove any <code>-sourcepath</code> options and the argument to that option from
+     * {@link CompileOptions#getCompilerArgs()}.
+     * <p>
+     * For Java 9 compilation, the default behavior is to omit the <code>-sourcepath</code> element entirely when
+     * there is a <code>module-info.java</code> in the {@link JvmLanguageCompileSpec#getSource()} file collection.
+     */
+    boolean respectsSourcepath();
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -155,7 +155,7 @@ public class JavaCompilerArgumentsBuilder {
         }
 
         FileCollection sourcepath = compileOptions.getSourcepath();
-        if (!noEmptySourcePath || sourcepath != null && sourcepath.isEmpty()) {
+        if (!noEmptySourcePath || sourcepath != null && !sourcepath.isEmpty()) {
             args.add("-sourcepath");
             args.add(sourcepath == null ? "" : sourcepath.getAsPath());
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -19,14 +19,25 @@ package org.gradle.api.internal.tasks.compile;
 import com.google.common.base.Joiner;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
+import org.gradle.internal.Factory;
+import org.gradle.internal.jvm.Jvm;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class JavaCompilerArgumentsBuilder {
+    private static final Pattern SOURCEPATH_ARGUMENT = Pattern.compile("-{1,2}source-?path");
+    private static final String SOURCEPATH_WARNING = "Gradle does not support passing a custom sourcepath to javac. Removing:";
+
+    public static final Logger LOGGER = Logging.getLogger(JavaCompilerArgumentsBuilder.class);
     public static final String USE_UNSHARED_COMPILER_TABLE_OPTION = "-XDuseUnsharedTable=true";
     public static final String EMPTY_SOURCE_PATH_REF_DIR = "emptySourcePathRef";
 
@@ -103,7 +114,7 @@ public class JavaCompilerArgumentsBuilder {
             return;
         }
 
-        CompileOptions compileOptions = spec.getCompileOptions();
+        final CompileOptions compileOptions = spec.getCompileOptions();
         List<String> compilerArgs = compileOptions.getCompilerArgs();
         if (!releaseOptionIsSet(compilerArgs)) {
             String sourceCompatibility = spec.getSourceCompatibility();
@@ -154,7 +165,16 @@ public class JavaCompilerArgumentsBuilder {
             args.add("-g:none");
         }
 
-        FileCollection sourcepath = compileOptions.getSourcepath();
+        FileCollection sourcepath = DeprecationLogger.whileDisabled(new Factory<FileCollection>() {
+            @Override
+            @SuppressWarnings("deprecation")
+            public FileCollection create() {
+                return compileOptions.getSourcepath();
+            }
+        });
+        if (Jvm.current().getJavaVersion().isJava9Compatible() && containsModuleDescriptor(spec.getSource())) {
+            noEmptySourcePath();
+        }
         if (!noEmptySourcePath || sourcepath != null && !sourcepath.isEmpty()) {
             args.add("-sourcepath");
             args.add(sourcepath == null ? "" : sourcepath.getAsPath());
@@ -188,6 +208,9 @@ public class JavaCompilerArgumentsBuilder {
 
         List<String> compilerArgs = spec.getCompileOptions().getCompilerArgs();
         if (compilerArgs != null) {
+            if (!spec.respectsSourcepath()) {
+                stripSourcePath(compilerArgs);
+            }
             args.addAll(compilerArgs);
         }
     }
@@ -214,5 +237,31 @@ public class JavaCompilerArgumentsBuilder {
         for (File file : spec.getSource()) {
             args.add(file.getPath());
         }
+    }
+
+    private static void stripSourcePath(List<String> args) {
+        Iterator<String> i = args.iterator();
+        while(i.hasNext()) {
+            String arg = i.next();
+            if (SOURCEPATH_ARGUMENT.matcher(arg).matches()) {
+                i.remove();
+                if (i.hasNext()) {
+                    String next = i.next();
+                    LOGGER.warn("{} {} {}.", SOURCEPATH_WARNING, arg, next);
+                    i.remove();
+                } else {
+                    LOGGER.warn("{} {}.", SOURCEPATH_WARNING, arg);
+                }
+            }
+        }
+    }
+
+    private boolean containsModuleDescriptor(FileCollection source) {
+        for (File f : source) {
+            if (f.getName().equals("module-info.java")) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -29,6 +29,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ import java.util.Map;
  */
 public class CompileOptions extends AbstractOptions {
     private static final long serialVersionUID = 0;
+    private static final String SOURCEPATH_DEPRECATION_MESSAGE = "Specify all the sources needed for compilation in the \"source\" FileCollection.";
 
     private static final ImmutableSet<String> EXCLUDE_FROM_ANT_PROPERTIES =
             ImmutableSet.of("debugOptions", "forkOptions", "compilerArgs", "incremental");
@@ -383,6 +385,7 @@ public class CompileOptions extends AbstractOptions {
     @Deprecated
     @Incubating
     public FileCollection getSourcepath() {
+        DeprecationLogger.nagUserOfDiscontinuedProperty("sourcepath", SOURCEPATH_DEPRECATION_MESSAGE);
         return sourcepath;
     }
 
@@ -398,6 +401,7 @@ public class CompileOptions extends AbstractOptions {
     @Deprecated
     @Incubating
     public void setSourcepath(FileCollection sourcepath) {
+        DeprecationLogger.nagUserOfDiscontinuedProperty("sourcepath", SOURCEPATH_DEPRECATION_MESSAGE);
         this.sourcepath = sourcepath;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -373,12 +373,14 @@ public class CompileOptions extends AbstractOptions {
      * Note that this is different to the default value for the {@code -sourcepath} option for {@code javac}, which is to use the value specified by {@code -classpath}.
      * If you wish to use any source path, it must be explicitly set.
      *
+     * @deprecated See: #setSourcePath(FileCollection) for deprecation reason.
      * @return the source path
      * @see #setSourcepath(FileCollection)
      */
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     @Optional
+    @Deprecated
     @Incubating
     public FileCollection getSourcepath() {
         return sourcepath;
@@ -387,8 +389,13 @@ public class CompileOptions extends AbstractOptions {
     /**
      * Sets the source path to use for the compilation.
      *
+     * @deprecated you can still set sourcepath using #setCompilerArgs(), but some compile tasks
+     *     (e.g. {@link JavaCompile}) will throw an exception if a sourcepath argument is set.
+     *     Given the rich semantics of the {@link JavaCompile#setSource(Object)} method, users
+     *     really shouldn't need to set the sourcepath.
      * @param sourcepath the source path
      */
+    @Deprecated
     @Incubating
     public void setSourcepath(FileCollection sourcepath) {
         this.sourcepath = sourcepath;

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -322,6 +322,14 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         builder.noEmptySourcePath().build() == ["-g", "-sourcepath", fc.asPath, "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
     }
 
+    def "strips user-supplied -sourcepath args"() {
+        given:
+        spec.compileOptions.compilerArgs = ["-d", "some/other/directory", "-sourcepath", "some/source/path", "--source-path", "and/another", "-sourcepath"]
+
+        expect:
+        builder.build() == ["-g", "-sourcepath", "", "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", "", "-d", "some/other/directory"]
+    }
+
     String defaultEmptySourcePathRefFolder() {
         new File(spec.tempDir, JavaCompilerArgumentsBuilder.EMPTY_SOURCE_PATH_REF_DIR).absolutePath
     }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -319,6 +319,7 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
 
         expect:
         builder.build() == ["-g", "-sourcepath", fc.asPath, "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
+        builder.noEmptySourcePath().build() == ["-g", "-sourcepath", fc.asPath, "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
     }
 
     String defaultEmptySourcePathRefFolder() {


### PR DESCRIPTION
The sourcepath property of CompileOptions really should not ever be
necessary for Java compilation. It's also of dubious value for any
compilation task given our ability to model the complete set of
sources in the Gradle DSL.

There is a performance optimiztion used by the `ApiGroovyCompiler`
which is an exception to the above statement about not setting the
sourcepath, but that code can be updated to set the sourcepath
command-line option directly in the `CompileOptions.compilerArgs`
array and we can use some other mechanism to communicate between
the `ApiGroovyCompiler` and the `Compiler<JavaCompileSpec>` used
by the `ApiGroovyCompiler` to communicate that in this case it
makes sense to respect the `sourcepath` argument.
