### PR TITLE
Use Google Snappy to compress task output cache artifacts

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/modules/PatchExternalModules.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/modules/PatchExternalModules.groovy
@@ -87,6 +87,7 @@ class PatchExternalModules extends DefaultTask {
             .exclude("META-INF/native/**/*jansi.*")
             .includeJar("native-platform-")
             .includeJar("jansi-", "META-INF/native/**", "org/fusesource/jansi/internal/CLibrary*.class")
+            .exclude("org/iq80/snappy/**").includeJar("snappy", "org/iq80/snappy/**")
             .writePatchedFilesTo(destination)
     }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -101,7 +101,8 @@ libraries += [
     jansi: dependencies.module('org.fusesource.jansi:jansi:1.14'),
     xerces: "xerces:xercesImpl:2.9.1",
     objenesis: 'org.objenesis:objenesis:1.2@jar',
-    jsoup:'org.jsoup:jsoup:1.6.3'
+    jsoup:'org.jsoup:jsoup:1.6.3',
+    snappy: 'org.iq80.snappy:snappy:0.4',
 ]
 
 libraries.maven3 = dependencies.module("org.apache.maven:maven-core:${versions.maven}") {

--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation libraries.commons_lang
     implementation libraries.jcip
     implementation libraries.nativePlatform
+    implementation libraries.snappy
 
     runtimeOnly project(":docs")
 

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/BuildCacheTaskServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/BuildCacheTaskServices.java
@@ -45,7 +45,7 @@ public class BuildCacheTaskServices {
     TaskOutputPacker createTaskResultPacker(
         FileSystem fileSystem
     ) {
-        return new GZipTaskOutputPacker(new TarTaskOutputPacker(fileSystem));
+        return new SnappyTaskOutputPacker(new TarTaskOutputPacker(fileSystem));
     }
 
     TaskOutputOriginFactory createTaskOutputOriginFactory(

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/SnappyTaskOutputPacker.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/SnappyTaskOutputPacker.java
@@ -41,7 +41,7 @@ public class SnappyTaskOutputPacker implements TaskOutputPacker {
 
     @Override
     public PackResult pack(SortedSet<ResolvedTaskOutputFilePropertySpec> propertySpecs, OutputStream output, TaskOutputOriginWriter writeOrigin) throws IOException {
-        OutputStream compressedOutput = new SnappyFramedOutputStream(output);
+        OutputStream compressedOutput = new SnappyFramedOutputStream(output, SnappyFramedOutputStream.DEFAULT_BLOCK_SIZE, 1.0);
         try {
             return delegate.pack(propertySpecs, compressedOutput, writeOrigin);
         } finally {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputPacker.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputPacker.java
@@ -27,13 +27,13 @@ import java.io.OutputStream;
 import java.util.SortedSet;
 
 public interface TaskOutputPacker {
-    // Initial format version
+    // Cache artifact format version
     // NOTE: This should be changed whenever we change the way we pack a cache entry, such as
-    // - changing from gzip to bzip2.
+    // - changing from Snappy to gzip.
     // - adding/removing properties to the origin metadata
     // - using a different format for the origin metadata
     // - any major changes of the layout of a cache entry
-    int CACHE_ENTRY_FORMAT = 1;
+    int CACHE_ENTRY_FORMAT = 2;
 
     PackResult pack(SortedSet<ResolvedTaskOutputFilePropertySpec> propertySpecs, OutputStream output, TaskOutputOriginWriter writeOrigin) throws IOException;
 

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
     abstract String getDistributionLabel()
 
     int getLibJarsCount() {
-        170
+        171
     }
 
     def "no duplicate entries"() {


### PR DESCRIPTION
Use [Snappy](https://github.com/dain/snappy) instead of GZip.