### PR TITLE
Keep parameter names in compiled class files

### DIFF
--- a/gradle/compile.gradle
+++ b/gradle/compile.gradle
@@ -40,7 +40,12 @@ tasks.withType(JavaCompile) {
     // We need to ignore the path warning since the launcher.jar references
     // core.jar and base-services.jar in its Manifest - and these are not present
     // while compiling.
-    options.compilerArgs = ['-Xlint:-options', '-Xlint:-path']
+    options.compilerArgs = [
+        '-Xlint:-options',
+        '-Xlint:-path',
+        '-Xlint:-classfile',
+        '-parameters' // https://github.com/gradle/kotlin-dsl/issues/464
+    ]
     options.incremental = true
     inputs.property('javaInstallation') {
         javaInstallationForCompilation.displayName
@@ -48,7 +53,12 @@ tasks.withType(JavaCompile) {
 }
 tasks.withType(GroovyCompile) {
     options.encoding = 'utf-8'
-    options.compilerArgs = ['-Xlint:-options', '-Xlint:-path']
+    options.compilerArgs = [
+        '-Xlint:-options',
+        '-Xlint:-path',
+        '-Xlint:-classfile',
+        '-parameters' // https://github.com/gradle/kotlin-dsl/issues/464
+    ]
     groovyOptions.encoding = 'utf-8'
     inputs.property('javaInstallation') {
         currentJavaInstallation.displayName


### PR DESCRIPTION
Closes https://github.com/gradle/kotlin-dsl/issues/464

### Context
See https://github.com/gradle/kotlin-dsl/issues/464

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
