### PR TITLE
Merge sourcepaths from compilerArgs with sourcepath property

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.util.Requires
 import org.gradle.util.Resources
 import org.gradle.util.TestPrecondition
@@ -25,7 +26,7 @@ import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
-import static org.gradle.util.TestPrecondition.JDK9_OR_LATER
+import static org.gradle.api.JavaVersion.VERSION_1_9
 
 class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
@@ -647,7 +648,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ':compileJava'
     }
 
-    @Requires(JDK9_OR_LATER)
+    @Requires(adhoc = {AvailableJavaHomes.getJdk(VERSION_1_9)})
     def "compile a module"() {
         given:
         buildFile << '''
@@ -655,7 +656,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
                 id 'org.gradle.java.experimental-jigsaw' version '0.1.1'
             }
         '''
-        file("src/main/java/module-info.java") << 'module example { exports io.example }'
+        file("src/main/java/module-info.java") << 'module example { exports io.example; }'
         file("src/main/java/io/example/Example.java") << '''
             package io.example;
             
@@ -663,7 +664,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         '''
 
         when:
-        run 'compileJava'
+        executer.requireGradleDistribution()
+        executer.withJavaHome AvailableJavaHomes.getJdk(VERSION_1_9).javaHome
+        succeeds "compileJava"
 
         then:
         noExceptionThrown()

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -205,8 +205,12 @@ public class JavaCompilerArgumentsBuilder {
                     "Specifying the source path in the CompilerOptions compilerArgs property",
                     "Instead, use the CompilerOptions sourcepath property directly");
                 argIterator.remove();
-                userProvidedSourcepath = argIterator.next();
-                argIterator.remove();
+                if (argIterator.hasNext()) {
+                    // Only conditional in case the user didn't supply an argument to the -sourcepath option.
+                    // Protecting the call to "next()" inside the conditional protects against a NoSuchElementException
+                    userProvidedSourcepath = argIterator.next();
+                    argIterator.remove();
+                }
             }
         }
         return userProvidedSourcepath;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -67,7 +67,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         return compiler.getTask(null, fileManager, null, options, null, compilationUnits);
     }
 
-    private boolean emptySourcepathIn(List<String> options) {
+    private static boolean emptySourcepathIn(List<String> options) {
         Iterator<String> optionsIter = options.iterator();
         while (optionsIter.hasNext()) {
             String current = optionsIter.next();

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.tasks.compile;
 
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.internal.tasks.compile.files.SourcepathIgnoringJavaFileManager;
 import org.gradle.api.tasks.WorkResult;
@@ -31,6 +30,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import java.io.Serializable;
 import java.nio.charset.Charset;
+import java.util.Iterator;
 import java.util.List;
 
 public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable {
@@ -61,10 +61,20 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(null, null, compileOptions.getEncoding() != null ? Charset.forName(compileOptions.getEncoding()) : null);
         Iterable<? extends JavaFileObject> compilationUnits = standardFileManager.getJavaFileObjectsFromFiles(spec.getSource());
         JavaFileManager fileManager = standardFileManager;
-        FileCollection sourcepath = spec.getCompileOptions().getSourcepath();
-        if (sourcepath != null && sourcepath.isEmpty()) {
+        if (emptySourcepathIn(options)) {
             fileManager = new SourcepathIgnoringJavaFileManager(standardFileManager);
         }
         return compiler.getTask(null, fileManager, null, options, null, compilationUnits);
+    }
+
+    private boolean emptySourcepathIn(List<String> options) {
+        Iterator<String> optionsIter = options.iterator();
+        while (optionsIter.hasNext()) {
+            String current = optionsIter.next();
+            if (current.equals("-sourcepath") || current.equals("--source-path")) {
+                return optionsIter.next().isEmpty();
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
This change also deprecates specifying a sourcepath in the
compilerArgs. We don't want users doing that so that we can correctly
cache their tasks. But, we also don't want to break them as they
migrate from passing the sourcepath command line argument via the
property on CompileOptions.