### PR TITLE
Prevent file hashing from blocking on named pipes

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
@@ -20,6 +20,7 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.internal.file.FileMetadataSnapshot;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -27,6 +28,7 @@ import java.io.InputStream;
 
 public class DefaultFileHasher implements FileHasher {
     private final StreamHasher streamHasher;
+    private static final byte[] EMPTY_BYTES = {};
 
     public DefaultFileHasher(StreamHasher streamHasher) {
         this.streamHasher = streamHasher;
@@ -35,6 +37,10 @@ public class DefaultFileHasher implements FileHasher {
     @Override
     public HashCode hash(File file) {
         try {
+            // Do not try to read empty files, to avoid blocking on reading from named pipes:
+            if (file.length() == 0) {
+                return streamHasher.hash(new ByteArrayInputStream(EMPTY_BYTES));
+            }
             InputStream inputStream = new FileInputStream(file);
             try {
                 return streamHasher.hash(inputStream);

--- a/subprojects/core/src/test/groovy/org/gradle/internal/hash/DefaultFileHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/hash/DefaultFileHasherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 package org.gradle.internal.hash
 
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
 import java.util.concurrent.TimeUnit
 
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.junit.Assume
 import org.junit.Rule
 
 import com.google.common.base.Charsets
@@ -53,8 +55,9 @@ class DefaultFileHasherTest extends Specification {
         0 * _._
     }
 
-    @Issue("gradle/gradle#2552")
+    @Issue("https://github.com/gradle/gradle/issues/2552")
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @Requires(TestPrecondition.UNIX_DERIVATIVE)
     def "named pipe returns correct hash"() {
         def hash = getStringHash("")
         def pipe = new File(tmpDir.createDir("testdir"), "testpipe")
@@ -86,16 +89,8 @@ class DefaultFileHasherTest extends Specification {
     }
 
     def createPipe(def name) {
-        def supportFifo = false
-        try {
-            def mkfifo = new ProcessBuilder("mkfifo", name).redirectErrorStream(true).start()
-            def exitValue = mkfifo.waitFor()
-            supportFifo = (exitValue == 0)
-        } catch (IOException e) {
-            supportFifo = false
-        }
-        // Skip test if mkfifo doesn't work on this platform:
-        Assume.assumeTrue(supportFifo)
+        def mkfifo = new ProcessBuilder("mkfifo", name).redirectErrorStream(true).start()
+        assert mkfifo.waitFor() == 0
     }
 
     def getStringHash(String text) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/hash/DefaultFileHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/hash/DefaultFileHasherTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.hash
+
+import java.util.concurrent.TimeUnit
+
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Assume
+import org.junit.Rule
+
+import com.google.common.base.Charsets
+
+import spock.lang.Issue
+import spock.lang.Specification
+import spock.lang.Timeout
+
+class DefaultFileHasherTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    def file = tmpDir.createFile("testfile")
+    DefaultFileHasher hasher
+    DefaultStreamHasher streamHasher
+
+    def setup() {
+        streamHasher = new DefaultStreamHasher(new DefaultContentHasherFactory())
+        hasher = new DefaultFileHasher(streamHasher)
+    }
+
+    def "empty file returns correct hash"() {
+        def hash = getStringHash("")
+
+        when:
+        def result = hasher.hash(file)
+
+        then:
+        file.length() == 0
+        result == hash
+
+        and:
+        0 * _._
+    }
+
+    @Issue("gradle/gradle#2552")
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    def "named pipe returns correct hash"() {
+        def hash = getStringHash("")
+        def pipe = new File(tmpDir.createDir("testdir"), "testpipe")
+        createPipe(pipe.absolutePath)
+
+        when:
+        def result = hasher.hash(pipe)
+
+        then:
+        pipe.length() == 0
+        result == hash
+
+        and:
+        0 * _._
+    }
+
+    def "non-empty file returns correct hash"() {
+        file.write("hello world")
+        def hash = getStringHash("hello world")
+
+        when:
+        def result = hasher.hash(file)
+
+        then:
+        result == hash
+
+        and:
+        0 * _._
+    }
+
+    def createPipe(def name) {
+        def supportFifo = false
+        try {
+            def mkfifo = new ProcessBuilder("mkfifo", name).redirectErrorStream(true).start()
+            def exitValue = mkfifo.waitFor()
+            supportFifo = (exitValue == 0)
+        } catch (IOException e) {
+            supportFifo = false
+        }
+        // Skip test if mkfifo doesn't work on this platform:
+        Assume.assumeTrue(supportFifo)
+    }
+
+    def getStringHash(String text) {
+        return streamHasher.hash(new ByteArrayInputStream(text.getBytes(Charsets.UTF_8)))
+    }
+}


### PR DESCRIPTION
### Context

As documented on issue #2552, under certain circumstances it is possible for Gradle to hang indefinitely while performing `Copy` or `Sync` tasks.

This pull request implements a shortcut to avoid reading from zero-length files, including named pipes, if they are encountered during file hashing operations. It also adds some unit tests for the modified class to verify the new behavior as well as confirm it still works as intended for non-empty files.

Resolves: #2552

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew quickCheck <impacted-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes