### PR TITLE
Explicit clean up before performance test measurements

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -141,7 +141,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
 
         @Override
         BuildDisplayInfo getDisplayInfo() {
-            new BuildDisplayInfo(projectName, displayName, [], [], [], true)
+            new BuildDisplayInfo(projectName, displayName, [], [], [], [], true)
         }
 
         @Override
@@ -173,6 +173,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
                 vcsCommits: [Git.current().commitId],
                 startTime: timeProvider.getCurrentTime(),
                 tasks: [],
+                cleanTasks: [],
                 args: [],
                 gradleOpts: [],
                 daemon: true,

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentSpec.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentSpec.groovy
@@ -32,7 +32,7 @@ class GradleBuildExperimentSpec extends BuildExperimentSpec {
 
     @Override
     BuildDisplayInfo getDisplayInfo() {
-        new BuildDisplayInfo(projectName, displayName, invocation.tasksToRun, invocation.args, invocation.jvmOpts, invocation.useDaemon)
+        new BuildDisplayInfo(projectName, displayName, invocation.tasksToRun, invocation.cleanTasks, invocation.args, invocation.jvmOpts, invocation.useDaemon)
     }
 
     static class GradleBuilder implements BuildExperimentSpec.Builder {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleInvocationSpec.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleInvocationSpec.groovy
@@ -131,7 +131,11 @@ class GradleInvocationSpec implements InvocationSpec {
         }
 
         InvocationBuilder cleanTasks(String... cleanTasks) {
-            this.cleanTasks.addAll(Arrays.asList(cleanTasks))
+            this.cleanTasks(Arrays.asList(cleanTasks))
+        }
+
+        InvocationBuilder cleanTasks(Iterable<String> cleanTasks) {
+            this.cleanTasks.addAll(cleanTasks)
             this
         }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleInvocationSpec.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleInvocationSpec.groovy
@@ -30,16 +30,18 @@ class GradleInvocationSpec implements InvocationSpec {
     final List<String> tasksToRun
     final List<String> args
     final List<String> jvmOpts
+    final List<String> cleanTasks
     final boolean useDaemon
     final boolean useToolingApi
     final boolean expectFailure
 
-    GradleInvocationSpec(GradleDistribution gradleDistribution, File workingDirectory, List<String> tasksToRun, List<String> args, List<String> jvmOpts, boolean useDaemon, boolean useToolingApi, boolean expectFailure) {
+    GradleInvocationSpec(GradleDistribution gradleDistribution, File workingDirectory, List<String> tasksToRun, List<String> args, List<String> jvmOpts, List<String> cleanTasks, boolean useDaemon, boolean useToolingApi, boolean expectFailure) {
         this.gradleDistribution = gradleDistribution
         this.workingDirectory = workingDirectory
         this.tasksToRun = tasksToRun
         this.args = args
         this.jvmOpts = jvmOpts
+        this.cleanTasks = cleanTasks
         this.useDaemon = useDaemon
         this.useToolingApi = useToolingApi
         this.expectFailure = expectFailure
@@ -60,6 +62,7 @@ class GradleInvocationSpec implements InvocationSpec {
         builder.tasksToRun.addAll(this.tasksToRun)
         builder.args.addAll(args)
         builder.gradleOptions.addAll(jvmOpts)
+        builder.cleanTasks.addAll(cleanTasks)
         builder.useDaemon = useDaemon
         builder.useToolingApi = useToolingApi
         builder.expectFailure = expectFailure
@@ -86,6 +89,7 @@ class GradleInvocationSpec implements InvocationSpec {
         List<String> args = []
         List<String> gradleOptions = []
         Map<String, Object> profilerOpts = [:]
+        List<String> cleanTasks = []
         boolean useDaemon
         boolean useToolingApi
         boolean useProfiler
@@ -123,6 +127,11 @@ class GradleInvocationSpec implements InvocationSpec {
         }
         InvocationBuilder gradleOpts(Iterable<String> gradleOpts) {
             this.gradleOptions.addAll(gradleOpts)
+            this
+        }
+
+        InvocationBuilder cleanTasks(String... cleanTasks) {
+            this.cleanTasks.addAll(Arrays.asList(cleanTasks))
             this
         }
 
@@ -191,7 +200,7 @@ class GradleInvocationSpec implements InvocationSpec {
                 jvmOptsSet.addAll(profiler.profilerArguments(profilerOpts))
             }
 
-            return new GradleInvocationSpec(gradleDistribution, workingDirectory, tasksToRun.asImmutable(), args.asImmutable(), new ArrayList<String>(jvmOptsSet).asImmutable(), useDaemon, useToolingApi, expectFailure)
+            return new GradleInvocationSpec(gradleDistribution, workingDirectory, tasksToRun.asImmutable(), args.asImmutable(), new ArrayList<String>(jvmOptsSet).asImmutable(), cleanTasks.asImmutable(), useDaemon, useToolingApi, expectFailure)
         }
 
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenBuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenBuildExperimentRunner.java
@@ -69,7 +69,7 @@ public class GradleVsMavenBuildExperimentRunner extends BuildExperimentRunner {
 
                         MavenInvocationSpec invocation = invocationCustomizer.customize(invocationInfo, buildSpec);
                         final ExecAction run = createMavenInvocation(invocation, invocation.getTasksToRun());
-                        System.out.println("Measuring Maven tasks: " + Joiner.on(" ").join(buildSpec.getCleanTasks()));
+                        System.out.println("Measuring Maven tasks: " + Joiner.on(" ").join(buildSpec.getTasksToRun()));
                         DurationMeasurementImpl.measure(measuredOperation, new Runnable() {
                             @Override
                             public void run() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
@@ -34,7 +34,9 @@ class GradleVsMavenPerformanceTestRunner extends AbstractGradleBuildPerformanceT
 
     String testProject
     String gradleTasks
+    String gradleCleanTasks = ""
     String equivalentMavenTasks
+    String equivalentMavenCleanTasks = ""
     List<Object> jvmOpts = []
     List<Object> mvnArgs = []
 
@@ -61,14 +63,14 @@ class GradleVsMavenPerformanceTestRunner extends AbstractGradleBuildPerformanceT
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject).displayName("Gradle $commonBaseDisplayName").invocation {
-                tasksToRun(gradleTasks.split(' ')).useDaemon().gradleOpts(jvmOpts.collect {it.toString()})
+                tasksToRun(gradleTasks.split(' ')).cleanTasks(gradleCleanTasks.split(' ')).useDaemon().gradleOpts(jvmOpts.collect {it.toString()})
             }
         }
         mavenBuildSpec {
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject).displayName("Maven $commonBaseDisplayName").invocation {
-                tasksToRun(equivalentMavenTasks.split(' ')).mavenOpts(jvmOpts.collect {it.toString()}).args(mvnArgs.collect {it.toString()})
+                tasksToRun(equivalentMavenTasks.split(' ')).cleanTasks(equivalentMavenCleanTasks.split(' ')).mavenOpts(jvmOpts.collect {it.toString()}).args(mvnArgs.collect {it.toString()})
             }
         }
         super.run()

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
@@ -58,7 +58,7 @@ class GradleVsMavenPerformanceTestRunner extends AbstractGradleBuildPerformanceT
 
     @Override
     GradleVsMavenBuildPerformanceResults run() {
-        def commonBaseDisplayName = "$gradleTasks on $testProject"
+        def commonBaseDisplayName = "${gradleTasks.join(' ')} on $testProject"
         baseline {
             warmUpCount = warmUpRuns
             invocationCount = runs

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleVsMavenPerformanceTestRunner.groovy
@@ -33,10 +33,10 @@ class GradleVsMavenPerformanceTestRunner extends AbstractGradleBuildPerformanceT
     final M2Installation m2
 
     String testProject
-    String gradleTasks
-    String gradleCleanTasks = ""
-    String equivalentMavenTasks
-    String equivalentMavenCleanTasks = ""
+    List<String> gradleTasks
+    List<String> gradleCleanTasks = []
+    List<String> equivalentMavenTasks
+    List<String> equivalentMavenCleanTasks = []
     List<Object> jvmOpts = []
     List<Object> mvnArgs = []
 
@@ -63,14 +63,14 @@ class GradleVsMavenPerformanceTestRunner extends AbstractGradleBuildPerformanceT
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject).displayName("Gradle $commonBaseDisplayName").invocation {
-                tasksToRun(gradleTasks.split(' ')).cleanTasks(gradleCleanTasks.split(' ')).useDaemon().gradleOpts(jvmOpts.collect {it.toString()})
+                tasksToRun(gradleTasks).cleanTasks(gradleCleanTasks).useDaemon().gradleOpts(jvmOpts.collect {it.toString()})
             }
         }
         mavenBuildSpec {
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject).displayName("Maven $commonBaseDisplayName").invocation {
-                tasksToRun(equivalentMavenTasks.split(' ')).cleanTasks(equivalentMavenCleanTasks.split(' ')).mavenOpts(jvmOpts.collect {it.toString()}).args(mvnArgs.collect {it.toString()})
+                tasksToRun(equivalentMavenTasks).cleanTasks(equivalentMavenCleanTasks).mavenOpts(jvmOpts.collect {it.toString()}).args(mvnArgs.collect {it.toString()})
             }
         }
         super.run()

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenBuildExperimentSpec.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenBuildExperimentSpec.groovy
@@ -37,7 +37,7 @@ class MavenBuildExperimentSpec extends BuildExperimentSpec {
 
     @Override
     BuildDisplayInfo getDisplayInfo() {
-        new BuildDisplayInfo(projectName, displayName, invocation.tasksToRun, invocation.getArgs(), invocation.getMavenOpts(), false)
+        new BuildDisplayInfo(projectName, displayName, invocation.tasksToRun, invocation.cleanTasks, invocation.args, invocation.mavenOpts, false)
     }
 
     static class MavenBuilder implements BuildExperimentSpec.Builder {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenInvocationSpec.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenInvocationSpec.groovy
@@ -34,8 +34,9 @@ class MavenInvocationSpec implements InvocationSpec {
     final List<String> jvmOpts
     final List<String> mavenOpts
     final List<String> args
+    final List<String> cleanTasks
 
-    MavenInvocationSpec(MavenInstallation installation, File workingDirectory, List<String> tasksToRun, List<String> jvmOpts, List<String> mavenOpts, List<String> args) {
+    MavenInvocationSpec(MavenInstallation installation, File workingDirectory, List<String> tasksToRun, List<String> jvmOpts, List<String> mavenOpts, List<String> args, List<String> cleanTasks) {
         this.installation = installation
         this.mavenVersion = installation.version
         this.mavenHome = installation.home
@@ -44,6 +45,7 @@ class MavenInvocationSpec implements InvocationSpec {
         this.jvmOpts = jvmOpts
         this.mavenOpts = mavenOpts
         this.args = args
+        this.cleanTasks = cleanTasks
     }
 
     @Override
@@ -64,6 +66,7 @@ class MavenInvocationSpec implements InvocationSpec {
         builder.jvmOpts(this.jvmOpts)
         builder.mavenOpts(this.mavenOpts)
         builder.args(this.args)
+        builder.cleanTasks.addAll(cleanTasks)
         builder
     }
 
@@ -75,6 +78,7 @@ class MavenInvocationSpec implements InvocationSpec {
         List<String> jvmOpts = []
         List<String> mavenOpts = []
         List<String> args = []
+        List<String> cleanTasks = []
 
         InvocationBuilder mavenVersion(String mavenVersion) {
             this.mavenVersion = mavenVersion
@@ -131,6 +135,11 @@ class MavenInvocationSpec implements InvocationSpec {
             this
         }
 
+        InvocationBuilder cleanTasks(String... cleanTasks) {
+            this.cleanTasks.addAll(Arrays.asList(cleanTasks))
+            this
+        }
+
         @Override
         InvocationSpec.Builder expectFailure() {
             throw new UnsupportedOperationException()
@@ -151,7 +160,7 @@ class MavenInvocationSpec implements InvocationSpec {
             assert mavenHome != null
             assert workingDirectory != null
             mavenInstallation = mavenInstallation ?: new MavenInstallation(mavenVersion, mavenHome)
-            return new MavenInvocationSpec(mavenInstallation, workingDirectory, tasksToRun.asImmutable(), jvmOpts.asImmutable(), mavenOpts.asImmutable(), args.asImmutable())
+            return new MavenInvocationSpec(mavenInstallation, workingDirectory, tasksToRun.asImmutable(), jvmOpts.asImmutable(), mavenOpts.asImmutable(), args.asImmutable(), cleanTasks.asImmutable())
         }
 
         private void assertMavenHomeAndVersionMatch() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenInvocationSpec.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenInvocationSpec.groovy
@@ -136,7 +136,11 @@ class MavenInvocationSpec implements InvocationSpec {
         }
 
         InvocationBuilder cleanTasks(String... cleanTasks) {
-            this.cleanTasks.addAll(Arrays.asList(cleanTasks))
+            this.cleanTasks(Arrays.asList(cleanTasks))
+        }
+
+        InvocationBuilder cleanTasks(Iterable<String> cleanTasks) {
+            this.cleanTasks.addAll(cleanTasks)
             this
         }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BuildDisplayInfo.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BuildDisplayInfo.groovy
@@ -28,14 +28,16 @@ class BuildDisplayInfo {
     final String projectName
     final String displayName
     final List<String> tasksToRun
+    final List<String> cleanTasks
     final List<String> args
     final List<String> gradleOpts
     final Boolean daemon
 
-    BuildDisplayInfo(String projectName, String displayName, List<String> tasksToRun, List<String> args, List<String> gradleOpts, Boolean daemon) {
+    BuildDisplayInfo(String projectName, String displayName, List<String> tasksToRun, List<String> cleanTasks, List<String> args, List<String> gradleOpts, Boolean daemon) {
         this.projectName = projectName
         this.displayName = displayName
         this.tasksToRun = tasksToRun
+        this.cleanTasks = cleanTasks
         this.args = args
         this.gradleOpts = gradleOpts
         this.daemon = daemon

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossBuildPerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossBuildPerformanceTestHistory.java
@@ -96,6 +96,11 @@ public class CrossBuildPerformanceTestHistory implements PerformanceTestHistory 
                     }
 
                     @Override
+                    public List<String> getCleanTasks() {
+                        return input.getCleanTasks();
+                    }
+
+                    @Override
                     public List<String> getArgs() {
                         return input.getArgs();
                     }
@@ -187,6 +192,12 @@ public class CrossBuildPerformanceTestHistory implements PerformanceTestHistory 
         @Nullable
         @Override
         public List<String> getTasks() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public List<String> getCleanTasks() {
             return null;
         }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceResults.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceResults.groovy
@@ -18,16 +18,13 @@ package org.gradle.performance.results
 
 import groovy.transform.CompileStatic
 import org.gradle.api.Transformer
-import org.gradle.api.logging.Logger
-import org.gradle.api.logging.Logging
 
 @CompileStatic
-public class CrossVersionPerformanceResults extends PerformanceTestResult {
-    private final static Logger LOGGER = Logging.getLogger(CrossVersionPerformanceResults.class)
-
+class CrossVersionPerformanceResults extends PerformanceTestResult {
     String testProject
     List<String> args
     List<String> tasks
+    List<String> cleanTasks
     List<String> gradleOpts
     Boolean daemon
 
@@ -41,7 +38,11 @@ public class CrossVersionPerformanceResults extends PerformanceTestResult {
     }
 
     String getDisplayName() {
-        return "Results for test project '$testProject' with tasks ${tasks.join(', ')}"
+        def displayName = "Results for test project '$testProject' with tasks ${tasks.join(', ')}"
+        if (cleanTasks) {
+            displayName += ", cleaned with ${cleanTasks.join(', ')}"
+        }
+        return displayName
     }
 
     Collection<BaselineVersion> getBaselineVersions() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceTestHistory.java
@@ -120,6 +120,11 @@ public class CrossVersionPerformanceTestHistory implements PerformanceTestHistor
                     }
 
                     @Override
+                    public List<String> getCleanTasks() {
+                        return mostRecent.getCleanTasks();
+                    }
+
+                    @Override
                     public List<String> getArgs() {
                         return mostRecent.getArgs();
                     }
@@ -223,6 +228,12 @@ public class CrossVersionPerformanceTestHistory implements PerformanceTestHistor
         @Override
         public List<String> getTasks() {
             return result.getTasks();
+        }
+
+        @Nullable
+        @Override
+        public List<String> getCleanTasks() {
+            return result.getCleanTasks();
         }
 
         @Nullable

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestExecution.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestExecution.java
@@ -59,6 +59,12 @@ public interface PerformanceTestExecution {
     List<String> getTasks();
 
     /**
+     * The clean tasks executed. Null if not known or not constant for all experiments
+     */
+    @Nullable
+    List<String> getCleanTasks();
+
+    /**
      * The Gradle arguments. Null if not known or not constant for all experiments
      */
     @Nullable

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioDefinition.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioDefinition.java
@@ -36,6 +36,11 @@ public interface ScenarioDefinition {
     List<String> getTasks();
 
     /**
+     * The clean tasks executed.
+     */
+    List<String> getCleanTasks();
+
+    /**
      * The Gradle arguments.
      */
     List<String> getArgs();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
@@ -53,6 +53,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             h2().text(String.format("Test: %s", testHistory.getDisplayName())).end();
             text(getReproductionInstructions(testHistory));
             p().text("Tasks: " + getTasks(testHistory)).end();
+            p().text("Clean tasks: " + getCleanTasks(testHistory)).end();
 
             addPerformanceGraph("Average total time", "totalTimeChart", "totalTime", "total time", "s");
 
@@ -65,6 +66,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
                 th().text("Scenario").end();
                 th().text("Test project").end();
                 th().text("Tasks").end();
+                th().text("Clean tasks").end();
                 th().text("Gradle args").end();
                 th().text("Gradle JVM args").end();
                 th().text("Daemon").end();
@@ -74,6 +76,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
                     textCell(scenario.getDisplayName());
                     textCell(scenario.getTestProject());
                     textCell(scenario.getTasks());
+                    textCell(scenario.getCleanTasks());
                     textCell(scenario.getArgs());
                     textCell(scenario.getGradleOpts());
                     textCell(scenario.getDaemon());
@@ -102,6 +105,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             th().text("JVM").end();
             th().text("Test project").end();
             th().text("Tasks").end();
+            th().text("Clean tasks").end();
             th().text("Gradle args").end();
             th().text("Gradle JVM opts").end();
             th().text("Daemon").end();
@@ -130,6 +134,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
                 textCell(results.getJvm());
                 textCell(results.getTestProject());
                 textCell(results.getTasks());
+                textCell(results.getCleanTasks());
                 textCell(results.getArgs());
                 textCell(results.getGradleOpts());
                 textCell(results.getDaemon());
@@ -183,16 +188,28 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
         };
     }
 
-    private String getTasks(PerformanceTestHistory testHistory) {
-        List<? extends PerformanceTestExecution> executions = testHistory.getExecutions();
-        if (executions.isEmpty()) {
-            return "";
-        }
-        PerformanceTestExecution performanceTestExecution = executions.get(0);
+    private static String getTasks(PerformanceTestHistory testHistory) {
+        PerformanceTestExecution performanceTestExecution = getExecution(testHistory);
         if (performanceTestExecution == null || performanceTestExecution.getTasks() == null) {
             return "";
         }
         return Joiner.on(" ").join(performanceTestExecution.getTasks());
+    }
+
+    private static String getCleanTasks(PerformanceTestHistory testHistory) {
+        PerformanceTestExecution performanceTestExecution = getExecution(testHistory);
+        if (performanceTestExecution == null || performanceTestExecution.getCleanTasks() == null) {
+            return "";
+        }
+        return Joiner.on(" ").join(performanceTestExecution.getCleanTasks());
+    }
+
+    private static PerformanceTestExecution getExecution(PerformanceTestHistory testHistory) {
+        List<? extends PerformanceTestExecution> executions = testHistory.getExecutions();
+        if (executions.isEmpty()) {
+            return null;
+        }
+        return executions.get(0);
     }
 
     private String getReproductionInstructions(PerformanceTestHistory history) {

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
@@ -33,7 +33,8 @@ abstract class ResultSpecification extends Specification {
         results.testId = "test-id"
         results.previousTestIds = []
         results.testProject = "test-project"
-        results.tasks = ["clean", "build"]
+        results.tasks = ["build"]
+        results.cleanTasks = ["clean"]
         results.args = []
         results.gradleOpts = []
         results.daemon = false

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestExecutionTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestExecutionTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.performance.ResultSpecification
 import org.gradle.performance.results.CrossVersionPerformanceResults
 
 class CrossVersionPerformanceTestExecutionTest extends ResultSpecification {
-    def CrossVersionPerformanceResults result = new CrossVersionPerformanceResults(testProject: "some-project", tasks: [])
+    def result = new CrossVersionPerformanceResults(testProject: "some-project", tasks: [], cleanTasks: [])
 
     def "passes when average execution time for current release is smaller than average execution time for previous releases"() {
         given:

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
@@ -73,7 +73,8 @@ class CrossVersionPerformanceTestRunnerTest extends ResultSpecification {
         runner.previousTestIds = ['prev 1']
         runner.testProject = 'test1'
         runner.targetVersions = ['1.0', '1.1']
-        runner.tasksToRun = ['clean', 'build']
+        runner.tasksToRun = ['build']
+        runner.cleanTasks = ['clean']
         runner.args = ['--arg1', '--arg2']
         runner.gradleOpts = ['-Xmx24']
         runner.useDaemon = true
@@ -87,7 +88,8 @@ class CrossVersionPerformanceTestRunnerTest extends ResultSpecification {
         results.testId == 'some-test'
         results.previousTestIds == ['prev 1']
         results.testProject == 'test1'
-        results.tasks == ['clean', 'build']
+        results.tasks == ['build']
+        results.cleanTasks == ['clean']
         results.args == ['--arg1', '--arg2']
         runner.gradleOpts.find { it == '-Xmx24' }
         runner.gradleOpts.sort(false) == (runner.gradleOpts as Set).sort(false)

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossBuildResultsStoreTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossBuildResultsStoreTest.groovy
@@ -36,22 +36,23 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         def results1 = crossBuildResults(testId: "test1", testGroup: "group1")
         def buildResults1 = results1.buildResult(
                 new BuildDisplayInfo(
-                        "simple",
-                        "simple display",
-                        ["build"],
-                        ["-i"],
-                        [],
-                        true
+                    "simple",
+                    "simple display",
+                    ["build"],
+                    ["clean"],
+                    ["-i"],
+                    [],
+                    true
                 )
         )
         buildResults1 << operation(totalTime: minutes(12))
-        def buildResults2 = results1.buildResult(new BuildDisplayInfo("complex", "complex display", [], [], ["--go-faster"], false))
+        def buildResults2 = results1.buildResult(new BuildDisplayInfo("complex", "complex display", [], [], [], ["--go-faster"], false))
         buildResults2 << operation()
         buildResults2 << operation()
 
         and:
         def results2 = crossBuildResults(testId: "test2", testGroup: "group2")
-        results2.buildResult(new BuildDisplayInfo("simple", "simple display", ["build"], ["-i"], [], true))
+        results2.buildResult(new BuildDisplayInfo("simple", "simple display", ["build"], [], ["-i"], [], true))
 
         when:
         def writeStore = new BaseCrossBuildResultsStore(dbName)
@@ -81,19 +82,21 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         history.scenarios[0].displayName == "complex display"
         history.scenarios[0].testProject == "complex"
         history.scenarios[0].tasks == []
+        history.scenarios[0].cleanTasks == []
         history.scenarios[0].args == []
         history.scenarios[0].gradleOpts == ["--go-faster"]
         history.scenarios[0].daemon == false
         history.scenarios[1].displayName == "simple display"
         history.scenarios[1].testProject == "simple"
         history.scenarios[1].tasks == ["build"]
+        history.scenarios[1].cleanTasks == ["clean"]
         history.scenarios[1].args == ["-i"]
         history.scenarios[1].gradleOpts == []
         history.scenarios[1].daemon
 
         and:
         def firstSpecification = history.builds[0]
-        firstSpecification == new BuildDisplayInfo("complex", "complex display", [], [], ["--go-faster"], false)
+        firstSpecification == new BuildDisplayInfo("complex", "complex display", [], [], [], ["--go-faster"], false)
         history.results.first().buildResult(firstSpecification).size() == 2
         history.results.first().buildResult("complex display").size() == 2
 
@@ -110,7 +113,7 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
 
         and:
         def secondSpecification = history.builds[1]
-        secondSpecification == new BuildDisplayInfo("simple", "simple display", ["build"], ["-i"], [], true)
+        secondSpecification == new BuildDisplayInfo("simple", "simple display", ["build"], ["clean"], ["-i"], [], true)
         def operation = crossBuildPerformanceResults.buildResult(secondSpecification).first
         operation.totalTime == minutes(12)
 
@@ -124,12 +127,13 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         def results1 = crossBuildResults(testId: "test1", testGroup: "group1")
         def buildResults1 = results1.buildResult(
                 new BuildDisplayInfo(
-                        "simple",
-                        "simple display",
-                        ["build"],
-                        ["-i"],
-                        null,
-                        null
+                    "simple",
+                    "simple display",
+                    ["build"],
+                    ["clean"],
+                    ["-i"],
+                    null,
+                    null
                 )
         )
         buildResults1 << operation()
@@ -151,7 +155,7 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         history.displayName == "test1"
         history.scenarioCount == 1
         def firstSpecification = history.builds[0]
-        firstSpecification == new BuildDisplayInfo("simple", "simple display", ["build"], ["-i"], null, null)
+        firstSpecification == new BuildDisplayInfo("simple", "simple display", ["build"], ["clean"], ["-i"], null, null)
         history.results.first().buildResult(firstSpecification).size() == 1
         history.results.first().buildResult("simple display").size() == 1
 
@@ -165,23 +169,25 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         def results1 = crossBuildResults(testId: "test1", testGroup: "group1", startTime: 100)
         def buildResults1 = results1.buildResult(
                 new BuildDisplayInfo(
-                        "project-1",
-                        "scenario 1",
-                        ["build"],
-                        ["-1"],
-                        null,
-                        null
+                    "project-1",
+                    "scenario 1",
+                    ["build"],
+                    [],
+                    ["-1"],
+                    null,
+                    null
                 )
         )
         buildResults1 << operation()
         def buildResults2 = results1.buildResult(
                 new BuildDisplayInfo(
-                        "project-1",
-                        "scenario 2",
-                        ["clean", "build"],
-                        ["-1"],
-                        null,
-                        null
+                    "project-1",
+                    "scenario 2",
+                    ["build"],
+                    ["clean"],
+                    ["-1"],
+                    null,
+                    null
                 )
         )
         buildResults2 << operation()
@@ -189,23 +195,25 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         def results2 = crossBuildResults(testId: "test1", testGroup: "group1", startTime: 200)
         def buildResults3 = results2.buildResult(
                 new BuildDisplayInfo(
-                        "project-1",
-                        "scenario 1",
-                        ["build"],
-                        ["-2"],
-                        ["--new"],
-                        true
+                    "project-1",
+                    "scenario 1",
+                    ["build"],
+                    [],
+                    ["-2"],
+                    ["--new"],
+                    true
                 )
         )
         buildResults3 << operation()
         def buildResults4 = results2.buildResult(
                 new BuildDisplayInfo(
-                        "project-1",
-                        "scenario 2",
-                        ["clean", "build"],
-                        ["-1"],
-                        ["--new"],
-                        true
+                    "project-1",
+                    "scenario 2",
+                    ["build"],
+                    ["clean"],
+                    ["-1"],
+                    ["--new"],
+                    true
                 )
         )
         buildResults4 << operation()
@@ -213,23 +221,25 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         def results3 = crossBuildResults(testId: "test1", testGroup: "group1", startTime: 300)
         def buildResults5 = results3.buildResult(
                 new BuildDisplayInfo(
-                        "project-1-new",
-                        "scenario 1",
-                        ["assemble"],
-                        ["-2", "-3"],
-                        ["--new", "--old"],
-                        true
+                    "project-1-new",
+                    "scenario 1",
+                    ["assemble"],
+                    [],
+                    ["-2", "-3"],
+                    ["--new", "--old"],
+                    true
                 )
         )
         buildResults5 << operation()
         def buildResults6 = results3.buildResult(
                 new BuildDisplayInfo(
-                        "project-2-new",
-                        "scenario 2",
-                        ["clean", "assemble"],
-                        ["-4"],
-                        [],
-                        true
+                    "project-2-new",
+                    "scenario 2",
+                    ["assemble"],
+                    ["clean"],
+                    ["-4"],
+                    [],
+                    true
                 )
         )
         buildResults6 << operation()
@@ -284,23 +294,25 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         def results1 = crossBuildResults(testId: "test1", testGroup: "group1", startTime: 100)
         def buildResults1 = results1.buildResult(
                 new BuildDisplayInfo(
-                        "project-1",
-                        "scenario 1",
-                        ["build"],
-                        ["-1"],
-                        null,
-                        null
+                    "project-1",
+                    "scenario 1",
+                    ["build"],
+                    [],
+                    ["-1"],
+                    null,
+                    null
                 )
         )
         buildResults1 << operation()
         def buildResults2 = results1.buildResult(
                 new BuildDisplayInfo(
-                        "project-1",
-                        "scenario 2",
-                        ["clean", "build"],
-                        ["-1"],
-                        null,
-                        null
+                    "project-1",
+                    "scenario 2",
+                    ["build"],
+                    ["clean"],
+                    ["-1"],
+                    null,
+                    null
                 )
         )
         buildResults2 << operation()
@@ -308,23 +320,25 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         def results2 = crossBuildResults(testId: "test1", testGroup: "group1", startTime: 200)
         def buildResults3 = results2.buildResult(
                 new BuildDisplayInfo(
-                        "project-1",
-                        "scenario 1",
-                        ["build"],
-                        ["-2"],
-                        ["--new"],
-                        true
+                    "project-1",
+                    "scenario 1",
+                    ["build"],
+                    [],
+                    ["-2"],
+                    ["--new"],
+                    true
                 )
         )
         buildResults3 << operation()
         def buildResults4 = results2.buildResult(
                 new BuildDisplayInfo(
-                        "project-1",
-                        "scenario 3",
-                        ["clean", "build"],
-                        ["-1"],
-                        ["--new"],
-                        true
+                    "project-1",
+                    "scenario 3",
+                    ["build"],
+                    ["clean"],
+                    ["-1"],
+                    ["--new"],
+                    true
                 )
         )
         buildResults4 << operation()
@@ -332,12 +346,13 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         def results3 = crossBuildResults(testId: "test1", testGroup: "group1", startTime: 300)
         def buildResults5 = results3.buildResult(
                 new BuildDisplayInfo(
-                        "project-1-old",
-                        "scenario 4",
-                        ["assemble"],
-                        ["-2", "-3"],
-                        ["--new", "--old"],
-                        true
+                    "project-1-old",
+                    "scenario 4",
+                    ["assemble"],
+                    [],
+                    ["-2", "-3"],
+                    ["--new", "--old"],
+                    true
                 )
         )
         buildResults5 << operation()
@@ -391,15 +406,15 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
     def "returns top n results in descending date order"() {
         given:
         def results1 = crossBuildResults(testId: "test1", startTime: 1000)
-        results1.buildResult(new BuildDisplayInfo("simple1", "simple 1", ["build"], ["-i"], [], true))
+        results1.buildResult(new BuildDisplayInfo("simple1", "simple 1", ["build"], [], ["-i"], [], true))
 
         and:
         def results2 = crossBuildResults(testId: "test1", startTime: 2000)
-        results2.buildResult(new BuildDisplayInfo("simple2", "simple 2", ["build"], ["-i"], [], true))
+        results2.buildResult(new BuildDisplayInfo("simple2", "simple 2", ["build"], [], ["-i"], [], true))
 
         and:
         def results3 = crossBuildResults(testId: "test1", startTime: 3000)
-        results3.buildResult(new BuildDisplayInfo("simple3", "simple 3", ["build"], ["-i"], [], true))
+        results3.buildResult(new BuildDisplayInfo("simple3", "simple 3", ["build"], [], ["-i"], [], true))
 
         and:
         def writeStore = new BaseCrossBuildResultsStore(dbName)

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossVersionResultsStoreTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossVersionResultsStoreTest.groovy
@@ -34,7 +34,8 @@ class CrossVersionResultsStoreTest extends ResultSpecification {
     def "persists results"() {
         def result1 = crossVersionResults(testId: "test1",
                 testProject: "test-project",
-                tasks: ["clean", "build"],
+                tasks: ["build"],
+                cleanTasks: ["clean"],
                 args: ["--arg1"],
                 gradleOpts: ["--opt-1", "--opt-2"],
                 daemon: true,
@@ -90,7 +91,8 @@ class CrossVersionResultsStoreTest extends ResultSpecification {
         history.scenarios[1].displayName == "1.5"
         history.scenarios[2].displayName == "master"
         history.scenarios.every { it.testProject == "test-project" }
-        history.scenarios.every { it.tasks == ["clean", "build"] }
+        history.scenarios.every { it.tasks == ["build"] }
+        history.scenarios.every { it.cleanTasks == ["clean"] }
         history.scenarios.every { it.args == ["--arg1"] }
         history.scenarios.every { it.gradleOpts == ["--opt-1", "--opt-2"] }
         history.scenarios.every { it.daemon }
@@ -99,9 +101,10 @@ class CrossVersionResultsStoreTest extends ResultSpecification {
         def results = history.results
         results.size() == 1
         results[0].testId == "test1"
-        results[0].displayName == "Results for test project 'test-project' with tasks clean, build"
+        results[0].displayName == "Results for test project 'test-project' with tasks build, cleaned with clean"
         results[0].testProject == "test-project"
-        results[0].tasks == ["clean", "build"]
+        results[0].tasks == ["build"]
+        results[0].cleanTasks == ["clean"]
         results[0].args == ["--arg1"]
         results[0].gradleOpts == ["--opt-1", "--opt-2"]
         results[0].daemon
@@ -267,7 +270,8 @@ class CrossVersionResultsStoreTest extends ResultSpecification {
         results.scenarios[5].displayName == "master"
         results.scenarios[6].displayName == "release"
         results.scenarios.every { it.testProject == "test-project" }
-        results.scenarios.every { it.tasks == ["clean", "build"] }
+        results.scenarios.every { it.tasks == ["build"] }
+        results.scenarios.every { it.cleanTasks == ["clean"] }
         results.scenarios.every { it.args == [] }
         results.scenarios.every { it.gradleOpts == [] }
         results.scenarios.every { !it.daemon }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/buildcache/LocalTaskOutputCacheCrossBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/buildcache/LocalTaskOutputCacheCrossBuildPerformanceTest.groovy
@@ -62,14 +62,14 @@ class LocalTaskOutputCacheCrossBuildPerformanceTest extends AbstractCrossBuildPe
         runner.testGroup = "task output cache"
         runner.buildSpec {
             projectName(testProject.projectName).displayName("always-miss pull-only cache").invocation {
-                tasksToRun("clean", *tasks.split(' ')).gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").useDaemon().args(
+                tasksToRun(tasks.split(' ')).cleanTasks("clean").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").useDaemon().args(
                     "--build-cache",
                     "--init-script", noPushInitScript.absolutePath.replace('\\', '/'))
             }
         }
         runner.buildSpec {
             projectName(testProject.projectName).displayName("fully cached").invocation {
-                tasksToRun("clean", *tasks.split(' ')).gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").useDaemon().args(
+                tasksToRun(tasks.split(' ')).cleanTasks("clean").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").useDaemon().args(
                     "--build-cache")
             }
         }
@@ -80,7 +80,7 @@ class LocalTaskOutputCacheCrossBuildPerformanceTest extends AbstractCrossBuildPe
         }
         runner.baseline {
             projectName(testProject.projectName).displayName("non-cached").invocation {
-                tasksToRun("clean", *tasks.split(' ')).gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").useDaemon()
+                tasksToRun(tasks.split(' ')).cleanTasks('clean').gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").useDaemon()
             }
         }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
@@ -38,16 +38,16 @@ class JavaTestGradleVsMavenPerformanceTest extends AbstractGradleVsMavenPerforma
         if (testProject.parallel) {
             runner.mvnArgs << '-T' << testProject.maxWorkers
         }
-        runner.gradleTasks = gradleTask
-        runner.equivalentMavenTasks = mavenTask
+        runner.gradleTasks = [gradleTask]
+        runner.equivalentMavenTasks = [mavenTask]
         if (mavenTask == "package") {
             runner.mvnArgs << "-Dmaven.test.skip=true"
         }
         runner.warmUpRuns = 2
         runner.runs = 5
 
-        runner.gradleCleanTasks = "clean"
-        runner.equivalentMavenCleanTasks = "clean"
+        runner.gradleCleanTasks = ["clean"]
+        runner.equivalentMavenCleanTasks = ["clean"]
 
         when:
         def results = runner.run()
@@ -73,14 +73,14 @@ class JavaTestGradleVsMavenPerformanceTest extends AbstractGradleVsMavenPerforma
         if (testProject.parallel) {
             runner.mvnArgs << '-T' << testProject.maxWorkers
         }
-        runner.gradleTasks = gradleTask
-        runner.equivalentMavenTasks = mavenTask
+        runner.gradleTasks = gradleTask.split(' ')
+        runner.equivalentMavenTasks = mavenTask.split(' ')
         if (mavenTask == "package") {
             runner.mvnArgs << "-Dmaven.test.skip=true"
         }
         runner.buildExperimentListener = new ApplyNonAbiChangeToJavaSourceFileMutator(fileToChange)
-        runner.warmUpRuns = 4
-        runner.runs = 10
+        runner.warmUpRuns = 1
+        runner.runs = 1
 
         when:
         def results = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
@@ -17,14 +17,6 @@
 package org.gradle.performance.experiment.maven
 
 import org.gradle.performance.AbstractGradleVsMavenPerformanceTest
-import org.gradle.performance.fixture.BuildExperimentInvocationInfo
-import org.gradle.performance.fixture.BuildExperimentListener
-import org.gradle.performance.fixture.BuildExperimentListenerAdapter
-import org.gradle.performance.fixture.GradleInvocationSpec
-import org.gradle.performance.fixture.InvocationCustomizer
-import org.gradle.performance.fixture.InvocationSpec
-import org.gradle.performance.fixture.MavenInvocationSpec
-import org.gradle.performance.measure.MeasuredOperation
 import org.gradle.performance.mutator.ApplyNonAbiChangeToJavaSourceFileMutator
 import spock.lang.Unroll
 
@@ -54,7 +46,8 @@ class JavaTestGradleVsMavenPerformanceTest extends AbstractGradleVsMavenPerforma
         runner.warmUpRuns = 4
         runner.runs = 10
 
-        setupCleanupOnOddRounds()
+        runner.gradleCleanTasks = "clean"
+        runner.equivalentMavenCleanTasks = "clean"
 
         when:
         def results = runner.run()
@@ -102,35 +95,5 @@ class JavaTestGradleVsMavenPerformanceTest extends AbstractGradleVsMavenPerforma
 
         MEDIUM_JAVA_MULTI_PROJECT      | 'test'     | 'clean test'    | "project0/src/main/java/org/gradle/test/performance/mediumjavamultiproject/project0/p0/Production0.java"
         MEDIUM_JAVA_MULTI_PROJECT      | 'assemble' | 'clean package' | "project0/src/main/java/org/gradle/test/performance/mediumjavamultiproject/project0/p0/Production0.java"
-    }
-
-
-    void setupCleanupOnOddRounds() {
-        runner.invocationCustomizer = new InvocationCustomizer() {
-            @Override
-            def <T extends InvocationSpec> T customize(BuildExperimentInvocationInfo invocationInfo, T invocationSpec) {
-                if (invocationInfo.iterationNumber % 2 == 1) {
-                    if (invocationSpec instanceof GradleInvocationSpec) {
-                        invocationSpec.withBuilder()
-                            .tasksToRun(["clean"])
-                            .build() as T
-                    } else {
-                        (invocationSpec as MavenInvocationSpec).withBuilder()
-                            .tasksToRun(["clean"])
-                            .build() as T
-                    }
-                } else {
-                    invocationSpec
-                }
-            }
-        }
-        runner.buildExperimentListener = new BuildExperimentListenerAdapter() {
-            @Override
-            void afterInvocation(BuildExperimentInvocationInfo invocationInfo, MeasuredOperation operation, BuildExperimentListener.MeasurementCallback measurementCallback) {
-                if (invocationInfo.iterationNumber % 2 == 1) {
-                    measurementCallback.omitMeasurement()
-                }
-            }
-        }
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/maven/JavaTestGradleVsMavenPerformanceTest.groovy
@@ -43,8 +43,8 @@ class JavaTestGradleVsMavenPerformanceTest extends AbstractGradleVsMavenPerforma
         if (mavenTask == "package") {
             runner.mvnArgs << "-Dmaven.test.skip=true"
         }
-        runner.warmUpRuns = 4
-        runner.runs = 10
+        runner.warmUpRuns = 2
+        runner.runs = 5
 
         runner.gradleCleanTasks = "clean"
         runner.equivalentMavenCleanTasks = "clean"

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
@@ -29,13 +29,9 @@ class AbstractTaskOutputCacheJavaPerformanceTest extends AbstractCrossVersionPer
     int firstWarmupWithCache = 1
 
     def setup() {
-        /*
-         * Since every second build is a 'clean', we need more iterations
-         * than usual to get reliable results.
-         */
-        runner.warmUpRuns = 10
-        runner.runs = 26
-        runner.setupCleanupOnOddRounds()
+        runner.warmUpRuns = 5
+        runner.runs = 13
+        runner.cleanTasks = ["clean"]
         runner.args = ["-D${GradleProperties.BUILD_CACHE_PROPERTY}=true"]
         runner.minimumVersion = "3.5"
         runner.targetVersions = ["4.1-20170607235835+0000"]
@@ -62,9 +58,5 @@ class AbstractTaskOutputCacheJavaPerformanceTest extends AbstractCrossVersionPer
 
     boolean isFirstRunWithCache(BuildExperimentInvocationInfo invocationInfo) {
         invocationInfo.iterationNumber == firstWarmupWithCache && invocationInfo.phase == WARMUP
-    }
-
-    static boolean isCleanupRun(BuildExperimentInvocationInfo invocationInfo) {
-        invocationInfo.iterationNumber % 2 == 1
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -78,6 +78,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = tasks.split(' ')
+        runner.cleanTasks = ["clean"]
         protocol = "http"
         pushToRemote = true
         runner.addBuildExperimentListener(cleanLocalCache())
@@ -96,6 +97,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = tasks.split(' ')
+        runner.cleanTasks = ["clean"]
         firstWarmupWithCache = 3 // Do one run without the cache to populate the dependency cache from maven central
         protocol = "https"
         pushToRemote = true
@@ -138,6 +140,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = tasks.split(' ')
+        runner.cleanTasks = ["clean"]
         runner.warmUpRuns = 6
         runner.runs = 8
         pushToRemote = false
@@ -158,6 +161,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = tasks.split(' ')
+        runner.cleanTasks = ["clean"]
         runner.warmUpRuns = 6
         runner.runs = 8
         pushToRemote = true
@@ -182,6 +186,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = tasks.split(' ') as List
+        runner.cleanTasks = ["clean"]
         if (parallel) {
             runner.args += "--parallel"
         }
@@ -203,6 +208,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = tasks.split(' ') as List
+        runner.cleanTasks = ["clean"]
         runner.addBuildExperimentListener(new ApplyAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
         runner.args += "--parallel"
         pushToRemote = false
@@ -222,6 +228,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = tasks.split(' ') as List
+        runner.cleanTasks = ["clean"]
         runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
         runner.args += "--parallel"
         pushToRemote = false
@@ -240,9 +247,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         new BuildExperimentListenerAdapter() {
             @Override
             void beforeInvocation(BuildExperimentInvocationInfo invocationInfo) {
-                if (isCleanupRun(invocationInfo)) {
-                    cacheDir.deleteDir().mkdirs()
-                }
+                cacheDir.deleteDir().mkdirs()
             }
         }
     }
@@ -251,9 +256,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         new BuildExperimentListenerAdapter() {
             @Override
             void beforeInvocation(BuildExperimentInvocationInfo invocationInfo) {
-                if (isCleanupRun(invocationInfo)) {
-                    buildCacheServer.cacheDir.deleteDir().mkdirs()
-                }
+                buildCacheServer.cacheDir.deleteDir().mkdirs()
             }
         }
     }


### PR DESCRIPTION
Previously we were using a workaround where odd runs were removed from measurements, and executed a `clean` build instead of the measured build.

Performance tests can now specify `cleanTasks`, similar to how they specify `tasksToRun`. These `cleanTasks` will be executed before each run (warm-up and measurement alike).

A new column is added to performance test tables to track this new information. It is a nullable column to allow for test results added by older versions of Gradle.

I've updated the task output caching tests and the Maven vs. Gradle comparisons to declare `cleanTasks` instead of the old hack with the odd-even runs.