### PR TITLE
Fix issue with enforced tasks and task graph exception

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -550,7 +550,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
                 try {
                     selected.set(selectNextTask(workerLease));
                 } catch (Throwable t) {
-                    abortAndFail(t);
+                    abortAllAndFail(t);
                     workRemaining.set(false);
                 }
 
@@ -864,8 +864,8 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
         }
     }
 
-    private void abortAndFail(Throwable t) {
-        abortExecution();
+    private void abortAllAndFail(Throwable t) {
+        abortExecution(true);
         this.failures.add(t);
     }
 
@@ -890,11 +890,21 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     }
 
     private boolean abortExecution() {
-        // Allow currently executing and enforced tasks to complete, but skip everything else.
+        return abortExecution(false);
+    }
+
+    private boolean abortExecution(boolean abortAll) {
         boolean aborted = false;
         for (TaskInfo taskInfo : executionPlan.values()) {
+            // Allow currently executing and enforced tasks to complete, but skip everything else.
             if (taskInfo.isRequired()) {
                 taskInfo.skipExecution();
+                aborted = true;
+            }
+
+            // If abortAll is set, also stop enforced tasks.
+            if (abortAll && taskInfo.isReady()) {
+                taskInfo.abortExecution();
                 aborted = true;
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
@@ -98,6 +98,11 @@ public class TaskInfo implements Comparable<TaskInfo> {
         state = TaskExecutionState.SKIPPED;
     }
 
+    public void abortExecution() {
+        assert isReady();
+        state = TaskExecutionState.SKIPPED;
+    }
+
     public void require() {
         state = TaskExecutionState.SHOULD_RUN;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
@@ -20,12 +20,14 @@ import com.google.common.collect.Queues
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.tasks.Destroys
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.OutputFiles
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
@@ -663,6 +665,24 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
         operation."${c.path}".start > operation."${b.path}".end
     }
 
+    def "handles an exception while while walking the task graph when an enforced task is present"() {
+        given:
+        Task finalizer = root.task("finalizer", type: BrokenTask)
+        Task finalized = root.task("finalized")
+        finalized.finalizedBy finalizer
+
+        when:
+        addToGraphAndPopulate(finalized)
+        async {
+            startTaskWorkers(2)
+            releaseTasks(finalized)
+        }
+
+        then:
+        executionPlan.executionPlan[finalized].isSuccessful()
+        executionPlan.executionPlan[finalizer].state == TaskInfo.TaskExecutionState.SKIPPED
+    }
+
     private void addToGraphAndPopulate(Task... tasks) {
         executionPlan.addToTaskGraph(Arrays.asList(tasks))
         executionPlan.determineExecutionPlan()
@@ -735,5 +755,12 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
     static class AsyncWithInputDirectory extends Async {
         @InputDirectory
         File inputDirectory
+    }
+
+    static class BrokenTask extends DefaultTask {
+        @OutputFiles
+        FileCollection getOutputFiles() {
+            throw new Exception("BOOM!")
+        }
     }
 }


### PR DESCRIPTION
Fixes issue #2407 where an exception thrown while walking a task
graph with a finalizer can cause the build to hang.
