### PR TITLE
Add deprecation advice

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -543,7 +543,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     public boolean dependsOnTaskDidWork() {
         DeprecationLogger.nagUserOfDiscontinuedMethod(
             "Task.dependsOnTaskDidWork()",
-            "instead, carefully declare the task inputs and outputs and let Gradle decide what needs to be run");
+            "Instead, carefully declare the task inputs and outputs and let Gradle decide what needs to be run.");
         TaskDependency dependency = getTaskDependencies();
         for (Task depTask : dependency.getDependencies(this)) {
             if (depTask.getDidWork()) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -541,7 +541,9 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public boolean dependsOnTaskDidWork() {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("Task.dependsOnTaskDidWork()");
+        DeprecationLogger.nagUserOfDiscontinuedMethod(
+            "Task.dependsOnTaskDidWork()",
+            "instead, carefully declare the task inputs and outputs and let Gradle decide what needs to be run");
         TaskDependency dependency = getTaskDependencies();
         for (Task depTask : dependency.getDependencies(this)) {
             if (depTask.getDidWork()) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -543,7 +543,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     public boolean dependsOnTaskDidWork() {
         DeprecationLogger.nagUserOfDiscontinuedMethod(
             "Task.dependsOnTaskDidWork()",
-            "Instead, carefully declare the task inputs and outputs and let Gradle decide what needs to be run.");
+            "Instead, check the value of \"didWork()\" for each task, or declare the task inputs and outputs and let Gradle decide what needs to be run.");
         TaskDependency dependency = getTaskDependencies();
         for (Task depTask : dependency.getDependencies(this)) {
             if (depTask.getDidWork()) {


### PR DESCRIPTION
Before, users who were using the `dependsOnTaskDidWork()` weren't
given any advice about how to get back on the happy path.

Fixes #2671
