### PR TITLE
Enhanced FindBugs plugin to work with SpotBugs which is FindBugs successor

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsExtension.java
@@ -65,8 +65,9 @@ public class FindBugsExtension extends CodeQualityExtension {
     private TextResource excludeBugsFilterConfig;
     private Collection<String> extraArgs;
     private boolean showProgress;
+    private boolean validateClasspath;
 
-    public FindBugsExtension(Project project) {
+    public FindBugsExtension(final Project project) {
         this.project = project;
     }
 
@@ -84,7 +85,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * The value specified should be one of {@code min}, {@code default}, or {@code max}.
      * Higher levels increase precision and find more bugs at the expense of running time and memory consumption.
      */
-    public void setEffort(String effort) {
+    public void setEffort(final String effort) {
         this.effort = effort;
     }
 
@@ -104,7 +105,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * If set to {@code medium} (the default), medium and high priority bugs are reported.
      * If set to {@code high}, only high priority bugs are reported.
      */
-    public void setReportLevel(String reportLevel) {
+    public void setReportLevel(final String reportLevel) {
         this.reportLevel = reportLevel;
     }
 
@@ -122,7 +123,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * The bug detectors are specified by their class names, without any package qualification.
      * By default, all detectors which are not disabled by default are run.
      */
-    public void setVisitors(Collection<String> visitors) {
+    public void setVisitors(final Collection<String> visitors) {
         this.visitors = visitors;
     }
 
@@ -138,7 +139,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * Similar to {@code visitors} except that it specifies bug detectors which should not be run.
      * By default, no visitors are omitted.
      */
-    public void setOmitVisitors(Collection<String> omitVisitors) {
+    public void setOmitVisitors(final Collection<String> omitVisitors) {
         this.omitVisitors = omitVisitors;
     }
 
@@ -158,7 +159,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * @since 2.2
      */
     @Incubating
-    public void setIncludeFilterConfig(TextResource includeFilterConfig) {
+    public void setIncludeFilterConfig(final TextResource includeFilterConfig) {
         this.includeFilterConfig = includeFilterConfig;
     }
 
@@ -166,7 +167,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * The filename of a filter specifying which bugs are reported.
      */
     public File getIncludeFilter() {
-        TextResource includeFilterConfig = getIncludeFilterConfig();
+        final TextResource includeFilterConfig = getIncludeFilterConfig();
         if (includeFilterConfig == null) {
             return null;
         }
@@ -176,7 +177,7 @@ public class FindBugsExtension extends CodeQualityExtension {
     /**
      * The filename of a filter specifying which bugs are reported.
      */
-    public void setIncludeFilter(File filter) {
+    public void setIncludeFilter(final File filter) {
         setIncludeFilterConfig(project.getResources().getText().fromFile(filter));
     }
 
@@ -196,7 +197,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * @since 2.2
      */
     @Incubating
-    public void setExcludeFilterConfig(TextResource excludeFilterConfig) {
+    public void setExcludeFilterConfig(final TextResource excludeFilterConfig) {
         this.excludeFilterConfig = excludeFilterConfig;
     }
 
@@ -204,7 +205,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * The filename of a filter specifying bugs to exclude from being reported.
      */
     public File getExcludeFilter() {
-        TextResource excludeFilterConfig = getExcludeFilterConfig();
+        final TextResource excludeFilterConfig = getExcludeFilterConfig();
         if (excludeFilterConfig == null) {
             return null;
         }
@@ -214,7 +215,7 @@ public class FindBugsExtension extends CodeQualityExtension {
     /**
      * The filename of a filter specifying bugs to exclude from being reported.
      */
-    public void setExcludeFilter(File filter) {
+    public void setExcludeFilter(final File filter) {
         setExcludeFilterConfig(project.getResources().getText().fromFile(filter));
     }
 
@@ -234,7 +235,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * @since 2.4
      */
     @Incubating
-    public void setExcludeBugsFilterConfig(TextResource excludeBugsFilterConfig) {
+    public void setExcludeBugsFilterConfig(final TextResource excludeBugsFilterConfig) {
         this.excludeBugsFilterConfig = excludeBugsFilterConfig;
     }
 
@@ -242,7 +243,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      * The filename of a filter specifying baseline bugs to exclude from being reported.
      */
     public File getExcludeBugsFilter() {
-        TextResource excludeBugsFilterConfig = getExcludeBugsFilterConfig();
+        final TextResource excludeBugsFilterConfig = getExcludeBugsFilterConfig();
         if (excludeBugsFilterConfig == null) {
             return null;
         }
@@ -252,7 +253,7 @@ public class FindBugsExtension extends CodeQualityExtension {
     /**
      * The filename of a filter specifying baseline bugs to exclude from being reported.
      */
-    public void setExcludeBugsFilter(File filter) {
+    public void setExcludeBugsFilter(final File filter) {
         setExcludeBugsFilterConfig(project.getResources().getText().fromFile(filter));
     }
 
@@ -284,7 +285,7 @@ public class FindBugsExtension extends CodeQualityExtension {
      *
      * @since 2.6
      */
-    public void setExtraArgs(Collection<String> extraArgs) {
+    public void setExtraArgs(final Collection<String> extraArgs) {
         this.extraArgs = extraArgs;
     }
 
@@ -304,7 +305,29 @@ public class FindBugsExtension extends CodeQualityExtension {
      * @since 4.2
      */
     @Incubating
-    public void setShowProgress(boolean showProgress) {
+    public void setShowProgress(final boolean showProgress) {
         this.showProgress = showProgress;
+    }
+
+    /**
+     * Indicates whether the <code>findbugs</code> configuration classpath will be validated for JDK compatibility. This
+     * is useful to disable when using <em>SpotBugs</em> which is FindBugs' successor. <em>SpotBugs</em> currently
+     * uses the same package structure as <em>FindBugs</em> but is packaged in a different artifact name.
+     *
+     * @since 4.2
+     */
+    public boolean isValidateClasspath() {
+        return validateClasspath;
+    }
+
+    /**
+     * Indicates whether the <code>findbugs</code> configuration classpath will be validated for JDK compatibility. This
+     * is useful to disable when using <em>SpotBugs</em> which is FindBugs' successor. <em>SpotBugs</em> currently
+     * uses the same package structure as <em>FindBugs</em> but is packaged in a different artifact name.
+     *
+     * @since 4.2
+     */
+    public void setValidateClasspath(final boolean validateClasspath) {
+        this.validateClasspath = validateClasspath;
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
@@ -65,7 +65,7 @@ public class FindBugsPlugin extends AbstractCodeQualityPlugin<FindBugs> {
     }
 
     private void configureFindBugsConfigurations() {
-        Configuration configuration = project.getConfigurations().create("findbugsPlugins");
+        final Configuration configuration = project.getConfigurations().create("findbugsPlugins");
         configuration.setVisible(false);
         configuration.setTransitive(true);
         configuration.setDescription("The FindBugs plugins to be used for this project.");
@@ -75,29 +75,30 @@ public class FindBugsPlugin extends AbstractCodeQualityPlugin<FindBugs> {
     protected CodeQualityExtension createExtension() {
         extension = project.getExtensions().create("findbugs", FindBugsExtension.class, project);
         extension.setToolVersion(DEFAULT_FINDBUGS_VERSION);
+        extension.setValidateClasspath(true);
         return extension;
     }
 
     @Override
-    protected void configureTaskDefaults(FindBugs task, String baseName) {
+    protected void configureTaskDefaults(final FindBugs task, final String baseName) {
         task.setPluginClasspath(project.getConfigurations().getAt("findbugsPlugins"));
-        Configuration configuration = project.getConfigurations().getAt("findbugs");
+        final Configuration configuration = project.getConfigurations().getAt("findbugs");
         configureDefaultDependencies(configuration);
         configureTaskConventionMapping(configuration, task);
         configureReportsConventionMapping(task, baseName);
     }
 
-    private void configureDefaultDependencies(Configuration configuration) {
+    private void configureDefaultDependencies(final Configuration configuration) {
         configuration.defaultDependencies(new Action<DependencySet>() {
             @Override
-            public void execute(DependencySet dependencies) {
+            public void execute(final DependencySet dependencies) {
                 dependencies.add(project.getDependencies().create("com.google.code.findbugs:findbugs:" + extension.getToolVersion()));
             }
         });
     }
 
-    private void configureTaskConventionMapping(Configuration configuration, FindBugs task) {
-        ConventionMapping taskMapping = task.getConventionMapping();
+    private void configureTaskConventionMapping(final Configuration configuration, final FindBugs task) {
+        final ConventionMapping taskMapping = task.getConventionMapping();
         taskMapping.map("findbugsClasspath", Callables.returning(configuration));
         taskMapping.map("ignoreFailures", new Callable<Boolean>() {
             @Override
@@ -162,13 +163,20 @@ public class FindBugsPlugin extends AbstractCodeQualityPlugin<FindBugs> {
                 return extension.isShowProgress();
             }
         });
+
+        taskMapping.map("validateClasspath", new Callable<Boolean>() {
+            @Override
+            public Boolean call() {
+                return extension.isValidateClasspath();
+            }
+        });
     }
 
-    private void configureReportsConventionMapping(FindBugs task, final String baseName) {
+    private void configureReportsConventionMapping(final FindBugs task, final String baseName) {
         task.getReports().all(new Action<SingleFileReport>() {
             @Override
             public void execute(final SingleFileReport report) {
-                ConventionMapping reportMapping = conventionMappingOf(report);
+                final ConventionMapping reportMapping = conventionMappingOf(report);
                 reportMapping.map("enabled", new Callable<Boolean>() {
                     @Override
                     public Boolean call() {
@@ -186,10 +194,10 @@ public class FindBugsPlugin extends AbstractCodeQualityPlugin<FindBugs> {
     }
 
     @Override
-    protected void configureForSourceSet(final SourceSet sourceSet, FindBugs task) {
+    protected void configureForSourceSet(final SourceSet sourceSet, final FindBugs task) {
         task.setDescription("Run FindBugs analysis for " + sourceSet.getName() + " classes");
         task.setSource(sourceSet.getAllJava());
-        ConventionMapping taskMapping = task.getConventionMapping();
+        final ConventionMapping taskMapping = task.getConventionMapping();
         taskMapping.map("classes", new Callable<FileCollection>() {
             @Override
             public FileCollection call() {

--- a/subprojects/docs/src/docs/userguide/findBugsPlugin.xml
+++ b/subprojects/docs/src/docs/userguide/findBugsPlugin.xml
@@ -101,7 +101,24 @@
                 </td>
                 <td>The FindBugs libraries to use</td>
             </tr>
+            <tr>
+                <td>
+                    <filename>findbugsPlugins</filename>
+                </td>
+                <td>The FindBugs plugin libraries to use</td>
+            </tr>
         </table>
+        <para>
+            A common setup to include additional third-party FindBugs plugins such as the excellent "Find Security Bugs" would be defined as follows:
+            <programlisting>
+                dependencies {
+                    //Dependencies for FindBugs and FindBugs plugins
+                    findbugs 'com.google.code.findbugs:findbugs:3.0.1'
+                    findbugs configurations.findbugsPlugins.dependencies
+                    findbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.6.0'
+                }
+            </programlisting>
+        </para>
     </section>
 
     <section id="sec:findbugs_configuration">
@@ -121,6 +138,22 @@
         <para>
             <ulink url="https://github.com/findbugsproject/findbugs/tree/master/findbugs/src/xsl">View a sample FindBugs stylesheet.</ulink>
         </para>
+        <para>
+            The built-in FindBugs stylesheets may also be selected using the <code>extraArgs</code> property:
+            <programlisting>
+                extraArgs = ['-html:fancy-hist.xsl']
+            </programlisting>
+        </para>
+        <tip>
+            <title>Built-in FindBugs stylesheets</title>
+            <itemizedlist>
+                <listitem><filename>-html:default.xsl</filename></listitem>
+                <listitem><filename>-html:plain.xsl</filename></listitem>
+                <listitem><filename>-html:color.xsl</filename></listitem>
+                <listitem><filename>-html:fancy.xsl</filename></listitem>
+                <listitem><filename>-html:fancy-hist.xsl</filename></listitem>
+                <listitem><filename>-html:summary.xsl</filename></listitem>
+            </itemizedlist>
+        </tip>
     </section>
-
 </chapter>


### PR DESCRIPTION
successor.

FindBugs development has been discontinued. SpotBugs is the spiritual
successor of FindBugs, carrying on from the point where it left off
with support of its community.

The FindBugs plugin made an assumption that the FindBugs code was
present in an artifact named "findbugs-3.0.1.jar" in order to
extract the FindBugs version number to ensure it was compatible
with the current JDK.

In order to work with SpotBugs a new optional parameter
named "validateClasspath" which defaults to true was added.

Each updated file was also improved to use immutable parameters and
local variables whenever possible. This is common strategy in other
languages (Kotlin, Scala, JavaScript, etc.)

The documents were also updated to include some helpful tips with
using the FindBugs plugin (e.g. adding the "Find Security Bugs")

See "https://spotbugs.github.io/" and "http://find-sec-bugs.github.io/" for more information.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
