### PR TITLE
Support detecting Gradle is started on JDK 10

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -24,7 +24,9 @@ import java.util.regex.Pattern;
  * An enumeration of Java versions.
  */
 public enum JavaVersion {
-    VERSION_1_1(false), VERSION_1_2(false), VERSION_1_3(false), VERSION_1_4(false), VERSION_1_5(true), VERSION_1_6(true), VERSION_1_7(true), VERSION_1_8(true), VERSION_1_9(true);
+    VERSION_1_1(false), VERSION_1_2(false), VERSION_1_3(false), VERSION_1_4(false),
+    // starting from here versions are 1_ but their official name is "Java 6", "Java 7", ...
+    VERSION_1_5(true), VERSION_1_6(true), VERSION_1_7(true), VERSION_1_8(true), VERSION_1_9(true), VERSION_1_10(true);
     private static JavaVersion currentJavaVersion;
     private final boolean hasMajorVersion;
     private final String versionName;
@@ -52,7 +54,7 @@ public enum JavaVersion {
         }
 
         String name = value.toString();
-        Matcher matcher = Pattern.compile("(\\d)(-.+)?").matcher(name);
+        Matcher matcher = Pattern.compile("(\\d{1,2})(-.+)?").matcher(name);
         if (matcher.matches()) {
             int index = Integer.parseInt(matcher.group(1)) - 1;
             if (index < values().length && values()[index].hasMajorVersion) {
@@ -60,7 +62,7 @@ public enum JavaVersion {
             }
         }
 
-        matcher = Pattern.compile("1\\.(\\d)(\\D.+)?").matcher(name);
+        matcher = Pattern.compile("1\\.(\\d{1,2})(\\D.+)?").matcher(name);
         if (matcher.matches()) {
             int versionIdx = Integer.parseInt(matcher.group(1)) - 1;
             if (versionIdx >= 0 && versionIdx < values().length) {
@@ -122,6 +124,10 @@ public enum JavaVersion {
         return this == VERSION_1_9;
     }
 
+    private boolean isJava10() {
+        return this == VERSION_1_10;
+    }
+
     public boolean isJava5Compatible() {
         return this.compareTo(VERSION_1_5) >= 0;
     }
@@ -140,6 +146,10 @@ public enum JavaVersion {
 
     public boolean isJava9Compatible() {
         return this.compareTo(VERSION_1_9) >= 0;
+    }
+
+    public boolean isJava10Compatible() {
+        return this.compareTo(VERSION_1_10) >= 0;
     }
 
     @Override

--- a/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
@@ -41,6 +41,7 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.VERSION_1_7.toString() == "1.7"
         JavaVersion.VERSION_1_8.toString() == "1.8"
         JavaVersion.VERSION_1_9.toString() == "1.9"
+        JavaVersion.VERSION_1_10.toString() == "1.10"
     }
 
     def convertsStringToVersion() {
@@ -57,10 +58,13 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.toVersion("7") == JavaVersion.VERSION_1_7
         JavaVersion.toVersion("8") == JavaVersion.VERSION_1_8
         JavaVersion.toVersion("9") == JavaVersion.VERSION_1_9
+        JavaVersion.toVersion("10") == JavaVersion.VERSION_1_10
 
         JavaVersion.toVersion("1.9.0-internal") == JavaVersion.VERSION_1_9
         JavaVersion.toVersion("1.9.0-ea") == JavaVersion.VERSION_1_9
         JavaVersion.toVersion("9-ea") == JavaVersion.VERSION_1_9
+
+        JavaVersion.toVersion("10-ea") == JavaVersion.VERSION_1_10
     }
 
     def convertClassVersionToJavaVersion() {
@@ -74,6 +78,7 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.forClassVersion(51) == JavaVersion.VERSION_1_7
         JavaVersion.forClassVersion(52) == JavaVersion.VERSION_1_8
         JavaVersion.forClassVersion(53) == JavaVersion.VERSION_1_9
+        JavaVersion.forClassVersion(54) == JavaVersion.VERSION_1_10
     }
 
     def failsToConvertStringToVersionForUnknownVersion() {
@@ -81,7 +86,6 @@ public class JavaVersionSpec extends Specification {
         conversionFails("1");
         conversionFails("2");
 
-        conversionFails("10");
         conversionFails("17");
 
         conversionFails("a");
@@ -91,7 +95,6 @@ public class JavaVersionSpec extends Specification {
 
         conversionFails("0.1");
         conversionFails("1.54");
-        conversionFails("1.10");
         conversionFails("2.0");
         conversionFails("1_4");
         conversionFails("8.1");
@@ -100,7 +103,7 @@ public class JavaVersionSpec extends Specification {
         conversionFails("10.1.2");
 
         conversionFails("9-");
-        conversionFails("10-ea");
+        conversionFails("11-ea");
     }
 
     def convertsVersionToVersion() {
@@ -118,6 +121,8 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.toVersion(1.7) == JavaVersion.VERSION_1_7
         JavaVersion.toVersion(1.8) == JavaVersion.VERSION_1_8
         JavaVersion.toVersion(1.9) == JavaVersion.VERSION_1_9
+        JavaVersion.toVersion(9) == JavaVersion.VERSION_1_9
+        JavaVersion.toVersion(10) == JavaVersion.VERSION_1_10
     }
 
     def failsToConvertNumberToVersionForUnknownVersion() {
@@ -232,5 +237,28 @@ public class JavaVersionSpec extends Specification {
 
         where:
         javaVersion << ['1.9', '9-ea']
+    }
+
+    def "uses system property to determine if compatible with Java 10"() {
+        System.properties['java.version'] = javaVersion
+
+        expect:
+        !JavaVersion.current().java5
+        !JavaVersion.current().java6
+        !JavaVersion.current().java7
+        !JavaVersion.current().java8
+        !JavaVersion.current().java9
+        JavaVersion.current().java10
+
+        and:
+        JavaVersion.current().java5Compatible
+        JavaVersion.current().java6Compatible
+        JavaVersion.current().java7Compatible
+        JavaVersion.current().java8Compatible
+        JavaVersion.current().java9Compatible
+        JavaVersion.current().java10Compatible
+
+        where:
+        javaVersion << ['1.10', '10-ea']
     }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
@@ -65,6 +65,7 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.toVersion("9-ea") == JavaVersion.VERSION_1_9
 
         JavaVersion.toVersion("10-ea") == JavaVersion.VERSION_1_10
+        JavaVersion.toVersion("10-internal") == JavaVersion.VERSION_1_10
     }
 
     def convertClassVersionToJavaVersion() {


### PR DESCRIPTION
This is a _hotfix_ to unblock the JDK team: they are using Gradle to build JavaFX, but Gradle fails to recognize 10 as a valid Java version. This pull request does **not** intend to rewrite how `JavaVersion` works (it's an enum, so we're doomed to catch up and have not super nice constant value names), but just adds support for recognizing the JDK.

It won't guarantee that Gradle runs on JDK 10 either. It will only prevent it from blowing up at startup. See the commit message for more details.