### PR TITLE
Only accept binary breaking changes to Incubating methods

### DIFF
--- a/buildSrc/src/main/java/org/gradle/binarycompatibility/rules/AbstractGradleViolationRule.java
+++ b/buildSrc/src/main/java/org/gradle/binarycompatibility/rules/AbstractGradleViolationRule.java
@@ -47,9 +47,9 @@ public abstract class AbstractGradleViolationRule extends AbstractContextAwareVi
 
     boolean isIncubating(JApiHasAnnotations member) {
         if (member instanceof JApiClass) {
-            return isIncubating((JApiClass)member);
+            return isIncubating((JApiClass) member);
         } else if (member instanceof JApiMethod) {
-            return isIncubating((JApiMethod)member);
+            return isIncubating((JApiMethod) member);
         }
         return isAnnotatedWithIncubating(member);
     }
@@ -81,17 +81,10 @@ public abstract class AbstractGradleViolationRule extends AbstractContextAwareVi
         String describe = Violation.describe(member);
         String acceptationReason = acceptedViolations.get(describe);
         if (acceptationReason == null) {
-            for (String key: acceptedViolations.keySet()) {
+            for (String key : acceptedViolations.keySet()) {
                 if (describe.startsWith(key)) {
                     acceptationReason = acceptedViolations.get(key);
                     seenRegressions.add(key);
-                }
-            }
-            if (acceptationReason == null) {
-                if (member instanceof JApiHasAnnotations) {
-                    if (isIncubating((JApiHasAnnotations)member)) {
-                        acceptationReason = "Removed member was incubating";
-                    }
                 }
             }
         } else {
@@ -102,4 +95,5 @@ public abstract class AbstractGradleViolationRule extends AbstractContextAwareVi
         }
         return rejection;
     }
+
 }

--- a/buildSrc/src/main/java/org/gradle/binarycompatibility/rules/AcceptedRegressionsRulePostProcess.java
+++ b/buildSrc/src/main/java/org/gradle/binarycompatibility/rules/AcceptedRegressionsRulePostProcess.java
@@ -16,20 +16,23 @@
 
 package org.gradle.binarycompatibility.rules;
 
-import java.util.Set;
-import java.util.HashSet;
 import me.champeau.gradle.japicmp.report.PostProcessViolationsRule;
 import me.champeau.gradle.japicmp.report.ViolationCheckContextWithViolations;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class AcceptedRegressionsRulePostProcess implements PostProcessViolationsRule {
+
     @SuppressWarnings("unchecked")
     public void execute(ViolationCheckContextWithViolations context) {
         Set<String> declaredRegressions = (Set<String>) context.getUserData().get("declaredRegressions");
         Set<String> seenRegressions = (Set<String>) context.getUserData().get("seenRegressions");
-        Set<String> left = new HashSet<String>(declaredRegressions);
+        Set<String> left = new HashSet<>(declaredRegressions);
         left.removeAll(seenRegressions);
         if (!left.isEmpty()) {
             throw new RuntimeException("The following regressions are declared as accepted, but didn't match any rule " + left);
         }
     }
+
 }

--- a/buildSrc/src/main/java/org/gradle/binarycompatibility/rules/AcceptedRegressionsRuleSetup.java
+++ b/buildSrc/src/main/java/org/gradle/binarycompatibility/rules/AcceptedRegressionsRuleSetup.java
@@ -16,13 +16,15 @@
 
 package org.gradle.binarycompatibility.rules;
 
-import java.util.Set;
+import me.champeau.gradle.japicmp.report.SetupRule;
+import me.champeau.gradle.japicmp.report.ViolationCheckContext;
+
 import java.util.HashSet;
 import java.util.Map;
-import me.champeau.gradle.japicmp.report.ViolationCheckContext;
-import me.champeau.gradle.japicmp.report.SetupRule;
+import java.util.Set;
 
 public class AcceptedRegressionsRuleSetup implements SetupRule {
+
     private final Set<String> declaredRegressions;
 
     public AcceptedRegressionsRuleSetup(Map<String, String> regressions) {
@@ -35,4 +37,5 @@ public class AcceptedRegressionsRuleSetup implements SetupRule {
         userData.put("declaredRegressions", declaredRegressions);
         userData.put("seenRegressions", new HashSet<String>());
     }
+
 }

--- a/buildSrc/src/main/java/org/gradle/binarycompatibility/rules/BinaryBreakingChangesRule.java
+++ b/buildSrc/src/main/java/org/gradle/binarycompatibility/rules/BinaryBreakingChangesRule.java
@@ -17,13 +17,14 @@
 package org.gradle.binarycompatibility.rules;
 
 import japicmp.model.JApiCompatibility;
+import japicmp.model.JApiHasAnnotations;
 import me.champeau.gradle.japicmp.report.Violation;
 
 import java.util.Map;
 
-public class AcceptedRegressionRule extends AbstractGradleViolationRule {
+public class BinaryBreakingChangesRule extends AbstractGradleViolationRule {
 
-    public AcceptedRegressionRule(Map<String, String> acceptedViolations) {
+    public BinaryBreakingChangesRule(Map<String, String> acceptedViolations) {
         super(acceptedViolations);
     }
 
@@ -31,8 +32,15 @@ public class AcceptedRegressionRule extends AbstractGradleViolationRule {
     @SuppressWarnings("unchecked")
     public Violation maybeViolation(final JApiCompatibility member) {
         if (!member.isBinaryCompatible()) {
+            if (member instanceof JApiHasAnnotations) {
+                if (isIncubating((JApiHasAnnotations) member)) {
+                    return Violation.accept(member, "Removed member was incubating");
+                }
+            }
+
             return acceptOrReject(member, Violation.notBinaryCompatible(member));
         }
         return null;
     }
+
 }

--- a/subprojects/distributions/binary-compatibility.gradle
+++ b/subprojects/distributions/binary-compatibility.gradle
@@ -117,7 +117,7 @@ task checkBinaryCompatibility(type: JapicmpTask) {
         title = "Binary compatibility report for Gradle ${version} since ${baselineVersion}"
         destinationDir = file("$buildDir/reports/binary-compatibility")
         reportName = "report.html"
-        addRule(AcceptedRegressionRule, acceptedViolations)
+        addRule(BinaryBreakingChangesRule, acceptedViolations)
         addRule(JApiChangeStatus.NEW, IncubatingMissingRule, acceptedViolations)
         addSetupRule(AcceptedRegressionsRuleSetup, acceptedViolations)
         addPostProcessRule(AcceptedRegressionsRulePostProcess)

--- a/subprojects/distributions/src/changes/changes-since-4.0.1.txt
+++ b/subprojects/distributions/src/changes/changes-since-4.0.1.txt
@@ -1,5 +1,4 @@
 Implemented interface org.gradle.api.initialization.IncludedBuild;@Incubating interface has been removed
-Method org.gradle.api.initialization.IncludedBuild;@Incubating interface has been removed
 Class org.gradle.api.invocation.Gradle;All regressions accepted
 Class org.gradle.StartParameter;All regressions accepted
 Implemented interface org.gradle.initialization.ParallelismConfiguration;Interface was incubating


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
