### PR TITLE
Revert sourcepath deprecation and use custom JavaFileManager

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -148,9 +148,10 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
                             // When annotation processing isn't required, it's better to add the Groovy stubs as part of the source path.
                             // This allows compilations to complete faster, because only the Groovy stubs that are needed by the java source are compiled.
                             FileCollection sourcepath = new SimpleFileCollection(stubDir);
-                            List<String> args = spec.getCompileOptions().getCompilerArgs();
-                            args.add("-sourcepath");
-                            args.add(sourcepath.getAsPath());
+                            if (spec.getCompileOptions().getSourcepath() != null) {
+                                sourcepath = spec.getCompileOptions().getSourcepath().plus(sourcepath);
+                            }
+                            spec.getCompileOptions().setSourcepath(sourcepath);
                         }
 
                         spec.setSource(spec.getSource().filter(new Spec<File>() {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpec.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpec.java
@@ -43,9 +43,4 @@ public class DefaultGroovyJavaJointCompileSpec extends DefaultJavaCompileSpec im
     public void setGroovyClasspath(List<File> groovyClasspath) {
         this.groovyClasspath = groovyClasspath;
     }
-
-    @Override
-    public boolean respectsSourcepath() {
-        return true;
-    }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -25,6 +25,8 @@ import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
+import static org.gradle.util.TestPrecondition.JDK9_OR_LATER
+
 class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     @Rule
@@ -645,4 +647,27 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ':compileJava'
     }
 
+    @Requires(JDK9_OR_LATER)
+    def "compile a module"() {
+        given:
+        buildFile << '''
+            plugins {
+                id 'org.gradle.java.experimental-jigsaw' version '0.1.1'
+            }
+        '''
+        file("src/main/java/module-info.java") << 'module example { exports io.example }'
+        file("src/main/java/io/example/Example.java") << '''
+            package io.example;
+            
+            public class Example {}
+        '''
+
+        when:
+        run 'compileJava'
+
+        then:
+        noExceptionThrown()
+        file("build/classes/java/main/module-info.class").exists()
+        file("build/classes/java/main/io/example/Example.class").exists()
+    }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -70,7 +70,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         // This makes sure the test above is correct AND you can get back javac's default behavior if needed
         when:
         buildFile << "project(':b').compileJava { options.sourcepath = classpath }"
-        executer.noDeprecationChecks().withTasks("compileJava").run()
+        run("compileJava")
         then:
         file("b/build/classes/java/main/Bar.class").exists()
         file("b/build/classes/java/main/Foo.class").exists()

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
@@ -43,9 +43,4 @@ public class DefaultJavaCompileSpec extends DefaultJvmLanguageCompileSpec implem
     public void setAnnotationProcessorPath(List<File> annotationProcessorPath) {
         this.annotationProcessorPath = annotationProcessorPath;
     }
-
-    @Override
-    public boolean respectsSourcepath() {
-        return false;
-    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
@@ -33,20 +33,4 @@ public interface JavaCompileSpec extends JvmLanguageCompileSpec {
     List<File> getAnnotationProcessorPath();
 
     void setAnnotationProcessorPath(List<File> path);
-
-    /**
-     * Whether or not the {@link javax.tools.JavaCompiler} should allow the following two things.
-     * <ul>
-     *     <li>Specifying a <code>-sourcepath</code> command line argument.</li>
-     *     <li>Find implicit sources on the sourcepath.</li>
-     * </ul>
-     * <p>
-     * If this is false for a spec and an empty <code>-sourcepath</code> argument to the compiler,
-     * and silently remove any <code>-sourcepath</code> options and the argument to that option from
-     * {@link CompileOptions#getCompilerArgs()}.
-     * <p>
-     * For Java 9 compilation, the default behavior is to omit the <code>-sourcepath</code> element entirely when
-     * there is a <code>module-info.java</code> in the {@link JvmLanguageCompileSpec#getSource()} file collection.
-     */
-    boolean respectsSourcepath();
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -19,24 +19,14 @@ package org.gradle.api.internal.tasks.compile;
 import com.google.common.base.Joiner;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
-import org.gradle.internal.Factory;
-import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.regex.Pattern;
 
 public class JavaCompilerArgumentsBuilder {
-    private static final Pattern SOURCEPATH_ARGUMENT = Pattern.compile("-{1,2}source-?path");
-    private static final String SOURCEPATH_WARNING = "Gradle does not support passing a custom sourcepath to javac. Removing:";
-
-    public static final Logger LOGGER = Logging.getLogger(JavaCompilerArgumentsBuilder.class);
     public static final String USE_UNSHARED_COMPILER_TABLE_OPTION = "-XDuseUnsharedTable=true";
     public static final String EMPTY_SOURCE_PATH_REF_DIR = "emptySourcePathRef";
 
@@ -113,7 +103,7 @@ public class JavaCompilerArgumentsBuilder {
             return;
         }
 
-        final CompileOptions compileOptions = spec.getCompileOptions();
+        CompileOptions compileOptions = spec.getCompileOptions();
         List<String> compilerArgs = compileOptions.getCompilerArgs();
         if (!releaseOptionIsSet(compilerArgs)) {
             String sourceCompatibility = spec.getSourceCompatibility();
@@ -164,13 +154,7 @@ public class JavaCompilerArgumentsBuilder {
             args.add("-g:none");
         }
 
-        FileCollection sourcepath = DeprecationLogger.whileDisabled(new Factory<FileCollection>() {
-            @Override
-            @SuppressWarnings("deprecation")
-            public FileCollection create() {
-                return compileOptions.getSourcepath();
-            }
-        });
+        FileCollection sourcepath = compileOptions.getSourcepath();
         if (!noEmptySourcePath || sourcepath != null && !sourcepath.isEmpty()) {
             args.add("-sourcepath");
             args.add(sourcepath == null ? "" : sourcepath.getAsPath());
@@ -204,9 +188,6 @@ public class JavaCompilerArgumentsBuilder {
 
         List<String> compilerArgs = spec.getCompileOptions().getCompilerArgs();
         if (compilerArgs != null) {
-            if (!spec.respectsSourcepath()) {
-                stripSourcePath(compilerArgs);
-            }
             args.addAll(compilerArgs);
         }
     }
@@ -233,31 +214,5 @@ public class JavaCompilerArgumentsBuilder {
         for (File file : spec.getSource()) {
             args.add(file.getPath());
         }
-    }
-
-    private static void stripSourcePath(List<String> args) {
-        Iterator<String> i = args.iterator();
-        while(i.hasNext()) {
-            String arg = i.next();
-            if (SOURCEPATH_ARGUMENT.matcher(arg).matches()) {
-                i.remove();
-                if (i.hasNext()) {
-                    String next = i.next();
-                    LOGGER.warn("{} {} {}.", SOURCEPATH_WARNING, arg, next);
-                    i.remove();
-                } else {
-                    LOGGER.warn("{} {}.", SOURCEPATH_WARNING, arg);
-                }
-            }
-        }
-    }
-
-    private boolean containsModuleDescriptor(FileCollection source) {
-        for (File f : source) {
-            if (f.getName().equals("module-info.java")) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -24,7 +24,6 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.internal.Factory;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
@@ -172,9 +171,6 @@ public class JavaCompilerArgumentsBuilder {
                 return compileOptions.getSourcepath();
             }
         });
-        if (Jvm.current().getJavaVersion().isJava9Compatible() && containsModuleDescriptor(spec.getSource())) {
-            noEmptySourcePath();
-        }
         if (!noEmptySourcePath || sourcepath != null && !sourcepath.isEmpty()) {
             args.add("-sourcepath");
             args.add(sourcepath == null ? "" : sourcepath.getAsPath());

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.tasks.compile;
 
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.internal.tasks.compile.files.SourcepathIgnoringJavaFileManager;
 import org.gradle.api.tasks.WorkResult;
@@ -60,7 +61,8 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(null, null, compileOptions.getEncoding() != null ? Charset.forName(compileOptions.getEncoding()) : null);
         Iterable<? extends JavaFileObject> compilationUnits = standardFileManager.getJavaFileObjectsFromFiles(spec.getSource());
         JavaFileManager fileManager = standardFileManager;
-        if (!spec.respectsSourcepath()) {
+        FileCollection sourcepath = spec.getCompileOptions().getSourcepath();
+        if (sourcepath != null && sourcepath.isEmpty()) {
             fileManager = new SourcepathIgnoringJavaFileManager(standardFileManager);
         }
         return compiler.getTask(null, fileManager, null, options, null, compilationUnits);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.internal.tasks.SimpleWorkResult;
+import org.gradle.api.internal.tasks.compile.files.SourcepathIgnoringJavaFileManager;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.internal.Factory;
@@ -24,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.tools.JavaCompiler;
+import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import java.io.Serializable;
@@ -55,8 +57,12 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         List<String> options = new JavaCompilerArgumentsBuilder(spec).build();
         JavaCompiler compiler = javaHomeBasedJavaCompilerFactory.create();
         CompileOptions compileOptions = spec.getCompileOptions();
-        StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, compileOptions.getEncoding() != null ? Charset.forName(compileOptions.getEncoding()) : null);
-        Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(spec.getSource());
-        return compiler.getTask(null, null, null, options, null, compilationUnits);
+        StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(null, null, compileOptions.getEncoding() != null ? Charset.forName(compileOptions.getEncoding()) : null);
+        Iterable<? extends JavaFileObject> compilationUnits = standardFileManager.getJavaFileObjectsFromFiles(spec.getSource());
+        JavaFileManager fileManager = standardFileManager;
+        if (!spec.respectsSourcepath()) {
+            fileManager = new SourcepathIgnoringJavaFileManager(standardFileManager);
+        }
+        return compiler.getTask(null, fileManager, null, options, null, compilationUnits);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/files/SourcepathIgnoringJavaFileManager.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/files/SourcepathIgnoringJavaFileManager.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.files;
+
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileManager;
+import javax.tools.StandardLocation;
+
+/**
+ * Pretends not to know about the <code>sourcepath</code>.
+ */
+public class SourcepathIgnoringJavaFileManager extends ForwardingJavaFileManager<JavaFileManager> {
+
+    public SourcepathIgnoringJavaFileManager(JavaFileManager fileManager) {
+        super(fileManager);
+    }
+
+    /**
+     * There is currently a requirement in the JDK9 javac implementation
+     * that when javac is invoked with an explicitly empty sourcepath
+     * (i.e. {@code --sourcepath ""}), it won't allow you to compile a java 9
+     * module. However, we really want to explicitly set an empty sourcepath
+     * so that we don't implicitly pull in unrequested sourcefiles which
+     * haven't been snapshotted because we will consider the task up-to-date
+     * if the implicit files change.
+     * <p>
+     * This implementation of hasLocation() pretends that the JavaFileManager
+     * has no concept of a source path.
+     */
+    public boolean hasLocation(Location location) {
+        return !location.equals(StandardLocation.SOURCE_PATH) && fileManager.hasLocation(location);
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -29,7 +29,6 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
-import org.gradle.util.DeprecationLogger;
 
 import java.util.List;
 import java.util.Map;
@@ -39,7 +38,6 @@ import java.util.Map;
  */
 public class CompileOptions extends AbstractOptions {
     private static final long serialVersionUID = 0;
-    private static final String SOURCEPATH_DEPRECATION_MESSAGE = "Specify all the sources needed for compilation in the \"source\" FileCollection.";
 
     private static final ImmutableSet<String> EXCLUDE_FROM_ANT_PROPERTIES =
             ImmutableSet.of("debugOptions", "forkOptions", "compilerArgs", "incremental");
@@ -375,33 +373,24 @@ public class CompileOptions extends AbstractOptions {
      * Note that this is different to the default value for the {@code -sourcepath} option for {@code javac}, which is to use the value specified by {@code -classpath}.
      * If you wish to use any source path, it must be explicitly set.
      *
-     * @deprecated See: #setSourcePath(FileCollection) for deprecation reason.
      * @return the source path
      * @see #setSourcepath(FileCollection)
      */
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     @Optional
-    @Deprecated
     @Incubating
     public FileCollection getSourcepath() {
-        DeprecationLogger.nagUserOfDiscontinuedProperty("sourcepath", SOURCEPATH_DEPRECATION_MESSAGE);
         return sourcepath;
     }
 
     /**
      * Sets the source path to use for the compilation.
      *
-     * @deprecated you can still set sourcepath using #setCompilerArgs(), but some compile tasks
-     *     (e.g. {@link JavaCompile}) will throw an exception if a sourcepath argument is set.
-     *     Given the rich semantics of the {@link JavaCompile#setSource(Object)} method, users
-     *     really shouldn't need to set the sourcepath.
      * @param sourcepath the source path
      */
-    @Deprecated
     @Incubating
     public void setSourcepath(FileCollection sourcepath) {
-        DeprecationLogger.nagUserOfDiscontinuedProperty("sourcepath", SOURCEPATH_DEPRECATION_MESSAGE);
         this.sourcepath = sourcepath;
     }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -322,14 +322,6 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         builder.noEmptySourcePath().build() == ["-g", "-sourcepath", fc.asPath, "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
     }
 
-    def "strips user-supplied -sourcepath args"() {
-        given:
-        spec.compileOptions.compilerArgs = ["-d", "some/other/directory", "-sourcepath", "some/source/path", "--source-path", "and/another", "-sourcepath"]
-
-        expect:
-        builder.build() == ["-g", "-sourcepath", "", "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", "", "-d", "some/other/directory"]
-    }
-
     String defaultEmptySourcePathRefFolder() {
         new File(spec.tempDir, JavaCompilerArgumentsBuilder.EMPTY_SOURCE_PATH_REF_DIR).absolutePath
     }


### PR DESCRIPTION
This change allows us to build jigsaw modules on Java 9 without having to ignore the
sourcepath property.
