### PR TITLE
Bump version of zinc to 0.3.15

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -193,7 +193,7 @@ libraries.awsS3 = [
 ] + libraries.commons_httpclient + libraries.joda
 
 // keep in sync with ScalaLanguagePlugin code
-libraries.zinc = 'com.typesafe.zinc:zinc:0.3.13'
+libraries.zinc = 'com.typesafe.zinc:zinc:0.3.15'
 
 allprojects {
     configurations.all {

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/internal/toolchain/DefaultScalaToolProvider.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/internal/toolchain/DefaultScalaToolProvider.java
@@ -30,7 +30,7 @@ import java.io.File;
 import java.util.Set;
 
 public class DefaultScalaToolProvider implements ToolProvider {
-    public static final String DEFAULT_ZINC_VERSION = "0.3.13";
+    public static final String DEFAULT_ZINC_VERSION = "0.3.15";
 
     private final File gradleUserHomeDir;
     private final File rootProjectDir;


### PR DESCRIPTION
### Context
This release adds preliminary Java 9 support:

https://github.com/sbt/sbt/releases/tag/v0.13.15

./gradlew :scala:check passes locally with JDK 8u131 and JDK 7u80.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- N/A [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- N/A Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- N/A Provide unit tests (under `<subproject>/src/test`) to verify logic
- N/A Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
