### PR TITLE
Workers api javadoc publishing

### DIFF
--- a/gradle/publicApi.gradle
+++ b/gradle/publicApi.gradle
@@ -42,7 +42,8 @@ ext.publicApiIncludes = [
     'org/gradle/tooling/**',
     'org/gradle/model/**',
     'org/gradle/testkit/**',
-    'org/gradle/testing/**'
+    'org/gradle/testing/**',
+    'org/gradle/workers/**'
 ]
 
 ext.publicApiExcludes = ['**/internal/**']

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
@@ -53,6 +53,8 @@ public interface WorkerConfiguration extends Describable, ActionConfiguration {
     Iterable<File> getClasspath();
 
     /**
+     * Gets the isolation mode for this worker, see {@link IsolationMode}.
+     *
      * @return the isolation mode for this worker, see {@link IsolationMode}, defaults to {@link IsolationMode#AUTO}
      *
      * @since 4.0
@@ -69,6 +71,8 @@ public interface WorkerConfiguration extends Describable, ActionConfiguration {
     void setIsolationMode(IsolationMode isolationMode);
 
     /**
+     * Gets the forking mode for this worker, see {@link ForkMode}.
+     *
      * @return the forking mode for this worker, see {@link ForkMode}, defaults to {@link ForkMode#AUTO}
      */
     ForkMode getForkMode();


### PR DESCRIPTION
### Context

The workers API Javadoc is currently not being published (see https://docs.gradle.org/nightly/javadoc/).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
