### PR TITLE
Show progress of buildSrc build on CLI progress bar

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildProgressLoggerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildProgressLoggerIntegrationTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.progress
+
+import org.gradle.integtests.fixtures.AbstractConsoleFunctionalSpec
+import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.junit.Rule
+
+class BuildProgressLoggerIntegrationTest extends AbstractConsoleFunctionalSpec {
+    private static final String SERVER_RESOURCE = 'test-resource'
+
+    @Rule
+    BlockingHttpServer server = new BlockingHttpServer(40000)
+
+    def setup() {
+        server.start()
+    }
+
+    def "buildSrc task progress is displayed in initialization phase"() {
+        given:
+        file("buildSrc/build.gradle") << """
+            // NOTE: groovy plugin is automatically applied to buildSrc
+            
+            repositories {
+                jcenter()
+            }
+            dependencies {
+                testCompile 'junit:junit:4.12'
+            }
+"""
+        file("buildSrc/src/test/groovy/org/gradle/integtest/BuildSrcTest.groovy") << """
+            package org.gradle.integtest
+            import org.junit.Test
+            
+            public class BuildSrcTest {
+                @Test
+                public void test() {
+                    ${server.callFromBuild(SERVER_RESOURCE)}
+                }
+            }
+        """
+
+        def testExecution = server.expectAndBlock(SERVER_RESOURCE)
+
+        buildFile << "task hello"
+
+        when:
+        def gradleHandle = executer.withTasks('hello').start()
+        testExecution.waitForAllPendingCalls()
+
+        then:
+        ConcurrentTestUtil.poll {
+            // This asserts that we see incremental progress, not just 0% => 100%
+            gradleHandle.standardOutput.matches(/(?s).*-> \d{2}% INITIALIZING \[.*$/)
+        }
+
+        testExecution.releaseAll()
+        gradleHandle.waitForFinish()
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
@@ -29,7 +29,8 @@ public class BuildProgressLogger implements LoggerProvider {
     public static final String WAITING_PHASE_DESCRIPTION = "WAITING";
 
     private final ProgressLoggerProvider loggerProvider;
-    private boolean taskGraphPopulated;
+    private boolean rootBuildInitComplete;
+    private boolean rootTaskGraphPopulated;
 
     private ProgressLogger buildProgress;
 
@@ -47,6 +48,7 @@ public class BuildProgressLogger implements LoggerProvider {
 
     public void settingsEvaluated() {
         buildProgress.completed();
+        rootBuildInitComplete = true;
     }
 
     public void projectsLoaded(int totalProjects) {
@@ -56,21 +58,34 @@ public class BuildProgressLogger implements LoggerProvider {
     public void beforeEvaluate(String projectPath) {}
 
     public void afterEvaluate(String projectPath) {
-        if (!taskGraphPopulated) {
+        if (!rootTaskGraphPopulated) {
             buildProgress.progress("", false);
         }
     }
 
     public void graphPopulated(int totalTasks) {
-        taskGraphPopulated = true;
+        rootTaskGraphPopulated = true;
         buildProgress.completed();
         buildProgress = loggerProvider.start(EXECUTION_PHASE_DESCRIPTION, EXECUTION_PHASE_SHORT_DESCRIPTION, totalTasks);
+    }
+
+    public void nestedTaskGraphPopulated(int totalTasks) {
+        if (!rootBuildInitComplete) {
+            buildProgress.completed();
+            buildProgress = loggerProvider.start(INITIALIZATION_PHASE_DESCRIPTION, INITIALIZATION_PHASE_SHORT_DESCRIPTION, totalTasks);
+        }
     }
 
     public void beforeExecute() {}
 
     public void afterExecute(boolean taskFailed) {
         buildProgress.progress("", taskFailed);
+    }
+
+    public void afterNestedExecute(boolean taskFailed) {
+        if (!rootBuildInitComplete) {
+            afterExecute(taskFailed);
+        }
     }
 
     public void beforeComplete() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressFilterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressFilterTest.groovy
@@ -70,7 +70,20 @@ class BuildProgressFilterTest extends Specification {
         then: 0 * logger._
     }
 
-    def "does not delegate when building nested projects"() {
+    def "delegates task graph population and execution when building nested projects"() {
+        gradle.getParent() >> Stub(Gradle)
+
+        when:
+        f.graphPopulated(graph)
+        f.afterExecute(task, Mock(TaskState))
+
+        then:
+        1 * logger.nestedTaskGraphPopulated(3)
+        1 * logger.afterNestedExecute(false)
+        0 * logger._
+    }
+
+    def "does not delegate when configuring nested builds"() {
         gradle.getParent() >> Stub(Gradle)
 
         when:
@@ -79,8 +92,6 @@ class BuildProgressFilterTest extends Specification {
         f.projectsLoaded(gradle)
         f.beforeEvaluate(project)
         f.afterEvaluate(project, null)
-        f.graphPopulated(graph)
-        f.afterExecute(task, null)
         f.buildFinished(result)
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressLoggerTest.groovy
@@ -42,6 +42,38 @@ class BuildProgressLoggerTest extends Specification {
         0 * _
     }
 
+    def "logs progress of nested build tasks during initialization phase"() {
+        when:
+        buildProgressLogger.buildStarted()
+        buildProgressLogger.nestedTaskGraphPopulated(50)
+
+        then:
+        1 * provider.start(BuildProgressLogger.INITIALIZATION_PHASE_DESCRIPTION, _, 0) >> buildProgress
+        1 * buildProgress.completed()
+        1 * provider.start(BuildProgressLogger.INITIALIZATION_PHASE_DESCRIPTION, _, 50) >> buildProgress
+        0 * _
+
+        when:
+        buildProgressLogger.afterNestedExecute(false)
+
+        then:
+        1 * buildProgress.progress("", false)
+        0 * _
+
+        when:
+        buildProgressLogger.settingsEvaluated()
+
+        then:
+        1 * buildProgress.completed()
+        0 * _
+
+        when:
+        buildProgressLogger.afterNestedExecute(false)
+
+        then:
+        0 * _
+    }
+
     def "logs configuration phase"() {
         when:
         buildProgressLogger.buildStarted()


### PR DESCRIPTION
Allow BuildProgressFilter to send task graph complete and
after task executed events to BuildProgressLogger for nested builds.

BuildProgressLogger will increment progress during initialization
phase.

Issue: #1538

### Context
[Branch build](https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger&branch_Gradle_Check=ew%2Flogging%2Fbuildsrc-progress&tab=buildTypeStatusDiv)

### Contributor Checklist
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
