### PR TITLE
Improve naming build operation names for task actions

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -359,6 +359,19 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     Task doFirst(Closure action);
 
     /**
+     * <p>Adds the given closure to the beginning of this task's action list. The closure is passed this task as a
+     * parameter when executed.</p>
+     *
+     * @param actionName An arbitrary string that is used for logging.
+     * @param action The action closure to execute.
+     * @return This task.
+     *
+     * @since 4.2
+     */
+    @Incubating
+    Task doFirst(String actionName, Closure action);
+
+    /**
      * <p>Adds the given {@link Action} to the end of this task's action list.</p>
      *
      * @param action The action to add.
@@ -374,6 +387,19 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * @return This task.
      */
     Task doLast(Closure action);
+
+    /**
+     * <p>Adds the given closure to the end of this task's action list.  The closure is passed this task as a parameter
+     * when executed.</p>
+     *
+     * @param actionName An arbitrary string that is used for logging.
+     * @param action The action closure to execute.
+     * @return This task.
+     *
+     * @since 4.2
+     */
+    @Incubating
+    Task doLast(String actionName, Closure action);
 
     /**
      * <p>Adds the given closure to the end of this task's action list.  The closure is passed this task as a parameter

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -371,19 +371,6 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     Task doFirst(String actionName, Action<? super Task> action);
 
     /**
-     * <p>Adds the given closure to the beginning of this task's action list. The closure is passed this task as a
-     * parameter when executed.</p>
-     *
-     * @param actionName An arbitrary string that is used for logging.
-     * @param action The action closure to execute.
-     * @return This task.
-     *
-     * @since 4.2
-     */
-    @Incubating
-    Task doFirst(String actionName, Closure action);
-
-    /**
      * <p>Adds the given {@link Action} to the end of this task's action list.</p>
      *
      * @param action The action to add.
@@ -397,7 +384,7 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * @param actionName An arbitrary string that is used for logging.
      * @param action The action to add.
      * @return the task object this method is applied to
-     * 
+     *
      * @since 4.2
      */
     @Incubating
@@ -411,19 +398,6 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * @return This task.
      */
     Task doLast(Closure action);
-
-    /**
-     * <p>Adds the given closure to the end of this task's action list.  The closure is passed this task as a parameter
-     * when executed.</p>
-     *
-     * @param actionName An arbitrary string that is used for logging.
-     * @param action The action closure to execute.
-     * @return This task.
-     *
-     * @since 4.2
-     */
-    @Incubating
-    Task doLast(String actionName, Closure action);
 
     /**
      * <p>Adds the given closure to the end of this task's action list.  The closure is passed this task as a parameter

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -359,6 +359,18 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     Task doFirst(Closure action);
 
     /**
+     * <p>Adds the given {@link Action} to the beginning of this task's action list.</p>
+     *
+     * @param actionName An arbitrary string that is used for logging.
+     * @param action The action to add
+     * @return the task object this method is applied to
+     *
+     * @since 4.2
+     */
+    @Incubating
+    Task doFirst(String actionName, Action<? super Task> action);
+
+    /**
      * <p>Adds the given closure to the beginning of this task's action list. The closure is passed this task as a
      * parameter when executed.</p>
      *
@@ -378,6 +390,18 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * @return the task object this method is applied to
      */
     Task doLast(Action<? super Task> action);
+
+    /**
+     * <p>Adds the given {@link Action} to the end of this task's action list.</p>
+     *
+     * @param actionName An arbitrary string that is used for logging.
+     * @param action The action to add.
+     * @return the task object this method is applied to
+     * 
+     * @since 4.2
+     */
+    @Incubating
+    Task doLast(String actionName, Action<? super Task> action);
 
     /**
      * <p>Adds the given closure to the end of this task's action list.  The closure is passed this task as a parameter

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -566,18 +566,13 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public Task doFirst(final Closure action) {
-        return doFirst("doFirst {} action", action);
-    }
-
-    @Override
-    public Task doFirst(final String actionName, final Closure action) {
         hasCustomActions = true;
         if (action == null) {
             throw new InvalidUserDataException("Action must not be null!");
         }
         taskMutator.mutate("Task.doFirst(Closure)", new Runnable() {
             public void run() {
-                getTaskActions().add(0, convertClosureToAction(action, actionName));
+                getTaskActions().add(0, convertClosureToAction(action, "doFirst {} action"));
             }
         });
         return this;
@@ -585,18 +580,13 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public Task doLast(final Closure action) {
-        return doLast("doLast {} action", action);
-    }
-
-    @Override
-    public Task doLast(final String actionName, final Closure action) {
         hasCustomActions = true;
         if (action == null) {
             throw new InvalidUserDataException("Action must not be null!");
         }
         taskMutator.mutate("Task.doLast(Closure)", new Runnable() {
             public void run() {
-                getTaskActions().add(convertClosureToAction(action, actionName));
+                getTaskActions().add(convertClosureToAction(action, "doLast {} action"));
             }
         });
         return this;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -401,13 +401,18 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public Task doFirst(final Action<? super Task> action) {
+        return doFirst("doFirst {} action", action);
+    }
+
+    @Override
+    public Task doFirst(final String actionName, final Action<? super Task> action) {
         hasCustomActions = true;
         if (action == null) {
             throw new InvalidUserDataException("Action must not be null!");
         }
         taskMutator.mutate("Task.doFirst(Action)", new Runnable() {
             public void run() {
-                getTaskActions().add(0, wrap(action, "doFirst(Action)"));
+                getTaskActions().add(0, wrap(action, actionName));
             }
         });
         return this;
@@ -415,13 +420,18 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public Task doLast(final Action<? super Task> action) {
+        return doLast("doLast {} action", action);
+    }
+
+    @Override
+    public Task doLast(final String actionName, final Action<? super Task> action) {
         hasCustomActions = true;
         if (action == null) {
             throw new InvalidUserDataException("Action must not be null!");
         }
         taskMutator.mutate("Task.doLast(Action)", new Runnable() {
             public void run() {
-                getTaskActions().add(wrap(action, "doLast(Action)"));
+                getTaskActions().add(wrap(action, actionName));
             }
         });
         return this;
@@ -648,14 +658,14 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     }
 
     private ContextAwareTaskAction wrap(final Action<? super Task> action) {
-        return wrap(action, "unnamed");
+        return wrap(action, "unnamed action");
     }
 
-    private ContextAwareTaskAction wrap(final Action<? super Task> action, String displayHint) {
+    private ContextAwareTaskAction wrap(final Action<? super Task> action, String actionName) {
         if (action instanceof ContextAwareTaskAction) {
             return (ContextAwareTaskAction) action;
         }
-        return new TaskActionWrapper(action, displayHint);
+        return new TaskActionWrapper(action, actionName);
     }
 
     private static class TaskInfo {
@@ -728,16 +738,16 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private static class TaskActionWrapper implements ContextAwareTaskAction {
         private final Action<? super Task> action;
-        private final String displayHint;
+        private final String maybeActionName;
 
         /**
-         * The <i>displayHint</i> is used to construct a human readable name for
+         * The <i>action name</i> is used to construct a human readable name for
          * the actions to be used in progress logging. It is only used if
          * the wrapped action does not already implement {@link Describable}.
          */
-        public TaskActionWrapper(Action<? super Task> action, String displayHint) {
+        public TaskActionWrapper(Action<? super Task> action, String maybeActionName) {
             this.action = action;
-            this.displayHint = displayHint;
+            this.maybeActionName = maybeActionName;
         }
 
         @Override
@@ -811,7 +821,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
             if (action instanceof Describable) {
                 return ((Describable) action).getDisplayName();
             }
-            return "Execute " + displayHint + " action";
+            return "Execute " + maybeActionName;
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -556,13 +556,18 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public Task doFirst(final Closure action) {
+        return doFirst("doFirst {} action", action);
+    }
+
+    @Override
+    public Task doFirst(final String actionName, final Closure action) {
         hasCustomActions = true;
         if (action == null) {
             throw new InvalidUserDataException("Action must not be null!");
         }
         taskMutator.mutate("Task.doFirst(Closure)", new Runnable() {
             public void run() {
-                getTaskActions().add(0, convertClosureToAction(action, "doFirst {}"));
+                getTaskActions().add(0, convertClosureToAction(action, actionName));
             }
         });
         return this;
@@ -570,13 +575,18 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public Task doLast(final Closure action) {
+        return doLast("doLast {} action", action);
+    }
+
+    @Override
+    public Task doLast(final String actionName, final Closure action) {
         hasCustomActions = true;
         if (action == null) {
             throw new InvalidUserDataException("Action must not be null!");
         }
         taskMutator.mutate("Task.doLast(Closure)", new Runnable() {
             public void run() {
-                getTaskActions().add(convertClosureToAction(action, "doLast {}"));
+                getTaskActions().add(convertClosureToAction(action, actionName));
             }
         });
         return this;
@@ -592,7 +602,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         }
         taskMutator.mutate("Task.leftShift(Closure)", new Runnable() {
             public void run() {
-                getTaskActions().add(taskMutator.leftShift(convertClosureToAction(action, "doLast {}")));
+                getTaskActions().add(taskMutator.leftShift(convertClosureToAction(action, "doLast {} action")));
             }
         });
         return this;
@@ -633,8 +643,8 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         return validators;
     }
 
-    private ContextAwareTaskAction convertClosureToAction(Closure actionClosure, String displayHint) {
-        return new ClosureTaskAction(actionClosure, displayHint);
+    private ContextAwareTaskAction convertClosureToAction(Closure actionClosure, String actionName) {
+        return new ClosureTaskAction(actionClosure, actionName);
     }
 
     private ContextAwareTaskAction wrap(final Action<? super Task> action) {
@@ -662,11 +672,11 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private static class ClosureTaskAction implements ContextAwareTaskAction {
         private final Closure closure;
-        private final String displayHint;
+        private final String actionName;
 
-        private ClosureTaskAction(Closure closure, String displayHint) {
+        private ClosureTaskAction(Closure closure, String actionName) {
             this.closure = closure;
-            this.displayHint = displayHint;
+            this.actionName = actionName;
         }
 
         @Override
@@ -712,7 +722,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
         @Override
         public String getDisplayName() {
-            return "Execute " + displayHint + " action";
+            return "Execute " + actionName;
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
@@ -20,6 +20,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.gradle.api.Action;
+import org.gradle.api.Describable;
 import org.gradle.api.GradleException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.changedetection.TaskArtifactState;
@@ -118,7 +119,7 @@ public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
         };
     }
 
-    private static class StandardTaskAction implements ClassLoaderAwareTaskAction {
+    private static class StandardTaskAction implements ClassLoaderAwareTaskAction, Describable {
         private final Class<? extends Task> type;
         private final Method method;
 
@@ -149,6 +150,11 @@ public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
         @Override
         public String getActionClassName() {
             return type.getName();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Execute " + method.getName();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.project.taskfactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.api.Action;
+import org.gradle.api.Describable;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.execution.TaskValidator;
@@ -29,7 +30,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-public class TaskClassValidator implements TaskValidator, Action<Task> {
+public class TaskClassValidator implements TaskValidator, Action<Task>, Describable {
     private final ImmutableSortedSet<TaskPropertyInfo> annotatedProperties;
     private final ImmutableList<TaskClassValidationMessage> validationMessages;
     private final boolean cacheable;
@@ -49,6 +50,11 @@ public class TaskClassValidator implements TaskValidator, Action<Task> {
         for (TaskPropertyInfo property : annotatedProperties) {
             property.getConfigureAction().update(task, new FutureValue(property, task));
         }
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Validate task input";
     }
 
     private static class FutureValue implements Callable<Object> {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
@@ -54,7 +54,7 @@ public class TaskClassValidator implements TaskValidator, Action<Task>, Describa
 
     @Override
     public String getDisplayName() {
-        return "Validate task input";
+        return "Validate task inputs";
     }
 
     private static class FutureValue implements Callable<Object> {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ContextAwareTaskAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ContextAwareTaskAction.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.internal.tasks;
 
-public interface ContextAwareTaskAction extends ClassLoaderAwareTaskAction {
+import org.gradle.api.Describable;
+
+public interface ContextAwareTaskAction extends ClassLoaderAwareTaskAction, Describable {
     void contextualise(TaskExecutionContext context);
     void releaseContext();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskMutator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskMutator.java
@@ -129,5 +129,10 @@ public class TaskMutator {
         public String getActionClassName() {
             return action.getActionClassName();
         }
+
+        @Override
+        public String getDisplayName() {
+            return action.getDisplayName();
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuter.java
@@ -45,6 +45,7 @@ import java.util.Map;
 public class ResolveBuildCacheKeyExecuter implements TaskExecuter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResolveBuildCacheKeyExecuter.class);
+    private static final String BUILD_OPERATION_NAME = "Snapshot task inputs";
 
     private final TaskExecuter delegate;
     private final BuildOperationExecutor buildOperationExecutor;
@@ -88,7 +89,7 @@ public class ResolveBuildCacheKeyExecuter implements TaskExecuter {
             @Override
             public BuildOperationDescriptor.Builder description() {
                 return BuildOperationDescriptor
-                    .displayName("Snapshot task inputs for " + task.getIdentityPath())
+                    .displayName(BUILD_OPERATION_NAME + " for " + task.getIdentityPath()).name(BUILD_OPERATION_NAME)
                     .details(OperationDetailsImpl.INSTANCE);
             }
         });

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/TaskTypeTaskStateChangesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/rules/TaskTypeTaskStateChangesTest.groovy
@@ -233,5 +233,10 @@ class TaskTypeTaskStateChangesTest extends Specification {
         @Override
         void execute(Task task) {
         }
+
+        @Override
+        String getDisplayName() {
+            return "Execute test action"
+        }
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
@@ -148,7 +148,7 @@ public abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
         getTask().actions = [action2]
 
         then:
-        [new AbstractTask.TaskActionWrapper(action2)] ==  getTask().actions
+        [new AbstractTask.TaskActionWrapper(action2, "doLast(Action)")] ==  getTask().actions
     }
 
     def testAddActionWithNull() {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -59,6 +59,10 @@ Script plugins are applied to Gradle settings or projects via the `apply from: '
 - HTTP script plugins are cached for [`--offline`](userguide/dependency_management.html#sub:cache_offline) use.
 - Download of HTTP script plugins honours [proxy authentication settings](userguide/build_environment.html#sec:accessing_the_web_via_a_proxy).
 
+### Naming task actions defined with doFirst {} and doLast {}
+
+Task actions that are defined in build scripts can now be named using `doFirst("First things first") {}` or `doLast("One last thing") {}`. Gradle uses the names for logging, which allows the user, for example, to see the order in which actions are executed in the task execution views of IDEs. The action names will also be utilised in build scans in the future. This feature is supported in both Kotlin and Groovy build scripts.
+
 ### Improved Play support
 
 #### Support for Play 2.6

--- a/subprojects/integ-test/integ-test.gradle
+++ b/subprojects/integ-test/integ-test.gradle
@@ -9,6 +9,8 @@ dependencies {
     crossVersionTestCompile project(':ide')
     crossVersionTestCompile project(':codeQuality')
     crossVersionTestCompile project(':signing')
+
+    crossVersionTestRuntime rootProject.configurations.testRuntime.allDependencies
 }
 useTestFixtures(sourceSet: 'integTest', project: ':diagnostics')
 useTestFixtures(sourceSet: 'integTest', project: ':platformNative')

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildProgressCrossVersionSpec.groovy
@@ -269,7 +269,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        def compileJavaActions = events.operations.findAll { it.descriptor.displayName.matches('Execute task action [0-9]+/[0-9]+ for :compileJava') }
+        def compileJavaActions = events.operations.findAll { it.descriptor.displayName.matches('Execute .*( action [0-9]+/[0-9]+)? for :compileJava') }
         compileJavaActions.size() > 0
         compileJavaActions[0].parent.descriptor.displayName == 'Task :compileJava'
     }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ResolveArtifactsProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ResolveArtifactsProgressCrossVersionSpec.groovy
@@ -42,7 +42,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
-        resolveArtifacts.parent.descriptor.name.startsWith("Execute task action")
+        resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve a.jar (project :provider)")
     }
@@ -63,7 +63,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
-        resolveArtifacts.parent.descriptor.name.startsWith("Execute task action")
+        resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve a.jar (project :provider)")
     }
@@ -84,7 +84,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
-        resolveArtifacts.parent.descriptor.name.startsWith("Execute task action")
+        resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve a.jar (project :provider)")
     }
@@ -105,7 +105,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
-        resolveArtifacts.parent.descriptor.name.startsWith("Execute task action")
+        resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve a.jar (project :provider)")
     }
@@ -127,7 +127,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
-        resolveArtifacts.parent.descriptor.name.startsWith("Execute task action")
+        resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve b.jar (project :provider)")
     }
@@ -149,7 +149,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
-        resolveArtifacts.parent.descriptor.name.startsWith("Execute task action")
+        resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve b.jar (project :provider)")
     }
@@ -170,7 +170,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
-        resolveArtifacts.parent.descriptor.name.startsWith("Execute task action")
+        resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 0
     }
 
@@ -191,7 +191,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
-        resolveArtifacts.parent.descriptor.name.startsWith("Execute task action")
+        resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve b.jar (project :provider)")
     }
@@ -212,7 +212,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def resolveDependencies = events.operation('Resolve dependencies of :configurationWithoutDependency')
-        resolveDependencies.parent.descriptor.name.startsWith("Execute task action")
+        resolveDependencies.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveDependencies.parent.children.size() == 1
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r42
+
+import org.gradle.integtests.tooling.fixture.ProgressEvents
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.ProjectConnection
+import org.gradle.util.Requires
+
+import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
+import static org.gradle.util.TestPrecondition.NOT_WINDOWS
+
+@ToolingApiVersion(">=2.5")
+@TargetGradleVersion(">=4.2")
+class BuildProgressTaskActionsCrossVersionSpec extends ToolingApiSpecification {
+
+    ProgressEvents events
+
+    def setup() {
+        events = ProgressEvents.create()
+        settingsFile << "rootProject.name = 'root'"
+    }
+
+    //This is not a task action, but it is logged on the same level as the actions
+    def "clean stale output action has an informative name"() {
+        given:
+        buildFile << "task custom { doLast {} }"
+
+        when:
+        runCustomTask()
+
+        then:
+        def op = events.operation('Clean stale outputs')
+        op.parent.children.size() == 2
+    }
+
+    //This is the current behavior. Snapshoting might become not-a-task-action in the future.
+    def "snapshot task inputs action has an informative name"() {
+        given:
+        buildFile << "task custom { doLast {} }"
+        file("gradle.properties") << "org.gradle.caching=true"
+
+        when:
+        runCustomTask()
+
+        then:
+        def op = events.operation('Snapshot task inputs for :custom')
+        op.parent.children.size() == 3
+    }
+
+    //This is the current behavior. Validating input might become not-a-task-action in the future.
+    def "validate task inputs action has an informative name"() {
+        given:
+        buildFile << """
+        task custom(type: CustomTask) {
+            customInString1 = "1"
+            customInString2 = "2"
+            customOut = file("\$buildDir/out")
+        }
+        
+        class CustomTask extends DefaultTask {
+            @OutputDirectory File customOut
+            @Input String customInString1
+            @Input String customInString2
+            @TaskAction void doSomthing() { }
+        }    
+        """
+
+        when:
+        runCustomTask()
+
+        then:
+        def op = events.operation('Validate task inputs for :custom')
+        op.parent.children.size() == 4
+    }
+
+    //This is the current behavior. The behavior of creating each output directory in a separate action might change in the future.
+    def "create output directories actions have informative names"() {
+        given:
+        buildFile << """
+        task custom(type: CustomTask) {
+            customInString = ""
+            customOut1 = file("\$buildDir/out1")
+            customOut2 = file("\$buildDir/out2")
+        }
+        
+        class CustomTask extends DefaultTask {
+            @OutputDirectory File customOut1
+            @OutputDirectory File customOut2
+            @Input String customInString
+            @TaskAction void doSomething() { }
+        }    
+        """
+
+        when:
+        runCustomTask()
+
+        then:
+        def op1 = events.operation('Create customOut1 output directory for :custom')
+        def op2 = events.operation('Create customOut2 output directory for :custom')
+        op1.parent == op2.parent
+        op1.parent.children.size() == 5
+    }
+
+    def "task actions implemented in annotated methods are named after the method"() {
+        given:
+        buildFile << """
+        task custom(type: CustomTask)
+        
+        class CustomTask extends DefaultTask {
+            @TaskAction void doSomethingAmazing() { }
+        }    
+        """
+
+        when:
+        runCustomTask()
+
+        then:
+        def op = events.operation('Execute doSomethingAmazing for :custom')
+        op.parent.children.size() == 2
+    }
+
+    def "task actions defined in doFirst and doLast blocks of Groovy build scripts have informative names"() {
+        given:
+        buildFile << """
+            task custom { 
+                doFirst {}
+                doLast {}
+            }
+        """
+
+        when:
+        runCustomTask()
+
+        then:
+        def op1 = events.operation('Execute doFirst {} action for :custom')
+        def op2 = events.operation('Execute doLast {} action for :custom')
+        op1.parent == op2.parent
+        op1.parent.children.size() == 3
+    }
+
+    @Requires([KOTLIN_SCRIPT, NOT_WINDOWS])
+    def "task actions defined in doFirst and doLast blocks of Kotlin build scripts have informative names"() {
+        given:
+        buildFileKts << """
+            tasks { "custom" { 
+                doFirst {}
+                doLast {}
+            }}
+        """
+
+        when:
+        runCustomTask()
+
+        then:
+        def op1 = events.operation('Execute doFirst {} action for :custom')
+        def op2 = events.operation('Execute doLast {} action for :custom')
+        op1.parent == op2.parent
+        op1.parent.children.size() == 3
+    }
+
+    def "task actions defined in doFirst and doLast blocks of Groovy build scripts can be named"() {
+        given:
+        buildFile << """
+            task custom { 
+                doFirst("A first step") {}
+                doLast("One last thing...") {}
+            }
+        """
+
+        when:
+        runCustomTask()
+
+        then:
+        def op1 = events.operation('Execute A first step for :custom')
+        def op2 = events.operation('Execute One last thing... for :custom')
+        op1.parent == op2.parent
+        op1.parent.children.size() == 3
+    }
+
+    @Requires([KOTLIN_SCRIPT, NOT_WINDOWS])
+    def "task actions defined in doFirst and doLast blocks of Kotlin build scripts can be named"() {
+        given:
+        buildFileKts << """
+            tasks { "custom" { 
+                doFirst("A first step") {}
+                doLast("One last thing...") {}
+            }}
+        """
+
+        when:
+        runCustomTask()
+
+        then:
+        def op1 = events.operation('Execute A first step for :custom')
+        def op2 = events.operation('Execute One last thing... for :custom')
+        op1.parent == op2.parent
+        op1.parent.children.size() == 3
+    }
+
+    private runCustomTask() {
+        withConnection {
+            ProjectConnection connection ->
+                connection.newBuild().
+                    forTasks('custom').addProgressListener(events).run()
+        }
+    }
+}

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -101,6 +101,10 @@ abstract class ToolingApiSpecification extends Specification {
         file("build.gradle")
     }
 
+    TestFile getBuildFileKts() {
+        file("build.gradle.kts")
+    }
+
     TestFile getSettingsFile() {
         file("settings.gradle")
     }

--- a/subprojects/tooling-api/tooling-api.gradle
+++ b/subprojects/tooling-api/tooling-api.gradle
@@ -17,6 +17,7 @@ dependencies {
     testFixturesCompile project(':internalIntegTesting')
 
     integTestRuntime project(":toolingApiBuilders")
+    integTestRuntime rootProject.configurations.testRuntime.allDependencies
 
     // Need these to be loaded into the crossVersionTestRuntime, so that the modules are available on the classpath and the services can be registered
     // I think this is only really required for the TAPI tests in embedded mode, where we use `GradleConnector.useClasspathDistribution()`.
@@ -26,6 +27,7 @@ dependencies {
     crossVersionTestRuntime project(":ivy")
     crossVersionTestRuntime project(":maven")
     crossVersionTestRuntime project(":compositeBuilds")
+    crossVersionTestRuntime rootProject.configurations.testRuntime.allDependencies
 }
 
 useTestFixtures()


### PR DESCRIPTION
Here is a spike for initial feedback (no functional tests were adjusted or added yet).

This gives meaningful names to task actions by making `ContextAwareTaskAction` a `Describable` and implementing `getDisplayName()` for all commonly used task action implementations.

The names are not necessarily unique anymore. As, for simplification, there is no counter on the `doFirst {}` and `doLast {}` closure actions, which do not have a name. I think it is not a very common case, and not a recommended one, to add several of these.

There is `Execute unnamed task action` fallback, where I am not yet sure if/when we would hit that.

Here is how it looks like in IDEA:

![task-actions](https://user-images.githubusercontent.com/1963746/28774225-edebeec8-75ec-11e7-82ef-ac48e0abcc2c.png)


