### PR TITLE
Abbreviate long qualified test classes when displaying in console

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -10,29 +10,6 @@ Add-->
 ### Example new and noteworthy
 -->
 
-### Features for easier plugin authoring
-
-While it is easy for a plugin author to extend the Gradle DSL to add top level blocks to the DSL using project extensions, in previous versions of Gradle it was awkward to create a deeply nested DSL inside these top level blocks, often requiring the use of internal Gradle APIs.
-
-In this release of Gradle, API methods have been added to allow a plugin author to create nested DSL elements. See the [example in the user guide](userguide/custom_plugins.html#sec:nested_dsl_elements) section on custom plugins.
-
-### Better stale output cleanup
-
-Sometimes, tasks may yield incorrect results since earlier versions of Gradle or other processes created files in their output directories.
-Gradle now is able to detect this situation and cleans up the directories if it is safe to do so.
-Currently, only outputs within the `build` directory and directories registered as targets for the `clean` task are considered safe to remove.
-
-## Promoted features
-
-Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
-See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
-
-The following are the features that have been promoted in this Gradle release.
-
-<!--
-### Example promoted
--->
-
 ### Support for Google Cloud Storage backed repositories
 
 It is now possible to consume dependencies from, and publish to, [Google Cloud Storage](https://cloud.google.com/storage/) buckets when using [`MavenArtifactRepository`](dsl/org.gradle.api.artifacts.repositories.MavenArtifactRepository.html) or [`IvyArtifactRepository`](dsl/org.gradle.api.artifacts.repositories.IvyArtifactRepository.html).
@@ -50,6 +27,33 @@ It is now possible to consume dependencies from, and publish to, [Google Cloud S
 Downloading dependencies from Google Cloud Storage is supported for Maven and Ivy type repositories as shown above. Publishing to Google Cloud Storage is supported with both the [Ivy Publishing](userguide/publishing_ivy.html) and [Maven Publishing](userguide/publishing_maven.html) plugins, as well as when using an `IvyArtifactRepository` with an `Upload` task (see section [publishing artifacts of the user guide](userguide/artifact_management.html#sec:publishing_artifacts)).
 
 Please see the [repositories section of the dependency management chapter](userguide/dependency_management.html#sec:repositories) in the user guide for more information on configuring Google Cloud Storage repository access.
+
+### Features for easier plugin authoring
+
+While it is easy for a plugin author to extend the Gradle DSL to add top level blocks to the DSL using project extensions, in previous versions of Gradle it was awkward to create a deeply nested DSL inside these top level blocks, often requiring the use of internal Gradle APIs.
+
+In this release of Gradle, API methods have been added to allow a plugin author to create nested DSL elements. See the [example in the user guide](userguide/custom_plugins.html#sec:nested_dsl_elements) section on custom plugins.
+
+### Better stale output cleanup
+
+Sometimes, tasks may yield incorrect results since earlier versions of Gradle or other processes created files in their output directories.
+Gradle now is able to detect this situation and cleans up the directories if it is safe to do so.
+Currently, only outputs within the `build` directory and directories registered as targets for the `clean` task are considered safe to remove.
+
+### CLI abbreviates long test names
+
+In Gradle 4.1, the Gradle CLI began displaying tests in-progress. We received feedback that long packages and test names caused the test name to be truncated or omitted. This version will abbreviate java packages of long test names to 60 characters to make it highly likely to fit on terminal screens. 
+
+## Promoted features
+
+Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
+See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
+
+The following are the features that have been promoted in this Gradle release.
+
+<!--
+### Example promoted
+-->
 
 ## Fixed issues
 

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
@@ -97,8 +97,8 @@ class ConsoleJvmTestWorkerFunctionalTest extends AbstractConsoleFunctionalSpec {
 
         then:
         ConcurrentTestUtil.poll {
-            assert matchesOutput(gradleHandle.standardOutput, ".*> :test > Executing test org\\.\\.\\.AdvancedJavaPackageAbbreviatingClassFunctionalTest.*")
-            assert matchesOutput(gradleHandle.standardOutput, ".*> :test > Executing test \\.\\.\\.EvenMoreAdvancedJavaPackageAbbreviatingJavaClassFunctionalTest.*")
+            assert containsTestExecutionWorkInProgressLine(gradleHandle, ':test', 'org...AdvancedJavaPackageAbbreviatingClassFunctionalTest')
+            assert containsTestExecutionWorkInProgressLine(gradleHandle, ':test', '...EvenMoreAdvancedJavaPackageAbbreviatingJavaClassFunctionalTest')
         }
 
         testExecution.releaseAll()

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
@@ -84,6 +84,27 @@ class ConsoleJvmTestWorkerFunctionalTest extends AbstractConsoleFunctionalSpec {
         gradleHandle.waitForFinish()
     }
 
+    def "shows abbreviated package when qualified test class is longer than 60 characters"() {
+        given:
+        buildFile << testableJavaProject()
+        file('src/test/java/org/gradle/AdvancedJavaPackageAbbreviatingClassFunctionalTest.java') << junitTest('AdvancedJavaPackageAbbreviatingClassFunctionalTest', SERVER_RESOURCE_1)
+        file('src/test/java/org/gradle/EvenMoreAdvancedJavaPackageAbbreviatingJavaClassFunctionalTest.java') << junitTest('EvenMoreAdvancedJavaPackageAbbreviatingJavaClassFunctionalTest', SERVER_RESOURCE_2)
+        def testExecution = server.expectConcurrentAndBlock(SERVER_RESOURCE_1, SERVER_RESOURCE_2)
+
+        when:
+        def gradleHandle = executer.withTasks('test').start()
+        testExecution.waitForAllPendingCalls()
+
+        then:
+        ConcurrentTestUtil.poll {
+            assert matchesOutput(gradleHandle.standardOutput, ".*> :test > Executing test org\\.\\.\\.AdvancedJavaPackageAbbreviatingClassFunctionalTest.*")
+            assert matchesOutput(gradleHandle.standardOutput, ".*> :test > Executing test \\.\\.\\.EvenMoreAdvancedJavaPackageAbbreviatingJavaClassFunctionalTest.*")
+        }
+
+        testExecution.releaseAll()
+        gradleHandle.waitForFinish()
+    }
+
     private String junitTest(String testClassName, String serverResource) {
         """
             package org.gradle;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/JavaClassNameFormatter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/JavaClassNameFormatter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks.testing.logging;
+
+import javax.annotation.Nullable;
+
+public class JavaClassNameFormatter {
+    private static final char PACKAGE_SEPARATOR = '.';
+
+    public static String abbreviateJavaPackage(@Nullable String qualifiedClassName, int maxLength) {
+        if (qualifiedClassName == null || qualifiedClassName.length() <= maxLength || qualifiedClassName.indexOf(PACKAGE_SEPARATOR) == -1) {
+            return qualifiedClassName;
+        }
+
+        final int maxLengthWithoutEllipsis = maxLength - 3;
+        int beginIdx = 0;
+        // We always want to include className, even if longer than max length
+        int endIdx = qualifiedClassName.lastIndexOf(PACKAGE_SEPARATOR);
+        int iterations = 0;
+
+        while(beginIdx + (qualifiedClassName.length() - endIdx) <= maxLengthWithoutEllipsis) {
+            // Alternate appending packages at beginning and end until we reach max length
+            if (iterations % 2 == 0) {
+                int tmp = qualifiedClassName.indexOf(PACKAGE_SEPARATOR, beginIdx + 1);
+                if (tmp == -1 || tmp + (qualifiedClassName.length() - endIdx) > maxLengthWithoutEllipsis) {
+                    break;
+                }
+                beginIdx = tmp;
+            } else {
+                int tmp = qualifiedClassName.lastIndexOf(PACKAGE_SEPARATOR, endIdx - 1);
+                if (tmp == -1 || beginIdx + (qualifiedClassName.length() - tmp) > maxLengthWithoutEllipsis) {
+                    break;
+                }
+                endIdx = tmp;
+            }
+            iterations++;
+        }
+
+        return qualifiedClassName.substring(0, beginIdx) + "..." + qualifiedClassName.substring(endIdx + 1);
+    }
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/JavaClassNameFormatter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/JavaClassNameFormatter.java
@@ -15,13 +15,13 @@
  */
 package org.gradle.api.internal.tasks.testing.logging;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 public class JavaClassNameFormatter {
     private static final char PACKAGE_SEPARATOR = '.';
 
-    public static String abbreviateJavaPackage(@Nullable String qualifiedClassName, int maxLength) {
-        if (qualifiedClassName == null || qualifiedClassName.length() <= maxLength || qualifiedClassName.indexOf(PACKAGE_SEPARATOR) == -1) {
+    public static String abbreviateJavaPackage(@Nonnull String qualifiedClassName, int maxLength) {
+        if (qualifiedClassName.length() <= maxLength || qualifiedClassName.indexOf(PACKAGE_SEPARATOR) == -1) {
             return qualifiedClassName;
         }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/TestWorkerProgressListener.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/TestWorkerProgressListener.java
@@ -33,7 +33,6 @@ import java.util.Map;
 public class TestWorkerProgressListener implements TestListenerInternal {
 
     private static final int MAX_TEST_NAME_LENGTH = 60;
-    private static final char PACKAGE_SEPARATOR = '.';
 
     private final ProgressLoggerFactory factory;
     private final ProgressLogger parentProgressLogger;
@@ -101,39 +100,7 @@ public class TestWorkerProgressListener implements TestListenerInternal {
     private String createProgressLoggerDescription(TestDescriptorInternal testDescriptor) {
         DecoratingTestDescriptor decoratingTestDescriptor = (DecoratingTestDescriptor)testDescriptor;
         DefaultTestClassDescriptor defaultTestClassDescriptor = (DefaultTestClassDescriptor)decoratingTestDescriptor.getDescriptor();
-        return "Executing test " + abbreviateJavaPackage(defaultTestClassDescriptor.getClassName());
-    }
-
-    protected String abbreviateJavaPackage(String qualifiedClassName) {
-        if (qualifiedClassName == null || qualifiedClassName.length() <= MAX_TEST_NAME_LENGTH || qualifiedClassName.indexOf(PACKAGE_SEPARATOR) == -1) {
-            return qualifiedClassName;
-        }
-
-        final int maxLengthWithoutEllipsis = MAX_TEST_NAME_LENGTH - 3;
-        int beginIdx = 0;
-        // We always want to include className, even if longer than max length
-        int endIdx = qualifiedClassName.lastIndexOf(PACKAGE_SEPARATOR);
-        int iterations = 0;
-
-        while(beginIdx + (qualifiedClassName.length() - endIdx) <= maxLengthWithoutEllipsis) {
-            // Alternate appending packages at beginning and end until we reach max length
-            if (iterations % 2 == 0) {
-                int tmp = qualifiedClassName.indexOf(PACKAGE_SEPARATOR, beginIdx + 1);
-                if (tmp == -1 || tmp + (qualifiedClassName.length() - endIdx) > maxLengthWithoutEllipsis) {
-                    break;
-                }
-                beginIdx = tmp;
-            } else {
-                int tmp = qualifiedClassName.lastIndexOf(PACKAGE_SEPARATOR, endIdx - 1);
-                if (tmp == -1 || beginIdx + (qualifiedClassName.length() - tmp) > maxLengthWithoutEllipsis) {
-                    break;
-                }
-                endIdx = tmp;
-            }
-            iterations++;
-        }
-
-        return qualifiedClassName.substring(0, beginIdx) + "..." + qualifiedClassName.substring(endIdx + 1);
+        return "Executing test " + JavaClassNameFormatter.abbreviateJavaPackage(defaultTestClassDescriptor.getClassName(), MAX_TEST_NAME_LENGTH);
     }
 
     Map<String, ProgressLogger> getTestWorkerProgressLoggers() {

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/JavaClassNameFormatterTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/JavaClassNameFormatterTest.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks.testing.logging
+
+import spock.lang.Specification
+
+class JavaClassNameFormatterTest extends Specification {
+    def "abbreviates long java packages"() {
+        expect:
+        JavaClassNameFormatter.abbreviateJavaPackage(null, 60) == null
+        JavaClassNameFormatter.abbreviateJavaPackage("", 60) == ""
+        JavaClassNameFormatter.abbreviateJavaPackage("org.gradle.FooTest", 60) == "org.gradle.FooTest"
+        JavaClassNameFormatter.abbreviateJavaPackage("TestNoPackageFunctionalIntegrationTestWithAReallyReallyLongName", 60) == "TestNoPackageFunctionalIntegrationTestWithAReallyReallyLongName"
+        JavaClassNameFormatter.abbreviateJavaPackage("org.gradle.api.internal.tasks.testing.logging.TestWorkerProgressListenerTest", 60) == "org.gradle...testing.logging.TestWorkerProgressListenerTest"
+        JavaClassNameFormatter.abbreviateJavaPackage("short.pkg.TestWorkerProgressListenerIntegrationTestWithAReallyReallyLongName", 60) == "...TestWorkerProgressListenerIntegrationTestWithAReallyReallyLongName"
+    }
+}

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/JavaClassNameFormatterTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/JavaClassNameFormatterTest.groovy
@@ -20,7 +20,6 @@ import spock.lang.Specification
 class JavaClassNameFormatterTest extends Specification {
     def "abbreviates long java packages"() {
         expect:
-        JavaClassNameFormatter.abbreviateJavaPackage(null, 60) == null
         JavaClassNameFormatter.abbreviateJavaPackage("", 60) == ""
         JavaClassNameFormatter.abbreviateJavaPackage("org.gradle.FooTest", 60) == "org.gradle.FooTest"
         JavaClassNameFormatter.abbreviateJavaPackage("TestNoPackageFunctionalIntegrationTestWithAReallyReallyLongName", 60) == "TestNoPackageFunctionalIntegrationTestWithAReallyReallyLongName"

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestWorkerProgressListenerTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestWorkerProgressListenerTest.groovy
@@ -180,16 +180,6 @@ class TestWorkerProgressListenerTest extends Specification {
         testWorkerProgressListener.testWorkerProgressLoggers.isEmpty()
     }
 
-    def "abbreviates long java packages"() {
-        expect:
-        testWorkerProgressListener.abbreviateJavaPackage(null) == null
-        testWorkerProgressListener.abbreviateJavaPackage("") == ""
-        testWorkerProgressListener.abbreviateJavaPackage("org.gradle.FooTest") == "org.gradle.FooTest"
-        testWorkerProgressListener.abbreviateJavaPackage("TestNoPackageFunctionalIntegrationTestWithAReallyReallyLongName") == "TestNoPackageFunctionalIntegrationTestWithAReallyReallyLongName"
-        testWorkerProgressListener.abbreviateJavaPackage("org.gradle.api.internal.tasks.testing.logging.TestWorkerProgressListenerTest") == "org.gradle...testing.logging.TestWorkerProgressListenerTest"
-        testWorkerProgressListener.abbreviateJavaPackage("short.pkg.TestWorkerProgressListenerIntegrationTestWithAReallyReallyLongName") == "...TestWorkerProgressListenerIntegrationTestWithAReallyReallyLongName"
-    }
-
     static TestStartEvent createTestStartEvent() {
         new TestStartEvent(new Date().time)
     }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestWorkerProgressListenerTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestWorkerProgressListenerTest.groovy
@@ -180,6 +180,16 @@ class TestWorkerProgressListenerTest extends Specification {
         testWorkerProgressListener.testWorkerProgressLoggers.isEmpty()
     }
 
+    def "abbreviates long java packages"() {
+        expect:
+        testWorkerProgressListener.abbreviateJavaPackage(null) == null
+        testWorkerProgressListener.abbreviateJavaPackage("") == ""
+        testWorkerProgressListener.abbreviateJavaPackage("org.gradle.FooTest") == "org.gradle.FooTest"
+        testWorkerProgressListener.abbreviateJavaPackage("TestNoPackageFunctionalIntegrationTestWithAReallyReallyLongName") == "TestNoPackageFunctionalIntegrationTestWithAReallyReallyLongName"
+        testWorkerProgressListener.abbreviateJavaPackage("org.gradle.api.internal.tasks.testing.logging.TestWorkerProgressListenerTest") == "org.gradle...testing.logging.TestWorkerProgressListenerTest"
+        testWorkerProgressListener.abbreviateJavaPackage("short.pkg.TestWorkerProgressListenerIntegrationTestWithAReallyReallyLongName") == "...TestWorkerProgressListenerIntegrationTestWithAReallyReallyLongName"
+    }
+
     static TestStartEvent createTestStartEvent() {
         new TestStartEvent(new Date().time)
     }


### PR DESCRIPTION
Omit the middle packages of a long test class name. For example:

`org.gradle.api.internal.tasks.testing.logging.TestWorkerProgressListenerTest`
becomes
`org.gradle...testing.logging.TestWorkerProgressListenerTest`

Basically, it keeps the name under 60 characters (though it _always_ includes the unqualified class name). Technically, it doesn't perfectly optimize the name, for example a package name on one side may not fit but the other does; however, I found that to add much complexity for little gain.

Issue: #2547

### Context
Based on discussion in #2547 and [suggestions from contributors](https://twitter.com/jon_k_schneider/status/888429174947540992).
