### PR TITLE
Improve contention handling of persistent cache locks

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/locklistener/NoOpFileLockContentionHandler.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/locklistener/NoOpFileLockContentionHandler.java
@@ -26,6 +26,7 @@ public class NoOpFileLockContentionHandler implements FileLockContentionHandler 
         return -1;
     }
 
-    public void pingOwner(int port, long lockId, String displayName) {
+    public boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed) {
+        return false;
     }
 }

--- a/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
+++ b/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.cache.FileLock
+import org.gradle.cache.FileLockManager
+import org.gradle.cache.internal.filelock.LockOptionsBuilder
+import org.gradle.cache.internal.locklistener.DefaultFileLockContentionHandler
+import org.gradle.cache.internal.locklistener.FileLockContentionHandler
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleHandle
+import org.gradle.internal.concurrent.DefaultExecutorFactory
+import org.gradle.internal.remote.internal.inet.InetAddressFactory
+import org.gradle.internal.time.TrueTimeProvider
+
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
+
+class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegrationSpec {
+    def timeProvider = new TrueTimeProvider()
+    def addressFactory = new InetAddressFactory()
+
+    FileLockContentionHandler receivingFileLockContentionHandler
+    DatagramSocket receivingSocket
+    FileLock receivingLock
+
+    def setup() {
+        executer.withArguments("-d")
+        executer.requireOwnGradleUserHomeDir().withDaemonBaseDir(file("daemonsRequestingLock")).requireDaemon()
+        buildFile << ""
+    }
+
+    def "the lock holder is not hammered with ping requests for the shared fileHashes lock"() {
+        given:
+        setupLockOwner()
+        def pingRequestCount = 0
+        //do not handle requests: this simulates the situation were pings do not arrive
+        replaceSocketReceiver { pingRequestCount++ }
+
+        when:
+        def build = executer.withTasks("help").start()
+        def startTime = timeProvider.currentTime
+        poll {
+            assert (build.standardOutput =~ 'Pinged owner at port').count == 3
+        }
+        receivingLock.close()
+
+        then:
+        build.waitForFinish()
+        pingRequestCount == 3 || pingRequestCount == 4
+        timeProvider.currentTime - startTime > 3000 // See: DefaultFileLockContentionHandler.PING_DELAY
+    }
+
+    def "the lock holder starts the release request only once and discards additional requests in the meantime"() {
+        given:
+        def requestReceived = false
+        setupLockOwner {
+            requestReceived = true
+            while(true) { Thread.sleep(100000) } //block the release action thread
+        }
+
+        when:
+        def build = executer.withTasks("help").start()
+        poll { assert requestReceived }
+
+        // simulate additional requests
+        def socket = new DatagramSocket(0, addressFactory.localBindingAddress)
+        (1..500).each {
+            addressFactory.communicationAddresses.each { address ->
+                byte[] bytes = [1, 0, 0, 0, 0, 0, 0, 0, 0]
+                DatagramPacket confirmPacket = new DatagramPacket(bytes, bytes.length, address, receivingSocket.localPort)
+                socket.send(confirmPacket)
+            }
+        }
+
+        then:
+        waitCloseAndFinish(build)
+        assertReceivingSocketEmpty()
+    }
+
+    def "if the lock holder confirmed the request, it is not pinged again"() {
+        given:
+        def requestReceived = false
+        def additionalRequests = 0
+        setupLockOwner() { requestReceived = true }
+
+        when:
+        def build = executer.withTasks("help").start()
+        poll {
+            assert requestReceived
+        }
+        replaceSocketReceiver {
+            additionalRequests++
+        }
+
+        then:
+        waitCloseAndFinish(build)
+        countPingsSent(build) == 1
+        additionalRequests == 0
+    }
+
+    def "the lock holder confirms that a request is in process to multiple requesters"() {
+        given:
+        def requestReceived = false
+        def additionalRequests = 0
+        setupLockOwner() { requestReceived = true }
+
+        when:
+        def build1 = executer.withArguments("-d").withTasks("help").start()
+        def build2 = executer.withArguments("-d").withTasks("help").start()
+        def build3 = executer.withArguments("-d").withTasks("help").start()
+        poll {
+            assert requestReceived
+            assert assertConfirmationCount(build1)
+            assert assertConfirmationCount(build2)
+            assert assertConfirmationCount(build3)
+        }
+        replaceSocketReceiver { additionalRequests++ }
+
+        then:
+        waitCloseAndFinish(build1)
+        build2.waitForFinish()
+        build3.waitForFinish()
+        assertConfirmationCount(build1)
+        assertConfirmationCount(build2)
+        assertConfirmationCount(build3)
+        additionalRequests == 0
+    }
+
+    def "if the lock was released by one lock holder, but taken away again, the new lock holder is pinged once"() {
+        given:
+        def requestReceived = false
+        def lock1 = setupLockOwner() { requestReceived = true }
+
+        when:
+        def build = executer.withTasks("help").start()
+        poll {
+            assert requestReceived
+            assert countPingsSent(build) == 1
+        }
+
+        requestReceived = false
+        def prevReceivingSocket = receivingSocket
+        lock1.close()
+        def lock2 = setupLockOwner() {
+            requestReceived = true
+        }
+        poll {
+            assert requestReceived
+            assert countPingsSent(build, prevReceivingSocket) == 1
+            assert countPingsSent(build, receivingSocket) == 1
+        }
+        lock2.close()
+
+        then:
+        build.waitForFinish()
+        countPingsSent(build, prevReceivingSocket) == 1
+        countPingsSent(build, receivingSocket) == 1
+        assertConfirmationCount(build, prevReceivingSocket)
+        assertConfirmationCount(build, receivingSocket)
+        assertConfirmationCount(build, prevReceivingSocket)
+    }
+
+    def assertConfirmationCount(GradleHandle build, DatagramSocket socket = receivingSocket) {
+        (build.standardOutput =~ "Gradle process at port ${socket.localPort} confirmed unlock request").count == addressFactory.communicationAddresses.size()
+    }
+
+    def assertReceivingSocketEmpty() {
+        try {
+            Executors.newSingleThreadExecutor().submit {
+                DatagramPacket packet = new DatagramPacket(new byte[9], 9)
+                receivingSocket.receive(packet)
+            }.get(1, TimeUnit.SECONDS)
+        } catch (TimeoutException e) {
+            return true
+        }
+        return false
+    }
+
+    def countPingsSent(GradleHandle build, DatagramSocket socket = receivingSocket) {
+        (build.standardOutput =~ "Pinged owner at port ${socket.localPort}").count
+    }
+
+    def waitCloseAndFinish(GradleHandle build) {
+        Thread.sleep(10 * 1000) //wait 10 seconds, in which the build should only wait for the lock to become available
+        receivingLock.close()
+        build.waitForFinish()
+    }
+
+    def replaceSocketReceiver(Runnable reactOnRequest) {
+        receivingFileLockContentionHandler.fileLockRequestListener?.shutdownNow()
+        new Thread() {
+            void run() {
+                InetAddress selectedAddress = null
+                while (true) {
+                    byte[] bytes = new byte[9]
+                    DatagramPacket packet = new DatagramPacket(bytes, bytes.length)
+                    receivingSocket.receive(packet)
+                    if (selectedAddress == null) {
+                        selectedAddress = packet.address
+                    }
+                    if (selectedAddress == packet.address) {
+                        reactOnRequest.run()
+                    }
+                }
+
+            }
+        }.start()
+    }
+
+    def setupLockOwner(Runnable whenContended = null) {
+        receivingFileLockContentionHandler = new DefaultFileLockContentionHandler(new DefaultExecutorFactory(), addressFactory)
+        def fileLockManager = new DefaultFileLockManager(new ProcessMetaDataProvider() {
+            String getProcessIdentifier() { return "pid" }
+            String getProcessDisplayName() { return "process" }
+        }, receivingFileLockContentionHandler)
+        receivingSocket = receivingFileLockContentionHandler.communicator.socket
+        receivingLock = fileLockManager.lock(new File(executer.gradleUserHomeDir, "caches/${executer.gradleVersion.version}/fileHashes/fileHashes"), LockOptionsBuilder.mode(FileLockManager.LockMode.Exclusive), "fileHashes", "", whenContended)
+    }
+
+}

--- a/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
+++ b/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
@@ -76,9 +76,10 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
     def "the lock holder starts the release request only once and discards additional requests in the meantime"() {
         given:
         def requestReceived = false
+        def terminate = false
         setupLockOwner {
             requestReceived = true
-            while(true) { Thread.sleep(100000) } //block the release action thread
+            while(!terminate) { Thread.sleep(100) } //block the release action thread
         }
 
         when:
@@ -98,6 +99,9 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
         then:
         waitCloseAndFinish(build)
         assertReceivingSocketEmpty()
+
+        cleanup:
+        terminate = true
     }
 
     def "if the lock holder confirmed the request, it is not pinged again"() {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.cache;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 public interface FileLockManager {
@@ -40,14 +41,20 @@ public interface FileLockManager {
     FileLock lock(File target, LockOptions options, String targetDisplayName, String operationDisplayName) throws LockTimeoutException;
 
     /**
-     * Enables other processes to request access to the provided lock. Provided action runs when the lock access request is received
+     * Creates a locks for the given file with the given mode. Acquires a lock with the given mode, which is held until the lock is
+     * released by calling {@link FileLock#close()}. This method blocks until the lock can be acquired.
+     * <p>
+     * Enable other processes to request access to the provided lock. Provided action runs when the lock access request is received
      * (it means that the lock is contended).
      *
-     * @param fileLock the lock
+     * @param target The file to be locked.
+     * @param options The lock options.
+     * @param targetDisplayName A display name for the target file. This is used in log and error messages.
+     * @param operationDisplayName A display name for the operation being performed on the target file. This is used in log and error messages.
      * @param whenContended will be called asynchronously by the thread that listens for cache access requests, when such request is received.
      * Note: currently, implementations are permitted to invoke the action <em>after</em> the lock as been closed.
      */
-    void allowContention(FileLock fileLock, Runnable whenContended);
+    FileLock lock(File target, LockOptions options, String targetDisplayName, String operationDisplayName, @Nullable Runnable whenContended) throws LockTimeoutException;
 
     enum LockMode {
         /**

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedExclusiveModeCrossProcessCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedExclusiveModeCrossProcessCacheAccess.java
@@ -33,6 +33,11 @@ import static org.gradle.cache.FileLockManager.LockMode.Exclusive;
  * A {@link CrossProcessCacheAccess} implementation used when a cache is opened with an exclusive lock that is held until the cache is closed. This implementation is simply a no-op for these methods.
  */
 public class FixedExclusiveModeCrossProcessCacheAccess extends AbstractCrossProcessCacheAccess {
+    private final static Runnable NO_OP_CONTENDED_ACTION = new Runnable() {
+        @Override
+        public void run() { }
+    };
+
     private final String cacheDisplayName;
     private final File lockTarget;
     private final LockOptions lockOptions;
@@ -59,7 +64,7 @@ public class FixedExclusiveModeCrossProcessCacheAccess extends AbstractCrossProc
         if (fileLock != null) {
             throw new IllegalStateException("File lock " + lockTarget + " is already open.");
         }
-        final FileLock fileLock = lockManager.lock(lockTarget, lockOptions, cacheDisplayName);
+        final FileLock fileLock = lockManager.lock(lockTarget, lockOptions, cacheDisplayName, "", NO_OP_CONTENDED_ACTION);
         try {
             boolean rebuild = initializationAction.requiresInitialization(fileLock);
             if (rebuild) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandCrossProcessCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandCrossProcessCacheAccess.java
@@ -102,7 +102,7 @@ class LockOnDemandCrossProcessCacheAccess extends AbstractCrossProcessCacheAcces
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Acquiring file lock for {}", cacheDisplayName);
                 }
-                fileLock = lockManager.lock(lockTarget, lockOptions, cacheDisplayName);
+                fileLock = lockManager.lock(lockTarget, lockOptions, cacheDisplayName, "", whenContended);
                 try {
                     if (initAction.requiresInitialization(fileLock)) {
                         fileLock.writeFile(new Runnable() {
@@ -113,7 +113,6 @@ class LockOnDemandCrossProcessCacheAccess extends AbstractCrossProcessCacheAcces
                         });
                     }
                     onOpen.execute(fileLock);
-                    lockManager.allowContention(fileLock, whenContended);
                 } catch (Exception e) {
                     fileLock.close();
                     fileLock = null;

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandler.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandler.java
@@ -128,8 +128,8 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
     }
 
     private void startLockReleaseAsLockHolder(ContendedAction contendedAction) {
-        unlockActionExecutor.execute(contendedAction.action);
         contendedAction.running = true;
+        unlockActionExecutor.execute(contendedAction.action);
     }
 
     private void acceptConfirmationAsLockRequester(long lockId, int port) {
@@ -163,11 +163,11 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
     }
 
     public boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed) {
-        if (unlocksConfirmedFrom.containsKey(lockId) && unlocksConfirmedFrom.get(lockId) == port) {
+        if (Integer.valueOf(port).equals(unlocksConfirmedFrom.get(lockId))) {
             //the unlock was confirmed we are waiting
             return false;
         }
-        if (unlocksRequestedFrom.containsKey(lockId) && unlocksRequestedFrom.get(lockId) == port && timeElapsed < PING_DELAY) {
+        if (Integer.valueOf(port).equals(unlocksRequestedFrom.get(lockId)) && timeElapsed < PING_DELAY) {
             //the unlock was just requested but not yet confirmed, give it some more time
             return false;
         }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockContentionHandler.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockContentionHandler.java
@@ -23,5 +23,13 @@ public interface FileLockContentionHandler {
 
     int reservePort();
 
-    void pingOwner(int port, long lockId, String displayName);
+    /**
+     * Pings the lock owner with the give port to start the lock releasing
+     * process in the owner. May not ping the owner if:
+     * - The owner was already pinged about the given lock before and the lock release is in progress
+     * - The ping through the underlying socket failed
+     *
+     * @return true if the owner was pinged in this call
+     */
+    boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed);
 }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionTest.groovy
@@ -53,8 +53,7 @@ class DefaultFileLockManagerContentionTest extends ConcurrentSpec {
         def file = tmpDir.file("lock-file.bin")
         def action = Mock(Runnable)
 
-        def lock = createLock(Exclusive, file)
-        manager.allowContention(lock, action)
+        def lock = createLock(Exclusive, file, manager, action)
 
         when:
         def lock2 = createLock(lockMode, file, manager2)
@@ -85,8 +84,8 @@ class DefaultFileLockManagerContentionTest extends ConcurrentSpec {
         lockMode << [Exclusive, Shared]
     }
 
-    FileLock createLock(FileLockManager.LockMode lockMode, File file, FileLockManager lockManager = manager) {
-        def lock = lockManager.lock(file, LockOptionsBuilder.mode(lockMode), "foo", "operation")
+    FileLock createLock(FileLockManager.LockMode lockMode, File file, FileLockManager lockManager = manager, Runnable whenContended = null) {
+        def lock = lockManager.lock(file, LockOptionsBuilder.mode(lockMode), "foo", "operation", whenContended)
         openedLocks << lock
         lock
     }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedExclusiveModeCrossProcessCacheAccessTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedExclusiveModeCrossProcessCacheAccessTest.groovy
@@ -38,7 +38,7 @@ class FixedExclusiveModeCrossProcessCacheAccessTest extends Specification {
         cacheAccess.open()
 
         then:
-        1 * lockManager.lock(file, _, _) >> lock
+        1 * lockManager.lock(file, _, _, "", _) >> lock
 
         then:
         1 * initAction.requiresInitialization(lock) >> false
@@ -55,7 +55,7 @@ class FixedExclusiveModeCrossProcessCacheAccessTest extends Specification {
         cacheAccess.open()
 
         then:
-        1 * lockManager.lock(file, _, _) >> lock
+        1 * lockManager.lock(file, _, _, "", _) >> lock
 
         then:
         1 * initAction.requiresInitialization(lock) >> true
@@ -79,7 +79,7 @@ class FixedExclusiveModeCrossProcessCacheAccessTest extends Specification {
         e == failure
 
         and:
-        1 * lockManager.lock(file, _, _) >> lock
+        1 * lockManager.lock(file, _, _, "", _) >> lock
 
         then:
         1 * initAction.requiresInitialization(lock) >> true
@@ -101,7 +101,7 @@ class FixedExclusiveModeCrossProcessCacheAccessTest extends Specification {
         def lock = Mock(FileLock)
 
         given:
-        lockManager.lock(file, _, _) >> lock
+        lockManager.lock(file, _, _, "", _) >> lock
         cacheAccess.open()
 
         when:

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockCommunicatorTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockCommunicatorTest.groovy
@@ -46,7 +46,8 @@ class FileLockCommunicatorTest extends ConcurrentSpecification {
 
     def "can receive lock id"() {
         start {
-            receivedId = communicator.receive()
+            def packet = communicator.receive()
+            receivedId = communicator.decodeLockId(packet)
         }
 
         poll {


### PR DESCRIPTION
The contention handling of lock of mode `Exclusive` and `None` (release on request) can become inefficient if the process holding a lock becomes unresponsive/slow (e.g. a daemon under memory pressure) or if many processes fight for the same lock.

This PR improves this by:
1. **Requesting Side** - Do not send hundreds of similar lock release request over the socket if a lock release takes longer
2. **Receiving Side** - Confirm a request to the receiver to support (1.)
3. **Receiving Side** - Do not block the socket listener thread by executing the _lock release action_ on a separate thread
4. **Requesting Side** -In case several processes fight for the lock: reset timeout if the lock owner changes