### PR TITLE
Introduce Build Operation Recorder

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationServices.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.operations.notify;
 
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.internal.operations.recorder.BuildOperationRecorder;
 import org.gradle.internal.progress.BuildOperationListenerManager;
 
 /**
@@ -26,10 +28,12 @@ import org.gradle.internal.progress.BuildOperationListenerManager;
 public class BuildOperationNotificationServices {
 
     BuildOperationNotificationListenerRegistrar createBuildOperationNotificationListenerRegistrar(
-        BuildOperationListenerManager buildOperationListenerManager
+        BuildOperationListenerManager buildOperationListenerManager,
+        BuildOperationRecorder buildOperationRecorder,
+        GradleInternal gradleInternal
     ) {
         // The listener manager must be build session scoped, not global.
-        return new BuildOperationNotificationBridge(buildOperationListenerManager);
+        return new BuildOperationNotificationBridge(buildOperationListenerManager, buildOperationRecorder, gradleInternal);
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/recorder/BuildOperationRecorder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/recorder/BuildOperationRecorder.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations.recorder;
+
+import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.internal.progress.BuildOperationDescriptor;
+import org.gradle.internal.progress.BuildOperationListener;
+import org.gradle.internal.progress.BuildOperationListenerManager;
+import org.gradle.internal.progress.OperationFinishEvent;
+import org.gradle.internal.progress.OperationStartEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BuildOperationRecorder implements Stoppable {
+
+    private final BuildOperationListenerManager listenerManager;
+    private final BuildOperationListener listener;
+
+    private List<RecordedBuildOperation> recordedEvents = new ArrayList<RecordedBuildOperation>();
+
+    public BuildOperationRecorder(BuildOperationListenerManager listenerManager) {
+        this.listenerManager = listenerManager;
+        this.listener = new BuildOperationListener() {
+            @Override
+            public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+                recordedEvents.add(new RecordedBuildOperation(buildOperation, startEvent));
+            }
+
+            @Override
+            public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+                recordedEvents.add(new RecordedBuildOperation(buildOperation, finishEvent));
+            }
+        };
+        this.listenerManager.addListener(listener);
+    }
+
+    public List<RecordedBuildOperation> getRecordedEvents() {
+        List<RecordedBuildOperation> returnEvents = recordedEvents;
+        recordedEvents = new ArrayList<RecordedBuildOperation>();
+        return returnEvents;
+    }
+
+    @Override
+    public void stop() {
+        listenerManager.removeListener(listener);
+    }
+
+    public static class RecordedBuildOperation {
+        public final BuildOperationDescriptor buildOperation;
+        public final Object event;
+
+        public RecordedBuildOperation(BuildOperationDescriptor buildOperation, Object event) {
+            this.buildOperation = buildOperation;
+            this.event = event;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -65,6 +65,7 @@ import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationIdFactory;
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory;
+import org.gradle.internal.operations.recorder.BuildOperationRecorder;
 import org.gradle.internal.operations.trace.BuildOperationTrace;
 import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.BuildOperationListenerManager;
@@ -134,6 +135,10 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new BuildOperationTrace(startParameter, listenerManager);
     }
 
+    BuildOperationRecorder createBuildOperationRecorder(BuildOperationListenerManager listenerManager) {
+        return new BuildOperationRecorder(listenerManager);
+    }
+
     BuildOperationExecutor createBuildOperationExecutor(
         ListenerManager listenerManager,
         TimeProvider timeProvider,
@@ -143,7 +148,9 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         ResourceLockCoordinationService resourceLockCoordinationService,
         ParallelismConfigurationManager parallelismConfigurationManager,
         BuildOperationIdFactory buildOperationIdFactory,
-        @SuppressWarnings("unused") BuildOperationTrace buildOperationTrace // required in order to init this
+        @SuppressWarnings("unused") BuildOperationTrace buildOperationTrace, // required in order to init this
+        @SuppressWarnings("unused") BuildOperationRecorder buildOperationRecorder // required in order to init this
+
     ) {
         return new DefaultBuildOperationExecutor(
             listenerManager.getBroadcaster(BuildOperationListener.class),


### PR DESCRIPTION
- Introduce BuildOperationRecorder to record early fired build operations during build
- Allows BuildOperationNotificationListener to handle operations fired before listeners are registered.
- recording is stopped after root project is evaluated