### PR TITLE
Add task path to task output build cache key

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
@@ -62,7 +62,8 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends AbstractIntegrat
         withBuildCache().succeeds "customTask"
 
         then:
-        output ==~ /(?s).*org\.gradle\.caching\.BuildCacheException: Unable to store entry at .*: ${errorPattern}.*/
+        output =~ /Could not store entry .* for task :customTask in remote build cache/
+        output =~ /.*org\.gradle\.caching\.BuildCacheException: Unable to store entry at .*: ${errorPattern}/
     }
 
     private void startServer() {

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
@@ -62,7 +62,7 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends AbstractIntegrat
         withBuildCache().succeeds "customTask"
 
         then:
-        output =~ /Could not store entry .* for task :customTask in remote build cache/
+        output =~ /Could not store entry .* for task ':customTask' in remote build cache/
         output =~ /.*org\.gradle\.caching\.BuildCacheException: Unable to store entry at .*: ${errorPattern}/
     }
 

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
@@ -67,6 +67,11 @@ class HttpBuildCacheServiceTest extends Specification {
         String toString() {
             return getHashCode()
         }
+
+        @Override
+        String getDisplayName() {
+            return getHashCode()
+        }
     }
 
     def setup() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/VerifyNoTaskInputChangesTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/VerifyNoTaskInputChangesTaskExecutionIntegrationTest.groovy
@@ -34,7 +34,7 @@ class VerifyNoTaskInputChangesTaskExecutionIntegrationTest extends AbstractInteg
         expect:
         fails '-Dorg.gradle.tasks.verifyinputs=true', 'someTask'
         failure.assertHasDescription('Execution failed for task \':someTask\'.')
-        failure.assertHasCause('The inputs for the task changed during the execution! Check if you have a `doFirst` changing the inputs.')
+        failure.assertHasCause('The inputs for the task changed during the execution! Check if you have a task action changing the inputs.')
 
         where:
         what | expression

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
@@ -50,20 +50,18 @@ public class DefaultTaskArtifactStateRepository implements TaskArtifactStateRepo
     private final Instantiator instantiator;
     private final FileCollectionFactory fileCollectionFactory;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
-    private final TaskCacheKeyCalculator cacheKeyCalculator;
     private final ValueSnapshotter valueSnapshotter;
     private final TaskOutputFilesRepository taskOutputFilesRepository;
 
     public DefaultTaskArtifactStateRepository(TaskHistoryRepository taskHistoryRepository, Instantiator instantiator,
                                               FileCollectionSnapshotterRegistry fileCollectionSnapshotterRegistry,
                                               FileCollectionFactory fileCollectionFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
-                                              TaskCacheKeyCalculator cacheKeyCalculator, ValueSnapshotter valueSnapshotter, TaskOutputFilesRepository taskOutputFilesRepository) {
+                                              ValueSnapshotter valueSnapshotter, TaskOutputFilesRepository taskOutputFilesRepository) {
         this.taskHistoryRepository = taskHistoryRepository;
         this.instantiator = instantiator;
         this.fileCollectionSnapshotterRegistry = fileCollectionSnapshotterRegistry;
         this.fileCollectionFactory = fileCollectionFactory;
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
-        this.cacheKeyCalculator = cacheKeyCalculator;
         this.valueSnapshotter = valueSnapshotter;
         this.taskOutputFilesRepository = taskOutputFilesRepository;
     }
@@ -127,7 +125,7 @@ public class DefaultTaskArtifactStateRepository implements TaskArtifactStateRepo
         public TaskOutputCachingBuildCacheKey calculateCacheKey() {
             // Ensure that states are created
             getStates();
-            return cacheKeyCalculator.calculate(history.getCurrentExecution());
+            return TaskCacheKeyCalculator.calculate(task, history.getCurrentExecution());
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
@@ -21,13 +21,40 @@ import org.gradle.api.internal.OverlappingOutputs;
 import org.gradle.api.internal.TaskExecutionHistory;
 import org.gradle.api.internal.changedetection.TaskArtifactState;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
-import org.gradle.caching.internal.tasks.DefaultTaskOutputCachingBuildCacheKeyBuilder;
+import org.gradle.caching.internal.tasks.BuildCacheKeyInputs;
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey;
 import org.gradle.internal.id.UniqueId;
 
 import java.util.Collection;
 
 class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory {
+
+    public static final TaskArtifactState INSTANCE = new NoHistoryArtifactState();
+    private static final TaskOutputCachingBuildCacheKey NO_CACHE_KEY = new TaskOutputCachingBuildCacheKey() {
+        @Override
+        public String getHashCode() {
+            return null;
+        }
+
+        @Override
+        public BuildCacheKeyInputs getInputs() {
+            return null;
+        }
+
+        @Override
+        public boolean isValid() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "INVALID";
+        }
+    };
+
+    private NoHistoryArtifactState() {
+    }
+
     @Override
     public boolean isUpToDate(Collection<String> messages) {
         messages.add("Task has not declared any outputs.");
@@ -46,7 +73,7 @@ class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory 
 
     @Override
     public TaskOutputCachingBuildCacheKey calculateCacheKey() {
-        return DefaultTaskOutputCachingBuildCacheKeyBuilder.NO_CACHE_KEY;
+        return NO_CACHE_KEY;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
@@ -56,6 +56,11 @@ class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory 
         public BuildCacheKeyInputs getInputs() {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public String getDisplayName() {
+            return toString();
+        }
     };
 
     private NoHistoryArtifactState() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
@@ -31,6 +31,16 @@ import java.util.Collection;
 class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory {
 
     public static final TaskArtifactState INSTANCE = new NoHistoryArtifactState();
+
+    private static final BuildCacheKeyInputs NO_CACHE_KEY_INPUTS = new BuildCacheKeyInputs(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+    );
+
     private static final TaskOutputCachingBuildCacheKey NO_CACHE_KEY = new TaskOutputCachingBuildCacheKey() {
         @Override
         public boolean isValid() {
@@ -49,12 +59,12 @@ class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory 
 
         @Override
         public String getHashCode() {
-            throw new UnsupportedOperationException();
+            return null;
         }
 
         @Override
         public BuildCacheKeyInputs getInputs() {
-            throw new UnsupportedOperationException();
+            return NO_CACHE_KEY_INPUTS;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.caching.internal.tasks.BuildCacheKeyInputs;
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey;
 import org.gradle.internal.id.UniqueId;
+import org.gradle.util.Path;
 
 import java.util.Collection;
 
@@ -32,16 +33,6 @@ class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory 
     public static final TaskArtifactState INSTANCE = new NoHistoryArtifactState();
     private static final TaskOutputCachingBuildCacheKey NO_CACHE_KEY = new TaskOutputCachingBuildCacheKey() {
         @Override
-        public String getHashCode() {
-            return null;
-        }
-
-        @Override
-        public BuildCacheKeyInputs getInputs() {
-            return null;
-        }
-
-        @Override
         public boolean isValid() {
             return false;
         }
@@ -49,6 +40,21 @@ class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory 
         @Override
         public String toString() {
             return "INVALID";
+        }
+
+        @Override
+        public Path getTaskPath() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getHashCode() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BuildCacheKeyInputs getInputs() {
+            throw new UnsupportedOperationException();
         }
     };
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ShortCircuitTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ShortCircuitTaskArtifactStateRepository.java
@@ -42,11 +42,12 @@ public class ShortCircuitTaskArtifactStateRepository implements TaskArtifactStat
 
     public TaskArtifactState getStateFor(final TaskInternal task) {
 
-        if (!task.getOutputs().getHasOutput()) { // Only false if no declared outputs AND no Task.upToDateWhen spec. We force to true for incremental tasks.
-            return new NoHistoryArtifactState();
+        // Only false if no declared outputs AND no Task.upToDateWhen spec. We force to true for incremental tasks.
+        if (!task.getOutputs().getHasOutput()) {
+            return NoHistoryArtifactState.INSTANCE;
         }
 
-        final TaskArtifactState state = repository.getStateFor(task);
+        TaskArtifactState state = repository.getStateFor(task);
 
         if (startParameter.isRerunTasks()) {
             return new RerunTaskArtifactState(state, task, "Executed with '--rerun-tasks'.");

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
@@ -111,7 +111,7 @@ public class SkipCachedTaskExecuter implements TaskExecuter {
                     try {
                         buildCache.store(buildCacheCommandFactory.createStore(cacheKey, outputProperties, task, clock));
                     } catch (Exception e) {
-                        LOGGER.warn("Failed to store cache entry {} for {}", cacheKey, task, e);
+                        LOGGER.warn("Failed to store cache entry {}", cacheKey.getDisplayName(), task, e);
                     }
                 } else {
                     LOGGER.debug("Not pushing result from {} to cache because the task failed", task);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuter.java
@@ -45,7 +45,7 @@ public class VerifyNoInputChangesTaskExecuter implements TaskExecuter {
                 throw new TaskExecutionException(task, new GradleException("The build cache key became invalid after the task has been executed!"));
             }
             if (!beforeExecution.getHashCode().equals(afterExecution.getHashCode())) {
-                throw new TaskExecutionException(task, new GradleException("The inputs for the task changed during the execution! Check if you have a `doFirst` changing the inputs."));
+                throw new TaskExecutionException(task, new GradleException("The inputs for the task changed during the execution! Check if you have a task action changing the inputs."));
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/caching/BuildCacheKey.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/BuildCacheKey.java
@@ -16,6 +16,7 @@
 
 package org.gradle.caching;
 
+import org.gradle.api.Describable;
 import org.gradle.api.Incubating;
 
 /**
@@ -24,7 +25,7 @@ import org.gradle.api.Incubating;
  * @since 3.3
  */
 @Incubating
-public interface BuildCacheKey {
+public interface BuildCacheKey extends Describable {
     /**
      * Returns the string representation of the cache key.
      */

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/service/BaseBuildCacheServiceHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/service/BaseBuildCacheServiceHandle.java
@@ -56,7 +56,7 @@ public class BaseBuildCacheServiceHandle implements BuildCacheServiceHandle {
 
     @Override
     public final void load(BuildCacheKey key, LoadTarget loadTarget) {
-        String description = "Load entry " + key + " from " + role.getDisplayName() + " build cache";
+        String description = "Load entry " + key.getHashCode() + " from " + role.getDisplayName() + " build cache";
         LOGGER.debug(description);
         try {
             loadInner(description, key, loadTarget);
@@ -80,7 +80,7 @@ public class BaseBuildCacheServiceHandle implements BuildCacheServiceHandle {
 
     @Override
     public final void store(BuildCacheKey key, StoreTarget storeTarget) {
-        String description = "Store entry " + key + " in " + role.getDisplayName() + " build cache";
+        String description = "Store entry " + key.getHashCode() + " in " + role.getDisplayName() + " build cache";
         LOGGER.debug(description);
         try {
             storeInner(description, key, storeTarget);
@@ -96,7 +96,7 @@ public class BaseBuildCacheServiceHandle implements BuildCacheServiceHandle {
     private void failure(String verb, String preposition, BuildCacheKey key, Throwable e) {
         disabled = true;
 
-        String description = "Could not " + verb + " entry " + key + " " + preposition + " " + role.getDisplayName() + " build cache";
+        String description = "Could not " + verb + " entry " + key.getDisplayName() + " " + preposition + " " + role.getDisplayName() + " build cache";
         if (LOGGER.isWarnEnabled()) {
             if (logStackTraces) {
                 LOGGER.warn(description, e);

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/BuildCacheTaskServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/BuildCacheTaskServices.java
@@ -38,10 +38,6 @@ import java.io.File;
 
 public class BuildCacheTaskServices {
 
-    TaskCacheKeyCalculator createTaskCacheKeyCalculator() {
-        return new TaskCacheKeyCalculator();
-    }
-
     TaskOutputPacker createTaskResultPacker(
         FileSystem fileSystem
     ) {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/DefaultTaskOutputCachingBuildCacheKeyBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/DefaultTaskOutputCachingBuildCacheKeyBuilder.java
@@ -133,6 +133,11 @@ public class DefaultTaskOutputCachingBuildCacheKeyBuilder implements TaskOutputC
         }
 
         @Override
+        public Path getTaskPath() {
+            return taskPath;
+        }
+
+        @Override
         public String getHashCode() {
             return Preconditions.checkNotNull(hashCode, "Cannot determine hash code for invalid build cache key").toString();
         }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/DefaultTaskOutputCachingBuildCacheKeyBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/DefaultTaskOutputCachingBuildCacheKeyBuilder.java
@@ -153,11 +153,16 @@ public class DefaultTaskOutputCachingBuildCacheKeyBuilder implements TaskOutputC
         }
 
         @Override
-        public String toString() {
+        public String getDisplayName() {
             if (hashCode == null) {
-                return "INVALID task cache key";
+                return "INVALID cache key for task " + taskPath;
             }
             return hashCode + " for task " + taskPath;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(hashCode);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/DefaultTaskOutputCachingBuildCacheKeyBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/DefaultTaskOutputCachingBuildCacheKeyBuilder.java
@@ -155,9 +155,9 @@ public class DefaultTaskOutputCachingBuildCacheKeyBuilder implements TaskOutputC
         @Override
         public String getDisplayName() {
             if (hashCode == null) {
-                return "INVALID cache key for task " + taskPath;
+                return "INVALID cache key for task '" + taskPath + "'";
             }
-            return hashCode + " for task " + taskPath;
+            return hashCode + " for task '" + taskPath + "'";
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskCacheKeyCalculator.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskCacheKeyCalculator.java
@@ -17,6 +17,7 @@
 package org.gradle.caching.internal.tasks;
 
 import com.google.common.hash.HashCode;
+import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshot;
 import org.gradle.api.internal.changedetection.state.TaskExecution;
 import org.gradle.api.internal.changedetection.state.ValueSnapshot;
@@ -28,8 +29,8 @@ import java.util.SortedSet;
 
 public class TaskCacheKeyCalculator {
 
-    public TaskOutputCachingBuildCacheKey calculate(TaskExecution execution) {
-        TaskOutputCachingBuildCacheKeyBuilder builder = new DefaultTaskOutputCachingBuildCacheKeyBuilder();
+    public static TaskOutputCachingBuildCacheKey calculate(TaskInternal task, TaskExecution execution) {
+        TaskOutputCachingBuildCacheKeyBuilder builder = new DefaultTaskOutputCachingBuildCacheKeyBuilder(task.getIdentityPath());
         builder.appendTaskImplementation(execution.getTaskImplementation());
         builder.appendTaskActionImplementations(execution.getTaskActionImplementations());
 

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputCachingBuildCacheKey.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputCachingBuildCacheKey.java
@@ -17,8 +17,11 @@
 package org.gradle.caching.internal.tasks;
 
 import org.gradle.caching.BuildCacheKey;
+import org.gradle.util.Path;
 
 public interface TaskOutputCachingBuildCacheKey extends BuildCacheKey {
+    Path getTaskPath();
+
     BuildCacheKeyInputs getInputs();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
@@ -63,7 +63,6 @@ import org.gradle.cache.PersistentCache;
 import org.gradle.cache.internal.FileLockManager;
 import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.caching.internal.tasks.BuildCacheTaskServices;
-import org.gradle.caching.internal.tasks.TaskCacheKeyCalculator;
 import org.gradle.caching.internal.tasks.TaskOutputCacheCommandFactory;
 import org.gradle.execution.taskgraph.TaskPlanExecutor;
 import org.gradle.execution.taskgraph.TaskPlanExecutorFactory;
@@ -186,7 +185,7 @@ public class TaskExecutionServices {
         return new DefaultTaskOutputFilesRepository(cacheAccess, fileSystemMirror, inMemoryCacheDecoratorFactory);
     }
 
-    TaskArtifactStateRepository createTaskArtifactStateRepository(Instantiator instantiator, StartParameter startParameter, FileCollectionFactory fileCollectionFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, FileCollectionSnapshotterRegistry fileCollectionSnapshotterRegistry, TaskHistoryRepository taskHistoryRepository, TaskOutputFilesRepository taskOutputsRepository, TaskCacheKeyCalculator cacheKeyCalculator, ValueSnapshotter valueSnapshotter) {
+    TaskArtifactStateRepository createTaskArtifactStateRepository(Instantiator instantiator, StartParameter startParameter, FileCollectionFactory fileCollectionFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, FileCollectionSnapshotterRegistry fileCollectionSnapshotterRegistry, TaskHistoryRepository taskHistoryRepository, TaskOutputFilesRepository taskOutputsRepository, ValueSnapshotter valueSnapshotter) {
 
         return new ShortCircuitTaskArtifactStateRepository(
             startParameter,
@@ -197,7 +196,6 @@ public class TaskExecutionServices {
                 fileCollectionSnapshotterRegistry,
                 fileCollectionFactory,
                 classLoaderHierarchyHasher,
-                cacheKeyCalculator,
                 valueSnapshotter,
                 taskOutputsRepository
             )

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
@@ -42,7 +42,6 @@ import org.gradle.api.tasks.incremental.InputFileDetails
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.internal.CacheScopeMapping
 import org.gradle.cache.internal.DefaultCacheRepository
-import org.gradle.caching.internal.tasks.TaskCacheKeyCalculator
 import org.gradle.internal.classloader.ConfigurableClassLoaderHierarchyHasher
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.id.RandomLongIdGenerator
@@ -82,7 +81,6 @@ class DefaultTaskArtifactStateRepositoryTest extends AbstractProjectBuilderSpec 
     DefaultGenericFileCollectionSnapshotter fileCollectionSnapshotter
     DefaultTaskArtifactStateRepository repository
     DefaultFileSystemMirror fileSystemMirror
-    TaskCacheKeyCalculator cacheKeyCalculator = Mock(TaskCacheKeyCalculator)
     TaskOutputFilesRepository taskOutputFilesRepository = Stub(TaskOutputFilesRepository)
 
     def setup() {
@@ -101,7 +99,7 @@ class DefaultTaskArtifactStateRepositoryTest extends AbstractProjectBuilderSpec 
         SerializerRegistry serializerRegistry = new DefaultSerializerRegistry()
         fileCollectionSnapshotter.registerSerializers(serializerRegistry)
         TaskHistoryRepository taskHistoryRepository = new CacheBackedTaskHistoryRepository(cacheAccess, new CacheBackedFileSnapshotRepository(cacheAccess, serializerRegistry.build(FileCollectionSnapshot), new RandomLongIdGenerator()), stringInterner, buildScopeId)
-        repository = new DefaultTaskArtifactStateRepository(taskHistoryRepository, DirectInstantiator.INSTANCE, new DefaultFileCollectionSnapshotterRegistry([fileCollectionSnapshotter]), TestFiles.fileCollectionFactory(), classLoaderHierarchyHasher, cacheKeyCalculator, new ValueSnapshotter(classLoaderHierarchyHasher), taskOutputFilesRepository)
+        repository = new DefaultTaskArtifactStateRepository(taskHistoryRepository, DirectInstantiator.INSTANCE, new DefaultFileCollectionSnapshotterRegistry([fileCollectionSnapshotter]), TestFiles.fileCollectionFactory(), classLoaderHierarchyHasher, new ValueSnapshotter(classLoaderHierarchyHasher), taskOutputFilesRepository)
     }
 
     def "artifacts are not up to date when cache is empty"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuterTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskExecutionContext
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.caching.internal.tasks.BuildCacheKeyInputs
-import org.gradle.caching.internal.tasks.DefaultTaskOutputCachingBuildCacheKeyBuilder
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.testing.internal.util.Specification
@@ -94,20 +93,21 @@ class ResolveBuildCacheKeyExecuterTest extends Specification {
     }
 
     def "does not calculate cache key when task has no outputs"() {
+        def noCacheKey = Mock(TaskOutputCachingBuildCacheKey)
         when:
         executer.execute(task, taskState, taskContext)
 
         then:
         1 * task.getIdentityPath() >> Path.path(":foo")
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
-        1 * taskArtifactState.calculateCacheKey() >> DefaultTaskOutputCachingBuildCacheKeyBuilder.NO_CACHE_KEY
+        1 * taskArtifactState.calculateCacheKey() >> noCacheKey
 
         then:
         1 * task.getOutputs() >> taskOutputs
         1 * taskOutputs.getHasOutput() >> false
 
         then:
-        1 * taskContext.setBuildCacheKey(DefaultTaskOutputCachingBuildCacheKeyBuilder.NO_CACHE_KEY)
+        1 * taskContext.setBuildCacheKey(noCacheKey)
 
         then:
         1 * delegate.execute(task, taskState, taskContext)
@@ -115,7 +115,7 @@ class ResolveBuildCacheKeyExecuterTest extends Specification {
 
         and:
         with(buildOpResult(), ResolveBuildCacheKeyExecuter.OperationResultImpl) {
-            key == DefaultTaskOutputCachingBuildCacheKeyBuilder.NO_CACHE_KEY
+            key == noCacheKey
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
@@ -285,6 +285,7 @@ class SkipCachedTaskExecuterTest extends Specification {
 
         then:
         1 * cacheKey.isValid() >> true
+        1 * cacheKey.getDisplayName() >> "cache key"
         1 * taskState.getFailure() >> null
         1 * buildCacheCommandFactory.createStore(*_)
         1 * buildCacheController.store(_) >> { throw new RuntimeException("unknown error") }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuterTest.groovy
@@ -83,7 +83,7 @@ class VerifyNoInputChangesTaskExecuterTest extends Specification {
 
         TaskExecutionException e = thrown(TaskExecutionException)
         e.task == task
-        e.cause.message == "The inputs for the task changed during the execution! Check if you have a `doFirst` changing the inputs."
+        e.cause.message == "The inputs for the task changed during the execution! Check if you have a task action changing the inputs."
     }
 
     def 'exception if cache key became invalid'() {
@@ -125,6 +125,16 @@ class VerifyNoInputChangesTaskExecuterTest extends Specification {
             @Override
             boolean isValid() {
                 return true
+            }
+
+            @Override
+            String getDisplayName() {
+                return "test: $hash"
+            }
+
+            @Override
+            String toString() {
+                return getDisplayName()
             }
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuterTest.groovy
@@ -108,6 +108,11 @@ class VerifyNoInputChangesTaskExecuterTest extends Specification {
     private static TaskOutputCachingBuildCacheKey cacheKey(String hash) {
         new TaskOutputCachingBuildCacheKey() {
             @Override
+            Path getTaskPath() {
+                return Path.path(":test")
+            }
+
+            @Override
             String getHashCode() {
                 return hash
             }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/VerifyNoInputChangesTaskExecuterTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.caching.internal.tasks.BuildCacheKeyInputs
 import org.gradle.caching.internal.tasks.DefaultTaskOutputCachingBuildCacheKeyBuilder
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey
+import org.gradle.util.Path
 import spock.lang.Specification
 
 class VerifyNoInputChangesTaskExecuterTest extends Specification {
@@ -124,6 +125,6 @@ class VerifyNoInputChangesTaskExecuterTest extends Specification {
     }
 
     private static TaskOutputCachingBuildCacheKey invalidCacheKey() {
-        return new DefaultTaskOutputCachingBuildCacheKeyBuilder().build()
+        return new DefaultTaskOutputCachingBuildCacheKeyBuilder(Path.path(":invalid")).build()
     }
 }


### PR DESCRIPTION
This has the side-effect to display the task name for every failure involving a task output build cache key.