### PR TITLE
Format Javadoc to improve readability

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
@@ -20,12 +20,18 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Matches version ranges: [1.0,2.0] matches all versions greater or equal to 1.0 and lower or equal
- * to 2.0 [1.0,2.0[ matches all versions greater or equal to 1.0 and lower than 2.0 ]1.0,2.0]
- * matches all versions greater than 1.0 and lower or equal to 2.0 ]1.0,2.0[ matches all versions
- * greater than 1.0 and lower than 2.0 [1.0,) matches all versions greater or equal to 1.0 ]1.0,)
- * matches all versions greater than 1.0 (,2.0] matches all versions lower or equal to 2.0 (,2.0[
- * matches all versions lower than 2.0 This class uses a latest strategy to compare revisions. If
+ * Matches version ranges:
+ * <ul>
+ * <li>[1.0,2.0] matches all versions greater or equal to 1.0 and lower or equal to 2.0 </li>
+ * <li>[1.0,2.0[ matches all versions greater or equal to 1.0 and lower than 2.0 </li>
+ * <li>]1.0,2.0] matches all versions greater than 1.0 and lower or equal to 2.0 </li>
+ * <li>]1.0,2.0[ matches all versions greater than 1.0 and lower than 2.0 </li>
+ * <li>[1.0,) matches all versions greater or equal to 1.0 </li>
+ * <li>]1.0,) matches all versions greater than 1.0 </li>
+ * <li>(,2.0] matches all versions lower or equal to 2.0 </li>
+ * <li>(,2.0[matches all versions lower than 2.0 </li>
+ * </ul>
+ * This class uses a latest strategy to compare revisions. If
  * none is set, it uses the default one of the ivy instance set through setIvy(). If neither a
  * latest strategy nor a ivy instance is set, an IllegalStateException will be thrown when calling
  * accept(). Note that it can't work with latest time strategy, cause no time is known for the


### PR DESCRIPTION
### Context
`VersionRangeSelector`'s javadoc is such a mess that developer can hardly read it. This PR formats it to make it more readable.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
