### PR TITLE
Update version for developer builds only once a day

### DIFF
--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -25,7 +25,13 @@ if (incomingDistributionsBuildReceipt) {
     if (project.hasProperty("buildTimestamp")) {
         buildTime = timestampFormat.parse(buildTimestamp)
     } else {
-        buildTime = new Date()
+        if (isCiServer) {
+            buildTime = new Date()
+        } else {
+            def sdf = new java.text.SimpleDateFormat("yyyy-MM-dd");
+            Date dateWithoutTime = sdf.parse(sdf.format(new Date()))
+            buildTime = dateWithoutTime
+        }
     }
     ext.buildTimestamp = timestampFormat.format(buildTime)
 }


### PR DESCRIPTION
In order to improve incrementalness for developer builds
(i.e. more tasks should be up-to-date) we only update the version
once a day.