### PR TITLE
Improve block pointer error handling

### DIFF
--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/btree/BlockPointer.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/btree/BlockPointer.java
@@ -27,7 +27,7 @@ public class BlockPointer implements Comparable<BlockPointer> {
 
     public static BlockPointer pos(long pos) {
         if (pos < -1) {
-            throw new IllegalArgumentException("pos must be >= -1");
+            throw new CorruptedCacheException("block pointer must be >= -1, but was" + pos);
         }
         if (pos == -1) {
             return NULL;

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/BlockPointerTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/BlockPointerTest.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal.btree
+
+import spock.lang.Specification
+
+class BlockPointerTest extends Specification {
+
+    def "detects corrupt pointers"() {
+        when:
+        BlockPointer.pos(-10)
+        then:
+        def e = thrown(CorruptedCacheException)
+        e.message.contains("-10")
+    }
+}


### PR DESCRIPTION
Don't throw a vanilla IllegalArgumentException, but
a CacheCorruptedException. This ensures that the layers
further up can discard the cache and recreate the value.