### PR TITLE
Jetty docs cleanup

### DIFF
--- a/subprojects/docs/src/docs/userguide/userguide.xml
+++ b/subprojects/docs/src/docs/userguide/userguide.xml
@@ -93,6 +93,7 @@
         <xi:include href='../../../build/asciidoc/userguide/webTutorial.xml'/>
         <xi:include href='warPlugin.xml'/>
         <xi:include href='earPlugin.xml'/>
+        <xi:include href='jettyPlugin.xml'/>
         <xi:include href='../../../build/asciidoc/userguide/applicationPlugin.xml'/>
         <xi:include href='javaLibraryDistributionPlugin.xml'/>
         <xi:include href='../../../build/asciidoc/userguide/groovyTutorial.xml'/>

--- a/subprojects/docs/src/docs/userguide/webTutorial.adoc
+++ b/subprojects/docs/src/docs/userguide/webTutorial.adoc
@@ -18,12 +18,12 @@
 
 [NOTE]
 ====
- 
+
 This chapter is a work in progress.
- 
+
 ====
 
-This chapter introduces the Gradle support for web applications. Gradle provides two plugins for web application development: the War plugin and the Jetty plugin. The War plugin extends the Java plugin to build a WAR file for your project. The Jetty plugin extends the War plugin to allow you to deploy your web application to an embedded Jetty web container.
+This chapter introduces the Gradle support for web applications. Gradle recommends two plugins for web application development: the War plugin and the https://plugins.gradle.org/plugin/org.akhikhl.gretty[Gretty plugin]. The War plugin extends the Java plugin to build a WAR file for your project. The Gretty plugin extends the War plugin to allow you to deploy your web application to an embedded Jetty web container.
 
 
 [[sec:building_a_war_file]]

--- a/subprojects/docs/src/docs/userguide/webTutorial.adoc
+++ b/subprojects/docs/src/docs/userguide/webTutorial.adoc
@@ -23,7 +23,7 @@ This chapter is a work in progress.
 
 ====
 
-This chapter introduces the Gradle support for web applications. Gradle recommends two plugins for web application development: the War plugin and the https://plugins.gradle.org/plugin/org.akhikhl.gretty[Gretty plugin]. The War plugin extends the Java plugin to build a WAR file for your project. The Gretty plugin extends the War plugin to allow you to deploy your web application to an embedded Jetty web container.
+This chapter introduces the Gradle support for web applications. Gradle recommends two plugins for web application development: the War plugin and the https://plugins.gradle.org/plugin/org.akhikhl.gretty[Gretty plugin]. The War plugin extends the Java plugin to build a WAR file for your project. The Gretty plugin allows you to deploy your web application to an embedded Jetty web container.
 
 
 [[sec:building_a_war_file]]


### PR DESCRIPTION
This puts the jetty page back in the user guide with references to use the Gretty plugin
