### PR TITLE
Use static WorkResult objects

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
@@ -70,7 +70,7 @@ public class TarCopyAction implements CopyAction {
             }
         });
 
-        return new SimpleWorkResult(true);
+        return SimpleWorkResult.DID_WORK;
     }
 
     private class StreamAction implements CopyActionProcessingStreamAction {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
@@ -93,7 +93,7 @@ public class ZipCopyAction implements CopyAction {
             }
         }
 
-        return new SimpleWorkResult(true);
+        return SimpleWorkResult.DID_WORK;
     }
 
     private class StreamAction implements CopyActionProcessingStreamAction {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
@@ -33,7 +33,7 @@ public class FileCopyAction implements CopyAction {
     public WorkResult execute(CopyActionProcessingStream stream) {
         FileCopyDetailsInternalAction action = new FileCopyDetailsInternalAction();
         stream.process(action);
-        return new SimpleWorkResult(action.didWork);
+        return SimpleWorkResult.didWork(action.didWork);
     }
 
     private class FileCopyDetailsInternalAction implements CopyActionProcessingStreamAction {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
@@ -70,7 +70,7 @@ public class SyncCopyActionDecorator implements CopyAction {
         walker.visit(fileVisitor);
         visited.clear();
 
-        return new SimpleWorkResult(didWork.getDidWork() || fileVisitor.didWork);
+        return SimpleWorkResult.didWork(didWork.getDidWork() || fileVisitor.didWork);
     }
 
     private static class SyncCopyActionDecoratorFileVisitor implements FileVisitor {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
@@ -65,7 +65,7 @@ public class Deleter {
             didWork = true;
             doDeleteInternal(file, deleteSpec);
         }
-        return new SimpleWorkResult(didWork);
+        return SimpleWorkResult.didWork(didWork);
     }
 
     private void doDeleteInternal(File file, DeleteSpecInternal deleteSpec) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SimpleWorkResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SimpleWorkResult.java
@@ -17,14 +17,21 @@ package org.gradle.api.internal.tasks;
 
 import org.gradle.api.tasks.WorkResult;
 
-public class SimpleWorkResult implements WorkResult {
-    private final boolean didWork;
+public class SimpleWorkResult {
+    public static final WorkResult DID_WORK = new WorkResult() {
+        @Override
+        public boolean getDidWork() {
+            return true;
+        }
+    };
+    public static final WorkResult DID_NO_WORK = new WorkResult() {
+        @Override
+        public boolean getDidWork() {
+            return false;
+        }
+    };
 
-    public SimpleWorkResult(boolean didWork) {
-        this.didWork = didWork;
-    }
-
-    public boolean getDidWork() {
-        return didWork;
+    public static WorkResult didWork(boolean didWork) {
+        return didWork ? DID_WORK : DID_NO_WORK;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SimpleWorkResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SimpleWorkResult.java
@@ -31,6 +31,8 @@ public class SimpleWorkResult {
         }
     };
 
+    private SimpleWorkResult() {}
+
     public static WorkResult didWork(boolean didWork) {
         return didWork ? DID_WORK : DID_NO_WORK;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopyActionExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopyActionExecuterTest.groovy
@@ -53,7 +53,7 @@ class CopyActionExecuterTest extends WorkspaceTest {
         def copyAction = new CopyAction() {
             WorkResult execute(CopyActionProcessingStream stream) {
                 stream.process(action)
-                new SimpleWorkResult(workResult)
+                SimpleWorkResult.didWork(workResult)
             }
         }
         def executer = new CopyActionExecuter(DirectInstantiator.INSTANCE, TestFiles.fileSystem(), false)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionExecutorTest.groovy
@@ -46,7 +46,7 @@ class DuplicateHandlingCopyActionExecutorTest extends Specification {
     def delegate = new CopyAction() {
         WorkResult execute(CopyActionProcessingStream stream) {
             stream.process(delegateAction)
-            return new SimpleWorkResult(true)
+            return SimpleWorkResult.DID_WORK
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.java
@@ -39,7 +39,7 @@ public class NormalizingCopyActionDecoratorTest {
     private final CopyAction delegate = new CopyAction() {
         public WorkResult execute(CopyActionProcessingStream stream) {
             stream.process(delegateAction);
-            return new SimpleWorkResult(true);
+            return SimpleWorkResult.DID_WORK;
         }
     };
     private final NormalizingCopyActionDecorator decorator = new NormalizingCopyActionDecorator(delegate, fileSystem());

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -185,7 +185,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
             compileClasspathLoader.shutdown();
         }
 
-        return new SimpleWorkResult(true);
+        return SimpleWorkResult.DID_WORK;
     }
 
     private boolean shouldProcessAnnotations(GroovyJavaJointCompileSpec spec) {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
@@ -127,7 +127,7 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
                 throw e;
             }
             LOGGER.debug("Ignoring compilation failure.");
-            return new SimpleWorkResult(false);
+            return SimpleWorkResult.DID_NO_WORK;
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
@@ -47,7 +47,7 @@ public class CommandLineJavaCompiler implements Compiler<JavaCompileSpec>, Seria
         ExecHandle handle = createCompilerHandle(executable, spec);
         executeCompiler(handle);
 
-        return new SimpleWorkResult(true);
+        return SimpleWorkResult.DID_WORK;
     }
 
     private ExecHandle createCompilerHandle(String executable, JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -51,7 +51,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
             throw new CompilationFailedException();
         }
 
-        return new SimpleWorkResult(true);
+        return SimpleWorkResult.DID_WORK;
     }
 
     private JavaCompiler.CompilationTask createCompileTask(JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
@@ -102,7 +102,7 @@ public class NormalizingJavaCompiler implements Compiler<JavaCompileSpec> {
                 throw e;
             }
             LOGGER.debug("Ignoring compilation failure.");
-            return new SimpleWorkResult(false);
+            return SimpleWorkResult.DID_NO_WORK;
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
@@ -58,6 +58,6 @@ public class JavadocGenerator implements Compiler<JavadocSpec> {
             throw new GradleException(String.format("Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '%s'", spec.getOptionsFile()), e);
         }
 
-        return new SimpleWorkResult(true);
+        return SimpleWorkResult.DID_WORK;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
@@ -142,7 +142,7 @@ public class IncrementalNativeCompiler<T extends NativeCompileSpec> implements C
         boolean deleted = cleanPreviousOutputs(spec);
         WorkResult compileResult = delegateCompiler.execute(spec);
         if (deleted && !compileResult.getDidWork()) {
-            return new SimpleWorkResult(deleted);
+            return SimpleWorkResult.didWork(deleted);
         }
         return compileResult;
     }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
@@ -89,7 +89,7 @@ class IncrementalNativeCompilerTest extends Specification {
         1 * spec.getObjectFileDir() >> outputFile.parentFile
         1 * outputs.previousOutputFiles >> Sets.newHashSet(outputFile)
         0 * spec._
-        1 * delegateCompiler.execute(spec) >> new SimpleWorkResult(false)
+        1 * delegateCompiler.execute(spec) >> SimpleWorkResult.DID_NO_WORK
 
         and:
         result.didWork

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
@@ -104,7 +104,7 @@ public class NormalizingScalaCompiler implements Compiler<ScalaJavaJointCompileS
                 throw e;
             }
             LOGGER.debug("Ignoring compilation failure.");
-            return new SimpleWorkResult(false);
+            return SimpleWorkResult.DID_NO_WORK;
         }
     }
 }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
@@ -84,7 +84,7 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec>, S
             }
             LOGGER.info("Completed Scala compilation: {}", timer.getElapsed());
 
-            return new SimpleWorkResult(true);
+            return SimpleWorkResult.DID_WORK;
         }
 
         private static IncOptions getIncOptions() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractCompiler.java
@@ -47,7 +47,7 @@ public abstract class AbstractCompiler<T extends BinaryToolSpec> implements Comp
     public WorkResult execute(T spec) {
         buildOperationExecutor.runAll(commandLineToolInvocationWorker, newInvocationAction(spec));
 
-        return new SimpleWorkResult(true);
+        return SimpleWorkResult.DID_WORK;
     }
 
     // TODO(daniel): Should support in a better way multi file invocation.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
@@ -59,7 +59,7 @@ public abstract class NativeCompiler<T extends NativeCompileSpec> extends Abstra
 
         super.execute(spec);
 
-        return new SimpleWorkResult(!transformedSpec.getSourceFiles().isEmpty());
+        return SimpleWorkResult.didWork(!transformedSpec.getSourceFiles().isEmpty());
     }
 
     // TODO(daniel): Should support in a better way multi file invocation.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompiler.java
@@ -39,7 +39,7 @@ public class OutputCleaningCompiler<T extends NativeCompileSpec> implements Comp
     public WorkResult execute(T spec) {
         boolean didRemove = deleteOutputsForRemovedSources(spec);
         boolean didCompile = compileSources(spec);
-        return new SimpleWorkResult(didRemove || didCompile);
+        return SimpleWorkResult.didWork(didRemove || didCompile);
     }
 
     private boolean compileSources(T spec) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/javascript/GoogleClosureCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/javascript/GoogleClosureCompiler.java
@@ -63,7 +63,7 @@ public class GoogleClosureCompiler implements Compiler<JavaScriptCompileSpec>, S
         }
 
         if (allErrors.isEmpty()) {
-            return new SimpleWorkResult(true);
+            return SimpleWorkResult.DID_WORK;
         } else {
             throw new SourceTransformationException(String.format("Minification failed with the following errors:\n\t%s", StringUtils.join(allErrors, "\n\t")), null);
         }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompiler.java
@@ -59,7 +59,7 @@ public class RoutesCompiler implements Compiler<RoutesCompileSpec>, Serializable
             didWork = ret || didWork;
         }
 
-        return new SimpleWorkResult(didWork);
+        return SimpleWorkResult.didWork(didWork);
     }
 
     private Boolean compile(File sourceFile, RoutesCompileSpec spec) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompiler.java
@@ -65,7 +65,7 @@ public class TwirlCompiler implements Compiler<TwirlCompileSpec>, Serializable {
             }
         }
 
-        return new SimpleWorkResult(!outputFiles.isEmpty());
+        return SimpleWorkResult.didWork(!outputFiles.isEmpty());
     }
 
     private ScalaMethod getCompileMethod(ClassLoader cl) {


### PR DESCRIPTION
There's no need to create new ones all the time. Should save a tiny bit of heap.