### PR TITLE
Fix `StringIndexOutOfBoundsException` on Windows

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -192,6 +192,7 @@ We would like to thank the following community members for making contributions 
  - [Seth Jackson](https://github.com/sethjackson) - Fix the default daemon JVM args on Java 8 (gradle/gradle#2310)
  - [Steve Dougherty](https://github.com/Thynix) - Prevent spurious gradle-wrapper.jar changes (gradle/gradle#2183)
  - [Marcin Zajączkowski](https://github.com/szpak) - Add `@since` tag to `Project.findProperty()` (gradle/gradle#2403)
+ - [Bo Zhang](https://github.com/blindpirate) - Fix `StringIndexOutOfBoundsException` on Windows (#2291)
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
@@ -122,7 +122,7 @@ public abstract class AbstractLineChoppingStyledTextOutput extends AbstractStyle
                     data = text.substring(start, pos);
                 }
 
-                if (!data.isEmpty()) {
+                if (data.length() > 0) {
                     doLineText(data);
                 }
             }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
@@ -185,6 +185,8 @@ public abstract class AbstractLineChoppingStyledTextOutput extends AbstractStyle
                 context.next(2);
                 context.reset();
                 context.setState(START_LINE_STATE);
+            } else if (context.isCurrentCharEquals('\r')) {
+                context.next();
             } else {
                 context.seenCharsFromEol = 0;
                 context.next(2);

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutput.java
@@ -110,11 +110,20 @@ public abstract class AbstractLineChoppingStyledTextOutput extends AbstractStyle
         }
 
         void flushLineText() {
+            // Left over data from previous append is only possible when a multi-chars new line is
+            // been processed and split across multiple append calls.
             if (start < pos) {
-                if (start < 0) {
-                    doLineText(eol.substring(0, AbstractLineChoppingStyledTextOutput.this.seenCharsFromEol) + text.substring(0, seenCharsFromEol - AbstractLineChoppingStyledTextOutput.this.seenCharsFromEol));
-                } else {
-                    doLineText(text.substring(start, pos));
+                String data = "";
+                // Flushing data split across previous and current appending
+                if (start < 0 && pos >= 0) {
+                    data = eol.substring(0, Math.abs(start)) + text.substring(0, pos);
+                // Flushing data coming only from current appending
+                } else if (start >= 0) {
+                    data = text.substring(start, pos);
+                }
+
+                if (!data.isEmpty()) {
+                    doLineText(data);
                 }
             }
         }
@@ -188,8 +197,8 @@ public abstract class AbstractLineChoppingStyledTextOutput extends AbstractStyle
             } else if (context.isCurrentCharEquals('\r')) {
                 context.next();
             } else {
+                context.next();
                 context.seenCharsFromEol = 0;
-                context.next(2);
                 context.setState(INITIAL_STATE);
             }
         }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
@@ -161,6 +161,30 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
         result.toString() == "[\r]{eol}{start}[a]"
     }
 
+    def "can append data after a carriage return on Windows"() {
+        System.setProperty("line.separator", "\r\n")
+        def output = output()
+
+        when:
+        output.text('\r')
+        output.text('a')
+
+        then:
+        result.toString() == "[\ra]"
+    }
+
+    def "can append new line after multiple carriage return followed by data on Windows"() {
+        System.setProperty("line.separator", "\r\n")
+        def output = output()
+
+        when:
+        output.text('\r\r\r')
+        output.text('\r\r\r\na')
+
+        then:
+        result.toString() == "[\r\r][\r\r\r]{eol}{start}[a]"
+    }
+
     def "can split eol across style changes"() {
         System.setProperty("line.separator", "----")
         def output = output()

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/AbstractLineChoppingStyledTextOutputTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.logging.text
 import org.gradle.internal.SystemProperties
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -145,6 +146,19 @@ class AbstractLineChoppingStyledTextOutputTest extends Specification {
 
         then:
         result.toString() == "[a][---][a][---][a]"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/2077")
+    def "can append consecutive return character on Windows"() {
+        System.setProperty("line.separator", "\r\n")
+        def output = output()
+
+        when:
+        output.text('\r')
+        output.text("\r\na")
+
+        then:
+        result.toString() == "[\r]{eol}{start}[a]"
     }
 
     def "can split eol across style changes"() {


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle/issues/2077  for context. This PR is the code review of PR https://github.com/gradle/gradle/pull/2291 with additional fixes.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=dl%2Fpr-2291)
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
