### PR TITLE
Guard use of Proxy on Java 9 use

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.tasks.compile;
 
+import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.internal.tasks.compile.reflect.SourcepathIgnoringProxy;
 import org.gradle.api.tasks.WorkResult;
@@ -60,7 +61,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(null, null, compileOptions.getEncoding() != null ? Charset.forName(compileOptions.getEncoding()) : null);
         Iterable<? extends JavaFileObject> compilationUnits = standardFileManager.getJavaFileObjectsFromFiles(spec.getSource());
         StandardJavaFileManager fileManager = standardFileManager;
-        if (emptySourcepathIn(options)) {
+        if (JavaVersion.current().isJava9Compatible() && emptySourcepathIn(options)) {
             fileManager = (StandardJavaFileManager) SourcepathIgnoringProxy.proxy(standardFileManager, StandardJavaFileManager.class);
         }
         return compiler.getTask(null, fileManager, null, options, null, compilationUnits);


### PR DESCRIPTION
We notice that using reflection during java compilation for the
`StandardJavaFileManager` implementation causes too much of a
performance slow-down (1% to be exact).

For now, we've decided to accept that performance impact for Java 9
builds where we need to override the default behavior of the
`StandardJavaFileManager`, but we don't want to slow down any pre-Java
9 builds.
