### PR TITLE
Minor review items from enabling max workers notifications

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/DefaultParallelismConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/DefaultParallelismConfiguration.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.initialization;
+package org.gradle.internal.concurrent;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.gradle.api.Incubating;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
 
 import java.io.Serializable;
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ManagedExecutorImpl.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ManagedExecutorImpl.java
@@ -92,8 +92,6 @@ class ManagedExecutorImpl extends AbstractDelegatingExecutorService implements M
     public void setFixedPoolSize(int numThreads) {
         if (executor instanceof ThreadPoolExecutor) {
             ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executor;
-            // we do this because in jdk9 these methods throw an exception if you
-            // try to set one such that maximumPoolSize < corePoolSize
             if (numThreads < threadPoolExecutor.getCorePoolSize()) {
                 threadPoolExecutor.setCorePoolSize(numThreads);
                 threadPoolExecutor.setMaximumPoolSize(numThreads);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationListener.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationListener.java
@@ -25,5 +25,5 @@ public interface ParallelismConfigurationListener {
      *
      * @param parallelismConfiguration - the new parallelism configuration
      */
-    void onConfigurationChange(ParallelismConfiguration parallelismConfiguration);
+    void onParallelismConfigurationChange(ParallelismConfiguration parallelismConfiguration);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationManager.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationManager.java
@@ -19,7 +19,7 @@ package org.gradle.internal.concurrent;
 /**
  * Maintains information about max workers that can be accessed from any scope
  */
-public interface ParallelExecutionManager {
+public interface ParallelismConfigurationManager {
     /**
      * Get the current parallelism configuration.
      */

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -23,7 +23,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.Transformer;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.resources.AbstractResourceLockRegistry;
@@ -55,15 +55,15 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
     private final ResourceLockCoordinationService coordinationService;
     private final ProjectLockRegistry projectLockRegistry;
     private final WorkerLeaseLockRegistry workerLeaseLockRegistry;
-    private final ParallelExecutionManager parallelExecutionManager;
+    private final ParallelismConfigurationManager parallelismConfigurationManager;
 
-    public DefaultWorkerLeaseService(ResourceLockCoordinationService coordinationService, ParallelExecutionManager parallelExecutionManager) {
-        this.maxWorkerCount = parallelExecutionManager.getParallelismConfiguration().getMaxWorkerCount();
+    public DefaultWorkerLeaseService(ResourceLockCoordinationService coordinationService, ParallelismConfigurationManager parallelismConfigurationManager) {
+        this.maxWorkerCount = parallelismConfigurationManager.getParallelismConfiguration().getMaxWorkerCount();
         this.coordinationService = coordinationService;
-        this.projectLockRegistry = new ProjectLockRegistry(coordinationService, parallelExecutionManager.getParallelismConfiguration().isParallelProjectExecutionEnabled());
+        this.projectLockRegistry = new ProjectLockRegistry(coordinationService, parallelismConfigurationManager.getParallelismConfiguration().isParallelProjectExecutionEnabled());
         this.workerLeaseLockRegistry = new WorkerLeaseLockRegistry(coordinationService);
-        this.parallelExecutionManager = parallelExecutionManager;
-        parallelExecutionManager.addListener(this);
+        this.parallelismConfigurationManager = parallelismConfigurationManager;
+        parallelismConfigurationManager.addListener(this);
         LOGGER.info("Using {} worker leases.", maxWorkerCount);
     }
 
@@ -102,7 +102,7 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
 
     @Override
     public void stop() {
-        parallelExecutionManager.removeListener(this);
+        parallelismConfigurationManager.removeListener(this);
         coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
             @Override
             public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -68,7 +68,7 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
     }
 
     @Override
-    public void onConfigurationChange(ParallelismConfiguration parallelismConfiguration) {
+    public void onParallelismConfigurationChange(ParallelismConfiguration parallelismConfiguration) {
         this.maxWorkerCount = parallelismConfiguration.getMaxWorkerCount();
         projectLockRegistry.setParallelEnabled(parallelismConfiguration.isParallelProjectExecutionEnabled());
     }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ManagedExecutor
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.logging.events.OperationIdentifier
 import org.gradle.internal.progress.BuildOperationDescriptor
@@ -47,7 +47,7 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
     ExecutorFactory executorFactory = new DefaultExecutorFactory()
 
     def setupBuildOperationExecutor(int maxThreads) {
-        ParallelExecutionManager parallelExecutionManager = parallelism(maxThreads)
+        ParallelismConfigurationManager parallelExecutionManager = parallelism(maxThreads)
         workerRegistry = new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), parallelExecutionManager)
         buildOperationExecutor = new DefaultBuildOperationExecutor(
             operationListener, Mock(TimeProvider), new NoOpProgressLoggerFactory(),
@@ -62,7 +62,7 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
     }
 
     def parallelism(int maxThreads) {
-        return Mock(ParallelExecutionManager) {
+        return Mock(ParallelismConfigurationManager) {
             _ * getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, maxThreads)
         }
     }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
@@ -17,11 +17,12 @@
 package org.gradle.internal.operations
 
 import org.gradle.api.GradleException
-import org.gradle.initialization.DefaultParallelismConfiguration
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.logging.events.OperationIdentifier
 import org.gradle.internal.progress.BuildOperationDescriptor
@@ -47,7 +48,7 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
     ExecutorFactory executorFactory = new DefaultExecutorFactory()
 
     def setupBuildOperationExecutor(int maxThreads) {
-        ParallelismConfigurationManager parallelExecutionManager = parallelism(maxThreads)
+        ParallelismConfigurationManager parallelExecutionManager = new ParallelismConfigurationManagerFixture(true, maxThreads)
         workerRegistry = new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), parallelExecutionManager)
         buildOperationExecutor = new DefaultBuildOperationExecutor(
             operationListener, Mock(TimeProvider), new NoOpProgressLoggerFactory(),
@@ -59,12 +60,6 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
     static class SimpleWorker implements BuildOperationWorker<DefaultBuildOperationQueueTest.TestBuildOperation> {
         void execute(DefaultBuildOperationQueueTest.TestBuildOperation run, BuildOperationContext context) { run.run(context) }
         String getDisplayName() { return getClass().simpleName }
-    }
-
-    def parallelism(int maxThreads) {
-        return Mock(ParallelismConfigurationManager) {
-            _ * getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, maxThreads)
-        }
     }
 
     def "cleanup"() {
@@ -218,7 +213,7 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
         }
 
         def buildOperationExecutor = new DefaultBuildOperationExecutor(operationListener, Mock(TimeProvider), new NoOpProgressLoggerFactory(),
-            buildOperationQueueFactory, Stub(ExecutorFactory), Mock(ResourceLockCoordinationService), parallelism(1))
+            buildOperationQueueFactory, Stub(ExecutorFactory), Mock(ResourceLockCoordinationService), new ParallelismConfigurationManagerFixture(true, 1))
         def worker = Stub(BuildOperationWorker)
         def operation = Mock(DefaultBuildOperationQueueTest.TestBuildOperation)
 
@@ -246,7 +241,7 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
         }
         def buildOperationExecutor = new DefaultBuildOperationExecutor(
             operationListener, Mock(TimeProvider), new NoOpProgressLoggerFactory(),
-            buildOperationQueueFactory, Stub(ExecutorFactory), Mock(ResourceLockCoordinationService), parallelism(1))
+            buildOperationQueueFactory, Stub(ExecutorFactory), Mock(ResourceLockCoordinationService), new ParallelismConfigurationManagerFixture(true, 1))
         def worker = Stub(BuildOperationWorker)
         def operation = Mock(DefaultBuildOperationQueueTest.TestBuildOperation)
 
@@ -401,20 +396,20 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
     }
 
     def "registers/deregisters a listener for parallelism changes"() {
-        def parallelExecutionManager = parallelism(1)
+        def parallelExecutionManager = new ParallelismConfigurationManagerFixture(true, 1)
 
         when:
         buildOperationExecutor = new DefaultBuildOperationExecutor(operationListener, Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             Stub(BuildOperationQueueFactory), Stub(ExecutorFactory), Mock(ResourceLockCoordinationService), parallelExecutionManager)
 
         then:
-        1 * parallelExecutionManager.addListener(_)
+        parallelExecutionManager.listeners.size() == 1
 
         when:
         buildOperationExecutor.stop()
 
         then:
-        1 * parallelExecutionManager.removeListener(_)
+        parallelExecutionManager.listeners.size() == 0
     }
 
     def "adjusts thread pool size when parallelism configuration changes"() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorParallelExecutionTest.groovy
@@ -428,13 +428,13 @@ class DefaultBuildOperationExecutorParallelExecutionTest extends ConcurrentSpec 
         1 * executorFactory.create(_, 2) >> managedExecutor
 
         when:
-        buildOperationExecutor.onConfigurationChange(new DefaultParallelismConfiguration(true, 3))
+        buildOperationExecutor.onParallelismConfigurationChange(new DefaultParallelismConfiguration(true, 3))
 
         then:
         1 * managedExecutor.setFixedPoolSize(3)
 
         when:
-        buildOperationExecutor.onConfigurationChange(new DefaultParallelismConfiguration(false, 1))
+        buildOperationExecutor.onParallelismConfigurationChange(new DefaultParallelismConfiguration(false, 1))
 
         then:
         1 * managedExecutor.setFixedPoolSize(1)

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
@@ -17,8 +17,7 @@
 package org.gradle.internal.operations
 
 import org.gradle.api.GradleException
-import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.progress.BuildOperationDescriptor
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.work.DefaultWorkerLeaseService
@@ -63,14 +62,8 @@ class DefaultBuildOperationQueueTest extends Specification {
     WorkerLeaseService workerRegistry
 
     void setupQueue(int threads) {
-        workerRegistry = new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), parallelism(threads)) {};
+        workerRegistry = new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), new ParallelismConfigurationManagerFixture(true, threads)) {};
         operationQueue = new DefaultBuildOperationQueue(workerRegistry, Executors.newFixedThreadPool(threads), new SimpleWorker())
-    }
-
-    ParallelismConfigurationManager parallelism(int maxWorkers) {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, maxWorkers)
-        }
     }
 
     def "cleanup"() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.operations
 
 import org.gradle.api.GradleException
 import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.progress.BuildOperationDescriptor
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.work.DefaultWorkerLeaseService
@@ -67,8 +67,8 @@ class DefaultBuildOperationQueueTest extends Specification {
         operationQueue = new DefaultBuildOperationQueue(workerRegistry, Executors.newFixedThreadPool(threads), new SimpleWorker())
     }
 
-    ParallelExecutionManager parallelism(int maxWorkers) {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelism(int maxWorkers) {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, maxWorkers)
         }
     }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.operations
 
 import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
 import org.gradle.internal.progress.NoOpProgressLoggerFactory
@@ -157,8 +157,8 @@ class MaxWorkersTest extends ConcurrentSpec {
         return new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), parallelism(maxWorkers))
     }
 
-    ParallelExecutionManager parallelism(int maxWorkers) {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelism(int maxWorkers) {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, maxWorkers)
         }
     }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/MaxWorkersTest.groovy
@@ -16,9 +16,8 @@
 
 package org.gradle.internal.operations
 
-import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.progress.BuildOperationListener
 import org.gradle.internal.progress.DefaultBuildOperationExecutor
 import org.gradle.internal.progress.NoOpProgressLoggerFactory
@@ -37,7 +36,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         def registry = buildOperationWorkerRegistry(maxWorkers)
         def processor = new DefaultBuildOperationExecutor(
             Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
-            new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), parallelism(maxWorkers))
+            new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), new ParallelismConfigurationManagerFixture(true, maxWorkers))
         def processorWorker = new SimpleWorker()
 
         when:
@@ -79,7 +78,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         def registry = buildOperationWorkerRegistry(maxWorkers)
         def processor = new DefaultBuildOperationExecutor(
             Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
-            new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), parallelism(maxWorkers))
+            new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), new ParallelismConfigurationManagerFixture(true, maxWorkers))
         def processorWorker = new SimpleWorker()
 
         when:
@@ -121,7 +120,7 @@ class MaxWorkersTest extends ConcurrentSpec {
         def registry = buildOperationWorkerRegistry(maxWorkers)
         def processor = new DefaultBuildOperationExecutor(
             Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
-            new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), parallelism(maxWorkers))
+            new DefaultBuildOperationQueueFactory(registry), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), new ParallelismConfigurationManagerFixture(true, maxWorkers))
         def processorWorker = new SimpleWorker()
 
         when:
@@ -154,13 +153,7 @@ class MaxWorkersTest extends ConcurrentSpec {
     }
 
     WorkerLeaseRegistry buildOperationWorkerRegistry(int maxWorkers) {
-        return new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), parallelism(maxWorkers))
-    }
-
-    ParallelismConfigurationManager parallelism(int maxWorkers) {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, maxWorkers)
-        }
+        return new DefaultWorkerLeaseService(new DefaultResourceLockCoordinationService(), new ParallelismConfigurationManagerFixture(true, maxWorkers))
     }
 
     static class SimpleWorker implements BuildOperationWorker<DefaultBuildOperationQueueTest.TestBuildOperation> {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.work
 
 import org.gradle.api.Transformer
 import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ResourceLock
 import org.gradle.internal.resources.ResourceLockState
@@ -304,17 +304,17 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
         return held.get()
     }
 
-    ParallelExecutionManager parallel(boolean parallelEnabled) {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallel(boolean parallelEnabled) {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> new DefaultParallelismConfiguration(parallelEnabled, 1)
         }
     }
 
-    ParallelExecutionManager notParallel() {
+    ParallelismConfigurationManager notParallel() {
         return parallel(false)
     }
 
-    ParallelExecutionManager parallel() {
+    ParallelismConfigurationManager parallel() {
         return parallel(true)
     }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.internal.work
 
 import org.gradle.api.Transformer
-import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ResourceLock
 import org.gradle.internal.resources.ResourceLockState
@@ -305,9 +305,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
     }
 
     ParallelismConfigurationManager parallel(boolean parallelEnabled) {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> new DefaultParallelismConfiguration(parallelEnabled, 1)
-        }
+        return new ParallelismConfigurationManagerFixture(parallelEnabled, 1)
     }
 
     ParallelismConfigurationManager notParallel() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
@@ -174,13 +174,13 @@ class DefaultWorkerLeaseServiceTest extends Specification {
 
     def "adjusts max worker count on parallelism configuration change"() {
         when:
-        workerLeaseService.onConfigurationChange(new DefaultParallelismConfiguration(true, 2))
+        workerLeaseService.onParallelismConfigurationChange(new DefaultParallelismConfiguration(true, 2))
 
         then:
         workerLeaseService.getMaxWorkerCount() == 2
 
         when:
-        workerLeaseService.onConfigurationChange(new DefaultParallelismConfiguration(false, 4))
+        workerLeaseService.onParallelismConfigurationChange(new DefaultParallelismConfiguration(false, 4))
 
         then:
         workerLeaseService.getMaxWorkerCount() == 4

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.work
 
 import org.gradle.api.Action
 import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ResourceLockCoordinationService
 import org.gradle.internal.resources.TestTrackedResourceLock
@@ -157,7 +157,7 @@ class DefaultWorkerLeaseServiceTest extends Specification {
     }
 
     def "registers/deregisters a listener for parallelism configuration changes"() {
-        ParallelExecutionManager parallelExecutionManager = parallelExecutionManager()
+        ParallelismConfigurationManager parallelExecutionManager = parallelExecutionManager()
 
         when:
         workerLeaseService = new DefaultWorkerLeaseService(Mock(ResourceLockCoordinationService), parallelExecutionManager)
@@ -212,8 +212,8 @@ class DefaultWorkerLeaseServiceTest extends Specification {
         }
     }
 
-    ParallelExecutionManager parallelExecutionManager() {
-        return Mock(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelExecutionManager() {
+        return Mock(ParallelismConfigurationManager) {
             _ * getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, 1)
         }
     }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
@@ -16,8 +16,7 @@
 
 package org.gradle.internal.work
 
-import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ResourceLockCoordinationService
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
@@ -293,12 +292,6 @@ class DefaultWorkerLeaseServiceWorkerLeaseTest extends ConcurrentSpec {
     }
 
     WorkerLeaseService workerLeaseService(int maxWorkers) {
-        return new DefaultWorkerLeaseService(coordinationService, parallelism(maxWorkers))
-    }
-
-    ParallelismConfigurationManager parallelism(int maxWorkers) {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, maxWorkers)
-        }
+        return new DefaultWorkerLeaseService(coordinationService, new ParallelismConfigurationManagerFixture(true, maxWorkers))
     }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.work
 
 import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ResourceLockCoordinationService
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
@@ -296,8 +296,8 @@ class DefaultWorkerLeaseServiceWorkerLeaseTest extends ConcurrentSpec {
         return new DefaultWorkerLeaseService(coordinationService, parallelism(maxWorkers))
     }
 
-    ParallelExecutionManager parallelism(int maxWorkers) {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelism(int maxWorkers) {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, maxWorkers)
         }
     }

--- a/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/concurrent/ParallelismConfigurationManagerFixture.groovy
+++ b/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/concurrent/ParallelismConfigurationManagerFixture.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.concurrent
+
+class ParallelismConfigurationManagerFixture implements ParallelismConfigurationManager {
+    ParallelismConfiguration parallelismConfiguration
+    List<ParallelismConfigurationListener> listeners = []
+
+    ParallelismConfigurationManagerFixture(boolean isParallelEnabled, int maxWorkers) {
+        this.parallelismConfiguration = new DefaultParallelismConfiguration(isParallelEnabled, maxWorkers)
+    }
+
+    ParallelismConfigurationManagerFixture(ParallelismConfiguration parallelismConfiguration) {
+        this.parallelismConfiguration = parallelismConfiguration
+    }
+
+    @Override
+    ParallelismConfiguration getParallelismConfiguration() {
+        return parallelismConfiguration
+    }
+
+    @Override
+    void setParallelismConfiguration(ParallelismConfiguration parallelismConfiguration) {
+        this.parallelismConfiguration = parallelismConfiguration
+    }
+
+    @Override
+    void addListener(ParallelismConfigurationListener listener) {
+        listeners.add(listener)
+    }
+
+    @Override
+    void removeListener(ParallelismConfigurationListener listener) {
+        listeners.remove(listener)
+    }
+}

--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -78,6 +78,7 @@ useTestFixtures()
 useTestFixtures(project: ":messaging")
 useTestFixtures(project: ":modelCore")
 useTestFixtures(project: ":logging")
+useTestFixtures(project: ":baseServices")
 
 test {
     forkEvery = 200

--- a/subprojects/core/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core/src/main/java/org/gradle/StartParameter.java
@@ -27,7 +27,7 @@ import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.CompositeInitScriptFinder;
-import org.gradle.initialization.DefaultParallelismConfiguration;
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.initialization.DistributionInitScriptFinder;
 import org.gradle.internal.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.UserHomeInitScriptFinder;

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskPlanExecutorFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskPlanExecutorFactory.java
@@ -19,31 +19,31 @@ package org.gradle.execution.taskgraph;
 import com.google.common.collect.Lists;
 import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.work.WorkerLeaseService;
 
 import java.util.List;
 
 public class TaskPlanExecutorFactory implements Factory<TaskPlanExecutor> {
-    private final ParallelExecutionManager parallelExecutionManager;
+    private final ParallelismConfigurationManager parallelismConfigurationManager;
     private final ExecutorFactory executorFactory;
     private final WorkerLeaseService workerLeaseService;
     private final List<TaskPlanExecutor> taskPlanExecutors = Lists.newArrayList();
 
-    public TaskPlanExecutorFactory(ParallelExecutionManager parallelExecutionManager, ExecutorFactory executorFactory, WorkerLeaseService workerLeaseService) {
-        this.parallelExecutionManager = parallelExecutionManager;
+    public TaskPlanExecutorFactory(ParallelismConfigurationManager parallelismConfigurationManager, ExecutorFactory executorFactory, WorkerLeaseService workerLeaseService) {
+        this.parallelismConfigurationManager = parallelismConfigurationManager;
         this.executorFactory = executorFactory;
         this.workerLeaseService = workerLeaseService;
     }
 
     public TaskPlanExecutor create() {
-        int parallelThreads = parallelExecutionManager.getParallelismConfiguration().getMaxWorkerCount();
+        int parallelThreads = parallelismConfigurationManager.getParallelismConfiguration().getMaxWorkerCount();
         if (parallelThreads < 1) {
             throw new IllegalStateException(String.format("Cannot create executor for requested number of worker threads: %s.", parallelThreads));
         }
 
         // TODO: Make task plan executor respond to changes in parallelism configuration
-        TaskPlanExecutor taskPlanExecutor = new DefaultTaskPlanExecutor(parallelExecutionManager.getParallelismConfiguration(), executorFactory, workerLeaseService);
+        TaskPlanExecutor taskPlanExecutor = new DefaultTaskPlanExecutor(parallelismConfigurationManager.getParallelismConfiguration(), executorFactory, workerLeaseService);
         taskPlanExecutors.add(taskPlanExecutor);
         return taskPlanExecutor;
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
@@ -39,7 +39,7 @@ public class DefaultParallelismConfigurationManager implements ParallelismConfig
     @Override
     public void setParallelismConfiguration(ParallelismConfiguration parallelismConfiguration) {
         this.parallelismConfiguration = parallelismConfiguration;
-        broadcaster.onConfigurationChange(parallelismConfiguration);
+        broadcaster.onParallelismConfigurationChange(parallelismConfiguration);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization;
 
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
@@ -16,17 +16,17 @@
 
 package org.gradle.initialization;
 
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.event.ListenerManager;
 
-public class DefaultParallelExecutionManager implements ParallelExecutionManager {
+public class DefaultParallelismConfigurationManager implements ParallelismConfigurationManager {
     private final ListenerManager listenerManager;
     private final ParallelismConfigurationListener broadcaster;
     private ParallelismConfiguration parallelismConfiguration = DefaultParallelismConfiguration.DEFAULT;
 
-    public DefaultParallelExecutionManager(ListenerManager listenerManager) {
+    public DefaultParallelismConfigurationManager(ListenerManager listenerManager) {
         this.listenerManager = listenerManager;
         this.broadcaster = listenerManager.getBroadcaster(ParallelismConfigurationListener.class);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
@@ -27,7 +27,7 @@ import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.GradleThread;
 import org.gradle.internal.concurrent.ManagedExecutor;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.concurrent.Stoppable;
@@ -69,22 +69,22 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
     private final BuildOperationQueueFactory buildOperationQueueFactory;
     private final ResourceLockCoordinationService resourceLockCoordinationService;
     private final ManagedExecutor fixedSizePool;
-    private final ParallelExecutionManager parallelExecutionManager;
+    private final ParallelismConfigurationManager parallelismConfigurationManager;
 
     private final AtomicLong nextId = new AtomicLong(ROOT_BUILD_OPERATION_ID_VALUE);
     private final ThreadLocal<DefaultBuildOperationState> currentOperation = new ThreadLocal<DefaultBuildOperationState>();
 
     public DefaultBuildOperationExecutor(BuildOperationListener listener, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory,
                                          BuildOperationQueueFactory buildOperationQueueFactory, ExecutorFactory executorFactory,
-                                         ResourceLockCoordinationService resourceLockCoordinationService, ParallelExecutionManager parallelExecutionManager) {
+                                         ResourceLockCoordinationService resourceLockCoordinationService, ParallelismConfigurationManager parallelismConfigurationManager) {
         this.listener = listener;
         this.timeProvider = timeProvider;
         this.progressLoggerFactory = progressLoggerFactory;
         this.buildOperationQueueFactory = buildOperationQueueFactory;
         this.resourceLockCoordinationService = resourceLockCoordinationService;
-        this.fixedSizePool = executorFactory.create("build operations", parallelExecutionManager.getParallelismConfiguration().getMaxWorkerCount());
-        this.parallelExecutionManager = parallelExecutionManager;
-        parallelExecutionManager.addListener(this);
+        this.fixedSizePool = executorFactory.create("build operations", parallelismConfigurationManager.getParallelismConfiguration().getMaxWorkerCount());
+        this.parallelismConfigurationManager = parallelismConfigurationManager;
+        parallelismConfigurationManager.addListener(this);
     }
 
     @Override
@@ -294,7 +294,7 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
 
     @Override
     public void stop() {
-        parallelExecutionManager.removeListener(this);
+        parallelismConfigurationManager.removeListener(this);
         fixedSizePool.stop();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
@@ -88,7 +88,7 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
     }
 
     @Override
-    public void onConfigurationChange(ParallelismConfiguration parallelismConfiguration) {
+    public void onParallelismConfigurationChange(ParallelismConfiguration parallelismConfiguration) {
         fixedSizePool.setFixedPoolSize(parallelismConfiguration.getMaxWorkerCount());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -57,7 +57,7 @@ import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
@@ -135,7 +135,7 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         WorkerLeaseService workerLeaseService,
         ExecutorFactory executorFactory,
         ResourceLockCoordinationService resourceLockCoordinationService,
-        ParallelExecutionManager parallelExecutionManager,
+        ParallelismConfigurationManager parallelismConfigurationManager,
         @SuppressWarnings("unused") BuildOperationTrace buildOperationTrace // required in order to init this
     ) {
         return new DefaultBuildOperationExecutor(
@@ -144,7 +144,7 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
             new DefaultBuildOperationQueueFactory(workerLeaseService),
             executorFactory,
             resourceLockCoordinationService,
-            parallelExecutionManager
+            parallelismConfigurationManager
         );
     }
 
@@ -212,8 +212,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new DefaultAsyncWorkTracker(projectLeaseRegistry);
     }
 
-    WorkerLeaseService createWorkerLeaseService(ResourceLockCoordinationService coordinationService, ParallelExecutionManager parallelExecutionManager) {
-        return new DefaultWorkerLeaseService(coordinationService, parallelExecutionManager);
+    WorkerLeaseService createWorkerLeaseService(ResourceLockCoordinationService coordinationService, ParallelismConfigurationManager parallelismConfigurationManager) {
+        return new DefaultWorkerLeaseService(coordinationService, parallelismConfigurationManager);
     }
 
     UserScopeId createUserScopeId(PersistentScopeIdLoader persistentScopeIdLoader) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -60,7 +60,7 @@ import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.DefaultGradleLauncherFactory;
 import org.gradle.initialization.DefaultJdkToolsInitializer;
 import org.gradle.initialization.DefaultLegacyTypesSupport;
-import org.gradle.initialization.DefaultParallelExecutionManager;
+import org.gradle.initialization.DefaultParallelismConfigurationManager;
 import org.gradle.initialization.FlatClassLoaderRegistry;
 import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.initialization.JdkToolsInitializer;
@@ -69,7 +69,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.DefaultClassLoaderFactory;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.environment.GradleBuildEnvironment;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.filewatch.DefaultFileWatcherFactory;
@@ -328,8 +328,8 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return new DefaultTaskInputsListener();
     }
 
-    ParallelExecutionManager createMaxWorkersManager(ListenerManager listenerManager) {
-        return new DefaultParallelExecutionManager(listenerManager);
+    ParallelismConfigurationManager createMaxWorkersManager(ListenerManager listenerManager) {
+        return new DefaultParallelismConfigurationManager(listenerManager);
     }
 
     PatternSpecFactory createPatternSpecFactory() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
@@ -63,7 +63,7 @@ import org.gradle.execution.taskgraph.TaskPlanExecutor;
 import org.gradle.execution.taskgraph.TaskPlanExecutorFactory;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.environment.GradleBuildEnvironment;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.id.RandomLongIdGenerator;
@@ -179,8 +179,8 @@ public class TaskExecutionServices {
     }
 
 
-    TaskPlanExecutor createTaskExecutorFactory(ParallelExecutionManager parallelExecutionManager, ExecutorFactory executorFactory, WorkerLeaseService workerLeaseService) {
-        return new TaskPlanExecutorFactory(parallelExecutionManager, executorFactory, workerLeaseService).create();
+    TaskPlanExecutor createTaskExecutorFactory(ParallelismConfigurationManager parallelismConfigurationManager, ExecutorFactory executorFactory, WorkerLeaseService workerLeaseService) {
+        return new TaskPlanExecutorFactory(parallelismConfigurationManager, executorFactory, workerLeaseService).create();
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
@@ -19,7 +19,7 @@ import org.gradle.cache.internal.CacheFactory;
 import org.gradle.cache.internal.FileLockManager;
 import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
@@ -42,8 +42,8 @@ public class TestGlobalScopeServices extends GlobalScopeServices {
         return new InMemoryCacheFactory();
     }
 
-    BuildOperationExecutor createBuildOperationExecutor(ListenerManager listenerManager, TimeProvider timeProvider, WorkerLeaseService workerLeaseService, ProgressLoggerFactory progressLoggerFactory, ExecutorFactory executorFactory, ResourceLockCoordinationService resourceLockCoordinationService, ParallelExecutionManager parallelExecutionManager) {
-        return new ProjectBuilderBuildOperationExecutor(listenerManager.getBroadcaster(BuildOperationListener.class), timeProvider, progressLoggerFactory, new DefaultBuildOperationQueueFactory(workerLeaseService), executorFactory, resourceLockCoordinationService, parallelExecutionManager);
+    BuildOperationExecutor createBuildOperationExecutor(ListenerManager listenerManager, TimeProvider timeProvider, WorkerLeaseService workerLeaseService, ProgressLoggerFactory progressLoggerFactory, ExecutorFactory executorFactory, ResourceLockCoordinationService resourceLockCoordinationService, ParallelismConfigurationManager parallelismConfigurationManager) {
+        return new ProjectBuilderBuildOperationExecutor(listenerManager.getBroadcaster(BuildOperationListener.class), timeProvider, progressLoggerFactory, new DefaultBuildOperationQueueFactory(workerLeaseService), executorFactory, resourceLockCoordinationService, parallelismConfigurationManager);
     }
 
     LoggingManagerInternal createLoggingManager(Factory<LoggingManagerInternal> loggingManagerFactory) {
@@ -52,8 +52,8 @@ public class TestGlobalScopeServices extends GlobalScopeServices {
 
     private static class ProjectBuilderBuildOperationExecutor extends DefaultBuildOperationExecutor {
 
-        public ProjectBuilderBuildOperationExecutor(BuildOperationListener broadcaster, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory, DefaultBuildOperationQueueFactory defaultBuildOperationQueueFactory, ExecutorFactory executorFactory, ResourceLockCoordinationService resourceLockCoordinationService, ParallelExecutionManager parallelExecutionManager) {
-            super(broadcaster, timeProvider, progressLoggerFactory, defaultBuildOperationQueueFactory, executorFactory, resourceLockCoordinationService, parallelExecutionManager);
+        public ProjectBuilderBuildOperationExecutor(BuildOperationListener broadcaster, TimeProvider timeProvider, ProgressLoggerFactory progressLoggerFactory, DefaultBuildOperationQueueFactory defaultBuildOperationQueueFactory, ExecutorFactory executorFactory, ResourceLockCoordinationService resourceLockCoordinationService, ParallelismConfigurationManager parallelismConfigurationManager) {
+            super(broadcaster, timeProvider, progressLoggerFactory, defaultBuildOperationQueueFactory, executorFactory, resourceLockCoordinationService, parallelismConfigurationManager);
             createRunningRootOperation("ProjectBuilder");
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
@@ -28,8 +28,7 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.initialization.BuildCancellationToken
-import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.work.DefaultWorkerLeaseService
@@ -60,7 +59,7 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
     ProjectInternal root
     def cancellationHandler = Mock(BuildCancellationToken)
     def coordinationService = new DefaultResourceLockCoordinationService()
-    def workerLeaseService = new DefaultWorkerLeaseService(coordinationService, parallelExecutionManager())
+    def workerLeaseService = new DefaultWorkerLeaseService(coordinationService, new ParallelismConfigurationManagerFixture(true, 1))
     def parentWorkerLease = workerLeaseService.workerLease
     def gradle = Mock(GradleInternal)
 
@@ -739,11 +738,5 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
     static class AsyncWithInputDirectory extends Async {
         @InputDirectory
         File inputDirectory
-    }
-
-    ParallelismConfigurationManager parallelExecutionManager() {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, 3)
-        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.work.DefaultWorkerLeaseService
@@ -741,8 +741,8 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
         File inputDirectory
     }
 
-    ParallelExecutionManager parallelExecutionManager() {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelExecutionManager() {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, 3)
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterSpec.groovy
@@ -32,11 +32,11 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.execution.TaskFailureHandler
 import org.gradle.initialization.BuildCancellationToken
-import org.gradle.initialization.DefaultParallelismConfiguration
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.Factories
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ManagedExecutor
-import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
@@ -53,7 +53,8 @@ class DefaultTaskGraphExecuterSpec extends Specification {
     def buildOperationExecutor = new TestBuildOperationExecutor()
     def coordinationService = new DefaultResourceLockCoordinationService()
     def parallelismConfiguration = new DefaultParallelismConfiguration(true, 1)
-    def workerLeases = new DefaultWorkerLeaseService(coordinationService, parallelExecutionManager())
+    def parallelismConfigurationManager = new ParallelismConfigurationManagerFixture(parallelismConfiguration)
+    def workerLeases = new DefaultWorkerLeaseService(coordinationService, parallelismConfigurationManager)
     def executorFactory = Mock(ExecutorFactory)
     def taskExecuter = new DefaultTaskGraphExecuter(listenerManager, new DefaultTaskPlanExecutor(parallelismConfiguration, executorFactory, workerLeases), Factories.constant(executer), cancellationToken, buildOperationExecutor, workerLeases, coordinationService, Mock(GradleInternal))
     WorkerLeaseRegistry.WorkerLeaseCompletion parentWorkerLease
@@ -604,11 +605,5 @@ class DefaultTaskGraphExecuterSpec extends Specification {
         }
         _ * mock.path >> ":${name}"
         return mock
-    }
-
-    ParallelismConfigurationManager parallelExecutionManager() {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> parallelismConfiguration
-        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskGraphExecuterSpec.groovy
@@ -36,7 +36,7 @@ import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.Factories
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ManagedExecutor
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
@@ -606,8 +606,8 @@ class DefaultTaskGraphExecuterSpec extends Specification {
         return mock
     }
 
-    ParallelExecutionManager parallelExecutionManager() {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelExecutionManager() {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> parallelismConfiguration
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskPlanExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskPlanExecutorTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.Project
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.invocation.Gradle
-import org.gradle.initialization.DefaultParallelismConfiguration
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.work.WorkerLeaseService

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/TaskPlanExecutorFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/TaskPlanExecutorFactoryTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.execution.taskgraph
 import org.gradle.api.internal.changedetection.state.TaskHistoryStore
 import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ExecutorFactory
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.work.WorkerLeaseService
 import spock.lang.Specification
 
@@ -42,8 +42,8 @@ public class TaskPlanExecutorFactoryTest extends Specification {
         factory.create().class == DefaultTaskPlanExecutor
     }
 
-    ParallelExecutionManager parallelism(boolean parallelEnabled, int maxWorkers) {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelism(boolean parallelEnabled, int maxWorkers) {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> new DefaultParallelismConfiguration(parallelEnabled, maxWorkers)
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/TaskPlanExecutorFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/TaskPlanExecutorFactoryTest.groovy
@@ -17,9 +17,8 @@
 package org.gradle.execution.taskgraph
 
 import org.gradle.api.internal.changedetection.state.TaskHistoryStore
-import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ExecutorFactory
-import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.work.WorkerLeaseService
 import spock.lang.Specification
 
@@ -30,21 +29,16 @@ public class TaskPlanExecutorFactoryTest extends Specification {
 
     def "can create a task plan executor"() {
         when:
-        def factory = new TaskPlanExecutorFactory(parallelism(false, 1), executorFactory, workerLeaseService)
+        def factory = new TaskPlanExecutorFactory(new ParallelismConfigurationManagerFixture(false, 1), executorFactory, workerLeaseService)
 
         then:
         factory.create().class == DefaultTaskPlanExecutor
 
         when:
-        factory = new TaskPlanExecutorFactory(parallelism(true, 3), executorFactory, workerLeaseService)
+        factory = new TaskPlanExecutorFactory(new ParallelismConfigurationManagerFixture(true, 3), executorFactory, workerLeaseService)
 
         then:
         factory.create().class == DefaultTaskPlanExecutor
     }
 
-    ParallelismConfigurationManager parallelism(boolean parallelEnabled, int maxWorkers) {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> new DefaultParallelismConfiguration(parallelEnabled, maxWorkers)
-        }
-    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -33,7 +33,7 @@ import org.gradle.execution.BuildConfigurationActionExecuter
 import org.gradle.execution.BuildExecuter
 import org.gradle.execution.TaskGraphExecuter
 import org.gradle.includedbuild.internal.IncludedBuildControllers
-import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
@@ -73,7 +73,7 @@ class DefaultGradleLauncherSpec extends Specification {
     private BuildCompletionListener buildCompletionListener = Mock(BuildCompletionListener.class)
     private TestBuildOperationExecutor buildOperationExecutor = new TestBuildOperationExecutor()
     private ResourceLockCoordinationService coordinationService = new DefaultResourceLockCoordinationService()
-    private WorkerLeaseService workerLeaseService = new DefaultWorkerLeaseService(coordinationService, parallelExecutionManager())
+    private WorkerLeaseService workerLeaseService = new DefaultWorkerLeaseService(coordinationService, new ParallelismConfigurationManagerFixture(true, 1))
     private BuildScopeServices buildServices = Mock(BuildScopeServices.class)
     private Stoppable otherService = Mock(Stoppable)
     private IncludedBuildControllers includedBuildControllers = Mock()
@@ -328,11 +328,5 @@ class DefaultGradleLauncherSpec extends Specification {
 
     private void expectTasksRunWithFailure(final Throwable failure) {
         1 * buildExecuter.execute(gradleMock) >> { throw failure }
-    }
-
-    ParallelismConfigurationManager parallelExecutionManager() {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, 1)
-        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -33,7 +33,7 @@ import org.gradle.execution.BuildConfigurationActionExecuter
 import org.gradle.execution.BuildExecuter
 import org.gradle.execution.TaskGraphExecuter
 import org.gradle.includedbuild.internal.IncludedBuildControllers
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
@@ -330,8 +330,8 @@ class DefaultGradleLauncherSpec extends Specification {
         1 * buildExecuter.execute(gradleMock) >> { throw failure }
     }
 
-    ParallelExecutionManager parallelExecutionManager() {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelExecutionManager() {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, 1)
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
@@ -34,7 +34,7 @@ class DefaultParallelismConfigurationManagerTest extends Specification {
         parallelExecutionManager.setParallelismConfiguration(configuration)
 
         then:
-        1 * broadcaster.onConfigurationChange(configuration)
+        1 * broadcaster.onParallelismConfigurationChange(configuration)
     }
 
     def "registers/deregisters listeners with listener manager"() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
@@ -16,17 +16,17 @@
 
 package org.gradle.initialization
 
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.concurrent.ParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationListener
 import org.gradle.internal.event.ListenerManager
 import spock.lang.Specification
 
 
-class DefaultParallelExecutionManagerTest extends Specification {
+class DefaultParallelismConfigurationManagerTest extends Specification {
     ParallelismConfigurationListener broadcaster = Mock(ParallelismConfigurationListener)
     ListenerManager listenerManager = Mock(ListenerManager) { 1 * getBroadcaster(ParallelismConfigurationListener.class) >> broadcaster }
-    ParallelExecutionManager parallelExecutionManager = new DefaultParallelExecutionManager(listenerManager)
+    ParallelismConfigurationManager parallelExecutionManager = new DefaultParallelismConfigurationManager(listenerManager)
     ParallelismConfiguration configuration = Mock(ParallelismConfiguration)
 
     def "notifies listeners when parallelism configuration changes"() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization
 
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.concurrent.ParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationListener

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.initialization
 
 import org.gradle.cli.CommandLineArgumentException
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfiguration
 import spock.lang.Specification
 import spock.lang.Unroll

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.api.Action
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.GradleThread
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationQueueFactory
 import org.gradle.internal.operations.CallableBuildOperation
@@ -671,8 +671,8 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         void run(BuildOperationContext buildOperationContext) {}
     }
 
-    ParallelExecutionManager parallelExecutionManager() {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelExecutionManager() {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, 1)
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
@@ -16,11 +16,10 @@
 
 package org.gradle.internal.progress
 
-import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.api.Action
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.GradleThread
-import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationQueueFactory
 import org.gradle.internal.operations.CallableBuildOperation
@@ -38,7 +37,7 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
     def timeProvider = Mock(TimeProvider)
     def progressLoggerFactory = Spy(NoOpProgressLoggerFactory)
     def resourceLockCoordinator = Mock(ResourceLockCoordinationService)
-    def operationExecutor = new DefaultBuildOperationExecutor(listener, timeProvider, progressLoggerFactory, Mock(BuildOperationQueueFactory), Mock(ExecutorFactory), resourceLockCoordinator, parallelExecutionManager())
+    def operationExecutor = new DefaultBuildOperationExecutor(listener, timeProvider, progressLoggerFactory, Mock(BuildOperationQueueFactory), Mock(ExecutorFactory), resourceLockCoordinator, new ParallelismConfigurationManagerFixture(true, 1))
 
     def "fires events when operation starts and finishes successfully"() {
         setup:
@@ -669,11 +668,5 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         String toString() { getClass().simpleName }
 
         void run(BuildOperationContext buildOperationContext) {}
-    }
-
-    ParallelismConfigurationManager parallelExecutionManager() {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, 1)
-        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildSessionScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildSessionScopeServicesTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.deployment.internal.DefaultDeploymentRegistry
 import org.gradle.deployment.internal.DeploymentRegistry
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.concurrent.ExecutorFactory
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.installation.CurrentGradleInstallation
 import org.gradle.internal.logging.events.OutputEventListener
@@ -56,7 +56,7 @@ class BuildSessionScopeServicesTest extends Specification {
         parent.get(ModuleRegistry) >> new DefaultModuleRegistry(CurrentGradleInstallation.get())
         parent.get(FileResolver) >> Stub(FileResolver)
         parent.get(OutputEventListener) >> Stub(OutputEventListener)
-        parent.get(ParallelExecutionManager) >> Stub(ParallelExecutionManager)
+        parent.get(ParallelismConfigurationManager) >> Stub(ParallelismConfigurationManager)
         parent.hasService(_) >> true
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleScopeServicesTest.groovy
@@ -31,8 +31,9 @@ import org.gradle.execution.TaskGraphExecuter
 import org.gradle.execution.TaskSelector
 import org.gradle.execution.taskgraph.DefaultTaskGraphExecuter
 import org.gradle.initialization.BuildCancellationToken
-import org.gradle.initialization.DefaultParallelismConfiguration
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.internal.work.WorkerLeaseRegistry
@@ -78,7 +79,7 @@ public class GradleScopeServicesTest extends Specification {
         parent.get(ResourceLockCoordinationService) >> Stub(ResourceLockCoordinationService)
         parent.get(Instantiator) >> Stub(Instantiator)
         parent.get(WorkerLeaseRegistry) >> Stub(WorkerLeaseRegistry)
-        parent.get(ParallelismConfigurationManager) >> Stub(ParallelismConfigurationManager) { _ * getParallelismConfiguration() >> DefaultParallelismConfiguration.DEFAULT }
+        parent.get(ParallelismConfigurationManager) >> new ParallelismConfigurationManagerFixture(DefaultParallelismConfiguration.DEFAULT)
         parent.get(StyledTextOutputFactory) >> new TestStyledTextOutputFactory()
         gradle.getStartParameter() >> startParameter
         pluginRegistryParent.createChild(_, _, _) >> pluginRegistryChild

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleScopeServicesTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.execution.TaskSelector
 import org.gradle.execution.taskgraph.DefaultTaskGraphExecuter
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.internal.work.WorkerLeaseRegistry
@@ -78,7 +78,7 @@ public class GradleScopeServicesTest extends Specification {
         parent.get(ResourceLockCoordinationService) >> Stub(ResourceLockCoordinationService)
         parent.get(Instantiator) >> Stub(Instantiator)
         parent.get(WorkerLeaseRegistry) >> Stub(WorkerLeaseRegistry)
-        parent.get(ParallelExecutionManager) >> Stub(ParallelExecutionManager) { _ * getParallelismConfiguration() >> DefaultParallelismConfiguration.DEFAULT }
+        parent.get(ParallelismConfigurationManager) >> Stub(ParallelismConfigurationManager) { _ * getParallelismConfiguration() >> DefaultParallelismConfiguration.DEFAULT }
         parent.get(StyledTextOutputFactory) >> new TestStyledTextOutputFactory()
         gradle.getStartParameter() >> startParameter
         pluginRegistryParent.createChild(_, _, _) >> pluginRegistryChild

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
@@ -41,8 +41,8 @@ import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.internal.classloader.HashingClassLoaderFactory
 import org.gradle.internal.classpath.CachedClasspathTransformer
 import org.gradle.internal.concurrent.ExecutorFactory
-import org.gradle.internal.concurrent.ParallelExecutionManager
 import org.gradle.internal.concurrent.ParallelismConfiguration
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.jvm.inspection.JvmVersionDetector
 import org.gradle.internal.logging.LoggingManagerInternal
@@ -90,7 +90,7 @@ class GradleUserHomeScopeServicesTest extends Specification {
         expectParentServiceLocated(ListenerManager) {
             _ * it.createChild() >> Mock(ListenerManager)
         }
-        expectParentServiceLocated(ParallelExecutionManager) {
+        expectParentServiceLocated(ParallelismConfigurationManager) {
             _ * it.getParallelismConfiguration() >> Mock(ParallelismConfiguration)
         }
         expectParentServiceLocated(InMemoryCacheDecoratorFactory) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
@@ -16,8 +16,7 @@
 
 package org.gradle.internal.work
 
-import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.progress.BuildOperationState
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
@@ -27,7 +26,7 @@ import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
     ResourceLockCoordinationService coordinationService = new DefaultResourceLockCoordinationService()
-    WorkerLeaseService workerLeaseService = new DefaultWorkerLeaseService(coordinationService, parallelExecutionManager())
+    WorkerLeaseService workerLeaseService = new DefaultWorkerLeaseService(coordinationService, new ParallelismConfigurationManagerFixture(true, 1))
     AsyncWorkTracker asyncWorkTracker = new DefaultAsyncWorkTracker(workerLeaseService)
 
     def "can wait for async work to complete"() {
@@ -345,12 +344,6 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
             boolean isComplete() {
                 return true
             }
-        }
-    }
-
-    ParallelismConfigurationManager parallelExecutionManager() {
-        return Stub(ParallelismConfigurationManager) {
-            getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, 1)
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.work
 
 import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.progress.BuildOperationState
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
@@ -348,8 +348,8 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
         }
     }
 
-    ParallelExecutionManager parallelExecutionManager() {
-        return Stub(ParallelExecutionManager) {
+    ParallelismConfigurationManager parallelExecutionManager() {
+        return Stub(ParallelismConfigurationManager) {
             getParallelismConfiguration() >> new DefaultParallelismConfiguration(true, 1)
         }
     }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/MaxWorkersIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/MaxWorkersIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.launcher.cli
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.RunnableBuildOperation
@@ -28,7 +28,7 @@ import org.gradle.internal.work.WorkerLeaseService
 class MaxWorkersIntegrationTest extends AbstractIntegrationSpec {
     def "max workers is honored when it changes between invocations"() {
         buildFile << """
-            import ${ParallelExecutionManager.class.name}
+            import ${ParallelismConfigurationManager.class.name}
             import ${WorkerLeaseService.class.name}
             import ${BuildOperationExecutor.class.name}
             import ${RunnableBuildOperation.class.name}
@@ -43,7 +43,7 @@ class MaxWorkersIntegrationTest extends AbstractIntegrationSpec {
                         doLast {
                             def count = (taskName - "verifyMaxWorkers") as int
                             def latch = new CountDownLatch(count)
-                            assert task.services.get(ParallelExecutionManager).parallelismConfiguration.maxWorkerCount == count
+                            assert task.services.get(ParallelismConfigurationManager).parallelismConfiguration.maxWorkerCount == count
                             assert task.services.get(WorkerLeaseService).maxWorkerCount == count
                             task.services.get(BuildOperationExecutor).runAll { queue ->
                                 count.times { i ->

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -27,7 +27,7 @@ import org.gradle.cli.ParsedCommandLine;
 import org.gradle.cli.SystemPropertiesCommandLineConverter;
 import org.gradle.configuration.GradleLauncherMetaData;
 import org.gradle.initialization.BuildLayoutParameters;
-import org.gradle.initialization.DefaultParallelismConfiguration;
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.initialization.LayoutCommandLineConverter;
 import org.gradle.internal.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.ParallelismConfigurationCommandLineConverter;

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -20,7 +20,7 @@ import org.gradle.api.execution.internal.TaskInputsListener;
 import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.filewatch.FileWatcherFactory;
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.logging.LoggingManagerInternal;
@@ -66,7 +66,7 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                           ExecutorFactory executorFactory,
                                           LoggingManagerInternal loggingManager,
                                           GradleUserHomeScopeServiceRegistry userHomeServiceRegistry,
-                                          ParallelExecutionManager parallelExecutionManager) {
+                                          ParallelismConfigurationManager parallelismConfigurationManager) {
             return new SetupLoggingActionExecuter(
                 new SessionFailureReportingActionExecuter(
                     new StartParamsValidatingActionExecuter(
@@ -86,9 +86,9 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                         styledTextOutputFactory,
                                         executorFactory),
                                     userHomeServiceRegistry)),
-                        parallelExecutionManager)),
+                            parallelismConfigurationManager)),
                     styledTextOutputFactory),
-                loggingManager, parallelExecutionManager);
+                loggingManager, parallelismConfigurationManager);
         }
 
         ExecuteBuildActionRunner createExecuteBuildActionRunner() {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ParallelismConfigurationBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ParallelismConfigurationBuildActionExecuter.java
@@ -19,7 +19,7 @@ package org.gradle.tooling.internal.provider;
 import org.gradle.StartParameter;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.DefaultParallelismConfiguration;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.exec.BuildActionExecuter;
@@ -28,21 +28,21 @@ import org.gradle.launcher.exec.BuildExecuter;
 
 public class ParallelismConfigurationBuildActionExecuter implements BuildExecuter {
     private final BuildActionExecuter<BuildActionParameters> delegate;
-    private final ParallelExecutionManager parallelExecutionManager;
+    private final ParallelismConfigurationManager parallelismConfigurationManager;
 
-    public ParallelismConfigurationBuildActionExecuter(BuildActionExecuter<BuildActionParameters> delegate, ParallelExecutionManager parallelExecutionManager) {
+    public ParallelismConfigurationBuildActionExecuter(BuildActionExecuter<BuildActionParameters> delegate, ParallelismConfigurationManager parallelismConfigurationManager) {
         this.delegate = delegate;
-        this.parallelExecutionManager = parallelExecutionManager;
+        this.parallelismConfigurationManager = parallelismConfigurationManager;
     }
 
     @Override
     public Object execute(BuildAction action, BuildRequestContext requestContext, BuildActionParameters actionParameters, ServiceRegistry contextServices) {
         StartParameter startParameter = action.getStartParameter();
-        parallelExecutionManager.setParallelismConfiguration(new DefaultParallelismConfiguration(startParameter.isParallelProjectExecutionEnabled(), startParameter.getMaxWorkerCount()));
+        parallelismConfigurationManager.setParallelismConfiguration(new DefaultParallelismConfiguration(startParameter.isParallelProjectExecutionEnabled(), startParameter.getMaxWorkerCount()));
         try {
             return delegate.execute(action, requestContext, actionParameters, contextServices);
         } finally {
-            parallelExecutionManager.setParallelismConfiguration(DefaultParallelismConfiguration.DEFAULT);
+            parallelismConfigurationManager.setParallelismConfiguration(DefaultParallelismConfiguration.DEFAULT);
         }
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ParallelismConfigurationBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ParallelismConfigurationBuildActionExecuter.java
@@ -18,7 +18,7 @@ package org.gradle.tooling.internal.provider;
 
 import org.gradle.StartParameter;
 import org.gradle.initialization.BuildRequestContext;
-import org.gradle.initialization.DefaultParallelismConfiguration;
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.service.ServiceRegistry;

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
@@ -48,7 +48,7 @@ public class SetupLoggingActionExecuter implements BuildExecuter {
         setupLogging(startParameter);
         ParallelismConfigurationListener listener = new ParallelismConfigurationListener() {
             @Override
-            public void onConfigurationChange(ParallelismConfiguration parallelismConfiguration) {
+            public void onParallelismConfigurationChange(ParallelismConfiguration parallelismConfiguration) {
                 setupLogging(parallelismConfiguration);
             }
         };

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
@@ -18,7 +18,7 @@ package org.gradle.tooling.internal.provider;
 
 import org.gradle.StartParameter;
 import org.gradle.initialization.BuildRequestContext;
-import org.gradle.internal.concurrent.ParallelExecutionManager;
+import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.invocation.BuildAction;
@@ -33,12 +33,12 @@ import org.gradle.launcher.exec.BuildExecuter;
 public class SetupLoggingActionExecuter implements BuildExecuter {
     private final BuildExecuter delegate;
     private final LoggingManagerInternal loggingManager;
-    private final ParallelExecutionManager parallelExecutionManager;
+    private final ParallelismConfigurationManager parallelismConfigurationManager;
 
-    public SetupLoggingActionExecuter(BuildExecuter delegate, LoggingManagerInternal loggingManager, ParallelExecutionManager parallelExecutionManager) {
+    public SetupLoggingActionExecuter(BuildExecuter delegate, LoggingManagerInternal loggingManager, ParallelismConfigurationManager parallelismConfigurationManager) {
         this.delegate = delegate;
         this.loggingManager = loggingManager;
-        this.parallelExecutionManager = parallelExecutionManager;
+        this.parallelismConfigurationManager = parallelismConfigurationManager;
     }
 
     @Override
@@ -52,13 +52,13 @@ public class SetupLoggingActionExecuter implements BuildExecuter {
                 setupLogging(parallelismConfiguration);
             }
         };
-        parallelExecutionManager.addListener(listener);
+        parallelismConfigurationManager.addListener(listener);
         loggingManager.start();
         try {
             return delegate.execute(action, requestContext, actionParameters, contextServices);
         } finally {
             loggingManager.stop();
-            parallelExecutionManager.removeListener(listener);
+            parallelismConfigurationManager.removeListener(listener);
         }
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ParallelismConfigurationBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ParallelismConfigurationBuildActionExecuterTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.tooling.internal.provider
 
 import org.gradle.StartParameter
 import org.gradle.initialization.BuildRequestContext
-import org.gradle.initialization.DefaultParallelismConfiguration
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.service.ServiceRegistry

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ParallelismConfigurationBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ParallelismConfigurationBuildActionExecuterTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.tooling.internal.provider
 import org.gradle.StartParameter
 import org.gradle.initialization.BuildRequestContext
 import org.gradle.initialization.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.launcher.exec.BuildActionExecuter
@@ -30,7 +30,7 @@ import spock.lang.Specification
 class ParallelismConfigurationBuildActionExecuterTest extends Specification {
     def delegate = Mock(BuildActionExecuter)
     def action = Mock(BuildAction)
-    def parallelExecutionManager = Mock(ParallelExecutionManager)
+    def parallelExecutionManager = Mock(ParallelismConfigurationManager)
     def parallelismConfigurationBuildActionExecuter = new ParallelismConfigurationBuildActionExecuter(delegate, parallelExecutionManager)
     def buildRequestContext = Stub(BuildRequestContext)
     def buildActionParameters = Stub(BuildActionParameters)

--- a/subprojects/platform-native/platform-native.gradle
+++ b/subprojects/platform-native/platform-native.gradle
@@ -34,6 +34,7 @@ useTestFixtures(sourceSet: 'testFixtures')
 useTestFixtures(project: ':platformBase')
 useTestFixtures(project: ':modelCore')
 useTestFixtures(project: ':diagnostics')
+useTestFixtures(project: ':baseServices')
 
 strictCompile()
 useClassycle(exclude: ['org/gradle/nativeplatform/plugins/**',

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -19,8 +19,9 @@ package org.gradle.nativeplatform.toolchain.internal
 import org.gradle.api.Action
 import org.gradle.api.internal.file.BaseDirFileResolver
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.test.fixtures.work.TestWorkerLeaseService
-import org.gradle.initialization.DefaultParallelismConfiguration
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.GradleThread
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
@@ -62,7 +63,7 @@ abstract class NativeCompilerTest extends Specification {
 
     private BuildOperationListener buildOperationListener = Mock(BuildOperationListener)
     private TimeProvider timeProvider = Mock(TimeProvider)
-    ParallelismConfigurationManager parallelExecutionManager = Stub(ParallelismConfigurationManager) { getParallelismConfiguration() >> DefaultParallelismConfiguration.DEFAULT }
+    ParallelismConfigurationManager parallelExecutionManager = new ParallelismConfigurationManagerFixture(DefaultParallelismConfiguration.DEFAULT)
     protected BuildOperationExecutor buildOperationExecutor = new DefaultBuildOperationExecutor(buildOperationListener, timeProvider, new NoOpProgressLoggerFactory(),
         new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), resourceLockCoordinationService, parallelExecutionManager)
 

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.GradleThread
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
 import org.gradle.internal.operations.logging.BuildOperationLogger
@@ -62,7 +62,7 @@ abstract class NativeCompilerTest extends Specification {
 
     private BuildOperationListener buildOperationListener = Mock(BuildOperationListener)
     private TimeProvider timeProvider = Mock(TimeProvider)
-    ParallelExecutionManager parallelExecutionManager = Stub(ParallelExecutionManager) { getParallelismConfiguration() >> DefaultParallelismConfiguration.DEFAULT }
+    ParallelismConfigurationManager parallelExecutionManager = Stub(ParallelismConfigurationManager) { getParallelismConfiguration() >> DefaultParallelismConfiguration.DEFAULT }
     protected BuildOperationExecutor buildOperationExecutor = new DefaultBuildOperationExecutor(buildOperationListener, timeProvider, new NoOpProgressLoggerFactory(),
         new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), resourceLockCoordinationService, parallelExecutionManager)
 

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
 import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
 import org.gradle.internal.progress.BuildOperationListener
@@ -48,7 +48,7 @@ class DefaultTestReportTest extends Specification {
     final WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     def reportWithMaxThreads(int numThreads) {
-        ParallelExecutionManager parallelExecutionManager = Mock(ParallelExecutionManager) { _ * getParallelismConfiguration() >> new DefaultParallelismConfiguration(false, numThreads)}
+        ParallelismConfigurationManager parallelExecutionManager = Mock(ParallelismConfigurationManager) { _ * getParallelismConfiguration() >> new DefaultParallelismConfiguration(false, numThreads)}
         buildOperationExecutor = new DefaultBuildOperationExecutor(
             Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), parallelExecutionManager)

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/report/DefaultTestReportTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.api.internal.tasks.testing.junit.report
 import org.gradle.api.internal.tasks.testing.BuildableTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.AggregateTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.test.fixtures.work.TestWorkerLeaseService
-import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -48,7 +48,7 @@ class DefaultTestReportTest extends Specification {
     final WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     def reportWithMaxThreads(int numThreads) {
-        ParallelismConfigurationManager parallelExecutionManager = Mock(ParallelismConfigurationManager) { _ * getParallelismConfiguration() >> new DefaultParallelismConfiguration(false, numThreads)}
+        ParallelismConfigurationManager parallelExecutionManager = new ParallelismConfigurationManagerFixture(false, numThreads)
         buildOperationExecutor = new DefaultBuildOperationExecutor(
             Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), parallelExecutionManager)

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.Action
+import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.test.fixtures.work.TestWorkerLeaseService
-import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -44,7 +44,7 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
     final WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     def generatorWithMaxThreads(int numThreads) {
-        ParallelismConfigurationManager parallelExecutionManager = Mock(ParallelismConfigurationManager) { _ * getParallelismConfiguration() >> new DefaultParallelismConfiguration(false, numThreads)}
+        ParallelismConfigurationManager parallelExecutionManager = new ParallelismConfigurationManagerFixture(false, numThreads)
         buildOperationExecutor = new DefaultBuildOperationExecutor(
             Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), parallelExecutionManager)

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.Action
 import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.initialization.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.concurrent.ParallelExecutionManager
+import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
 import org.gradle.internal.operations.MultipleBuildOperationFailures
@@ -44,7 +44,7 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
     final WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     def generatorWithMaxThreads(int numThreads) {
-        ParallelExecutionManager parallelExecutionManager = Mock(ParallelExecutionManager) { _ * getParallelismConfiguration() >> new DefaultParallelismConfiguration(false, numThreads)}
+        ParallelismConfigurationManager parallelExecutionManager = Mock(ParallelismConfigurationManager) { _ * getParallelismConfiguration() >> new DefaultParallelismConfiguration(false, numThreads)}
         buildOperationExecutor = new DefaultBuildOperationExecutor(
             Mock(BuildOperationListener), Mock(TimeProvider), new NoOpProgressLoggerFactory(),
             new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), Mock(ResourceLockCoordinationService), parallelExecutionManager)

--- a/subprojects/testing-jvm/testing-jvm.gradle
+++ b/subprojects/testing-jvm/testing-jvm.gradle
@@ -38,7 +38,8 @@ configure([test, java9Test]) {
 useTestFixtures()
 useTestFixtures(project: ':testingBase', sourceSet: 'testFixtures')
 useTestFixtures(project: ':diagnostics')
-useTestFixtures(project: ":messaging")
+useTestFixtures(project: ':messaging')
+useTestFixtures(project: ':baseServices')
 
 // TODO: re-enable if we are ready to do breaking changes, because this subproject includes classes migrated from the "plugins" subproject
 //useClassycle()


### PR DESCRIPTION
A few minor issues from the review of the max workers notification story:

- Remove the comment [here](https://github.com/gradle/gradle/pull/2149/files/1cbe38119652761075b88d84e0c1621901719cbe#r118905116)
- Rename `ParallelExecutionManager` to `ParallelismConfigurationManager` [comment](https://github.com/gradle/gradle/pull/2149#discussion_r118905289)
- Rename `ParallelismConfigurationManager.onConfigurationChange()` to `onParallelismConfigurationChage()` [comment](https://github.com/gradle/gradle/pull/2149#discussion_r118906082)
- Extract [this](https://github.com/gradle/gradle/pull/2149#discussion_r118907050) into a stub implementation.
