### PR TITLE
Add useful links when build fails

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -211,15 +211,18 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
                 resolution.append(' ');
             }
         }
+        boolean addedScanLink = false;
         if (details.exceptionStyle == ExceptionStyle.NONE) {
             resolution.text("Run with ");
-            maybeAddBuildScan(resolution);
+            addedScanLink = maybeAddBuildScan(resolution);
             resolution.withStyle(UserInput).format("--%s", LoggingCommandLineConverter.STACKTRACE_LONG);
             resolution.text(" option to get the stack trace. ");
         }
         if (loggingConfiguration.getLogLevel() != LogLevel.DEBUG) {
             resolution.text("Run with ");
-            maybeAddBuildScan(resolution);
+            if (!addedScanLink) {
+                maybeAddBuildScan(resolution);
+            }
             if (loggingConfiguration.getLogLevel() != LogLevel.INFO) {
                 resolution.withStyle(UserInput).format("--%s", LoggingCommandLineConverter.INFO_LONG);
                 resolution.text(" or ");
@@ -229,12 +232,14 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
         }
     }
 
-    private void maybeAddBuildScan(BufferingStyledTextOutput resolution) {
+    private boolean maybeAddBuildScan(BufferingStyledTextOutput resolution) {
         // todo: replace this test with something which _effectively_ checks what the status of build scan generation is
         if (gradle == null || gradle.getStartParameter().isNoBuildScan() || !gradle.getStartParameter().isBuildScan()) {
             resolution.withStyle(UserInput).text("--scan");
             resolution.text(" to generate a build scan, ");
+            return true;
         }
+        return false;
     }
 
     private void writeGeneralTips(StyledTextOutput resolution) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -189,11 +189,13 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
         }
         if (details.exceptionStyle == ExceptionStyle.NONE) {
             resolution.text("Run with ");
+            maybeAddBuildScan(resolution);
             resolution.withStyle(UserInput).format("--%s", LoggingCommandLineConverter.STACKTRACE_LONG);
             resolution.text(" option to get the stack trace. ");
         }
         if (loggingConfiguration.getLogLevel() != LogLevel.DEBUG) {
             resolution.text("Run with ");
+            maybeAddBuildScan(resolution);
             if (loggingConfiguration.getLogLevel() != LogLevel.INFO) {
                 resolution.withStyle(UserInput).format("--%s", LoggingCommandLineConverter.INFO_LONG);
                 resolution.text(" or ");
@@ -201,6 +203,11 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
             resolution.withStyle(UserInput).format("--%s", LoggingCommandLineConverter.DEBUG_LONG);
             resolution.text(" option to get more log output.");
         }
+    }
+
+    private void maybeAddBuildScan(BufferingStyledTextOutput resolution) {
+        resolution.withStyle(UserInput).text("--scan");
+        resolution.text(" to generate a build scan, ");
     }
 
     private void writeGeneralTips(StyledTextOutput resolution) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -18,8 +18,6 @@ package org.gradle.internal.buildevents;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.Action;
-import org.gradle.api.initialization.Settings;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
@@ -51,36 +49,13 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
     private final LoggingConfiguration loggingConfiguration;
     private final BuildClientMetaData clientMetaData;
 
-    private Gradle gradle;
-
     public BuildExceptionReporter(StyledTextOutputFactory textOutputFactory, LoggingConfiguration loggingConfiguration, BuildClientMetaData clientMetaData) {
         this.textOutputFactory = textOutputFactory;
         this.loggingConfiguration = loggingConfiguration;
         this.clientMetaData = clientMetaData;
     }
 
-    @Override
-    public void settingsEvaluated(Settings settings) {
-        this.gradle = settings.getGradle();
-    }
-
-    @Override
-    public void projectsLoaded(Gradle gradle) {
-        this.gradle = gradle;
-    }
-
-    @Override
-    public void buildStarted(Gradle gradle) {
-        this.gradle = gradle;
-    }
-
-    @Override
-    public void projectsEvaluated(Gradle gradle) {
-        this.gradle = gradle;
-    }
-
     public void buildFinished(BuildResult result) {
-        this.gradle = result.getGradle();
         Throwable failure = result.getFailure();
         if (failure == null) {
             return;

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -211,18 +211,13 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
                 resolution.append(' ');
             }
         }
-        boolean addedScanLink = false;
         if (details.exceptionStyle == ExceptionStyle.NONE) {
             resolution.text("Run with ");
-            addedScanLink = maybeAddBuildScan(resolution);
             resolution.withStyle(UserInput).format("--%s", LoggingCommandLineConverter.STACKTRACE_LONG);
             resolution.text(" option to get the stack trace. ");
         }
         if (loggingConfiguration.getLogLevel() != LogLevel.DEBUG) {
             resolution.text("Run with ");
-            if (!addedScanLink) {
-                maybeAddBuildScan(resolution);
-            }
             if (loggingConfiguration.getLogLevel() != LogLevel.INFO) {
                 resolution.withStyle(UserInput).format("--%s", LoggingCommandLineConverter.INFO_LONG);
                 resolution.text(" or ");
@@ -230,16 +225,6 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
             resolution.withStyle(UserInput).format("--%s", LoggingCommandLineConverter.DEBUG_LONG);
             resolution.text(" option to get more log output.");
         }
-    }
-
-    private boolean maybeAddBuildScan(BufferingStyledTextOutput resolution) {
-        // todo: replace this test with something which _effectively_ checks what the status of build scan generation is
-        if (gradle == null || gradle.getStartParameter().isNoBuildScan() || !gradle.getStartParameter().isBuildScan()) {
-            resolution.withStyle(UserInput).text("--scan");
-            resolution.text(" to generate a build scan, ");
-            return true;
-        }
-        return false;
     }
 
     private void writeGeneralTips(StyledTextOutput resolution) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -230,23 +230,37 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
     }
 
     private void writeGeneralTips(StyledTextOutput resolution) {
-        boolean hasBuildScans = gradle!=null && hasBuildScans(gradle.getRootProject());
+        boolean hasBuildScans = gradle != null && hasBuildScans(maybeGetRoot());
         resolution.println();
         resolution.text("* Need more help?");
         resolution.println();
-        addTip(resolution, "Sign-up for a free training: https://gradle.org/training/");
+        addTip(resolution, "Sign-up for a", "free training", "https://gradle.org/training/");
         if (!hasBuildScans) {
-            addTip(resolution, "Get insight using a Build Scan: https://scans.gradle.com/");
+            addTip(resolution, "Get insight using a", "Build Scan", "https://scans.gradle.com/");
         }
-        addTip(resolution, "Seek help on our forums: https://discuss.gradle.org/");
+        addTip(resolution, "Seek help on our", "forums", "https://discuss.gradle.org/");
     }
 
-    private void addTip(StyledTextOutput resolution, String tip) {
-        resolution.text("   - " + tip);
+    private Project maybeGetRoot() {
+        try {
+            return gradle.getRootProject();
+        } catch (IllegalStateException e) {
+            // project may not be available at this point
+            return null;
+        }
+    }
+
+    private void addTip(StyledTextOutput resolution, String tip, String label, String link) {
+        resolution.text("   - " + tip + " ");
+        resolution.withStyle(UserInput).text(label);
+        resolution.text(": " + link);
         resolution.println();
     }
 
     private boolean hasBuildScans(Project project) {
+        if (project == null) {
+            return false;
+        }
         if (project.getPlugins().findPlugin("com.gradle.build-scan") != null) {
             return true;
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -18,9 +18,6 @@ package org.gradle.internal.buildevents;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.Action;
-import org.gradle.api.Project;
-import org.gradle.api.initialization.Settings;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
@@ -37,7 +34,6 @@ import org.gradle.util.GUtil;
 import org.gradle.util.TreeVisitor;
 
 import java.util.List;
-import java.util.Set;
 
 import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
 
@@ -53,36 +49,14 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
     private final LoggingConfiguration loggingConfiguration;
     private final BuildClientMetaData clientMetaData;
 
-    private Gradle gradle;
-
     public BuildExceptionReporter(StyledTextOutputFactory textOutputFactory, LoggingConfiguration loggingConfiguration, BuildClientMetaData clientMetaData) {
         this.textOutputFactory = textOutputFactory;
         this.loggingConfiguration = loggingConfiguration;
         this.clientMetaData = clientMetaData;
     }
 
-    @Override
-    public void settingsEvaluated(Settings settings) {
-        this.gradle = settings.getGradle();
-    }
-
-    @Override
-    public void projectsLoaded(Gradle gradle) {
-        this.gradle = gradle;
-    }
-
-    @Override
-    public void buildStarted(Gradle gradle) {
-        this.gradle = gradle;
-    }
-
-    @Override
-    public void projectsEvaluated(Gradle gradle) {
-        this.gradle = gradle;
-    }
 
     public void buildFinished(BuildResult result) {
-        this.gradle = result.getGradle();
         Throwable failure = result.getFailure();
         if (failure == null) {
             return;
@@ -230,47 +204,9 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
     }
 
     private void writeGeneralTips(StyledTextOutput resolution) {
-        boolean hasBuildScans = gradle != null && hasBuildScans(maybeGetRoot());
         resolution.println();
-        resolution.text("* Need more help?");
+        resolution.text("* Get more help at https://help.gradle.org");
         resolution.println();
-        addTip(resolution, "Sign-up for a", "free training", "https://gradle.org/training/");
-        if (!hasBuildScans) {
-            addTip(resolution, "Get insight using a", "Build Scan", "https://scans.gradle.com/");
-        }
-        addTip(resolution, "Seek help on our", "forums", "https://discuss.gradle.org/");
-    }
-
-    private Project maybeGetRoot() {
-        try {
-            return gradle.getRootProject();
-        } catch (IllegalStateException e) {
-            // project may not be available at this point
-            return null;
-        }
-    }
-
-    private void addTip(StyledTextOutput resolution, String tip, String label, String link) {
-        resolution.text("   - " + tip + " ");
-        resolution.withStyle(UserInput).text(label);
-        resolution.text(": " + link);
-        resolution.println();
-    }
-
-    private boolean hasBuildScans(Project project) {
-        if (project == null) {
-            return false;
-        }
-        if (project.getPlugins().findPlugin("com.gradle.build-scan") != null) {
-            return true;
-        }
-        Set<Project> subprojects = project.getSubprojects();
-        for (Project subproject : subprojects) {
-            if (hasBuildScans(subproject)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private String getMessage(Throwable throwable) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -63,7 +63,7 @@ class BuildExceptionReporterTest extends Specification {
 <message>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -115,7 +115,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <message>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -133,7 +133,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 org.gradle.api.GradleException (no error message)
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -155,7 +155,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 {info}> {normal}<cause>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -177,7 +177,7 @@ java.lang.RuntimeException (no error message)
 {info}> {normal}java.io.IOException (no error message)
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -200,7 +200,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 {info}> {normal}<cause2>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -228,7 +228,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
    {info}> {normal}<cause2.1>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -250,7 +250,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 {info}> {normal}java.lang.RuntimeException (no error message)
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -274,7 +274,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 {info}> {normal}<failure>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Exception is:
 org.gradle.api.GradleException: <message>
@@ -304,7 +304,7 @@ org.gradle.api.GradleException: <message>
 {info}> {normal}<cause>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
 {failure}2: {normal}{failure}Task failed with an exception.{normal}
@@ -313,7 +313,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 <failure>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
 {failure}3: {normal}{failure}Task failed with an exception.{normal}
@@ -322,7 +322,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 <error>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
 * Get more help at https://help.gradle.org
@@ -343,7 +343,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 <message>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Exception is:
 org.gradle.api.GradleException: <message>
@@ -366,7 +366,7 @@ org.gradle.api.GradleException: <message>
 <message>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Exception is:
 org.gradle.api.GradleException: <message>

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -61,7 +61,7 @@ class BuildExceptionReporterTest extends Specification {
 <message>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -79,7 +79,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 org.gradle.api.GradleException (no error message)
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -101,7 +101,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 {info}> {normal}<cause>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -123,7 +123,7 @@ java.lang.RuntimeException (no error message)
 {info}> {normal}java.io.IOException (no error message)
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -146,7 +146,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 {info}> {normal}<cause2>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -174,7 +174,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
    {info}> {normal}<cause2.1>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -196,7 +196,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 {info}> {normal}java.lang.RuntimeException (no error message)
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -220,7 +220,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 {info}> {normal}<failure>
 
 * Try:
-Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Exception is:
 org.gradle.api.GradleException: <message>
@@ -250,7 +250,7 @@ org.gradle.api.GradleException: <message>
 {info}> {normal}<cause>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
 {failure}2: {normal}{failure}Task failed with an exception.{normal}
@@ -259,7 +259,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <failure>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
 {failure}3: {normal}{failure}Task failed with an exception.{normal}
@@ -268,7 +268,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <error>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
 * Get more help at https://help.gradle.org
@@ -289,7 +289,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <message>
 
 * Try:
-Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Exception is:
 org.gradle.api.GradleException: <message>
@@ -312,7 +312,7 @@ org.gradle.api.GradleException: <message>
 <message>
 
 * Try:
-Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Exception is:
 org.gradle.api.GradleException: <message>

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -63,7 +63,7 @@ class BuildExceptionReporterTest extends Specification {
 <message>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -115,7 +115,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <message>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -133,7 +133,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 org.gradle.api.GradleException (no error message)
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -155,7 +155,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 {info}> {normal}<cause>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -177,7 +177,7 @@ java.lang.RuntimeException (no error message)
 {info}> {normal}java.io.IOException (no error message)
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -200,7 +200,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 {info}> {normal}<cause2>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -228,7 +228,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
    {info}> {normal}<cause2.1>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -250,7 +250,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 {info}> {normal}java.lang.RuntimeException (no error message)
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
 * Get more help at https://help.gradle.org
 '''
@@ -304,7 +304,7 @@ org.gradle.api.GradleException: <message>
 {info}> {normal}<cause>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
 {failure}2: {normal}{failure}Task failed with an exception.{normal}
@@ -313,7 +313,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 <failure>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
 {failure}3: {normal}{failure}Task failed with an exception.{normal}
@@ -322,7 +322,7 @@ Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stackt
 <error>
 
 * Try:
-Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--scan{normal} to generate a build scan, {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--scan{normal} to generate a build scan, {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
 * Get more help at https://help.gradle.org

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -62,6 +62,11 @@ class BuildExceptionReporterTest extends Specification {
 
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 
@@ -78,6 +83,11 @@ org.gradle.api.GradleException (no error message)
 
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 
@@ -98,6 +108,11 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 
@@ -118,6 +133,11 @@ java.lang.RuntimeException (no error message)
 
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 
@@ -139,6 +159,11 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 
@@ -165,6 +190,11 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 
@@ -185,6 +215,11 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 
@@ -211,6 +246,10 @@ Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get m
 * Exception is:
 org.gradle.api.GradleException: <message>
 {stacktrace}
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 
@@ -255,6 +294,11 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
+
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 ''';
     }
 
@@ -277,6 +321,10 @@ Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get m
 * Exception is:
 org.gradle.api.GradleException: <message>
 {stacktrace}
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 
@@ -299,6 +347,10 @@ Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get m
 * Exception is:
 org.gradle.api.GradleException: <message>
 {stacktrace}
+* Need more help?
+   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
+   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
+   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
 '''
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -63,10 +63,7 @@ class BuildExceptionReporterTest extends Specification {
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 
@@ -84,10 +81,7 @@ org.gradle.api.GradleException (no error message)
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 
@@ -109,10 +103,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 
@@ -134,10 +125,7 @@ java.lang.RuntimeException (no error message)
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 
@@ -160,10 +148,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 
@@ -191,10 +176,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 
@@ -216,10 +198,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 * Try:
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 
@@ -246,10 +225,7 @@ Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get m
 * Exception is:
 org.gradle.api.GradleException: <message>
 {stacktrace}
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 
@@ -295,10 +271,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
 ==============================================================================
 
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 ''';
     }
 
@@ -321,10 +294,7 @@ Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get m
 * Exception is:
 org.gradle.api.GradleException: <message>
 {stacktrace}
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 
@@ -347,10 +317,7 @@ Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get m
 * Exception is:
 org.gradle.api.GradleException: <message>
 {stacktrace}
-* Need more help?
-   - Sign-up for a {userinput}free training{normal}: https://gradle.org/training/
-   - Get insight using a {userinput}Build Scan{normal}: https://scans.gradle.com/
-   - Seek help on our {userinput}forums{normal}: https://discuss.gradle.org/
+* Get more help at https://help.gradle.org
 '''
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractStyledTextOutput.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractStyledTextOutput.java
@@ -98,7 +98,7 @@ public abstract class AbstractStyledTextOutput implements StyledTextOutput, Stan
     public Style getStyle() {
         return style;
     }
-    
+
     protected abstract void doAppend(String text);
 
     protected void doStyleChange(Style style) {


### PR DESCRIPTION
### Context

Whenever a build fails, it might not be super obvious for a user what to do. Either because they don't know Gradle, or because the error message is too obscure. For this reason, this pull request makes sure that whenever a build fails:

- a link to the free training registration page is shown
- a link to our forums is added
- a link to build scans is added if the build scan plugin wasn't applied

This PR adds those unconditionally, but we might want in the future to try to display a selection of links/hints depending on the context (is it a test failure? is it a build script compile error?)
