### PR TITLE
Test binary compatibility on each commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -223,39 +223,7 @@ apply from: "gradle/noDependencyResolutionDuringConfiguration.gradle"
 apply from: "gradle/testSetup.gradle"
 apply from: "gradle/fix-GRADLE-2492.gradle"
 apply from: 'gradle/customM2Check.gradle'
-
-ext.publicApiIncludes = [
-    'org/gradle/*',
-    'org/gradle/api/**',
-    'org/gradle/authentication/**',
-    'org/gradle/buildinit/**',
-    'org/gradle/caching/**',
-    'org/gradle/external/javadoc/**',
-    'org/gradle/ide/**',
-    'org/gradle/includedbuild/**',
-    'org/gradle/ivy/**',
-    'org/gradle/jvm/**',
-    'org/gradle/language/**',
-    'org/gradle/maven/**',
-    'org/gradle/nativeplatform/**',
-    'org/gradle/normalization/**',
-    'org/gradle/platform/**',
-    'org/gradle/play/**',
-    'org/gradle/plugin/devel/**',
-    'org/gradle/plugin/repository/*',
-    'org/gradle/plugin/use/*',
-    'org/gradle/plugin/management/*',
-    'org/gradle/plugins/**',
-    'org/gradle/process/**',
-    'org/gradle/testfixtures/**',
-    'org/gradle/testing/jacoco/**',
-    'org/gradle/tooling/**',
-    'org/gradle/model/**',
-    'org/gradle/testkit/**',
-    'org/gradle/testing/**'
-]
-
-ext.publicApiExcludes = ['**/internal/**']
+apply from: "gradle/publicApi.gradle"
 
 allprojects {
     group = 'org.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -224,6 +224,39 @@ apply from: "gradle/testSetup.gradle"
 apply from: "gradle/fix-GRADLE-2492.gradle"
 apply from: 'gradle/customM2Check.gradle'
 
+ext.publicApiIncludes = [
+    'org/gradle/*',
+    'org/gradle/api/**',
+    'org/gradle/authentication/**',
+    'org/gradle/buildinit/**',
+    'org/gradle/caching/**',
+    'org/gradle/external/javadoc/**',
+    'org/gradle/ide/**',
+    'org/gradle/includedbuild/**',
+    'org/gradle/ivy/**',
+    'org/gradle/jvm/**',
+    'org/gradle/language/**',
+    'org/gradle/maven/**',
+    'org/gradle/nativeplatform/**',
+    'org/gradle/normalization/**',
+    'org/gradle/platform/**',
+    'org/gradle/play/**',
+    'org/gradle/plugin/devel/**',
+    'org/gradle/plugin/repository/*',
+    'org/gradle/plugin/use/*',
+    'org/gradle/plugin/management/*',
+    'org/gradle/plugins/**',
+    'org/gradle/process/**',
+    'org/gradle/testfixtures/**',
+    'org/gradle/testing/jacoco/**',
+    'org/gradle/tooling/**',
+    'org/gradle/model/**',
+    'org/gradle/testkit/**',
+    'org/gradle/testing/**'
+]
+
+ext.publicApiExcludes = ['**/internal/**']
+
 allprojects {
     group = 'org.gradle'
 

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -223,6 +223,8 @@ idea {
                 "-Dorg.gradle.integtest.versions=latest",
                 "-Dorg.gradle.integtest.multiversion=default",
                 "-Dorg.gradle.integtest.testkit.compatibility=current",
+                "-Dorg.gradle.public.api.includes=${publicApiIncludes.join(':')}",
+                "-Dorg.gradle.public.api.excludes=${publicApiExcludes.join(':')}",
                 "-ea",
                 "-Xmx512m"
         ]

--- a/gradle/publicApi.gradle
+++ b/gradle/publicApi.gradle
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ext.publicApiIncludes = [
+    'org/gradle/*',
+    'org/gradle/api/**',
+    'org/gradle/authentication/**',
+    'org/gradle/buildinit/**',
+    'org/gradle/caching/**',
+    'org/gradle/external/javadoc/**',
+    'org/gradle/ide/**',
+    'org/gradle/includedbuild/**',
+    'org/gradle/ivy/**',
+    'org/gradle/jvm/**',
+    'org/gradle/language/**',
+    'org/gradle/maven/**',
+    'org/gradle/nativeplatform/**',
+    'org/gradle/normalization/**',
+    'org/gradle/platform/**',
+    'org/gradle/play/**',
+    'org/gradle/plugin/devel/**',
+    'org/gradle/plugin/repository/*',
+    'org/gradle/plugin/use/*',
+    'org/gradle/plugin/management/*',
+    'org/gradle/plugins/**',
+    'org/gradle/process/**',
+    'org/gradle/testfixtures/**',
+    'org/gradle/testing/jacoco/**',
+    'org/gradle/tooling/**',
+    'org/gradle/model/**',
+    'org/gradle/testkit/**',
+    'org/gradle/testing/**'
+]
+
+ext.publicApiExcludes = ['**/internal/**']

--- a/subprojects/distributions/distributions.gradle
+++ b/subprojects/distributions/distributions.gradle
@@ -123,4 +123,10 @@ artifacts {
 
 integTestTasks.all {
     requiresDists = true
+    systemProperty 'org.gradle.public.api.includes', publicApiIncludes.join(':')
+    systemProperty 'org.gradle.public.api.excludes', publicApiExcludes.join(':')
+}
+
+dependencies {
+    testCompile "com.github.siom79.japicmp:japicmp:0.10.0"
 }

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/BinaryBreakageIntegrationTest.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/BinaryBreakageIntegrationTest.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle
+
+import japicmp.cmp.JApiCmpArchive
+import japicmp.cmp.JarArchiveComparator
+import japicmp.cmp.JarArchiveComparatorOptions
+import japicmp.config.Options
+import japicmp.model.JApiClass
+import japicmp.output.stdout.StdoutOutputGenerator
+import org.gradle.api.internal.file.pattern.PathMatcher
+import org.gradle.api.internal.file.pattern.PatternMatcherFactory
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleDistribution
+import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution
+import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
+import spock.lang.Unroll
+
+import static org.junit.Assume.assumeTrue
+
+@Unroll
+class BinaryBreakageIntegrationTest extends AbstractIntegrationSpec{
+
+    private static final List<String> PUBLIC_API_INCLUDES = System.getProperty('org.gradle.public.api.includes').split(':')
+    private static final List<String> PUBLIC_API_EXCLUDES = System.getProperty('org.gradle.public.api.excludes').split(':')
+    private static final Map<String, String> ACCEPTED_CHANGES = [
+        'org.gradle.api.initialization.ConfigurableIncludedBuild': '''---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) org.gradle.api.initialization.ConfigurableIncludedBuild  (not serializable)
+\t---! REMOVED INTERFACE: org.gradle.api.initialization.IncludedBuild
+\t---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) void dependencySubstitution(org.gradle.api.Action)''',
+
+        'org.gradle.api.initialization.IncludedBuild': '''---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) org.gradle.api.initialization.IncludedBuild  (not serializable)
+\t---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String getName()
+\t---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.io.File getProjectDir()
+\t---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) org.gradle.api.tasks.TaskReference task(java.lang.String)''',
+
+        'org.gradle.api.invocation.Gradle': '''***! MODIFIED INTERFACE: PUBLIC ABSTRACT org.gradle.api.invocation.Gradle  (not serializable)
+\t***! MODIFIED METHOD: PUBLIC ABSTRACT org.gradle.includedbuild.IncludedBuild (<-org.gradle.api.initialization.IncludedBuild) includedBuild(java.lang.String)''',
+        'org.gradle.StartParameter': '''***! MODIFIED CLASS: PUBLIC org.gradle.StartParameter  (default serialVersionUID changed)
+\t---! REMOVED INTERFACE: org.gradle.initialization.ParallelismConfiguration'''
+    ]
+
+    private List<PathMatcher> publicApiIncludeMatchers
+
+    private List<PathMatcher> publicApiExcludeMatchers
+
+    def setup() {
+        publicApiIncludeMatchers = PUBLIC_API_INCLUDES.collect { PatternMatcherFactory.compile(true, it) }
+        publicApiExcludeMatchers = PUBLIC_API_EXCLUDES.collect { PatternMatcherFactory.compile(true, it) }
+        assert !publicApiIncludeMatchers.empty
+        assert !publicApiExcludeMatchers.empty
+    }
+
+    def "should be binary compatibility with Gradle #version"() {
+        GradleDistribution current = new UnderDevelopmentGradleDistribution()
+
+        // For a hotfix release we need to trust our own judgement or run this test manually
+        assumeTrue(previous.version < current.version)
+
+        when:
+        def comparison = comparePublicApi(previous, current)
+
+        then:
+        def binaryIncompatibleChanges = comparison.findAll { !it.binaryCompatible }.collectEntries { JApiClass apiClass ->
+            [(apiClass.fullyQualifiedName): describeBinaryBreakingChange(apiClass)]
+        }
+        def remainingChanges = binaryIncompatibleChanges - ACCEPTED_CHANGES
+        remainingChanges.values().isEmpty()
+
+
+        where:
+        previous << [new ReleasedVersionDistributions(buildContext).mostRecentFinalRelease]
+        version = previous.version.version
+    }
+
+    private static String describeBinaryBreakingChange(JApiClass binaryIncompatibleChange) {
+        def outputOptions = Options.newDefault()
+        outputOptions.outputOnlyBinaryIncompatibleModifications = true
+        new StdoutOutputGenerator(outputOptions, [binaryIncompatibleChange]).generate().readLines().tail().join('\n')
+    }
+
+    private List<JApiClass> comparePublicApi(GradleDistribution previous, GradleDistribution current) {
+        def options = new JarArchiveComparatorOptions()
+
+        def currentJars = getDistributionJars(current)
+        def oldJars = getDistributionJars(previous)
+
+        options.classPathMode = JarArchiveComparatorOptions.ClassPathMode.TWO_SEPARATE_CLASSPATHS
+        options.newClassPath = currentJars.external*.absolutePath as List
+        options.oldClassPath = oldJars.external*.absolutePath as List
+
+        def oldGradleJars = oldJars.internal.collect { new JApiCmpArchive(it, previous.version.version) }
+        def currentGradleJars = currentJars.internal.collect { new JApiCmpArchive(it, buildContext.version.version) }
+
+        def comparator = new JarArchiveComparator(options)
+        def comparison = comparator.compare(oldGradleJars, currentGradleJars)
+        comparison.findAll { isPublicApi(it.fullyQualifiedName) }
+    }
+
+    private static Map getDistributionJars(GradleDistribution current) {
+        def libDir = current.gradleHomeDir.file('lib')
+        def allDescendants = libDir.allDescendants()
+        def gradleDeps = allDescendants.findAll { it.startsWith('gradle-') }.collect { libDir.file(it) }
+        def externalDeps = allDescendants.findAll { !it.startsWith('gradle-') }.collect { libDir.file(it) }
+        [
+            external: externalDeps,
+            internal: gradleDeps
+        ]
+    }
+
+    boolean isPublicApi(String fullyQualifiedClassname) {
+        String[] path = fullyQualifiedClassname.split('\\.')
+        return !publicApiExcludeMatchers.any { it.matches(path, 0) } &&
+            publicApiIncludeMatchers.any { it.matches(path, 0) }
+    }
+
+    private static String formatChange(JApiClass apiClass) {
+        "Class ${apiClass.fullyQualifiedName} changed: ${apiClass.compatibilityChanges*.toString().join(', ')}"
+    }
+}

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/BinaryBreakageIntegrationTest.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/BinaryBreakageIntegrationTest.groovy
@@ -66,7 +66,7 @@ class BinaryBreakageIntegrationTest extends AbstractIntegrationSpec{
         }
         def remainingChanges = binaryIncompatibleChanges - acceptedChanges
         remainingChanges.values().isEmpty()
-
+        (acceptedChanges - binaryIncompatibleChanges).isEmpty() // Make sure we do not forget to remove fixed binary breakages
 
         where:
         previous << [new ReleasedVersionDistributions(buildContext).mostRecentFinalRelease]

--- a/subprojects/distributions/src/integTest/resources/breaking-changes-4.2.txt
+++ b/subprojects/distributions/src/integTest/resources/breaking-changes-4.2.txt
@@ -1,0 +1,22 @@
+BREAKING-CHANGE: org.gradle.api.initialization.ConfigurableIncludedBuild
+REASON: ???
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) org.gradle.api.initialization.ConfigurableIncludedBuild  (not serializable)
+	---! REMOVED INTERFACE: org.gradle.api.initialization.IncludedBuild
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) void dependencySubstitution(org.gradle.api.Action)
+
+BREAKING-CHANGE: org.gradle.api.initialization.IncludedBuild
+REASON: ???
+---! REMOVED INTERFACE: PUBLIC(-) ABSTRACT(-) org.gradle.api.initialization.IncludedBuild  (not serializable)
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.lang.String getName()
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) java.io.File getProjectDir()
+	---! REMOVED METHOD: PUBLIC(-) ABSTRACT(-) org.gradle.api.tasks.TaskReference task(java.lang.String)
+
+BREAKING-CHANGE: org.gradle.api.invocation.Gradle
+REASON: ???
+***! MODIFIED INTERFACE: PUBLIC ABSTRACT org.gradle.api.invocation.Gradle  (not serializable)
+	***! MODIFIED METHOD: PUBLIC ABSTRACT org.gradle.includedbuild.IncludedBuild (<-org.gradle.api.initialization.IncludedBuild) includedBuild(java.lang.String)
+
+BREAKING-CHANGE: org.gradle.StartParameter
+REASON: ???
+***! MODIFIED CLASS: PUBLIC org.gradle.StartParameter  (default serialVersionUID changed)
+	---! REMOVED INTERFACE: org.gradle.initialization.ParallelismConfiguration

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -430,35 +430,12 @@ task javadocAll(type: Javadoc) {
     source publicGroovyProjects.collect {project -> project.sourceSets.main.allJava }
     destinationDir = new File(docsDir, 'javadoc')
     classpath = files(publicGroovyProjects.collect {project -> [project.sourceSets.main.compileClasspath, project.sourceSets.main.output] })
-    include 'org/gradle/*'
-    include 'org/gradle/api/**'
-    include 'org/gradle/authentication/**'
-    include 'org/gradle/buildinit/**'
-    include 'org/gradle/caching/**'
-    include 'org/gradle/external/javadoc/**'
-    include 'org/gradle/ide/**'
-    include 'org/gradle/includedbuild/**'
-    include 'org/gradle/ivy/**'
-    include 'org/gradle/jvm/**'
-    include 'org/gradle/language/**'
-    include 'org/gradle/maven/**'
-    include 'org/gradle/nativeplatform/**'
-    include 'org/gradle/normalization/**'
-    include 'org/gradle/platform/**'
-    include 'org/gradle/play/**'
-    include 'org/gradle/plugin/devel/**'
-    include 'org/gradle/plugin/repository/*'
-    include 'org/gradle/plugin/use/*'
-    include 'org/gradle/plugin/management/*'
-    include 'org/gradle/plugins/**'
-    include 'org/gradle/process/**'
-    include 'org/gradle/testfixtures/**'
-    include 'org/gradle/testing/jacoco/**'
-    include 'org/gradle/tooling/**'
-    include 'org/gradle/model/**'
-    include 'org/gradle/testkit/**'
-    include 'org/gradle/testing/**'
-    exclude '**/internal/**'
+    publicApiIncludes.each {
+        include it
+    }
+    publicApiExcludes.each {
+        exclude it
+    }
     options.links(javaApiUrl, groovyApiUrl, mavenApiUrl)
     title = "Gradle API $version"
     ext.entryPoint = "$destinationDir/index.html"


### PR DESCRIPTION
We add a test which checks if the public API of the current version is binary compatible to the last released version. 
Currently, this test lives in `distributions` until it has found a better home. We could also run this test as part of sanity check since it is pretty fast (6s). It should not run in every stage of the pipeline and this is why `distributions` seem to be a good fit.
The public API definition has been extracted to the root build script. It could be nice to have the definition in a place where the test could easily load it without going through using system properties.
