### PR TITLE
Fix typo on S3 AwsImAuthentication Log

### DIFF
--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
@@ -96,7 +96,7 @@ repositories {
         fails 'retrieve'
         then:
         failure.assertHasDescription("Could not resolve all dependencies for configuration ':compile'.")
-                .assertHasCause("S3 resource should either specify AwsIamAutentication or provide some AwsCredentials.")
+                .assertHasCause("S3 resource should either specify AwsImAuthentication or provide some AwsCredentials.")
 
     }
 

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactory.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactory.java
@@ -64,6 +64,6 @@ public class S3ConnectorFactory implements ResourceConnectorFactory {
             }
         }
 
-        throw new IllegalArgumentException("S3 resource should either specify AwsIamAutentication or provide some AwsCredentials.");
+        throw new IllegalArgumentException("S3 resource should either specify AwsImAuthentication or provide some AwsCredentials.");
     }
 }


### PR DESCRIPTION
This fixes a Typo present on the error log message shown when trying to authenticate to AWS S3 with an invalid authentication method.

The error message suggests you have to either specify **AwsIamAutentication** or provide some AwsCredentials

I've run into this when trying to use the suggested **AwsIamAutentication**. As you can see there is a Typo (missing h). Also the correct name, as conforming to the current  Gradle implementation, should be **AwsImAuthentication**, with the **h** and without the **a**. As per here: https://github.com/gradle/gradle/blob/31458868dd76176016df8d4817ca5da548d14d7b/subprojects/resources-s3/src/main/java/org/gradle/authentication/aws/AwsImAuthentication.java.

It took me some time until I figured this out, as you can see it's very tricky to notice :grimacing:

For the future, I think Gradle could use **AwsIamAuthentication** instead to keep consistency with AWS IAM.





