### PR TITLE
Introduce `@ToBeImplemented`

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AbstractFindBugsPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AbstractFindBugsPluginIntegrationTest.groovy
@@ -15,11 +15,11 @@
  */
 package org.gradle.api.plugins.quality
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Matchers
 import org.gradle.util.Resources
+import org.gradle.util.ToBeImplemented
 import org.hamcrest.Matcher
 import org.junit.Rule
 import spock.lang.IgnoreIf
@@ -578,7 +578,7 @@ abstract class AbstractFindBugsPluginIntegrationTest extends AbstractIntegration
     }
 
     @Issue("https://github.com/gradle/gradle/issues/2326")
-    @NotYetImplemented
+    @ToBeImplemented
     def "check task should not be up-to-date after clean if it only outputs to console"() {
         given:
         badCode()
@@ -600,8 +600,9 @@ abstract class AbstractFindBugsPluginIntegrationTest extends AbstractIntegration
         succeeds('clean', 'check')
 
         then:
-        nonSkippedTasks.contains(':findbugsMain')
-        output.contains("Analyzing classes")
+        // TODO These should match
+        !!! nonSkippedTasks.contains(':findbugsMain')
+        !!! output.contains("Analyzing classes")
     }
 
     private static boolean containsXmlMessages(File xmlReportFile) {

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginVersionIntegrationTest.groovy
@@ -16,12 +16,12 @@
 
 package org.gradle.api.plugins.quality
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.quality.integtest.fixtures.CheckstyleCoverage
 import org.gradle.util.Resources
+import org.gradle.util.ToBeImplemented
 import org.hamcrest.Matcher
 import org.junit.Rule
 import spock.lang.IgnoreIf
@@ -59,7 +59,7 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         file("build/reports/checkstyle/test.html").assertContents(containsClass("org.gradle.TestClass2"))
     }
 
-    @NotYetImplemented
+    @ToBeImplemented
     @Issue("GRADLE-3432")
     def "analyze bad resources"() {
         defaultLanguage('en')
@@ -67,10 +67,12 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         badResources()
 
         expect:
-        fails('check')
+        // TODO Should fail
+        succeeds('check')
 
-        file("build/reports/checkstyle/main.xml").assertContents(containsLine(containsString("bad.properties")))
-        file("build/reports/checkstyle/main.html").assertContents(containsLine(containsString("bad.properties")))
+        // TODO These should match
+        // file("build/reports/checkstyle/main.xml").assertContents(containsLine(containsString("bad.properties")))
+        // file("build/reports/checkstyle/main.html").assertContents(containsLine(containsString("bad.properties")))
     }
 
     def "analyze bad code"() {
@@ -309,7 +311,7 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
     }
 
     @Issue("https://github.com/gradle/gradle/issues/2326")
-    @NotYetImplemented
+    @ToBeImplemented
     def "check task should not be up-to-date after clean if it only outputs to console"() {
         given:
         defaultLanguage('en')
@@ -329,8 +331,9 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         succeeds('clean', 'check')
 
         then:
-        nonSkippedTasks.contains(':checkstyleMain')
-        errorOutput.contains("[ant:checkstyle] [WARN]")
+        // TODO These should match
+        !!! nonSkippedTasks.contains(':checkstyleMain')
+        !!! errorOutput.contains("[ant:checkstyle] [WARN]")
     }
 
     private goodCode() {

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcPluginVersionIntegrationTest.groovy
@@ -16,11 +16,11 @@
 
 package org.gradle.api.plugins.quality
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.ToBeImplemented
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
@@ -153,7 +153,7 @@ class CodeNarcPluginVersionIntegrationTest extends MultiVersionIntegrationSpec {
         expect:
         succeeds("check")
     }
-    
+
     def "output should be printed in stdout if console type is specified"() {
         when:
         buildFile << '''
@@ -171,7 +171,7 @@ class CodeNarcPluginVersionIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/2326")
-    @NotYetImplemented
+    @ToBeImplemented
     def "check task should not be up-to-date after clean if console type is specified"() {
         given:
         buildFile << '''
@@ -187,9 +187,10 @@ class CodeNarcPluginVersionIntegrationTest extends MultiVersionIntegrationSpec {
         succeeds('clean', 'check')
 
         then:
-        nonSkippedTasks.contains(':codenarcMain')
-        output.contains('CodeNarc Report')
-        output.contains('CodeNarc completed: (p1=0; p2=0; p3=0)')
+        // TODO These should match
+        !!! nonSkippedTasks.contains(':codenarcMain')
+        !!! output.contains('CodeNarc Report')
+        !!! output.contains('CodeNarc completed: (p1=0; p2=0; p3=0)')
     }
 
     private goodCode() {

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
@@ -15,8 +15,8 @@
  */
 package org.gradle.api.plugins.quality
 
-import groovy.transform.NotYetImplemented
 import org.gradle.util.TestPrecondition
+import org.gradle.util.ToBeImplemented
 import org.gradle.util.VersionNumber
 import org.hamcrest.Matcher
 import spock.lang.Issue
@@ -202,7 +202,7 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
     }
 
     @Issue("https://github.com/gradle/gradle/issues/2326")
-    @NotYetImplemented
+    @ToBeImplemented
     def "check task should not be up-to-date after clean if it only outputs to console"() {
         given:
         badCode()
@@ -224,8 +224,9 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
         succeeds('clean', 'check')
 
         then:
-        nonSkippedTasks.contains(':pmdMain')
-        output.contains("PMD rule violations were found")
+        // TODO These should match
+        !!! nonSkippedTasks.contains(':pmdMain')
+        !!! output.contains("PMD rule violations were found")
     }
 
     private static Matcher<String> containsClass(String className) {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildContinueOnFailureIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildContinueOnFailureIntegrationTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.integtests.composite
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.util.ToBeImplemented
 import spock.lang.Ignore
-
+import spock.lang.Issue
 /**
  * Tests for composite build delegating to tasks in an included build.
  */
@@ -88,7 +88,8 @@ class CompositeBuildContinueOnFailureIntegrationTest extends AbstractCompositeBu
         assertTaskExecutedOnce(":buildB", ":succeeds")
     }
 
-    @NotYetImplemented // gradle/composite-builds#117
+    @Issue("https://github.com/gradle/gradle/issues/2520")
+    @ToBeImplemented
     def "continues build when delegated task fails when run with --continue"() {
         when:
         buildA.buildFile << """
@@ -110,7 +111,8 @@ class CompositeBuildContinueOnFailureIntegrationTest extends AbstractCompositeBu
         // Thus ":delegateWithSuccess" is never executed.
         assertTaskExecutedOnce(":buildB", ":fails")
         assertTaskExecutedOnce(":buildB", ":succeeds")
-        assertTaskExecutedOnce(":", ":delegateWithSuccess")
+        // TODO Should be executed once
+        assertTaskNotExecuted(":", ":delegateWithSuccess")
     }
 
     def "executes delegate task with --continue"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyArtifactsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyArtifactsIntegrationTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.integtests.composite
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.ToBeImplemented
 /**
  * Tests for resolving dependency artifacts with substitution within a composite build.
  */
@@ -640,7 +640,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
             .assertHasCause("jar task failed")
     }
 
-    @NotYetImplemented
+    @ToBeImplemented
     // We execute do not execute included build with --continue,
     // and we attach the single failure to every delegated task
     def "builds artifacts and reports failures for dependency on multiple subprojects where one fails"() {
@@ -670,8 +670,9 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         fails buildA, ":resolveRuntime"
 
         then:
-        executed ":buildB:b1:jar", ":resolve", ":buildB:b2:jar", ":resolveRuntime"
-        assertResolved buildB.file('b1/build/libs/b1-1.0.jar')
+        // TODO These should pass
+        !!! executedTasks.containsAll(":buildB:b1:jar", ":resolve", ":buildB:b2:jar", ":resolveRuntime")
+        // assertResolved buildB.file('b1/build/libs/b1-1.0.jar')
     }
 
     private void resolveArtifacts() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdeaProjectIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdeaProjectIntegrationTest.groovy
@@ -16,10 +16,12 @@
 
 package org.gradle.integtests.composite
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.plugins.ide.fixtures.IdeaFixtures
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.ToBeImplemented
+import spock.lang.Issue
+
 /**
  * Tests for generating IDEA metadata for projects within a composite build.
  */
@@ -417,7 +419,8 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractCompositeBuildInt
         imlHasDependencies "buildC-buildA", "buildA-b1", "buildB-b1"
     }
 
-    @NotYetImplemented // Should be fixed with gradle/composite-builds#99
+    @ToBeImplemented
+    @Issue("https://github.com/gradle/gradle/issues/2526")
     def "de-duplicates module names when not all projects have IDEA plugin applied"() {
         given:
         dependency "org.test:b1:1.0"
@@ -449,15 +452,23 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractCompositeBuildInt
         idea()
 
         then:
-        iprHasModules "buildA.iml",
+        // TODO Each of these should have modules
+        iprHasModules([
+            "buildA.iml",
             "../buildB/buildB.iml",
             "../buildB/b1/buildB-b1.iml",
             "../buildB/b2/b2.iml",
             "../buildC/buildC.iml",
-            "../buildC/b1/buildC-b1.iml",
-            "../b1/b1.iml"
+            // "../buildC/b1/buildC-b1.iml",
+            // "../b1/b1.iml"
+        ] as String[])
 
-        imlHasDependencies "buildB-b1", "buildC-b1", "b1"
+        // TODO Each of these should have dependencies
+        imlHasDependencies(
+            "buildB-b1",
+            // "buildC-b1",
+            "b1"
+        )
     }
 
     def idea(BuildTestFile projectDir = buildA) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/rules/OverlappingOutputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/rules/OverlappingOutputsIntegrationTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.api.internal.changedetection.rules
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.ToBeImplemented
 import spock.lang.Unroll
 
 class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
@@ -302,7 +302,7 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
 
     // This fails because cleanDirTask will remove fileTask's outputs.
     // So, unless we change this to only clean the *real* outputs of dirTask, this won't work.
-    @NotYetImplemented
+    @ToBeImplemented
     def "overlapping output with fileTask, dirTask then fileTask, cleanDirTask, dirTask"() {
         def cleanDirTask = ":cleanDirTask"
         def (fileTask, fileTaskOutput,
@@ -310,7 +310,8 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
         when:
         withBuildCache().succeeds(fileTask, cleanDirTask, dirTask)
         then:
-        fileTaskOutput.assertExists()
+        // TODO fileTaskOutput should exist
+        fileTaskOutput.assertDoesNotExist()
         dirTaskOutput.assertExists()
         // Both tasks can be cached since fileTask's outputs are removed before dirTask executes
         listCacheFiles().size() == 2

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -16,12 +16,12 @@
 
 package org.gradle.api.tasks
 
-import groovy.transform.NotYetImplemented
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Matchers
+import org.gradle.util.ToBeImplemented
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Issue
@@ -1080,7 +1080,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         skippedTasks.empty
     }
 
-    @NotYetImplemented
+    @ToBeImplemented
     @Issue("https://issues.gradle.org/browse/GRADLE-1276")
     def "changing expansion makes task out-of-date"() {
         given:
@@ -1103,10 +1103,11 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         when:
         run "copy"
         then:
-        skippedTasks.empty
+        // TODO Task should not be skipped
+        !!! skippedTasks.empty
     }
 
-    @NotYetImplemented
+    @ToBeImplemented
     @Issue("https://issues.gradle.org/browse/GRADLE-1298")
     def "changing filter makes task out-of-date"() {
         given:
@@ -1129,10 +1130,11 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         when:
         run "copy"
         then:
-        skippedTasks.empty
+        // TODO Task should not be skipped
+        !!! skippedTasks.empty
     }
 
-    @NotYetImplemented
+    @ToBeImplemented
     @Issue("https://issues.gradle.org/browse/GRADLE-3549")
     def "changing rename makes task out-of-date"() {
         given:
@@ -1155,7 +1157,8 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         when:
         run "copy"
         then:
-        skippedTasks.empty
+        // TODO Task should not be skipped
+        !!! skippedTasks.empty
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3554")

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/ToBeImplemented.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/ToBeImplemented.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates a test that is explicitly testing for some failure that is to be fixed later.
+ *
+ * <p>This annotation replaces {@literal @}{@link groovy.transform.NotYetImplemented}.
+ * The problem with {@code NotYetImplemented} is that it succeeds no matter what causes the marked test
+ * to fail. Tests like that can pass because the expected failure is still present, or even if the
+ * expected failure is replaced by some other failure. It's better to write a test that explicitly
+ * tests for the expected failure, so when it fails for some other reason, it becomes noticeable.
+ * The purpose of this annotation is to keep such tests easy to find in the code.</p>
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ToBeImplemented {
+    String value() default "";
+}


### PR DESCRIPTION
The `@ToBeImplemented` annotation replaces Groovy's `@NotYetImplemented`.

The problem with `NotYetImplemented` is that tests marked with it succeed no matter what causes the test to fail. Marked tests can pass because the expected failure is still present (which is the purpose of the test), or if the expected failure is replaced by some other failure.

It's better to write a test that explicitly tests for the expected failure, so when it fails for some other reason, it becomes noticeable. The purpose of the `@ToBeImplemented` annotation is to keep such tests easy to find in the code.