### PR TITLE
Build cache: faster copy operations

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/BuildCacheBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/internal/BuildCacheBuildOperationsIntegrationTest.groovy
@@ -230,7 +230,7 @@ class BuildCacheBuildOperationsIntegrationTest extends AbstractIntegrationSpec i
         def failedLoadOp = operations.only(BuildCacheArchiveUnpackBuildOperationType)
         failedLoadOp.details.cacheKey != null
         failedLoadOp.result == null
-        failedLoadOp.failure.startsWith "org.gradle.api.UncheckedIOException: java.io.FileNotFoundException: not.there"
+        failedLoadOp.failure =~ /org.gradle.api.UncheckedIOException:.* not.there/
     }
 
     def "records ops for miss then store"() {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
@@ -49,6 +49,8 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.progress.BuildOperationDescriptor;
 
 import javax.annotation.Nullable;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -166,7 +168,7 @@ public class DefaultBuildCacheController implements BuildCacheController {
                 public void run(BuildOperationContext context) {
                     InputStream input;
                     try {
-                        input = new FileInputStream(file);
+                        input = new BufferedInputStream(new FileInputStream(file));
                     } catch (FileNotFoundException e) {
                         throw new UncheckedIOException(e);
                     }
@@ -239,7 +241,7 @@ public class DefaultBuildCacheController implements BuildCacheController {
                 @Override
                 public void run(BuildOperationContext context) {
                     try {
-                        BuildCacheStoreCommand.Result result = command.store(new FileOutputStream(file));
+                        BuildCacheStoreCommand.Result result = command.store(new BufferedOutputStream(new FileOutputStream(file)));
                         context.setResult(new PackOperationResult(
                             result.getArtifactEntryCount(),
                             file.length()


### PR DESCRIPTION
- ~~Use Java 7 NIO APIs to open streams~~
- Use a fixed number of copy buffers instead of allocating them on demand per file
- Buffer input and output streams
