### PR TITLE
Refactor continuous build and play reload methods in preparation for fixing #2085 

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/filewatch/DefaultFileSystemChangeWaiterTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/filewatch/DefaultFileSystemChangeWaiterTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.filewatch
 import org.gradle.api.Action
 import org.gradle.api.internal.file.FileSystemSubset
 import org.gradle.initialization.DefaultBuildCancellationToken
+import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -180,6 +181,11 @@ class DefaultFileSystemChangeWaiterTest extends ConcurrentSpec {
         @Override
         void onChange(FileWatcherEvent event) {
             logger.log(event)
+        }
+
+        @Override
+        void reportChanges(StyledTextOutput logger) {
+
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/DefaultFileWatcherEventListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/DefaultFileWatcherEventListener.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 import static org.gradle.internal.filewatch.FileWatcherEvent.Type.*;
 
-public class ChangeReporter implements FileWatcherEventListener {
+public class DefaultFileWatcherEventListener implements FileWatcherEventListener {
     public static final int SHOW_INDIVIDUAL_CHANGES_LIMIT = 3;
     private static final boolean IS_MAC_OSX = OperatingSystem.current().isMacOsX();
     private final Map<File, FileWatcherEvent.Type> aggregatedEvents = Maps.newLinkedHashMap();

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/FileWatcherEventListenerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/FileWatcherEventListenerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 package org.gradle.internal.filewatch;
 
-import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.Factory;
 
-public interface FileWatcherEventListener {
-    void onChange(FileWatcherEvent event);
-    void reportChanges(StyledTextOutput logger);
+public class FileWatcherEventListenerFactory implements Factory<FileWatcherEventListener> {
+    @Override
+    public FileWatcherEventListener create() {
+        return new DefaultFileWatcherEventListener();
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/filewatch/DefaultFileWatcherEventListenerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/filewatch/DefaultFileWatcherEventListenerTest.groovy
@@ -22,12 +22,12 @@ import spock.lang.Specification
 import static org.gradle.internal.filewatch.FileWatcherEvent.Type.*
 
 
-class ChangeReporterTest extends Specification {
+class DefaultFileWatcherEventListenerTest extends Specification {
     def "should report individual changes when there are less than 4 changes"() {
         given:
         def events = [new FileWatcherEvent(CREATE, new File('/a/b/c1')), new FileWatcherEvent(CREATE, new File('/a/b/c2')), new FileWatcherEvent(CREATE, new File('/a/b/c3'))]
         def logger = Mock(StyledTextOutput)
-        def changeReporter = new ChangeReporter()
+        def changeReporter = new DefaultFileWatcherEventListener()
         when:
         events.each { changeReporter.onChange(it) }
         changeReporter.reportChanges(logger)
@@ -48,7 +48,7 @@ class ChangeReporterTest extends Specification {
             [new FileWatcherEvent(CREATE, file), new FileWatcherEvent(MODIFY, file)]
         }.flatten()
         def logger = Mock(StyledTextOutput)
-        def changeReporter = new ChangeReporter()
+        def changeReporter = new DefaultFileWatcherEventListener()
         when:
         events.each { changeReporter.onChange(it) }
         changeReporter.reportChanges(logger)
@@ -66,7 +66,7 @@ class ChangeReporterTest extends Specification {
 
     def "should not log anything when an empty list is given as input"() {
         def logger = Mock(StyledTextOutput)
-        def changeReporter = new ChangeReporter()
+        def changeReporter = new DefaultFileWatcherEventListener()
         when:
         changeReporter.reportChanges(logger)
         then:
@@ -77,7 +77,7 @@ class ChangeReporterTest extends Specification {
         given:
         def events = [new FileWatcherEvent(CREATE, new File('a')), new FileWatcherEvent(CREATE, new File('a')), new FileWatcherEvent(DELETE, new File('a'))]
         def logger = Mock(StyledTextOutput)
-        def changeReporter = new ChangeReporter()
+        def changeReporter = new DefaultFileWatcherEventListener()
         when:
         events.each { changeReporter.onChange(it) }
         changeReporter.reportChanges(logger)
@@ -95,7 +95,7 @@ class ChangeReporterTest extends Specification {
         }.flatten()
         events << new FileWatcherEvent(DELETE, events[0].file)
         def logger = Mock(StyledTextOutput)
-        def changeReporter = new ChangeReporter()
+        def changeReporter = new DefaultFileWatcherEventListener()
         when:
         events.each { changeReporter.onChange(it) }
         changeReporter.reportChanges(logger)
@@ -111,7 +111,7 @@ class ChangeReporterTest extends Specification {
         given:
         def events = [new FileWatcherEvent(CREATE, new File('a')), new FileWatcherEvent(MODIFY, new File('a')), new FileWatcherEvent(MODIFY, new File('a'))]
         def logger = Mock(StyledTextOutput)
-        def changeReporter = new ChangeReporter()
+        def changeReporter = new DefaultFileWatcherEventListener()
         when:
         events.each { changeReporter.onChange(it) }
         changeReporter.reportChanges(logger)
@@ -125,7 +125,7 @@ class ChangeReporterTest extends Specification {
         given:
         def events = [new FileWatcherEvent(CREATE, new File('a')), new FileWatcherEvent(UNDEFINED, null), new FileWatcherEvent(MODIFY, new File('a')), new FileWatcherEvent(MODIFY, new File('a')), new FileWatcherEvent(UNDEFINED, null)]
         def logger = Mock(StyledTextOutput)
-        def changeReporter = new ChangeReporter()
+        def changeReporter = new DefaultFileWatcherEventListener()
         when:
         events.each { changeReporter.onChange(it) }
         changeReporter.reportChanges(logger)

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
@@ -20,7 +20,7 @@ import groovy.transform.TupleConstructor
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.file.TestFile
 
-import static org.gradle.internal.filewatch.ChangeReporter.SHOW_INDIVIDUAL_CHANGES_LIMIT
+import static org.gradle.internal.filewatch.DefaultFileWatcherEventListener.SHOW_INDIVIDUAL_CHANGES_LIMIT
 import static org.gradle.internal.filewatch.DefaultFileSystemChangeWaiterFactory.QUIET_PERIOD_SYSPROP
 
 // Developer is able to easily determine the file(s) that triggered a rebuild

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/InProcessBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/InProcessBuildActionExecuter.java
@@ -30,7 +30,7 @@ public class InProcessBuildActionExecuter implements BuildActionExecuter<BuildAc
     private final GradleLauncherFactory gradleLauncherFactory;
     private final BuildActionRunner buildActionRunner;
 
-    public InProcessBuildActionExecuter(GradleLauncherFactory gradleLauncherFactory, BuildActionRunner buildActionRunner) {
+    public InProcessBuildActionExecuter(BuildActionRunner buildActionRunner, GradleLauncherFactory gradleLauncherFactory) {
         this.gradleLauncherFactory = gradleLauncherFactory;
         this.buildActionRunner = buildActionRunner;
     }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -21,6 +21,8 @@ import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
+import org.gradle.internal.filewatch.DefaultFileSystemChangeWaiterFactory;
+import org.gradle.internal.filewatch.FileWatcherEventListenerFactory;
 import org.gradle.internal.filewatch.FileWatcherFactory;
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.logging.LoggingManagerInternal;
@@ -81,7 +83,8 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                                         new ValidatingBuildActionRunner(
                                                             new ChainingBuildActionRunner(buildActionRunners))),
                                                     buildOperationListenerManager, registrations))),
-                                        fileWatcherFactory,
+                                        new DefaultFileSystemChangeWaiterFactory(fileWatcherFactory),
+                                        new FileWatcherEventListenerFactory(),
                                         inputsListener,
                                         styledTextOutputFactory,
                                         executorFactory),

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -22,6 +22,7 @@ import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.filewatch.DefaultFileSystemChangeWaiterFactory;
+import org.gradle.internal.filewatch.FileSystemChangeWaiterFactory;
 import org.gradle.internal.filewatch.FileWatcherEventListenerFactory;
 import org.gradle.internal.filewatch.FileWatcherFactory;
 import org.gradle.internal.invocation.BuildActionRunner;
@@ -62,12 +63,13 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                           List<SubscribableBuildActionRunnerRegistration> registrations,
                                           GradleLauncherFactory gradleLauncherFactory,
                                           BuildOperationListenerManager buildOperationListenerManager,
-                                          FileWatcherFactory fileWatcherFactory,
                                           TaskInputsListener inputsListener,
                                           StyledTextOutputFactory styledTextOutputFactory,
                                           ExecutorFactory executorFactory,
                                           LoggingManagerInternal loggingManager,
                                           GradleUserHomeScopeServiceRegistry userHomeServiceRegistry,
+                                          FileSystemChangeWaiterFactory fileSystemChangeWaiterFactory,
+                                          FileWatcherEventListenerFactory fileWatcherEventListenerFactory,
                                           ParallelismConfigurationManager parallelismConfigurationManager) {
             return new SetupLoggingActionExecuter(
                 new SessionFailureReportingActionExecuter(
@@ -85,8 +87,8 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                                     buildOperationListenerManager,
                                                     registrations),
                                                 gradleLauncherFactory)),
-                                        new DefaultFileSystemChangeWaiterFactory(fileWatcherFactory),
-                                        new FileWatcherEventListenerFactory(),
+                                        fileSystemChangeWaiterFactory,
+                                        fileWatcherEventListenerFactory,
                                         inputsListener,
                                         styledTextOutputFactory,
                                         executorFactory),
@@ -94,6 +96,14 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                             parallelismConfigurationManager)),
                     styledTextOutputFactory),
                 loggingManager);
+        }
+
+        FileWatcherEventListenerFactory createFileWatcherEventListenerFactory() {
+            return new FileWatcherEventListenerFactory();
+        }
+
+        FileSystemChangeWaiterFactory createFileSystemChangeWaiterFactory(FileWatcherFactory fileWatcherFactory) {
+            return new DefaultFileSystemChangeWaiterFactory(fileWatcherFactory);
         }
 
         ExecuteBuildActionRunner createExecuteBuildActionRunner() {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -77,12 +77,14 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                 new ServicesSetupBuildActionExecuter(
                                     new ContinuousBuildActionExecuter(
                                         new BuildTreeScopeBuildActionExecuter(
-                                            new InProcessBuildActionExecuter(gradleLauncherFactory,
+                                            new InProcessBuildActionExecuter(
                                                 new SubscribableBuildActionRunner(
                                                     new RunAsBuildOperationBuildActionRunner(
                                                         new ValidatingBuildActionRunner(
                                                             new ChainingBuildActionRunner(buildActionRunners))),
-                                                    buildOperationListenerManager, registrations))),
+                                                    buildOperationListenerManager,
+                                                    registrations),
+                                                gradleLauncherFactory)),
                                         new DefaultFileSystemChangeWaiterFactory(fileWatcherFactory),
                                         new FileWatcherEventListenerFactory(),
                                         inputsListener,

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/exec/InProcessBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/exec/InProcessBuildActionExecuterTest.groovy
@@ -52,7 +52,7 @@ class InProcessBuildActionExecuterTest extends Specification {
         getStartParameter() >> startParameter
     }
     final ServiceRegistry sessionServices = Mock()
-    final InProcessBuildActionExecuter executer = new InProcessBuildActionExecuter(factory, actionRunner)
+    final InProcessBuildActionExecuter executer = new InProcessBuildActionExecuter(actionRunner, factory)
 
     def setup() {
         _ * param.buildRequestMetaData >> metaData

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
@@ -27,9 +27,9 @@ import org.gradle.initialization.ReportedException
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.filewatch.FileSystemChangeWaiter
 import org.gradle.internal.filewatch.FileSystemChangeWaiterFactory
+import org.gradle.internal.filewatch.FileWatcherEventListenerFactory
 import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.launcher.exec.BuildActionExecuter
 import org.gradle.launcher.exec.BuildActionParameters
@@ -52,6 +52,7 @@ class ContinuousBuildActionExecuterTest extends Specification {
     def requestContext = new DefaultBuildRequestContext(requestMetadata, cancellationToken, new NoOpBuildEventConsumer())
     def actionParameters = Stub(BuildActionParameters)
     def waiterFactory = Mock(FileSystemChangeWaiterFactory)
+    def changeWatcherFactory = new FileWatcherEventListenerFactory()
     def waiter = Mock(FileSystemChangeWaiter)
     def inputsListener = new DefaultTaskInputsListener()
     @AutoCleanup("stop")
@@ -180,7 +181,6 @@ class ContinuousBuildActionExecuterTest extends Specification {
     }
 
     private ContinuousBuildActionExecuter executer() {
-        new ContinuousBuildActionExecuter(delegate, inputsListener, new TestStyledTextOutputFactory(), OperatingSystem.current(), executorFactory, waiterFactory)
+        new ContinuousBuildActionExecuter(delegate, waiterFactory, changeWatcherFactory, inputsListener, new TestStyledTextOutputFactory(), executorFactory)
     }
-
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/DefaultVersionedPlayRunAdapter.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/DefaultVersionedPlayRunAdapter.java
@@ -157,7 +157,7 @@ public abstract class DefaultVersionedPlayRunAdapter implements VersionedPlayRun
 
     }
 
-    private static class PendingChanges {
+    private static class PendingChanges implements Serializable {
         private int pendingChanges;
 
         synchronized void more() {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/DefaultVersionedPlayRunAdapter.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/DefaultVersionedPlayRunAdapter.java
@@ -152,7 +152,7 @@ public abstract class DefaultVersionedPlayRunAdapter implements VersionedPlayRun
     }
 
     @Override
-    public void rebuildInProgress() {
+    public void expectPendingChanges() {
         pendingChanges.more();
 
     }
@@ -166,7 +166,7 @@ public abstract class DefaultVersionedPlayRunAdapter implements VersionedPlayRun
 
         synchronized void done() {
             pendingChanges--;
-            
+
             if (pendingChanges == 0) {
                 notifyAll();
             }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/DefaultVersionedPlayRunAdapter.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/DefaultVersionedPlayRunAdapter.java
@@ -165,7 +165,8 @@ public abstract class DefaultVersionedPlayRunAdapter implements VersionedPlayRun
         }
 
         synchronized void done() {
-            pendingChanges--;
+            // Clamp to 0
+            pendingChanges = Math.max(0, pendingChanges-1);
 
             if (pendingChanges == 0) {
                 notifyAll();

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationDeploymentHandle.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationDeploymentHandle.java
@@ -52,7 +52,7 @@ public class PlayApplicationDeploymentHandle implements DeploymentHandle {
             }
         });
         if (isRunning()) {
-            runnerToken.rebuildInProgress();
+            runnerToken.expectPendingChanges();
         }
     }
 

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunnerToken.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunnerToken.java
@@ -54,7 +54,7 @@ public class PlayApplicationRunnerToken {
         return !stopped.get();
     }
 
-    public void rebuildInProgress() {
-        workerServer.rebuildInProgress();
+    public void expectPendingChanges() {
+        workerServer.expectPendingChanges();
     }
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayRunWorkerServerProtocol.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayRunWorkerServerProtocol.java
@@ -21,5 +21,5 @@ import org.gradle.internal.concurrent.Stoppable;
 public interface PlayRunWorkerServerProtocol extends Stoppable {
     void buildSuccess();
     void buildError(Throwable throwable);
-    void rebuildInProgress();
+    void expectPendingChanges();
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayWorkerServer.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayWorkerServer.java
@@ -99,8 +99,8 @@ public class PlayWorkerServer implements Action<WorkerProcessContext>, PlayRunWo
     }
 
     @Override
-    public void rebuildInProgress() {
-        runAdapter.rebuildInProgress();
+    public void expectPendingChanges() {
+        runAdapter.expectPendingChanges();
     }
 
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/VersionedPlayRunAdapter.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/VersionedPlayRunAdapter.java
@@ -34,5 +34,5 @@ public interface VersionedPlayRunAdapter {
 
     Iterable<Dependency> getRunsupportClasspathDependencies(String playVersion, String scalaCompatibilityVersion);
 
-    void rebuildInProgress();
+    void expectPendingChanges();
 }


### PR DESCRIPTION
This doesn't change any behavior, but it renames some of the methods and pulls out a couple of existing types (with better names) so the diff for fixing #2085 is simpler.