### PR TITLE
Optionally use absolute paths in Jacoco getAsJvmArgs

### DIFF
--- a/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
@@ -48,7 +48,7 @@ class JacocoPluginSpec extends AbstractProjectBuilderSpec {
     @Requires(TestPrecondition.ONLINE)
     @Unroll
     @Issue("GRADLE-3498")
-    def 'jacoco task extension can be configured. includeNoLocationClasses: #includeNoLocationClassesValue'() {
+    def 'jacoco task extension can be configured. includeNoLocationClasses: #includeNoLocationClassesValue absolutePaths: #absolutePaths'() {
         given:
         project.apply plugin: 'java'
         project.repositories.jcenter()
@@ -72,8 +72,16 @@ class JacocoPluginSpec extends AbstractProjectBuilderSpec {
             jmx = true
         }
 
+        def buildDir
+        if (absolutePaths) {
+            buildDir = project.file('build').toString()
+        } else {
+            buildDir = 'build';
+        }
+
+
         def expected = new StringBuilder().with { builder ->
-            builder << "destfile=build/jacoco/fake.exec,"
+            builder << "destfile=${buildDir}/jacoco/fake.exec,"
             builder << "append=false,"
             builder << "includes=org.*:*.?acoco*,"
             builder << "excludes=org.?joberstar,"
@@ -84,17 +92,18 @@ class JacocoPluginSpec extends AbstractProjectBuilderSpec {
             builder << "output=tcpserver,"
             builder << "address=1.1.1.1,"
             builder << "port=100,"
-            builder << "classdumpdir=build/jacoco-dump,"
+            builder << "classdumpdir=${buildDir}/jacoco-dump,"
             builder << "jmx=true"
             builder.toString()
         }
 
         then:
-        def jvmArg = extension.asJvmArg
+        def jvmArg = extension.getAsJvmArg(absolutePaths)
         jvmArg.replaceFirst(/-javaagent:[^=]*\.jar=/, '') == expected
 
         where:
         includeNoLocationClassesValue << [true, false]
+        absolutePaths << [true, false]
     }
 
     def "declares task property values for group and description"() {


### PR DESCRIPTION

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
In a project, we use Jacoco with the Jacoco plugin. Some tests start a new JVM. We also want to record coverage data for the code in the new JVMs, so we use JacocoTaskExtension's getAsJvmArg to get the javaagent argument, which is then used to start the new JVM. The returned string contains the path to the javaagent and the output file. They are given as relative paths.

However, some of the tests run in a different working directory. Therefore, neither the Jacoco javaagent is found, nor is the output file in the correct directory. This PR adds an optional parameter to getAsJvmArg to return absolute paths.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
