### PR TITLE
Deprecate Task.dependsOnTaskDidWork()

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core/src/main/java/org/gradle/api/Task.java
@@ -543,7 +543,11 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * <p>Checks if any of the tasks that this task depends on {@link Task#getDidWork() didWork}.</p>
      *
      * @return true if any task this task depends on did work.
+     *
+     * @deprecated Build logic should not depend on this information about a task. Instead, declare
+     * task inputs and outputs to allow Gradle to optimize task execution.
      */
+    @Deprecated
     boolean dependsOnTaskDidWork();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -541,6 +541,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public boolean dependsOnTaskDidWork() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("Task.dependsOnTaskDidWork()");
         TaskDependency dependency = getTaskDependencies();
         for (Task depTask : dependency.getDependencies(this)) {
             if (depTask.getDidWork()) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -74,6 +74,8 @@ The following are the newly deprecated items in this Gradle release. If you have
 ### Example deprecation
 -->
 
+- `Task.dependsOnTaskDidWork()` is now deprecated. Build logic should not depend on this information about a task. Instead, declare task inputs and outputs to allow Gradle to optimize task execution.
+
 ## Potential breaking changes
 
 ### Changes to handling of project dependencies from a project that does not use the Java plugin to a project that does


### PR DESCRIPTION
From @adammurdoch (https://github.com/gradle/task-output-cache/issues/662#issuecomment-302965871):

> `didWork()` can stay. It's maybe not the best modelling but at least it has some meaning. We might refactor how the information is presented.
> 
> `dependsOnTaskDidWork()` doesn't have any real meaning. The task should describe its inputs, and the other tasks their outputs, and we should connect the tasks together via these.