### PR TITLE
Fix flakiness of issue #854

### DIFF
--- a/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
@@ -69,7 +69,9 @@ configurations {
 }
 
 dependencies {
-    compile 'org.gradle:changing:1.0'
+    compile('org.gradle:changing:1.0') {
+        changing = true
+    }
 }
 
 task check {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
@@ -139,28 +139,28 @@ task check {
         private void handleGetIvy(HttpServletResponse response) {
             println "* GET IVY FILE"
             def ivy = resources.ivy
-            setResourceInfo(response, ivy)
+            provideHeadersForResource(response, ivy)
             ivy.writeContentTo(response.outputStream)
         }
 
         private void handleHeadIvy(HttpServletResponse response) {
             println "* HEAD IVY FILE"
-            setResourceInfo(response, resources.ivy)
+            provideHeadersForResource(response, resources.ivy)
         }
 
         private void handleGetJar(HttpServletResponse response) {
             println "* GET JAR"
             def jar = resources.jar
-            setResourceInfo(response, jar)
+            provideHeadersForResource(response, jar)
             jar.writeContentTo(response.outputStream)
         }
 
         private void handleHeadJar(HttpServletResponse response) {
             println "* HEAD JAR"
-            setResourceInfo(response, resources.jar)
+            provideHeadersForResource(response, resources.jar)
         }
 
-        private void setResourceInfo(HttpServletResponse response, Resource resource) {
+        private void provideHeadersForResource(HttpServletResponse response, Resource resource) {
             response.setDateHeader(HttpHeaders.LAST_MODIFIED, resource.lastModified)
             response.setContentLength(resource.contentLength)
             response.setContentType(resource.contentType)

--- a/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
@@ -93,7 +93,7 @@ task check {
                 GradleExecuter executer = distribution.executer(workspace, IntegrationTestBuildContext.INSTANCE).
                         requireGradleDistribution().
                         withGradleUserHomeDir(workspace.file("user-home"))
-                10.times {
+                8.times {
                     executer.inDirectory(buildDir).withArgument("--refresh-dependencies").withTasks('check').run()
                 }
             }

--- a/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
@@ -106,12 +106,12 @@ task check {
         private static final String HEAD_METHOD = 'HEAD'
         private static final String METADATA_FILE_PATH = '/org.gradle/changing/1.0/ivy-1.0.xml'
         private static final String JAR_FILE_PATH = '/org.gradle/changing/1.0/changing-1.0.jar'
-        final Server server = new Server(0)
-        final Resources resources = new Resources()
+        private final Server server = new Server(0)
+        private final SelectChannelConnector connector = new SelectChannelConnector()
+        private final Resources resources = new Resources()
 
         @Override
         protected void before() {
-            SelectChannelConnector connector = new SelectChannelConnector()
             server.setConnectors([connector] as Connector[])
             server.addHandler(new AbstractHandler() {
                 void handle(String target, HttpServletRequest request, HttpServletResponse response, int dispatch) {
@@ -170,7 +170,7 @@ task check {
         }
 
         URI getUri() {
-            return new URI("http://localhost:${server.connectors[0].localPort}/")
+            return new URI("http://localhost:${connector.localPort}/")
         }
     }
 

--- a/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
@@ -23,8 +23,6 @@ import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistributio
 import org.gradle.soak.categories.SoakTest
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import org.junit.experimental.categories.Category
 import org.junit.rules.ExternalResource
@@ -41,7 +39,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 @Category(SoakTest)
-@Requires(TestPrecondition.NOT_WINDOWS) // This test is really flaky on Windows.
 class DependencyResolutionStressTest extends Specification {
     @Rule TestNameTestDirectoryProvider workspace = new TestNameTestDirectoryProvider()
     GradleDistribution distribution = new UnderDevelopmentGradleDistribution()


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/854

__Attempt to fix flakiness:__

- By default Jetty uses `SocketConnector`. The one based on NIO is more optimized if you deal with situations with a lot of threads making calls to the server.

From the Javadocs of `SelectChannelConnector`:
> This connector is best used when there are a many connections that have idle periods.

- Runs less builds concurrently. On my machine my CPUs are maxed out. On CI the same thing might happen leading to more contention and thus running into a timeout.

__Unrelated changes:__

- The test method suggests that we are testing a "changing" module here. However, it wasn't configure to be changing.
- Close `ZipEntry`s to avoid leaking resources.
- Simplify logic to make code more readable and maintainable.