### PR TITLE
Increase default timeout for BlockingHttpServer

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildProgressLoggerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildProgressLoggerIntegrationTest.groovy
@@ -24,7 +24,7 @@ class BuildProgressLoggerIntegrationTest extends AbstractConsoleFunctionalSpec {
     private static final String SERVER_RESOURCE = 'test-resource'
 
     @Rule
-    BlockingHttpServer server = new BlockingHttpServer(40000)
+    BlockingHttpServer server = new BlockingHttpServer()
 
     def setup() {
         server.start()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
@@ -51,7 +51,7 @@ public class BlockingHttpServer extends ExternalResource {
     private boolean running;
 
     public BlockingHttpServer() throws IOException {
-        this(30000);
+        this(120000);
     }
 
     public BlockingHttpServer(int timeoutMs) throws IOException {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
@@ -30,7 +30,7 @@ class ConsoleJvmTestWorkerFunctionalTest extends AbstractConsoleFunctionalSpec {
     private static final String SERVER_RESOURCE_2 = 'test-2'
 
     @Rule
-    BlockingHttpServer server = new BlockingHttpServer(50000)
+    BlockingHttpServer server = new BlockingHttpServer()
 
     def setup() {
         server.start()

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishConsoleIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishConsoleIntegrationTest.groovy
@@ -25,7 +25,7 @@ import static org.gradle.integtests.fixtures.AbstractConsoleFunctionalSpec.workI
 
 class MavenPublishConsoleIntegrationTest extends AbstractMavenPublishIntegTest {
     @Rule
-    BlockingHttpServer server = new BlockingHttpServer(40000)
+    BlockingHttpServer server = new BlockingHttpServer()
 
     def setup() {
         server.start()

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayReloadIntegrationTest.groovy
@@ -28,7 +28,7 @@ import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 
 abstract class PlayReloadIntegrationTest extends AbstractMultiVersionPlayReloadIntegrationTest {
-    @Rule BlockingHttpServer server = new BlockingHttpServer(60000)
+    @Rule BlockingHttpServer server = new BlockingHttpServer()
 
     RunningPlayApp runningApp = new AdvancedRunningPlayApp(testDirectory)
     PlayApp playApp = new AdvancedPlayApp()


### PR DESCRIPTION
This class is used in long-running end-to-end tests which
often take a significant amount of time to even reach the
start of the work that the server is waiting for. This is
especially true on a heavily loaded build server.

The timeout is there as a last resort, to avoid builds hanging
forever. Making it a bit longer by default shouldn't hurt.