### PR TITLE
Enforce exact deprecation warning count in tests

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
@@ -36,7 +36,6 @@ class CachedPathSensitivityIntegrationTest extends AbstractPathSensitivityIntegr
 
     @Override
     void cleanWorkspace() {
-        executer.expectDeprecationWarning()
         run "clean"
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
@@ -47,7 +47,7 @@ class ExecutionTimeTaskConfigurationIntegrationTest extends AbstractIntegrationS
 
         when:
         executer.withArgument("--continue")
-        executer.expectDeprecationWarnings(2)
+        executer.expectDeprecationWarning()
         fails("broken", "broken2", "broken4")
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
@@ -47,8 +47,7 @@ class ExecutionTimeTaskConfigurationIntegrationTest extends AbstractIntegrationS
 
         when:
         executer.withArgument("--continue")
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
+        executer.expectDeprecationWarnings(2)
         fails("broken", "broken2", "broken4")
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AddingConfigurationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AddingConfigurationIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class AddingConfigurationIntegrationTest extends AbstractIntegrationSpec {
     def "can add configurations" () {
-        executer.expectDeprecationWarning()
         buildFile << """
             def file1 = file('file1')
             def file2 = file('file2')
@@ -50,7 +49,6 @@ class AddingConfigurationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "can subtract configurations" () {
-        executer.expectDeprecationWarning()
         buildFile << """
             def file1 = file('file1')
             def file2 = file('file2')

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -44,7 +44,6 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
         when:
         executer.with {
-            expectDeprecationWarning()
             inDirectory(contentsDir)
             usingExecutable('gradlew')
             withTasks('binZip')

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
@@ -186,7 +186,7 @@ sourceSets.main.java {
 
     @Test
     public void canUseANonStandardBuildDir() {
-        executer.withTasks('build').run()
+        executer.expectDeprecationWarning().withTasks('build').run()
 
         file('build').assertDoesNotExist()
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesWebProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesWebProjectIntegrationTest.groovy
@@ -23,15 +23,13 @@ import org.gradle.util.ports.ReleasingPortAllocator
 import org.junit.Rule
 
 class SamplesWebProjectIntegrationTest extends AbstractIntegrationSpec {
-    static final String WEB_PROJECT_NAME = 'customized'
-
     @Rule public final Sample sample = new Sample(temporaryFolder, 'webApplication/customized')
     @Rule ReleasingPortAllocator portAllocator = new ReleasingPortAllocator()
 
     def "can build war"() {
         when:
         sample sample
-        runWithExpectedDeprecationWarning('clean', 'assemble')
+        succeeds('clean', 'assemble')
 
         then:
         TestFile tmpDir = file('unjar')
@@ -50,9 +48,5 @@ class SamplesWebProjectIntegrationTest extends AbstractIntegrationSpec {
                 'WEB-INF/webapp.xml',
                 'WEB-INF/web.xml',
                 'webapp.html')
-    }
-
-    private void runWithExpectedDeprecationWarning(String... tasks) {
-        result = executer.withTasks(tasks).expectDeprecationWarning().run()
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesWebQuickstartIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesWebQuickstartIntegrationTest.groovy
@@ -31,7 +31,7 @@ class SamplesWebQuickstartIntegrationTest extends AbstractIntegrationSpec {
         sample sample
 
         when:
-        executer.withTasks('clean', 'build').expectDeprecationWarning().run()
+        executer.withTasks('clean', 'build').run()
 
         then:
         // Check contents of War

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesRunner.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesRunner.groovy
@@ -257,8 +257,6 @@ class UserGuideSamplesRunner extends Runner {
         samplesByDir.get('userguide/multiproject/dependencies/firstMessages/messages')*.brokenForParallel = true
         samplesByDir.get('userguide/multiproject/dependencies/messagesHack/messages')*.brokenForParallel = true
         samplesByDir.get('userguide/tutorial/helloShortcut')*.allowDeprecation = true
-        samplesByDir.get('webApplication/customized')*.allowDeprecation = true
-        samplesByDir.get('webApplication/quickstart')*.allowDeprecation = true
         samplesByDir.values().findAll() { it.subDir.startsWith('buildCache/') }.each {
             it.args = ['--build-cache', 'help']
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
@@ -90,7 +90,6 @@ abstract class CrossVersionIntegrationSpec extends Specification {
         if (gradleUserHomeDir) {
             executer.withGradleUserHomeDir(gradleUserHomeDir)
         }
-        executer.expectDeprecationWarning()
         executer.inDirectory(testDirectory)
         executers << executer
         return executer

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
@@ -85,7 +85,7 @@ abstract class CrossVersionIntegrationSpec extends Specification {
         return mavenRepo
     }
 
-    GradleExecuter version(GradleDistribution dist) {
+    GradleExecuter version(GradleDistribution dist, boolean withDeprecationWarnings = false) {
         def executer = dist.executer(temporaryFolder, IntegrationTestBuildContext.INSTANCE)
         if (gradleUserHomeDir) {
             executer.withGradleUserHomeDir(gradleUserHomeDir)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ZincScalaCompileFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ZincScalaCompileFixture.groovy
@@ -24,7 +24,7 @@ import org.gradle.test.fixtures.file.TestDirectoryProvider
 
 class ZincScalaCompileFixture extends InitScriptExecuterFixture {
     ZincScalaCompileFixture(GradleExecuter executer, TestDirectoryProvider testDir) {
-        super(executer.expectDeprecationWarning(), testDir)
+        super(executer, testDir)
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.integtests.fixtures.executer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
@@ -174,6 +175,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return logger;
     }
 
+    @Override
     public GradleExecuter reset() {
         args.clear();
         tasks.clear();
@@ -207,30 +209,37 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return this;
     }
 
+    @Override
     public GradleDistribution getDistribution() {
         return distribution;
     }
 
+    @Override
     public TestDirectoryProvider getTestDirectoryProvider() {
         return testDirectoryProvider;
     }
 
+    @Override
     public void beforeExecute(Action<? super GradleExecuter> action) {
         beforeExecute.add(action);
     }
 
+    @Override
     public void beforeExecute(@DelegatesTo(GradleExecuter.class) Closure action) {
         beforeExecute.add(new ClosureBackedAction<GradleExecuter>(action));
     }
 
+    @Override
     public void afterExecute(Action<? super GradleExecuter> action) {
         afterExecute = afterExecute.add(action);
     }
 
+    @Override
     public void afterExecute(@DelegatesTo(GradleExecuter.class) Closure action) {
         afterExecute(new ClosureBackedAction<GradleExecuter>(action));
     }
 
+    @Override
     public GradleExecuter inDirectory(File directory) {
         workingDir = directory;
         return this;
@@ -240,6 +249,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return workingDir == null ? getTestDirectoryProvider().getTestDirectory() : workingDir;
     }
 
+    @Override
     public GradleExecuter copyTo(GradleExecuter executer) {
         executer.withGradleUserHomeDir(gradleUserHomeDir);
         executer.withDaemonIdleTimeoutSecs(daemonIdleTimeoutSecs);
@@ -307,8 +317,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         }
         executer.noExtraLogging();
 
-        for (int i = 0; i < expectedDeprecationWarnings; i++) {
-            executer.expectDeprecationWarning();
+        if (expectedDeprecationWarnings > 0) {
+            executer.expectDeprecationWarnings(expectedDeprecationWarnings);
         }
         if (!eagerClassLoaderCreationChecksOn) {
             executer.withEagerClassLoaderCreationCheckDisabled();
@@ -346,35 +356,42 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return executer;
     }
 
+    @Override
     public GradleExecuter usingBuildScript(File buildScript) {
         this.buildScript = buildScript;
         return this;
     }
 
+    @Override
     public GradleExecuter usingProjectDirectory(File projectDir) {
         this.projectDir = projectDir;
         return this;
     }
 
+    @Override
     public GradleExecuter usingSettingsFile(File settingsFile) {
         this.settingsFile = settingsFile;
         return this;
     }
 
+    @Override
     public GradleExecuter usingInitScript(File initScript) {
         initScripts.add(initScript);
         return this;
     }
 
+    @Override
     public TestFile getGradleUserHomeDir() {
         return gradleUserHomeDir;
     }
 
+    @Override
     public GradleExecuter withGradleUserHomeDir(File userHomeDir) {
         this.gradleUserHomeDir = userHomeDir == null ? null : new TestFile(userHomeDir);
         return this;
     }
 
+    @Override
     public GradleExecuter requireOwnGradleUserHomeDir() {
         return withGradleUserHomeDir(testDirectoryProvider.getTestDirectory().file("user-home"));
     }
@@ -467,6 +484,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return buildJvmOpts;
     }
 
+    @Override
     public GradleExecuter withUserHomeDir(File userHomeDir) {
         this.userHomeDir = userHomeDir;
         return this;
@@ -476,11 +494,13 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return javaHome == null ? Jvm.current().getJavaHome() : javaHome;
     }
 
+    @Override
     public GradleExecuter withJavaHome(File javaHome) {
         this.javaHome = javaHome;
         return this;
     }
 
+    @Override
     public GradleExecuter usingExecutable(String script) {
         this.executable = script;
         return this;
@@ -513,6 +533,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return stdinPipe;
     }
 
+    @Override
     public GradleExecuter withDefaultCharacterEncoding(String defaultCharacterEncoding) {
         this.defaultCharacterEncoding = defaultCharacterEncoding;
         return this;
@@ -522,6 +543,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return defaultCharacterEncoding == null ? Charset.defaultCharset().name() : defaultCharacterEncoding;
     }
 
+    @Override
     public GradleExecuter withDefaultLocale(Locale defaultLocale) {
         this.defaultLocale = defaultLocale;
         return this;
@@ -531,6 +553,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return defaultLocale;
     }
 
+    @Override
     public GradleExecuter withSearchUpwards() {
         searchUpwards = true;
         return this;
@@ -540,36 +563,43 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return quiet;
     }
 
+    @Override
     public GradleExecuter withQuietLogging() {
         quiet = true;
         return this;
     }
 
+    @Override
     public GradleExecuter withTaskList() {
         taskList = true;
         return this;
     }
 
+    @Override
     public GradleExecuter withDependencyList() {
         dependencyList = true;
         return this;
     }
 
+    @Override
     public GradleExecuter withArguments(String... args) {
         return withArguments(Arrays.asList(args));
     }
 
+    @Override
     public GradleExecuter withArguments(List<String> args) {
         this.args.clear();
         this.args.addAll(args);
         return this;
     }
 
+    @Override
     public GradleExecuter withArgument(String arg) {
         this.args.add(arg);
         return this;
     }
 
+    @Override
     public GradleExecuter withEnvironmentVars(Map<String, ?> environment) {
         environmentVars.clear();
         for (Map.Entry<String, ?> entry : environment.entrySet()) {
@@ -597,31 +627,37 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return result.toString();
     }
 
+    @Override
     public GradleExecuter withTasks(String... names) {
         return withTasks(Arrays.asList(names));
     }
 
+    @Override
     public GradleExecuter withTasks(List<String> names) {
         tasks.clear();
         tasks.addAll(names);
         return this;
     }
 
+    @Override
     public GradleExecuter withDaemonIdleTimeoutSecs(int secs) {
         daemonIdleTimeoutSecs = secs;
         return this;
     }
 
+    @Override
     public GradleExecuter useOnlyRequestedJvmOpts() {
         useOnlyRequestedJvmOpts = true;
         return this;
     }
 
+    @Override
     public GradleExecuter withDaemonBaseDir(File daemonBaseDir) {
         this.daemonBaseDir = daemonBaseDir;
         return this;
     }
 
+    @Override
     public GradleExecuter requireIsolatedDaemons() {
         return withDaemonBaseDir(testDirectoryProvider.getTestDirectory().file("daemon"));
     }
@@ -631,10 +667,12 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return withArgument("-Dorg.gradle.workers.internal.disable-daemons-expiration=true");
     }
 
+    @Override
     public boolean usesSharedDaemons() {
         return isSharedDaemons();
     }
 
+    @Override
     public File getDaemonBaseDir() {
         return daemonBaseDir;
     }
@@ -649,6 +687,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return daemonBaseDir.equals(buildContext.getDaemonBaseDir());
     }
 
+    @Override
     public boolean isUseDaemon() {
         CliDaemonArgument cliDaemonArgument = resolveCliDaemonArgument();
         if (cliDaemonArgument == DAEMON) {
@@ -848,6 +887,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return true;
     }
 
+    @Override
     public final GradleHandle start() {
         assert afterExecute.isEmpty() : "afterExecute actions are not implemented for async execution";
         return startHandle();
@@ -866,6 +906,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         }
     }
 
+    @Override
     public final ExecutionResult run() {
         fireBeforeExecute();
         assertCanExecute();
@@ -885,6 +926,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         }
     }
 
+    @Override
     public final ExecutionFailure runWithFailure() {
         fireBeforeExecute();
         assertCanExecute();
@@ -967,6 +1009,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
                 }
 
                 validate(error, "Standard error");
+
+                if (expectedDeprecationWarnings > 0) {
+                    throw new AssertionError(String.format("Expected %d more deprecation warnings", expectedDeprecationWarnings));
+                }
             }
 
             private boolean isExecutionFailure(ExecutionResult executionResult) {
@@ -1016,20 +1062,32 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         };
     }
 
+    @Override
     public GradleExecuter expectDeprecationWarning() {
-        expectedDeprecationWarnings++;
+        return expectDeprecationWarnings(1);
+    }
+
+    @Override
+    public GradleExecuter expectDeprecationWarnings(int count) {
+        Preconditions.checkState(expectedDeprecationWarnings == 0, "expected deprecation count is already set for this execution");
+        Preconditions.checkArgument(count > 0, "expected deprecation count must be positive");
+        expectedDeprecationWarnings = count;
         return this;
     }
+
+    @Override
     public GradleExecuter noDeprecationChecks() {
         checkDeprecations = false;
         return this;
     }
 
+    @Override
     public GradleExecuter withEagerClassLoaderCreationCheckDisabled() {
         eagerClassLoaderCreationChecksOn = false;
         return this;
     }
 
+    @Override
     public GradleExecuter withStackTraceChecksDisabled() {
         stackTraceChecksOn = false;
         return this;
@@ -1039,6 +1097,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return buildContext.getTmpDir().createDir();
     }
 
+    @Override
     public GradleExecuter noExtraLogging() {
         this.allowExtraLogging = false;
         return this;
@@ -1052,6 +1111,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return requiresGradleDistribution;
     }
 
+    @Override
     public GradleExecuter requireGradleDistribution() {
         this.requiresGradleDistribution = true;
         return this;
@@ -1074,6 +1134,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return debugLauncher;
     }
 
+    @Override
     public GradleExecuter withProfiler(String args) {
         profiler = args;
         return this;
@@ -1097,6 +1158,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return this;
     }
 
+    @Override
     public GradleExecuter withFullDeprecationStackTraceDisabled() {
         fullDeprecationStackTrace = false;
         return this;
@@ -1107,6 +1169,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return debug;
     }
 
+    @Override
     public boolean isProfile() {
         return !profiler.isEmpty();
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -279,9 +279,18 @@ public interface GradleExecuter extends Stoppable {
     TestDirectoryProvider getTestDirectoryProvider();
 
     /**
-     * Expects exactly one deprecation warning in the build output. Call multiple times to expect multiple warnings.
+     * Expects exactly one deprecation warning in the build output. If more than one warning is produced,
+     * or no warning is produced at all, the assertion fails.
+     *
+     * @see #expectDeprecationWarnings(int)
      */
     GradleExecuter expectDeprecationWarning();
+
+    /**
+     * Expects exactly the given number of deprecation warnings. If fewer or more warnings are produced during
+     * the execution, the assertion fails.
+     */
+    GradleExecuter expectDeprecationWarnings(int count);
 
     /**
      * Disable deprecation warning checks.

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCrossVersionIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCrossVersionIntegrationTest.groovy
@@ -112,6 +112,6 @@ task retrieve(type: Sync) {
 }
 """
 
-        version previous requireOwnGradleUserHomeDir() expectDeprecationWarning() withTasks 'retrieve' run()
+        version previous requireOwnGradleUserHomeDir() withTasks 'retrieve' run()
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -534,7 +534,6 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.withFullDeprecationStackTraceDisabled()
-        executer.expectDeprecationWarning()
         run 'compileJava'
 
         then:
@@ -560,7 +559,6 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.withFullDeprecationStackTraceDisabled()
-        executer.expectDeprecationWarning()
         run 'compileJava'
 
         then:
@@ -592,7 +590,6 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.withFullDeprecationStackTraceDisabled()
-        executer.expectDeprecationWarning()
         run 'compileJava'
 
         then:
@@ -615,7 +612,6 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.withFullDeprecationStackTraceDisabled()
-        executer.expectDeprecationWarning()
         run 'compileJava'
 
         then:

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/EnablingParallelExecutionIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/EnablingParallelExecutionIntegrationTest.groovy
@@ -23,10 +23,6 @@ import spock.lang.IgnoreIf
 @IgnoreIf({ GradleContextualExecuter.parallel })
 class EnablingParallelExecutionIntegrationTest extends AbstractIntegrationSpec {
 
-    def setup() {
-        executer.expectDeprecationWarning()
-    }
-
     def "parallel mode enabled via gradle.properties"() {
         file("gradle.properties") << "org.gradle.parallel=true"
         buildFile << "assert gradle.startParameter.parallelProjectExecutionEnabled"

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -78,10 +78,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.withFullDeprecationStackTraceDisabled()
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
+        executer.expectDeprecationWarnings(4)
         run('deprecated', 'broken')
 
         then:
@@ -116,10 +113,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
 
         when:
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
+        executer.expectDeprecationWarnings(4)
         run('deprecated', 'broken')
 
         then:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCrossVersionIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCrossVersionIntegrationTest.groovy
@@ -101,6 +101,6 @@ task retrieve(type: Sync) {
 }
 """
 
-        version previous requireOwnGradleUserHomeDir() expectDeprecationWarning() withTasks 'retrieve' run()
+        version previous requireOwnGradleUserHomeDir() withTasks 'retrieve' run()
     }
 }

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/resolve/service/PluginResolutionDeprecatedClientIntegrationTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/resolve/service/PluginResolutionDeprecatedClientIntegrationTest.groovy
@@ -51,7 +51,6 @@ class PluginResolutionDeprecatedClientIntegrationTest extends AbstractIntegratio
     def setup() {
         executer.requireOwnGradleUserHomeDir()
         executer.beforeExecute {
-            it.expectDeprecationWarning()
             moduleResolution()
         }
 
@@ -125,7 +124,7 @@ class PluginResolutionDeprecatedClientIntegrationTest extends AbstractIntegratio
         deprecateClient(null)
         usePlugin2() // use a different plugin, because the response for the previous will be cached
         pluginQuery2()
-        build()
+        build(false)
         containsNoDeprecationMessage()
     }
 
@@ -204,11 +203,11 @@ class PluginResolutionDeprecatedClientIntegrationTest extends AbstractIntegratio
         usePlugin1()
         pluginQuery1()
         service.expectStatusQuery404()
-        build()
+        build(false)
         output.contains("Received error response fetching client status from")
 
         service.expectStatusQuery404()
-        build()
+        build(false)
         output.contains("Received error response fetching client status from")
     }
 
@@ -218,10 +217,10 @@ class PluginResolutionDeprecatedClientIntegrationTest extends AbstractIntegratio
         usePlugin1()
         pluginQuery1()
         service.expectStatusQueryOutOfProtocol()
-        build()
+        build(false)
 
         service.expectStatusQueryOutOfProtocol()
-        build()
+        build(false)
 
         // Test that if the issue gets resolved, everything works as it should
         service.expectStatusQuery()
@@ -259,7 +258,10 @@ class PluginResolutionDeprecatedClientIntegrationTest extends AbstractIntegratio
         service.http.resetExpectations()
     }
 
-    void build() {
+    void build(boolean withDeprecationWarning = true) {
+        if (withDeprecationWarning) {
+            executer.expectDeprecationWarning()
+        }
         run "tasks"
     }
 
@@ -275,16 +277,25 @@ class PluginResolutionDeprecatedClientIntegrationTest extends AbstractIntegratio
         (failure == null ? result : failure).output
     }
 
-    void failPluginNotFound() {
+    void failPluginNotFound(boolean withDeprecationWarning = true) {
+        if (withDeprecationWarning) {
+            executer.expectDeprecationWarning()
+        }
         fails "tasks"
         failure.assertThatDescription(containsText("Plugin [id: '${PLUGIN_ID_1}', version: '1.0'] was not found"))
     }
 
-    void fail() {
+    void fail(boolean withDeprecationWarning = true) {
+        if (withDeprecationWarning) {
+            executer.expectDeprecationWarning()
+        }
         fails "tasks"
     }
 
-    void failError() {
+    void failError(boolean withDeprecationWarning = true) {
+        if (withDeprecationWarning) {
+            executer.expectDeprecationWarning()
+        }
         fails "tasks"
         failure.assertThatDescription(containsText("Error resolving plugin"))
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -61,6 +61,7 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec {
         then:
         file("build/classes/java/main").assertDoesNotExist()
         file("build/classes/main/Main.class").assertExists()
+        result.assertOutputContains("Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set.")
     }
 
     def "emits deprecation message if something uses classesDir"() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerForExecutableIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerForExecutableIntegrationTest.groovy
@@ -25,12 +25,6 @@ import org.gradle.util.TextUtil
 @IgnoreIf({ !Jvm.current().getExecutable("javac").exists() })
 class CommandLineJavaCompilerForExecutableIntegrationTest extends JavaCompilerIntegrationSpec {
 
-    def setup() {
-        executer.beforeExecute {
-            expectDeprecationWarning()
-        }
-    }
-
     def compilerConfiguration() {
         def executable = TextUtil.escapeString(Jvm.current().getExecutable("javac"))
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 public class DefaultSourceSetOutput extends CompositeFileCollection implements SourceSetOutput {
+    public static final String SINGLE_CLASSES_DIR_DEPRECATION_MESSAGE = "Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set";
     private final DefaultConfigurableFileCollection outputDirectories;
     private Object resourcesDir;
     private Object classesDir;
@@ -76,7 +77,7 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
         if (isLegacyLayout()) {
             return fileResolver.resolve(classesDir);
         }
-        SingleMessageLogger.nagUserOfDeprecatedBehaviour("Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set");
+        SingleMessageLogger.nagUserOfDeprecatedBehaviour(SINGLE_CLASSES_DIR_DEPRECATION_MESSAGE);
         Object firstClassesDir = CollectionUtils.findFirst(classesDirs.getFrom(), Specs.SATISFIES_ALL);
         if (firstClassesDir!=null) {
             return fileResolver.resolve(firstClassesDir);
@@ -91,6 +92,7 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
 
     @Override
     public void setClassesDir(Object classesDir) {
+        SingleMessageLogger.nagUserOfDeprecatedBehaviour(SINGLE_CLASSES_DIR_DEPRECATION_MESSAGE);
         this.classesDir = classesDir;
         this.classesDirs.setFrom(classesDir);
     }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/samples/SamplesScalaZincIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/samples/SamplesScalaZincIntegrationTest.groovy
@@ -31,7 +31,7 @@ class SamplesScalaZincIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         // Build and test projects
-        executer.expectDeprecationWarning().inDirectory(projectDir).withTasks('clean', 'build').run()
+        executer.inDirectory(projectDir).withTasks('clean', 'build').run()
 
         then:
         // Check contents of Jar

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/BasicScalaCompilerIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/BasicScalaCompilerIntegrationTest.groovy
@@ -25,9 +25,6 @@ abstract class BasicScalaCompilerIntegrationTest extends MultiVersionIntegration
     def setup() {
         args("-i", "-PscalaVersion=$version")
         buildFile << buildScript()
-
-        // We've deprecated some getters that are used by all scala compiler calls.
-        executer.expectDeprecationWarning()
     }
 
     def compileGoodCode() {
@@ -150,8 +147,6 @@ compileScala.scalaCompileOptions.encoding = "ISO8859_7"
 """
 compileScala.scalaCompileOptions.debugLevel = "line"
 """
-        // This resets every time run is called.
-        executer.expectDeprecationWarning()
         run("compileScala")
 
         then:
@@ -168,8 +163,6 @@ compileScala.scalaCompileOptions.debugLevel = "line"
 """
 compileScala.scalaCompileOptions.debugLevel = "none"
 """
-        // This resets every time run is called.
-        executer.expectDeprecationWarning()
         run("compileScala")
 
         then:

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest.groovy
@@ -36,12 +36,7 @@ class IncrementalScalaCompileIntegrationTest extends AbstractIntegrationSpec {
             compileScala.options.debug = false
 '''
         then:
-        // This gets reset each time you run() is run.
-        executer.expectDeprecationWarning();
         run('compileScala').assertTasksSkipped(':compileJava')
-
-        // This gets reset each time you run() is run.
-        executer.expectDeprecationWarning();
         run('compileScala').assertTasksSkipped(':compileJava', ':compileScala')
     }
 
@@ -53,8 +48,6 @@ class IncrementalScalaCompileIntegrationTest extends AbstractIntegrationSpec {
         file('src/main/scala/IPerson.scala').assertIsFile().copyFrom(file('NewIPerson.scala'))
 
         then:
-        // This gets reset each time you run() is run.
-        executer.expectDeprecationWarning();
         runAndFail("classes").assertHasDescription("Execution failed for task ':compileScala'.")
     }
 
@@ -85,8 +78,6 @@ class IncrementalScalaCompileIntegrationTest extends AbstractIntegrationSpec {
         file("src/main/java/Person.java").text = "public interface Person { String fooBar(); }"
 
         then:
-        // This gets reset each time you run() is run.
-        executer.expectDeprecationWarning();
         //the build should fail because the interface the scala class needs has changed
         runAndFail("classes").assertHasDescription("Execution failed for task ':compileScala'.")
     }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
@@ -39,7 +39,6 @@ class ZincScalaCompilerIntegrationTest extends BasicScalaCompilerIntegrationTest
         file("src/main/scala/Person.scala").delete()
         file("src/main/scala/Person.scala") << "class Person"
         args("-i", "-PscalaVersion=$version") // each run clears args (argh!)
-        executer.expectDeprecationWarning() // each run clears args (argh!)
         run("compileScala")
 
         then:
@@ -62,7 +61,6 @@ class ZincScalaCompilerIntegrationTest extends BasicScalaCompilerIntegrationTest
         file("src/main/scala/Person.java").delete()
         file("src/main/scala/Person.java") << "public class Person {}"
         args("-i", "-PscalaVersion=$version") // each run clears args (argh!)
-        executer.expectDeprecationWarning() // each run clears args (argh!)
         run("compileScala")
 
         then:
@@ -82,7 +80,6 @@ class ZincScalaCompilerIntegrationTest extends BasicScalaCompilerIntegrationTest
         file("prj1/src/main/scala/Person.scala").delete()
         file("prj1/src/main/scala/Person.scala") << "class Person"
         args("-i", "-PscalaVersion=$version") // each run clears args (argh!)
-        executer.expectDeprecationWarning() // each run clears args (argh!)
         run("compileScala")
 
         then:
@@ -102,7 +99,6 @@ class ZincScalaCompilerIntegrationTest extends BasicScalaCompilerIntegrationTest
         file("src/main/scala/Person.scala").delete()
         file("src/main/scala/Person.scala") << "class Person"
         args("-i", "-PscalaVersion=$version") // each run clears args (argh!)
-        executer.expectDeprecationWarning() // each run clears args (argh!)
         run("compileScala")
 
         then:

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerMultiVersionIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerMultiVersionIntegrationTest.groovy
@@ -36,7 +36,6 @@ class ZincScalaCompilerMultiVersionIntegrationTest extends MultiVersionIntegrati
             }
         """
         args("--info")
-        executer.expectDeprecationWarning()
     }
 
     def "can build with configured zinc compiler version" () {

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/environment/JreJavaHomeScalaIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/environment/JreJavaHomeScalaIntegrationTest.groovy
@@ -53,7 +53,6 @@ class JreJavaHomeScalaIntegrationTest extends AbstractIntegrationSpec {
                     }
                     """
         when:
-        executer.expectDeprecationWarnings(2)
         executer.withEnvironmentVars("JAVA_HOME": jreJavaHome.absolutePath).withTasks("compileScala").run()
 
         then:

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/environment/JreJavaHomeScalaIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/environment/JreJavaHomeScalaIntegrationTest.groovy
@@ -53,8 +53,7 @@ class JreJavaHomeScalaIntegrationTest extends AbstractIntegrationSpec {
                     }
                     """
         when:
-        executer.expectDeprecationWarning()
-        executer.expectDeprecationWarning()
+        executer.expectDeprecationWarnings(2)
         executer.withEnvironmentVars("JAVA_HOME": jreJavaHome.absolutePath).withTasks("compileScala").run()
 
         then:

--- a/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/AndroidDexingSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/AndroidDexingSoakTest.groovy
@@ -82,7 +82,7 @@ class AndroidDexingSoakTest extends DaemonIntegrationSpec {
             file("inputs").deleteDir()
 
             executer.withStackTraceChecksDisabled()
-            3.times { executer.expectDeprecationWarning() }
+            executer.expectDeprecationWarnings(3)
             executer.withBuildJvmOpts("-Xmx2560m", "-D${HeapProportionalCacheSizer.CACHE_RESERVED_SYSTEM_PROPERTY}=1536")
             args('-x', 'lint')
             succeeds('clean', 'transformClassesWithDexForRelease')

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -258,7 +258,6 @@ allprojects {
 
         when:
         GradleHandle handle = executer.inDirectory(projectDir)
-            .expectDeprecationWarning() // tapi on java 6
             .withTasks('run')
             .start()
 


### PR DESCRIPTION
There are many calls to `GradleExecuter.expectDeprecationWarning()` around in integration tests that don't actually produce any deprecation warnings anymore. This PR is to tighten the checks on deprecations, to check for the exact number of deprecations specified to be produced.