### PR TITLE
Ask contributor to enable option "Allow edits from maintainers"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 - [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
 - [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
 - [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
-- [ ] Checked ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
+- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
 - [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
 - [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
 - [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@
 - [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
 - [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
 - [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
+- [ ] Checked ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
 - [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
 - [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
 - [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes


### PR DESCRIPTION
### Context

The Gradle core team will be able to make additional changes to a fork before merging a pull request. This leads to a smoother review workflow.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
