### PR TITLE
Touch cache entries for external resources when they are revalidated

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
@@ -204,7 +204,6 @@ task check {
         def scriptName = "script-once.gradle"
         def scriptFile = file("script.gradle")
         scriptFile.setText("""println 'loaded external script'""", "UTF-8")
-        server.expectGet('/' + scriptName, scriptFile)
 
         and:
         settingsFile << """
@@ -218,10 +217,23 @@ task check {
         }
 
         when:
+        server.expectGet('/' + scriptName, scriptFile)
         args('-I', 'init.gradle')
-        succeeds 'tasks'
 
         then:
+        succeeds 'tasks'
+        output.count('loaded external script') == 4
+
+        when:
+        server.resetExpectations()
+        server.expectHead('/' + scriptName, scriptFile)
+        server.expectHead('/' + scriptName, scriptFile)
+        server.expectHead('/' + scriptName, scriptFile)
+        server.expectHead('/' + scriptName, scriptFile)
+        args('-I', 'init.gradle')
+
+        then:
+        succeeds 'tasks'
         output.count('loaded external script') == 4
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
@@ -227,9 +227,6 @@ task check {
         when:
         server.resetExpectations()
         server.expectHead('/' + scriptName, scriptFile)
-        server.expectHead('/' + scriptName, scriptFile)
-        server.expectHead('/' + scriptName, scriptFile)
-        server.expectHead('/' + scriptName, scriptFile)
         args('-I', 'init.gradle')
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -461,10 +461,6 @@ group:projectB:2.2;integration
         !output.contains('Parsing status file call count: 2')
 
         when: "resolving the same dependencies"
-        // the following 2 HEAD requests document the current behavior, not necessarily what
-        // we want in the end. There are 2 HEAD requests because the file was cached in a previous
-        // build, and we're getting the resource twice (once for each module) in this build
-        server.expectHead("/repo/status.txt", statusFile)
         server.expectHead("/repo/status.txt", statusFile)
 
         checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
@@ -115,7 +115,8 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
 
                     if (isUnchanged) {
                         LOGGER.info("Cached resource {} is up-to-date (lastModified: {}).", location, cached.getExternalLastModified());
-                        // TODO - update the index with the new remote meta-data
+                        // Update the cache entry in the index: this resets the age of the cached entry to zero
+                        cachedExternalResourceIndex.store(location.toString(), cached.getCachedFile(), cached.getExternalResourceMetaData());
                         return fileResourceRepository.resource(cached.getCachedFile(), location.getUri(), cached.getExternalResourceMetaData());
                     }
                 }


### PR DESCRIPTION
Previously, the cache entry for an external resource retained it's original
timestamp, even after we had revalidated it against the source (ie. via HTTP HEAD).
This resulted in multiple HEAD revalidation requests being required, for a
cached resource that was requested multiple times in the same build.

This issue was made more apparent with the introduction of caching for
HTTP script plugins, but it had already been observed to affect the
caching of resources used by `ComponentMetadataSupplier`.

The fix supplied effectively 're-stores' the cache entry, forcing the
cache entry time to be updated.

This change fixes a bug that was introduced with caching of URL resources. Before caching was added we performed a single GET for the resource on every build, this regressed to performing a HEAD request for _every use_ of the resource when it existed in the cache.