### PR TITLE
Use snapshots while packing task outputs

### DIFF
--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TarTaskOutputPackerTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TarTaskOutputPackerTest.groovy
@@ -271,14 +271,19 @@ class TarTaskOutputPackerTest extends Specification {
     def prop(String name = "test", OutputType type, File output) {
         switch (type) {
             case FILE:
-                return new PropertyDefinition(new ResolvedTaskOutputFilePropertySpec(name, FILE, output), {[:]})
-            case DIRECTORY:
-                return new PropertyDefinition(new ResolvedTaskOutputFilePropertySpec(name, DIRECTORY, output), {
-                    def descendants = []
+                return new PropertyDefinition(new ResolvedTaskOutputFilePropertySpec(name, FILE, output), {
                     if (output == null || !output.exists()) {
                         return [:]
                     }
-                    output.traverse(type: FileType.ANY, visitRoot: false) { descendants += it }
+                    return [(output.absolutePath): new FileHashSnapshot(Files.hash(output, Hashing.md5()))]
+                })
+            case DIRECTORY:
+                return new PropertyDefinition(new ResolvedTaskOutputFilePropertySpec(name, DIRECTORY, output), {
+                    if (output == null || !output.exists()) {
+                        return [:]
+                    }
+                    def descendants = []
+                    output.traverse(type: FileType.ANY, visitRoot: true) { descendants += it }
                     return descendants.collectEntries { File file ->
                         def snapshot
                         if (file.isDirectory()) {

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TaskOutputCacheCommandFactoryTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TaskOutputCacheCommandFactoryTest.groovy
@@ -171,7 +171,8 @@ class TaskOutputCacheCommandFactoryTest extends Specification {
     def "store invokes packer"() {
         def output = Mock(OutputStream)
         def outputProperties = props("output")
-        def command = commandFactory.createStore(key, outputProperties, task, timer)
+        def outputSnapshots = Mock(Map)
+        def command = commandFactory.createStore(key, outputProperties, outputSnapshots, task, timer)
 
         when:
         def result = command.store(output)
@@ -180,7 +181,7 @@ class TaskOutputCacheCommandFactoryTest extends Specification {
         1 * originFactory.createWriter(task, _)
 
         then:
-        1 * packer.pack(outputProperties, output, _) >> new TaskOutputPacker.PackResult(123)
+        1 * packer.pack(outputProperties, outputSnapshots, output, _) >> new TaskOutputPacker.PackResult(123)
 
         then:
         result.artifactEntryCount == 123

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/TaskArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/TaskArtifactState.java
@@ -18,12 +18,14 @@ package org.gradle.api.internal.changedetection;
 import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.api.internal.TaskExecutionHistory;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshot;
+import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey;
 import org.gradle.internal.id.UniqueId;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Encapsulates the state of the task when its outputs were last generated.
@@ -72,6 +74,11 @@ public interface TaskArtifactState {
      * Returns the history for this task.
      */
     TaskExecutionHistory getExecutionHistory();
+
+    /**
+     * Returns the current output file content snapshots indexed by property name.
+     */
+    Map<String, Map<String, FileContentSnapshot>> getOutputContentSnapshots();
 
     /**
      * The ID of the build that created the outputs that might be reused.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
@@ -16,10 +16,12 @@
 
 package org.gradle.api.internal.changedetection.changes;
 
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import org.gradle.api.internal.OverlappingOutputs;
 import org.gradle.api.internal.TaskExecutionHistory;
 import org.gradle.api.internal.TaskInternal;
@@ -28,6 +30,7 @@ import org.gradle.api.internal.changedetection.TaskArtifactStateRepository;
 import org.gradle.api.internal.changedetection.rules.TaskStateChange;
 import org.gradle.api.internal.changedetection.rules.TaskUpToDateState;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshot;
+import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
 import org.gradle.api.internal.changedetection.state.TaskExecution;
 import org.gradle.api.internal.changedetection.state.TaskHistoryRepository;
 import org.gradle.api.internal.changedetection.state.TaskOutputFilesRepository;
@@ -42,6 +45,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class DefaultTaskArtifactStateRepository implements TaskArtifactStateRepository {
@@ -126,6 +130,17 @@ public class DefaultTaskArtifactStateRepository implements TaskArtifactStateRepo
                 outputs.addAll(fileCollectionSnapshot.getElements());
             }
             return outputs;
+        }
+
+        @Override
+        public Map<String, Map<String, FileContentSnapshot>> getOutputContentSnapshots() {
+            ImmutableSortedMap<String, FileCollectionSnapshot> outputFilesSnapshot = history.getCurrentExecution().getOutputFilesSnapshot();
+            return Maps.transformValues(outputFilesSnapshot, new Function<FileCollectionSnapshot, Map<String, FileContentSnapshot>>() {
+                @Override
+                public Map<String, FileContentSnapshot> apply(FileCollectionSnapshot fileCollectionSnapshot) {
+                    return fileCollectionSnapshot.getContentSnapshots();
+                }
+            });
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.OverlappingOutputs;
 import org.gradle.api.internal.TaskExecutionHistory;
 import org.gradle.api.internal.changedetection.TaskArtifactState;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshot;
+import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.caching.internal.tasks.BuildCacheKeyInputs;
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey;
@@ -30,6 +31,7 @@ import org.gradle.util.Path;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory {
@@ -125,6 +127,11 @@ class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory 
 
     @Override
     public void snapshotAfterLoadedFromCache(ImmutableSortedMap<String, FileCollectionSnapshot> newOutputSnapshot) {
+    }
+
+    @Override
+    public Map<String, Map<String, FileContentSnapshot>> getOutputContentSnapshots() {
+        return Collections.emptyMap();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ShortCircuitTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ShortCircuitTaskArtifactStateRepository.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.changedetection.TaskArtifactState;
 import org.gradle.api.internal.changedetection.TaskArtifactStateRepository;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshot;
+import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey;
 import org.gradle.internal.id.UniqueId;
@@ -29,6 +30,7 @@ import org.gradle.internal.reflect.Instantiator;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Map;
 
 public class ShortCircuitTaskArtifactStateRepository implements TaskArtifactStateRepository {
 
@@ -99,6 +101,11 @@ public class ShortCircuitTaskArtifactStateRepository implements TaskArtifactStat
         @Override
         public TaskExecutionHistory getExecutionHistory() {
             return delegate.getExecutionHistory();
+        }
+
+        @Override
+        public Map<String, Map<String, FileContentSnapshot>> getOutputContentSnapshots() {
+            return delegate.getOutputContentSnapshots();
         }
 
         @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileCollectionSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileCollectionSnapshot.java
@@ -16,8 +16,10 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.rules.TaskStateChange;
 import org.gradle.caching.internal.BuildCacheHasher;
@@ -59,6 +61,15 @@ public class DefaultFileCollectionSnapshot implements FileCollectionSnapshot {
     @Override
     public Map<String, NormalizedFileSnapshot> getSnapshots() {
         return snapshots;
+    }
+
+    public Map<String, FileContentSnapshot> getContentSnapshots() {
+        return Maps.transformValues(snapshots, new Function<NormalizedFileSnapshot, FileContentSnapshot>() {
+            @Override
+            public FileContentSnapshot apply(NormalizedFileSnapshot normalizedSnapshot) {
+                return normalizedSnapshot.getSnapshot();
+            }
+        });
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DirContentSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DirContentSnapshot.java
@@ -21,8 +21,8 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import org.gradle.internal.file.FileType;
 
-class DirContentSnapshot implements FileContentSnapshot {
-    private static final DirContentSnapshot INSTANCE = new DirContentSnapshot();
+public class DirContentSnapshot implements FileContentSnapshot {
+    public static final DirContentSnapshot INSTANCE = new DirContentSnapshot();
     private static final HashCode SIGNATURE = Hashing.md5().hashString(DirContentSnapshot.class.getName(), Charsets.UTF_8);
 
     private DirContentSnapshot() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileCollectionSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileCollectionSnapshot.java
@@ -50,4 +50,6 @@ public interface FileCollectionSnapshot extends Snapshot {
     Collection<File> getFiles();
 
     Map<String, NormalizedFileSnapshot> getSnapshots();
+
+    Map<String, FileContentSnapshot> getContentSnapshots();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/MissingFileContentSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/MissingFileContentSnapshot.java
@@ -21,8 +21,8 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import org.gradle.internal.file.FileType;
 
-class MissingFileContentSnapshot implements FileContentSnapshot {
-    private static final MissingFileContentSnapshot INSTANCE = new MissingFileContentSnapshot();
+public class MissingFileContentSnapshot implements FileContentSnapshot {
+    public static final MissingFileContentSnapshot INSTANCE = new MissingFileContentSnapshot();
     private static final HashCode SIGNATURE = Hashing.md5().hashString(MissingFileContentSnapshot.class.getName(), Charsets.UTF_8);
 
     private MissingFileContentSnapshot() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.execution;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.internal.changedetection.TaskArtifactState;
+import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
 import org.gradle.api.internal.tasks.ResolvedTaskOutputFilePropertySpec;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
@@ -35,6 +36,7 @@ import org.gradle.internal.time.Timers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.SortedSet;
 
 public class SkipCachedTaskExecuter implements TaskExecuter {
@@ -109,7 +111,9 @@ public class SkipCachedTaskExecuter implements TaskExecuter {
             if (cacheKey.isValid()) {
                 if (state.getFailure() == null) {
                     try {
-                        buildCache.store(buildCacheCommandFactory.createStore(cacheKey, outputProperties, task, clock));
+                        TaskArtifactState taskState = context.getTaskArtifactState();
+                        Map<String, Map<String, FileContentSnapshot>> outputSnapshots = taskState.getOutputContentSnapshots();
+                        buildCache.store(buildCacheCommandFactory.createStore(cacheKey, outputProperties, outputSnapshots, task, clock));
                     } catch (Exception e) {
                         LOGGER.warn("Failed to store cache entry {}", cacheKey.getDisplayName(), task, e);
                     }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/GZipTaskOutputPacker.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/GZipTaskOutputPacker.java
@@ -18,6 +18,7 @@ package org.gradle.caching.internal.tasks;
 
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
 import org.gradle.api.internal.tasks.ResolvedTaskOutputFilePropertySpec;
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginReader;
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginWriter;
@@ -25,6 +26,7 @@ import org.gradle.caching.internal.tasks.origin.TaskOutputOriginWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -40,10 +42,10 @@ public class GZipTaskOutputPacker implements TaskOutputPacker {
     }
 
     @Override
-    public PackResult pack(SortedSet<ResolvedTaskOutputFilePropertySpec> propertySpecs, OutputStream output, TaskOutputOriginWriter writeOrigin) throws IOException {
+    public PackResult pack(SortedSet<ResolvedTaskOutputFilePropertySpec> propertySpecs, Map<String, Map<String, FileContentSnapshot>> outputFiles, OutputStream output, TaskOutputOriginWriter writeOrigin) throws IOException {
         GZIPOutputStream gzipOutput = createGzipOutputStream(output);
         try {
-            return delegate.pack(propertySpecs, gzipOutput, writeOrigin);
+            return delegate.pack(propertySpecs, outputFiles, gzipOutput, writeOrigin);
         } finally {
             IOUtils.closeQuietly(gzipOutput);
         }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputPacker.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputPacker.java
@@ -17,6 +17,7 @@
 package org.gradle.caching.internal.tasks;
 
 import com.google.common.collect.ImmutableListMultimap;
+import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
 import org.gradle.api.internal.changedetection.state.FileSnapshot;
 import org.gradle.api.internal.tasks.ResolvedTaskOutputFilePropertySpec;
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginMetadata;
@@ -26,6 +27,7 @@ import org.gradle.caching.internal.tasks.origin.TaskOutputOriginWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Map;
 import java.util.SortedSet;
 
 public interface TaskOutputPacker {
@@ -37,7 +39,7 @@ public interface TaskOutputPacker {
     // - any major changes of the layout of a cache entry
     int CACHE_ENTRY_FORMAT = 1;
 
-    PackResult pack(SortedSet<ResolvedTaskOutputFilePropertySpec> propertySpecs, OutputStream output, TaskOutputOriginWriter writeOrigin) throws IOException;
+    PackResult pack(SortedSet<ResolvedTaskOutputFilePropertySpec> propertySpecs, Map<String, Map<String, FileContentSnapshot>> outputSnapshots, OutputStream output, TaskOutputOriginWriter writeOrigin) throws IOException;
 
     class PackResult {
         private final long entries;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
@@ -54,6 +54,7 @@ class SkipCachedTaskExecuterTest extends Specification {
     def loadCommand = Mock(BuildCacheLoadCommand)
     def storeCommand = Mock(BuildCacheStoreCommand)
     def buildCacheCommandFactory = Mock(TaskOutputCacheCommandFactory)
+    def outputContentSnapshots = [:]
 
     def executer = new SkipCachedTaskExecuter(buildCacheController, taskOutputGenerationListener, buildCacheCommandFactory, delegate)
 
@@ -111,7 +112,9 @@ class SkipCachedTaskExecuterTest extends Specification {
         1 * cacheKey.isValid() >> true
 
         then:
-        1 * buildCacheCommandFactory.createStore(cacheKey, _, task, _) >> storeCommand
+        1 * taskContext.getTaskArtifactState() >> taskArtifactState
+        1 * taskArtifactState.getOutputContentSnapshots() >> outputContentSnapshots
+        1 * buildCacheCommandFactory.createStore(cacheKey, _, outputContentSnapshots, task, _) >> storeCommand
 
         then:
         1 * buildCacheController.store(storeCommand)
@@ -140,7 +143,9 @@ class SkipCachedTaskExecuterTest extends Specification {
         1 * cacheKey.isValid() >> true
 
         then:
-        1 * buildCacheCommandFactory.createStore(cacheKey, _, task, _) >> storeCommand
+        1 * taskContext.getTaskArtifactState() >> taskArtifactState
+        1 * taskArtifactState.getOutputContentSnapshots() >> outputContentSnapshots
+        1 * buildCacheCommandFactory.createStore(cacheKey, _, outputContentSnapshots, task, _) >> storeCommand
 
         then:
         1 * buildCacheController.store(storeCommand)
@@ -230,7 +235,9 @@ class SkipCachedTaskExecuterTest extends Specification {
         1 * cacheKey.isValid() >> true
 
         then:
-        1 * buildCacheCommandFactory.createStore(cacheKey, _, task, _) >> storeCommand
+        1 * taskContext.getTaskArtifactState() >> taskArtifactState
+        1 * taskArtifactState.getOutputContentSnapshots() >> outputContentSnapshots
+        1 * buildCacheCommandFactory.createStore(cacheKey, _, outputContentSnapshots, task, _) >> storeCommand
 
         then:
         1 * buildCacheController.store(storeCommand)
@@ -285,8 +292,12 @@ class SkipCachedTaskExecuterTest extends Specification {
 
         then:
         1 * cacheKey.isValid() >> true
-        1 * cacheKey.getDisplayName() >> "cache key"
         1 * taskState.getFailure() >> null
+
+        then:
+        1 * cacheKey.getDisplayName() >> "cache key"
+        1 * taskContext.getTaskArtifactState() >> taskArtifactState
+        1 * taskArtifactState.getOutputContentSnapshots()
         1 * buildCacheCommandFactory.createStore(*_)
         1 * buildCacheController.store(_) >> { throw new RuntimeException("unknown error") }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
@@ -34,7 +34,7 @@ class AbstractTaskOutputCacheJavaPerformanceTest extends AbstractCrossVersionPer
         runner.cleanTasks = ["clean"]
         runner.args = ["-D${GradleProperties.BUILD_CACHE_PROPERTY}=true"]
         runner.minimumVersion = "3.5"
-        runner.targetVersions = ["4.2-20170817235727+0000"]
+        runner.targetVersions = ["4.2-20170823173646+0000"]
     }
 
     /**


### PR DESCRIPTION
We've already collected snapshots of all the outputs after the task executed, so no need to walk the file system again while packing up those outputs.