### PR TITLE
Attach XCode Swift sources to what is configured on `compileSwift`

### DIFF
--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
@@ -114,4 +114,25 @@ apply plugin: 'cpp-executable'
         xcodeProject("${rootProjectName}.xcodeproj").projectFile
             .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.library.allFiles*.name)
     }
+
+    def "changing source location still include them in the project"() {
+        given:
+        buildFile << """
+apply plugin: 'cpp-executable'
+
+def sourceTree = fileTree('src')
+sourceTree.include('**/*.cpp')
+tasks.compileCpp.source(sourceTree)
+tasks.compileCpp.includes(file('include'))
+"""
+
+        when:
+        app.sourceFiles*.writeToDir(file('src'))
+        app.headerFiles*.writeToDir(file('include'))
+        succeeds("xcode")
+
+        then:
+        xcodeProject("${rootProjectName}.xcodeproj").projectFile
+            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.allFiles*.name)
+    }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -114,4 +114,23 @@ apply plugin: 'swift-executable'
         xcodeProject("${rootProjectName}.xcodeproj").projectFile
             .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.library.sourceFiles*.name)
     }
+
+    def "changing source location still include them in the project"() {
+        given:
+        buildFile << """
+apply plugin: 'swift-executable'
+
+def sourceTree = fileTree('Sources')
+sourceTree.include('**/*.swift')
+tasks.compileSwift.source(sourceTree)
+"""
+
+        when:
+        app.writeSources(file('Sources'))
+        succeeds("xcode")
+
+        then:
+        xcodeProject("${rootProjectName}.xcodeproj").projectFile
+            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.sourceFiles*.name)
+    }
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
@@ -49,6 +49,7 @@ import org.gradle.initialization.ProjectPathRegistry;
 import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.PublishArtifactLocalArtifactMetadata;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.language.cpp.plugins.CppBasePlugin;
 import org.gradle.language.cpp.plugins.CppExecutablePlugin;
 import org.gradle.language.cpp.plugins.CppLibraryPlugin;
 import org.gradle.language.cpp.tasks.CppCompile;
@@ -224,9 +225,8 @@ public class XcodePlugin extends IdePlugin {
         FileCollection sourceTree = compileTask.getSource();
         xcode.getProject().getSources().from(sourceTree);
 
-        // TODO - These files can't be figured out from the compileTask and need the concept of source set
-        xcode.getProject().getSources().from(project.fileTree("src/main/headers"));
-        xcode.getProject().getSources().from(project.fileTree("src/main/public"));
+        FileCollection headers = compileTask.getIncludes().minus(project.getConfigurations().getByName(CppBasePlugin.CPP_INCLUDE_PATH));
+        xcode.getProject().getSources().from(headers.getAsFileTree());
 
         // TODO - Reuse the logic from `cpp-executable` or `cpp-library` to find the build task
         XcodeTarget target = newTarget(projectName(project) + " " + toString(productType), productType, toGradleCommand(project.getRootProject()), project.getTasks().getByName("linkMain").getPath(), project.file("build/exe/" + project.getName()), sourceTree);


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
If the source location is changed, XCode won't have any sources. This PR fixes this issue.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=dl%2Fxcode-ide-source)
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
