### PR TITLE
Remove `assumeCompatibleWhenMissing` from `CompatibilityRuleChain`

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -40,8 +40,8 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
             allprojects {
                 dependencies {
                     attributesSchema {
-                        attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
-                        attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
+                        attribute(buildType)
+                        attribute(flavor)
                     }
                 }
             }
@@ -152,8 +152,8 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
             allprojects {
                 dependencies {
                     attributesSchema {
-                        attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
-                        attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
+                        attribute(flavor)
+                        attribute(buildType)
                     }
                 }
             }

--- a/subprojects/core/src/main/java/org/gradle/api/attributes/CompatibilityRuleChain.java
+++ b/subprojects/core/src/main/java/org/gradle/api/attributes/CompatibilityRuleChain.java
@@ -78,10 +78,4 @@ public interface CompatibilityRuleChain<T> {
      */
     void add(Class<? extends AttributeCompatibilityRule<T>> rule, Action<? super ActionConfiguration> configureAction);
 
-    /**
-     * Adds a rule that tells that if an attribute is missing, either on the producer or the consumer, then
-     * it is deemed compatible.
-     */
-    void assumeCompatibleWhenMissing();
-
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -305,8 +305,8 @@ abstract class AbstractConfigurationAttributesResolveIntegrationTest extends Abs
 
             project(':a') {
                 dependencies.attributesSchema {
-                    attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
-                    attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
+                    attribute(buildType)
+                    attribute(flavor)
                 }
                 configurations {
                     compile
@@ -483,8 +483,8 @@ Configuration 'bar':
                 }
                 dependencies {
                     attributesSchema {
-                        attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
-                        attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
+                        attribute(buildType)
+                        attribute(flavor)
                     }
                     
                     _compileFreeDebug project(':b')
@@ -529,8 +529,8 @@ Configuration 'bar':
                     _compileFreeDebug.attributes { $freeDebug }
                 }
                 dependencies.attributesSchema {
-                    attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
-                    attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
+                    attribute(buildType)
+                    attribute(flavor)
                 }
                 dependencies {
                     _compileFreeDebug project(':b')
@@ -790,9 +790,7 @@ All of them match the consumer attributes:
                 }
                 dependencies {
                     attributesSchema {
-                        attribute(flavor) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(flavor)
                     }
                     _compileFreeDebug project(':b')
                 }
@@ -849,12 +847,8 @@ All of them match the consumer attributes:
                 }
                 dependencies {
                     attributesSchema {
-                        attribute(flavor) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
-                        attribute(buildType) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(flavor)
+                        attribute(buildType)
                     }
                     _compileFreeDebug project(':b')
                 }
@@ -930,9 +924,7 @@ All of them match the consumer attributes:
             project(':b') {
                 dependencies {
                     attributesSchema {
-                        attribute(extra) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(extra)
                     }
                 }
                 configurations {
@@ -1040,9 +1032,7 @@ All of them match the consumer attributes:
             project(':b') {
                 dependencies {
                     attributesSchema {
-                        attribute(extra) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(extra)
                     }
                 }
                 configurations {
@@ -1113,12 +1103,8 @@ All of them match the consumer attributes:
             project(':a') {
                 dependencies { 
                     attributesSchema {
-                        attribute(flavor) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
-                        attribute(buildType) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(flavor)
+                        attribute(buildType)
                     }
                 }
                 configurations {
@@ -1174,8 +1160,8 @@ All of them match the consumer attributes:
             allprojects {
                dependencies {
                    attributesSchema {
-                      attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
-                      attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
+                      attribute(flavor)
+                      attribute(buildType)
                    }
                }
             }
@@ -1260,8 +1246,8 @@ All of them match the consumer attributes:
             allprojects {
                dependencies {
                    attributesSchema {
-                      attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
-                      attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
+                      attribute(flavor)
+                      attribute(buildType)
                    }
                }
             }
@@ -1338,8 +1324,8 @@ All of them match the consumer attributes:
             allprojects {
                dependencies {
                    attributesSchema {
-                      attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
-                      attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
+                      attribute(flavor)
+                      attribute(buildType)
                    }
                }
             }
@@ -1420,9 +1406,7 @@ All of them match the consumer attributes:
             allprojects {
                 dependencies { 
                     attributesSchema {
-                        attribute(extra) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(extra)
                     }
                 }
             }
@@ -1538,8 +1522,8 @@ All of them match the consumer attributes:
             allprojects {
                dependencies {
                    attributesSchema {
-                      attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
-                      attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
+                      attribute(flavor)
+                      attribute(buildType)
                    }
                }
             }
@@ -1696,9 +1680,7 @@ All of them match the consumer attributes:
                 }
                 dependencies {
                     attributesSchema {
-                        attribute(flavor) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(flavor)
                     }
                     _compileFreeDebug project(':b')
                 }
@@ -1758,9 +1740,7 @@ All of them match the consumer attributes:
             project(':b') {
                 dependencies {
                     attributesSchema {
-                        attribute(flavor) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(flavor)
                     }
                 }
                 configurations {
@@ -1800,12 +1780,8 @@ All of them match the consumer attributes:
             allprojects {
                 dependencies {
                     attributesSchema {
-                        attribute(flavor) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
-                        attribute(buildType) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(flavor)
+                        attribute(buildType)
                     }
                 }
             }
@@ -1888,9 +1864,9 @@ All of them match the consumer attributes:
                 }
                 dependencies {
                     attributesSchema {
-                        attribute(extra).compatibilityRules.assumeCompatibleWhenMissing()
-                        attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
-                        attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
+                        attribute(extra)
+                        attribute(buildType)
+                        attribute(flavor)
                     }
                     _compileFreeDebug project(':b')
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -42,8 +42,8 @@ allprojects {
     }
     dependencies {
         attributesSchema {
-           attribute(usage).compatibilityRules.assumeCompatibleWhenMissing()
-           attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
+           attribute(usage)
+           attribute(buildType)
            attribute(flavor)
         }
     }
@@ -124,9 +124,7 @@ allprojects {
                     compile project(':lib'), project(':ui')
                     
                     attributesSchema {
-                        attribute(otherAttributeOptional) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
-                        }
+                        attribute(otherAttributeOptional)
                     }
                 }
 
@@ -266,7 +264,6 @@ dependencies.attributesSchema {
         compatibilityRules.add(BuildTypeCompatibilityRule)
     }
     attribute(flavor) {
-        compatibilityRules.assumeCompatibleWhenMissing()
         disambiguationRules.add(FlavorSelectionRule)
     }
 }
@@ -410,7 +407,6 @@ dependencies {
 project(':lib') {
     dependencies.attributesSchema {
         attribute(extra) {
-            compatibilityRules.assumeCompatibleWhenMissing()
             disambiguationRules.add(ExtraSelectionRule)
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactsApiIntegrationTest.groovy
@@ -35,9 +35,9 @@ def buildType = Attribute.of('buildType', String)
 allprojects {
     dependencies {
        attributesSchema {
-          attribute(usage).compatibilityRules.assumeCompatibleWhenMissing()
-          attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
-          attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
+          attribute(usage)
+          attribute(flavor)
+          attribute(buildType)
        }
     }
     configurations {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFilesApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFilesApiIntegrationTest.groovy
@@ -143,7 +143,7 @@ def flavor = Attribute.of('flavor', String)
 
 allprojects {
     dependencies {
-        attributesSchema.attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
+        attributesSchema.attribute(flavor)
     }
 }
 
@@ -243,7 +243,6 @@ dependencies {
 project(':a') {
     dependencies {
         attributesSchema.attribute(flavor) {
-            compatibilityRules.assumeCompatibleWhenMissing()
             disambiguationRules.add(SelectFreeRule)
         }
         compile project(':b')
@@ -264,7 +263,6 @@ project(':a') {
 project(':b') {
     dependencies {
             attributesSchema.attribute(flavor) {
-            compatibilityRules.assumeCompatibleWhenMissing()
             disambiguationRules.add(SelectPaidRule)
         }
     }    
@@ -318,9 +316,7 @@ dependencies {
 
 project(':a') {
     dependencies {
-        attributesSchema.attribute(flavor) {
-            compatibilityRules.assumeCompatibleWhenMissing()
-        }
+        attributesSchema.attribute(flavor)
         compile project(':b')
     }
     task freeJar(type: Jar) { archiveName = 'a-free.jar' }
@@ -338,9 +334,7 @@ project(':a') {
 }
 project(':b') {
     dependencies {
-            attributesSchema.attribute(flavor) {
-            compatibilityRules.assumeCompatibleWhenMissing()
-        }
+        attributesSchema.attribute(flavor)
     }    
     task freeJar(type: Jar) { archiveName = 'b-free.jar' }
     task paidJar(type: Jar) { archiveName = 'b-paid.jar' }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -83,8 +83,8 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
                     _compileFreeRelease.attributes { $freeRelease }
                 }
                 dependencies.attributesSchema {
-                    attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
-                    attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
+                    attribute(buildType)
+                    attribute(flavor)
                 }
                 dependencies {
                     _compileFreeDebug project(':b')
@@ -774,7 +774,6 @@ All of them match the consumer attributes:
             project(':b') {
                 dependencies.attributesSchema {
                     attribute(flavor) {
-                        compatibilityRules.assumeCompatibleWhenMissing()
                         disambiguationRules.add(FlavorSelectionRule)
                     }
                 }
@@ -831,7 +830,6 @@ All of them match the consumer attributes:
             }
             project(':b') {
                 dependencies.attributesSchema.attribute(platform) {
-                    compatibilityRules.assumeCompatibleWhenMissing()
                     disambiguationRules.add(SelectionRule)
                 }
                 configurations {
@@ -888,7 +886,6 @@ All of them match the consumer attributes:
             }
             project(':b') {
                 dependencies.attributesSchema.attribute(platform) {
-                    compatibilityRules.assumeCompatibleWhenMissing()
                     disambiguationRules.add(SelectionRule)
                 }
                 configurations {
@@ -938,7 +935,6 @@ All of them match the consumer attributes:
             project(':b') {
                dependencies.attributesSchema {
                     attribute(arch) {
-                       compatibilityRules.assumeCompatibleWhenMissing()
                        disambiguationRules.pickLast { a,b -> a<=>b }
                   }
                }
@@ -946,7 +942,6 @@ All of them match the consumer attributes:
             project(':c') {
                 dependencies.attributesSchema {
                     attribute(arch) {
-                       compatibilityRules.assumeCompatibleWhenMissing()
                        disambiguationRules.pickLast { a,b -> a<=>b }
                     }
                 }
@@ -1046,7 +1041,6 @@ All of them match the consumer attributes:
                             compatibilityRules.add(FlavorCompatibilityRule) { params("full") }
                         }
                         attribute(buildType) {
-                            compatibilityRules.assumeCompatibleWhenMissing()
                             disambiguationRules.add(BuildTypeSelectionRule) { params(BuildType.debug) }
                         }
                     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAwareResolutionWithConfigurationAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAwareResolutionWithConfigurationAttributesIntegrationTest.groovy
@@ -41,9 +41,9 @@ class VariantAwareResolutionWithConfigurationAttributesIntegrationTest extends A
                         def usage = Attribute.of('usage', String)
                         def flavor = Attribute.of('flavor', String)
                         p.dependencies.attributesSchema {
-                           attribute(buildType).compatibilityRules.assumeCompatibleWhenMissing()
-                           attribute(usage).compatibilityRules.assumeCompatibleWhenMissing()
-                           attribute(flavor).compatibilityRules.assumeCompatibleWhenMissing()
+                           attribute(buildType)
+                           attribute(usage)
+                           attribute(flavor)
                         }
                         def buildTypes = ['debug', 'release']
                         def flavors = ['free', 'paid']

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -34,7 +34,7 @@ allprojects {
 
     dependencies {
         attributesSchema {
-            attribute(usage).compatibilityRules.assumeCompatibleWhenMissing()
+            attribute(usage)
         }
     }
     configurations {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
@@ -62,11 +62,6 @@ public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChain<
     }
 
     @Override
-    public void assumeCompatibleWhenMissing() {
-        // Don't care. This method will be removed shortly
-    }
-
-    @Override
     public void execute(CompatibilityCheckResult<T> result) {
         for (Action<? super CompatibilityCheckDetails<T>> rule : rules) {
             rule.execute(result);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -116,16 +116,8 @@ class LocalComponentDependencyMetadataTest extends Specification {
             getConsumableConfigurationsHavingAttributes() >> [toFooConfig, toBarConfig]
             getAttributesSchema() >> EmptySchema.INSTANCE
         }
-        attributesSchema.attribute(Attribute.of('key', String), {
-            if (allowMissing) {
-                it.compatibilityRules.assumeCompatibleWhenMissing()
-            }
-        })
-        attributesSchema.attribute(Attribute.of('extra', String), {
-            if (allowMissing) {
-                it.compatibilityRules.assumeCompatibleWhenMissing()
-            }
-        })
+        attributesSchema.attribute(Attribute.of('key', String))
+        attributesSchema.attribute(Attribute.of('extra', String))
 
         given:
         toComponent.getConfiguration("default") >> defaultConfig
@@ -136,10 +128,10 @@ class LocalComponentDependencyMetadataTest extends Specification {
         dep.selectConfigurations(fromComponent, fromConfig, toComponent, attributesSchema)*.name as Set == [expected] as Set
 
         where:
-        scenario                                         | queryAttributes                 | allowMissing | expected
-        'exact match'                                    | [key: 'something']              | false        | 'foo'
-        'exact match'                                    | [key: 'something else']         | false        | 'bar'
-        'partial match on key but attribute is optional' | [key: 'something', extra: 'no'] | true         | 'foo'
+        scenario                                         | queryAttributes                 | expected
+        'exact match'                                    | [key: 'something']              | 'foo'
+        'exact match'                                    | [key: 'something else']         | 'bar'
+        'partial match on key but attribute is optional' | [key: 'something', extra: 'no'] | 'foo'
     }
 
     def "revalidates default configuration if it has attributes"() {
@@ -250,12 +242,8 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
             it.ordered { a, b -> a <=> b }
             it.ordered(true, { a, b -> a <=> b })
         })
-        attributesSchema.attribute(Attribute.of('flavor', String), {
-            it.compatibilityRules.assumeCompatibleWhenMissing()
-        })
-        attributesSchema.attribute(Attribute.of('extra', String), {
-            it.compatibilityRules.assumeCompatibleWhenMissing()
-        })
+        attributesSchema.attribute(Attribute.of('flavor', String))
+        attributesSchema.attribute(Attribute.of('extra', String))
 
         given:
         toComponent.getConfiguration("default") >> defaultConfig
@@ -329,12 +317,8 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
             it.ordered { a, b -> a <=> b }
             it.ordered(true, { a, b -> a <=> b })
         })
-        attributesSchema.attribute(Attribute.of('flavor', String), {
-            it.compatibilityRules.assumeCompatibleWhenMissing()
-        })
-        attributesSchema.attribute(Attribute.of('extra', String), {
-            it.compatibilityRules.assumeCompatibleWhenMissing()
-        })
+        attributesSchema.attribute(Attribute.of('flavor', String))
+        attributesSchema.attribute(Attribute.of('extra', String))
 
         given:
         toComponent.getConfiguration("default") >> defaultConfig


### PR DESCRIPTION
This PR is part of an API cleanup. It removes  `assumeCompatibleWhenMissing` from `CompatibilityRuleChain`. This method was already a no-op. Now is time for removal.

Fixed gradle/performance#540