### PR TITLE
Support parent POMs with version range

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/DescriptorParseContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/DescriptorParseContext.java
@@ -17,8 +17,11 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 
 public interface DescriptorParseContext {
     LocallyAvailableExternalResource getMetaDataArtifact(ModuleComponentIdentifier componentIdentifier, ArtifactType artifactType);
+
+    LocallyAvailableExternalResource getMetaDataArtifact(DependencyMetadata dependencyMetadata, ArtifactType artifactType);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/DisconnectedDescriptorParseContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/DisconnectedDescriptorParseContext.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 
 /**
@@ -25,9 +26,13 @@ import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
  * other resources from a DependencyResolver.
  */
 public class DisconnectedDescriptorParseContext implements DescriptorParseContext {
-
+    @Override
     public LocallyAvailableExternalResource getMetaDataArtifact(ModuleComponentIdentifier moduleComponentIdentifier, ArtifactType artifactType) {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public LocallyAvailableExternalResource getMetaDataArtifact(DependencyMetadata dependencyMetadata, ArtifactType artifactType) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/CachedModuleDescriptorParseContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/CachedModuleDescriptorParseContext.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.DescriptorParseContext;
 import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 
 /**
@@ -26,7 +27,13 @@ import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
  * Will only be used for parsing ivy.xml files, as pom files are converted before caching.
  */
 class CachedModuleDescriptorParseContext implements DescriptorParseContext {
+    @Override
     public LocallyAvailableExternalResource getMetaDataArtifact(ModuleComponentIdentifier componentIdentifier, ArtifactType artifactType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LocallyAvailableExternalResource getMetaDataArtifact(DependencyMetadata dependencyMetadata, ArtifactType artifactType) {
         throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
See #1898 for more details.

As stated in [Maven 3.2.2 release notes](https://maven.apache.org/docs/3.2.2/release-notes.html) ,
Maven supports parent POM version with range. When Gradle resolves
parent POMs, it didn't take version range into consideration. This PR
adds some resolution for dynamic parent POM version.

Since Gradle claims 100% compatibility with Maven, I think this improvement is necessary.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

