### PR TITLE
Disallow both --module-source-path and -sourcepath

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.util.Requires
 import org.gradle.util.Resources
 import org.gradle.util.TestPrecondition
@@ -25,8 +24,6 @@ import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
-
-import static org.gradle.api.JavaVersion.VERSION_1_9
 
 class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
@@ -644,7 +641,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ':compileJava'
     }
 
-    @Requires(adhoc = {AvailableJavaHomes.getJdk(VERSION_1_9)})
+    @Requires(TestPrecondition.JDK9_OR_LATER)
     def "compile a module"() {
         given:
         buildFile << '''
@@ -660,9 +657,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         '''
 
         when:
-        executer.requireGradleDistribution()
-        executer.withJavaHome AvailableJavaHomes.getJdk(VERSION_1_9).javaHome
-        succeeds "compileJava"
+        run "compileJava"
 
         then:
         noExceptionThrown()
@@ -670,7 +665,8 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         file("build/classes/java/main/io/example/Example.class").exists()
     }
 
-    @Requires(adhoc = {AvailableJavaHomes.getJdk(VERSION_1_9)})
+    @Issue("https://github.com/gradle/gradle/issues/2537")
+    @Requires(TestPrecondition.JDK9_OR_LATER)
     def "compile a module with --module-source-path"() {
         given:
         buildFile << '''
@@ -703,9 +699,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         '''
 
         when:
-        executer.requireGradleDistribution()
-        executer.withJavaHome AvailableJavaHomes.getJdk(VERSION_1_9).javaHome
-        succeeds "compileJava"
+        run "compileJava"
 
         then:
         noExceptionThrown()
@@ -713,6 +707,60 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         file("build/classes/java/main/example/io/example/Example.class").exists()
         file("build/classes/java/main/another/module-info.class").exists()
         file("build/classes/java/main/another/io/another/BaseExample.class").exists()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/2537")
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "compile a module with --module-source-path and sourcepath warns and removes sourcepath"() {
+        given:
+        buildFile << '''
+            plugins {
+                id 'java'
+            }
+            
+            compileJava {
+                options.compilerArgs = ['--module-source-path', files('src/main/java', 'src/main/moreJava').asPath]
+                options.sourcepath = files('src/main/ignoredJava')
+            }
+        '''
+        file("src/main/java/example/module-info.java") << '''
+        module example {
+            exports io.example;
+            requires another;
+        }
+        '''
+        file("src/main/java/example/io/example/Example.java") << '''
+            package io.example;
+            
+            import io.another.BaseExample;
+            
+            public class Example extends BaseExample {}
+        '''
+        file("src/main/moreJava/another/module-info.java") << 'module another { exports io.another; }'
+        file("src/main/moreJava/another/io/another/BaseExample.java") << '''
+            package io.another;
+            
+            public class BaseExample {}
+        '''
+        file("src/main/ignoredJava/ignored/module-info.java") << 'module ignored { exports io.ignored; }'
+        file("src/main/ignoredJava/ignored/io/ignored/IgnoredExample.java") << '''
+            package io.ignored;
+            
+            public class IgnoredExample {}
+        '''
+
+        when:
+        run "compileJava"
+
+        then:
+        noExceptionThrown()
+        result.output.contains("You specified both --module-source-path and a sourcepath. These options are mutually exclusive. Removing sourcepath.")
+        file("build/classes/java/main/example/module-info.class").exists()
+        file("build/classes/java/main/example/io/example/Example.class").exists()
+        file("build/classes/java/main/another/module-info.class").exists()
+        file("build/classes/java/main/another/io/another/BaseExample.class").exists()
+        !file("build/classes/java/main/ignored/module-info.class").exists()
+        !file("build/classes/java/main/ignored/io/ignored/IgnoredExample.class").exists()
     }
 
     def "sourcepath is merged from compilerArgs, but deprecation warning is emitted"() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -209,7 +209,7 @@ public class JavaCompilerArgumentsBuilder {
         while (argIterator.hasNext()) {
             String current = argIterator.next();
             if (current.equals("-sourcepath") || current.equals("--source-path")) {
-                if (silently) {
+                if (!silently) {
                     DeprecationLogger.nagUserOfDeprecated(
                         "Specifying the source path in the CompilerOptions compilerArgs property",
                         "Instead, use the CompilerOptions sourcepath property directly");

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -20,6 +20,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.util.DeprecationLogger;
@@ -30,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class JavaCompilerArgumentsBuilder {
+    public static final Logger LOGGER = Logging.getLogger(JavaCompilerArgumentsBuilder.class);
     public static final String USE_UNSHARED_COMPILER_TABLE_OPTION = "-XDuseUnsharedTable=true";
     public static final String EMPTY_SOURCE_PATH_REF_DIR = "emptySourcePathRef";
 
@@ -159,7 +162,7 @@ public class JavaCompilerArgumentsBuilder {
         }
 
         FileCollection sourcepath = compileOptions.getSourcepath();
-        String userProvidedSourcepath = extractSourcepathFrom(compilerArgs);
+        String userProvidedSourcepath = extractSourcepathFrom(compilerArgs, false);
         if (allowEmptySourcePath || sourcepath != null && !sourcepath.isEmpty() || !userProvidedSourcepath.isEmpty()) {
             args.add("-sourcepath");
             args.add(sourcepath == null ? userProvidedSourcepath : Joiner.on(File.pathSeparator).skipNulls().join(sourcepath.getAsPath(), userProvidedSourcepath.isEmpty() ? null : userProvidedSourcepath));
@@ -191,19 +194,26 @@ public class JavaCompilerArgumentsBuilder {
             return;
         }
         if (compilerArgs != null) {
+            if (compilerArgs.contains("--module-source-path")) {
+                if (!extractSourcepathFrom(args, true).isEmpty()) {
+                    LOGGER.warn("You specified both --module-source-path and a sourcepath. These options are mutually exclusive. Removing sourcepath.");
+                }
+            }
             args.addAll(compilerArgs);
         }
     }
 
-    private String extractSourcepathFrom(List<String> compilerArgs) {
+    private String extractSourcepathFrom(List<String> compilerArgs, boolean silently) {
         Iterator<String> argIterator = compilerArgs.iterator();
         String userProvidedSourcepath = "";
         while (argIterator.hasNext()) {
             String current = argIterator.next();
             if (current.equals("-sourcepath") || current.equals("--source-path")) {
-                DeprecationLogger.nagUserOfDeprecated(
-                    "Specifying the source path in the CompilerOptions compilerArgs property",
-                    "Instead, use the CompilerOptions sourcepath property directly");
+                if (silently) {
+                    DeprecationLogger.nagUserOfDeprecated(
+                        "Specifying the source path in the CompilerOptions compilerArgs property",
+                        "Instead, use the CompilerOptions sourcepath property directly");
+                }
                 argIterator.remove();
                 if (argIterator.hasNext()) {
                     // Only conditional in case the user didn't supply an argument to the -sourcepath option.

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -349,6 +349,16 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         builder.noEmptySourcePath().build() == expected
     }
 
+    def "removes sourcepath when module-source-path is provided"() {
+        given:
+        spec.compileOptions.compilerArgs = ['--module-source-path', '/src/other']
+        def expected = ["-g", "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", "", "--module-source-path", "/src/other"]
+
+        expect:
+        builder.build() == expected
+        builder.noEmptySourcePath().build() == expected
+    }
+
     String defaultEmptySourcePathRefFolder() {
         new File(spec.tempDir, JavaCompilerArgumentsBuilder.EMPTY_SOURCE_PATH_REF_DIR).absolutePath
     }


### PR DESCRIPTION
Java 9 introduces a `--module-source-path` option which is mutually
exclusive with `-sourcepath` or `--source-path`. If they are both
provided, the sourcepath should be stripped and the
`--module-source-path` should remain.

If both have been specified explicitly by the user either as a
`optiions.compilerArgs` argument or, in the case of `sourcepath` as
the `options.sourcepath` property, then a warning should also be
emitted to let the user know that they did something wrong.

Fixes #2537 
