### PR TITLE
Move ParallelismConfiguration to a public package

### DIFF
--- a/gradle/publicApi.gradle
+++ b/gradle/publicApi.gradle
@@ -20,6 +20,7 @@ ext.publicApiIncludes = [
     'org/gradle/authentication/**',
     'org/gradle/buildinit/**',
     'org/gradle/caching/**',
+    'org/gradle/concurrent/**',
     'org/gradle/external/javadoc/**',
     'org/gradle/ide/**',
     'org/gradle/includedbuild/**',

--- a/subprojects/base-services/src/main/java/org/gradle/api/concurrent/ParallelismConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/concurrent/ParallelismConfiguration.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.concurrent;
+package org.gradle.api.concurrent;
 
 import org.gradle.api.Incubating;
 

--- a/subprojects/base-services/src/main/java/org/gradle/concurrent/ParallelismConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/concurrent/ParallelismConfiguration.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.concurrent;
+package org.gradle.concurrent;
 
 import org.gradle.api.Incubating;
 

--- a/subprojects/base-services/src/main/java/org/gradle/concurrent/package-info.java
+++ b/subprojects/base-services/src/main/java/org/gradle/concurrent/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Classes related to Gradle parallelism and concurrency.
+ */
+package org.gradle.concurrent;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/DefaultParallelismConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/DefaultParallelismConfiguration.java
@@ -19,6 +19,7 @@ package org.gradle.internal.concurrent;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.gradle.api.Incubating;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 
 import java.io.Serializable;
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/DefaultParallelismConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/DefaultParallelismConfiguration.java
@@ -19,7 +19,7 @@ package org.gradle.internal.concurrent;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.gradle.api.Incubating;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 
 import java.io.Serializable;
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationListener.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationListener.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.concurrent;
 
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 
 /**
  * A listener that is notified when the parallelism configuration changes.

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationListener.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationListener.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.concurrent;
 
+import org.gradle.api.concurrent.ParallelismConfiguration;
+
 /**
  * A listener that is notified when the parallelism configuration changes.
  */

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationManager.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationManager.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.concurrent;
 
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 
 /**
  * Maintains information about max workers that can be accessed from any scope

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationManager.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ParallelismConfigurationManager.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.concurrent;
 
+import org.gradle.api.concurrent.ParallelismConfiguration;
+
 /**
  * Maintains information about max workers that can be accessed from any scope
  */

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -24,7 +24,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.resources.AbstractResourceLockRegistry;
 import org.gradle.internal.resources.AbstractTrackedResourceLock;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -24,7 +24,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.resources.AbstractResourceLockRegistry;
 import org.gradle.internal.resources.AbstractTrackedResourceLock;

--- a/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/concurrent/ParallelismConfigurationManagerFixture.groovy
+++ b/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/concurrent/ParallelismConfigurationManagerFixture.groovy
@@ -16,7 +16,8 @@
 
 package org.gradle.internal.concurrent
 
-import org.gradle.api.concurrent.ParallelismConfiguration
+import org.gradle.concurrent.ParallelismConfiguration
+
 
 class ParallelismConfigurationManagerFixture implements ParallelismConfigurationManager {
     ParallelismConfiguration parallelismConfiguration

--- a/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/concurrent/ParallelismConfigurationManagerFixture.groovy
+++ b/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/concurrent/ParallelismConfigurationManagerFixture.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.concurrent
 
+import org.gradle.api.concurrent.ParallelismConfiguration
+
 class ParallelismConfigurationManagerFixture implements ParallelismConfigurationManager {
     ParallelismConfiguration parallelismConfiguration
     List<ParallelismConfigurationListener> listeners = []

--- a/subprojects/core/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core/src/main/java/org/gradle/StartParameter.java
@@ -29,7 +29,7 @@ import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.CompositeInitScriptFinder;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.initialization.DistributionInitScriptFinder;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.UserHomeInitScriptFinder;
 import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.internal.FileUtils;

--- a/subprojects/core/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core/src/main/java/org/gradle/StartParameter.java
@@ -29,7 +29,7 @@ import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.CompositeInitScriptFinder;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.initialization.DistributionInitScriptFinder;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.UserHomeInitScriptFinder;
 import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.internal.FileUtils;

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.time.Timer;
 import org.gradle.internal.time.Timers;

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.time.Timer;
 import org.gradle.internal.time.Timers;

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
@@ -26,7 +26,7 @@ import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.cli.ProjectPropertiesCommandLineConverter;
 import org.gradle.cli.SystemPropertiesCommandLineConverter;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.internal.logging.LoggingCommandLineConverter;
 
 import java.io.File;

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
@@ -26,7 +26,7 @@ import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.cli.ProjectPropertiesCommandLineConverter;
 import org.gradle.cli.SystemPropertiesCommandLineConverter;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 import org.gradle.internal.logging.LoggingCommandLineConverter;
 
 import java.io.File;

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
@@ -18,7 +18,7 @@ package org.gradle.initialization;
 
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.event.ListenerManager;
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultParallelismConfigurationManager.java
@@ -18,7 +18,7 @@ package org.gradle.initialization;
 
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.event.ListenerManager;
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
@@ -20,7 +20,7 @@ import org.gradle.cli.AbstractCommandLineConverter;
 import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 
 public class ParallelismConfigurationCommandLineConverter extends AbstractCommandLineConverter<ParallelismConfiguration> {
     private static final String PARALLEL = "parallel";

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
@@ -20,7 +20,7 @@ import org.gradle.cli.AbstractCommandLineConverter;
 import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 
 public class ParallelismConfigurationCommandLineConverter extends AbstractCommandLineConverter<ParallelismConfiguration> {
     private static final String PARALLEL = "parallel";

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
@@ -28,7 +28,7 @@ import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.GradleThread;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/DefaultBuildOperationExecutor.java
@@ -28,7 +28,7 @@ import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.GradleThread;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.initialization
 
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
-import org.gradle.api.concurrent.ParallelismConfiguration
+import org.gradle.concurrent.ParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationListener
 import org.gradle.internal.event.ListenerManager
 import spock.lang.Specification

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.initialization
 
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
-import org.gradle.internal.concurrent.ParallelismConfiguration
+import org.gradle.api.concurrent.ParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationListener
 import org.gradle.internal.event.ListenerManager
 import spock.lang.Specification

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
@@ -17,7 +17,7 @@ package org.gradle.initialization
 
 import org.gradle.cli.CommandLineArgumentException
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ParallelismConfiguration
+import org.gradle.api.concurrent.ParallelismConfiguration
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
@@ -17,7 +17,7 @@ package org.gradle.initialization
 
 import org.gradle.cli.CommandLineArgumentException
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration
-import org.gradle.api.concurrent.ParallelismConfiguration
+import org.gradle.concurrent.ParallelismConfiguration
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
@@ -42,7 +42,7 @@ import org.gradle.internal.classloader.HashingClassLoaderFactory
 import org.gradle.internal.classpath.CachedClasspathTransformer
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
-import org.gradle.api.concurrent.ParallelismConfiguration
+import org.gradle.concurrent.ParallelismConfiguration
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.jvm.inspection.JvmVersionDetector
 import org.gradle.internal.logging.LoggingManagerInternal

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
@@ -41,8 +41,8 @@ import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.internal.classloader.HashingClassLoaderFactory
 import org.gradle.internal.classpath.CachedClasspathTransformer
 import org.gradle.internal.concurrent.ExecutorFactory
-import org.gradle.internal.concurrent.ParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
+import org.gradle.api.concurrent.ParallelismConfiguration
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.jvm.inspection.JvmVersionDetector
 import org.gradle.internal.logging.LoggingManagerInternal

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -29,7 +29,7 @@ import org.gradle.configuration.GradleLauncherMetaData;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.initialization.LayoutCommandLineConverter;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.ParallelismConfigurationCommandLineConverter;
 import org.gradle.internal.Actions;
 import org.gradle.internal.buildevents.BuildExceptionReporter;

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -29,7 +29,7 @@ import org.gradle.configuration.GradleLauncherMetaData;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.initialization.LayoutCommandLineConverter;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.ParallelismConfigurationCommandLineConverter;
 import org.gradle.internal.Actions;
 import org.gradle.internal.buildevents.BuildExceptionReporter;

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
@@ -17,7 +17,7 @@
 package org.gradle.launcher.cli.converter;
 
 import org.gradle.StartParameter;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.launcher.daemon.configuration.GradleProperties;
 
 import java.util.Map;

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
@@ -17,7 +17,7 @@
 package org.gradle.launcher.cli.converter;
 
 import org.gradle.StartParameter;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 import org.gradle.launcher.daemon.configuration.GradleProperties;
 
 import java.util.Map;

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
@@ -19,7 +19,7 @@ package org.gradle.tooling.internal.provider;
 import org.gradle.StartParameter;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
-import org.gradle.api.concurrent.ParallelismConfiguration;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.logging.LoggingManagerInternal;

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
@@ -19,7 +19,7 @@ package org.gradle.tooling.internal.provider;
 import org.gradle.StartParameter;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
-import org.gradle.internal.concurrent.ParallelismConfiguration;
+import org.gradle.api.concurrent.ParallelismConfiguration;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.logging.LoggingManagerInternal;


### PR DESCRIPTION
This moves `ParallelismConfiguration` to a public package so that `StartParameter` is not leaking an internal type.  