### PR TITLE
Report MISSING outputs as removed

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/FileChange.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/FileChange.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.changedetection.rules;
 
 import com.google.common.base.Objects;
 import org.gradle.api.tasks.incremental.InputFileDetails;
+import org.gradle.internal.nativeintegration.filesystem.FileType;
 
 import java.io.File;
 
@@ -25,11 +26,27 @@ public class FileChange implements TaskStateChange, InputFileDetails {
     private final String path;
     private final ChangeType change;
     private final String fileType;
+    private final FileType previousType;
+    private final FileType currentType;
 
-    public FileChange(String path, ChangeType change, String fileType) {
+    public static FileChange added(String path, String title) {
+        return new FileChange(path, ChangeType.ADDED, title, null, null);
+    }
+
+    public static FileChange removed(String path, String title) {
+        return new FileChange(path, ChangeType.REMOVED, title, null, null);
+    }
+
+    public static FileChange modified(String path, String title, FileType previousType, FileType currentType) {
+        return new FileChange(path, ChangeType.MODIFIED, title, previousType, currentType);
+    }
+
+    private FileChange(String path, ChangeType change, String fileType, FileType previousType, FileType currentType) {
         this.path = path;
         this.change = change;
         this.fileType = fileType;
+        this.previousType = previousType;
+        this.currentType = currentType;
     }
 
     public String getMessage() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/FileChange.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/FileChange.java
@@ -38,6 +38,11 @@ public class FileChange implements TaskStateChange, InputFileDetails {
     }
 
     public static FileChange modified(String path, String title, FileType previousType, FileType currentType) {
+        assert previousType != null;
+        assert currentType != null;
+        assert !(previousType == FileType.Missing && currentType == FileType.Missing);
+        assert !(previousType == FileType.Directory && currentType == FileType.Directory);
+
         return new FileChange(path, ChangeType.MODIFIED, title, previousType, currentType);
     }
 
@@ -50,7 +55,18 @@ public class FileChange implements TaskStateChange, InputFileDetails {
     }
 
     public String getMessage() {
-        return fileType + " file " + path + " " + change.describe() + ".";
+        ChangeType displayedChange = change != ChangeType.MODIFIED ? change : displayedChangeType(previousType, currentType);
+        return fileType + " file " + path + " " + displayedChange.describe() + ".";
+    }
+
+    private static ChangeType displayedChangeType(FileType previous, FileType current) {
+        if (previous == FileType.Missing) {
+            return ChangeType.ADDED;
+        }
+        if (current == FileType.Missing) {
+            return ChangeType.REMOVED;
+        }
+        return ChangeType.MODIFIED;
     }
 
     @Override
@@ -93,11 +109,13 @@ public class FileChange implements TaskStateChange, InputFileDetails {
         FileChange that = (FileChange) o;
         return Objects.equal(path, that.path)
             && change == that.change
-            && Objects.equal(fileType, that.fileType);
+            && Objects.equal(fileType, that.fileType)
+            && Objects.equal(previousType, that.previousType)
+            && Objects.equal(currentType, that.currentType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(path, change, fileType);
+        return Objects.hashCode(path, change, fileType, previousType, currentType);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/FileChange.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/FileChange.java
@@ -25,45 +25,42 @@ import java.io.File;
 public class FileChange implements TaskStateChange, InputFileDetails {
     private final String path;
     private final ChangeType change;
-    private final String fileType;
-    private final FileType previousType;
-    private final FileType currentType;
+    private final String title;
+    private final FileType previousFileType;
+    private final FileType currentFileType;
 
     public static FileChange added(String path, String title) {
-        return new FileChange(path, ChangeType.ADDED, title, null, null);
+        return new FileChange(path, ChangeType.ADDED, title, FileType.Missing, FileType.RegularFile);
     }
 
     public static FileChange removed(String path, String title) {
-        return new FileChange(path, ChangeType.REMOVED, title, null, null);
+        return new FileChange(path, ChangeType.REMOVED, title, FileType.RegularFile, FileType.Missing);
     }
 
     public static FileChange modified(String path, String title, FileType previousType, FileType currentType) {
-        assert previousType != null;
-        assert currentType != null;
-        assert !(previousType == FileType.Missing && currentType == FileType.Missing);
-        assert !(previousType == FileType.Directory && currentType == FileType.Directory);
-
         return new FileChange(path, ChangeType.MODIFIED, title, previousType, currentType);
     }
 
-    private FileChange(String path, ChangeType change, String fileType, FileType previousType, FileType currentType) {
+    private FileChange(String path, ChangeType change, String title, FileType previousFileType, FileType currentFileType) {
         this.path = path;
         this.change = change;
-        this.fileType = fileType;
-        this.previousType = previousType;
-        this.currentType = currentType;
+        this.title = title;
+        this.previousFileType = previousFileType;
+        this.currentFileType = currentFileType;
     }
 
     public String getMessage() {
-        ChangeType displayedChange = change != ChangeType.MODIFIED ? change : displayedChangeType(previousType, currentType);
-        return fileType + " file " + path + " " + displayedChange.describe() + ".";
+        return title + " file " + path + " " + getDisplayedChangeType().describe() + ".";
     }
 
-    private static ChangeType displayedChangeType(FileType previous, FileType current) {
-        if (previous == FileType.Missing) {
+    private ChangeType getDisplayedChangeType() {
+        if (change != ChangeType.MODIFIED) {
+            return change;
+        }
+        if (previousFileType == FileType.Missing) {
             return ChangeType.ADDED;
         }
-        if (current == FileType.Missing) {
+        if (currentFileType == FileType.Missing) {
             return ChangeType.REMOVED;
         }
         return ChangeType.MODIFIED;
@@ -109,13 +106,13 @@ public class FileChange implements TaskStateChange, InputFileDetails {
         FileChange that = (FileChange) o;
         return Objects.equal(path, that.path)
             && change == that.change
-            && Objects.equal(fileType, that.fileType)
-            && Objects.equal(previousType, that.previousType)
-            && Objects.equal(currentType, that.currentType);
+            && Objects.equal(title, that.title)
+            && Objects.equal(previousFileType, that.previousFileType)
+            && Objects.equal(currentFileType, that.currentFileType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(path, change, fileType, previousType, currentType);
+        return Objects.hashCode(path, change, title, previousFileType, currentFileType);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/FileChange.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/rules/FileChange.java
@@ -29,16 +29,16 @@ public class FileChange implements TaskStateChange, InputFileDetails {
     private final FileType previousFileType;
     private final FileType currentFileType;
 
-    public static FileChange added(String path, String title) {
-        return new FileChange(path, ChangeType.ADDED, title, FileType.Missing, FileType.RegularFile);
+    public static FileChange added(String path, String title, FileType currentFileType) {
+        return new FileChange(path, ChangeType.ADDED, title, FileType.Missing, currentFileType);
     }
 
-    public static FileChange removed(String path, String title) {
-        return new FileChange(path, ChangeType.REMOVED, title, FileType.RegularFile, FileType.Missing);
+    public static FileChange removed(String path, String title, FileType previousFileType) {
+        return new FileChange(path, ChangeType.REMOVED, title, previousFileType, FileType.Missing);
     }
 
-    public static FileChange modified(String path, String title, FileType previousType, FileType currentType) {
-        return new FileChange(path, ChangeType.MODIFIED, title, previousType, currentType);
+    public static FileChange modified(String path, String title, FileType previousFileType, FileType currentFileType) {
+        return new FileChange(path, ChangeType.MODIFIED, title, previousFileType, currentFileType);
     }
 
     private FileChange(String path, ChangeType change, String title, FileType previousFileType, FileType currentFileType) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderInsensitiveTaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderInsensitiveTaskFilePropertyCompareStrategy.java
@@ -89,7 +89,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
                 }
                 if (unaccountedForPreviousSnapshotsIterator.hasNext()) {
                     String previousAbsolutePath = unaccountedForPreviousSnapshotsIterator.next();
-                    return FileChange.removed(previousAbsolutePath, fileType);
+                    return FileChange.removed(previousAbsolutePath, fileType, previous.get(previousAbsolutePath).getSnapshot().getType());
                 }
 
                 if (includeAdded) {
@@ -97,8 +97,8 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
                         addedIterator = added.iterator();
                     }
                     if (addedIterator.hasNext()) {
-                        String newAbsolutePath = addedIterator.next();
-                        return FileChange.added(newAbsolutePath, fileType);
+                        String currentAbsolutePath = addedIterator.next();
+                        return FileChange.added(currentAbsolutePath, fileType, current.get(currentAbsolutePath).getSnapshot().getType());
                     }
                 }
 
@@ -162,7 +162,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
                         return FileChange.modified(modifiedSnapshot.getAbsolutePath(), fileType, previousSnapshot.getSnapshot().getType(), modifiedSnapshot.getSnapshot().getType());
                     } else {
                         IncrementalFileSnapshotWithAbsolutePath removedSnapshot = unaccountedForPreviousSnapshotEntry.getValue();
-                        return FileChange.removed(removedSnapshot.getAbsolutePath(), fileType);
+                        return FileChange.removed(removedSnapshot.getAbsolutePath(), fileType, removedSnapshot.getSnapshot().getType());
                     }
                 }
 
@@ -174,7 +174,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
 
                     if (addedFilesIterator.hasNext()) {
                         IncrementalFileSnapshotWithAbsolutePath addedFile = addedFilesIterator.next();
-                        return FileChange.added(addedFile.getAbsolutePath(), fileType);
+                        return FileChange.added(addedFile.getAbsolutePath(), fileType, addedFile.getSnapshot().getType());
                     }
                 }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderInsensitiveTaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderInsensitiveTaskFilePropertyCompareStrategy.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MultimapBuilder;
-import org.gradle.api.internal.changedetection.rules.ChangeType;
 import org.gradle.api.internal.changedetection.rules.FileChange;
 import org.gradle.api.internal.changedetection.rules.TaskStateChange;
 import org.gradle.caching.internal.BuildCacheHasher;
@@ -77,7 +76,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
                         NormalizedFileSnapshot previousNormalizedSnapshot = previous.get(currentAbsolutePath);
                         FileContentSnapshot previousSnapshot = previousNormalizedSnapshot.getSnapshot();
                         if (!currentSnapshot.isContentUpToDate(previousSnapshot)) {
-                            return new FileChange(currentAbsolutePath, ChangeType.MODIFIED, fileType);
+                            return FileChange.modified(currentAbsolutePath, fileType, previousSnapshot.getType(), currentSnapshot.getType());
                         }
                         // else, unchanged; check next file
                     } else {
@@ -90,7 +89,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
                 }
                 if (unaccountedForPreviousSnapshotsIterator.hasNext()) {
                     String previousAbsolutePath = unaccountedForPreviousSnapshotsIterator.next();
-                    return new FileChange(previousAbsolutePath, ChangeType.REMOVED, fileType);
+                    return FileChange.removed(previousAbsolutePath, fileType);
                 }
 
                 if (includeAdded) {
@@ -99,7 +98,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
                     }
                     if (addedIterator.hasNext()) {
                         String newAbsolutePath = addedIterator.next();
-                        return new FileChange(newAbsolutePath, ChangeType.ADDED, fileType);
+                        return FileChange.added(newAbsolutePath, fileType);
                     }
                 }
 
@@ -136,7 +135,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
                         IncrementalFileSnapshotWithAbsolutePath previousSnapshotWithAbsolutePath = previousSnapshotsForNormalizedPath.remove(0);
                         FileContentSnapshot previousSnapshot = previousSnapshotWithAbsolutePath.getSnapshot();
                         if (!currentSnapshot.isContentUpToDate(previousSnapshot)) {
-                            return new FileChange(currentAbsolutePath, ChangeType.MODIFIED, fileType);
+                            return FileChange.modified(currentAbsolutePath, fileType, previousSnapshot.getType(), currentSnapshot.getType());
                         }
                     }
                 }
@@ -154,15 +153,16 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
 
                 if (unaccountedForPreviousSnapshotsIterator.hasNext()) {
                     Entry<NormalizedFileSnapshot, IncrementalFileSnapshotWithAbsolutePath> unaccountedForPreviousSnapshotEntry = unaccountedForPreviousSnapshotsIterator.next();
-                    String normalizedPath = unaccountedForPreviousSnapshotEntry.getKey().getNormalizedPath();
+                    NormalizedFileSnapshot previousSnapshot = unaccountedForPreviousSnapshotEntry.getKey();
+                    String normalizedPath = previousSnapshot.getNormalizedPath();
                     List<IncrementalFileSnapshotWithAbsolutePath> addedFilesForNormalizedPath = addedFiles.get(normalizedPath);
                     if (!addedFilesForNormalizedPath.isEmpty()) {
                         // There might be multiple files with the same normalized path, here we choose one of them
                         IncrementalFileSnapshotWithAbsolutePath modifiedSnapshot = addedFilesForNormalizedPath.remove(0);
-                        return new FileChange(modifiedSnapshot.getAbsolutePath(), ChangeType.MODIFIED, fileType);
+                        return FileChange.modified(modifiedSnapshot.getAbsolutePath(), fileType, previousSnapshot.getSnapshot().getType(), modifiedSnapshot.getSnapshot().getType());
                     } else {
                         IncrementalFileSnapshotWithAbsolutePath removedSnapshot = unaccountedForPreviousSnapshotEntry.getValue();
-                        return new FileChange(removedSnapshot.getAbsolutePath(), ChangeType.REMOVED, fileType);
+                        return FileChange.removed(removedSnapshot.getAbsolutePath(), fileType);
                     }
                 }
 
@@ -174,7 +174,7 @@ class OrderInsensitiveTaskFilePropertyCompareStrategy implements TaskFilePropert
 
                     if (addedFilesIterator.hasNext()) {
                         IncrementalFileSnapshotWithAbsolutePath addedFile = addedFilesIterator.next();
-                        return new FileChange(addedFile.getAbsolutePath(), ChangeType.ADDED, fileType);
+                        return FileChange.added(addedFile.getAbsolutePath(), fileType);
                     }
                 }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderSensitiveTaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderSensitiveTaskFilePropertyCompareStrategy.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.collect.AbstractIterator;
-import org.gradle.api.internal.changedetection.rules.ChangeType;
 import org.gradle.api.internal.changedetection.rules.FileChange;
 import org.gradle.api.internal.changedetection.rules.TaskStateChange;
 import org.gradle.caching.internal.BuildCacheHasher;
@@ -48,30 +47,32 @@ class OrderSensitiveTaskFilePropertyCompareStrategy implements TaskFilePropertyC
                         Map.Entry<String, NormalizedFileSnapshot> current = currentEntries.next();
                         String absolutePath = current.getKey();
                         if (previousEntries.hasNext()) {
-                            Map.Entry<String, NormalizedFileSnapshot> other = previousEntries.next();
-                            NormalizedFileSnapshot normalizedSnapshot = current.getValue();
-                            NormalizedFileSnapshot otherNormalizedSnapshot = other.getValue();
-                            String normalizedPath = normalizedSnapshot.getNormalizedPath();
-                            String otherNormalizedPath = otherNormalizedSnapshot.getNormalizedPath();
-                            if (normalizedPath.equals(otherNormalizedPath)) {
-                                if (!normalizedSnapshot.getSnapshot().isContentUpToDate(otherNormalizedSnapshot.getSnapshot())) {
-                                    return new FileChange(absolutePath, ChangeType.MODIFIED, fileType);
+                            Map.Entry<String, NormalizedFileSnapshot> previous = previousEntries.next();
+                            NormalizedFileSnapshot currentNormalizedSnapshot = current.getValue();
+                            NormalizedFileSnapshot previousNormalizedSnapshot = previous.getValue();
+                            String currentNormalizedPath = currentNormalizedSnapshot.getNormalizedPath();
+                            String previousNormalizedPath = previousNormalizedSnapshot.getNormalizedPath();
+                            if (currentNormalizedPath.equals(previousNormalizedPath)) {
+                                if (!currentNormalizedSnapshot.getSnapshot().isContentUpToDate(previousNormalizedSnapshot.getSnapshot())) {
+                                    return FileChange.modified(absolutePath, fileType,
+                                        previousNormalizedSnapshot.getSnapshot().getType(),
+                                        currentNormalizedSnapshot.getSnapshot().getType());
                                 }
                             } else {
-                                String otherAbsolutePath = other.getKey();
+                                String otherAbsolutePath = previous.getKey();
                                 if (includeAdded) {
-                                    remaining = new FileChange(absolutePath, ChangeType.ADDED, fileType);
+                                    remaining = FileChange.added(absolutePath, fileType);
                                 }
-                                return new FileChange(otherAbsolutePath, ChangeType.REMOVED, fileType);
+                                return FileChange.removed(otherAbsolutePath, fileType);
                             }
                         } else {
                             if (includeAdded) {
-                                return new FileChange(absolutePath, ChangeType.ADDED, fileType);
+                                return FileChange.added(absolutePath, fileType);
                             }
                         }
                     } else {
                         if (previousEntries.hasNext()) {
-                            return new FileChange(previousEntries.next().getKey(), ChangeType.REMOVED, fileType);
+                            return FileChange.removed(previousEntries.next().getKey(), fileType);
                         } else {
                             return endOfData();
                         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderSensitiveTaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderSensitiveTaskFilePropertyCompareStrategy.java
@@ -61,18 +61,19 @@ class OrderSensitiveTaskFilePropertyCompareStrategy implements TaskFilePropertyC
                             } else {
                                 String previousAbsolutePath = previous.getKey();
                                 if (includeAdded) {
-                                    remaining = FileChange.added(currentAbsolutePath, fileType);
+                                    remaining = FileChange.added(currentAbsolutePath, fileType, currentNormalizedSnapshot.getSnapshot().getType());
                                 }
-                                return FileChange.removed(previousAbsolutePath, fileType);
+                                return FileChange.removed(previousAbsolutePath, fileType, previousNormalizedSnapshot.getSnapshot().getType());
                             }
                         } else {
                             if (includeAdded) {
-                                return FileChange.added(currentAbsolutePath, fileType);
+                                return FileChange.added(currentAbsolutePath, fileType, current.getValue().getSnapshot().getType());
                             }
                         }
                     } else {
                         if (previousEntries.hasNext()) {
-                            return FileChange.removed(previousEntries.next().getKey(), fileType);
+                            Map.Entry<String, NormalizedFileSnapshot> previousEntry = previousEntries.next();
+                            return FileChange.removed(previousEntry.getKey(), fileType, previousEntry.getValue().getSnapshot().getType());
                         } else {
                             return endOfData();
                         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderSensitiveTaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/OrderSensitiveTaskFilePropertyCompareStrategy.java
@@ -45,7 +45,7 @@ class OrderSensitiveTaskFilePropertyCompareStrategy implements TaskFilePropertyC
                 while (true) {
                     if (currentEntries.hasNext()) {
                         Map.Entry<String, NormalizedFileSnapshot> current = currentEntries.next();
-                        String absolutePath = current.getKey();
+                        String currentAbsolutePath = current.getKey();
                         if (previousEntries.hasNext()) {
                             Map.Entry<String, NormalizedFileSnapshot> previous = previousEntries.next();
                             NormalizedFileSnapshot currentNormalizedSnapshot = current.getValue();
@@ -54,20 +54,20 @@ class OrderSensitiveTaskFilePropertyCompareStrategy implements TaskFilePropertyC
                             String previousNormalizedPath = previousNormalizedSnapshot.getNormalizedPath();
                             if (currentNormalizedPath.equals(previousNormalizedPath)) {
                                 if (!currentNormalizedSnapshot.getSnapshot().isContentUpToDate(previousNormalizedSnapshot.getSnapshot())) {
-                                    return FileChange.modified(absolutePath, fileType,
+                                    return FileChange.modified(currentAbsolutePath, fileType,
                                         previousNormalizedSnapshot.getSnapshot().getType(),
                                         currentNormalizedSnapshot.getSnapshot().getType());
                                 }
                             } else {
-                                String otherAbsolutePath = previous.getKey();
+                                String previousAbsolutePath = previous.getKey();
                                 if (includeAdded) {
-                                    remaining = FileChange.added(absolutePath, fileType);
+                                    remaining = FileChange.added(currentAbsolutePath, fileType);
                                 }
-                                return FileChange.removed(otherAbsolutePath, fileType);
+                                return FileChange.removed(previousAbsolutePath, fileType);
                             }
                         } else {
                             if (includeAdded) {
-                                return FileChange.added(absolutePath, fileType);
+                                return FileChange.added(currentAbsolutePath, fileType);
                             }
                         }
                     } else {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategy.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
-import org.gradle.api.internal.changedetection.rules.ChangeType;
 import org.gradle.api.internal.changedetection.rules.FileChange;
 import org.gradle.api.internal.changedetection.rules.TaskStateChange;
 import org.gradle.caching.internal.BuildCacheHasher;
@@ -79,7 +78,7 @@ public enum TaskFilePropertyCompareStrategy {
                         return emptyIterator();
                     case 1:
                         String path = previous.keySet().iterator().next();
-                        TaskStateChange change = new FileChange(path, ChangeType.REMOVED, fileType);
+                        TaskStateChange change = FileChange.removed(path, fileType);
                         return singletonIterator(change);
                     default:
                         return null;
@@ -90,7 +89,7 @@ public enum TaskFilePropertyCompareStrategy {
                     case 0:
                         if (includeAdded) {
                             String path = current.keySet().iterator().next();
-                            TaskStateChange change = new FileChange(path, ChangeType.ADDED, fileType);
+                            TaskStateChange change = FileChange.added(path, fileType);
                             return singletonIterator(change);
                         } else {
                             return emptyIterator();
@@ -116,7 +115,7 @@ public enum TaskFilePropertyCompareStrategy {
             FileContentSnapshot currentSnapshot = normalizedCurrent.getSnapshot();
             if (!currentSnapshot.isContentUpToDate(previousSnapshot)) {
                 String path = currentEntry.getKey();
-                TaskStateChange change = new FileChange(path, ChangeType.MODIFIED, fileType);
+                TaskStateChange change = FileChange.modified(path, fileType, previousSnapshot.getType(), currentSnapshot.getType());
                 return singletonIterator(change);
             } else {
                 return emptyIterator();
@@ -125,12 +124,12 @@ public enum TaskFilePropertyCompareStrategy {
             if (includeAdded) {
                 String previousPath = previousEntry.getKey();
                 String currentPath = currentEntry.getKey();
-                TaskStateChange remove = new FileChange(previousPath, ChangeType.REMOVED, fileType);
-                TaskStateChange add = new FileChange(currentPath, ChangeType.ADDED, fileType);
+                TaskStateChange remove = FileChange.removed(previousPath, fileType);
+                TaskStateChange add = FileChange.added(currentPath, fileType);
                 return Iterators.forArray(remove, add);
             } else {
                 String path = previousEntry.getKey();
-                TaskStateChange change = new FileChange(path, ChangeType.REMOVED, fileType);
+                TaskStateChange change = FileChange.removed(path, fileType);
                 return singletonIterator(change);
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategy.java
@@ -77,8 +77,8 @@ public enum TaskFilePropertyCompareStrategy {
                     case 0:
                         return emptyIterator();
                     case 1:
-                        String path = previous.keySet().iterator().next();
-                        TaskStateChange change = FileChange.removed(path, fileType);
+                        Entry<String, NormalizedFileSnapshot> entry = previous.entrySet().iterator().next();
+                        TaskStateChange change = FileChange.removed(entry.getKey(), fileType, entry.getValue().getSnapshot().getType());
                         return singletonIterator(change);
                     default:
                         return null;
@@ -88,8 +88,8 @@ public enum TaskFilePropertyCompareStrategy {
                 switch (previous.size()) {
                     case 0:
                         if (includeAdded) {
-                            String path = current.keySet().iterator().next();
-                            TaskStateChange change = FileChange.added(path, fileType);
+                            Entry<String, NormalizedFileSnapshot> entry = current.entrySet().iterator().next();
+                            TaskStateChange change = FileChange.added(entry.getKey(), fileType, entry.getValue().getSnapshot().getType());
                             return singletonIterator(change);
                         } else {
                             return emptyIterator();
@@ -124,12 +124,12 @@ public enum TaskFilePropertyCompareStrategy {
             if (includeAdded) {
                 String previousPath = previousEntry.getKey();
                 String currentPath = currentEntry.getKey();
-                TaskStateChange remove = FileChange.removed(previousPath, fileType);
-                TaskStateChange add = FileChange.added(currentPath, fileType);
+                TaskStateChange remove = FileChange.removed(previousPath, fileType, normalizedPrevious.getSnapshot().getType());
+                TaskStateChange add = FileChange.added(currentPath, fileType, normalizedCurrent.getSnapshot().getType());
                 return Iterators.forArray(remove, add);
             } else {
                 String path = previousEntry.getKey();
-                TaskStateChange change = FileChange.removed(path, fileType);
+                TaskStateChange change = FileChange.removed(path, fileType, previousEntry.getValue().getSnapshot().getType());
                 return singletonIterator(change);
             }
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/FileChangeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/FileChangeTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.rules
+
+import org.gradle.internal.nativeintegration.filesystem.FileType
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class FileChangeTest extends Specification {
+
+    def "change message for ChangeType MODIFIED from #previous to #current is '#message'"() {
+        expect:
+        FileChange.modified("somePath", "test", previous, current).message == "test file somePath ${message}."
+
+        where:
+        previous             | current              | message
+        FileType.RegularFile | FileType.RegularFile | "has changed"
+        FileType.Missing     | FileType.RegularFile | "has been added"
+        FileType.Missing     | FileType.Directory   | "has been added"
+        FileType.RegularFile | FileType.Missing     | "has been removed"
+        FileType.Directory   | FileType.Missing     | "has been removed"
+    }
+
+    def "change message for ChangeType #fileChange.change is '#message'"() {
+        expect:
+        fileChange.message == "test file somePath ${message}."
+
+        where:
+        fileChange                             | message
+        FileChange.removed("somePath", "test") | "has been removed"
+        FileChange.added("somePath", "test")   | "has been added"
+    }
+
+    def "change cannot be from #type to #type"() {
+        when:
+        FileChange.modified("somePath", "test", type, type)
+
+        then:
+        thrown(AssertionError)
+
+        where:
+        type << [FileType.Missing, FileType.Directory]
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/FileChangeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/FileChangeTest.groovy
@@ -45,15 +45,4 @@ class FileChangeTest extends Specification {
         FileChange.removed("somePath", "test") | "has been removed"
         FileChange.added("somePath", "test")   | "has been added"
     }
-
-    def "change cannot be from #type to #type"() {
-        when:
-        FileChange.modified("somePath", "test", type, type)
-
-        then:
-        thrown(AssertionError)
-
-        where:
-        type << [FileType.Missing, FileType.Directory]
-    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/FileChangeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/FileChangeTest.groovy
@@ -41,8 +41,10 @@ class FileChangeTest extends Specification {
         fileChange.message == "test file somePath ${message}."
 
         where:
-        fileChange                             | message
-        FileChange.removed("somePath", "test") | "has been removed"
-        FileChange.added("somePath", "test")   | "has been added"
+        fileChange                                                   | message
+        FileChange.removed("somePath", "test", FileType.RegularFile) | "has been removed"
+        FileChange.removed("somePath", "test", FileType.Directory)   | "has been removed"
+        FileChange.added("somePath", "test", FileType.RegularFile)   | "has been added"
+        FileChange.added("somePath", "test", FileType.Directory)     | "has been added"
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/TaskFilePropertyCompareStrategyTest.groovy
@@ -292,11 +292,11 @@ class TaskFilePropertyCompareStrategyTest extends Specification {
     }
 
     def added(String path) {
-        FileChange.added(path, "test")
+        FileChange.added(path, "test", FileType.RegularFile)
     }
 
     def removed(String path) {
-        FileChange.removed(path, "test")
+        FileChange.removed(path, "test", FileType.RegularFile)
     }
 
     def modified(String path, FileType previous, FileType current) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/RecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/RecompilationSpecProvider.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.compile.incremental;
 
 import org.gradle.api.Action;
-import org.gradle.api.internal.changedetection.rules.ChangeType;
 import org.gradle.api.internal.changedetection.rules.FileChange;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarChangeProcessor;
@@ -27,6 +26,7 @@ import org.gradle.api.internal.tasks.compile.incremental.jar.PreviousCompilation
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.api.tasks.incremental.InputFileDetails;
+import org.gradle.internal.nativeintegration.filesystem.FileType;
 import org.gradle.internal.util.Alignment;
 
 import java.io.File;
@@ -72,10 +72,10 @@ public class RecompilationSpecProvider {
         for (Alignment<File> fileAlignment : alignment) {
             switch (fileAlignment.getKind()) {
                 case added:
-                    jarChangeProcessor.processChange(new FileChange(fileAlignment.getCurrentValue().getAbsolutePath(), ChangeType.ADDED, "jar"), spec);
+                    jarChangeProcessor.processChange(FileChange.added(fileAlignment.getCurrentValue().getAbsolutePath(), "jar"), spec);
                     break;
                 case removed:
-                    jarChangeProcessor.processChange(new FileChange(fileAlignment.getPreviousValue().getAbsolutePath(), ChangeType.REMOVED, "jar"), spec);
+                    jarChangeProcessor.processChange(FileChange.removed(fileAlignment.getPreviousValue().getAbsolutePath(), "jar"), spec);
                     break;
                 case transformed:
                     // If we detect a transformation in the classpath, we need to recompile, because we could typically be facing the case where
@@ -87,7 +87,7 @@ public class RecompilationSpecProvider {
                     JarSnapshot previousSnapshot = previousCompilationJarSnapshots.get(key);
                     JarSnapshot snapshot = currentJarSnapshots.getSnapshot(key);
                     if (!snapshot.getHash().equals(previousSnapshot.getHash())) {
-                        jarChangeProcessor.processChange(new FileChange(key.getAbsolutePath(), ChangeType.MODIFIED, "jar"), spec);
+                        jarChangeProcessor.processChange(FileChange.modified(key.getAbsolutePath(), "jar", FileType.RegularFile, FileType.RegularFile), spec);
                     }
                     break;
             }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/RecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/RecompilationSpecProvider.java
@@ -72,10 +72,10 @@ public class RecompilationSpecProvider {
         for (Alignment<File> fileAlignment : alignment) {
             switch (fileAlignment.getKind()) {
                 case added:
-                    jarChangeProcessor.processChange(FileChange.added(fileAlignment.getCurrentValue().getAbsolutePath(), "jar"), spec);
+                    jarChangeProcessor.processChange(FileChange.added(fileAlignment.getCurrentValue().getAbsolutePath(), "jar", FileType.RegularFile), spec);
                     break;
                 case removed:
-                    jarChangeProcessor.processChange(FileChange.removed(fileAlignment.getPreviousValue().getAbsolutePath(), "jar"), spec);
+                    jarChangeProcessor.processChange(FileChange.removed(fileAlignment.getPreviousValue().getAbsolutePath(), "jar", FileType.RegularFile), spec);
                     break;
                 case transformed:
                     // If we detect a transformation in the classpath, we need to recompile, because we could typically be facing the case where


### PR DESCRIPTION
When a file changes from File/Directory to Missing, then we report the
changes as "... changed." in the change message. We should better report this change as
"... has been removed".
This is a follow up of #2346, this time without breaking the contract for incremental tasks.