### PR TITLE
Respect --stacktrace for additional failures logged in afterEvaluate()

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
@@ -26,10 +26,10 @@ class LifecycleProjectEvaluatorIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    def "if two exceptions occur, prints both without stacktrace (with message=#message)"() {
+    def "if two exceptions occur, prints an info about both without stacktrace"() {
         given:
         buildFile << """
-            afterEvaluate { throw new RuntimeException(${message? "'$message'" :''}) }
+            afterEvaluate { throw new RuntimeException("after evaluate failure") }
             throw new RuntimeException("configure failure")
         """
         executer.withStacktraceDisabled()
@@ -38,15 +38,10 @@ class LifecycleProjectEvaluatorIntegrationTest extends AbstractIntegrationSpec {
         fails 'help'
 
         then:
-        errorOutput.contains("Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.\n> ${message? message : "RuntimeException"}")
+        errorOutput.contains("Project evaluation failed including an error in afterEvaluate {}. Run with --stacktrace for details of the afterEvaluate {} error.")
         !errorOutput.contains("java.lang.RuntimeException: after evaluate failure")
         errorOutput.contains("* What went wrong:\nA problem occurred evaluating root project 'root'.\n> configure failure")
         !errorOutput.contains("* Exception is:\norg.gradle.api.GradleScriptException: A problem occurred evaluating root project 'root'.")
-
-        where:
-        message                    | _
-        "after evaluate failure"   | _
-        null                       | _
     }
 
     def "if two exceptions occur with --stacktrace, prints both with stacktrace"() {
@@ -61,7 +56,7 @@ class LifecycleProjectEvaluatorIntegrationTest extends AbstractIntegrationSpec {
         fails 'help'
 
         then:
-        errorOutput.contains("Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.\njava.lang.RuntimeException: after evaluate failure")
+        errorOutput.contains("Project evaluation failed including an error in afterEvaluate {}.\njava.lang.RuntimeException: after evaluate failure")
         errorOutput.contains("* What went wrong:\nA problem occurred evaluating root project 'root'.\n> configure failure")
         errorOutput.contains("* Exception is:\norg.gradle.api.GradleScriptException: A problem occurred evaluating root project 'root'.")
     }
@@ -77,7 +72,7 @@ class LifecycleProjectEvaluatorIntegrationTest extends AbstractIntegrationSpec {
         fails 'help'
 
         then:
-        !errorOutput.contains("Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.")
+        !errorOutput.contains("Project evaluation failed including an error in afterEvaluate {}.")
         errorOutput.contains("* What went wrong:\nA problem occurred configuring root project 'root'.\n> after evaluate failure")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configuration.project
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+class LifecycleProjectEvaluatorIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        settingsFile << "rootProject.name='root'"
+    }
+
+    @Unroll
+    def "if two exceptions occur, prints both without stacktrace (with message=#message)"() {
+        given:
+        buildFile << """
+            afterEvaluate { throw new RuntimeException(${message? "'$message'" :''}) }
+            throw new RuntimeException("configure failure")
+        """
+        executer.withStacktraceDisabled()
+
+        when:
+        fails 'help'
+
+        then:
+        errorOutput.contains("Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.\n> ${message? message : "RuntimeException"}")
+        !errorOutput.contains("java.lang.RuntimeException: after evaluate failure")
+        errorOutput.contains("* What went wrong:\nA problem occurred evaluating root project 'root'.\n> configure failure")
+        !errorOutput.contains("* Exception is:\norg.gradle.api.GradleScriptException: A problem occurred evaluating root project 'root'.")
+
+        where:
+        message                    | _
+        "after evaluate failure"   | _
+        null                       | _
+    }
+
+    def "if two exceptions occur with --stacktrace, prints both with stacktrace"() {
+        given:
+        buildFile << """
+            afterEvaluate { throw new RuntimeException("after evaluate failure") }
+            throw new RuntimeException("configure failure")
+        """
+        executer.withStackTraceChecksDisabled()
+
+        when:
+        fails 'help'
+
+        then:
+        errorOutput.contains("Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.\njava.lang.RuntimeException: after evaluate failure")
+        errorOutput.contains("* What went wrong:\nA problem occurred evaluating root project 'root'.\n> configure failure")
+        errorOutput.contains("* Exception is:\norg.gradle.api.GradleScriptException: A problem occurred evaluating root project 'root'.")
+    }
+
+    def "if only one exception occurs in afterEvaluate, prints it as primary"() {
+        given:
+        buildFile << """
+            afterEvaluate { throw new RuntimeException("after evaluate failure") }
+        """
+        executer.withStacktraceDisabled()
+
+        when:
+        fails 'help'
+
+        then:
+        !errorOutput.contains("Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.")
+        errorOutput.contains("* What went wrong:\nA problem occurred configuring root project 'root'.\n> after evaluate failure")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
@@ -19,6 +19,7 @@ import org.gradle.api.ProjectConfigurationException;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateInternal;
+import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
@@ -76,7 +77,13 @@ public class LifecycleProjectEvaluator implements ProjectEvaluator {
         } catch (Exception e) {
             if (state.hasFailure()) {
                 // Just log this failure, and pass the existing failure out in the project state
-                LOGGER.error("Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.", e);
+                boolean logStackTraces = project.getGradle().getStartParameter().getShowStacktrace() != ShowStacktrace.INTERNAL_EXCEPTIONS;
+                String infoMessage = "Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.";
+                if (logStackTraces) {
+                    LOGGER.error(infoMessage, e);
+                } else {
+                    LOGGER.error(infoMessage + "\n> {}", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+                }
                 return;
             }
             addConfigurationFailure(project, state, e);

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
@@ -78,11 +78,11 @@ public class LifecycleProjectEvaluator implements ProjectEvaluator {
             if (state.hasFailure()) {
                 // Just log this failure, and pass the existing failure out in the project state
                 boolean logStackTraces = project.getGradle().getStartParameter().getShowStacktrace() != ShowStacktrace.INTERNAL_EXCEPTIONS;
-                String infoMessage = "Failed to notify ProjectEvaluationListener.afterEvaluate(), but primary configuration failure takes precedence.";
+                String infoMessage = "Project evaluation failed including an error in afterEvaluate {}.";
                 if (logStackTraces) {
                     LOGGER.error(infoMessage, e);
                 } else {
-                    LOGGER.error(infoMessage + "\n> {}", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+                    LOGGER.error(infoMessage + " Run with --stacktrace for details of the afterEvaluate {} error.");
                 }
                 return;
             }

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.configuration.project
 
+import org.gradle.StartParameter
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.ProjectEvaluationListener
 import org.gradle.api.internal.GradleInternal
@@ -41,6 +42,7 @@ class LifecycleProjectEvaluatorTest extends Specification {
         project.gradle >> gradle
         gradle.findIdentityPath() >> Path.path(":")
         gradle.identityPath >> gradle.findIdentityPath()
+        gradle.startParameter >> new StartParameter()
         project.projectPath >> Path.path(":project1")
         project.path >> project.projectPath.toString()
         project.identityPath >> Path.path(":project1")

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
@@ -134,7 +134,7 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         1 * buildOperation.run(_) >> { throw failure }
 
         then:
-        1 * progressLogger.completed(null, false)
+        1 * progressLogger.completed(null, true)
 
         then:
         1 * timeProvider.currentTime >> 124L
@@ -649,6 +649,10 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         then:
         1 * resourceLockCoordinator.current >> Stub(ResourceLockState)
         def e = thrown(ResourceDeadlockException)
+    }
+
+    def "Writes exception to "() {
+
     }
 
     def runnableBuildOperation(String name, Closure cl) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
@@ -651,10 +651,6 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         def e = thrown(ResourceDeadlockException)
     }
 
-    def "Writes exception to "() {
-
-    }
-
     def runnableBuildOperation(String name, Closure cl) {
         new RunnableBuildOperation() {
             void run(BuildOperationContext context) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -127,6 +127,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private boolean requiresGradleDistribution;
     private boolean useOwnUserHomeServices;
     private boolean useRichConsole;
+    private boolean showStacktrace = true;
 
     private int expectedDeprecationWarnings;
     private boolean eagerClassLoaderCreationChecksOn = true;
@@ -356,6 +357,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
             executer.withRichConsole();
         }
 
+        if (!showStacktrace) {
+            executer.withStacktraceDisabled();
+        }
         return executer;
     }
 
@@ -711,6 +715,11 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return this;
     }
 
+    public GradleExecuter withStacktraceDisabled() {
+        showStacktrace = false;
+        return this;
+    }
+
     /**
      * Performs cleanup at completion of the test.
      */
@@ -794,7 +803,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
                 allArgs.add("--no-daemon");
             }
         }
-        allArgs.add("--stacktrace");
+        if (showStacktrace) {
+            allArgs.add("--stacktrace");
+        }
         if (taskList) {
             allArgs.add("tasks");
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -424,4 +424,9 @@ public interface GradleExecuter extends Stoppable {
      * @see AbstractConsoleFunctionalSpec
      */
     GradleExecuter withRichConsole();
+
+    /**
+     * Execute the builds without adding the {@code "--stacktrace"} argument.
+     */
+    GradleExecuter withStacktraceDisabled();
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.file.TestFiles;
 import org.gradle.api.logging.StandardOutputListener;
 import org.gradle.api.logging.configuration.ConsoleOutput;
-import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.tasks.TaskState;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.configuration.GradleLauncherMetaData;
@@ -259,7 +258,6 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
         // TODO: Fix tests that rely on this being set before we process arguments like this...
         StartParameter startParameter = new StartParameter();
         startParameter.setCurrentDir(getWorkingDir());
-        startParameter.setShowStacktrace(ShowStacktrace.ALWAYS);
 
         // TODO: Reuse more of CommandlineActionFactory
         CommandLineParser parser = new CommandLineParser();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -115,7 +115,6 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
     protected List<String> getAllArgs() {
         List<String> args = new ArrayList<String>();
         args.addAll(super.getAllArgs());
-        args.add("--stacktrace");
         addPropagatedSystemProperties(args);
         return args;
     }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/BasicGroupedTaskLoggingFunctionalSpec.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/BasicGroupedTaskLoggingFunctionalSpec.groovy
@@ -234,6 +234,21 @@ class BasicGroupedTaskLoggingFunctionalSpec extends AbstractConsoleGroupedTaskFu
         result.output.contains(styled("> Task :succeeding", null, Ansi.Attribute.INTENSITY_BOLD))
     }
 
+    def "configure project group header is printed red if configuration fails with additional failures"() {
+        given:
+        buildFile << """
+            afterEvaluate { throw new RuntimeException("After Evaluate Failure...") }
+            throw new RuntimeException('Config Failure...')
+        """
+        executer.withStacktraceDisabled()
+
+        when:
+        fails('failing')
+
+        then:
+        result.output.contains(styled("> Configure project :", Ansi.Color.RED, Ansi.Attribute.INTENSITY_BOLD))
+    }
+
     private void assertOutputContains(GradleHandle gradle, String str) {
         ConcurrentTestUtil.poll {
             assert gradle.standardOutput =~ /(?ms)$str/


### PR DESCRIPTION
See: #874

As prerequisite, this PR contains:
- Fix for failure handling in BuildOperationExecutor
- Adding `withStacktraceDisabled()` to test executors 