### PR TITLE
Use internal maven repositories for integration tests running on CI

### DIFF
--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -43,6 +43,8 @@ distributionTestTasks.all { DistributionTest task ->
 
     systemProperties['org.gradle.integtest.mirrors.mavencentral'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/repo1' : ''
     systemProperties['org.gradle.integtest.mirrors.jcenter'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/jcenter' : ''
+    systemProperties['org.gradle.integtest.mirrors.typesafemaven'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/typesafe-maven-releases' : ''
+    systemProperties['org.gradle.integtest.mirrors.typesafeivy'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/typesafe-ivy-releases' : ''
 
     dependsOn project.task("configure${task.name.capitalize()}") {
         doLast {

--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -41,6 +41,7 @@ distributionTestTasks.all { DistributionTest task ->
 
     systemProperties['org.gradle.integtest.multiversion'] = project.hasProperty("testAllVersions") && project.testAllVersions ? 'all' : 'default'
 
+    systemProperties['org.gradle.integtest.mirrors.mavencentral'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/repo1' : ''
     systemProperties['org.gradle.integtest.mirrors.jcenter'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/jcenter' : ''
 
     dependsOn project.task("configure${task.name.capitalize()}") {

--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -41,6 +41,8 @@ distributionTestTasks.all { DistributionTest task ->
 
     systemProperties['org.gradle.integtest.multiversion'] = project.hasProperty("testAllVersions") && project.testAllVersions ? 'all' : 'default'
 
+    systemProperties['org.gradle.integtest.mirrors.jcenter'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/jcenter' : ''
+
     dependsOn project.task("configure${task.name.capitalize()}") {
         doLast {
             configure(task) {

--- a/subprojects/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AbstractAntlrIntegrationTest.groovy
+++ b/subprojects/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AbstractAntlrIntegrationTest.groovy
@@ -26,9 +26,7 @@ abstract class AbstractAntlrIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             allprojects {
                 apply plugin: 'java'
-                repositories() {
-                    jcenter()
-                }
+                ${jcenterRepository()}
             }
             project(":grammar-builder") {
                 apply plugin: "antlr"

--- a/subprojects/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AntlrPluginIntegrationTest.groovy
+++ b/subprojects/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AntlrPluginIntegrationTest.groovy
@@ -29,9 +29,7 @@ class AntlrPluginIntegrationTest extends WellBehavedPluginTest {
             apply plugin: "java"
             apply plugin: "antlr"
 
-            repositories() {
-                jcenter()
-            }
+            ${jcenterRepository()}
         """
         and:
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginClasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginClasspathIntegrationTest.groovy
@@ -45,9 +45,7 @@ subprojects {
     apply plugin: "java"
     apply plugin: "checkstyle"
 
-    repositories {
-        mavenCentral()
-    }
+    ${mavenCentralRepository()}
 
     checkstyle {
         toolVersion = '$version'

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginDependenciesIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginDependenciesIntegrationTest.groovy
@@ -53,9 +53,7 @@ class CheckstylePluginDependenciesIntegrationTest extends AbstractIntegrationSpe
 apply plugin: "groovy"
 apply plugin: "checkstyle"
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     compile localGroovy()

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcCompilationClasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcCompilationClasspathIntegrationTest.groovy
@@ -55,9 +55,7 @@ class CodeNarcCompilationClasspathIntegrationTest extends AbstractIntegrationSpe
             apply plugin: "codenarc"
             apply plugin: "groovy"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             codenarc {
                 toolVersion = '$codeNarcVersion'

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CodeNarcPluginIntegrationTest.groovy
@@ -208,9 +208,7 @@ class CodeNarcPluginIntegrationTest extends WellBehavedPluginTest {
             apply plugin: "groovy"
             apply plugin: "codenarc"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile localGroovy()

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/FindBugsRelocationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/FindBugsRelocationIntegrationTest.groovy
@@ -37,9 +37,7 @@ class FindBugsRelocationIntegrationTest extends AbstractTaskRelocationIntegratio
         """
             apply plugin: "findbugs"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             task compile(type: JavaCompile) {
                 sourceCompatibility = JavaVersion.current()

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/JDependPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/JDependPluginIntegrationTest.groovy
@@ -198,9 +198,7 @@ class JDependPluginIntegrationTest extends WellBehavedPluginTest {
 apply plugin: "java"
 apply plugin: "jdepend"
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
         """
     }
 }

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginSubtypeParamIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginSubtypeParamIntegrationTest.groovy
@@ -30,9 +30,7 @@ class PmdPluginSubtypeParamIntegrationTest extends AbstractPmdPluginVersionInteg
             apply plugin: 'java'
             apply plugin: 'pmd'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "${calculateDefaultDependencyNotation()}"

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginVersionIntegrationTest.groovy
@@ -33,9 +33,7 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
             apply plugin: "java"
             apply plugin: "pmd"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             pmd {
                 toolVersion = '$version'

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdRelocationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdRelocationIntegrationTest.groovy
@@ -39,9 +39,7 @@ class PmdRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest
             apply plugin: "java"
             apply plugin: "pmd"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             task pmd(type: Pmd) {
                 source "$sourceDir"

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildClassloadingIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildClassloadingIntegrationTest.groovy
@@ -30,9 +30,7 @@ class CompositeBuildClassloadingIntegrationTest extends AbstractCompositeBuildIn
         given:
         file('gradle-user-home/init.gradle') << """
             initscript {
-                repositories {
-                    mavenCentral()
-                }
+                ${mavenCentralRepository()}
 
                 File searchDir = gradle.startParameter.projectDir ?: gradle.startParameter.currentDir
                 def version = new File(searchDir, 'version.txt').text

--- a/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
@@ -142,9 +142,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
 
         buildFile << """
             buildscript {
-                repositories {
-                    mavenCentral()
-                }
+                ${mavenCentralRepository()}
                 dependencies {
                     classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion'
                 }
@@ -152,9 +150,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
 
             apply plugin: 'kotlin'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile 'org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion'
@@ -188,9 +184,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
         """
             apply plugin: 'java'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
         """
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
@@ -192,9 +192,7 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
         """
             apply plugin: 'groovy'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile gradleApi()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassPathIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassPathIntegrationTest.groovy
@@ -25,7 +25,7 @@ class BuildScriptClassPathIntegrationTest extends AbstractIntegrationSpec {
     def "script can use xerces without affecting that used for dependency resolution"() {
         buildFile << """
 buildscript {
-    repositories { jcenter() }
+    ${jcenterRepository()}
     dependencies {
         classpath 'xerces:xercesImpl:2.9.1'
     }
@@ -34,9 +34,7 @@ plugins {
     id 'java'
 }
 
-repositories {
-    jcenter()
-}
+${jcenterRepository()}
 
 dependencies {
     compile "com.google.guava:guava:19.0"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
@@ -213,9 +213,7 @@ assert repositories.empty
     def "can reference script level configure method from named container configure closure when that closure would fail with MME if applied to a new element"() {
         buildFile << """
 configurations {
-    repositories {
-        mavenCentral()
-    }
+    ${mavenCentralRepository()}
     someConf {
         allprojects { }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskTypeUpToDateIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskTypeUpToDateIntegrationTest.groovy
@@ -207,9 +207,7 @@ class TaskTypeUpToDateIntegrationTest extends AbstractIntegrationSpec {
 
     private static String guavaDependency(String version) {
         """
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
             dependencies {
                 compile "com.google.guava:guava:$version"
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedImplementationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedImplementationIntegrationTest.groovy
@@ -29,9 +29,7 @@ class CachedImplementationIntegrationTest extends AbstractIntegrationSpec {
         """
 
         file("buildSrc/build.gradle") << """
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "commons-codec:commons-codec:1.10"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1189,9 +1189,7 @@ task generate(type: TransformerTask) {
 
     def "produces a sensible error when a task output causes dependency resolution"() {
         buildFile << """
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
             
             configurations {
                 foo

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildProgressLoggerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/progress/BuildProgressLoggerIntegrationTest.groovy
@@ -35,9 +35,7 @@ class BuildProgressLoggerIntegrationTest extends AbstractConsoleFunctionalSpec {
         file("buildSrc/build.gradle") << """
             // NOTE: groovy plugin is automatically applied to buildSrc
             
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
             dependencies {
                 testCompile 'junit:junit:4.12'
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -1529,7 +1529,7 @@ All of them match the consumer attributes:
             }
 
             project(':a') {
-                repositories { jcenter() }
+                ${jcenterRepository()}
 
                 configurations {
                     _compileFreeDebug.attributes { $freeDebug }
@@ -1563,7 +1563,7 @@ All of them match the consumer attributes:
                 }
             }
             project(':c') {
-                repositories { jcenter() }
+                ${jcenterRepository()}
                 configurations {
                     foo.attributes { $freeDebug }
                     bar.attributes { $freeRelease }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DirectoryOutputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DirectoryOutputArtifactIntegrationTest.groovy
@@ -221,9 +221,9 @@ class DirectoryOutputArtifactIntegrationTest extends AbstractIntegrationSpec {
     def "can avoid building a jar when compiling against another project with transitive dependencies"() {
         given:
         file('settings.gradle') << "include 'a', 'b'"
-        file('a/build.gradle') << '''
+        file('a/build.gradle') << """
 
-        repositories { jcenter() }
+        ${jcenterRepository()}
 
         apply plugin: 'java'
 
@@ -231,7 +231,7 @@ class DirectoryOutputArtifactIntegrationTest extends AbstractIntegrationSpec {
             compile project(path: ':b', configuration: 'compile_output')
         }
 
-        '''
+        """
         file('a/src/main/java/World.java') << '''import org.apache.commons.lang3.StringUtils;
 
         public class World extends Hello {
@@ -242,11 +242,11 @@ class DirectoryOutputArtifactIntegrationTest extends AbstractIntegrationSpec {
 
         '''
 
-        file('b/build.gradle') << '''
+        file('b/build.gradle') << """
 
         apply plugin: 'java'
 
-        repositories { jcenter() }
+        ${jcenterRepository()}
 
         configurations {
             compile_output {
@@ -261,7 +261,7 @@ class DirectoryOutputArtifactIntegrationTest extends AbstractIntegrationSpec {
         artifacts {
             compile_output file:compileJava.destinationDir, builtBy: compileJava
         }
-        '''
+        """
         file('b/src/main/java/Hello.java') << '''import org.apache.commons.lang3.StringUtils;
             public class Hello {
                 String greet(String name) { return "Hello, " + StringUtils.capitalize(name); }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAwareResolutionWithConfigurationAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAwareResolutionWithConfigurationAttributesIntegrationTest.groovy
@@ -265,9 +265,7 @@ class VariantAwareResolutionWithConfigurationAttributesIntegrationTest extends A
 
     private static File withExternalDependencies(File buildFile, String dependenciesBlock) {
         buildFile << """
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
             dependencies {
                 $dependenciesBlock
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyManagementImportOrderTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyManagementImportOrderTest.groovy
@@ -26,8 +26,10 @@ public class MavenDependencyManagementImportOrderTest extends AbstractIntegratio
     @Requires(TestPrecondition.ONLINE)
 	def "Verify that gradle resolves org.wildfly.swarm:undertow the same as maven"() {
 		when:
-		buildFile.text = """
-${mavenCentralRepository()}
+		buildFile.text = '''
+repositories {
+	mavenCentral()
+}
 configurations {
 	test
 }
@@ -42,8 +44,8 @@ task verifyUndertowVersion {
 		assert fileNames.contains('undertow-servlet-1.4.11.Final.jar')
 		assert !fileNames.contains('undertow-servlet-1.2.9.Final.jar')
 	}
-
-		"""
+}
+		'''
 
 		then:
 		succeeds 'verifyUndertowVersion'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyManagementImportOrderTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyManagementImportOrderTest.groovy
@@ -26,10 +26,8 @@ public class MavenDependencyManagementImportOrderTest extends AbstractIntegratio
     @Requires(TestPrecondition.ONLINE)
 	def "Verify that gradle resolves org.wildfly.swarm:undertow the same as maven"() {
 		when:
-		buildFile.text = '''
-repositories {
-	mavenCentral()
-}
+		buildFile.text = """
+${mavenCentralRepository()}
 configurations {
 	test
 }
@@ -44,8 +42,8 @@ task verifyUndertowVersion {
 		assert fileNames.contains('undertow-servlet-1.4.11.Final.jar')
 		assert !fileNames.contains('undertow-servlet-1.2.9.Final.jar')
 	}
-}
-		'''
+
+		"""
 
 		then:
 		succeeds 'verifyUndertowVersion'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
@@ -166,9 +166,7 @@ dependencies {
 
         given:
         buildFile << """
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 configurations {
     compile

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m3/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m3/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -146,15 +146,15 @@ gradle.taskGraph.beforeTask { throw new RuntimeException() }
 include "a"
 rootProject.name = 'root'
 '''
-        projectDir.file('build.gradle').text = '''
+        projectDir.file('build.gradle').text = """
 allprojects { apply plugin: 'java' }
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies {
     compile 'commons-lang:commons-lang:2.5'
     compile project(':a')
     runtime 'commons-io:commons-io:1.4'
 }
-'''
+"""
 
         when:
         EclipseProject eclipseProject = loadToolingModel(EclipseProject)

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m5/ToolingApiHonorsProjectCustomizationsCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m5/ToolingApiHonorsProjectCustomizationsCrossVersionSpec.groovy
@@ -101,7 +101,7 @@ sourceSets {
     }
 
     def "can enable download of Javadoc for external dependencies"() {
-        file('build.gradle').text = '''
+        file('build.gradle').text = """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 ${mavenCentralRepository()}
@@ -110,7 +110,7 @@ dependencies {
     runtime 'commons-io:commons-io:1.4'
 }
 eclipse { classpath { downloadJavadoc = true } }
-'''
+"""
 
         when:
         EclipseProject eclipseProject = loadToolingModel(EclipseProject)

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m5/ToolingApiHonorsProjectCustomizationsCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m5/ToolingApiHonorsProjectCustomizationsCrossVersionSpec.groovy
@@ -104,7 +104,7 @@ sourceSets {
         file('build.gradle').text = '''
 apply plugin: 'java'
 apply plugin: 'eclipse'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies {
     compile 'commons-lang:commons-lang:2.5'
     runtime 'commons-io:commons-io:1.4'

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m8/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m8/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -24,7 +24,7 @@ class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
 apply plugin: 'java'
 
 gradle.projectsEvaluated {
-    repositories { mavenCentral() }
+    ${mavenCentralRepository()}
 }
 dependencies {
     compile 'commons-lang:commons-lang:2.5'

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r25/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r25/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -33,14 +33,12 @@ include 'a'
 rootProject.name = 'root'
 '''
 
-        projectDir.file('build.gradle').text = '''
+        projectDir.file('build.gradle').text = """
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-repositories {
-    jcenter()
-}
+${jcenterRepository()}
 
 configurations {
     provided
@@ -60,7 +58,7 @@ eclipse {
 
 configure(project(':a')){
     apply plugin:'java'
-}'''
+}"""
 
         when:
         EclipseProject rootProject = loadToolingModel(EclipseProject)

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelClasspathAttributesCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelClasspathAttributesCrossVersionSpec.groovy
@@ -31,7 +31,7 @@ class ToolingApiEclipseModelClasspathAttributesCrossVersionSpec extends ToolingA
         buildFile <<
         """apply plugin: 'java'
            apply plugin: 'eclipse'
-           repositories { jcenter() }
+           ${jcenterRepository()}
            dependencies { compile 'com.google.guava:guava:18.0' }
            eclipse {
                classpath {

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelCustomLibrarySourceAndJavadocCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelCustomLibrarySourceAndJavadocCrossVersionSpec.groovy
@@ -38,9 +38,7 @@ class ToolingApiEclipseModelCustomLibrarySourceAndJavadocCrossVersionSpec extend
             apply plugin: 'java'
             apply plugin: 'eclipse'
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencies {
                 compile 'org.example:example-lib:1.0'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.plugins.ide.eclipse
 
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.junit.Rule
@@ -47,7 +48,7 @@ apply plugin: 'eclipse'
 
 repositories {
     maven { url "${mavenRepo.uri}" }
-    mavenCentral()
+    ${RepoScriptBlockUtil.mavenCentralRepositoryDefinition()}
 }
 
 dependencies {
@@ -1028,7 +1029,7 @@ apply plugin: 'eclipse'
 
 repositories {
     maven { url "${mavenRepo.uri}" }
-    mavenCentral()
+    ${RepoScriptBlockUtil.mavenCentralRepositoryDefinition()}
 }
 
 dependencies {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseCustomSourceAndJavadocLocationIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseCustomSourceAndJavadocLocationIntegrationTest.groovy
@@ -26,9 +26,7 @@ class EclipseCustomSourceAndJavadocLocationIntegrationTest extends AbstractEclip
             apply plugin: 'java'
             apply plugin: 'eclipse'
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencies {
                 compile 'com.google.guava:guava:18.0'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencySubstitutionIntegrationTest.groovy
@@ -92,9 +92,7 @@ project(":project2") {
 }
 
 project(":project2") {
-    repositories {
-        mavenCentral()
-    }
+    ${mavenCentralRepository()}
 
     dependencies {
         compile project(":project1")

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarAndWebAndEjbProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarAndWebAndEjbProjectIntegrationTest.groovy
@@ -27,9 +27,7 @@ class EclipseWtpEarAndWebAndEjbProjectIntegrationTest extends AbstractEclipseInt
 subprojects {
     apply plugin: 'eclipse-wtp'
 
-    repositories {
-        jcenter()
-    }
+    ${jcenterRepository()}
 }
 project(':ear') {
     apply plugin: 'ear'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpJavaProjectIntegrationTest.groovy
@@ -26,9 +26,7 @@ class EclipseWtpJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpe
         """apply plugin: 'eclipse-wtp'
            apply plugin: 'java'
 
-           repositories {
-               jcenter()
-           }
+           ${jcenterRepository()}
 
            sourceCompatibility = 1.6
 

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
@@ -444,7 +444,7 @@ project(':contrib') {
               apply plugin: 'eclipse-wtp'
             }
 
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
 
             dependencies {
               compile 'commons-io:commons-io:1.4'
@@ -483,7 +483,7 @@ project(':contrib') {
             apply plugin: 'war'
             apply plugin: 'eclipse-wtp'
 
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
 
             dependencies {
               compile 'commons-io:commons-io:1.4'
@@ -521,9 +521,7 @@ project(':contrib') {
         """apply plugin: 'java'
            apply plugin: 'eclipse-wtp'
 
-           repositories {
-               mavenCentral()
-           }
+           ${mavenCentralRepository()}
 
            dependencies {
                runtime 'commons-io:commons-io:1.4'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
@@ -28,9 +28,7 @@ class EclipseWtpWebAndJavaProjectIntegrationTest extends AbstractEclipseIntegrat
         """subprojects {
                apply plugin: 'eclipse-wtp'
 
-               repositories {
-                   jcenter()
-               }
+              ${jcenterRepository()}
            }
            project(':web') {
                apply plugin: 'war'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebProjectIntegrationTest.groovy
@@ -31,9 +31,7 @@ class EclipseWtpWebProjectIntegrationTest extends AbstractEclipseIntegrationSpec
 
            sourceCompatibility = 1.6
 
-           repositories {
-               jcenter()
-           }
+           ${jcenterRepository()}
 
            dependencies {
                compile 'com.google.guava:guava:18.0'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
@@ -95,9 +95,7 @@ allprojects {
 }
 
 project(":project2") {
-    repositories {
-        mavenCentral()
-    }
+    ${mavenCentralRepository()}
 
     dependencies {
         compile project(":project1")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CustomPluginIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CustomPluginIntegrationTest.groovy
@@ -158,7 +158,7 @@ class CustomPluginTest {
 
         buildFile << """
 apply plugin: 'groovy'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies {
     compile gradleApi()
     compile localGroovy()
@@ -199,7 +199,7 @@ class CustomPluginTest {
 
         buildFile << """
 apply plugin: 'groovy'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies {
     compile gradleApi()
     compile localGroovy()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/DifferentJnaVersionInPluginIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/DifferentJnaVersionInPluginIntegrationSpec.groovy
@@ -26,9 +26,7 @@ class DifferentJnaVersionInPluginIntegrationSpec extends AbstractIntegrationSpec
                 id 'java'
             }
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
             dependencies {
                 compile gradleApi()
                 compile 'net.java.dev.jna:jna:4.1.0'

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IsolatedAntBuilderMemoryLeakIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IsolatedAntBuilderMemoryLeakIntegrationTest.groovy
@@ -29,9 +29,7 @@ class IsolatedAntBuilderMemoryLeakIntegrationTest extends AbstractIntegrationSpe
         buildFile << """
 
             allprojects {
-                repositories {
-                    jcenter()
-                }
+                ${jcenterRepository()}
             }
 
             allprojects {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaCompileOnlyDependencyIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaCompileOnlyDependencyIntegrationTest.groovy
@@ -36,9 +36,7 @@ public class Test {
         buildFile << """
 apply plugin: 'java'
 
-repositories {
-    jcenter()
-}
+${jcenterRepository()}
 
 dependencies {
     compileOnly 'commons-logging:commons-logging:1.2'
@@ -66,9 +64,7 @@ public class Test {
         buildFile << """
 apply plugin: 'java'
 
-repositories {
-    jcenter()
-}
+${jcenterRepository()}
 
 dependencies {
     compileOnly 'commons-logging:commons-logging:1.2'
@@ -253,9 +249,7 @@ project(':projectB') {
         buildFile << """
             apply plugin: 'java'
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             sourceSets {
                 additional

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
@@ -35,14 +35,12 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void canHaveSomeSourceAndResourcesInSameDirectoryAndSomeInDifferentDirectories() {
         file('settings.gradle') << 'rootProject.name = "sharedSource"'
-        file('build.gradle') << '''
+        file('build.gradle') << """
 apply plugin: 'java'
 apply plugin: 'groovy'
 apply plugin: 'scala'
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.10'
     compile 'org.scala-lang:scala-library:2.11.1'
@@ -64,7 +62,7 @@ sourceSets.each {
         scala.include "org/gradle/$name/**/*.scala"
     }
 }
-'''
+"""
         file('src/org/gradle/main/resource.txt') << 'some text'
         file('src/org/gradle/test/resource.txt') << 'some text'
         file('src/resources/org/gradle/main/resource2.txt') << 'some text'

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
@@ -35,12 +35,14 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void canHaveSomeSourceAndResourcesInSameDirectoryAndSomeInDifferentDirectories() {
         file('settings.gradle') << 'rootProject.name = "sharedSource"'
-        file('build.gradle') << """
+        file('build.gradle') << '''
 apply plugin: 'java'
 apply plugin: 'groovy'
 apply plugin: 'scala'
 
-${mavenCentralRepository()}
+repositories {
+    mavenCentral()
+}
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.10'
     compile 'org.scala-lang:scala-library:2.11.1'
@@ -62,7 +64,7 @@ sourceSets.each {
         scala.include "org/gradle/$name/**/*.scala"
     }
 }
-"""
+'''
         file('src/org/gradle/main/resource.txt') << 'some text'
         file('src/org/gradle/test/resource.txt') << 'some text'
         file('src/resources/org/gradle/main/resource2.txt') << 'some text'

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -374,4 +374,8 @@ class AbstractIntegrationSpec extends Specification {
     static String jcenterRepository() {
         RepoScriptBlockUtil.jcenterRepository()
     }
+
+    static String mavenCentralRepository() {
+        RepoScriptBlockUtil.mavenCentralRepository()
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -370,4 +370,8 @@ class AbstractIntegrationSpec extends Specification {
         assertHasResult()
         result.assertOutputContains(string.trim())
     }
+
+    static String jcenterRepository() {
+        RepoScriptBlockUtil.jcenterRepository()
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
@@ -136,4 +136,8 @@ public abstract class AbstractIntegrationTest {
         action.execute(executer);
         return executer;
     }
+
+    public static String mavenCentralRepository() {
+        return RepoScriptBlockUtil.mavenCentralRepository();
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -36,14 +36,35 @@ class RepoScriptBlockUtil {
     }
 
     static String jcenterRepositoryDefinition() {
-        repositoryDefinition('org.gradle.integtest.mirrors.jcenter', 'jcenter-remote', 'jcenter()')
+        mavenRepositoryDefinition('org.gradle.integtest.mirrors.jcenter', 'jcenter-remote', 'jcenter()')
     }
 
     static mavenCentralRepositoryDefinition() {
-        repositoryDefinition('org.gradle.integtest.mirrors.mavencentral', 'repo1-remote', 'mavenCentral()')
+        mavenRepositoryDefinition('org.gradle.integtest.mirrors.mavencentral', 'repo1-remote', 'mavenCentral()')
     }
 
-    private static repositoryDefinition(String repoUrlProperty, String repoName, String defaultRepo) {
+    static typesafeMavenRepositoryDefinition() {
+        String defaultRepo = '''
+           maven {
+               name "typesafe-maven-release"
+               url "https://repo.typesafe.com/typesafe/maven-releases"
+           }'''
+        mavenRepositoryDefinition('org.gradle.integtest.mirrors.typesafemaven', 'typesafe-maven-release-remote', defaultRepo)
+    }
+
+    static typesafeIvyRepositoryDefinition() {
+        String repoUrl = System.getProperty('org.gradle.integtest.mirrors.typesafeivy')
+        repoUrl = repoUrl ?: "https://repo.typesafe.com/typesafe/ivy-releases"
+        """
+            ivy {
+                name "typesafe-ivy-release"
+                url ${repoUrl}
+                layout "ivy"
+            }
+        """
+    }
+
+    private static mavenRepositoryDefinition(String repoUrlProperty, String repoName, String defaultRepo) {
         String repoUrl = System.getProperty(repoUrlProperty)
         if (repoUrl) {
             """maven {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -28,16 +28,31 @@ class RepoScriptBlockUtil {
         """
     }
 
+    static String mavenCentralRepository() {
+        """repositories {
+               ${mavenCentralRepositoryDefinition()}
+           }
+        """
+    }
+
     static String jcenterRepositoryDefinition() {
-        String mirrorUrl = System.getProperty('org.gradle.integtest.mirrors.jcenter')
-        if (mirrorUrl) {
+        repositoryDefinition('org.gradle.integtest.mirrors.jcenter', 'jcenter-remote', 'jcenter()')
+    }
+
+    static mavenCentralRepositoryDefinition() {
+        repositoryDefinition('org.gradle.integtest.mirrors.mavencentral', 'repo1-remote', 'mavenCentral()')
+    }
+
+    private static repositoryDefinition(String repoUrlProperty, String repoName, String defaultRepo) {
+        String repoUrl = System.getProperty(repoUrlProperty)
+        if (repoUrl) {
             """maven {
-                   name 'jcenter-mirror'
-                   url '${mirrorUrl}'
+                   name '${repoName}'
+                   url '${repoUrl}'
                }
             """
         } else {
-            'jcenter()'
+            defaultRepo
         }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+class RepoScriptBlockUtil {
+
+    private RepoScriptBlockUtil() {
+    }
+
+    static String jcenterRepository() {
+        """repositories {
+               ${jcenterRepositoryDefinition()}
+           }
+        """
+    }
+
+    static String jcenterRepositoryDefinition() {
+        String mirrorUrl = System.getProperty('org.gradle.integtest.mirrors.jcenter')
+        if (mirrorUrl) {
+            """maven {
+                   name 'jcenter-mirror'
+                   url '${mirrorUrl}'
+               }
+            """
+        } else {
+            'jcenter()'
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -22,58 +22,86 @@ class RepoScriptBlockUtil {
     }
 
     static String jcenterRepository() {
-        """repositories {
-               ${jcenterRepositoryDefinition()}
-           }
-        """
-    }
-
-    static String mavenCentralRepository() {
-        """repositories {
-               ${mavenCentralRepositoryDefinition()}
-           }
-        """
-    }
-
-    static String jcenterRepositoryDefinition() {
-        mavenRepositoryDefinition('org.gradle.integtest.mirrors.jcenter', 'jcenter-remote', 'jcenter()')
-    }
-
-    static mavenCentralRepositoryDefinition() {
-        mavenRepositoryDefinition('org.gradle.integtest.mirrors.mavencentral', 'repo1-remote', 'mavenCentral()')
-    }
-
-    static typesafeMavenRepositoryDefinition() {
-        String defaultRepo = '''
-           maven {
-               name "typesafe-maven-release"
-               url "https://repo.typesafe.com/typesafe/maven-releases"
-           }'''
-        mavenRepositoryDefinition('org.gradle.integtest.mirrors.typesafemaven', 'typesafe-maven-release-remote', defaultRepo)
-    }
-
-    static typesafeIvyRepositoryDefinition() {
-        String repoUrl = System.getProperty('org.gradle.integtest.mirrors.typesafeivy')
-        repoUrl = repoUrl ?: "https://repo.typesafe.com/typesafe/ivy-releases"
-        """
-            ivy {
-                name "typesafe-ivy-release"
-                url ${repoUrl}
-                layout "ivy"
+        return """
+            repositories {
+                ${jcenterRepositoryDefinition()}
             }
         """
     }
 
-    private static mavenRepositoryDefinition(String repoUrlProperty, String repoName, String defaultRepo) {
-        String repoUrl = System.getProperty(repoUrlProperty)
+    static String mavenCentralRepository() {
+        return """
+            repositories {
+                ${mavenCentralRepositoryDefinition()}
+            }
+        """
+    }
+
+    static String jcenterRepositoryDefinition() {
+        String repoUrl = System.getProperty('org.gradle.integtest.mirrors.jcenter')
         if (repoUrl) {
-            """maven {
-                   name '${repoName}'
-                   url '${repoUrl}'
-               }
+            return """
+                maven {
+                    name "jcenter-remote"
+                    url "${repoUrl}"
+                }
             """
         } else {
-            defaultRepo
+            return 'jcenter()'
+        }
+    }
+
+    static String mavenCentralRepositoryDefinition() {
+        String repoUrl = System.getProperty('org.gradle.integtest.mirrors.mavencentral')
+        if (repoUrl) {
+            return """
+                maven {
+                    name "repo1-remote"
+                    url "${repoUrl}"
+                }
+            """
+        } else {
+            return 'mavenCentral()'
+        }
+    }
+
+    static String typesafeMavenRepositoryDefinition() {
+        String repoUrl = System.getProperty('org.gradle.integtest.mirrors.typesafemaven')
+        if (repoUrl) {
+            return """
+                maven {
+                    name "typesafe-maven-release-remote'"
+                    url "${repoUrl}"
+                }
+            """
+        } else {
+            return """
+                maven {
+                    name "typesafe-maven-release"
+                    url "https://repo.typesafe.com/typesafe/maven-releases"
+                }
+            """
+        }
+    }
+
+    static String typesafeIvyRepositoryDefinition() {
+        String repoUrl = System.getProperty('org.gradle.integtest.mirrors.typesafeivy')
+        if (repoUrl) {
+            return """
+                ivy {
+                    name "typesafe-ivy-release-remote"
+                    url "${repoUrl}"
+                    layout "ivy"
+                }
+            """
+        } else {
+            return """
+                ivy {
+                    name "typesafe-ivy-release"
+                    url "https://repo.typesafe.com/typesafe/ivy-releases"
+                    layout "ivy"
+                }
+            """
         }
     }
 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishEarIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishEarIntegTest.groovy
@@ -31,9 +31,7 @@ class IvyPublishEarIntegTest extends AbstractIvyPublishIntegTest {
             group = 'org.gradle.test'
             version = '1.9'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "commons-collections:commons-collections:3.2.2"

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -197,9 +197,7 @@ $append
             group = 'org.gradle.test'
             version = '1.9'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "commons-collections:commons-collections:3.2.2"

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
@@ -179,9 +179,7 @@ allprojects {
 project(':project1') {
     apply plugin: 'java'
 
-    repositories {
-        jcenter()
-    }
+    ${jcenterRepository()}
 
     dependencies {
         compile 'commons-logging:commons-logging:1.2'

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishWarIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishWarIntegTest.groovy
@@ -30,9 +30,7 @@ class IvyPublishWarIntegTest extends AbstractIvyPublishIntegTest {
             group = 'org.gradle.test'
             version = '1.9'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "commons-collections:commons-collections:3.2.2"

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyWarProjectPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyWarProjectPublishIntegrationTest.groovy
@@ -30,9 +30,7 @@ apply plugin: 'war'
 group = 'org.gradle.test'
 version = '1.9'
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     compile "commons-collections:commons-collections:3.2.2"

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
@@ -31,9 +31,7 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
         buildFile << """
             apply plugin: "groovy"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "org.codehaus.groovy:${module}:${version}"
@@ -69,9 +67,7 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
         buildFile << """
             apply plugin: "groovy"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "org.codehaus.groovy:${module}:${version}"
@@ -119,9 +115,7 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
         buildScript """
             apply plugin: "groovy"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "org.codehaus.groovy:groovy:${version}"

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocStampsIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocStampsIntegrationTest.groovy
@@ -28,9 +28,7 @@ class GroovyDocStampsIntegrationTest extends MultiVersionIntegrationSpec {
         buildFile << """
             apply plugin: "groovy"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "org.codehaus.groovy:groovy:${version}"

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -144,9 +144,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             apply plugin: "java"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 testCompile "junit:junit:4.12"

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -250,18 +250,16 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     def "test runtime classpath includes implementation dependencies"() {
         given:
-        buildFile << '''
+        buildFile << """
             apply plugin: 'java'
 
-            repositories {
-                jcenter()
-            }
+             ${jcenterRepository()}
 
             dependencies {
                 implementation 'org.apache.commons:commons-lang3:3.4'
                 testCompile 'junit:junit:4.12' // not using testImplementation intentionally, that's not what we want to test
             }
-        '''
+        """
         file('src/main/java/Text.java') << '''import org.apache.commons.lang3.StringUtils;
             public class Text {
                 public static String sayHello(String name) { return "Hello, " + StringUtils.capitalize(name); }
@@ -288,18 +286,16 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     def "test runtime classpath includes test implementation dependencies"() {
         given:
-        buildFile << '''
+        buildFile << """
             apply plugin: 'java'
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencies {
                 implementation 'org.apache.commons:commons-lang3:3.4'
                 testImplementation 'junit:junit:4.12'
             }
-        '''
+        """
         file('src/main/java/Text.java') << '''import org.apache.commons.lang3.StringUtils;
             public class Text {
                 public static String sayHello(String name) { return "Hello, " + StringUtils.capitalize(name); }
@@ -326,18 +322,16 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     def "test compile classpath includes implementation dependencies"() {
         given:
-        buildFile << '''
+        buildFile << """
             apply plugin: 'java'
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencies {
                 implementation 'org.apache.commons:commons-lang3:3.4'
                 testImplementation 'junit:junit:4.12'
             }
-        '''
+        """
         file('src/main/java/Text.java') << '''import org.apache.commons.lang3.StringUtils;
             public class Text {
                 public static String sayHello(String name) { return "Hello, " + StringUtils.capitalize(name); }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
@@ -56,9 +56,7 @@ class JavaCompileParallelIntegrationTest extends AbstractIntegrationSpec {
             subprojects {
                 apply plugin: 'java'
 
-                repositories {
-                    mavenCentral()
-                }
+                ${mavenCentralRepository()}
 
                 dependencies {
                     compile 'commons-lang:commons-lang:2.5'

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -371,12 +371,12 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
     @NotYetImplemented
     def "doesn't recompile if external dependency has ABI incompatible change but not on class we use"() {
         given:
-        buildFile << '''
+        buildFile << """
             project(':impl') {
-                repositories { jcenter() }
+                ${jcenterRepository()}     
                 dependencies { compile 'org.apache.commons:commons-lang3:3.3' }
             }
-        '''
+        """
         java api: ["class A {}", "class B { }"], impl: ["class ImplA extends A {}", """import org.apache.commons.lang3.StringUtils;
 
             class ImplB extends B { 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -38,7 +38,7 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
                     options.incremental = true
                     options.fork = true
                 }
-                repositories { mavenCentral() }
+                ${mavenCentralRepository()}
             }
             $projectDependencyBlock
         """

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CompileAvoidanceWithIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CompileAvoidanceWithIncrementalJavaCompilationIntegrationTest.groovy
@@ -22,17 +22,15 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 class CompileAvoidanceWithIncrementalJavaCompilationIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
-        buildFile << '''
+        buildFile << """
             allprojects {
                 tasks.withType(JavaCompile) {
                     options.incremental = true
                 }
                 
-                repositories {
-                    jcenter()
-                }
+                ${jcenterRepository()}
             }
-        '''
+       """
     }
 
     @NotYetImplemented

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/SourceIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/SourceIncrementalJavaCompilationIntegrationTest.groovy
@@ -494,7 +494,7 @@ compileTestJava.options.incremental = true
         java "class A {}"
 
         buildFile << """
-repositories { jcenter() }
+        ${jcenterRepository()}
 dependencies { compile 'com.ibm.icu:icu4j:2.6.1' }
 """
         expect:
@@ -506,7 +506,7 @@ dependencies { compile 'com.ibm.icu:icu4j:2.6.1' }
         java "class A {}"
 
         buildFile << """
-repositories { jcenter() }
+${jcenterRepository()}
 dependencies { compile 'net.sf.ehcache:ehcache:2.10.2' }
 """
         expect:

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JavaLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JavaLanguageIncrementalBuildIntegrationTest.groovy
@@ -48,9 +48,7 @@ class JavaLanguageIncrementalBuildIntegrationTest extends AbstractJvmLanguageInc
                     apply plugin: 'jvm-component'
                     apply plugin: '${testComponent.languageName}-lang'
                     
-                    repositories {
-                        mavenCentral()
-                    }
+                    ${mavenCentralRepository()}
                 
                     tasks.withType(org.gradle.api.tasks.compile.AbstractCompile) {
                         it.options.incremental = true

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JvmApiSpecIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JvmApiSpecIntegrationTest.groovy
@@ -68,9 +68,7 @@ class JvmApiSpecIntegrationTest extends AbstractJvmLanguageIntegrationTest {
     def "can scan Annotations for public API"() {
         when:
         buildFile << """
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             model {
                 components {

--- a/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/ScalaComponentCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/ScalaComponentCompilerDaemonReuseIntegrationTest.groovy
@@ -33,9 +33,7 @@ class ScalaComponentCompilerDaemonReuseIntegrationTest extends AbstractComponent
             apply plugin: "jvm-component"
             apply plugin: "scala-lang"
             
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
             
             model {
                 components {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
@@ -28,7 +28,7 @@ class MultiProjectContinuousIntegrationTest extends Java7RequiringContinuousInte
         buildFile << """
             subprojects {
                 apply plugin: 'java'
-                repositories { mavenCentral() }
+                ${mavenCentralRepository()}
             }
 
             project(':downstream') {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishEarIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishEarIntegTest.groovy
@@ -33,9 +33,7 @@ apply plugin: 'maven-publish'
 group = 'org.gradle.test'
 version = '1.9'
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     compile "commons-collections:commons-collections:3.2.2"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -102,9 +102,7 @@ $append
             group = 'org.gradle.test'
             version = '1.9'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "commons-collections:commons-collections:3.2.2"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -203,9 +203,7 @@ allprojects {
 
     group = "org.gradle.test"
 
-    repositories {
-        mavenCentral()
-    }
+    ${mavenCentralRepository()}
 }
 
 project(":project1") {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishWarProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishWarProjectIntegTest.groovy
@@ -32,9 +32,7 @@ class MavenPublishWarProjectIntegTest extends AbstractMavenPublishIntegTest {
             group = 'org.gradle.test'
             version = '1.9'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "commons-collections:commons-collections:3.2.2"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenJavaProjectPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenJavaProjectPublishIntegrationTest.groovy
@@ -36,9 +36,7 @@ apply plugin: 'maven'
 group = 'org.gradle.test'
 version = '1.9'
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     compile "commons-collections:commons-collections:3.2.2"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
@@ -44,7 +44,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 group = 'group'
 version = '1.0'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 configurations { custom }
 dependencies {
     custom 'commons-collections:commons-collections:3.2.2'

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenSftpPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenSftpPublishIntegrationTest.groovy
@@ -48,9 +48,7 @@ class MavenSftpPublishIntegrationTest extends AbstractMavenPublishIntegTest {
             apply plugin: 'maven'
             version = '1.0'
             group = 'org.group.name'
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
             configurations {
                 deployerJars
             }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenWarProjectPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenWarProjectPublishIntegrationTest.groovy
@@ -32,9 +32,7 @@ apply plugin: 'maven'
 group = 'org.gradle.test'
 version = '1.9'
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     compile "commons-collections:commons-collections:3.2.2"

--- a/subprojects/messaging/src/integTest/groovy/org/gradle/internal/serialize/ExceptionPlaceholderIntegrationTest.groovy
+++ b/subprojects/messaging/src/integTest/groovy/org/gradle/internal/serialize/ExceptionPlaceholderIntegrationTest.groovy
@@ -24,18 +24,16 @@ class ExceptionPlaceholderIntegrationTest extends AbstractIntegrationSpec {
     @Issue("https://github.com/gradle/gradle/issues/1618")
     def "internal exception should not be thrown"() {
         given:
-        buildFile << '''
+        buildFile << """
             apply plugin: 'java'
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencies {
                 testCompile 'junit:junit:4.12'
                 testCompile 'org.mockito:mockito-core:2.3.7'
             }
-        '''
+        """
 
         file('src/test/java/example/Issue1618Test.java') << '''
             package example;

--- a/subprojects/osgi/src/integTest/groovy/org/gradle/api/plugins/osgi/OsgiPluginIntegrationSpec.groovy
+++ b/subprojects/osgi/src/integTest/groovy/org/gradle/api/plugins/osgi/OsgiPluginIntegrationSpec.groovy
@@ -164,9 +164,7 @@ class OsgiPluginIntegrationSpec extends AbstractIntegrationSpec {
             apply plugin: 'java'
             apply plugin: 'osgi'
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile 'org.eclipse:osgi:3.10.0-v20140606-1445'

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/CustomCoffeeScriptImplementationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/CustomCoffeeScriptImplementationIntegrationTest.groovy
@@ -32,7 +32,7 @@ class CustomCoffeeScriptImplementationIntegrationTest extends AbstractCoffeeScri
             }
 
             repositories{
-                jcenter()
+                ${jcenterRepository()}
                 maven {
                     name = "gradle-js"
                     url = "https://repo.gradle.org/gradle/javascript-public"

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/Repositories.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/Repositories.groovy
@@ -23,15 +23,8 @@ class Repositories {
     public static final String PLAY_REPOSITORIES = """
         repositories {
             ${RepoScriptBlockUtil.jcenterRepositoryDefinition()}
-            maven {
-                name "typesafe-maven-release"
-                url "https://repo.typesafe.com/typesafe/maven-releases"
-            }
-            ivy {
-                name "typesafe-ivy-release"
-                url "https://repo.typesafe.com/typesafe/ivy-releases"
-                layout "ivy"
-            }
+            ${RepoScriptBlockUtil.typesafeMavenRepositoryDefinition()}
+            ${RepoScriptBlockUtil.typesafeIvyRepositoryDefinition()}
         }
     """
 

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/Repositories.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/Repositories.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.play.integtest.fixtures
 
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil
+
 
 class Repositories {
     public static final String PLAY_REPOSITORIES = """
         repositories {
-            jcenter()
+            ${RepoScriptBlockUtil.jcenterRepositoryDefinition()}
             maven {
                 name "typesafe-maven-release"
                 url "https://repo.typesafe.com/typesafe/maven-releases"

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
@@ -43,14 +43,6 @@ abstract class BaseGradleImplDepsIntegrationTest extends AbstractIntegrationSpec
         """
     }
 
-    static String jcenterRepository() {
-        """
-            repositories {
-                jcenter()
-            }
-        """
-    }
-
     static String gradleApiDependency() {
         """
             dependencies {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaLibraryDistributionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaLibraryDistributionIntegrationTest.groovy
@@ -42,9 +42,7 @@ class JavaLibraryDistributionIntegrationTest extends WellBehavedPluginTest {
         buildFile << """
         apply plugin: 'java-library-distribution'
 
-        repositories {
-            mavenCentral()
-        }
+        ${mavenCentralRepository()}
         dependencies {
             compile 'commons-collections:commons-collections:3.2.2'
             runtime 'commons-lang:commons-lang:2.6'
@@ -103,9 +101,7 @@ class JavaLibraryDistributionIntegrationTest extends WellBehavedPluginTest {
             }
         }
 
-        repositories {
-            mavenCentral()
-        }
+        ${mavenCentralRepository()}
         dependencies {
             runtime 'commons-lang:commons-lang:2.6'
         }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyBasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyBasePluginIntegrationTest.groovy
@@ -26,9 +26,7 @@ sourceSets {
     custom
 }
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     customCompile "$dependency"
@@ -64,9 +62,7 @@ sourceSets {
     custom
 }
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     customCompile "org.codehaus.groovy:groovy-all:2.4.10"
@@ -97,9 +93,7 @@ task verify {
                 main {}
             }
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "com.google.guava:guava:11.0.2"

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyCrossCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyCrossCompilationIntegrationTest.groovy
@@ -44,7 +44,7 @@ class GroovyCrossCompilationIntegrationTest extends MultiVersionIntegrationSpec 
 apply plugin: 'groovy'
 sourceCompatibility = ${MultiVersionIntegrationSpec.version}
 targetCompatibility = ${MultiVersionIntegrationSpec.version}
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.10'

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovySecurityManagerIssuesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovySecurityManagerIssuesIntegrationTest.groovy
@@ -30,9 +30,7 @@ class GroovySecurityManagerIssuesIntegrationTest extends AbstractIntegrationSpec
         writeGroovyTestSource("src/test/groovy")
         file('build.gradle') << """
             apply plugin:'groovy'
-            repositories{
-                jcenter()
-            }
+            ${jcenterRepository()}
             dependencies{
                 compile localGroovy()
                 testCompile 'junit:junit:4.12'

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -405,7 +405,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         def gradleBaseServicesClass = Action
         buildScript """
             apply plugin: 'groovy'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
         """
 
         when:
@@ -426,7 +426,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         def gradleBaseServicesClass = Action
         buildScript """
             apply plugin: 'groovy'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies {
                 compile 'org.codehaus.groovy:groovy:2.4.3:grooid'
             }
@@ -446,7 +446,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         given:
         buildFile << """
             apply plugin: "groovy"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             compileGroovy.options.failOnError = false
         """.stripIndent()
 
@@ -461,7 +461,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         given:
         buildFile << """
             apply plugin: "groovy"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             compileGroovy.groovyOptions.failOnError = false
         """.stripIndent()
 
@@ -476,7 +476,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         given:
         buildFile << """
             apply plugin: "groovy"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             compileGroovy.options.failOnError = false
         """.stripIndent()
 
@@ -492,7 +492,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         given:
         buildFile << """
             apply plugin: "groovy"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             compileGroovy.groovyOptions.failOnError = false
         """.stripIndent()
 
@@ -685,7 +685,7 @@ ${compilerConfiguration()}
     def writeAnnotationProcessingBuild(String java, String groovy) {
         buildFile << """
             apply plugin: "groovy"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             compileGroovy {
                 groovyOptions.with {
                     stubDir = file("\$buildDir/classes/stub")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
@@ -34,9 +34,7 @@ class CachedGroovyCompileIntegrationTest extends AbstractCachedCompileIntegratio
 
             mainClassName = "Hello"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile 'org.codehaus.groovy:groovy-all:2.4.10'
@@ -72,7 +70,7 @@ class CachedGroovyCompileIntegrationTest extends AbstractCachedCompileIntegratio
         buildFile.text = """
             plugins { id 'groovy' }
 
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { compile 'org.codehaus.groovy:groovy-all:2.4.5' }
         """.stripIndent()
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/DaemonGroovyCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/DaemonGroovyCompilerIntegrationTest.groovy
@@ -36,7 +36,7 @@ class DaemonGroovyCompilerIntegrationTest extends ApiGroovyCompilerIntegrationSp
             import org.gradle.internal.jvm.Jvm
 
             apply plugin: "groovy"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             tasks.withType(GroovyCompile) {
                 options.forkOptions.executable = "${differentJavacExecutablePath}"
                 options.forkOptions.memoryInitialSize = "128m"

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
@@ -46,7 +46,7 @@ class JavaCrossCompilationIntegrationTest extends MultiVersionIntegrationSpec {
 apply plugin: 'java'
 sourceCompatibility = ${version}
 targetCompatibility = ${version}
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 tasks.withType(JavaCompile) {
     options.with {
         fork = true

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/ParallelTestTaskIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/ParallelTestTaskIntegrationTest.groovy
@@ -56,7 +56,7 @@ subprojects {
     sourceCompatibility = ${version}
     targetCompatibility = ${version}
 
-    repositories { mavenCentral() }
+    ${mavenCentralRepository()}
     dependencies { testCompile 'junit:junit:4.12' }
 
     test {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/UnsupportedJavaVersionCrossCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/UnsupportedJavaVersionCrossCompilationIntegrationTest.groovy
@@ -44,7 +44,7 @@ class UnsupportedJavaVersionCrossCompilationIntegrationTest extends MultiVersion
 apply plugin: 'java'
 sourceCompatibility = ${version}
 targetCompatibility = ${version}
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 tasks.withType(JavaCompile) {
     options.with {
         fork = true

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompileAvoidanceIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompileAvoidanceIntegrationSpec.groovy
@@ -1023,9 +1023,7 @@ public class ToolImpl {
     def "detects changes in compile classpath"() {
         given:
         buildFile << """
-            repositories {
-               jcenter()
-            }
+            ${jcenterRepository()}
             
             dependencies {
                if (project.hasProperty('useCommons')) {
@@ -1075,9 +1073,7 @@ public class ToolImpl {
             """
         }
         buildFile << """
-            repositories {
-               jcenter()
-            }
+            ${jcenterRepository()}
             
             dependencies {
                switch (project.getProperty('order') as int) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -186,16 +186,14 @@ compileJava.options.compilerArgs.addAll(['--release', '7'])
     }
 
     def buildScript() {
-        '''
+        """
 apply plugin: "java"
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     compile "org.codehaus.groovy:groovy:2.4.10"
 }
-'''
+"""
     }
 
     abstract compilerConfiguration()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CachedJavaCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CachedJavaCompileIntegrationTest.groovy
@@ -33,9 +33,7 @@ class CachedJavaCompileIntegrationTest extends AbstractCachedCompileIntegrationT
 
             mainClassName = "Hello"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile 'org.codehaus.groovy:groovy-all:2.4.10'

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
@@ -86,9 +86,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
             apply plugin: 'build-dashboard'
 
             allprojects {
-                repositories {
-                    mavenCentral()
-                }
+                ${mavenCentralRepository()}
             }
         """
     }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaBasePluginIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaBasePluginIntegrationTest.groovy
@@ -34,9 +34,7 @@ class ScalaBasePluginIntegrationTest extends MultiVersionIntegrationSpec {
            custom
         }
 
-        repositories {
-           mavenCentral()
-        }
+        ${mavenCentralRepository()}
 
         dependencies {
            customCompile "org.scala-lang:scala-library:$version"

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaCrossCompilationIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaCrossCompilationIntegrationTest.groovy
@@ -46,7 +46,7 @@ class ScalaCrossCompilationIntegrationTest extends MultiVersionIntegrationSpec {
 apply plugin: 'scala'
 sourceCompatibility = ${MultiVersionIntegrationSpec.version}
 targetCompatibility = ${MultiVersionIntegrationSpec.version}
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 
 dependencies {
     compile 'org.scala-lang:scala-library:2.11.1'

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
@@ -35,9 +35,7 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
 
             mainClassName = "Hello"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile group: 'org.scala-lang', name: 'scala-library', version: '2.11.8'
@@ -61,9 +59,7 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
                 id 'scala'
             }
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
             
             dependencies {
                 compile group: 'org.scala-lang', name: 'scala-library', version: '2.11.8'

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -92,9 +92,7 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec {
         return """
             apply plugin: 'scala'
                         
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencies {
                 zinc "com.typesafe.zinc:zinc:${zincVersion}"

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerMultiVersionIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerMultiVersionIntegrationTest.groovy
@@ -26,9 +26,7 @@ class ZincScalaCompilerMultiVersionIntegrationTest extends MultiVersionIntegrati
         buildFile << """
             apply plugin: "scala"
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencies {
                 compile "org.scala-lang:scala-library:2.10.4"

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/test/ScalaTestIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/test/ScalaTestIntegrationTest.groovy
@@ -29,9 +29,7 @@ class ScalaTestIntegrationTest extends AbstractIntegrationSpec {
         file("build.gradle") << """
 apply plugin: 'scala'
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     compile "org.scala-lang:scala-library:2.11.1"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -76,4 +76,8 @@ abstract class AbstractSmokeTest extends Specification {
     protected static String jcenterRepository() {
         RepoScriptBlockUtil.jcenterRepository()
     }
+
+    protected static String mavenCentralRepository() {
+        RepoScriptBlockUtil.mavenCentralRepository()
+    }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.smoketests
 
 import org.apache.commons.io.FileUtils
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -70,5 +71,9 @@ abstract class AbstractSmokeTest extends Specification {
             text = text.replaceAll("\\\$${var}".toString(), value)
         }
         buildFile.text = text
+    }
+
+    protected static String jcenterRepository() {
+        RepoScriptBlockUtil.jcenterRepository()
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -72,9 +72,7 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
         buildFile << buildscript() << """
             apply plugin: 'com.android.application'
 
-            repositories {
-                jcenter()
-            }
+           ${jcenterRepository()}
 
             android.defaultConfig.applicationId "org.gradle.android.myapplication"
         """.stripIndent() << androidPluginConfiguration() << activityDependency()
@@ -136,9 +134,7 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
 
         file('build.gradle') << buildscript() << """
             subprojects {
-                repositories {
-                    jcenter()
-                }
+                ${jcenterRepository()}
             }
         """
 
@@ -178,9 +174,7 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
     private String buildscript() {
         """
             buildscript {
-                repositories {
-                    jcenter()
-                }
+                ${jcenterRepository()}
 
 
                 dependencies {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -101,7 +101,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
             }
 
             apply plugin: 'java'
-            repositories { jcenter() }
+            ${jcenterRepository()}
 
             dependencies { 
                 testCompile 'junit:junit:4.12' 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -26,9 +26,7 @@ class NebulaPluginsSmokeTest extends AbstractSmokeTest {
                 id "nebula.dependency-recommender" version "4.1.2"
             }
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencyRecommendations {
                 mavenBom module: 'netflix:platform:latest.release'
@@ -71,9 +69,7 @@ class NebulaPluginsSmokeTest extends AbstractSmokeTest {
         given:
         buildFile << """
             buildscript {
-                repositories {
-                    jcenter()
-                }
+                ${jcenterRepository()}
             }
 
             plugins {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -36,9 +36,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
                 id 'com.github.johnrengelman.shadow' version '1.2.3'
             }
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencies {
                 compile 'commons-collections:commons-collections:3.2.2'
@@ -64,9 +62,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
         given:
         buildFile << """
             buildscript {
-                repositories {
-                    jcenter()
-                }
+                ${jcenterRepository()}
                 dependencies {
                     classpath "org.asciidoctor:asciidoctor-gradle-plugin:1.5.3"                
                 }
@@ -323,7 +319,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
                 id "org.xtext.xtend" version "1.0.17"
             }
 
-            repositories.jcenter()
+            ${jcenterRepository()}
 
             dependencies {
                 compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.11.0'

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -121,9 +121,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
                 id 'io.spring.dependency-management' version '1.0.1.RELEASE'
             }
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencyManagement {
                 dependencies {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/AndroidDexingSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/AndroidDexingSoakTest.groovy
@@ -190,9 +190,7 @@ class AndroidDexingSoakTest extends DaemonIntegrationSpec {
 
         buildFile << """
             buildscript {
-                repositories {
-                    jcenter()
-                }
+                ${jcenterRepository()}
 
 
                 dependencies {
@@ -228,9 +226,7 @@ class AndroidDexingSoakTest extends DaemonIntegrationSpec {
                 dexOptions.preDexLibraries=false
             }
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
         """
     }
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/TestKitDependencyClassVisibilityIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/TestKitDependencyClassVisibilityIntegrationTest.groovy
@@ -59,9 +59,7 @@ class TestKitDependencyClassVisibilityIntegrationTest extends AbstractIntegratio
         when:
         buildScript """
             plugins { id "org.gradle.java" }
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
             dependencies {
                 testCompile gradleTestKit()
                 testCompile 'com.google.guava:guava-jdk5:13.0'

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/CheckstyleEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/CheckstyleEndUserIntegrationTest.groovy
@@ -30,9 +30,7 @@ class CheckstyleEndUserIntegrationTest extends BaseTestKitEndUserIntegrationTest
                 id "org.gradle.java-gradle-plugin"
                 id "org.gradle.groovy"
             }
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
             dependencies {
                 testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
                     exclude module: 'groovy-all'

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/CheckstyleEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/CheckstyleEndUserIntegrationTest.groovy
@@ -54,9 +54,7 @@ class Test extends Specification {
 apply plugin: 'java'
 apply plugin: 'checkstyle'
 
-repositories {
-    mavenCentral()
-}
+${mavenCentralRepository()}
 
 dependencies {
     testCompile 'junit:junit:4.11'

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -28,9 +28,7 @@ class GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest ext
                 id "org.gradle.java-gradle-plugin"
                 id "org.gradle.groovy"
             }
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
             dependencies {
                 testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
                     exclude module: 'groovy-all'

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegationTest.groovy
@@ -37,9 +37,7 @@ class GradleRunnerMiscEndUserIntegationTest extends BaseTestKitEndUserIntegratio
                 }
             }
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             test.testLogging.exceptionFormat = 'full'
         """

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -46,9 +46,7 @@ class GradleRunnerPluginClasspathInjectionEndUserIntegrationTest extends BaseTes
                 testCompile files(createClasspathManifest)
             }
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
         """
     }
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerUserLoggingEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerUserLoggingEndUserIntegrationTest.groovy
@@ -24,9 +24,7 @@ class GradleRunnerUserLoggingEndUserIntegrationTest extends BaseTestKitEndUserIn
     def "can use user slfj logging in tests using testkit"() {
         when:
         buildFile << """
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             apply plugin: "groovy"
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/jvm/test/AbstractJUnitTestExecutionIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/jvm/test/AbstractJUnitTestExecutionIntegrationSpec.groovy
@@ -29,11 +29,7 @@ class AbstractJUnitTestExecutionIntegrationSpec extends AbstractIntegrationSpec 
             }
         '''
         if (declareRepo) {
-            buildFile << '''
-                repositories {
-                    jcenter()
-                }
-            '''
+            buildFile << jcenterRepository()
         }
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/jvm/test/JUnitTestSuiteComponentReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/jvm/test/JUnitTestSuiteComponentReportIntegrationTest.groovy
@@ -20,17 +20,15 @@ import org.gradle.api.reporting.components.AbstractComponentReportIntegrationTes
 
 class JUnitTestSuiteComponentReportIntegrationTest extends AbstractComponentReportIntegrationTest {
     def setup() {
-        buildFile << '''
+        buildFile << """
             plugins {
                 id 'jvm-component'
                 id 'junit-test-suite'
                 id 'java-lang'
             }
 
-            repositories {
-                jcenter()
-            }
-        '''
+            ${jcenterRepository()}
+        """
     }
 
     def "shows details of stand alone Junit test suite"() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
@@ -94,7 +94,7 @@ public class BarTest {
 
         file("build.gradle") << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             test.beforeTest { println "executed " + it }
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
@@ -32,7 +32,7 @@ class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << 'rootProject.name = "root"'
         buildFile << """
             plugins { id "java" }
-            repositories { jcenter() }
+            ${jcenterRepository()}
             dependencies {
                 testCompile localGroovy()
                 testCompile "junit:junit:4.12"
@@ -110,7 +110,7 @@ class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
         ["a", "b"].collect { file(it) }.each { TestFile build ->
             build.file("build.gradle") << """
                 plugins { id "java" }
-                repositories { jcenter() }
+                ${jcenterRepository()}
                 dependencies {
                     testCompile localGroovy()
                     testCompile "junit:junit:4.12"

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
@@ -55,7 +55,7 @@ public class SomeTest {
         def buildFile = file('build.gradle')
         buildFile << """
 apply plugin: 'java'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies { testCompile "junit:junit:4.12" }
 
 test.addTestOutputListener(new VerboseOutputListener(logger: project.logger))
@@ -108,7 +108,7 @@ public class SomeTest {
         def buildFile = file('build.gradle')
         buildFile << """
 apply plugin: 'java'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies { testCompile "junit:junit:4.12" }
 
 test.onOutput { descriptor, event ->
@@ -151,7 +151,7 @@ public class SomeTest {
         def buildFile = file('build.gradle')
         buildFile << """
 apply plugin: 'java'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies { testCompile "junit:junit:4.12" }
 
 test.testLogging {
@@ -185,7 +185,7 @@ public class SomeTest {
         def buildFile = file('build.gradle')
         buildFile << """
 apply plugin: 'java'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies { testCompile 'org.testng:testng:6.3.1' }
 
 test {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestProgressLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestProgressLoggingIntegrationTest.groovy
@@ -29,7 +29,7 @@ class TestProgressLoggingIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile "junit:junit:4.12" }
         """
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
@@ -419,7 +419,7 @@ public class SubClassTests extends SuperClassTests {
     String getJunitSetup() {
         """
         apply plugin: 'java'
-        repositories { mavenCentral() }
+        ${mavenCentralRepository()}
         dependencies { testCompile 'junit:junit:4.12' }
         """
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -106,7 +106,7 @@ class TestTaskIntegrationTest extends AbstractIntegrationSpec {
         and:
         buildFile << """
             apply plugin: 'java'
-            repositories { jcenter() }
+            ${jcenterRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             test {
                 maxParallelForks = $maxParallelForks
@@ -132,7 +132,7 @@ class TestTaskIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             allprojects {
                 apply plugin: 'java'
-                repositories { jcenter() }
+                ${jcenterRepository()}
             }
             dependencies { 
                 testCompile 'junit:junit:4.12'
@@ -173,7 +173,7 @@ class TestTaskIntegrationTest extends AbstractIntegrationSpec {
     def "re-runs tests when resources are renamed"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { jcenter() }
+            ${jcenterRepository()}
 
             dependencies { 
                 testCompile 'junit:junit:4.12' 
@@ -210,7 +210,7 @@ class TestTaskIntegrationTest extends AbstractIntegrationSpec {
     def "emits deprecation warning when using testClassesDir"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { jcenter() }
+            ${jcenterRepository()}
 
             dependencies { 
                 testCompile 'junit:junit:4.12' 
@@ -250,12 +250,10 @@ class TestTaskIntegrationTest extends AbstractIntegrationSpec {
     }
 
     private static String java9Build() {
-        '''
+        """
             apply plugin: 'java'
 
-            repositories {
-                jcenter()
-            }
+            ${jcenterRepository()}
 
             dependencies {
                 testCompile 'junit:junit:4.12'
@@ -263,7 +261,7 @@ class TestTaskIntegrationTest extends AbstractIntegrationSpec {
 
             sourceCompatibility = 1.9
             targetCompatibility = 1.9
-        '''
+        """
     }
 
     private int classFormat(TestFile path) {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -37,7 +37,7 @@ class TestingIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile "junit:junit:4.12" }
         """
 
@@ -127,7 +127,7 @@ class TestingIntegrationTest extends AbstractIntegrationSpec {
         """
         file('build.gradle') << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
         """
 
@@ -169,7 +169,7 @@ class TestingIntegrationTest extends AbstractIntegrationSpec {
         """
         file('build.gradle') << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies {
                 testCompile 'junit:junit:4.12'
             }
@@ -199,7 +199,7 @@ class TestingIntegrationTest extends AbstractIntegrationSpec {
 
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile "junit:junit:4.12" }
             test.workingDir = "${testWorkingDir.toURI()}"
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
@@ -34,7 +34,7 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         configureFramework()
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile '$dependency:$org.gradle.integtests.fixtures.MultiVersionIntegrationSpec.version' }
             test { use${framework}() }
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
@@ -24,7 +24,7 @@ class BuildSrcSpockIntegrationTest extends AbstractIntegrationSpec {
 apply plugin: 'groovy'
 
 repositories {
-    jcenter()
+    ${jcenterRepository()}
 }
 
 dependencies {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnit3FilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnit3FilteringIntegrationTest.groovy
@@ -27,7 +27,7 @@ public class JUnit3FilteringIntegrationTest extends MultiVersionIntegrationSpec 
     void "filters tests implemented using 3.x test cases"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:${version}' }
         """
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassLevelFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassLevelFilteringIntegrationTest.groovy
@@ -27,7 +27,7 @@ public class JUnitClassLevelFilteringIntegrationTest extends MultiVersionIntegra
     def "runs all tests for class instead of method when runner is not filterable"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:${version}' }
             test { useJUnit() }
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitConsoleLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitConsoleLoggingIntegrationTest.groovy
@@ -78,7 +78,7 @@ org.gradle.JUnit4StandardOutputTest > printTest STANDARD_OUT
     def "test logging is included in XML results"() {
         file("build.gradle") << """
             apply plugin: 'java'
-                repositories { mavenCentral() }
+                ${mavenCentralRepository()}
                 dependencies { testCompile 'junit:junit:4.12' }
         """
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -167,11 +167,11 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
     def canUseTestSuperClassesFromAnotherProject() {
         given:
         testDirectory.file('settings.gradle').write("include 'a', 'b'")
-        testDirectory.file('b/build.gradle') << """
+        testDirectory.file('b/build.gradle') << '''
             apply plugin: 'java'
-            ${mavenCentralRepository()}
+            repositories { mavenCentral() }
             dependencies { compile 'junit:junit:4.12' }
-        """
+        '''
         testDirectory.file('b/src/main/java/org/gradle/AbstractTest.java') << '''
             package org.gradle;
             public abstract class AbstractTest {
@@ -179,11 +179,11 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
             }
         '''
         TestFile buildFile = testDirectory.file('a/build.gradle')
-        buildFile << """
+        buildFile << '''
             apply plugin: 'java'
-            ${mavenCentralRepository()}
+            repositories { mavenCentral() }
             dependencies { testCompile project(':b') }
-        """
+        '''
         testDirectory.file('a/src/test/java/org/gradle/SomeTest.java') << '''
             package org.gradle;
             public class SomeTest extends AbstractTest {
@@ -202,12 +202,12 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
     def canExcludeSuperClassesFromExecution() {
         given:
         TestFile buildFile = testDirectory.file('build.gradle')
-        buildFile << """
+        buildFile << '''
             apply plugin: 'java'
-            ${mavenCentralRepository()}
+            repositories { mavenCentral() }
             dependencies { testCompile 'junit:junit:4.12' }
             test { exclude '**/BaseTest.*' }
-        """
+        '''
         testDirectory.file('src/test/java/org/gradle/BaseTest.java') << '''
             package org.gradle;
             public class BaseTest {
@@ -257,7 +257,7 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
         given:
         testDirectory.file('build.gradle').writelns(
                 "apply plugin: 'java'",
-                "${mavenCentralRepository()}",
+                "repositories { mavenCentral() }",
                 "dependencies { compile 'junit:junit:4.12' }"
         )
         testDirectory.file('src/test/java/org/gradle/AbstractTest.java').writelns(
@@ -292,7 +292,7 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
         given:
         testDirectory.file('build.gradle').writelns(
                 "apply plugin: 'java'",
-                "${mavenCentralRepository()}",
+                "repositories { mavenCentral() }",
                 "dependencies { compile 'junit:junit:4.12' }",
                 "test.forkEvery = 1"
         )
@@ -344,9 +344,9 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
                 "}"
         )
 
-        testDirectory.file('build.gradle') << """
+        testDirectory.file('build.gradle') << '''
             apply plugin: 'java'
-            ${mavenCentralRepository()}
+            repositories { mavenCentral() }
             dependencies { testCompile 'junit:junit:4.12' }
             def listener = new TestListenerImpl()
             test.addTestListener(listener)
@@ -357,7 +357,7 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
                 void beforeTest(TestDescriptor test) { println "START [$test] [$test.name]" }
                 void afterTest(TestDescriptor test, TestResult result) { println "FINISH [$test] [$test.name] [$result.resultType] [$result.testCount] [$result.exception]" }
             }
-        """
+        '''
 
         when:
         ExecutionResult result = executer.withTasks("test").run()
@@ -394,9 +394,9 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
                 "}"
         )
 
-        testDirectory.file('build.gradle') << """
+        testDirectory.file('build.gradle') << '''
             apply plugin: 'java'
-            ${mavenCentralRepository()}
+            repositories { mavenCentral() }
             dependencies { testCompile 'junit:junit:3.8' }
             def listener = new TestListenerImpl()
             test.addTestListener(listener)
@@ -407,7 +407,7 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
                 void beforeTest(TestDescriptor test) { println "START [$test] [$test.name]" }
                 void afterTest(TestDescriptor test, TestResult result) { println "FINISH [$test] [$test.name] [$result.exception]" }
             }
-        """
+        '''
 
         when:
         ExecutionResult result = executer.withTasks("test").run()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -167,11 +167,11 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
     def canUseTestSuperClassesFromAnotherProject() {
         given:
         testDirectory.file('settings.gradle').write("include 'a', 'b'")
-        testDirectory.file('b/build.gradle') << '''
+        testDirectory.file('b/build.gradle') << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { compile 'junit:junit:4.12' }
-        '''
+        """
         testDirectory.file('b/src/main/java/org/gradle/AbstractTest.java') << '''
             package org.gradle;
             public abstract class AbstractTest {
@@ -179,11 +179,11 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
             }
         '''
         TestFile buildFile = testDirectory.file('a/build.gradle')
-        buildFile << '''
+        buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile project(':b') }
-        '''
+        """
         testDirectory.file('a/src/test/java/org/gradle/SomeTest.java') << '''
             package org.gradle;
             public class SomeTest extends AbstractTest {
@@ -202,12 +202,12 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
     def canExcludeSuperClassesFromExecution() {
         given:
         TestFile buildFile = testDirectory.file('build.gradle')
-        buildFile << '''
+        buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             test { exclude '**/BaseTest.*' }
-        '''
+        """
         testDirectory.file('src/test/java/org/gradle/BaseTest.java') << '''
             package org.gradle;
             public class BaseTest {
@@ -257,7 +257,7 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
         given:
         testDirectory.file('build.gradle').writelns(
                 "apply plugin: 'java'",
-                "repositories { mavenCentral() }",
+                "${mavenCentralRepository()}",
                 "dependencies { compile 'junit:junit:4.12' }"
         )
         testDirectory.file('src/test/java/org/gradle/AbstractTest.java').writelns(
@@ -292,7 +292,7 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
         given:
         testDirectory.file('build.gradle').writelns(
                 "apply plugin: 'java'",
-                "repositories { mavenCentral() }",
+                "${mavenCentralRepository()}",
                 "dependencies { compile 'junit:junit:4.12' }",
                 "test.forkEvery = 1"
         )
@@ -344,9 +344,9 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
                 "}"
         )
 
-        testDirectory.file('build.gradle') << '''
+        testDirectory.file('build.gradle') << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             def listener = new TestListenerImpl()
             test.addTestListener(listener)
@@ -357,7 +357,7 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
                 void beforeTest(TestDescriptor test) { println "START [$test] [$test.name]" }
                 void afterTest(TestDescriptor test, TestResult result) { println "FINISH [$test] [$test.name] [$result.resultType] [$result.testCount] [$result.exception]" }
             }
-        '''
+        """
 
         when:
         ExecutionResult result = executer.withTasks("test").run()
@@ -394,9 +394,9 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
                 "}"
         )
 
-        testDirectory.file('build.gradle') << '''
+        testDirectory.file('build.gradle') << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:3.8' }
             def listener = new TestListenerImpl()
             test.addTestListener(listener)
@@ -407,7 +407,7 @@ class JUnitIntegrationTest extends AbstractIntegrationSpec {
                 void beforeTest(TestDescriptor test) { println "START [$test] [$test.name]" }
                 void afterTest(TestDescriptor test, TestResult result) { println "FINISH [$test] [$test.name] [$result.exception]" }
             }
-        '''
+        """
 
         when:
         ExecutionResult result = executer.withTasks("test").run()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
@@ -30,7 +30,7 @@ class JUnitLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationSp
     def setup() {
         buildFile << """
             apply plugin: "java"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:$version' }
             test {
                 reports.junitXml.outputPerTestCase = true

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
@@ -28,9 +28,7 @@ class TestNGConsoleLoggingIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             apply plugin: "groovy"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "org.codehaus.groovy:groovy:2.4.10"
@@ -119,9 +117,7 @@ Gradle suite FAILED
         buildFile.text = """
             apply plugin: "groovy"
 
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 compile "org.codehaus.groovy:groovy:2.4.10"

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
@@ -35,7 +35,7 @@ public class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegra
     void theUsualFiles() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies {
                 testCompile 'org.testng:testng:$version'
             }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesIntegrationTest.groovy
@@ -26,7 +26,7 @@ public class TestNGGroupByInstancesIntegrationTest extends MultiVersionIntegrati
     def "run tests using groupByInstances"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'org.testng:testng:$version' }
             test {
                 useTestNG {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesNotSupportedIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesNotSupportedIntegrationTest.groovy
@@ -24,7 +24,7 @@ public class TestNGGroupByInstancesNotSupportedIntegrationTest extends AbstractI
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'org.testng:testng:6.0.1' }
             test { useTestNG { groupByInstances true } }
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -32,9 +32,9 @@ class TestNGIntegrationTest extends AbstractIntegrationSpec {
 
     def "executes tests in correct environment"() {
         given:
-        buildFile << '''
+        buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'org.testng:testng:6.3.1' }
             test {
                 useTestNG()
@@ -42,7 +42,7 @@ class TestNGIntegrationTest extends AbstractIntegrationSpec {
                 systemProperties.testDir = projectDir
                 environment.TEST_ENV_VAR = 'value'
             }
-        '''.stripIndent()
+        """.stripIndent()
         file('src/test/java/org/gradle/OkTest.java') << '''
             package org.gradle;
             
@@ -89,7 +89,7 @@ class TestNGIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'org.testng:testng:6.3.1' }
             
             test {
@@ -141,15 +141,15 @@ class TestNGIntegrationTest extends AbstractIntegrationSpec {
     @Issue("GRADLE-1532")
     def "supports thread pool size"() {
         given:
-        buildFile << '''
+        buildFile << """
             apply plugin: "java"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'org.testng:testng:6.3.1' }
             
             test {
                 useTestNG()
             }
-        '''.stripIndent()
+        """.stripIndent()
         file('src/test/java/SomeTest.java') << '''
             import org.testng.Assert;
             import org.testng.annotations.Test;
@@ -165,9 +165,9 @@ class TestNGIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "supports test groups"() {
-        buildFile << '''
+        buildFile << """
             apply plugin: "java"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile "org.testng:testng:6.3.1" }
             ext {
                 ngIncluded = "database"
@@ -179,7 +179,7 @@ class TestNGIntegrationTest extends AbstractIntegrationSpec {
                     excludeGroups ngExcluded
                 }
             }
-        '''.stripIndent()
+        """.stripIndent()
         file('src/test/java/org/gradle/groups/SomeTest.java') << '''
             package org.gradle.groups;
             import org.testng.annotations.Test;
@@ -207,14 +207,14 @@ class TestNGIntegrationTest extends AbstractIntegrationSpec {
 
     def "supports test factory"() {
         given:
-        buildFile << '''
+        buildFile << """
             apply plugin: "java"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { compile "org.testng:testng:6.3.1" }
             test {
                 useTestNG()
             }
-        '''.stripIndent()
+        """.stripIndent()
         file('src/test/java/org/gradle/factory/FactoryTest.java') << '''
             package org.gradle.factory;
             import org.testng.annotations.Test;
@@ -255,15 +255,15 @@ class TestNGIntegrationTest extends AbstractIntegrationSpec {
     @Ignore("Not fixed yet.")
     def "picks up changes"() {
         given:
-        buildFile << '''
+        buildFile << """
             apply plugin: "java"
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'org.testng:testng:6.3.1' }
             
             test {
                 useTestNG()
             }
-        '''.stripIndent()
+        """.stripIndent()
         file('src/test/java/SomeTest.java') << """
             import org.testng.Assert;
             import org.testng.annotations.Test;

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
@@ -30,7 +30,7 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
     def setup() {
         buildFile << """
             apply plugin: "java"
-            repositories { jcenter() }
+            ${jcenterRepository()}
             dependencies { testCompile "org.testng:testng:$version" }
             test {
                 useTestNG()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
@@ -30,7 +30,7 @@ public class TestNGParallelSuiteIntegrationTest extends MultiVersionIntegrationS
     def "runs with multiple parallel threads"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies {
                 testCompile 'org.testng:testng:$version'
             }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderIntegrationTest.groovy
@@ -26,7 +26,7 @@ public class TestNGPreserveOrderIntegrationTest extends MultiVersionIntegrationS
     def "run tests using preserveOrder"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'org.testng:testng:$version' }
             test {
                 useTestNG { preserveOrder true }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderNotSupportedIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderNotSupportedIntegrationTest.groovy
@@ -24,7 +24,7 @@ public class TestNGPreserveOrderNotSupportedIntegrationTest extends AbstractInte
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'org.testng:testng:5.14.4' }
             test { useTestNG { preserveOrder true } }
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
@@ -43,7 +43,7 @@ public class MixedMethodsTest {
         def buildFile = file('build.gradle')
         buildFile << """
 apply plugin: 'java'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies { testCompile 'org.testng:testng:6.3.1' }
 
 test {
@@ -72,7 +72,7 @@ public class SomeTest {
         def buildFile = file('build.gradle')
         buildFile << """
 apply plugin: 'java'
-repositories { mavenCentral() }
+${mavenCentralRepository()}
 dependencies { testCompile 'org.testng:testng:6.3.1' }
 test {
   reports.html.enabled = false

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
@@ -28,7 +28,7 @@ class TestNGSuiteInitialisationIntegrationTest extends AbstractIntegrationSpec {
     def "reports suite fatal failure"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies {
                 testCompile "org.testng:testng:6.3.1"
             }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
@@ -59,7 +59,7 @@ public class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
     def "methodMissing propagates failures"() {
         buildFile << """
     apply plugin: 'java'
-    repositories { mavenCentral() }
+    ${mavenCentralRepository()}
     dependencies {
         testCompile 'org.testng:testng:$version'
     }
@@ -89,7 +89,7 @@ public class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
     def "can specify test suite by string"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies {
                 testCompile 'org.testng:testng:$version'
             }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
@@ -87,7 +87,7 @@ public class TestNGXmlResultAndHtmlReportIntegrationTest extends
         def buildFile = file('build.gradle')
         buildFile.text = """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'org.testng:testng:6.3.1' }
 
             test {

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/SuiteTimestampIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/SuiteTimestampIntegrationTest.groovy
@@ -28,7 +28,7 @@ class SuiteTimestampIntegrationTest extends AbstractIntegrationSpec {
     void "test logging is included in XML results"() {
         file("build.gradle") << """
             apply plugin: 'java'
-                repositories { mavenCentral() }
+                ${mavenCentralRepository()}
                 dependencies { testCompile 'junit:junit:4.12' }
         """
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -255,7 +255,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification {
         """
         allprojects{
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
         }
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r112/TestFilteringCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r112/TestFilteringCrossVersionSpec.groovy
@@ -25,7 +25,7 @@ class TestFilteringCrossVersionSpec extends ToolingApiSpecification {
     def "tooling api support test filtering when tasks configured via command line"() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r24/TestProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r24/TestProgressCrossVersionSpec.groovy
@@ -70,7 +70,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
         """
@@ -188,7 +188,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
             test.ignoreFailures = true
@@ -313,7 +313,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
         """
@@ -427,7 +427,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
             test.maxParallelForks = 2
@@ -511,7 +511,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         [projectDir.createDir('sub1'), projectDir.createDir('sub2')].eachWithIndex { TestFile it, def index ->
             it.file('build.gradle') << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true
             test.maxParallelForks = 2
@@ -616,7 +616,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
     def goodCode() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r24/TestProgressDaemonErrorsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r24/TestProgressDaemonErrorsCrossVersionSpec.groovy
@@ -64,7 +64,7 @@ class TestProgressDaemonErrorsCrossVersionSpec extends ToolingApiSpecification {
     def goodCode() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             test.doLast { new URL("$server.uri").text }
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/BuildProgressCrossVersionSpec.groovy
@@ -157,7 +157,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/ProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/ProgressCrossVersionSpec.groovy
@@ -129,7 +129,7 @@ class ProgressCrossVersionSpec extends ToolingApiSpecification {
     def goodCode() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TaskProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TaskProgressCrossVersionSpec.groovy
@@ -174,7 +174,7 @@ class TaskProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -141,7 +141,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
         """
@@ -210,7 +210,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
             test.ignoreFailures = true
@@ -293,7 +293,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
         """
@@ -327,7 +327,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
             test.maxParallelForks = 2
@@ -407,7 +407,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         [projectDir.createDir('sub1'), projectDir.createDir('sub2')].eachWithIndex { TestFile it, def index ->
             it.file('build.gradle') << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true
             test.maxParallelForks = 2
@@ -509,7 +509,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
     def goodCode() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressDaemonErrorsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressDaemonErrorsCrossVersionSpec.groovy
@@ -64,7 +64,7 @@ class TestProgressDaemonErrorsCrossVersionSpec extends ToolingApiSpecification {
     def goodCode() {
         buildFile << """
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
             test.doLast { new URL("$server.uri").text }
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
@@ -493,7 +493,7 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
         """
         allprojects{
             apply plugin: 'java'
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
             dependencies { testCompile 'junit:junit:4.12' }
         }
         """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BuildProgressCrossVersionSpec.groovy
@@ -174,7 +174,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         buildFile << """
             allprojects { 
                 apply plugin: 'java'
-                repositories { mavenCentral() }
+                ${mavenCentralRepository()}
                 dependencies { testCompile 'junit:junit:4.12' }
             }
 """
@@ -395,7 +395,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         buildFile << """
             allprojects { 
                 apply plugin: 'java'
-                repositories { mavenCentral() }
+                ${mavenCentralRepository()}
                 dependencies { testCompile 'junit:junit:4.12' }
             }
 """
@@ -413,7 +413,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         file("buildSrc/build.gradle") << """
             allprojects {   
                 apply plugin: 'java'
-                repositories { mavenCentral() }
+                ${mavenCentralRepository()}
                 dependencies { testCompile 'junit:junit:4.12' }
             }
             dependencies {

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -248,4 +248,8 @@ abstract class ToolingApiSpecification extends Specification {
     protected static String jcenterRepository() {
         RepoScriptBlockUtil.jcenterRepository()
     }
+
+    pritected static String mavenCentralRepository() {
+        RepoScriptBlockUtil.mavenCentralRepository()
+    }
 }

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -249,7 +249,7 @@ abstract class ToolingApiSpecification extends Specification {
         RepoScriptBlockUtil.jcenterRepository()
     }
 
-    pritected static String mavenCentralRepository() {
+    protected static String mavenCentralRepository() {
         RepoScriptBlockUtil.mavenCentralRepository()
     }
 }

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.tooling.fixture
 
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.RetryRuleUtil
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.build.BuildTestFixture
@@ -242,5 +243,9 @@ abstract class ToolingApiSpecification extends Specification {
 
     protected static GradleVersion getTargetVersion() {
         GradleVersion.version(targetDist.version.baseVersion.version)
+    }
+
+    protected static String jcenterRepository() {
+        RepoScriptBlockUtil.jcenterRepository()
     }
 }


### PR DESCRIPTION
### Context
We have a large number of integration tests that rely on external Maven repositories like the Maven Central or JCenter. If those repositories (for any reason) don't respond to our requests then the tests fail. This causes frequent CI build failures.

This pull request replaces the external Maven repository usages when the build is running on the CI.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
