### PR TITLE
Upgrade bnd jar to 3.4.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ libraries.ant = dependencies.module('org.apache.ant:ant:1.9.6') {
 
 libraries.asm =  'org.ow2.asm:asm-debug-all:6.0_ALPHA'
 libraries.cglib = 'cglib:cglib:3.2.5'
-libraries.bndlib = dependencies.module('biz.aQute.bnd:biz.aQute.bndlib:3.3.0')
+libraries.bndlib = dependencies.module('biz.aQute.bnd:biz.aQute.bndlib:3.4.0')
 libraries.commons_cli = 'commons-cli:commons-cli:1.2@jar'
 libraries.commons_io = dependencies.module(versions.commons_io)
 libraries.commons_lang = 'commons-lang:commons-lang:2.6@jar'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ libraries.ant = dependencies.module('org.apache.ant:ant:1.9.6') {
 
 libraries.asm =  'org.ow2.asm:asm-debug-all:6.0_ALPHA'
 libraries.cglib = 'cglib:cglib:3.2.5'
-libraries.bndlib = dependencies.module('biz.aQute.bnd:biz.aQute.bndlib:3.2.0')
+libraries.bndlib = dependencies.module('biz.aQute.bnd:biz.aQute.bndlib:3.3.0')
 libraries.commons_cli = 'commons-cli:commons-cli:1.2@jar'
 libraries.commons_io = dependencies.module(versions.commons_io)
 libraries.commons_lang = 'commons-lang:commons-lang:2.6@jar'

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -70,6 +70,12 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 These methods where not meant to be used, since Gradle does not allow to customize the PathSensitivity for output files.
 
+### Upgraded the bndlib to 3.3.0
+
+Gradle previously depended on `biz.aQute.bnd:biz.aQute.bndlib:3.2.0`. That version of the library didn't support Java 9.
+To fix [issue 2583](https://github.com/gradle/gradle/issues/2583), we upgraded to version 3.3.0 of the library. This
+should cause no changes as it is a minor version release.
+
 <!--
 ### Example breaking change
 -->

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/OsgiProjectSampleIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/OsgiProjectSampleIntegrationTest.groovy
@@ -44,7 +44,7 @@ class OsgiProjectSampleIntegrationTest extends AbstractIntegrationSpec {
         manifest != null
         manifest.mainAttributes.getValue('Bundle-Name') == 'Example Gradle Activator'
         manifest.mainAttributes.getValue('Bundle-ManifestVersion') == '2'
-        manifest.mainAttributes.getValue('Tool') == 'Bnd-3.3.0.201609221906'
+        manifest.mainAttributes.getValue('Tool') == 'Bnd-3.4.0.201707252008'
         manifest.mainAttributes.getValue('Bundle-Version') == '1.0.0'
         manifest.mainAttributes.getValue('Bundle-SymbolicName') == 'gradle_tooling.osgi'
         manifest.mainAttributes.getValue('Built-By') ==  GradleVersion.current().version

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/OsgiProjectSampleIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/OsgiProjectSampleIntegrationTest.groovy
@@ -44,7 +44,7 @@ class OsgiProjectSampleIntegrationTest extends AbstractIntegrationSpec {
         manifest != null
         manifest.mainAttributes.getValue('Bundle-Name') == 'Example Gradle Activator'
         manifest.mainAttributes.getValue('Bundle-ManifestVersion') == '2'
-        manifest.mainAttributes.getValue('Tool') == 'Bnd-3.2.0.201605172007'
+        manifest.mainAttributes.getValue('Tool') == 'Bnd-3.3.0.201609221906'
         manifest.mainAttributes.getValue('Bundle-Version') == '1.0.0'
         manifest.mainAttributes.getValue('Bundle-SymbolicName') == 'gradle_tooling.osgi'
         manifest.mainAttributes.getValue('Built-By') ==  GradleVersion.current().version


### PR DESCRIPTION
The 3.2.0 release of the jar was unaware of Java 9 manifest formats,
which could cause problems when applying the OSGI plugin.

Fixes #2583