### PR TITLE
[#2391] Add @since tag to Project.findProperty()

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core/src/main/java/org/gradle/api/Project.java
@@ -1397,6 +1397,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * </ol>
      *
      * @param propertyName The name of the property.
+     * @since 2.13
      * @return The value of the property, possibly null or null if not found.
      * @see Project#property(String)
      */


### PR DESCRIPTION
### Context
In relation to #2391. The method in `Project` which I was struggling recently in which version was added to declare compatibility range of my plugin.

Related [release notes](https://docs.gradle.org/2.13/release-notes.html#project.findproperty()-method-for-safer-property-lookups).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [N/A] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [N/A] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [N/A] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [N/A] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [N/A] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
