### PR TITLE
Track failed outputs

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/FailingIncrementalTasksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/FailingIncrementalTasksIntegrationTest.groovy
@@ -105,9 +105,8 @@ class FailingIncrementalTasksIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         modifyOutputs | failiureCount | incremental | description
-        // TODO This doesn't work when the task adds new files
-//        "add"         | 1     | false       | "with additional outputs is fully rebuilt"
-//        "add"         | 2     | false       | "with additional outputs is fully rebuilt"
+        "add"         | 1     | false       | "with additional outputs is fully rebuilt"
+        "add"         | 2     | false       | "with additional outputs is fully rebuilt"
         "change"      | 1     | false       | "with changed outputs is fully rebuilt"
         "change"      | 2     | false       | "with changed outputs is fully rebuilt"
         "remove"      | 1     | false       | "with removed outputs is fully rebuilt"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/FailingIncrementalTasksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/FailingIncrementalTasksIntegrationTest.groovy
@@ -39,7 +39,7 @@ class FailingIncrementalTasksIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         file("out.txt") << "force rerun"
-        fails"foo"
+        fails "foo"
         then:
         failureHasCause "Boo!"
 
@@ -52,7 +52,7 @@ class FailingIncrementalTasksIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    def "incremental task after previous #failiureCount failure(s) #description"() {
+    def "incremental task after previous #failureCount failure(s) #description"() {
         file("src/input.txt") << "input"
         buildFile << """
             class IncrementalTask extends DefaultTask {
@@ -96,7 +96,7 @@ class FailingIncrementalTasksIntegrationTest extends AbstractIntegrationSpec {
         succeeds "incrementalTask"
 
         file("src/input-change.txt") << "input"
-        failiureCount.times {
+        failureCount.times {
             fails "incrementalTask", "-PmodifyOutputs=$modifyOutputs", "-Pfail"
         }
 
@@ -104,13 +104,13 @@ class FailingIncrementalTasksIntegrationTest extends AbstractIntegrationSpec {
         succeeds "incrementalTask", "-PexpectIncremental=$incremental"
 
         where:
-        modifyOutputs | failiureCount | incremental | description
-        "add"         | 1     | false       | "with additional outputs is fully rebuilt"
-        "add"         | 2     | false       | "with additional outputs is fully rebuilt"
-        "change"      | 1     | false       | "with changed outputs is fully rebuilt"
-        "change"      | 2     | false       | "with changed outputs is fully rebuilt"
-        "remove"      | 1     | false       | "with removed outputs is fully rebuilt"
-        null          | 1     | true        | "with unmodified outputs is executed as incremental"
-        null          | 2     | true        | "with unmodified outputs is executed as incremental"
+        modifyOutputs | failureCount | incremental | description
+        "add"         | 1            | false       | "with additional outputs is fully rebuilt"
+        "add"         | 2            | false       | "with additional outputs is fully rebuilt"
+        "change"      | 1            | false       | "with changed outputs is fully rebuilt"
+        "change"      | 2            | false       | "with changed outputs is fully rebuilt"
+        "remove"      | 1            | false       | "with removed outputs is fully rebuilt"
+        "none"        | 1            | true        | "with unmodified outputs is executed as incremental"
+        "none"        | 2            | true        | "with unmodified outputs is executed as incremental"
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
@@ -162,15 +162,15 @@ public class DefaultTaskArtifactStateRepository implements TaskArtifactStateRepo
                 return;
             }
 
-            TaskUpToDateState states = getStates();
+            TaskUpToDateState taskState = getStates();
 
             if (taskInputs != null) {
-                states.newInputs(taskInputs.getDiscoveredInputs());
+                taskState.newInputs(taskInputs.getDiscoveredInputs());
             }
-            states.getAllTaskChanges().snapshotAfterTask();
+            taskState.getAllTaskChanges().snapshotAfterTask();
 
-            // Only store new states if there was no failure, or some output files have been changed
-            if (failure == null || !Iterables.isEmpty(states.getOutputFileChanges())) {
+            // Only store new taskState if there was no failure, or some output files have been changed
+            if (failure == null || taskState.hasAnyOutputFileChanges()) {
                 history.update();
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
@@ -158,19 +158,21 @@ public class DefaultTaskArtifactStateRepository implements TaskArtifactStateRepo
 
         @Override
         public void afterTask(Throwable failure) {
-            if (failure != null) {
-                return;
-            }
-
             if (upToDate) {
                 return;
             }
 
+            TaskUpToDateState states = getStates();
+
             if (taskInputs != null) {
-                getStates().newInputs(taskInputs.getDiscoveredInputs());
+                states.newInputs(taskInputs.getDiscoveredInputs());
             }
-            getStates().getAllTaskChanges().snapshotAfterTask();
-            history.update();
+            states.getAllTaskChanges().snapshotAfterTask();
+
+            // Only store new states if there was no failure, or some output files have been changed
+            if (failure == null || !Iterables.isEmpty(states.getOutputFileChanges())) {
+                history.update();
+            }
         }
 
         private TaskUpToDateState getStates() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/AbstractNamedFileSnapshotTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/AbstractNamedFileSnapshotTaskStateChanges.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.SortedSet;
 
 abstract class AbstractNamedFileSnapshotTaskStateChanges implements TaskStateChanges {
-    private final ImmutableSortedMap<String, FileCollectionSnapshot> fileSnapshotsBeforeExecution;
     private final String taskName;
     private final String title;
     private final ImmutableSortedSet<? extends TaskFilePropertySpec> fileProperties;
@@ -46,6 +45,7 @@ abstract class AbstractNamedFileSnapshotTaskStateChanges implements TaskStateCha
     protected final TaskExecution previous;
     protected final TaskExecution current;
     private final InputNormalizationStrategy normalizationStrategy;
+    protected ImmutableSortedMap<String, FileCollectionSnapshot> currentSnapshots;
 
     protected AbstractNamedFileSnapshotTaskStateChanges(String taskName, TaskExecution previous, TaskExecution current, FileCollectionSnapshotterRegistry snapshotterRegistry, String title, ImmutableSortedSet<? extends TaskFilePropertySpec> fileProperties, InputNormalizationStrategy normalizationStrategy) {
         this.taskName = taskName;
@@ -55,7 +55,7 @@ abstract class AbstractNamedFileSnapshotTaskStateChanges implements TaskStateCha
         this.title = title;
         this.fileProperties = fileProperties;
         this.normalizationStrategy = normalizationStrategy;
-        this.fileSnapshotsBeforeExecution = buildSnapshots(taskName, snapshotterRegistry, title, fileProperties);
+        this.currentSnapshots = buildSnapshots(taskName, snapshotterRegistry, title, fileProperties);
     }
 
     protected String getTaskName() {
@@ -77,7 +77,7 @@ abstract class AbstractNamedFileSnapshotTaskStateChanges implements TaskStateCha
     }
 
     protected ImmutableSortedMap<String, FileCollectionSnapshot> getCurrent() {
-        return fileSnapshotsBeforeExecution;
+        return currentSnapshots;
     }
 
     protected ImmutableSortedMap<String, FileCollectionSnapshot> buildSnapshots(String taskName, FileCollectionSnapshotterRegistry snapshotterRegistry, String title, SortedSet<? extends TaskFilePropertySpec> fileProperties) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/AbstractNamedFileSnapshotTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/AbstractNamedFileSnapshotTaskStateChanges.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 
-abstract class AbstractNamedFileSnapshotTaskStateChanges implements TaskStateChanges {
+abstract public class AbstractNamedFileSnapshotTaskStateChanges implements TaskStateChanges {
     private final String taskName;
     private final String title;
     private final ImmutableSortedSet<? extends TaskFilePropertySpec> fileProperties;
@@ -95,8 +95,7 @@ abstract class AbstractNamedFileSnapshotTaskStateChanges implements TaskStateCha
         return builder.build();
     }
 
-    @Override
-    public Iterator<TaskStateChange> iterator() {
+    protected Iterator<TaskStateChange> getFileChanges(final boolean includeAdded) {
         if (getPrevious() == null) {
             return Iterators.<TaskStateChange>singletonIterator(new DescriptiveChange(title + " file history is not available."));
         }
@@ -128,7 +127,7 @@ abstract class AbstractNamedFileSnapshotTaskStateChanges implements TaskStateCha
                 FileCollectionSnapshot currentSnapshot = entry.getValue();
                 FileCollectionSnapshot previousSnapshot = getPrevious().get(propertyName);
                 String propertyTitle = title + " property '" + propertyName + "'";
-                return currentSnapshot.iterateContentChangesSince(previousSnapshot, propertyTitle);
+                return currentSnapshot.iterateContentChangesSince(previousSnapshot, propertyTitle, includeAdded);
             }
         }).iterator());
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/AbstractNamedFileSnapshotTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/AbstractNamedFileSnapshotTaskStateChanges.java
@@ -86,7 +86,7 @@ abstract public class AbstractNamedFileSnapshotTaskStateChanges implements TaskS
             FileCollectionSnapshot result;
             try {
                 FileCollectionSnapshotter snapshotter = snapshotterRegistry.getSnapshotter(propertySpec.getSnapshotter());
-                result = snapshotter.snapshot(propertySpec.getPropertyFiles(), propertySpec.getCompareStrategy(), propertySpec.getSnapshotNormalizationStrategy(), normalizationStrategy);
+                result = snapshotter.snapshot(propertySpec.getPropertyFiles(), propertySpec.getSnapshotNormalizationStrategy(), normalizationStrategy);
             } catch (UncheckedIOException e) {
                 throw new UncheckedIOException(String.format("Failed to capture snapshot of %s files for task '%s' property '%s' during up-to-date check.", title.toLowerCase(), taskName, propertySpec.getPropertyName()), e);
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/DiscoveredInputsTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/DiscoveredInputsTaskStateChanges.java
@@ -74,7 +74,7 @@ public class DiscoveredInputsTaskStateChanges implements TaskStateChanges, Disco
         if (getPrevious() == null) {
             return Iterators.<TaskStateChange>singletonIterator(new DescriptiveChange("Discovered input file history is not available."));
         }
-        return getCurrent().iterateContentChangesSince(getPrevious(), "discovered input");
+        return getCurrent().iterateContentChangesSince(getPrevious(), "discovered input", true);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/DiscoveredInputsTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/DiscoveredInputsTaskStateChanges.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotterRegistry;
 import org.gradle.api.internal.changedetection.state.GenericFileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.TaskExecution;
-import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy;
 import org.gradle.api.internal.changedetection.state.TaskFilePropertySnapshotNormalizationStrategy;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.normalization.internal.InputNormalizationStrategy;
@@ -90,7 +89,7 @@ public class DiscoveredInputsTaskStateChanges implements TaskStateChanges, Disco
 
     private FileCollectionSnapshot createSnapshot(FileCollectionSnapshotter snapshotter, FileCollection fileCollection) {
         try {
-            return snapshotter.snapshot(fileCollection, TaskFilePropertyCompareStrategy.UNORDERED, TaskFilePropertySnapshotNormalizationStrategy.ABSOLUTE, normalizationStrategy);
+            return snapshotter.snapshot(fileCollection, TaskFilePropertySnapshotNormalizationStrategy.ABSOLUTE, normalizationStrategy);
         } catch (UncheckedIOException e) {
             throw new UncheckedIOException(String.format("Failed to capture snapshot of discovered input files for task '%s' during up-to-date check.", taskName), e);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/InputFilesTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/InputFilesTaskStateChanges.java
@@ -24,6 +24,8 @@ import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotterRe
 import org.gradle.api.internal.changedetection.state.TaskExecution;
 import org.gradle.normalization.internal.InputNormalizationStrategy;
 
+import java.util.Iterator;
+
 public class InputFilesTaskStateChanges extends AbstractNamedFileSnapshotTaskStateChanges {
     public InputFilesTaskStateChanges(@Nullable TaskExecution previous, TaskExecution current, TaskInternal task, FileCollectionSnapshotterRegistry snapshotterRegistry, InputNormalizationStrategy normalizationStrategy) {
         super(task.getName(), previous, current, snapshotterRegistry, "Input", task.getInputs().getFileProperties(), normalizationStrategy);
@@ -34,6 +36,11 @@ public class InputFilesTaskStateChanges extends AbstractNamedFileSnapshotTaskSta
     @Override
     protected ImmutableSortedMap<String, FileCollectionSnapshot> getPrevious() {
         return previous == null ? null : previous.getInputFilesSnapshot();
+    }
+
+    @Override
+    public Iterator<TaskStateChange> iterator() {
+        return getFileChanges(true);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/InputFilesTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/InputFilesTaskStateChanges.java
@@ -33,7 +33,7 @@ public class InputFilesTaskStateChanges extends AbstractNamedFileSnapshotTaskSta
 
     @Override
     protected ImmutableSortedMap<String, FileCollectionSnapshot> getPrevious() {
-        return previous.getInputFilesSnapshot();
+        return previous == null ? null : previous.getInputFilesSnapshot();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/OutputFilesTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/OutputFilesTaskStateChanges.java
@@ -42,7 +42,7 @@ public class OutputFilesTaskStateChanges extends AbstractNamedFileSnapshotTaskSt
 
     @Override
     public ImmutableSortedMap<String, FileCollectionSnapshot> getPrevious() {
-        return previous.getOutputFilesSnapshot();
+        return previous == null ? null : previous.getOutputFilesSnapshot();
     }
 
     @Override
@@ -58,6 +58,7 @@ public class OutputFilesTaskStateChanges extends AbstractNamedFileSnapshotTaskSt
             }
         }));
         current.setOutputFilesSnapshot(results);
+        currentSnapshots = results;
     }
 
     private FileCollectionSnapshot getSnapshotAfterPreviousExecution(String propertyName) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/OutputFilesTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/OutputFilesTaskStateChanges.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStra
 import org.gradle.normalization.internal.InputNormalizationStrategy;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 public class OutputFilesTaskStateChanges extends AbstractNamedFileSnapshotTaskStateChanges {
@@ -43,6 +44,15 @@ public class OutputFilesTaskStateChanges extends AbstractNamedFileSnapshotTaskSt
     @Override
     public ImmutableSortedMap<String, FileCollectionSnapshot> getPrevious() {
         return previous == null ? null : previous.getOutputFilesSnapshot();
+    }
+
+    @Override
+    public Iterator<TaskStateChange> iterator() {
+        return getFileChanges(false);
+    }
+
+    public Iterator<TaskStateChange> iteratorIncludingAdded() {
+        return getFileChanges(true);
     }
 
     @Override
@@ -115,7 +125,7 @@ public class OutputFilesTaskStateChanges extends AbstractNamedFileSnapshotTaskSt
             if (newEntryCount == afterSnapshots.size()) {
                 filesSnapshot = afterExecution;
             } else {
-                filesSnapshot = new DefaultFileCollectionSnapshot(outputEntries.build(), TaskFilePropertyCompareStrategy.OUTPUT, true);
+                filesSnapshot = new DefaultFileCollectionSnapshot(outputEntries.build(), TaskFilePropertyCompareStrategy.UNORDERED, true);
             }
         } else {
             filesSnapshot = afterExecution;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/PreviousSuccessTaskStateChanges.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/PreviousSuccessTaskStateChanges.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.rules;
+
+import com.google.common.collect.Iterators;
+import org.gradle.api.Nullable;
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.changedetection.state.TaskExecution;
+
+import java.util.Iterator;
+
+public class PreviousSuccessTaskStateChanges implements TaskStateChanges {
+    private static final TaskStateChange PREVIOUS_FAILURE = new DescriptiveChange("Task has failed previously.");
+    private final TaskExecution previousExecution;
+    private final TaskExecution currentExecution;
+    private final TaskInternal task;
+
+    public PreviousSuccessTaskStateChanges(@Nullable TaskExecution previousExecution, TaskExecution currentExecution, TaskInternal task) {
+        this.previousExecution = previousExecution;
+        this.currentExecution = currentExecution;
+        this.task = task;
+    }
+
+    @Override
+    public void snapshotAfterTask() {
+        currentExecution.setSuccessful(task.getState().getFailure() == null);
+    }
+
+    @Override
+    public Iterator<TaskStateChange> iterator() {
+        if (previousExecution == null || previousExecution.isSuccessful()) {
+            return Iterators.emptyIterator();
+        } else {
+            return Iterators.singletonIterator(PREVIOUS_FAILURE);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/TaskUpToDateState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/TaskUpToDateState.java
@@ -37,6 +37,7 @@ public class TaskUpToDateState {
     public static final int MAX_OUT_OF_DATE_MESSAGES = 3;
 
     private final TaskStateChanges inputFileChanges;
+    private final TaskStateChanges outputFileChanges;
     private final DiscoveredInputsListener discoveredInputsListener;
     private final TaskStateChanges allTaskChanges;
     private final TaskStateChanges rebuildChanges;
@@ -49,11 +50,13 @@ public class TaskUpToDateState {
         InputNormalizationStrategy inputNormalizationStrategy = ((InputNormalizationHandlerInternal) task.getProject().getNormalization()).buildFinalStrategy();
 
         TaskStateChanges noHistoryState = new NoHistoryTaskStateChanges(lastExecution);
+        TaskStateChanges previousSuccessState = new PreviousSuccessTaskStateChanges(lastExecution, thisExecution, task);
         TaskStateChanges taskTypeState = new TaskTypeTaskStateChanges(lastExecution, thisExecution, task.getPath(), task.getClass(), task.getTaskActions(), classLoaderHierarchyHasher);
         TaskStateChanges inputPropertiesState = new InputPropertiesTaskStateChanges(lastExecution, thisExecution, task, valueSnapshotter);
 
         // Capture outputs state
         TaskStateChanges outputFileChanges = caching(new OutputFilesTaskStateChanges(lastExecution, thisExecution, task, fileCollectionSnapshotterRegistry, inputNormalizationStrategy));
+        this.outputFileChanges = new ErrorHandlingTaskStateChanges(task, outputFileChanges);
 
         // Capture inputs state
         InputFilesTaskStateChanges directInputFileChanges = new InputFilesTaskStateChanges(lastExecution, thisExecution, task, fileCollectionSnapshotterRegistry, inputNormalizationStrategy);
@@ -65,26 +68,45 @@ public class TaskUpToDateState {
         this.discoveredInputsListener = discoveredChanges;
         TaskStateChanges discoveredInputFilesChanges = caching(discoveredChanges);
 
-        this.allTaskChanges = new ErrorHandlingTaskStateChanges(task, new SummaryTaskStateChanges(MAX_OUT_OF_DATE_MESSAGES, noHistoryState, taskTypeState, inputPropertiesState, outputFileChanges, inputFileChanges, discoveredInputFilesChanges));
-        this.rebuildChanges = new ErrorHandlingTaskStateChanges(task, new SummaryTaskStateChanges(1, noHistoryState, taskTypeState, inputPropertiesState, outputFileChanges));
+        this.allTaskChanges = new ErrorHandlingTaskStateChanges(task, new SummaryTaskStateChanges(MAX_OUT_OF_DATE_MESSAGES, previousSuccessState, noHistoryState, taskTypeState, inputPropertiesState, outputFileChanges, inputFileChanges, discoveredInputFilesChanges));
+        this.rebuildChanges = new ErrorHandlingTaskStateChanges(task, new SummaryTaskStateChanges(1, previousSuccessState, noHistoryState, taskTypeState, inputPropertiesState, outputFileChanges));
     }
 
-    private TaskStateChanges caching(TaskStateChanges wrapped) {
+    private static TaskStateChanges caching(TaskStateChanges wrapped) {
         return new CachingTaskStateChanges(MAX_OUT_OF_DATE_MESSAGES, wrapped);
     }
 
+    /**
+     * Returns changes to input files only.
+     */
     public TaskStateChanges getInputFilesChanges() {
         return inputFileChanges;
     }
 
+    /**
+     * Returns changes to output files only.
+     */
+    public TaskStateChanges getOutputFileChanges() {
+        return outputFileChanges;
+    }
+
+    /**
+     * Returns any change to task inputs or outputs.
+     */
     public TaskStateChanges getAllTaskChanges() {
         return allTaskChanges;
     }
 
+    /**
+     * Returns changes that would force an incremental task to fully rebuild.
+     */
     public TaskStateChanges getRebuildChanges() {
         return rebuildChanges;
     }
 
+    /**
+     * Record discovered inputs.
+     */
     public void newInputs(Set<File> discoveredInputs) {
         discoveredInputsListener.newInputs(discoveredInputs);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/TaskUpToDateState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/TaskUpToDateState.java
@@ -37,7 +37,7 @@ public class TaskUpToDateState {
     public static final int MAX_OUT_OF_DATE_MESSAGES = 3;
 
     private final TaskStateChanges inputFileChanges;
-    private final TaskStateChanges outputFileChanges;
+    private final OutputFilesTaskStateChanges outputFileChanges;
     private final DiscoveredInputsListener discoveredInputsListener;
     private final TaskStateChanges allTaskChanges;
     private final TaskStateChanges rebuildChanges;
@@ -55,8 +55,9 @@ public class TaskUpToDateState {
         TaskStateChanges inputPropertiesState = new InputPropertiesTaskStateChanges(lastExecution, thisExecution, task, valueSnapshotter);
 
         // Capture outputs state
-        TaskStateChanges outputFileChanges = caching(new OutputFilesTaskStateChanges(lastExecution, thisExecution, task, fileCollectionSnapshotterRegistry, inputNormalizationStrategy));
-        this.outputFileChanges = new ErrorHandlingTaskStateChanges(task, outputFileChanges);
+        OutputFilesTaskStateChanges uncachedOutputChanges = new OutputFilesTaskStateChanges(lastExecution, thisExecution, task, fileCollectionSnapshotterRegistry, inputNormalizationStrategy);
+        TaskStateChanges outputFileChanges = caching(uncachedOutputChanges);
+        this.outputFileChanges = uncachedOutputChanges;
 
         // Capture inputs state
         InputFilesTaskStateChanges directInputFileChanges = new InputFilesTaskStateChanges(lastExecution, thisExecution, task, fileCollectionSnapshotterRegistry, inputNormalizationStrategy);
@@ -84,10 +85,10 @@ public class TaskUpToDateState {
     }
 
     /**
-     * Returns changes to output files only.
+     * Returns if any output files have been changed, added or removed.
      */
-    public TaskStateChanges getOutputFileChanges() {
-        return outputFileChanges;
+    public boolean hasAnyOutputFileChanges() {
+        return outputFileChanges.iteratorIncludingAdded().hasNext();
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
@@ -167,6 +167,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
          */
         LazyTaskExecution(TaskExecutionSnapshot taskExecutionSnapshot, FileSnapshotRepository snapshotRepository) {
             this(snapshotRepository);
+            setSuccessful(taskExecutionSnapshot.isSuccessful());
             setBuildInvocationId(taskExecutionSnapshot.getBuildInvocationId());
             setTaskImplementation(taskExecutionSnapshot.getTaskImplementation());
             setTaskActionImplementations(taskExecutionSnapshot.getTaskActionsImplementations());
@@ -240,6 +241,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
 
         public TaskExecutionSnapshot snapshot() {
             return new TaskExecutionSnapshot(
+                isSuccessful(),
                 getBuildInvocationId(),
                 getTaskImplementation(),
                 getTaskActionImplementations(),
@@ -262,6 +264,8 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
             }
 
             public TaskExecutionSnapshot read(Decoder decoder) throws Exception {
+                boolean successful = decoder.readBoolean();
+
                 UniqueId buildId = UniqueId.from(decoder.readString());
 
                 ImmutableSortedMap<String, Long> inputFilesSnapshotIds = readSnapshotIds(decoder);
@@ -296,6 +300,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
                 ImmutableSortedMap<String, ValueSnapshot> inputProperties = inputPropertiesSerializer.read(decoder);
 
                 return new TaskExecutionSnapshot(
+                    successful,
                     buildId,
                     taskImplementation,
                     taskActionImplementations,
@@ -309,6 +314,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
             }
 
             public void write(Encoder encoder, TaskExecutionSnapshot execution) throws Exception {
+                encoder.writeBoolean(execution.isSuccessful());
                 encoder.writeString(execution.getBuildInvocationId().asString());
                 writeSnapshotIds(encoder, execution.getInputFilesSnapshotIds());
                 writeSnapshotIds(encoder, execution.getOutputFilesSnapshotIds());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotter.java
@@ -35,7 +35,7 @@ public class DefaultClasspathSnapshotter extends AbstractFileCollectionSnapshott
     }
 
     @Override
-    public FileCollectionSnapshot snapshot(FileCollection files, TaskFilePropertyCompareStrategy compareStrategy, SnapshotNormalizationStrategy snapshotNormalizationStrategy, InputNormalizationStrategy normalizationStrategy) {
+    public FileCollectionSnapshot snapshot(FileCollection files, SnapshotNormalizationStrategy snapshotNormalizationStrategy, InputNormalizationStrategy normalizationStrategy) {
         ResourceHasher classpathResourceHasher = normalizationStrategy.getRuntimeClasspathNormalizationStrategy().getRuntimeClasspathResourceHasher();
         return super.snapshot(files, new RuntimeClasspathSnapshotBuilder(classpathResourceHasher, cacheService, getStringInterner()));
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultCompileClasspathSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultCompileClasspathSnapshotter.java
@@ -32,7 +32,7 @@ public class DefaultCompileClasspathSnapshotter extends AbstractFileCollectionSn
     }
 
     @Override
-    public FileCollectionSnapshot snapshot(FileCollection files, TaskFilePropertyCompareStrategy compareStrategy, SnapshotNormalizationStrategy snapshotNormalizationStrategy, InputNormalizationStrategy normalizationStrategy) {
+    public FileCollectionSnapshot snapshot(FileCollection files, SnapshotNormalizationStrategy snapshotNormalizationStrategy, InputNormalizationStrategy normalizationStrategy) {
         return super.snapshot(
             files,
             new CompileClasspathSnapshotBuilder(classpathResourceHasher, cacheService, getStringInterner()));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileCollectionSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileCollectionSnapshot.java
@@ -67,8 +67,8 @@ public class DefaultFileCollectionSnapshot implements FileCollectionSnapshot {
     }
 
     @Override
-    public Iterator<TaskStateChange> iterateContentChangesSince(FileCollectionSnapshot oldSnapshot, String fileType) {
-        return compareStrategy.iterateContentChangesSince(snapshots, oldSnapshot.getSnapshots(), fileType, pathIsAbsolute);
+    public Iterator<TaskStateChange> iterateContentChangesSince(FileCollectionSnapshot oldSnapshot, String fileType, boolean includeAdded) {
+        return compareStrategy.iterateContentChangesSince(snapshots, oldSnapshot.getSnapshots(), fileType, pathIsAbsolute, includeAdded);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -97,7 +97,7 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
             public Snapshot create() {
                 Snapshot snapshot = fileSystemMirror.getContent(path);
                 if (snapshot == null) {
-                    FileCollectionSnapshot fileCollectionSnapshot = snapshotter.snapshot(new SimpleFileCollection(file), TaskFilePropertyCompareStrategy.UNORDERED, TaskFilePropertySnapshotNormalizationStrategy.ABSOLUTE, InputNormalizationStrategy.NOT_CONFIGURED);
+                    FileCollectionSnapshot fileCollectionSnapshot = snapshotter.snapshot(new SimpleFileCollection(file), TaskFilePropertySnapshotNormalizationStrategy.ABSOLUTE, InputNormalizationStrategy.NOT_CONFIGURED);
                     DefaultBuildCacheHasher hasher = new DefaultBuildCacheHasher();
                     fileCollectionSnapshot.appendToHasher(hasher);
                     HashCode hashCode = hasher.hash();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotter.java
@@ -32,7 +32,7 @@ public class DefaultGenericFileCollectionSnapshotter extends AbstractFileCollect
     }
 
     @Override
-    public FileCollectionSnapshot snapshot(FileCollection files, TaskFilePropertyCompareStrategy compareStrategy, SnapshotNormalizationStrategy snapshotNormalizationStrategy, InputNormalizationStrategy normalizationStrategy) {
-        return super.snapshot(files, new FileCollectionSnapshotBuilder(compareStrategy, snapshotNormalizationStrategy, getStringInterner()));
+    public FileCollectionSnapshot snapshot(FileCollection files, SnapshotNormalizationStrategy snapshotNormalizationStrategy, InputNormalizationStrategy normalizationStrategy) {
+        return super.snapshot(files, new FileCollectionSnapshotBuilder(TaskFilePropertyCompareStrategy.UNORDERED, snapshotNormalizationStrategy, getStringInterner()));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileCollectionSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileCollectionSnapshot.java
@@ -37,7 +37,7 @@ public interface FileCollectionSnapshot extends Snapshot {
     /**
      * Returns an iterator over the changes to file contents since the given snapshot, subject to the given filters.
      */
-    Iterator<TaskStateChange> iterateContentChangesSince(FileCollectionSnapshot oldSnapshot, String title);
+    Iterator<TaskStateChange> iterateContentChangesSince(FileCollectionSnapshot oldSnapshot, String title, boolean includeAdded);
 
     /**
      * Returns the elements of this snapshot, including regular files, directories and missing files

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileCollectionSnapshotter.java
@@ -35,10 +35,9 @@ public interface FileCollectionSnapshotter {
      * Creates a snapshot of the contents of the given collection.
      *
      * @param files The files to snapshot.
-     * @param compareStrategy How to compare this collection snapshot to others.
      * @param snapshotNormalizationStrategy How to normalize file snapshots.
      * @param normalizationStrategy The input normalization strategy to take into account.
      * @return The snapshot.
      */
-    FileCollectionSnapshot snapshot(FileCollection files, TaskFilePropertyCompareStrategy compareStrategy, SnapshotNormalizationStrategy snapshotNormalizationStrategy, InputNormalizationStrategy normalizationStrategy);
+    FileCollectionSnapshot snapshot(FileCollection files, SnapshotNormalizationStrategy snapshotNormalizationStrategy, InputNormalizationStrategy normalizationStrategy);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderInsensitiveTaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderInsensitiveTaskFilePropertyCompareStrategy.java
@@ -46,25 +46,19 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
         }
     };
 
-    private final boolean includeAdded;
-
-    public OrderInsensitiveTaskFilePropertyCompareStrategy(boolean includeAdded) {
-        this.includeAdded = includeAdded;
-    }
-
     @Override
-    public Iterator<TaskStateChange> iterateContentChangesSince(Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous, String fileType, boolean pathIsAbsolute) {
+    public Iterator<TaskStateChange> iterateContentChangesSince(Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous, String fileType, boolean pathIsAbsolute, boolean includeAdded) {
         if (pathIsAbsolute) {
-            return iterateChangesForAbsolutePaths(current, previous, fileType);
+            return iterateChangesForAbsolutePaths(current, previous, fileType, includeAdded);
         } else {
-            return iterateChangesForRelativePaths(current, previous, fileType);
+            return iterateChangesForRelativePaths(current, previous, fileType, includeAdded);
         }
     }
 
     /**
      * A more efficient implementation when absolute paths are used.
      */
-    private Iterator<TaskStateChange> iterateChangesForAbsolutePaths(final Map<String, NormalizedFileSnapshot> current, final Map<String, NormalizedFileSnapshot> previous, final String fileType) {
+    private Iterator<TaskStateChange> iterateChangesForAbsolutePaths(final Map<String, NormalizedFileSnapshot> current, final Map<String, NormalizedFileSnapshot> previous, final String fileType, final boolean includeAdded) {
         final Set<String> unaccountedForPreviousSnapshots = new LinkedHashSet<String>(previous.keySet());
         final Iterator<Entry<String, NormalizedFileSnapshot>> currentEntries = current.entrySet().iterator();
         final List<String> added = new ArrayList<String>();
@@ -114,7 +108,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
         };
     }
 
-    private Iterator<TaskStateChange> iterateChangesForRelativePaths(final Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous, final String fileType) {
+    private Iterator<TaskStateChange> iterateChangesForRelativePaths(final Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous, final String fileType, final boolean includeAdded) {
         final ListMultimap<NormalizedFileSnapshot, IncrementalFileSnapshotWithAbsolutePath> unaccountedForPreviousSnapshots = MultimapBuilder.hashKeys().linkedListValues().build();
         for (Entry<String, NormalizedFileSnapshot> entry : previous.entrySet()) {
             String absolutePath = entry.getKey();
@@ -196,11 +190,6 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
         for (NormalizedFileSnapshot normalizedSnapshot : normalizedSnapshots) {
             normalizedSnapshot.appendToHasher(hasher);
         }
-    }
-
-    @Override
-    public boolean isIncludeAdded() {
-        return includeAdded;
     }
 
     private static class IncrementalFileSnapshotWithAbsolutePath {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecution.java
@@ -26,6 +26,7 @@ import org.gradle.internal.id.UniqueId;
  * The state for a single task execution.
  */
 public abstract class TaskExecution {
+    private boolean successful;
     private UniqueId buildInvocationId;
     private ImplementationSnapshot taskImplementation;
     private ImmutableList<ImplementationSnapshot> taskActionImplementations;
@@ -33,6 +34,14 @@ public abstract class TaskExecution {
     private Iterable<String> outputPropertyNamesForCacheKey;
     private ImmutableSet<String> declaredOutputFilePaths;
     private OverlappingOutputs detectedOverlappingOutputs;
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+    public void setSuccessful(boolean successful) {
+        this.successful = successful;
+    }
 
     public UniqueId getBuildInvocationId() {
         return buildInvocationId;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecutionSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecutionSnapshot.java
@@ -27,6 +27,7 @@ import org.gradle.internal.id.UniqueId;
  */
 public class TaskExecutionSnapshot {
     private final UniqueId buildInvocationId;
+    private final boolean successful;
     private final ImplementationSnapshot taskImplementation;
     private final ImmutableList<ImplementationSnapshot> taskActionsImplementations;
     private final ImmutableSortedMap<String, ValueSnapshot> inputProperties;
@@ -36,7 +37,8 @@ public class TaskExecutionSnapshot {
     private final ImmutableSortedMap<String, Long> outputFilesSnapshotIds;
     private final Long discoveredFilesSnapshotId;
 
-    public TaskExecutionSnapshot(UniqueId buildInvocationId, ImplementationSnapshot taskImplementation, ImmutableList<ImplementationSnapshot> taskActionsImplementations, ImmutableSortedSet<String> cacheableOutputProperties, ImmutableSet<String> declaredOutputFilePaths, ImmutableSortedMap<String, ValueSnapshot> inputProperties, ImmutableSortedMap<String, Long> inputFilesSnapshotIds, Long discoveredFilesSnapshotId, ImmutableSortedMap<String, Long> outputFilesSnapshotIds) {
+    public TaskExecutionSnapshot(boolean successful, UniqueId buildInvocationId, ImplementationSnapshot taskImplementation, ImmutableList<ImplementationSnapshot> taskActionsImplementations, ImmutableSortedSet<String> cacheableOutputProperties, ImmutableSet<String> declaredOutputFilePaths, ImmutableSortedMap<String, ValueSnapshot> inputProperties, ImmutableSortedMap<String, Long> inputFilesSnapshotIds, Long discoveredFilesSnapshotId, ImmutableSortedMap<String, Long> outputFilesSnapshotIds) {
+        this.successful = successful;
         this.buildInvocationId = buildInvocationId;
         this.taskImplementation = taskImplementation;
         this.taskActionsImplementations = taskActionsImplementations;
@@ -46,6 +48,10 @@ public class TaskExecutionSnapshot {
         this.inputFilesSnapshotIds = inputFilesSnapshotIds;
         this.discoveredFilesSnapshotId = discoveredFilesSnapshotId;
         this.outputFilesSnapshotIds = outputFilesSnapshotIds;
+    }
+
+    public boolean isSuccessful() {
+        return successful;
     }
 
     public UniqueId getBuildInvocationId() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategy.java
@@ -33,8 +33,7 @@ import static com.google.common.collect.Iterators.singletonIterator;
 
 public enum TaskFilePropertyCompareStrategy {
     ORDERED(new OrderSensitiveTaskFilePropertyCompareStrategy()),
-    UNORDERED(new OrderInsensitiveTaskFilePropertyCompareStrategy(true)),
-    OUTPUT(new OrderInsensitiveTaskFilePropertyCompareStrategy(false));
+    UNORDERED(new OrderInsensitiveTaskFilePropertyCompareStrategy());
 
     private final Impl delegate;
 
@@ -42,13 +41,13 @@ public enum TaskFilePropertyCompareStrategy {
         this.delegate = delegate;
     }
 
-    public Iterator<TaskStateChange> iterateContentChangesSince(Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous, String fileType, boolean pathIsAbsolute) {
+    public Iterator<TaskStateChange> iterateContentChangesSince(Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous, String fileType, boolean pathIsAbsolute, boolean includeAdded) {
         // Handle trivial cases with 0 or 1 elements in both current and previous
-        Iterator<TaskStateChange> trivialResult = compareTrivialSnapshots(current, previous, fileType, delegate.isIncludeAdded());
+        Iterator<TaskStateChange> trivialResult = compareTrivialSnapshots(current, previous, fileType, includeAdded);
         if (trivialResult != null) {
             return trivialResult;
         }
-        return delegate.iterateContentChangesSince(current, previous, fileType, pathIsAbsolute);
+        return delegate.iterateContentChangesSince(current, previous, fileType, pathIsAbsolute, includeAdded);
     }
 
     public void appendToHasher(BuildCacheHasher hasher, Collection<NormalizedFileSnapshot> snapshots) {
@@ -56,9 +55,8 @@ public enum TaskFilePropertyCompareStrategy {
     }
 
     interface Impl {
-        Iterator<TaskStateChange> iterateContentChangesSince(Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous, String fileType, boolean pathIsAbsolute);
+        Iterator<TaskStateChange> iterateContentChangesSince(Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous, String fileType, boolean pathIsAbsolute, boolean includeAdded);
         void appendToHasher(BuildCacheHasher hasher, Collection<NormalizedFileSnapshot> snapshots);
-        boolean isIncludeAdded();
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClasspathHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClasspathHasher.java
@@ -36,7 +36,7 @@ public class DefaultClasspathHasher implements ClasspathHasher {
 
     @Override
     public HashCode hash(ClassPath classpath) {
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(new SimpleFileCollection(classpath.getAsFiles()), null, null, InputNormalizationStrategy.NOT_CONFIGURED);
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(new SimpleFileCollection(classpath.getAsFiles()), null, InputNormalizationStrategy.NOT_CONFIGURED);
         BuildCacheHasher hasher = new DefaultBuildCacheHasher();
         snapshot.appendToHasher(hasher);
         return hasher.hash();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputPropertySpec.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.changedetection.state.TaskFilePropertySnapshotNor
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 
-import static org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy.OUTPUT;
+import static org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy.UNORDERED;
 
 abstract class AbstractTaskOutputPropertySpec extends AbstractTaskOutputsDeprecatingTaskPropertyBuilder implements TaskOutputPropertySpecAndBuilder {
     private boolean optional;
@@ -62,7 +62,7 @@ abstract class AbstractTaskOutputPropertySpec extends AbstractTaskOutputsDepreca
     }
 
     public TaskFilePropertyCompareStrategy getCompareStrategy() {
-        return OUTPUT;
+        return UNORDERED;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputPropertySpec.java
@@ -19,12 +19,9 @@ package org.gradle.api.internal.tasks;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.GenericFileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.SnapshotNormalizationStrategy;
-import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy;
 import org.gradle.api.internal.changedetection.state.TaskFilePropertySnapshotNormalizationStrategy;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
-
-import static org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy.UNORDERED;
 
 abstract class AbstractTaskOutputPropertySpec extends AbstractTaskOutputsDeprecatingTaskPropertyBuilder implements TaskOutputPropertySpecAndBuilder {
     private boolean optional;
@@ -61,13 +58,9 @@ abstract class AbstractTaskOutputPropertySpec extends AbstractTaskOutputsDepreca
         return this;
     }
 
-    public TaskFilePropertyCompareStrategy getCompareStrategy() {
-        return UNORDERED;
-    }
-
     @Override
     public String toString() {
-        return getPropertyName() + " (" + getCompareStrategy() + " " + snapshotNormalizationStrategy + ")";
+        return getPropertyName() + " (" + snapshotNormalizationStrategy + ")";
     }
 
     public Class<? extends FileCollectionSnapshotter> getSnapshotter() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CacheableTaskOutputCompositeFilePropertyElementSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CacheableTaskOutputCompositeFilePropertyElementSpec.java
@@ -20,7 +20,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.GenericFileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.SnapshotNormalizationStrategy;
-import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
 
 import java.io.File;
@@ -57,11 +56,6 @@ class CacheableTaskOutputCompositeFilePropertyElementSpec implements CacheableTa
     @Override
     public OutputType getOutputType() {
         return parentProperty.getOutputType();
-    }
-
-    @Override
-    public TaskFilePropertyCompareStrategy getCompareStrategy() {
-        return parentProperty.getCompareStrategy();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
@@ -20,7 +20,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.GenericFileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.SnapshotNormalizationStrategy;
-import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy;
 import org.gradle.api.internal.changedetection.state.TaskFilePropertySnapshotNormalizationStrategy;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.tasks.PathSensitivity;
@@ -82,11 +81,6 @@ public class DefaultTaskInputPropertySpec extends AbstractTaskPropertyBuilder im
     @Override
     public TaskInputFilePropertyBuilderInternal optional() {
         return optional(true);
-    }
-
-    @Override
-    public TaskFilePropertyCompareStrategy getCompareStrategy() {
-        return TaskFilePropertyCompareStrategy.UNORDERED;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.SnapshotNormalizationStrategy;
-import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.tasks.TaskPropertyBuilder;
 
@@ -46,11 +45,6 @@ public class NonCacheableTaskOutputPropertySpec extends AbstractTaskOutputsDepre
     @Override
     public Class<? extends FileCollectionSnapshotter> getSnapshotter() {
         return parent.getSnapshotter();
-    }
-
-    @Override
-    public TaskFilePropertyCompareStrategy getCompareStrategy() {
-        return parent.getCompareStrategy();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskFilePropertySpec.java
@@ -19,11 +19,9 @@ package org.gradle.api.internal.tasks;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.SnapshotNormalizationStrategy;
-import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy;
 
 public interface TaskFilePropertySpec extends TaskPropertySpec {
     FileCollection getPropertyFiles();
     Class<? extends FileCollectionSnapshotter> getSnapshotter();
-    TaskFilePropertyCompareStrategy getCompareStrategy();
     SnapshotNormalizationStrategy getSnapshotNormalizationStrategy();
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/AbstractTaskStateChangesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/AbstractTaskStateChangesTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter
 import org.gradle.api.internal.changedetection.state.GenericFileCollectionSnapshotter
 import org.gradle.api.internal.changedetection.state.SnapshotNormalizationStrategy
-import org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy
 import org.gradle.api.internal.changedetection.state.TaskFilePropertySnapshotNormalizationStrategy
 import org.gradle.api.internal.file.collections.SimpleFileCollection
 import org.gradle.api.internal.tasks.TaskInputFilePropertySpec
@@ -55,7 +54,6 @@ abstract class AbstractTaskStateChangesTest extends Specification {
             return new PropertySpec(
                 propertyName: entry.key,
                 propertyFiles: new SimpleFileCollection([new File(entry.value)]),
-                compareStrategy: TaskFilePropertyCompareStrategy.UNORDERED,
                 snapshotNormalizationStrategy: TaskFilePropertySnapshotNormalizationStrategy.ABSOLUTE
             )
         })
@@ -64,7 +62,6 @@ abstract class AbstractTaskStateChangesTest extends Specification {
     protected static class PropertySpec implements TaskInputFilePropertySpec {
         String propertyName
         FileCollection propertyFiles
-        TaskFilePropertyCompareStrategy compareStrategy
         SnapshotNormalizationStrategy snapshotNormalizationStrategy
         Class<? extends FileCollectionSnapshotter> snapshotter = GenericFileCollectionSnapshotter
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/InputFilesTaskStateChangesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/InputFilesTaskStateChangesTest.groovy
@@ -42,7 +42,7 @@ class InputFilesTaskStateChangesTest extends AbstractTaskStateChangesTest {
         then:
         1 * mockInputFileSnapshotterRegistry.getSnapshotter(GenericFileCollectionSnapshotter) >> mockInputFileSnapshotter
         1 * mockInputs.getFileProperties() >> fileProperties(prop: "a")
-        1 * mockInputFileSnapshotter.snapshot(_, _, _, _) >> { throw cause }
+        1 * mockInputFileSnapshotter.snapshot(_, _, _) >> { throw cause }
         0 * _
 
         def e = thrown(UncheckedIOException)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/OutputFilesTaskStateChangesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/OutputFilesTaskStateChangesTest.groovy
@@ -41,7 +41,7 @@ class OutputFilesTaskStateChangesTest extends AbstractTaskStateChangesTest {
         then:
         1 * snapshotterRegistry.getSnapshotter(GenericFileCollectionSnapshotter) >> fileCollectionSnapshotter
         1 * mockOutputs.getFileProperties() >> fileProperties(out: "b")
-        1 * fileCollectionSnapshotter.snapshot(_, _, _, _) >> { throw cause }
+        1 * fileCollectionSnapshotter.snapshot(_, _, _) >> { throw cause }
         0 * _
 
         def e = thrown(UncheckedIOException)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/TaskUpToDateStateTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/TaskUpToDateStateTest.groovy
@@ -46,6 +46,6 @@ class TaskUpToDateStateTest extends AbstractTaskStateChangesTest {
         1 * mockInputs.getFileProperties() >> fileProperties(prop: "a")
         1 * mockOutputs.getFileProperties() >> fileProperties(out: "b")
         (1.._) * mockInputFileSnapshotterRegistry.getSnapshotter(GenericFileCollectionSnapshotter) >> mockInputFileSnapshotter
-        (1.._) * mockInputFileSnapshotter.snapshot(_, _, _, _) >> stubSnapshot
+        (1.._) * mockInputFileSnapshotter.snapshot(_, _, _) >> stubSnapshot
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
@@ -205,7 +205,7 @@ class DefaultClasspathSnapshotterTest extends Specification {
 
     def snapshot(TestFile... classpath) {
         fileSystemMirror.beforeTaskOutputsGenerated()
-        def fileCollectionSnapshot = snapshotter.snapshot(files(classpath), null, null, InputNormalizationStrategy.NOT_CONFIGURED)
+        def fileCollectionSnapshot = snapshotter.snapshot(files(classpath), null, InputNormalizationStrategy.NOT_CONFIGURED)
         return fileCollectionSnapshot.snapshots.collect { String path, NormalizedFileSnapshot normalizedFileSnapshot ->
             [new File(path).getName(), normalizedFileSnapshot.normalizedPath, normalizedFileSnapshot.snapshot.toString()]
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
@@ -135,8 +135,8 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         when:
         def snapshot = snapshotter.snapshot(files(file1, file2), UNORDERED, ABSOLUTE, normalizationStrategy)
         file2.createFile()
-        def target = snapshotter.snapshot(files(file1, file2, file3, file4), OUTPUT, ABSOLUTE, normalizationStrategy)
-        Iterators.size(target.iterateContentChangesSince(snapshot, "TYPE")) == 0
+        def target = snapshotter.snapshot(files(file1, file2, file3, file4), UNORDERED, ABSOLUTE, normalizationStrategy)
+        Iterators.size(target.iterateContentChangesSince(snapshot, "TYPE", false)) == 0
 
         then:
         0 * _
@@ -306,7 +306,7 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
     }
 
     private void changes(FileCollectionSnapshot newSnapshot, FileCollectionSnapshot oldSnapshot, ChangeListener<String> listener) {
-        newSnapshot.iterateContentChangesSince(oldSnapshot, "TYPE").each { FileChange change ->
+        newSnapshot.iterateContentChangesSince(oldSnapshot, "TYPE", true).each { FileChange change ->
             switch (change.type) {
                 case ChangeType.ADDED:
                     listener.added(change.path)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
@@ -30,7 +30,6 @@ import org.gradle.util.ChangeListener
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.gradle.api.internal.changedetection.state.TaskFilePropertyCompareStrategy.*
 import static org.gradle.api.internal.changedetection.state.TaskFilePropertySnapshotNormalizationStrategy.ABSOLUTE
 
 class DefaultGenericFileCollectionSnapshotterTest extends Specification {
@@ -50,7 +49,7 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile noExist = tmpDir.file('file3')
 
         when:
-        def snapshot = snapshotter.snapshot(files(file, dir, noExist), UNORDERED, ABSOLUTE, normalizationStrategy)
+        def snapshot = snapshotter.snapshot(files(file, dir, noExist), ABSOLUTE, normalizationStrategy)
 
         then:
         snapshot.files as List == [file, file2]
@@ -63,7 +62,7 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file3 = tmpDir.createFile('file3')
 
         when:
-        def snapshot = snapshotter.snapshot(files(file, file2, file3), ORDERED, ABSOLUTE, normalizationStrategy)
+        def snapshot = snapshotter.snapshot(files(file, file2, file3), ABSOLUTE, normalizationStrategy)
 
         then:
         snapshot.files == [file, file2, file3]
@@ -75,7 +74,7 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile noExist = tmpDir.file('file3')
 
         when:
-        def snapshot = snapshotter.snapshot(files(file, noExist), UNORDERED, ABSOLUTE, normalizationStrategy)
+        def snapshot = snapshotter.snapshot(files(file, noExist), ABSOLUTE, normalizationStrategy)
 
         then:
         snapshot.elements == [file, noExist]
@@ -90,7 +89,7 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile noExist = tmpDir.file('file3')
 
         when:
-        def snapshot = snapshotter.snapshot(files(file, dir, noExist), UNORDERED, ABSOLUTE, normalizationStrategy)
+        def snapshot = snapshotter.snapshot(files(file, dir, noExist), ABSOLUTE, normalizationStrategy)
 
         then:
         snapshot.elements == [file, dir, dir2, file2, noExist]
@@ -104,7 +103,7 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file4 = tmpDir.createFile('file4')
 
         when:
-        def snapshot = snapshotter.snapshot(files(file, file2, file3, file4), ORDERED, ABSOLUTE, normalizationStrategy)
+        def snapshot = snapshotter.snapshot(files(file, file2, file3, file4), ABSOLUTE, normalizationStrategy)
 
         then:
         snapshot.elements == [file, file2, file3, file4]
@@ -116,9 +115,9 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file2 = tmpDir.createFile('file2')
 
         when:
-        def snapshot = snapshotter.snapshot(files(file1), UNORDERED, ABSOLUTE, normalizationStrategy)
+        def snapshot = snapshotter.snapshot(files(file1), ABSOLUTE, normalizationStrategy)
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(files(file1, file2), UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(files(file1, file2), ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         1 * listener.added(file2.path)
@@ -133,9 +132,9 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file4 = tmpDir.createDir('file4')
 
         when:
-        def snapshot = snapshotter.snapshot(files(file1, file2), UNORDERED, ABSOLUTE, normalizationStrategy)
+        def snapshot = snapshotter.snapshot(files(file1, file2), ABSOLUTE, normalizationStrategy)
         file2.createFile()
-        def target = snapshotter.snapshot(files(file1, file2, file3, file4), UNORDERED, ABSOLUTE, normalizationStrategy)
+        def target = snapshotter.snapshot(files(file1, file2, file3, file4), ABSOLUTE, normalizationStrategy)
         Iterators.size(target.iterateContentChangesSince(snapshot, "TYPE", false)) == 0
 
         then:
@@ -148,9 +147,9 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file2 = tmpDir.createFile('file2')
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file1, file2), UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file1, file2), ABSOLUTE, normalizationStrategy)
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(files(file1), UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(files(file1), ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         1 * listener.removed(file2.path)
@@ -163,12 +162,12 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         file.setLastModified(1234L)
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file), UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file), ABSOLUTE, normalizationStrategy)
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(files(file), UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(files(file), ABSOLUTE, normalizationStrategy), snapshot, listener)
         file.setLastModified(45600L)
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(files(file), UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(files(file), ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         0 * listener._
@@ -181,11 +180,11 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         def fileCollection = files(root)
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(fileCollection, UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(fileCollection, ABSOLUTE, normalizationStrategy)
         file.delete()
         file.createDir()
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(fileCollection, UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(fileCollection, ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         1 * listener.changed(file.path)
@@ -196,10 +195,10 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file = tmpDir.createFile('file')
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file), UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file), ABSOLUTE, normalizationStrategy)
         file.write('new content')
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(files(file), UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(files(file), ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         1 * listener.changed(file.path)
@@ -210,9 +209,9 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile dir = tmpDir.createDir('dir')
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(dir), UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(dir), ABSOLUTE, normalizationStrategy)
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(files(dir), UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(files(dir), ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         0 * _
@@ -224,11 +223,11 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile dir = root.createDir('dir')
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(fileCollection, UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(fileCollection, ABSOLUTE, normalizationStrategy)
         dir.deleteDir()
         dir.createFile()
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(fileCollection, UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(fileCollection, ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         1 * listener.changed(dir.path)
@@ -239,9 +238,9 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file = tmpDir.file('unknown')
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file), UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file), ABSOLUTE, normalizationStrategy)
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(files(file), UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(files(file), ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         0 * _
@@ -253,10 +252,10 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file = root.file('newfile')
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(fileCollection, UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(fileCollection, ABSOLUTE, normalizationStrategy)
         file.createFile()
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(fileCollection, UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(fileCollection, ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         1 * listener.added(file.path)
@@ -268,10 +267,10 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file = root.createFile('file')
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(fileCollection, UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(fileCollection, ABSOLUTE, normalizationStrategy)
         file.delete()
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(fileCollection, UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(fileCollection, ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         1 * listener.removed(file.path)
@@ -282,9 +281,9 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
         TestFile file2 = tmpDir.createFile('file')
 
         when:
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file1, file2), UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(files(file1, file2), ABSOLUTE, normalizationStrategy)
         fileSystemMirror.beforeTaskOutputsGenerated()
-        changes(snapshotter.snapshot(files(file1), UNORDERED, ABSOLUTE, normalizationStrategy), snapshot, listener)
+        changes(snapshotter.snapshot(files(file1), ABSOLUTE, normalizationStrategy), snapshot, listener)
 
         then:
         0 * _
@@ -295,7 +294,7 @@ class DefaultGenericFileCollectionSnapshotterTest extends Specification {
 
         when:
         FileCollectionSnapshot snapshot = FileCollectionSnapshot.EMPTY
-        FileCollectionSnapshot newSnapshot = snapshotter.snapshot(files(file), UNORDERED, ABSOLUTE, normalizationStrategy)
+        FileCollectionSnapshot newSnapshot = snapshotter.snapshot(files(file), ABSOLUTE, normalizationStrategy)
         fileSystemMirror.beforeTaskOutputsGenerated()
         changes(newSnapshot, snapshot, listener)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategyTest.groovy
@@ -31,205 +31,241 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     @Unroll
     def "empty snapshots (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             [:],
             [:]
         ) as List == []
 
         where:
-        strategy << [ORDERED, UNORDERED, OUTPUT]
+        strategy  | includeAdded
+        ORDERED   | true
+        ORDERED   | false
+        UNORDERED | true
+        UNORDERED | false
     }
 
     @Unroll
     def "trivial addition (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             ["one-new": snapshot("one")],
             [:]
         ) as List == results
 
         where:
-        strategy  | results
-        ORDERED   | [new FileChange("one-new", ADDED, "test")]
-        UNORDERED | [new FileChange("one-new", ADDED, "test")]
-        OUTPUT    | []
+        strategy  | includeAdded | results
+        ORDERED   | true         | [new FileChange("one-new", ADDED, "test")]
+        ORDERED   | false        | []
+        UNORDERED | true         | [new FileChange("one-new", ADDED, "test")]
+        UNORDERED | false        | []
     }
 
     @Unroll
     def "non-trivial addition (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             ["one-new": snapshot("one"), "two-new": snapshot("two")],
             ["one-old": snapshot("one")]
         ) == results
 
         where:
-        strategy  | results
-        ORDERED   | [change("two-new", ADDED)]
-        UNORDERED | [change("two-new", ADDED)]
-        OUTPUT    | []
+        strategy  | includeAdded | results
+        ORDERED   | true         | [change("two-new", ADDED)]
+        ORDERED   | false        | []
+        UNORDERED | true         | [change("two-new", ADDED)]
+        UNORDERED | false        | []
     }
 
     @Unroll
     def "non-trivial addition with absolute paths (#strategy)"() {
         expect:
-        changesUsingAbsolutePaths(strategy,
+        changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one"), "two": snapshot("two")],
             ["one": snapshot("one")]
         ) == results
 
         where:
-        strategy  | results
-        ORDERED   | [change("two", ADDED)]
-        UNORDERED | [change("two", ADDED)]
-        OUTPUT    | []
+        strategy  | includeAdded | results
+        ORDERED   | true         | [change("two", ADDED)]
+        ORDERED   | false        | []
+        UNORDERED | true         | [change("two", ADDED)]
+        UNORDERED | false        | []
     }
 
     @Unroll
     def "trivial removal (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             [:],
             ["one-old": snapshot("one")]
         ) as List == [new FileChange("one-old", REMOVED, "test")]
 
         where:
-        strategy << [ORDERED, UNORDERED, OUTPUT]
+        strategy  | includeAdded
+        ORDERED   | true
+        ORDERED   | false
+        UNORDERED | true
+        UNORDERED | false
     }
 
     @Unroll
     def "non-trivial removal (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             ["one-new": snapshot("one")],
             ["one-old": snapshot("one"), "two-old": snapshot("two")]
         ) == [change("two-old", REMOVED)]
 
         where:
-        strategy << [ORDERED, UNORDERED, OUTPUT]
+        strategy  | includeAdded
+        ORDERED   | true
+        ORDERED   | false
+        UNORDERED | true
+        UNORDERED | false
     }
 
     @Unroll
     def "non-trivial removal with absolute paths (#strategy)"() {
         expect:
-        changesUsingAbsolutePaths(strategy,
+        changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one")],
             ["one": snapshot("one"), "two": snapshot("two")]
         ) == [change("two", REMOVED)]
 
         where:
-        strategy << [ORDERED, UNORDERED, OUTPUT]
+        strategy  | includeAdded
+        ORDERED   | true
+        ORDERED   | false
+        UNORDERED | true
+        UNORDERED | false
     }
 
     @Unroll
     def "non-trivial modification (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             ["one-new": snapshot("one"), "two-new": snapshot("two", "9876cafe")],
             ["one-old": snapshot("one"), "two-old": snapshot("two", "face1234")]
         ) == [change("two-new", MODIFIED)]
 
         where:
-        strategy << [ORDERED, UNORDERED, OUTPUT]
+        strategy  | includeAdded
+        ORDERED   | true
+        ORDERED   | false
+        UNORDERED | true
+        UNORDERED | false
     }
 
     @Unroll
     def "non-trivial modification with absolute paths (#strategy)"() {
         expect:
-        changesUsingAbsolutePaths(strategy,
+        changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one"), "two": snapshot("two", "9876cafe")],
             ["one": snapshot("one"), "two": snapshot("two", "face1234")]
         ) == [change("two", MODIFIED)]
 
         where:
-        strategy << [ORDERED, UNORDERED, OUTPUT]
+        strategy  | includeAdded
+        ORDERED   | true
+        ORDERED   | false
+        UNORDERED | true
+        UNORDERED | false
     }
 
     @Unroll
     def "trivial replacement (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             ["two-new": snapshot("two")],
             ["one-old": snapshot("one")]
         ) as List == results
 
         where:
-        strategy | results
-        ORDERED   | [new FileChange("one-old", REMOVED, "test"), new FileChange("two-new", ADDED, "test")]
-        UNORDERED | [new FileChange("one-old", REMOVED, "test"), new FileChange("two-new", ADDED, "test")]
-        OUTPUT    | [new FileChange("one-old", REMOVED, "test")]
+        strategy  | includeAdded | results
+        ORDERED   | true         | [new FileChange("one-old", REMOVED, "test"), new FileChange("two-new", ADDED, "test")]
+        ORDERED   | false        | [new FileChange("one-old", REMOVED, "test")]
+        UNORDERED | true         | [new FileChange("one-old", REMOVED, "test"), new FileChange("two-new", ADDED, "test")]
+        UNORDERED | false        | [new FileChange("one-old", REMOVED, "test")]
     }
 
     @Unroll
     def "non-trivial replacement (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             ["one-new": snapshot("one"), "two-new": snapshot("two"), "four-new": snapshot("four")],
             ["one-old": snapshot("one"), "three-old": snapshot("three"), "four-old": snapshot("four")]
         ) == results
 
         where:
-        strategy  | results
-        ORDERED   | [change("three-old", REMOVED), change("two-new", ADDED)]
-        UNORDERED | [change("three-old", REMOVED), change("two-new", ADDED)]
-        OUTPUT    | [change("three-old", REMOVED)]
+        strategy  | includeAdded | results
+        ORDERED   | true         | [change("three-old", REMOVED), change("two-new", ADDED)]
+        ORDERED   | false        | [change("three-old", REMOVED)]
+        UNORDERED | true         | [change("three-old", REMOVED), change("two-new", ADDED)]
+        UNORDERED | false        | [change("three-old", REMOVED)]
     }
 
     @Unroll
     def "non-trivial replacement with absolute paths (#strategy)"() {
         expect:
-        changesUsingAbsolutePaths(strategy,
+        changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one"), "two": snapshot("two"), "four": snapshot("four")],
             ["one": snapshot("one"), "three": snapshot("three"), "four": snapshot("four")]
         ) == results
 
         where:
-        strategy  | results
-        ORDERED   | [change("three", REMOVED), change("two", ADDED)]
-        UNORDERED | [change("three", REMOVED), change("two", ADDED)]
-        OUTPUT    | [change("three", REMOVED)]
+        strategy  | includeAdded | results
+        ORDERED   | true         | [change("three", REMOVED), change("two", ADDED)]
+        ORDERED   | false        | [change("three", REMOVED)]
+        UNORDERED | true         | [change("three", REMOVED), change("two", ADDED)]
+        UNORDERED | false        | [change("three", REMOVED)]
     }
 
     @Unroll
     def "reordering (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             ["one-new": snapshot("one"), "two-new": snapshot("two"), "three-new": snapshot("three")],
             ["one-old": snapshot("one"), "three-old": snapshot("three"), "two-old": snapshot("two")]
         ) == results
 
         where:
-        strategy | results
-        ORDERED   | [change("three-old", REMOVED), change("two-new", ADDED), change("two-old", REMOVED), change("three-new", ADDED)]
-        UNORDERED | []
-        OUTPUT    | []
+        strategy  | includeAdded | results
+        ORDERED   | true         | [change("three-old", REMOVED), change("two-new", ADDED), change("two-old", REMOVED), change("three-new", ADDED)]
+        ORDERED   | false        | [change("three-old", REMOVED), change("two-old", REMOVED)]
+        UNORDERED | true         | []
+        UNORDERED | false        | []
     }
 
     @Unroll
     def "reordering with absolute paths (#strategy)"() {
         expect:
-        changesUsingAbsolutePaths(strategy,
+        changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one"), "two": snapshot("two"), "three": snapshot("three")],
             ["one": snapshot("one"), "three": snapshot("three"), "two": snapshot("two")]
         ) == results
 
         where:
-        strategy | results
-        ORDERED   | [change("three", REMOVED), change("two", ADDED), change("two", REMOVED), change("three", ADDED)]
-        UNORDERED | []
-        OUTPUT    | []
+        strategy  | includeAdded | results
+        ORDERED   | true         | [change("three", REMOVED), change("two", ADDED), change("two", REMOVED), change("three", ADDED)]
+        ORDERED   | false        | [change("three", REMOVED), change("two", REMOVED)]
+        UNORDERED | true         | []
+        UNORDERED | false        | []
     }
 
     @Unroll
     def "handling duplicates (#strategy)"() {
         expect:
-        changes(strategy,
+        changes(strategy, includeAdded,
             ["one-new-1": snapshot("one"), "one-new-2": snapshot("one"), "two-new": snapshot("two")],
             ["one-old-1": snapshot("one"), "one-old-2": snapshot("one"), "two-old": snapshot("two")]
         ) == []
 
         where:
-        strategy << [ORDERED, UNORDERED, OUTPUT]
+        strategy  | includeAdded
+        ORDERED   | true
+        ORDERED   | false
+        UNORDERED | true
+        UNORDERED | false
     }
 
     @Unroll
@@ -244,12 +280,12 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
         ["one": snapshot("one"), "two": snapshot("two")] | [:]
     }
 
-    def changes(TaskFilePropertyCompareStrategy strategy, Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous) {
-        Lists.newArrayList(strategy.iterateContentChangesSince(current, previous, "test", false))
+    def changes(TaskFilePropertyCompareStrategy strategy, boolean includeAdded, Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous) {
+        Lists.newArrayList(strategy.iterateContentChangesSince(current, previous, "test", false, includeAdded))
     }
 
-    def changesUsingAbsolutePaths(TaskFilePropertyCompareStrategy strategy, Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous) {
-        Lists.newArrayList(strategy.iterateContentChangesSince(current, previous, "test", true))
+    def changesUsingAbsolutePaths(TaskFilePropertyCompareStrategy strategy, boolean includeAdded, Map<String, NormalizedFileSnapshot> current, Map<String, NormalizedFileSnapshot> previous) {
+        Lists.newArrayList(strategy.iterateContentChangesSince(current, previous, "test", true, includeAdded))
     }
 
     def snapshot(String normalizedPath, String hashCode = "1234abcd") {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategyTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.api.internal.changedetection.state.TaskFilePropertyComp
 class TaskFilePropertyCompareStrategyTest extends Specification {
 
     @Unroll
-    def "empty snapshots (#strategy)"() {
+    def "empty snapshots (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             [:],
@@ -45,7 +45,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "trivial addition (#strategy)"() {
+    def "trivial addition (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             ["one-new": snapshot("one")],
@@ -61,7 +61,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "non-trivial addition (#strategy)"() {
+    def "non-trivial addition (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             ["one-new": snapshot("one"), "two-new": snapshot("two")],
@@ -77,7 +77,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "non-trivial addition with absolute paths (#strategy)"() {
+    def "non-trivial addition with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
         changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one"), "two": snapshot("two")],
@@ -93,7 +93,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "trivial removal (#strategy)"() {
+    def "trivial removal (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             [:],
@@ -109,7 +109,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "non-trivial removal (#strategy)"() {
+    def "non-trivial removal (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             ["one-new": snapshot("one")],
@@ -125,7 +125,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "non-trivial removal with absolute paths (#strategy)"() {
+    def "non-trivial removal with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
         changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one")],
@@ -141,7 +141,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "non-trivial modification (#strategy)"() {
+    def "non-trivial modification (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             ["one-new": snapshot("one"), "two-new": snapshot("two", "9876cafe")],
@@ -157,7 +157,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "non-trivial modification with absolute paths (#strategy)"() {
+    def "non-trivial modification with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
         changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one"), "two": snapshot("two", "9876cafe")],
@@ -173,7 +173,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "trivial replacement (#strategy)"() {
+    def "trivial replacement (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             ["two-new": snapshot("two")],
@@ -189,7 +189,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "non-trivial replacement (#strategy)"() {
+    def "non-trivial replacement (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             ["one-new": snapshot("one"), "two-new": snapshot("two"), "four-new": snapshot("four")],
@@ -205,7 +205,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "non-trivial replacement with absolute paths (#strategy)"() {
+    def "non-trivial replacement with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
         changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one"), "two": snapshot("two"), "four": snapshot("four")],
@@ -221,7 +221,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "reordering (#strategy)"() {
+    def "reordering (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             ["one-new": snapshot("one"), "two-new": snapshot("two"), "three-new": snapshot("three")],
@@ -237,7 +237,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "reordering with absolute paths (#strategy)"() {
+    def "reordering with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
         changesUsingAbsolutePaths(strategy, includeAdded,
             ["one": snapshot("one"), "two": snapshot("two"), "three": snapshot("three")],
@@ -253,7 +253,7 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     @Unroll
-    def "handling duplicates (#strategy)"() {
+    def "handling duplicates (#strategy, include added: #includeAdded)"() {
         expect:
         changes(strategy, includeAdded,
             ["one-new-1": snapshot("one"), "one-new-2": snapshot("one"), "two-new": snapshot("two")],

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuterTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.internal.id.UniqueId
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class SkipUpToDateTaskExecuterTest extends Specification {
 
@@ -38,7 +39,7 @@ class SkipUpToDateTaskExecuterTest extends Specification {
 
     def executer = new SkipUpToDateTaskExecuter(delegate)
 
-    def skipsTaskWhenOutputsAreUpToDate() {
+    def "skips task when outputs are up to date"() {
         given:
         def originBuildInvocationId = UniqueId.generate()
 
@@ -54,7 +55,8 @@ class SkipUpToDateTaskExecuterTest extends Specification {
         0 * _
     }
 
-    def executesTaskWhenOutputsAreNotUpToDate() {
+    @Unroll
+    def "executes task when outputs are not up to date"() {
         when:
         executer.execute(task, taskState, taskContext);
 


### PR DESCRIPTION
### Context

The problem addressed in this PR is the following:

Take a task that has been executed successfully before. After changing some inputs the task is re-executed, and it produces a new output file, and then promptly fails. The next time the task is to be executed, it will detect the new file as unknown, even though it was created by the very task. This triggers overlapping output detection, and thus caching for the task is disabled.

The problem is caused by task outputs not being snapshotted after a failed execution.

The change in this PR is that we now snapshot task outputs even when the task has failed. To prevent failed tasks from becoming `UP-TO-DATE`, we also store whether the task failed or succeeded as part of the task's history now.