### PR TITLE
Prevent parallel project configuration

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectAccessListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectAccessListener.java
@@ -28,7 +28,7 @@ public class DefaultProjectAccessListener implements ProjectAccessListener {
         evaluateProjectAndDiscoverTasks(targetProject);
     }
 
-    private void evaluateProjectAndDiscoverTasks(ProjectInternal targetProject) {
+    private synchronized void evaluateProjectAndDiscoverTasks(final ProjectInternal targetProject) {
         targetProject.evaluate();
         targetProject.getTasks().discoverTasks();
     }


### PR DESCRIPTION
When a Task resolves a Configuration that it didn't declare
as an input and another task does the same in parallel, then
both tasks can end up trying to configure a Project which was
not discovered as a dependency at configuration time. Configuring
projects in parallel is not safe.

This change guards access to the project from parallel resolvers
by acquiring the project lock first.

Stage 4 build: https://builds.gradle.org/viewLog.html?buildId=7565032&tab=buildResultsDiv&buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger