### PR TITLE
Make zipTree and tarTree faster

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/FileHasher.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/FileHasher.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 
 public interface FileHasher {
     /**
-     * Returns the hash of the given input stream. This method buffers reads on the stream.
+     * Returns the hash of the given input stream.
      */
     HashCode hash(InputStream inputStream);
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/FileHasher.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/FileHasher.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 
 public interface FileHasher {
     /**
-     * Returns the hash of the given input stream.
+     * Returns the hash of the given input stream. This method buffers reads on the stream.
      */
     HashCode hash(InputStream inputStream);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -33,7 +33,7 @@ import org.gradle.api.internal.file.collections.FileTreeAdapter;
 import org.gradle.api.internal.file.copy.DefaultCopySpec;
 import org.gradle.api.internal.file.copy.FileCopier;
 import org.gradle.api.internal.file.delete.Deleter;
-import org.gradle.api.internal.hash.FileHasher;
+import org.gradle.internal.hash.FileHasher;
 import org.gradle.api.internal.resources.DefaultResourceHandler;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.resources.ReadableResource;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.file.collections.FileTreeAdapter;
 import org.gradle.api.internal.file.copy.DefaultCopySpec;
 import org.gradle.api.internal.file.copy.FileCopier;
 import org.gradle.api.internal.file.delete.Deleter;
+import org.gradle.api.internal.hash.FileHasher;
 import org.gradle.api.internal.resources.DefaultResourceHandler;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.resources.ReadableResource;
@@ -62,17 +63,19 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
     private final Instantiator instantiator;
     private final Deleter deleter;
     private final DefaultResourceHandler resourceHandler;
+    private final FileHasher fileHasher;
     private final FileCopier fileCopier;
     private final FileSystem fileSystem;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public DefaultFileOperations(FileResolver fileResolver, TaskResolver taskResolver, TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    public DefaultFileOperations(FileResolver fileResolver, TaskResolver taskResolver, TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, FileHasher fileHasher) {
         this.fileResolver = fileResolver;
         this.taskResolver = taskResolver;
         this.temporaryFileProvider = temporaryFileProvider;
         this.instantiator = instantiator;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
         this.resourceHandler = new DefaultResourceHandler(this, temporaryFileProvider);
+        this.fileHasher = fileHasher;
         this.fileCopier = new FileCopier(this.instantiator, this.fileResolver, fileLookup, directoryFileTreeFactory);
         this.fileSystem = fileLookup.getFileSystem();
         this.deleter = new Deleter(fileResolver, fileSystem);
@@ -103,7 +106,7 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
     }
 
     public FileTree zipTree(Object zipPath) {
-        return new FileTreeAdapter(new ZipFileTree(file(zipPath), getExpandDir(), fileSystem, directoryFileTreeFactory));
+        return new FileTreeAdapter(new ZipFileTree(file(zipPath), getExpandDir(), fileSystem, directoryFileTreeFactory, fileHasher));
     }
 
     public FileTree tarTree(Object tarPath) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -121,7 +121,7 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
             tarFile = file(tarPath);
             resource = new LocalResourceAdapter(new LocalFileStandInExternalResource(tarFile, fileSystem));
         }
-        TarFileTree tarTree = new TarFileTree(tarFile, new MaybeCompressedFileResource(resource), getExpandDir(), fileSystem, fileSystem, directoryFileTreeFactory);
+        TarFileTree tarTree = new TarFileTree(tarFile, new MaybeCompressedFileResource(resource), getExpandDir(), fileSystem, fileSystem, directoryFileTreeFactory, fileHasher);
         return new FileTreeAdapter(tarTree);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
@@ -30,7 +30,7 @@ import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.internal.file.collections.SingletonFileTree;
-import org.gradle.api.internal.hash.FileHasher;
+import org.gradle.internal.hash.FileHasher;
 import org.gradle.api.resources.ResourceException;
 import org.gradle.api.resources.internal.ReadableResourceInternal;
 import org.gradle.internal.IoActions;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
@@ -30,7 +30,7 @@ import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.internal.file.collections.SingletonFileTree;
-import org.gradle.api.internal.hash.FileHasher;
+import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.nativeintegration.filesystem.Chmod;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
-import org.gradle.api.internal.hash.FileHasher;
+import org.gradle.internal.hash.FileHasher;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerInternal;

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
+import org.gradle.api.internal.hash.FileHasher;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerInternal;
@@ -74,6 +75,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
     private final PluginRepositoryFactory pluginRepositoryFactory;
     private final ProviderFactory providerFactory;
     private final TextResourceLoader textResourceLoader;
+    private final FileHasher fileHasher;
     private ScriptPluginFactory scriptPluginFactory;
 
     public DefaultScriptPluginFactory(ScriptCompilerFactory scriptCompilerFactory,
@@ -88,7 +90,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
                                       PluginRepositoryRegistry pluginRepositoryRegistry,
                                       PluginRepositoryFactory pluginRepositoryFactory,
                                       ProviderFactory providerFactory,
-                                      TextResourceLoader textResourceLoader) {
+                                      TextResourceLoader textResourceLoader, FileHasher fileHasher) {
         this.scriptCompilerFactory = scriptCompilerFactory;
         this.loggingManagerFactory = loggingManagerFactory;
         this.instantiator = instantiator;
@@ -103,6 +105,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
         this.providerFactory = providerFactory;
         this.textResourceLoader = textResourceLoader;
         this.scriptPluginFactory = this;
+        this.fileHasher = fileHasher;
     }
 
     public void setScriptPluginFactory(ScriptPluginFactory scriptPluginFactory) {
@@ -151,6 +154,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
             services.add(PluginRepositoryFactory.class, pluginRepositoryFactory);
             services.add(ProviderFactory.class, providerFactory);
             services.add(TextResourceLoader.class, textResourceLoader);
+            services.add(FileHasher.class, fileHasher);
 
             final ScriptTarget initialPassScriptTarget = initialPassTarget(target);
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
@@ -90,7 +90,8 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
                                       PluginRepositoryRegistry pluginRepositoryRegistry,
                                       PluginRepositoryFactory pluginRepositoryFactory,
                                       ProviderFactory providerFactory,
-                                      TextResourceLoader textResourceLoader, FileHasher fileHasher) {
+                                      TextResourceLoader textResourceLoader,
+                                      FileHasher fileHasher) {
         this.scriptCompilerFactory = scriptCompilerFactory;
         this.loggingManagerFactory = loggingManagerFactory;
         this.instantiator = instantiator;

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -32,7 +32,7 @@ import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
-import org.gradle.api.internal.hash.FileHasher;
+import org.gradle.internal.hash.FileHasher;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
+import org.gradle.api.internal.hash.FileHasher;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;
@@ -76,14 +77,15 @@ public abstract class DefaultScript extends BasicScript {
         Instantiator instantiator = services.get(Instantiator.class);
         FileLookup fileLookup = services.get(FileLookup.class);
         DirectoryFileTreeFactory directoryFileTreeFactory = services.get(DirectoryFileTreeFactory.class);
+        FileHasher fileHasher = services.get(FileHasher.class);
         if (target instanceof FileOperations) {
             fileOperations = (FileOperations) target;
         } else {
             File sourceFile = getScriptSource().getResource().getLocation().getFile();
             if (sourceFile != null) {
-                fileOperations = new DefaultFileOperations(fileLookup.getFileResolver(sourceFile.getParentFile()), null, null, instantiator, fileLookup, directoryFileTreeFactory);
+                fileOperations = new DefaultFileOperations(fileLookup.getFileResolver(sourceFile.getParentFile()), null, null, instantiator, fileLookup, directoryFileTreeFactory, fileHasher);
             } else {
-                fileOperations = new DefaultFileOperations(fileLookup.getFileResolver(), null, null, instantiator, fileLookup, directoryFileTreeFactory);
+                fileOperations = new DefaultFileOperations(fileLookup.getFileResolver(), null, null, instantiator, fileLookup, directoryFileTreeFactory, fileHasher);
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -131,6 +131,7 @@ import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.composite.CompositeContextBuilder;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -291,7 +291,8 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             get(PluginRepositoryRegistry.class),
             get(PluginRepositoryFactory.class),
             get(ProviderFactory.class),
-            get(TextResourceLoader.class));
+            get(TextResourceLoader.class),
+            get(FileHasher.class));
     }
 
     protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, NestedBuildFactory nestedBuildFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -39,7 +39,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
-import org.gradle.api.internal.hash.FileHasher;
+import org.gradle.internal.hash.FileHasher;
 import org.gradle.api.internal.initialization.DefaultScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.model.DefaultObjectFactory;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -39,6 +39,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
+import org.gradle.api.internal.hash.FileHasher;
 import org.gradle.api.internal.initialization.DefaultScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.model.DefaultObjectFactory;
@@ -139,8 +140,8 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultProjectConfigurationActionContainer();
     }
 
-    protected DefaultFileOperations createFileOperations(FileResolver fileResolver, TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory) {
-        return new DefaultFileOperations(fileResolver, project.getTasks(), temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory);
+    protected DefaultFileOperations createFileOperations(FileResolver fileResolver, TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, FileHasher fileHasher) {
+        return new DefaultFileOperations(fileResolver, project.getTasks(), temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory, fileHasher);
     }
 
     protected DefaultExecActionFactory createExecActionFactory(FileResolver fileResolver) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
@@ -36,7 +36,7 @@ import org.gradle.api.internal.changedetection.state.TaskHistoryStore
 import org.gradle.api.internal.changedetection.state.TaskOutputFilesRepository
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.hash.TestFileHasher
+import org.gradle.internal.hash.TestFileHasher
 import org.gradle.api.tasks.incremental.InputFileDetails
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.internal.CacheScopeMapping

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
@@ -20,7 +20,7 @@ import com.google.common.hash.HashCode
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.SimpleFileCollection
-import org.gradle.api.internal.hash.TestFileHasher
+import org.gradle.internal.hash.TestFileHasher
 import org.gradle.internal.serialize.HashCodeSerializer
 import org.gradle.normalization.internal.InputNormalizationStrategy
 import org.gradle.test.fixtures.file.CleanupTestDirectory

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotterTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.internal.changedetection.state
 
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.hash.TestFileHasher
+import org.gradle.internal.hash.TestFileHasher
 import org.gradle.caching.internal.DefaultBuildCacheHasher
 import org.gradle.internal.file.FileType
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.internal.changedetection.rules.ChangeType
 import org.gradle.api.internal.changedetection.rules.FileChange
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.SimpleFileCollection
-import org.gradle.api.internal.hash.TestFileHasher
+import org.gradle.internal.hash.TestFileHasher
 import org.gradle.normalization.internal.InputNormalizationStrategy
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollectio
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.file.collections.FileTreeAdapter
 import org.gradle.api.internal.file.copy.DefaultCopySpec
-import org.gradle.api.internal.hash.FileHasher
+import org.gradle.internal.hash.FileHasher
 import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.internal.reflect.DirectInstantiator

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollectio
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.file.collections.FileTreeAdapter
 import org.gradle.api.internal.file.copy.DefaultCopySpec
+import org.gradle.api.internal.hash.FileHasher
 import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.internal.reflect.DirectInstantiator
@@ -54,10 +55,11 @@ public class DefaultFileOperationsTest extends Specification {
     private final Instantiator instantiator = new ClassGeneratorBackedInstantiator(new AsmBackedClassGenerator(), DirectInstantiator.INSTANCE)
     private final FileLookup fileLookup = Mock()
     private final DefaultDirectoryFileTreeFactory directoryFileTreeFactory = Mock()
+    private final FileHasher fileHasher = Mock()
     private DefaultFileOperations fileOperations = instance()
 
     private DefaultFileOperations instance(FileResolver resolver = resolver) {
-        instantiator.newInstance(DefaultFileOperations, resolver, taskResolver, temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory)
+        instantiator.newInstance(DefaultFileOperations, resolver, taskResolver, temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory, fileHasher)
     }
 
     @Rule

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
@@ -165,8 +165,8 @@ public class TarFileTreeTest {
 
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
         TestFile content = expandDir.listFiles()[0].listFiles()[0];
+        content.makeOlder();
         TestFile.Snapshot snapshot = content.snapshot();
-        Thread.sleep(1000);
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
         content.assertHasNotChangedSince(snapshot);
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
@@ -27,19 +27,17 @@ import org.gradle.util.Resources;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.gradle.api.file.FileVisitorUtil.*;
-import static org.gradle.api.internal.file.TestFiles.directoryFileTreeFactory;
-import static org.gradle.api.internal.file.TestFiles.fileHasher;
-import static org.gradle.api.internal.file.TestFiles.fileSystem;
+import static org.gradle.api.internal.file.TestFiles.*;
 import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForAllTypes;
 import static org.gradle.util.WrapUtil.toList;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class TarFileTreeTest {
     @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
@@ -166,7 +164,9 @@ public class TarFileTreeTest {
         rootDir.tarTo(tarFile);
 
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
-        expandDir.listFiles()[0].listFiles()[0].setWritable(false);
+        File unpackedFile = expandDir.listFiles()[0].listFiles()[0];
+        unpackedFile.setWritable(false);
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
+        assertFalse(unpackedFile.canWrite());
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
@@ -27,7 +27,6 @@ import org.gradle.util.Resources;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +36,8 @@ import static org.gradle.api.internal.file.TestFiles.*;
 import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForAllTypes;
 import static org.gradle.util.WrapUtil.toList;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class TarFileTreeTest {
     @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
@@ -159,14 +159,15 @@ public class TarFileTreeTest {
     }
 
     @Test
-    public void doesNotOverwriteFilesOnSecondVisit() {
+    public void doesNotOverwriteFilesOnSecondVisit() throws InterruptedException {
         rootDir.file("file1.txt").write("content");
         rootDir.tarTo(tarFile);
 
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
-        File unpackedFile = expandDir.listFiles()[0].listFiles()[0];
-        unpackedFile.setWritable(false);
+        TestFile content = expandDir.listFiles()[0].listFiles()[0];
+        TestFile.Snapshot snapshot = content.snapshot();
+        Thread.sleep(1000);
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
-        assertFalse(unpackedFile.canWrite());
+        content.assertHasNotChangedSince(snapshot);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipFileTreeTest.java
@@ -130,8 +130,8 @@ public class ZipFileTreeTest {
 
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
         TestFile content = expandDir.listFiles()[0].listFiles()[0];
+        content.makeOlder();
         TestFile.Snapshot snapshot = content.snapshot();
-        Thread.sleep(1000);
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
         content.assertHasNotChangedSince(snapshot);
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipFileTreeTest.java
@@ -23,6 +23,7 @@ import org.gradle.util.Resources;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,8 +33,7 @@ import static org.gradle.api.internal.file.TestFiles.*;
 import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForAllTypes;
 import static org.gradle.util.WrapUtil.toList;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class ZipFileTreeTest {
     @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
@@ -129,7 +129,9 @@ public class ZipFileTreeTest {
         rootDir.zipTo(zipFile);
 
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
-        expandDir.listFiles()[0].listFiles()[0].setWritable(false);
+        File unpackedFile = expandDir.listFiles()[0].listFiles()[0];
+        unpackedFile.setWritable(false);
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
+        assertFalse(unpackedFile.canWrite());
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipFileTreeTest.java
@@ -23,7 +23,6 @@ import org.gradle.util.Resources;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +32,8 @@ import static org.gradle.api.internal.file.TestFiles.*;
 import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForAllTypes;
 import static org.gradle.util.WrapUtil.toList;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class ZipFileTreeTest {
     @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
@@ -124,14 +124,15 @@ public class ZipFileTreeTest {
     }
 
     @Test
-    public void doesNotOverwriteFilesOnSecondVisit() {
+    public void doesNotOverwriteFilesOnSecondVisit() throws InterruptedException {
         rootDir.file("file1.txt").write("content");
         rootDir.zipTo(zipFile);
 
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
-        File unpackedFile = expandDir.listFiles()[0].listFiles()[0];
-        unpackedFile.setWritable(false);
+        TestFile content = expandDir.listFiles()[0].listFiles()[0];
+        TestFile.Snapshot snapshot = content.snapshot();
+        Thread.sleep(1000);
         assertVisits(tree, toList("file1.txt"), new ArrayList<String>());
-        assertFalse(unpackedFile.canWrite());
+        content.assertHasNotChangedSince(snapshot);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
@@ -121,10 +121,8 @@ public class MapFileTreeTest {
         TestFile file = rootDir.file("path/file.txt");
 
         file.assertContents(equalTo("content"));
+        file.makeOlder();
         TestFile.Snapshot snapshot = file.snapshot();
-
-        // make sure file modification time would change if file would get written
-        Thread.sleep(1000L);
 
         assertVisits(tree, toList("path/file.txt"), toList("path"));
         file.assertContents(equalTo("content"));

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
@@ -112,7 +112,7 @@ public class MapFileTreeTest {
     }
 
     @Test
-    public void doesNotOverwriteFileWhenGeneratedContentRemainsTheSame() {
+    public void doesNotOverwriteFileWhenGeneratedContentRemainsTheSame() throws InterruptedException {
         Action<OutputStream> action = getAction();
         tree.add("path/file.txt", action);
 
@@ -123,12 +123,8 @@ public class MapFileTreeTest {
         file.assertContents(equalTo("content"));
         TestFile.Snapshot snapshot = file.snapshot();
 
-        try {
-            // make sure file modification time would change if file would get written
-            Thread.sleep(1000L);
-        } catch (InterruptedException e) {
-            // ignore
-        }
+        // make sure file modification time would change if file would get written
+        Thread.sleep(1000L);
 
         assertVisits(tree, toList("path/file.txt"), toList("path"));
         file.assertContents(equalTo("content"));

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
-import org.gradle.api.internal.hash.FileHasher
+import org.gradle.internal.hash.FileHasher
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.internal.tasks.TaskResolver

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
+import org.gradle.api.internal.hash.FileHasher
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.internal.tasks.TaskResolver
@@ -160,7 +161,8 @@ class DefaultProjectSpec extends Specification {
         def tempFileProvider = Mock(TemporaryFileProvider)
         def fileLookup = Mock(FileLookup)
         def directoryFileTreeFactory = Mock(DefaultDirectoryFileTreeFactory)
-        def fileOperations = instantiator.newInstance(DefaultFileOperations, fileResolver, taskResolver, tempFileProvider, instantiator, fileLookup, directoryFileTreeFactory)
+        def fileHasher = Mock(FileHasher)
+        def fileOperations = instantiator.newInstance(DefaultFileOperations, fileResolver, taskResolver, tempFileProvider, instantiator, fileLookup, directoryFileTreeFactory, fileHasher)
 
         return Spy(DefaultProject, constructorArgs: [name, parent, new File("project"), Stub(ScriptSource), build, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope)]) {
             getFileOperations() >> fileOperations

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
-import org.gradle.api.internal.hash.FileHasher
+import org.gradle.internal.hash.FileHasher
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
 import org.gradle.api.internal.initialization.ScriptHandlerInternal

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.internal.hash.FileHasher
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
@@ -76,9 +77,10 @@ class DefaultScriptPluginFactoryTest extends Specification {
     def pluginRepositoryFactory = Mock(PluginRepositoryFactory)
     def providerFactory = Mock(ProviderFactory)
     def textResourceLoader = Mock(TextResourceLoader)
+    def fileHasher = Mock(FileHasher)
 
     def factory = new DefaultScriptPluginFactory(scriptCompilerFactory, loggingManagerFactory, instantiator, scriptHandlerFactory, pluginRequestApplicator, fileLookup,
-        directoryFileTreeFactory, documentationRegistry, new ModelRuleSourceDetector(), pluginRepositoryRegistry, pluginRepositoryFactory, providerFactory, textResourceLoader)
+        directoryFileTreeFactory, documentationRegistry, new ModelRuleSourceDetector(), pluginRepositoryRegistry, pluginRepositoryFactory, providerFactory, textResourceLoader, fileHasher)
 
     def setup() {
         def configurations = Mock(ConfigurationContainer)

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/DefaultScriptTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/DefaultScriptTest.groovy
@@ -22,7 +22,7 @@ import org.codehaus.groovy.control.CompilerConfiguration
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.file.FileLookup
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
-import org.gradle.api.internal.hash.FileHasher
+import org.gradle.internal.hash.FileHasher
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.logging.LoggingManager
 import org.gradle.api.provider.ProviderFactory

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/DefaultScriptTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/DefaultScriptTest.groovy
@@ -22,6 +22,7 @@ import org.codehaus.groovy.control.CompilerConfiguration
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.file.FileLookup
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.internal.hash.FileHasher
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.logging.LoggingManager
 import org.gradle.api.provider.ProviderFactory
@@ -61,6 +62,8 @@ class DefaultScriptTest {
             will(returnValue(context.mock(DirectoryFileTreeFactory)))
             allowing(serviceRegistryMock).get(ProviderFactory)
             will(returnValue(context.mock(ProviderFactory)))
+            allowing(serviceRegistryMock).get(FileHasher)
+            will(returnValue(context.mock(FileHasher)))
         }
 
         DefaultScript script = new GroovyShell(createBaseCompilerConfiguration()).parse(testScriptText)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
@@ -34,7 +34,7 @@ import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
-import org.gradle.api.internal.hash.FileHasher
+import org.gradle.internal.hash.FileHasher
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.DefaultScriptHandler
 import org.gradle.api.internal.plugins.PluginRegistry

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.internal.hash.FileHasher
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.DefaultScriptHandler
 import org.gradle.api.internal.plugins.PluginRegistry
@@ -108,6 +109,7 @@ class ProjectScopeServicesTest extends Specification {
         parent.get(ToolingModelBuilderRegistry) >> Mock(ToolingModelBuilderRegistry)
         parent.get(InstantiatorFactory) >> instantiatorFactory
         parent.get(ScriptClassPathResolver) >> Mock(ScriptClassPathResolver)
+        parent.get(FileHasher) >> Mock(FileHasher)
         parent.hasService(_) >> true
         registry = new ProjectScopeServices(parent, project, loggingManagerInternalFactory)
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -17,7 +17,8 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
-import org.gradle.api.internal.hash.DefaultFileHasher;
+import org.gradle.internal.hash.DefaultFileContentHasherFactory;
+import org.gradle.internal.hash.DefaultFileHasher;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.api.tasks.util.internal.PatternSets;
 import org.gradle.internal.Factory;
@@ -72,7 +73,7 @@ public class TestFiles {
     }
 
     public static DefaultFileHasher fileHasher() {
-        return new DefaultFileHasher();
+        return new DefaultFileHasher(new DefaultFileContentHasherFactory());
     }
 
     public static FileCollectionFactory fileCollectionFactory() {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
+import org.gradle.api.internal.hash.DefaultFileHasher;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.api.tasks.util.internal.PatternSets;
 import org.gradle.internal.Factory;
@@ -67,7 +68,11 @@ public class TestFiles {
     }
 
     public static FileOperations fileOperations(File basedDir) {
-        return new DefaultFileOperations(resolver(basedDir), null, null, DirectInstantiator.INSTANCE, fileLookup(), directoryFileTreeFactory());
+        return new DefaultFileOperations(resolver(basedDir), null, null, DirectInstantiator.INSTANCE, fileLookup(), directoryFileTreeFactory(), fileHasher());
+    }
+
+    public static DefaultFileHasher fileHasher() {
+        return new DefaultFileHasher();
     }
 
     public static FileCollectionFactory fileCollectionFactory() {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/hash/TestFileHasher.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/hash/TestFileHasher.groovy
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.hash
+package org.gradle.internal.hash
 
 import com.google.common.hash.HashCode
 import com.google.common.hash.Hashing
 import com.google.common.io.Files
 import org.gradle.api.file.FileTreeElement
 import org.gradle.internal.file.FileMetadataSnapshot
-import org.gradle.internal.hash.FileHasher
 
 class TestFileHasher implements FileHasher {
     private final static HASH_FUNCTION = Hashing.md5()

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -18,7 +18,7 @@ It is now possible to consume dependencies from, and publish to, [Google Cloud S
         maven {
             url "gcs://someGcsBucket/maven2"
         }
-    
+
         ivy {
             url "gcs://someGcsBucket/ivy"
         }
@@ -50,7 +50,7 @@ Only files within `buildDir`, paths registered as targets for the `clean` task a
 
 ### CLI abbreviates long test names
 
-In Gradle 4.1, the Gradle CLI began displaying tests in-progress. We received feedback that long packages and test names caused the test name to be truncated or omitted. This version will abbreviate java packages of long test names to 60 characters to make it highly likely to fit on terminal screens. 
+In Gradle 4.1, the Gradle CLI began displaying tests in-progress. We received feedback that long packages and test names caused the test name to be truncated or omitted. This version will abbreviate java packages of long test names to 60 characters to make it highly likely to fit on terminal screens.
 
 ### Better support for script plugins loaded via HTTP
 
@@ -70,6 +70,10 @@ Task actions that are defined in build scripts can now be named using `doFirst("
 TODO Placeholder
 
 #### Only trigger a rebuild when someone reloads the Play app
+
+### Faster zipTree and tarTree
+
+The `zipTree` and `tarTree` implementations had a major performance issue, unpacking files every time the tree was traversed. This has now been fixed and should speed up builds using these trees a lot.
 
 TODO Placeholder
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.regression.corefeature
+
+import org.gradle.performance.AbstractCrossVersionPerformanceTest
+
+class ArchiveTreePerformanceTest extends AbstractCrossVersionPerformanceTest {
+
+    def "visiting zip trees"() {
+        given:
+        runner.testProject = "archivePerformanceProject"
+        runner.tasksToRun = ['visitZip']
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+    }
+    def "visiting tar trees"() {
+        given:
+        runner.testProject = "archivePerformanceProject"
+        runner.tasksToRun = ['visitTar']
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+    }
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
@@ -42,4 +42,16 @@ class ArchiveTreePerformanceTest extends AbstractCrossVersionPerformanceTest {
         then:
         result.assertCurrentVersionHasNotRegressed()
     }
+
+    def "visiting gzip tar trees"() {
+        given:
+        runner.testProject = "archivePerformanceProject"
+        runner.tasksToRun = ['visitTarGz']
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+    }
 }

--- a/subprojects/performance/src/templates/archivePerformanceProject/build.gradle
+++ b/subprojects/performance/src/templates/archivePerformanceProject/build.gradle
@@ -1,0 +1,43 @@
+/*
+* Copyright 2017 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+task zip(type: Zip) {
+    from 'build.gradle'
+}
+
+task visitZip(dependsOn: zip) {
+    doLast {
+        (1..10000).each {
+            zipTree(zip.archivePath).each {
+                logger.info it.path
+            }
+        }
+    }
+}
+
+task tar(type: Tar) {
+    from 'build.gradle'
+}
+
+task visitTar(dependsOn: tar) {
+    doLast {
+        (1..10000).each {
+            tarTree(tar.archivePath).each {
+                logger.info it.path
+            }
+        }
+    }
+}

--- a/subprojects/performance/src/templates/archivePerformanceProject/build.gradle
+++ b/subprojects/performance/src/templates/archivePerformanceProject/build.gradle
@@ -15,12 +15,16 @@
 */
 
 task zip(type: Zip) {
-    from 'build.gradle'
+    (1..10000).each { suffix ->
+        from ('build.gradle') {
+            into "folder$suffix"
+        }
+    }
 }
 
 task visitZip(dependsOn: zip) {
     doLast {
-        (1..10000).each {
+        (1..4).each {
             zipTree(zip.archivePath).each {
                 logger.info it.path
             }
@@ -29,13 +33,28 @@ task visitZip(dependsOn: zip) {
 }
 
 task tar(type: Tar) {
-    from 'build.gradle'
+    with zip
 }
 
 task visitTar(dependsOn: tar) {
     doLast {
-        (1..10000).each {
+        (1..4).each {
             tarTree(tar.archivePath).each {
+                logger.info it.path
+            }
+        }
+    }
+}
+
+task tarGz(type: Tar) {
+    with zip
+    compression = 'gzip'
+}
+
+task visitTarGz(dependsOn: tarGz) {
+    doLast {
+        (1..4).each {
+            tarTree(tarGz.archivePath).each {
                 logger.info it.path
             }
         }

--- a/subprojects/performance/src/templates/archivePerformanceProject/settings.gradle
+++ b/subprojects/performance/src/templates/archivePerformanceProject/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "archivePerformanceProject"

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -245,6 +245,11 @@ task largeNativeBuildPrebuilt(type: GradleBuild) {
     tasks = ['build']
 }
 
+task archivePerformanceProject(type: Copy) {
+    into "build/$name"
+    from "src/templates/$name"
+}
+
 tasks.withType(JvmProjectGeneratorTask) {
     if (project.hasProperty("springDmPluginVersion")) {
         templateArgs['springDmPluginVersion'] = springDmPluginVersion


### PR DESCRIPTION
While investigating #2651, I found out that we unpack zipTrees and tarTrees *every time* the tree is visited. This can be up to 4 times per build, leading to a huge performance hit. 

Instead we now hash the input file and only unpack again if it changed. If a file in the temp directory is missing, it is created on the next visit. If a file in the temp directory is tampered with, we ignore that change. This is in line with how we handle other intermediate results like those of dependency transformations. 

#2651 is fixed by this as well, because the continuous watcher is no longer triggered by unnecessary unpack operations. However, that issue shows another problem - the fact that we start watching the unpacked dir instead of the zip in some cases. This should also be fixed in another step.