### PR TITLE
Fix flakiness in ConsoleJvmTestWorkerFunctionalTest

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
@@ -65,7 +65,6 @@ class ConsoleJvmTestWorkerFunctionalTest extends AbstractConsoleFunctionalSpec {
         testClass1                    | testClass2                    | description
         JavaTestClass.PRESERVED_TEST1 | JavaTestClass.PRESERVED_TEST2 | 'preserved'
         JavaTestClass.SHORTENED_TEST1 | JavaTestClass.SHORTENED_TEST2 | 'shortened'
-
     }
 
     @Unroll

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
@@ -46,7 +46,7 @@ class ConsoleJvmTestWorkerFunctionalTest extends AbstractConsoleFunctionalSpec {
         buildFile << testableJavaProject()
         file("src/test/java/${testClass1.fileRepresentation}") << junitTest(testClass1.classNameWithoutPackage, SERVER_RESOURCE_1)
         file("src/test/java/${testClass2.fileRepresentation}") << junitTest(testClass2.classNameWithoutPackage, SERVER_RESOURCE_2)
-        def testExecution = server.expectConcurrentAndBlock(SERVER_RESOURCE_1, SERVER_RESOURCE_2)
+        def testExecution = server.expectConcurrentAndBlock(2, SERVER_RESOURCE_1, SERVER_RESOURCE_2)
 
         when:
         def gradleHandle = executer.withTasks('test').start()
@@ -58,7 +58,7 @@ class ConsoleJvmTestWorkerFunctionalTest extends AbstractConsoleFunctionalSpec {
             assert containsTestExecutionWorkInProgressLine(gradleHandle, ':test', testClass2.renderedClassName)
         }
 
-        testExecution.releaseAll()
+        testExecution.release(2)
         gradleHandle.waitForFinish()
 
         where:
@@ -79,7 +79,7 @@ class ConsoleJvmTestWorkerFunctionalTest extends AbstractConsoleFunctionalSpec {
         """
         file("project1/src/test/java/${testClass1.fileRepresentation}") << junitTest(testClass1.classNameWithoutPackage, SERVER_RESOURCE_1)
         file("project2/src/test/java/${testClass2.fileRepresentation}") << junitTest(testClass2.classNameWithoutPackage, SERVER_RESOURCE_2)
-        def testExecution = server.expectConcurrentAndBlock(SERVER_RESOURCE_1, SERVER_RESOURCE_2)
+        def testExecution = server.expectConcurrentAndBlock(2, SERVER_RESOURCE_1, SERVER_RESOURCE_2)
 
         when:
         def gradleHandle = executer.withTasks('test').start()
@@ -91,7 +91,7 @@ class ConsoleJvmTestWorkerFunctionalTest extends AbstractConsoleFunctionalSpec {
             assert containsTestExecutionWorkInProgressLine(gradleHandle, ':project2:test', testClass2.renderedClassName)
         }
 
-        testExecution.releaseAll()
+        testExecution.release(2)
         gradleHandle.waitForFinish()
 
         where:

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/ConsoleJvmTestWorkerFunctionalTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Unroll
 @IgnoreIf({ GradleContextualExecuter.isParallel() })
 class ConsoleJvmTestWorkerFunctionalTest extends AbstractConsoleFunctionalSpec {
 
-    private static final int MAX_WORKERS = 4
+    private static final int MAX_WORKERS = 2
     private static final String SERVER_RESOURCE_1 = 'test-1'
     private static final String SERVER_RESOURCE_2 = 'test-2'
 


### PR DESCRIPTION
__Flakiness improvements:__

- Always define the exact number of workers needed for test execution
- Run in parallel so that multiple WIP lines are rendered in the console
- Expect exact number of invocations for blocking calls

__General test improvements:__

- Test preserved and shortened test class names in console output for single and multi-project builds
- Eliminate test method by rolling it into another test with the same setup
- Use test fixture to simplify code