### PR TITLE
Allow hexadecimal groovy versions Issue: #2623

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/GroovyJarFile.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/GroovyJarFile.java
@@ -23,7 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class GroovyJarFile {
-    private static final Pattern FILE_NAME_PATTERN = Pattern.compile("(groovy(?:-all)?)-(\\d.*?)(-indy)?.jar");
+    private static final Pattern FILE_NAME_PATTERN = Pattern.compile("(groovy(?:-all)?)-([a-f0-9].*?)(-indy)?.jar");
 
     private final File file;
     private final Matcher matcher;

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/GroovyJarFileTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/GroovyJarFileTest.groovy
@@ -16,52 +16,43 @@
 package org.gradle.api.internal.plugins
 
 import org.gradle.util.VersionNumber
+import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Unroll
+
 
 class GroovyJarFileTest extends Specification {
     def "parse non-Groovy file"() {
         expect:
         GroovyJarFile.parse(new File("groovy-other-2.0.5.jar")) == null
+        GroovyJarFile.parse(new File("groovy-1b3e1k20f5.jar")) == null
         GroovyJarFile.parse(new File("groovy-2.0.5.zip")) == null
     }
 
-    def "parse 'groovy' Jar"() {
-        def jar = GroovyJarFile.parse(new File("/lib/groovy-2.0.5.jar"))
+    @Unroll
+    @Issue("gradle/gradle#2623")
+    def "parse 'groovy' Jar with for #dependency"() {
+        def jar = GroovyJarFile.parse(new File(path))
 
         expect:
         jar != null
-        jar.file == new File("/lib/groovy-2.0.5.jar")
-        jar.baseName == "groovy"
-        jar.version == VersionNumber.parse("2.0.5")
-        !jar.groovyAll
-        !jar.indy
-        jar.dependencyNotation == "org.codehaus.groovy:groovy:2.0.5"
-    }
+        jar.file == new File(path)
+        jar.baseName == baseName
+        jar.version == VersionNumber.parse(version)
+        jar.groovyAll == isAll
+        jar.indy == isIndy
+        jar.dependencyNotation == dependency
 
-    def "parse 'groovy-all' Jar"() {
-        def jar = GroovyJarFile.parse(new File("/lib/groovy-all-2.0.5.jar"))
-
-        expect:
-        jar != null
-        jar.file == new File("/lib/groovy-all-2.0.5.jar")
-        jar.baseName == "groovy-all"
-        jar.version == VersionNumber.parse("2.0.5")
-        jar.groovyAll
-        !jar.indy
-        jar.dependencyNotation == "org.codehaus.groovy:groovy-all:2.0.5"
-
-    }
-
-    def "parse indy Jar"() {
-        def jar = GroovyJarFile.parse(new File("/lib/groovy-2.0.5-indy.jar"))
-
-        expect:
-        jar != null
-        jar.file == new File("/lib/groovy-2.0.5-indy.jar")
-        jar.baseName == "groovy"
-        jar.version == VersionNumber.parse("2.0.5")
-        !jar.groovyAll
-        jar.indy
-        jar.dependencyNotation == "org.codehaus.groovy:groovy:2.0.5:indy"
+        where:
+        path                                                            | baseName     | version                                    | isAll | isIndy | dependency
+        "/lib/groovy-2.0.5.jar"                                         | "groovy"     | "2.0.5"                                    | false | false  | "org.codehaus.groovy:groovy:2.0.5"
+        "/lib/groovy-1b3e1520f5.jar"                                    | "groovy"     | "1b3e1520f5"                               | false | false  | "org.codehaus.groovy:groovy:1b3e1520f5"
+        "/lib/groovy-ea60e33cb2fd4b66ae3c6e87200005fa941dca2c.jar"      | "groovy"     | "ea60e33cb2fd4b66ae3c6e87200005fa941dca2c" | false | false  | "org.codehaus.groovy:groovy:ea60e33cb2fd4b66ae3c6e87200005fa941dca2c"
+        "/lib/groovy-all-2.0.5.jar"                                     | "groovy-all" | "2.0.5"                                    | true  | false  | "org.codehaus.groovy:groovy-all:2.0.5"
+        "/lib/groovy-all-1b3e1520f5.jar"                                | "groovy-all" | "1b3e1520f5"                               | true  | false  | "org.codehaus.groovy:groovy-all:1b3e1520f5"
+        "/lib/groovy-all-ea60e33cb2fd4b66ae3c6e87200005fa941dca2c.jar"  | "groovy-all" | "ea60e33cb2fd4b66ae3c6e87200005fa941dca2c" | true  | false  | "org.codehaus.groovy:groovy-all:ea60e33cb2fd4b66ae3c6e87200005fa941dca2c"
+        "/lib/groovy-2.0.5-indy.jar"                                    | "groovy"     | "2.0.5"                                    | false | true   | "org.codehaus.groovy:groovy:2.0.5:indy"
+        "/lib/groovy-1b3e1520f5-indy.jar"                               | "groovy"     | "1b3e1520f5"                               | false | true   | "org.codehaus.groovy:groovy:1b3e1520f5:indy"
+        "/lib/groovy-ea60e33cb2fd4b66ae3c6e87200005fa941dca2c-indy.jar" | "groovy"     | "ea60e33cb2fd4b66ae3c6e87200005fa941dca2c" | false | true   | "org.codehaus.groovy:groovy:ea60e33cb2fd4b66ae3c6e87200005fa941dca2c:indy"
     }
 }


### PR DESCRIPTION
### Context
Allows to use snapshot versions of groovy (i.e. via jitpack.io)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
