### PR TITLE
Isolate script plugins from target's classloader

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
@@ -136,7 +136,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
             };
             services.add(ScriptPluginFactory.class, scriptPluginFactory);
             services.add(ScriptHandlerFactory.class, scriptHandlerFactory);
-            services.add(ClassLoaderScope.class, targetScope);
+            services.add(ClassLoaderScope.class, baseScope);
             services.add(LoggingManagerInternal.class, loggingManagerFactory.create());
             services.add(Instantiator.class, instantiator);
             services.add(ScriptHandler.class, scriptHandler);


### PR DESCRIPTION
Script plugins were unintentionally using the classloader scope of their target
as their parent scope. This means that types were leaking in the wrong direction
and that these script plugins were loaded many times (once per target) instead of
once.

In an especially severe situation this caused the script plugin to force resolution
of the parent scope too early, leading to a wrong script classloader cache key and
thus reloading that script on every single build. This increased configuration time
of a 250 project build by several seconds.

Script plugins now use the base scope of their target as their parent scope,
properly isolating the two and fixing the performance issue above.