### PR TITLE
Build operation queue wait thread can execute operations

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
@@ -140,28 +140,6 @@ class DefaultBuildOperationQueueTest extends Specification {
                 [1, 4, 10]].combinations()
     }
 
-    def "all failures reported in order for a single threaded executor"() {
-        given:
-        setupQueue(1)
-        operationQueue.add(Stub(TestBuildOperation) {
-            run(_) >> { throw new RuntimeException("first") }
-        })
-        operationQueue.add(Stub(TestBuildOperation) {
-            run(_) >> { throw new RuntimeException("second") }
-        })
-        operationQueue.add(Stub(TestBuildOperation) {
-            run(_) >> { throw new RuntimeException("third") }
-        })
-
-        when:
-        operationQueue.waitForCompletion()
-
-        then:
-        // assumes we don't fail early
-        MultipleBuildOperationFailures e = thrown()
-        e.getCauses()*.message == [ 'first', 'second', 'third' ]
-    }
-
     def "when log location is set value is propagated in exceptions"() {
         given:
         setupQueue(1)


### PR DESCRIPTION
This fixes an issue where when multiple tasks are running concurrently and submitting work to the build operation queue, performance can actually be worse because worker leases and the
executor thread pool compete with each other.  This fixes the issue by allowing the thread waiting for work to complete to also execute some of that work in the event that none of the workers for that queue actually make it onto the executor thread pool.
