### PR TITLE
System.currentTimeMillis() isn't monotonic

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildStatusRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/BuildStatusRenderer.java
@@ -87,7 +87,7 @@ public class BuildStatusRenderer extends BatchOutputEventListener {
     public void onOutput(Iterable<OutputEvent> events) {
         super.onOutput(events);
         listener.onOutput(events);
-        renderNow(timeProvider.getCurrentTime());
+        renderNow(timeProvider.getCurrentTimeForDuration());
     }
 
     private void renderNow(long now) {
@@ -98,7 +98,7 @@ public class BuildStatusRenderer extends BatchOutputEventListener {
     }
 
     private void buildStarted(ProgressStartEvent startEvent) {
-        buildStartTimestamp = timeProvider.getCurrentTime();
+        buildStartTimestamp = timeProvider.getCurrentTimeForDuration();
     }
 
     private void phaseStarted(ProgressStartEvent progressStartEvent) {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildStatusRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildStatusRendererTest.groovy
@@ -31,7 +31,7 @@ class BuildStatusRendererTest extends OutputSpecification {
     def renderer = new BuildStatusRenderer(listener, console.statusBar, console, consoleMetaData, timeProvider)
 
     def setup() {
-        timeProvider.getCurrentTime() >> { currentTimeMs }
+        timeProvider.getCurrentTimeForDuration() >> { currentTimeMs }
     }
 
     def "forwards event list to listener"() {


### PR DESCRIPTION
Should use `System.nanoTime()` to ensure correctness for elapsed time.

The [build result logger](https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildResultLogger.java#L55) does not have the same issue as it uses `Clock` which in turn calls `TimeProvider.getCurrentTimeForDuration()` under the covers.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
