### PR TITLE
Use foreground color for "> IDLE" placeholder

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/DefaultWorkInProgressFormatter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/DefaultWorkInProgressFormatter.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class DefaultWorkInProgressFormatter {
-    private final static List<Span> IDLE_SPANS = Arrays.asList(new Span(Style.of(Style.Color.GREY), "> IDLE"));
+    private final static List<Span> IDLE_SPANS = Arrays.asList(new Span("> IDLE"));
     private final ConsoleMetaData consoleMetaData;
 
     public DefaultWorkInProgressFormatter(ConsoleMetaData consoleMetaData) {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/DefaultWorkInProgressFormatterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/DefaultWorkInProgressFormatterTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.logging.console
 
 import org.gradle.internal.logging.events.OperationIdentifier
+import org.gradle.internal.logging.text.Style
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData
 import spock.lang.Specification
 import spock.lang.Subject
@@ -64,5 +65,6 @@ class DefaultWorkInProgressFormatterTest extends Specification {
 
         expect:
         statusBarFormatter.format(operation).first().text == "> IDLE"
+        statusBarFormatter.format(operation).first().style == Style.NORMAL
     }
 }


### PR DESCRIPTION
This avoids problems where the GREY color is mapped to something
illegible, as in solarized dark themes.

Issue: #2417

### Before
![before](https://user-images.githubusercontent.com/51534/28081460-2c921f90-6624-11e7-96ac-34f26a88cde0.gif)

### After
![screenflow](https://user-images.githubusercontent.com/51534/28081467-32993216-6624-11e7-9bca-3bb963ce51ab.gif)