### PR TITLE
Only apply integ testing scripts when project has integ tests

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/plugins/buildtypes/BuildTypesPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/plugins/buildtypes/BuildTypesPlugin.groovy
@@ -46,13 +46,18 @@ class BuildTypesPlugin implements Plugin<Project> {
                     taskNames.remove(index)
                     if (subproject.empty || project.findProject(subproject)) {
                         buildType.tasks.reverse().each {
-                            taskNames.add(index, subproject + it)
+                            def path = subproject + it
+                            if (project.tasks.findByPath(path)) {
+                                taskNames.add(index, path)
+                            } else {
+                                println "Skipping task '${path}' requested by build type ${name}, as it does not exist."
+                            }
                         }
                     } else {
                         println "Skipping execution of build type '${buildType.name}'. Project '$subproject' not found in root project '${project.name}'."
-                        if (taskNames.empty) {
-                            taskNames.add('help') //do not trigger the default tasks
-                        }
+                    }
+                    if (taskNames.empty) {
+                        taskNames.add('help') //do not trigger the default tasks
                     }
                     project.gradle.startParameter.taskNames = taskNames
                 }

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -86,13 +86,19 @@ ext.useTestFixtures = { params = [:] ->
     }
 }
 
+apply from: "$rootDir/gradle/distributionTesting.gradle"
+
 if (file("src/testFixtures").exists()) {
     apply from: "$rootDir/gradle/testFixtures.gradle"
 }
 
-apply from: "$rootDir/gradle/integTest.gradle"
+if (file("src/integTest").exists()) {
+    apply from: "$rootDir/gradle/integTest.gradle"
+}
 
-apply from: "$rootDir/gradle/crossVersionTest.gradle"
+if (file("src/crossVersionTest").exists()) {
+    apply from: "$rootDir/gradle/crossVersionTest.gradle"
+}
 
 if (file("src/performanceTest").exists()) {
     apply from: "$rootDir/gradle/performanceTest.gradle"

--- a/gradle/integTest.gradle
+++ b/gradle/integTest.gradle
@@ -1,7 +1,6 @@
 import org.gradle.testing.IntegrationTest
 
 apply plugin: 'java'
-apply from: "${rootDir}/gradle/distributionTesting.gradle"
 
 sourceSets {
     integTest {

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -256,7 +256,7 @@ tasks.withType(JvmProjectGeneratorTask) {
 // a dedicated project in order for the classpath to be setup properly
 def androidRemoteProjects = tasks.withType(RemoteProject).matching { it.name =~ /Android/ }
 androidRemoteProjects.all {
-    dependsOn project(':internalAndroidPerformanceTesting').buildClassPath
+    dependsOn tasks.findByPath(':internalAndroidPerformanceTesting:buildClassPath')
     doLast {
         file("$outputDirectory/tapi-classpath.txt") << project(':internalAndroidPerformanceTesting').buildClassPath.outputFile.text
     }

--- a/subprojects/smoke-test/smoke-test.gradle
+++ b/subprojects/smoke-test/smoke-test.gradle
@@ -16,6 +16,7 @@ configurations {
 
 dependencies {
     smokeTestCompile project(':testKit')
+    smokeTestCompile project(":internalIntegTesting")
     smokeTestCompile libraries.spock
 }
 

--- a/subprojects/test-kit/test-kit.gradle
+++ b/subprojects/test-kit/test-kit.gradle
@@ -5,13 +5,11 @@ dependencies {
     runtime project(':native')
 }
 
-task testKitVersionCompatibilityIntegTest(type: org.gradle.testing.IntegrationTest) {
+task crossVersionTests(type: org.gradle.testing.IntegrationTest) {
     description "Runs the TestKit version compatibility tests"
     systemProperties['org.gradle.integtest.testkit.compatibility'] = 'all'
     systemProperties['org.gradle.integtest.executer'] = 'forking'
 }
-
-crossVersionTests.dependsOn testKitVersionCompatibilityIntegTest
 
 strictCompile()
 useTestFixtures()


### PR DESCRIPTION
This reduces the number of tasks created and build scripts evaluated and thus speeds up our configuration time.

Removes at least 1/3 of the garbage and 1/3 of the configuration time