### PR TITLE
Use multiple classes dirs in Classycle plugin

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/plugins/classycle/Classycle.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/plugins/classycle/Classycle.groovy
@@ -59,13 +59,15 @@ class Classycle extends DefaultTask {
     Set<String> excludePatterns
 
     @Inject
-    public IsolatedAntBuilder getAntBuilder() {
-        throw new UnsupportedOperationException();
+    @SuppressWarnings("GrMethodMayBeStatic")
+    IsolatedAntBuilder getAntBuilder() {
+        throw new UnsupportedOperationException()
     }
 
     @TaskAction
     void generate() {
         def project = this.project
+        def existingClassesDirs = classesDirs.findAll { it.exists() }
         antBuilder.withClasspath(project.configurations.getByName(ClassyclePlugin.CLASSYCLE_CONFIGURATION_NAME).files).execute {
             ant.taskdef(name: "classycleDependencyCheck", classname: "classycle.ant.DependencyCheckingTask")
             ant.taskdef(name: "classycleReport", classname: "classycle.ant.ReportTask")
@@ -77,7 +79,7 @@ class Classycle extends DefaultTask {
                         check absenceOfPackageCycles > 1 in org.gradle.*
                     """
                 ) {
-                    classesDirs.each { classesDir ->
+                    existingClassesDirs.each { classesDir ->
                         fileset(dir: classesDir) {
                             excludePatterns.each { excludePattern ->
                                 exclude(name: excludePattern)
@@ -89,7 +91,7 @@ class Classycle extends DefaultTask {
                 try {
                     ant.unzip(src: project.rootProject.file("gradle/classycle_report_resources.zip"), dest: reportDir)
                     ant.classycleReport(reportFile: analysisFile, reportType: 'xml', mergeInnerClasses: true, title: "${project.name} ${reportName} (${path})") {
-                        classesDirs.each { classesDir ->
+                        existingClassesDirs.each { classesDir ->
                             fileset(dir: classesDir) {
                                 excludePatterns.each { excludePattern ->
                                     exclude(name: excludePattern)

--- a/buildSrc/src/main/groovy/org/gradle/plugins/classycle/Classycle.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/plugins/classycle/Classycle.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.internal.project.IsolatedAntBuilder
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
@@ -33,10 +33,10 @@ import javax.inject.Inject
 @CacheableTask
 class Classycle extends DefaultTask {
 
-    @InputDirectory
+    @InputFiles
     @SkipWhenEmpty
     @PathSensitive(PathSensitivity.RELATIVE)
-    File classesDir
+    Set<File> classesDirs
 
     @Input
     String reportName
@@ -64,6 +64,7 @@ class Classycle extends DefaultTask {
 
     @TaskAction
     void generate() {
+        def project = this.project
         antBuilder.withClasspath(project.configurations.getByName(ClassyclePlugin.CLASSYCLE_CONFIGURATION_NAME).files).execute {
             ant.taskdef(name: "classycleDependencyCheck", classname: "classycle.ant.DependencyCheckingTask")
             ant.taskdef(name: "classycleReport", classname: "classycle.ant.ReportTask")
@@ -75,9 +76,11 @@ class Classycle extends DefaultTask {
                         check absenceOfPackageCycles > 1 in org.gradle.*
                     """
                 ) {
-                    fileset(dir: classesDir) {
-                        excludePatterns.each { excludePattern ->
-                            exclude(name: excludePattern)
+                    classesDirs.each { classesDir ->
+                        fileset(dir: classesDir) {
+                            excludePatterns.each { excludePattern ->
+                                exclude(name: excludePattern)
+                            }
                         }
                     }
                 }
@@ -85,9 +88,11 @@ class Classycle extends DefaultTask {
                 try {
                     ant.unzip(src: project.rootProject.file("gradle/classycle_report_resources.zip"), dest: reportDir)
                     ant.classycleReport(reportFile: analysisFile, reportType: 'xml', mergeInnerClasses: true, title: "${project.name} ${reportName} (${path})") {
-                        fileset(dir: classesDir) {
-                            excludePatterns.each { excludePattern ->
-                                exclude(name: excludePattern)
+                        classesDirs.each { classesDir ->
+                            fileset(dir: classesDir) {
+                                excludePatterns.each { excludePattern ->
+                                    exclude(name: excludePattern)
+                                }
                             }
                         }
                     }

--- a/buildSrc/src/main/groovy/org/gradle/plugins/classycle/Classycle.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/plugins/classycle/Classycle.groovy
@@ -17,6 +17,7 @@
 package org.gradle.plugins.classycle
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.project.IsolatedAntBuilder
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -36,7 +37,7 @@ class Classycle extends DefaultTask {
     @InputFiles
     @SkipWhenEmpty
     @PathSensitive(PathSensitivity.RELATIVE)
-    Set<File> classesDirs
+    FileCollection classesDirs
 
     @Input
     String reportName

--- a/buildSrc/src/main/groovy/org/gradle/plugins/classycle/ClassyclePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/plugins/classycle/ClassyclePlugin.groovy
@@ -42,7 +42,7 @@ class ClassyclePlugin implements Plugin<Project> {
             def taskName = sourceSet.getTaskName('classycle', null)
             project.tasks.create(taskName, Classycle, { Classycle task ->
                 task.reportName = sourceSet.name
-                task.classesDir = sourceSet.output.classesDir
+                task.classesDirs = sourceSet.output.classesDirs.files.findAll { it.exists() }
                 task.reportDir = reporting.file('classycle')
                 task.dependsOn(sourceSet.output)
             } as Action<Classycle>)

--- a/buildSrc/src/main/groovy/org/gradle/plugins/classycle/ClassyclePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/plugins/classycle/ClassyclePlugin.groovy
@@ -42,7 +42,7 @@ class ClassyclePlugin implements Plugin<Project> {
             def taskName = sourceSet.getTaskName('classycle', null)
             project.tasks.create(taskName, Classycle, { Classycle task ->
                 task.reportName = sourceSet.name
-                task.classesDirs = project.files { sourceSet.output.classesDirs.files.findAll { it.exists() } }
+                task.classesDirs = sourceSet.output.classesDirs
                 task.reportDir = reporting.file('classycle')
                 task.dependsOn(sourceSet.output)
             } as Action<Classycle>)

--- a/buildSrc/src/main/groovy/org/gradle/plugins/classycle/ClassyclePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/plugins/classycle/ClassyclePlugin.groovy
@@ -42,7 +42,7 @@ class ClassyclePlugin implements Plugin<Project> {
             def taskName = sourceSet.getTaskName('classycle', null)
             project.tasks.create(taskName, Classycle, { Classycle task ->
                 task.reportName = sourceSet.name
-                task.classesDirs = sourceSet.output.classesDirs.files.findAll { it.exists() }
+                task.classesDirs = project.files { sourceSet.output.classesDirs.files.findAll { it.exists() } }
                 task.reportDir = reporting.file('classycle')
                 task.dependsOn(sourceSet.output)
             } as Action<Classycle>)


### PR DESCRIPTION
This is to upgrade Classycle used in the Gradle build to use Gradle 4.0-compatible way to access compiled classes produced from source sets.