### PR TITLE
Report removed outputs as REMOVED

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderInsensitiveTaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderInsensitiveTaskFilePropertyCompareStrategy.java
@@ -37,6 +37,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import static org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy.getChangeType;
+
 class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropertyCompareStrategy.Impl {
 
     private static final Comparator<Entry<NormalizedFileSnapshot, IncrementalFileSnapshotWithAbsolutePath>> ENTRY_COMPARATOR = new Comparator<Entry<NormalizedFileSnapshot, IncrementalFileSnapshotWithAbsolutePath>>() {
@@ -83,7 +85,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
                         NormalizedFileSnapshot previousNormalizedSnapshot = previous.get(currentAbsolutePath);
                         FileContentSnapshot previousSnapshot = previousNormalizedSnapshot.getSnapshot();
                         if (!currentSnapshot.isContentUpToDate(previousSnapshot)) {
-                            return new FileChange(currentAbsolutePath, ChangeType.MODIFIED, fileType);
+                            return new FileChange(currentAbsolutePath, getChangeType(previousSnapshot, currentSnapshot), fileType);
                         }
                         // else, unchanged; check next file
                     } else {
@@ -142,7 +144,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
                         IncrementalFileSnapshotWithAbsolutePath previousSnapshotWithAbsolutePath = previousSnapshotsForNormalizedPath.remove(0);
                         FileContentSnapshot previousSnapshot = previousSnapshotWithAbsolutePath.getSnapshot();
                         if (!currentSnapshot.isContentUpToDate(previousSnapshot)) {
-                            return new FileChange(currentAbsolutePath, ChangeType.MODIFIED, fileType);
+                            return new FileChange(currentAbsolutePath, getChangeType(previousSnapshot, currentSnapshot), fileType);
                         }
                     }
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderSensitiveTaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderSensitiveTaskFilePropertyCompareStrategy.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 
+import static org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy.getChangeType;
+
 class OrderSensitiveTaskFilePropertyCompareStrategy implements TaskFilePropertyCompareStrategy.Impl {
 
     @Override
@@ -57,7 +59,11 @@ class OrderSensitiveTaskFilePropertyCompareStrategy implements TaskFilePropertyC
                                 if (normalizedSnapshot.getSnapshot().isContentUpToDate(otherNormalizedSnapshot.getSnapshot())) {
                                     continue;
                                 } else {
-                                    return new FileChange(absolutePath, ChangeType.MODIFIED, fileType);
+                                    return new FileChange(
+                                        absolutePath,
+                                        getChangeType(otherNormalizedSnapshot.getSnapshot(), normalizedSnapshot.getSnapshot()),
+                                        fileType
+                                    );
                                 }
                             } else {
                                 String otherAbsolutePath = other.getKey();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategy.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import org.gradle.api.internal.changedetection.rules.ChangeType;
 import org.gradle.api.internal.changedetection.rules.FileChange;
@@ -35,6 +36,18 @@ public enum TaskFilePropertyCompareStrategy {
     ORDERED(new OrderSensitiveTaskFilePropertyCompareStrategy()),
     UNORDERED(new OrderInsensitiveTaskFilePropertyCompareStrategy(true)),
     OUTPUT(new OrderInsensitiveTaskFilePropertyCompareStrategy(false));
+
+    static ChangeType getChangeType(FileContentSnapshot previous, FileContentSnapshot current) {
+        boolean previousMissing = previous instanceof MissingFileContentSnapshot;
+        boolean currentMissing = current instanceof MissingFileContentSnapshot;
+        Preconditions.checkState(!(previousMissing && currentMissing), "snapshots need to be different in order to determine change type, but both missing");
+        if (previousMissing) {
+            return ChangeType.ADDED;
+        } else if (currentMissing) {
+            return ChangeType.REMOVED;
+        }
+        return ChangeType.MODIFIED;
+    }
 
     private final Impl delegate;
 
@@ -118,7 +131,7 @@ public enum TaskFilePropertyCompareStrategy {
             FileContentSnapshot currentSnapshot = normalizedCurrent.getSnapshot();
             if (!currentSnapshot.isContentUpToDate(previousSnapshot)) {
                 String path = currentEntry.getKey();
-                TaskStateChange change = new FileChange(path, ChangeType.MODIFIED, fileType);
+                TaskStateChange change = new FileChange(path, getChangeType(previousSnapshot, currentSnapshot), fileType);
                 return singletonIterator(change);
             } else {
                 return emptyIterator();

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
@@ -256,7 +256,7 @@ class DefaultTaskArtifactStateRepositoryTest extends AbstractProjectBuilderSpec 
         inputFile.delete()
 
         then:
-        inputsOutOfDate(task).withModifiedFile(inputFile)
+        inputsOutOfDate(task).withRemovedFile(inputFile)
     }
 
     def artifactsAreNotUpToDateWhenAnyInputFileDidNotExistAndNowDoes() {
@@ -268,7 +268,7 @@ class DefaultTaskArtifactStateRepositoryTest extends AbstractProjectBuilderSpec 
         inputFile.createNewFile()
 
         then:
-        inputsOutOfDate(task).withModifiedFile(inputFile)
+        inputsOutOfDate(task).withAddedFile(inputFile)
     }
 
     def artifactsAreNotUpToDateWhenAnyFileCreatedInInputDir() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategyTest.groovy
@@ -26,9 +26,9 @@ import spock.lang.Unroll
 import static org.gradle.api.internal.changedetection.rules.ChangeType.*
 import static org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy.*
 
+@Unroll
 class TaskFilePropertyCompareStrategyTest extends Specification {
 
-    @Unroll
     def "empty snapshots (#strategy)"() {
         expect:
         changes(strategy,
@@ -40,7 +40,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         strategy << [ORDERED, UNORDERED, OUTPUT]
     }
 
-    @Unroll
     def "trivial addition (#strategy)"() {
         expect:
         changes(strategy,
@@ -55,7 +54,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         OUTPUT    | []
     }
 
-    @Unroll
     def "non-trivial addition (#strategy)"() {
         expect:
         changes(strategy,
@@ -70,7 +68,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         OUTPUT    | []
     }
 
-    @Unroll
     def "non-trivial addition with absolute paths (#strategy)"() {
         expect:
         changesUsingAbsolutePaths(strategy,
@@ -85,7 +82,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         OUTPUT    | []
     }
 
-    @Unroll
     def "trivial removal (#strategy)"() {
         expect:
         changes(strategy,
@@ -97,7 +93,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         strategy << [ORDERED, UNORDERED, OUTPUT]
     }
 
-    @Unroll
     def "non-trivial removal (#strategy)"() {
         expect:
         changes(strategy,
@@ -109,7 +104,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         strategy << [ORDERED, UNORDERED, OUTPUT]
     }
 
-    @Unroll
     def "non-trivial removal with absolute paths (#strategy)"() {
         expect:
         changesUsingAbsolutePaths(strategy,
@@ -121,7 +115,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         strategy << [ORDERED, UNORDERED, OUTPUT]
     }
 
-    @Unroll
     def "non-trivial modification (#strategy)"() {
         expect:
         changes(strategy,
@@ -133,7 +126,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         strategy << [ORDERED, UNORDERED, OUTPUT]
     }
 
-    @Unroll
     def "non-trivial modification with absolute paths (#strategy)"() {
         expect:
         changesUsingAbsolutePaths(strategy,
@@ -145,7 +137,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         strategy << [ORDERED, UNORDERED, OUTPUT]
     }
 
-    @Unroll
     def "trivial replacement (#strategy)"() {
         expect:
         changes(strategy,
@@ -154,13 +145,12 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         ) as List == results
 
         where:
-        strategy | results
+        strategy  | results
         ORDERED   | [new FileChange("one-old", REMOVED, "test"), new FileChange("two-new", ADDED, "test")]
         UNORDERED | [new FileChange("one-old", REMOVED, "test"), new FileChange("two-new", ADDED, "test")]
         OUTPUT    | [new FileChange("one-old", REMOVED, "test")]
     }
 
-    @Unroll
     def "non-trivial replacement (#strategy)"() {
         expect:
         changes(strategy,
@@ -175,7 +165,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         OUTPUT    | [change("three-old", REMOVED)]
     }
 
-    @Unroll
     def "non-trivial replacement with absolute paths (#strategy)"() {
         expect:
         changesUsingAbsolutePaths(strategy,
@@ -190,7 +179,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         OUTPUT    | [change("three", REMOVED)]
     }
 
-    @Unroll
     def "reordering (#strategy)"() {
         expect:
         changes(strategy,
@@ -199,13 +187,12 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         ) == results
 
         where:
-        strategy | results
+        strategy  | results
         ORDERED   | [change("three-old", REMOVED), change("two-new", ADDED), change("two-old", REMOVED), change("three-new", ADDED)]
         UNORDERED | []
         OUTPUT    | []
     }
 
-    @Unroll
     def "reordering with absolute paths (#strategy)"() {
         expect:
         changesUsingAbsolutePaths(strategy,
@@ -214,13 +201,12 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         ) == results
 
         where:
-        strategy | results
+        strategy  | results
         ORDERED   | [change("three", REMOVED), change("two", ADDED), change("two", REMOVED), change("three", ADDED)]
         UNORDERED | []
         OUTPUT    | []
     }
 
-    @Unroll
     def "handling duplicates (#strategy)"() {
         expect:
         changes(strategy,
@@ -232,7 +218,6 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         strategy << [ORDERED, UNORDERED, OUTPUT]
     }
 
-    @Unroll
     def "too many elements not handled by trivial comparison (#current.size() current vs #previous.size() previous)"() {
         expect:
         compareTrivialSnapshots(current, previous, "test", true) == null
@@ -244,6 +229,19 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         ["one": snapshot("one"), "two": snapshot("two")] | [:]
     }
 
+    def "change type for #previous to #current is #changeType"() {
+        expect:
+        getChangeType(previous, current) == changeType
+
+        where:
+        previous                            | current                             | changeType
+        contentSnapshot()                   | contentSnapshot("5678abcd")         | MODIFIED
+        MissingFileContentSnapshot.instance | contentSnapshot()                   | ADDED
+        contentSnapshot()                   | MissingFileContentSnapshot.instance | REMOVED
+        DirContentSnapshot.instance         | MissingFileContentSnapshot.instance | REMOVED
+        MissingFileContentSnapshot.instance | DirContentSnapshot.instance         | ADDED
+    }
+
     def changes(TaskFilePropertyCompareStrategy strategy, Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous) {
         Lists.newArrayList(strategy.iterateContentChangesSince(current, previous, "test", false))
     }
@@ -253,7 +251,11 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     def snapshot(String normalizedPath, String hashCode = "1234abcd") {
-        return new DefaultNormalizedFileSnapshot(normalizedPath, new FileHashSnapshot(HashCode.fromString(hashCode)))
+        return new DefaultNormalizedFileSnapshot(normalizedPath, contentSnapshot(hashCode))
+    }
+
+    def contentSnapshot(String hashCode = "1234abcd") {
+        return new FileHashSnapshot(HashCode.fromString(hashCode))
     }
 
     def change(String path, ChangeType type) {


### PR DESCRIPTION
When a file changes from File/Directory to Missing, then we report the
changes as `MODIFIED`. We should better report this change as
`ADDED`/`REMOVED`.
