### PR TITLE
Remove deprecated constants

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
@@ -18,7 +18,6 @@ package org.gradle.api.attributes;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
-import org.gradle.api.internal.model.NamedObjectInstantiator;
 
 /**
  * Represents the usage of a configuration. Typical usages include compilation or runtime.
@@ -29,9 +28,6 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 @Incubating
 public interface Usage extends Named {
     Attribute<Usage> USAGE_ATTRIBUTE = Attribute.of(Usage.class);
-
-    Usage FOR_COMPILE = NamedObjectInstantiator.INSTANCE.named(Usage.class, "for compile");
-    Usage FOR_RUNTIME = NamedObjectInstantiator.INSTANCE.named(Usage.class, "for runtime");
 
     /**
      * The Java API of a library, packaged as class path elements, either a JAR or a classes directory.

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -94,6 +94,22 @@
             "changes": [
                 "Method return type has changed"
             ]
+        },
+        {
+            "type": "org.gradle.api.attributes.Usage",
+            "member": "Field FOR_RUNTIME",
+            "acceptation": "Part of API cleanup, validated with Google team",
+            "changes": [
+                "Field has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.attributes.Usage",
+            "member": "Field FOR_COMPILE",
+            "acceptation": "Part of API cleanup, validated with Google team",
+            "changes": [
+                "Field has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
@@ -34,7 +35,6 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.UnionFileCollection;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.publish.internal.ProjectDependencyPublicationResolver;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.publish.ivy.IvyConfigurationContainer;
@@ -57,10 +57,10 @@ import java.util.Set;
 public class DefaultIvyPublication implements IvyPublicationInternal {
 
     private static final Comparator<? super UsageContext> COMPILE_BEFORE_RUNTIME = new Comparator<UsageContext>() {
-        private final Comparator<? super Usage> compileBeforeRuntime = Ordering.explicit(Usage.FOR_COMPILE, Usage.FOR_RUNTIME);
+        private final Comparator<String> compileBeforeRuntime = Ordering.explicit(Usage.JAVA_API, Usage.JAVA_RUNTIME);
         @Override
         public int compare(UsageContext left, UsageContext right) {
-            return compileBeforeRuntime.compare(left.getUsage(), right.getUsage());
+            return compileBeforeRuntime.compare(left.getUsage().getName(), right.getUsage().getName());
         }
     };
 
@@ -147,10 +147,10 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     private String mapUsage(Usage usage) {
-        if (Usage.FOR_COMPILE.equals(usage)) {
+        if (Usage.JAVA_API.equals(usage.getName())) {
             return "compile";
         }
-        if (Usage.FOR_RUNTIME.equals(usage)) {
+        if (Usage.JAVA_RUNTIME.equals(usage.getName())) {
             return "runtime";
         }
         return usage.getName();

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.ClassGeneratorBackedInstantiator
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
@@ -29,7 +30,6 @@ import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.SimpleFileCollection
-import org.gradle.api.attributes.Usage
 import org.gradle.api.publish.internal.ProjectDependencyPublicationResolver
 import org.gradle.api.publish.internal.PublicationInternal
 import org.gradle.api.publish.ivy.IvyArtifact
@@ -287,7 +287,9 @@ class DefaultIvyPublicationTest extends Specification {
 
     def createComponent(def artifacts, def dependencies) {
         def usage = Stub(UsageContext) {
-            getUsage() >> Usage.FOR_RUNTIME
+            getUsage() >> Mock(Usage) {
+                getName() >> Usage.JAVA_RUNTIME
+            }
             getArtifacts() >> artifacts
             getDependencies() >> dependencies
         }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -68,12 +68,13 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
      */
     private static final Set<ExcludeRule> EXCLUDE_ALL_RULE = Collections.<ExcludeRule>singleton(new DefaultExcludeRule("*", "*"));
     private static final Comparator<? super UsageContext> COMPILE_BEFORE_RUNTIME = new Comparator<UsageContext>() {
-        private final Comparator<? super Usage> compileBeforeRuntime = Ordering.explicit(Usage.FOR_COMPILE, Usage.FOR_RUNTIME);
+        private final Comparator<String> compileBeforeRuntime = Ordering.explicit(Usage.JAVA_API, Usage.JAVA_RUNTIME);
         @Override
         public int compare(UsageContext left, UsageContext right) {
-            return compileBeforeRuntime.compare(left.getUsage(), right.getUsage());
+            return compileBeforeRuntime.compare(left.getUsage().getName(), right.getUsage().getName());
         }
     };
+
     private final String name;
     private final MavenPomInternal pom;
     private final MavenProjectIdentity projectIdentity;
@@ -148,7 +149,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     private Set<MavenDependencyInternal> dependenciesFor(Usage usage) {
-        if (Usage.FOR_COMPILE.equals(usage)) {
+        if (Usage.JAVA_API.equals(usage.getName())) {
             return apiDependencies;
         }
         return runtimeDependencies;

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -189,7 +189,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                configurations.consume.attributes.attribute(artifactType, JavaPlugin.JAR_TYPE)
+                configurations.consume.attributes.attribute(artifactType, ArtifactTypeDefinition.JAR_TYPE)
             }
 """
         when:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -139,7 +139,6 @@ project(':consumer') {
 
         where:
         usage                                          | _
-        "Usage.FOR_COMPILE"                            | _
         "objects.named(Usage, Usage.JAVA_API)"         | _
         "objects.named(Usage, Usage.JAVA_API_CLASSES)" | _
     }
@@ -182,7 +181,6 @@ project(':consumer') {
 
         where:
         usage                                           | _
-        "Usage.FOR_RUNTIME"                             | _
         "objects.named(Usage, Usage.JAVA_RUNTIME)"      | _
         "objects.named(Usage, Usage.JAVA_RUNTIME_JARS)" | _
     }
@@ -190,7 +188,7 @@ project(':consumer') {
     def "provides runtime JAR variant using artifactType attribute"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, Usage.FOR_RUNTIME)
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
                 configurations.consume.attributes.attribute(artifactType, JavaPlugin.JAR_TYPE)
             }
 """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -190,7 +190,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                configurations.consume.attributes.attribute(artifactType, JavaPlugin.JAR_TYPE)
+                configurations.consume.attributes.attribute(artifactType, ArtifactTypeDefinition.JAR_TYPE)
             }
 """
         when:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -140,7 +140,6 @@ project(':consumer') {
 
         where:
         usage                                          | _
-        "Usage.FOR_COMPILE"                            | _
         "objects.named(Usage, Usage.JAVA_API)"         | _
         "objects.named(Usage, Usage.JAVA_API_CLASSES)" | _
     }
@@ -183,7 +182,6 @@ project(':consumer') {
 
         where:
         usage                                           | _
-        "Usage.FOR_RUNTIME"                             | _
         "objects.named(Usage, Usage.JAVA_RUNTIME)"      | _
         "objects.named(Usage, Usage.JAVA_RUNTIME_JARS)" | _
     }
@@ -191,7 +189,7 @@ project(':consumer') {
     def "provides runtime JAR variant using artifactType"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, Usage.FOR_RUNTIME)
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
                 configurations.consume.attributes.attribute(artifactType, JavaPlugin.JAR_TYPE)
             }
 """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -138,7 +138,6 @@ project(':consumer') {
 
         where:
         usage                                          | _
-        "Usage.FOR_COMPILE"                            | _
         "objects.named(Usage, Usage.JAVA_API)"         | _
         "objects.named(Usage, Usage.JAVA_API_CLASSES)" | _
     }
@@ -181,7 +180,6 @@ project(':consumer') {
 
         where:
         usage                                           | _
-        "Usage.FOR_RUNTIME"                             | _
         "objects.named(Usage, Usage.JAVA_RUNTIME)"      | _
         "objects.named(Usage, Usage.JAVA_RUNTIME_JARS)" | _
     }
@@ -189,7 +187,7 @@ project(':consumer') {
     def "provides runtime JAR variant using artifactType"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, Usage.FOR_RUNTIME)
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
                 configurations.consume.attributes.attribute(artifactType, JavaPlugin.JAR_TYPE)
             }
 """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -188,7 +188,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                configurations.consume.attributes.attribute(artifactType, JavaPlugin.JAR_TYPE)
+                configurations.consume.attributes.attribute(artifactType, ArtifactTypeDefinition.JAR_TYPE)
             }
 """
         when:

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
+import org.gradle.api.internal.model.DefaultObjectFactory;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -36,6 +37,9 @@ import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_N
  * A SoftwareComponent representing a library that runs on a java virtual machine.
  */
 public class JavaLibrary implements SoftwareComponentInternal {
+    private final static Usage API = DefaultObjectFactory.INSTANCE.named(Usage.class, Usage.JAVA_API);
+    private final static Usage RUNTIME = DefaultObjectFactory.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME);
+
     private final LinkedHashSet<PublishArtifact> artifacts = new LinkedHashSet<PublishArtifact>();
     private final UsageContext runtimeUsage;
     private final UsageContext compileUsage;
@@ -55,8 +59,8 @@ public class JavaLibrary implements SoftwareComponentInternal {
     @Deprecated
     public JavaLibrary(PublishArtifact jarArtifact, DependencySet runtimeDependencies) {
         this.artifacts.add(jarArtifact);
-        this.runtimeUsage = new BackwardsCompatibilityUsageContext(Usage.FOR_RUNTIME, runtimeDependencies);
-        this.compileUsage = new BackwardsCompatibilityUsageContext(Usage.FOR_COMPILE, runtimeDependencies);
+        this.runtimeUsage = new BackwardsCompatibilityUsageContext(RUNTIME, runtimeDependencies);
+        this.compileUsage = new BackwardsCompatibilityUsageContext(API, runtimeDependencies);
         this.configurations = null;
     }
 
@@ -74,7 +78,7 @@ public class JavaLibrary implements SoftwareComponentInternal {
 
         @Override
         public Usage getUsage() {
-            return Usage.FOR_RUNTIME;
+            return RUNTIME;
         }
 
         public Set<PublishArtifact> getArtifacts() {
@@ -95,7 +99,7 @@ public class JavaLibrary implements SoftwareComponentInternal {
 
         @Override
         public Usage getUsage() {
-            return Usage.FOR_COMPILE;
+            return API;
         }
 
         public Set<PublishArtifact> getArtifacts() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
@@ -25,7 +25,9 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.model.DefaultObjectFactory;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.internal.reflect.DirectInstantiator;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -38,6 +40,9 @@ import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_N
  * A SoftwareComponent representing a library that runs on a java virtual machine.
  */
 public class JavaLibrary implements SoftwareComponentInternal {
+
+    // This must ONLY be used in the deprecated constructor, for backwards compatibility
+    private final static ObjectFactory DEPRECATED_OBJECT_FACTORY = new DefaultObjectFactory(DirectInstantiator.INSTANCE, NamedObjectInstantiator.INSTANCE);
 
     private final LinkedHashSet<PublishArtifact> artifacts = new LinkedHashSet<PublishArtifact>();
     private final UsageContext runtimeUsage;
@@ -58,8 +63,8 @@ public class JavaLibrary implements SoftwareComponentInternal {
     @Deprecated
     public JavaLibrary(PublishArtifact jarArtifact, DependencySet runtimeDependencies) {
         this.artifacts.add(jarArtifact);
-        this.runtimeUsage = new BackwardsCompatibilityUsageContext(DefaultObjectFactory.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME), runtimeDependencies);
-        this.compileUsage = new BackwardsCompatibilityUsageContext(DefaultObjectFactory.INSTANCE.named(Usage.class, Usage.JAVA_API), runtimeDependencies);
+        this.runtimeUsage = new BackwardsCompatibilityUsageContext(DEPRECATED_OBJECT_FACTORY.named(Usage.class, Usage.JAVA_RUNTIME), runtimeDependencies);
+        this.compileUsage = new BackwardsCompatibilityUsageContext(DEPRECATED_OBJECT_FACTORY.named(Usage.class, Usage.JAVA_API), runtimeDependencies);
         this.configurations = null;
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -520,7 +520,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                 }
             } else if (details.getConsumerValue() != null) {
                 Usage requested = details.getConsumerValue();
-                if ((requested.getName().equals(Usage.JAVA_API) || requested.getName().equals(Usage.JAVA_API_CLASSES) || requested.equals(Usage.FOR_COMPILE)) && details.getCandidateValues().equals(ImmutableSet.of(javaApi, javaRuntimeJars))) {
+                if ((requested.getName().equals(Usage.JAVA_API) || requested.getName().equals(Usage.JAVA_API_CLASSES)) && details.getCandidateValues().equals(ImmutableSet.of(javaApi, javaRuntimeJars))) {
                     // Prefer the API over the runtime when the API has been requested
                     details.closestMatch(javaApi);
                 }
@@ -531,16 +531,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     static class UsageCompatibilityRules implements AttributeCompatibilityRule<Usage> {
         @Override
         public void execute(CompatibilityCheckDetails<Usage> details) {
-            if (details.getConsumerValue().equals(Usage.FOR_COMPILE)) {
-                if (details.getProducerValue().getName().equals(Usage.JAVA_API)) {
-                    details.compatible();
-                } else if (details.getProducerValue().getName().equals(Usage.JAVA_API_CLASSES)) {
-                    details.compatible();
-                } else if (details.getProducerValue().getName().equals(Usage.JAVA_RUNTIME_JARS)) {
-                    // Can use the runtime Jars if present, but prefer Java API
-                    details.compatible();
-                }
-            } else if (details.getConsumerValue().getName().equals(Usage.JAVA_API)) {
+            if (details.getConsumerValue().getName().equals(Usage.JAVA_API)) {
                 if (details.getProducerValue().getName().equals(Usage.JAVA_API_CLASSES)) {
                     details.compatible();
                 } else if (details.getProducerValue().getName().equals(Usage.JAVA_RUNTIME_JARS)) {
@@ -555,8 +546,6 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                     // Can use the Java runtime jars if present, but prefer Java API classes
                     details.compatible();
                 }
-            } else if (details.getConsumerValue().equals(Usage.FOR_RUNTIME) && details.getProducerValue().getName().equals(Usage.JAVA_RUNTIME_JARS)) {
-                details.compatible();
             } else if (details.getConsumerValue().getName().equals(Usage.JAVA_RUNTIME) && details.getProducerValue().getName().equals(Usage.JAVA_RUNTIME_JARS)) {
                 details.compatible();
             } else if (details.getConsumerValue().getName().equals(Usage.JAVA_RUNTIME_CLASSES) && details.getProducerValue().getName().equals(Usage.JAVA_RUNTIME_JARS)) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -227,13 +227,6 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     @Incubating
     public static final String TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME = "testRuntimeClasspath";
 
-    /**
-     * Represents the "jar" format of a variant of a Java component.
-     * @since 3.5
-     */
-    @Incubating
-    public static final String JAR_TYPE = ArtifactTypeDefinition.JAR_TYPE;
-
     private final ObjectFactory objectFactory;
 
     @Inject
@@ -315,7 +308,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
 
         // Configure an implicit variant
         publications.getArtifacts().add(jarArtifact);
-        publications.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, JavaPlugin.JAR_TYPE);
+        publications.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.JAR_TYPE);
     }
 
     private void addRuntimeVariants(Configuration configuration, ArchivePublishArtifact jarArtifact, final JavaCompile javaCompile, final ProcessResources processResources) {
@@ -323,7 +316,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
 
         // Configure an implicit variant
         publications.getArtifacts().add(jarArtifact);
-        publications.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, JavaPlugin.JAR_TYPE);
+        publications.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.JAR_TYPE);
 
         // Define some additional variants
         NamedDomainObjectContainer<ConfigurationVariant> runtimeVariants = publications.getVariants();

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -300,7 +300,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         addJar(runtimeConfiguration, jarArtifact);
         addRuntimeVariants(runtimeElementsConfiguration, jarArtifact, javaCompile, processResources);
 
-        project.getComponents().add(new JavaLibrary(project.getConfigurations(), jarArtifact));
+        project.getComponents().add(new JavaLibrary(objectFactory, project.getConfigurations(), jarArtifact));
     }
 
     private void addJar(Configuration configuration, ArchivePublishArtifact jarArtifact) {


### PR DESCRIPTION
### Context

This PR is part of the variant aware dependency management API cleanup. It removes:

- `Usage.FOR_COMPILE` (superceded by `Usage.JAVA_API`)
- `Usage.FOR_RUNTIME` (superceded by `Usage.JAVA_RUNTIME`)
- `JavaPlugin.JAR_TYPE` (superceded by `ArtifactTypeDefinition.JAR_TYPE`)

This pull request **must not** be merged yet, only reviewed, because `alpha6` of the Android plugin still uses those constants. Once the sources of the Android plugin have no trace of the original constants, we can merge this PR.

Fixed gradle/performance#562
