### PR TITLE
Fix too early configuration of projects in TAPI

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/BuildModelAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/BuildModelAction.java
@@ -16,6 +16,7 @@
 package org.gradle.tooling.internal.provider;
 
 import org.gradle.StartParameter;
+import org.gradle.tooling.internal.protocol.ModelIdentifier;
 
 public class BuildModelAction extends SubscribableBuildAction {
     private final StartParameter startParameter;
@@ -40,6 +41,10 @@ public class BuildModelAction extends SubscribableBuildAction {
 
     public boolean isRunTasks() {
         return runTasks;
+    }
+
+    public boolean isModelRequest() {
+        return !ModelIdentifier.NULL_MODEL.equals(modelName);
     }
 
 }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r15/ToolingApiConfigurationOnDemandCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r15/ToolingApiConfigurationOnDemandCrossVersionSpec.groovy
@@ -31,7 +31,7 @@ class ToolingApiConfigurationOnDemandCrossVersionSpec extends ToolingApiSpecific
         given:
         file("settings.gradle") << "include 'api', 'impl', 'other'"
         file("build.gradle") << """
-            rootProject.description = 'Configure on demand: ' + gradle.startParameter.configureOnDemand + '. Projects configured: '
+            rootProject.description = 'Projects configured: '
             allprojects { afterEvaluate {
                 rootProject.description += project.path + ", "
             }}
@@ -41,7 +41,6 @@ class ToolingApiConfigurationOnDemandCrossVersionSpec extends ToolingApiSpecific
         def op = withModel(GradleProject.class)
 
         then:
-        op.model.description.contains 'Configure on demand: true'
         op.model.description.contains 'Projects configured: :, :api, :impl, :other'
     }
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r41/InitScriptCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/r41/InitScriptCrossVersionSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r41
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.gradle.GradleBuild
+
+@ToolingApiVersion(">=2.1")
+@TargetGradleVersion(">=4.1")
+class InitScriptCrossVersionSpec extends ToolingApiSpecification {
+
+    def "init scripts see the root project before it is evaluated"() {
+        given:
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+        def initScript = file("init.gradle") << """
+            rootProject { root ->
+                if (root.state.executed) {
+                    throw new IllegalStateException("Root project should not be evaluated too early")
+                }
+            }
+        """
+        when:
+        withConnection { ProjectConnection connection ->
+            connection.model(GradleBuild).withArguments("--init-script", initScript.getAbsolutePath()).get()
+        }
+
+        then:
+        noExceptionThrown()
+    }
+}


### PR DESCRIPTION
https://github.com/gradle/gradle/pull/2397 lead to a regression, as
it changed the order in which the rootProject {} hook is executed
relative to project configuration. This lead the build scan plugin to
fail, as it was now applied to an already configured project and thus
missing most of the configuration events.

The new solution simply disables configure-on-demand when the tooling
client requested any models. This fixes the problem that #2397 was trying
to address in a more elegant way. Since model builders require full configuration
of the project anyway, this does not affect performance.
