### PR TITLE
Always snapshot task state before execution, even if task is rerun

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/TaskArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/TaskArtifactState.java
@@ -47,6 +47,11 @@ public interface TaskArtifactState {
     TaskOutputCachingBuildCacheKey calculateCacheKey();
 
     /**
+     * Ensure snapshot is taken of the task's inputs and outputs before it is executed.
+     */
+    void ensureSnapshotBeforeTask();
+
+    /**
      * Called on completion of task execution.
      */
     void afterTask(Throwable failure);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
@@ -157,6 +157,11 @@ public class DefaultTaskArtifactStateRepository implements TaskArtifactStateRepo
         }
 
         @Override
+        public void ensureSnapshotBeforeTask() {
+            getStates();
+        }
+
+        @Override
         public void afterTask(Throwable failure) {
             if (failure != null) {
                 return;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
@@ -60,6 +60,10 @@ class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory 
     }
 
     @Override
+    public void ensureSnapshotBeforeTask() {
+    }
+
+    @Override
     public void afterTask(Throwable failure) {
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ShortCircuitTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ShortCircuitTaskArtifactStateRepository.java
@@ -103,6 +103,11 @@ public class ShortCircuitTaskArtifactStateRepository implements TaskArtifactStat
         }
 
         @Override
+        public void ensureSnapshotBeforeTask() {
+            delegate.ensureSnapshotBeforeTask();
+        }
+
+        @Override
         public void afterTask(Throwable failure) {
             delegate.afterTask(failure);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuter.java
@@ -48,6 +48,7 @@ public class SkipUpToDateTaskExecuter implements TaskExecuter {
         LOGGER.debug("Determining if {} is up-to-date", task);
         Timer clock = Timers.startTimer();
         TaskArtifactState taskArtifactState = context.getTaskArtifactState();
+        taskArtifactState.ensureSnapshotBeforeTask();
 
         List<String> messages = new ArrayList<String>(TaskUpToDateState.MAX_OUT_OF_DATE_MESSAGES);
         if (taskArtifactState.isUpToDate(messages)) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuterTest.groovy
@@ -46,6 +46,7 @@ class SkipUpToDateTaskExecuterTest extends Specification {
         executer.execute(task, taskState, taskContext)
 
         then:
+        1 * taskArtifactState.ensureSnapshotBeforeTask()
         1 * taskArtifactState.isUpToDate(_) >> true
         1 * taskArtifactState.getOriginBuildInvocationId() >> originBuildInvocationId
         1 * taskContext.taskArtifactState >> taskArtifactState
@@ -60,6 +61,7 @@ class SkipUpToDateTaskExecuterTest extends Specification {
 
         then:
         1 * taskContext.taskArtifactState >> taskArtifactState
+        1 * taskArtifactState.ensureSnapshotBeforeTask()
         1 * taskArtifactState.isUpToDate(_) >> false
         1 * taskContext.setUpToDateMessages(_)
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Issue
 import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.*
 import static org.hamcrest.Matchers.startsWith
 
-public class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
+class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
 
     def taskCanAccessTaskGraph() {
         buildFile << """
@@ -677,5 +677,37 @@ task someTask(dependsOn: [someDep, someOtherDep])
 
         then:
         failure.assertHasDescription('Task :a has both inputs and destroyables defined.  A task can define either inputs or destroyables, but not both.')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/2401")
+    def "re-run task does not query inputs after execution"() {
+        buildFile << """
+            class CustomTask extends DefaultTask {
+                private boolean executed
+
+                @InputDirectory
+                @Optional
+                File getInputDirectory() {
+                    if (!executed) {
+                        return null
+                    }
+                    throw new NullPointerException("Busted")
+                }
+
+                @OutputFile File outputFile
+
+                @TaskAction
+                void doStuff() {
+                    executed = true
+                }
+            }
+
+            task custom(type: CustomTask) {
+                outputFile = file("output.txt")
+            }
+        """
+
+        expect:
+        succeeds "custom", "--rerun-tasks"
     }
 }


### PR DESCRIPTION
This fixes the problem with reran tasks being snapshot after execution, which could lead to incorrect inputs being snapshots if they are mutated during execution.
