### PR TITLE
Fix sample usage of -Dtest.single on subproject

### DIFF
--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -829,7 +829,7 @@ Setting a system property of __taskName.single__ = __testNamePattern__ will only
 * `gradle -Dtest.single=a/b/ test`
 * `gradle -DintegTest.single=\*IntegrationTest integTest`
 * `gradle -D:proj1:test.single=ThisUniquelyNamedTest build`
-* `gradle -DintegTest.single=c/d/ :proj1:integTest`
+* `gradle -D:proj1:integTest.single=c/d/`
 
 
 [[sec:test_detection]]

--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -828,7 +828,7 @@ Setting a system property of __taskName.single__ = __testNamePattern__ will only
 * `gradle -Dtest.single=ThisUniquelyNamedTest test`
 * `gradle -Dtest.single=a/b/ test`
 * `gradle -DintegTest.single=\*IntegrationTest integTest`
-* `gradle -Dtest.single=:proj1:test:Customer build`
+* `gradle -D:proj1:test.single=ThisUniquelyNamedTest build`
 * `gradle -DintegTest.single=c/d/ :proj1:integTest`
 
 

--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -828,7 +828,7 @@ Setting a system property of __taskName.single__ = __testNamePattern__ will only
 * `gradle -Dtest.single=ThisUniquelyNamedTest test`
 * `gradle -Dtest.single=a/b/ test`
 * `gradle -DintegTest.single=\*IntegrationTest integTest`
-* `gradle -D:proj1:test.single=ThisUniquelyNamedTest build`
+* `gradle -D:proj1:test.single=Customer build`
 * `gradle -D:proj1:integTest.single=c/d/`
 
 


### PR DESCRIPTION
Minor change in the userguide, sample is different from the description about -Dtest.single .
One should specify subproject path on the task name not on the filter name.
