### PR TITLE
Configure all projects eagerly when requesting models

### DIFF
--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -21,6 +21,7 @@ import org.gradle.BuildResult;
 import org.gradle.api.BuildCancelledException;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.execution.ProjectConfigurer;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.invocation.BuildActionRunner;
@@ -65,6 +66,13 @@ public class BuildModelActionRunner implements BuildActionRunner {
         }
 
         @Override
+        public void projectsLoaded(Gradle gradle) {
+            if (!buildModelAction.isRunTasks()) {
+                forceFullConfiguration((GradleInternal) gradle);
+            }
+        }
+
+        @Override
         public void buildFinished(BuildResult result) {
             if (result.getFailure() == null) {
                 buildController.setResult(buildResult(gradle, buildModelAction));
@@ -82,11 +90,6 @@ public class BuildModelActionRunner implements BuildActionRunner {
         }
 
         private static Object buildModel(GradleInternal gradle, BuildModelAction buildModelAction) {
-
-            if (!buildModelAction.isRunTasks()) {
-                forceFullConfiguration(gradle);
-            }
-
             String modelName = buildModelAction.getModelName();
             ToolingModelBuilder builder = getModelBuilder(gradle, modelName);
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunner.java
@@ -21,6 +21,7 @@ import org.gradle.BuildResult;
 import org.gradle.api.BuildCancelledException;
 import org.gradle.includedbuild.IncludedBuild;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.composite.internal.IncludedBuildInternal;
 import org.gradle.execution.ProjectConfigurer;
 import org.gradle.internal.invocation.BuildAction;
@@ -51,6 +52,12 @@ public class ClientProvidedBuildActionRunner implements BuildActionRunner {
         final boolean isRunTasks = clientProvidedBuildAction.isRunTasks();
 
         gradle.addBuildListener(new BuildAdapter() {
+
+            @Override
+            public void projectsLoaded(Gradle gradle) {
+                forceFullConfiguration((GradleInternal) gradle);
+            }
+
             @Override
             public void buildFinished(BuildResult result) {
                 if (result.getFailure() == null) {

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r41/BuildListenerCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r41/BuildListenerCrossVersionSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r41
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.TestOutputStream
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.integtests.tooling.r18.FetchBuildEnvironment
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.gradle.GradleBuild
+
+@ToolingApiVersion(">=2.1")
+@TargetGradleVersion(">=4.1")
+class BuildListenerCrossVersionSpec extends ToolingApiSpecification {
+    TestOutputStream output
+
+    def setup() {
+        given:
+        settingsFile << """
+            rootProject.name = 'root'
+            include 'sub'
+        """
+        buildFile << """
+            gradle.buildFinished() {
+                println "Hello from root"
+            }
+        """
+        file("sub/build.gradle") << """
+            gradle.buildFinished() {
+                println "Hello from sub"
+            }
+        """
+        file("gradle.properties") << """
+            org.gradle.configureondemand = true
+        """
+        output = new TestOutputStream()
+    }
+
+    def "build listeners are called when using configure-on-demand model builders"() {
+        when:
+        withConnection {
+            ProjectConnection connection ->
+                connection.model(GradleBuild)
+                .setStandardOutput(output)
+                .get()
+        }
+
+        then:
+        listenersWereCalled()
+    }
+
+    def "build listeners are called when using configure-on-demand with build actions"() {
+        when:
+        withConnection {
+            ProjectConnection connection ->
+                connection.action(new FetchBuildEnvironment())
+                    .setStandardOutput(output)
+                    .run()
+        }
+
+        then:
+        listenersWereCalled()
+    }
+
+    def "build listeners are called when using configure-on-demand and running tasks"() {
+        when:
+        withConnection {
+            ProjectConnection connection ->
+                connection.newBuild()
+                    .setStandardOutput(output)
+                    .forTasks("help")
+                    .run()
+        }
+
+        then:
+        listenersWereCalled()
+    }
+
+    void listenersWereCalled() {
+        def result = output.toString()
+        assert result.contains("Hello from root")
+        assert result.contains("Hello from sub")
+    }
+}


### PR DESCRIPTION
The configuration was done in a buildFinished hook until now, which
meant that any buildFinished-calls that were discovered as part of
that configuration were not being called.

The configuration is now done right after loading the projects,
so that all buildFinished hooks are discovered long before that
event is fired.