### PR TITLE
Allow multi-version integration tests to set org.gradle.integtest.versions

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/MultiVersionSpecRunner.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/MultiVersionSpecRunner.groovy
@@ -21,6 +21,7 @@ package org.gradle.integtests.fixtures
  */
 class MultiVersionSpecRunner extends AbstractMultiTestRunner {
 
+    private static final String VERSIONS_SYSPROP_NAME = "org.gradle.integtest.versions"
     public static final String MULTI_VERSION_SYS_PROP = "org.gradle.integtest.multiversion"
 
     MultiVersionSpecRunner(Class<?> target) {
@@ -30,19 +31,36 @@ class MultiVersionSpecRunner extends AbstractMultiTestRunner {
     @Override
     protected void createExecutions() {
         boolean enableAllVersions = "all".equals(System.getProperty(MULTI_VERSION_SYS_PROP, "default"))
+        def selectionCriteria = System.getProperty(VERSIONS_SYSPROP_NAME, "latest").split(",") as List
         def versions = target.getAnnotation(TargetVersions)
         def coverage = target.getAnnotation(TargetCoverage)
         def versionUnderTest
 
         if (versions != null) {
-            versionUnderTest = enableAllVersions ? versions.value() : [versions.value().last()]
+            versionUnderTest = selectVersions(enableAllVersions, versions.value() as List, selectionCriteria)
         } else if (coverage != null) {
             def coverageTargets = coverage.value().newInstance(target, target).call()
-            versionUnderTest = enableAllVersions ? coverageTargets : [coverageTargets.last()]
+            versionUnderTest = selectVersions(enableAllVersions, coverageTargets as List, selectionCriteria)
         } else {
             throw new RuntimeException("Target class '$target' is not annotated with @${TargetVersions.simpleName} nor with @${TargetCoverage.simpleName}.")
         }
-        versionUnderTest.toUnique().each { add(new VersionExecution(it)) }
+        versionUnderTest.each { add(new VersionExecution(it)) }
+    }
+
+    private static List<String> selectVersions(boolean enableAllVersions, List<String> possibleVersions, List<String> selectionCriteria) {
+        final List result
+        if (enableAllVersions) {
+            result = possibleVersions
+        } else {
+            if (selectionCriteria.size() == 1 && selectionCriteria[0] == "latest") {
+                result = [ possibleVersions.last() ]
+            } else {
+                result = possibleVersions.findAll {
+                    it.toString() in selectionCriteria
+                }
+            }
+        }
+        return result.toUnique()
     }
 
     private static class VersionExecution extends AbstractMultiTestRunner.Execution {


### PR DESCRIPTION
This behaves similarly to TAPI tests that allow you to select a particular version
to test with.  This is an existing system property that was only used by
AbstractCompatibilityTestRunner.

Previously, you had to choose "latest" (which is the last element in the possible versions)
or "all" (which would test all versions) with org.gradle.integtest.multiversion.

For Play tests, I want to be able to test a single version that's not necessarily the last in the list.
