### PR TITLE
Make sure outgoing variants cannot be mutated after resolve

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/artifacts/ConfigurationVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/artifacts/ConfigurationVariant.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.attributes.HasConfigurableAttributes;
+import org.gradle.internal.HasInternalProtocol;
 
 /**
  * Represents some variant of an outgoing configuration.
@@ -27,6 +28,7 @@ import org.gradle.api.attributes.HasConfigurableAttributes;
  * @since 3.3
  */
 @Incubating
+@HasInternalProtocol
 public interface ConfigurationVariant extends Named, HasConfigurableAttributes<ConfigurationVariant> {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ConfigurationVariantInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ConfigurationVariantInternal.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.artifacts.ConfigurationVariant;
+
+public interface ConfigurationVariantInternal extends ConfigurationVariant {
+    void preventFurtherMutation();
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        buildFile << """
+            def usage = Attribute.of('usage', String)
+            def format = Attribute.of('format', String)
+            allprojects {
+                dependencies {
+                    attributesSchema {
+                        attribute(usage)
+                    }
+                }
+                configurations { compile { attributes.attribute(usage, 'for-compile') } }
+            }
+        """
+    }
+
+    def "cannot mutate outgoing variants after configuration is resolved"() {
+        given:
+        buildFile << """
+        
+        configurations {
+            compile {
+                attributes.attribute(usage, 'for compile')
+                outgoing {
+                    artifact file('lib1.jar')
+                    variants {
+                        classes {
+                            attributes.attribute(format, 'classes-dir')
+                            artifact file('classes')
+                        }
+                        jar {
+                            attributes.attribute(format, 'classes-jar')
+                            artifact file('lib.jar')
+                        }
+                        sources {
+                            attributes.attribute(format, 'source-jar')
+                            artifact file('source.zip')
+                        }
+                    }
+                }
+            }
+        }
+        task mutateBeforeResolve {
+            doLast {
+                def classes = configurations.compile.outgoing.variants['classes']
+                classes.attributes.attribute(format, 'classes2')
+            }
+        }
+        task mutateAfterResolve {
+            doLast {
+                configurations.compile.resolve()
+                def classes = configurations.compile.outgoing.variants['classes']
+                classes.attributes.attribute(format, 'classes-dir')
+            }
+        }
+        """
+
+        when:
+        run 'mutateBeforeResolve'
+
+        then:
+        noExceptionThrown()
+
+        when:
+        fails("mutateAfterResolve")
+
+        then:
+        failure.assertHasCause "Cannot change attributes of configuration ':compile' after it has been resolved"
+    }
+
+    def "cannot add outgoing variants after configuration is resolved"() {
+        given:
+        buildFile << """
+        
+        configurations {
+            compile {
+                attributes.attribute(usage, 'for compile')
+                outgoing {
+                    artifact file('lib1.jar')
+                    variants {
+                        classes {
+                            attributes.attribute(format, 'classes-dir')
+                            artifact file('classes')
+                        }
+                    }
+                }
+            }
+        }
+        task mutateBeforeResolve {
+            doLast {
+                configurations.compile.outgoing.variants {
+                    jar {
+                        attributes.attribute(format, 'classes-jar')
+                        artifact file('lib.jar')
+                    }
+                }
+            }
+        }
+        task mutateAfterResolve {
+            doLast {
+                configurations.compile.resolve()
+                configurations.compile.outgoing.variants {
+                    sources {
+                        attributes.attribute(format, 'source-jar')
+                        artifact file('source.zip')
+                    }
+                }
+            }
+        }
+        """
+
+        when:
+        run 'mutateBeforeResolve'
+
+        then:
+        noExceptionThrown()
+
+        when:
+        fails("mutateAfterResolve")
+
+        then:
+        failure.assertHasCause "Cannot create variant 'sources' after configuration ':compile' has been resolved"
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -46,5 +46,5 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
      */
     OutgoingVariant convertToOutgoingVariant();
 
-    void lockAttributes();
+    void preventFromFurtherMutation();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -24,19 +24,21 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributeContainerWithErrorMessage;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.Describables;
+import org.gradle.internal.DisplayName;
 import org.gradle.internal.typeconversion.NotationParser;
 
-public class DefaultVariant implements ConfigurationVariant {
+public class DefaultVariant implements ConfigurationVariantInternal {
     private final Describable parentDisplayName;
     private final String name;
-    private final AttributeContainerInternal attributes;
+    private AttributeContainerInternal attributes;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
     private final PublishArtifactSet artifacts;
 
@@ -91,5 +93,15 @@ public class DefaultVariant implements ConfigurationVariant {
         ConfigurablePublishArtifact publishArtifact = artifactNotationParser.parseNotation(notation);
         artifacts.add(publishArtifact);
         configureAction.execute(publishArtifact);
+    }
+
+    @Override
+    public String toString() {
+        return getAsDescribable().getDisplayName();
+    }
+
+    @Override
+    public void preventFurtherMutation() {
+        attributes = new ImmutableAttributeContainerWithErrorMessage(attributes.asImmutable(), parentDisplayName);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationComponentMetaDataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultConfigurationComponentMetaDataBuilder.java
@@ -44,7 +44,7 @@ public class DefaultConfigurationComponentMetaDataBuilder implements Configurati
     }
 
     private void addConfiguration(BuildableLocalComponentMetadata metaData, ConfigurationInternal configuration) {
-        configuration.lockAttributes();
+        configuration.preventFromFurtherMutation();
         Set<String> hierarchy = Configurations.getNames(configuration.getHierarchy());
         Set<String> extendsFrom = Configurations.getNames(configuration.getExtendsFrom());
         metaData.addConfiguration(configuration.getName(),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributeContainerWithErrorMessage.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributeContainerWithErrorMessage.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.attributes;
+
+import org.gradle.api.Describable;
+import org.gradle.api.Nullable;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
+
+import java.util.Set;
+
+public class ImmutableAttributeContainerWithErrorMessage implements AttributeContainerInternal {
+    private final AttributeContainerInternal delegate;
+    private final Describable owner;
+
+    public ImmutableAttributeContainerWithErrorMessage(AttributeContainerInternal delegate, Describable owner) {
+        this.delegate = delegate;
+        this.owner = owner;
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public ImmutableAttributes asImmutable() {
+        return delegate.asImmutable();
+    }
+
+    @Override
+    public AttributeContainerInternal copy() {
+        return delegate.copy();
+    }
+
+    @Override
+    public Set<Attribute<?>> keySet() {
+        return delegate.keySet();
+    }
+
+    @Override
+    public <T> AttributeContainer attribute(Attribute<T> key, T value) {
+        throw new IllegalArgumentException(String.format("Cannot change attributes of %s after it has been resolved", owner.getDisplayName()));
+    }
+
+    @Nullable
+    @Override
+    public <T> T getAttribute(Attribute<T> key) {
+        return delegate.getAttribute(key);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Attribute<?> key) {
+        return delegate.contains(key);
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return delegate.getAttributes();
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1480,7 +1480,7 @@ class DefaultConfigurationSpec extends Specification {
         def a1 = Attribute.of('a1', String)
 
         when:
-        conf.lockAttributes()
+        conf.preventFromFurtherMutation()
         conf.getAttributes().attribute(a1, "a1")
 
         then:
@@ -1498,7 +1498,7 @@ class DefaultConfigurationSpec extends Specification {
         def containerImmutable = conf.getAttributes().asImmutable()
 
         when:
-        conf.lockAttributes()
+        conf.preventFromFurtherMutation()
         def containerWrapped = conf.getAttributes()
 
         then:


### PR DESCRIPTION
This commit introduces changes to make sure that it is not possible to mutate the outgoing variants of a configuration after it has been resolved.

More specifically, this commit prevents from:

   - adding a new outgoing variant after configuration has been resolved
   - modifying the attributes of an outgoing variant after configuration has been resolved

Fixes gradle/performance#421