### PR TITLE
Use constant WorkResult objects

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/WorkResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/WorkResult.java
@@ -18,6 +18,23 @@ package org.gradle.api.tasks;
 /**
  * Provides information about some work which was performed.
  */
-public interface WorkResult {
-    public boolean getDidWork();
+public abstract class WorkResult {
+    private static final WorkResult DID_WORK = new WorkResult() {
+        @Override
+        public boolean getDidWork() {
+            return true;
+        }
+    };
+    private static final WorkResult DID_NO_WORK = new WorkResult() {
+        @Override
+        public boolean getDidWork() {
+            return false;
+        }
+    };
+
+    public static WorkResult didWork(boolean didWork) {
+        return didWork ? DID_WORK : DID_NO_WORK;
+    }
+
+    public abstract boolean getDidWork();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/WorkResults.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/WorkResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.api.tasks;
 
 /**
- * Provides information about some work which was performed.
+ * Helps create {@link WorkResult} objects.
  */
-public interface WorkResult {
-    boolean getDidWork();
+public class WorkResults {
+    private static final WorkResult DID_WORK = new WorkResult() {
+        @Override
+        public boolean getDidWork() {
+            return true;
+        }
+    };
+    private static final WorkResult DID_NO_WORK = new WorkResult() {
+        @Override
+        public boolean getDidWork() {
+            return false;
+        }
+    };
+
+    private WorkResults() {}
+
+    public static WorkResult didWork(boolean didWork) {
+        return didWork ? DID_WORK : DID_NO_WORK;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
@@ -25,7 +25,6 @@ import org.gradle.api.internal.file.archive.compression.ArchiveOutputStreamFacto
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream;
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
@@ -70,7 +69,7 @@ public class TarCopyAction implements CopyAction {
             }
         });
 
-        return new SimpleWorkResult(true);
+        return WorkResult.didWork(true);
     }
 
     private class StreamAction implements CopyActionProcessingStreamAction {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream;
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
 
@@ -69,7 +70,7 @@ public class TarCopyAction implements CopyAction {
             }
         });
 
-        return WorkResult.didWork(true);
+        return WorkResults.didWork(true);
     }
 
     private class StreamAction implements CopyActionProcessingStreamAction {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.file.copy.CopyActionProcessingStream;
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal;
 import org.gradle.api.internal.file.copy.ZipCompressor;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.internal.IoActions;
 
@@ -92,7 +93,7 @@ public class ZipCopyAction implements CopyAction {
             }
         }
 
-        return WorkResult.didWork(true);
+        return WorkResults.didWork(true);
     }
 
     private class StreamAction implements CopyActionProcessingStreamAction {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
@@ -29,7 +29,6 @@ import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream;
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal;
 import org.gradle.api.internal.file.copy.ZipCompressor;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.internal.IoActions;
@@ -93,7 +92,7 @@ public class ZipCopyAction implements CopyAction {
             }
         }
 
-        return new SimpleWorkResult(true);
+        return WorkResult.didWork(true);
     }
 
     private class StreamAction implements CopyActionProcessingStreamAction {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.file.copy;
 
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.file.PathToFileResolver;
 
@@ -33,7 +32,7 @@ public class FileCopyAction implements CopyAction {
     public WorkResult execute(CopyActionProcessingStream stream) {
         FileCopyDetailsInternalAction action = new FileCopyDetailsInternalAction();
         stream.process(action);
-        return new SimpleWorkResult(action.didWork);
+        return WorkResult.didWork(action.didWork);
     }
 
     private class FileCopyDetailsInternalAction implements CopyActionProcessingStreamAction {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.file.copy;
 
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.file.PathToFileResolver;
 
 import java.io.File;
@@ -32,7 +33,7 @@ public class FileCopyAction implements CopyAction {
     public WorkResult execute(CopyActionProcessingStream stream) {
         FileCopyDetailsInternalAction action = new FileCopyDetailsInternalAction();
         stream.process(action);
-        return WorkResult.didWork(action.didWork);
+        return WorkResults.didWork(action.didWork);
     }
 
     private class FileCopyDetailsInternalAction implements CopyActionProcessingStreamAction {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.util.GFileUtils;
@@ -69,7 +70,7 @@ public class SyncCopyActionDecorator implements CopyAction {
         walker.visit(fileVisitor);
         visited.clear();
 
-        return WorkResult.didWork(didWork.getDidWork() || fileVisitor.didWork);
+        return WorkResults.didWork(didWork.getDidWork() || fileVisitor.didWork);
     }
 
     private static class SyncCopyActionDecoratorFileVisitor implements FileVisitor {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
@@ -22,7 +22,6 @@ import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.util.PatternFilterable;
@@ -70,7 +69,7 @@ public class SyncCopyActionDecorator implements CopyAction {
         walker.visit(fileVisitor);
         visited.clear();
 
-        return new SimpleWorkResult(didWork.getDidWork() || fileVisitor.didWork);
+        return WorkResult.didWork(didWork.getDidWork() || fileVisitor.didWork);
     }
 
     private static class SyncCopyActionDecoratorFileVisitor implements FileVisitor {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
@@ -19,7 +19,6 @@ import org.gradle.api.Action;
 import org.gradle.api.file.DeleteSpec;
 import org.gradle.api.file.UnableToDeleteFileException;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.os.OperatingSystem;
@@ -65,7 +64,7 @@ public class Deleter {
             didWork = true;
             doDeleteInternal(file, deleteSpec);
         }
-        return new SimpleWorkResult(didWork);
+        return WorkResult.didWork(didWork);
     }
 
     private void doDeleteInternal(File file, DeleteSpecInternal deleteSpec) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
@@ -20,6 +20,7 @@ import org.gradle.api.file.DeleteSpec;
 import org.gradle.api.file.UnableToDeleteFileException;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.os.OperatingSystem;
 import org.slf4j.Logger;
@@ -64,7 +65,7 @@ public class Deleter {
             didWork = true;
             doDeleteInternal(file, deleteSpec);
         }
-        return WorkResult.didWork(didWork);
+        return WorkResults.didWork(didWork);
     }
 
     private void doDeleteInternal(File file, DeleteSpecInternal deleteSpec) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SimpleWorkResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SimpleWorkResult.java
@@ -16,14 +16,26 @@
 package org.gradle.api.internal.tasks;
 
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.util.DeprecationLogger;
 
-public class SimpleWorkResult implements WorkResult {
+/**
+ * @deprecated Use {@link WorkResult.didWork(boolean)} instead.
+ */
+@Deprecated
+public class SimpleWorkResult extends WorkResult {
+
     private final boolean didWork;
 
+    /**
+     * @deprecated Use {@link WorkResult#didWork(boolean)} instead.
+     */
+    @Deprecated
     public SimpleWorkResult(boolean didWork) {
+        DeprecationLogger.nagUserOfDiscontinuedApi("SimpleWorkResult type", "Please use WorkResult.didWork() instead.");
         this.didWork = didWork;
     }
 
+    @Override
     public boolean getDidWork() {
         return didWork;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SimpleWorkResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SimpleWorkResult.java
@@ -19,19 +19,19 @@ import org.gradle.api.tasks.WorkResult;
 import org.gradle.util.DeprecationLogger;
 
 /**
- * @deprecated Use {@link WorkResult.didWork(boolean)} instead.
+ * @deprecated Use {@link org.gradle.api.tasks.WorkResults#didWork(boolean)} instead.
  */
 @Deprecated
-public class SimpleWorkResult extends WorkResult {
+public class SimpleWorkResult implements WorkResult {
 
     private final boolean didWork;
 
     /**
-     * @deprecated Use {@link WorkResult#didWork(boolean)} instead.
+     * @deprecated Use {@link org.gradle.api.tasks.WorkResults#didWork(boolean)} instead.
      */
     @Deprecated
     public SimpleWorkResult(boolean didWork) {
-        DeprecationLogger.nagUserOfDiscontinuedApi("SimpleWorkResult type", "Please use WorkResult.didWork() instead.");
+        DeprecationLogger.nagUserOfDiscontinuedApi("SimpleWorkResult type", "Please use WorkResults.didWork() instead.");
         this.didWork = didWork;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopyActionExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopyActionExecuterTest.groovy
@@ -52,7 +52,7 @@ class CopyActionExecuterTest extends WorkspaceTest {
         def copyAction = new CopyAction() {
             WorkResult execute(CopyActionProcessingStream stream) {
                 stream.process(action)
-                WorkResult.didWork(workResult)
+                WorkResults.didWork(workResult)
             }
         }
         def executer = new CopyActionExecuter(DirectInstantiator.INSTANCE, TestFiles.fileSystem(), false)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopyActionExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopyActionExecuterTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.tasks.WorkResult
+import org.gradle.api.tasks.WorkResults
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.test.fixtures.file.WorkspaceTest
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopyActionExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/CopyActionExecuterTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.file.copy
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.tasks.SimpleWorkResult
 import org.gradle.api.tasks.WorkResult
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.test.fixtures.file.WorkspaceTest
@@ -53,7 +52,7 @@ class CopyActionExecuterTest extends WorkspaceTest {
         def copyAction = new CopyAction() {
             WorkResult execute(CopyActionProcessingStream stream) {
                 stream.process(action)
-                new SimpleWorkResult(workResult)
+                WorkResult.didWork(workResult)
             }
         }
         def executer = new CopyActionExecuter(DirectInstantiator.INSTANCE, TestFiles.fileSystem(), false)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionExecutorTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.file.RelativePath
 import org.gradle.api.internal.ClosureBackedAction
 import org.gradle.api.internal.ThreadGlobalInstantiator
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction
-import org.gradle.api.internal.tasks.SimpleWorkResult
 import org.gradle.api.tasks.WorkResult
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.logging.TestOutputEventListener
@@ -46,7 +45,7 @@ class DuplicateHandlingCopyActionExecutorTest extends Specification {
     def delegate = new CopyAction() {
         WorkResult execute(CopyActionProcessingStream stream) {
             stream.process(delegateAction)
-            return new SimpleWorkResult(true)
+            return WorkResult.didWork(true);
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionExecutorTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.ClosureBackedAction
 import org.gradle.api.internal.ThreadGlobalInstantiator
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction
 import org.gradle.api.tasks.WorkResult
+import org.gradle.api.tasks.WorkResults
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.logging.TestOutputEventListener
 import org.gradle.internal.nativeintegration.filesystem.FileSystem

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionExecutorTest.groovy
@@ -45,7 +45,7 @@ class DuplicateHandlingCopyActionExecutorTest extends Specification {
     def delegate = new CopyAction() {
         WorkResult execute(CopyActionProcessingStream stream) {
             stream.process(delegateAction)
-            return WorkResult.didWork(true);
+            return WorkResults.didWork(true);
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.file.copy;
 import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -39,7 +38,7 @@ public class NormalizingCopyActionDecoratorTest {
     private final CopyAction delegate = new CopyAction() {
         public WorkResult execute(CopyActionProcessingStream stream) {
             stream.process(delegateAction);
-            return new SimpleWorkResult(true);
+            return WorkResult.didWork(true);
         }
     };
     private final NormalizingCopyActionDecorator decorator = new NormalizingCopyActionDecorator(delegate, fileSystem());

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.java
@@ -19,6 +19,7 @@ import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -38,7 +39,7 @@ public class NormalizingCopyActionDecoratorTest {
     private final CopyAction delegate = new CopyAction() {
         public WorkResult execute(CopyActionProcessingStream stream) {
             stream.process(delegateAction);
-            return WorkResult.didWork(true);
+            return WorkResults.didWork(true);
         }
     };
     private final NormalizingCopyActionDecorator decorator = new NormalizingCopyActionDecorator(delegate, fileSystem());

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/compile/internal/rhino/RhinoCoffeeScriptCompiler.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/compile/internal/rhino/RhinoCoffeeScriptCompiler.java
@@ -44,10 +44,6 @@ public class RhinoCoffeeScriptCompiler implements CoffeeScriptCompiler {
 
         compiler.process(new SerializableCoffeeScriptCompileSpec(spec));
 
-        return new WorkResult() {
-            public boolean getDidWork() {
-                return true;
-            }
-        };
+        return WorkResult.didWork(true);
     }
 }

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/compile/internal/rhino/RhinoCoffeeScriptCompiler.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/compile/internal/rhino/RhinoCoffeeScriptCompiler.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.javascript.coffeescript.compile.internal.rhino;
 
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.plugins.javascript.coffeescript.CoffeeScriptCompileSpec;
 import org.gradle.plugins.javascript.coffeescript.CoffeeScriptCompiler;
 import org.gradle.plugins.javascript.coffeescript.compile.internal.SerializableCoffeeScriptCompileSpec;
@@ -44,6 +45,6 @@ public class RhinoCoffeeScriptCompiler implements CoffeeScriptCompiler {
 
         compiler.process(new SerializableCoffeeScriptCompileSpec(spec));
 
-        return WorkResult.didWork(true);
+        return WorkResults.didWork(true);
     }
 }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -33,7 +33,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.classloading.GroovySystemLoader;
 import org.gradle.api.internal.classloading.GroovySystemLoaderFactory;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.classloader.ClassLoaderUtils;
@@ -185,7 +184,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
             compileClasspathLoader.shutdown();
         }
 
-        return new SimpleWorkResult(true);
+        return WorkResult.didWork(true);
     }
 
     private boolean shouldProcessAnnotations(GroovyJavaJointCompileSpec spec) {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.classloading.GroovySystemLoaderFactory;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classloader.DefaultClassLoaderFactory;
 import org.gradle.internal.classloader.FilteringClassLoader;
@@ -184,7 +185,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
             compileClasspathLoader.shutdown();
         }
 
-        return WorkResult.didWork(true);
+        return WorkResults.didWork(true);
     }
 
     private boolean shouldProcessAnnotations(GroovyJavaJointCompileSpec spec) {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Lists;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
@@ -127,7 +126,7 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
                 throw e;
             }
             LOGGER.debug("Ignoring compilation failure.");
-            return new SimpleWorkResult(false);
+            return WorkResult.didWork(false);
         }
     }
 }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
@@ -24,6 +24,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.CollectionUtils;
 
@@ -126,7 +127,7 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
                 throw e;
             }
             LOGGER.debug("Ignoring compilation failure.");
-            return WorkResult.didWork(false);
+            return WorkResults.didWork(false);
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -46,7 +47,7 @@ public class CommandLineJavaCompiler implements Compiler<JavaCompileSpec>, Seria
         ExecHandle handle = createCompilerHandle(executable, spec);
         executeCompiler(handle);
 
-        return WorkResult.didWork(true);
+        return WorkResults.didWork(true);
     }
 
     private ExecHandle createCompilerHandle(String executable, JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.compile;
 
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.internal.jvm.Jvm;
@@ -47,7 +46,7 @@ public class CommandLineJavaCompiler implements Compiler<JavaCompileSpec>, Seria
         ExecHandle handle = createCompilerHandle(executable, spec);
         executeCompiler(handle);
 
-        return new SimpleWorkResult(true);
+        return WorkResult.didWork(true);
     }
 
     private ExecHandle createCompilerHandle(String executable, JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.tasks.compile.reflect.SourcepathIgnoringProxy;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.internal.Factory;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -50,7 +51,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
             throw new CompilationFailedException();
         }
 
-        return WorkResult.didWork(true);
+        return WorkResults.didWork(true);
     }
 
     private JavaCompiler.CompilationTask createCompileTask(JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.JavaVersion;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.internal.tasks.compile.reflect.SourcepathIgnoringProxy;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.CompileOptions;
@@ -51,7 +50,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
             throw new CompilationFailedException();
         }
 
-        return new SimpleWorkResult(true);
+        return WorkResult.didWork(true);
     }
 
     private JavaCompiler.CompilationTask createCompileTask(JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.compile;
 import com.google.common.base.Joiner;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
@@ -102,7 +101,7 @@ public class NormalizingJavaCompiler implements Compiler<JavaCompileSpec> {
                 throw e;
             }
             LOGGER.debug("Ignoring compilation failure.");
-            return new SimpleWorkResult(false);
+            return WorkResult.didWork(false);
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
@@ -22,6 +22,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.CollectionUtils;
 
@@ -101,7 +102,7 @@ public class NormalizingJavaCompiler implements Compiler<JavaCompileSpec> {
                 throw e;
             }
             LOGGER.debug("Ignoring compilation failure.");
-            return WorkResult.didWork(false);
+            return WorkResults.didWork(false);
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks.javadoc.internal;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
@@ -58,6 +57,6 @@ public class JavadocGenerator implements Compiler<JavadocSpec> {
             throw new GradleException(String.format("Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '%s'", spec.getOptionsFile()), e);
         }
 
-        return new SimpleWorkResult(true);
+        return WorkResult.didWork(true);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
@@ -20,6 +20,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.external.javadoc.internal.JavadocExecHandleBuilder;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.internal.ExecAction;
@@ -57,6 +58,6 @@ public class JavadocGenerator implements Compiler<JavadocSpec> {
             throw new GradleException(String.format("Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '%s'", spec.getOptionsFile()), e);
         }
 
-        return WorkResult.didWork(true);
+        return WorkResults.didWork(true);
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
@@ -21,7 +21,6 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.changedetection.changes.DiscoveredInputRecorder;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
@@ -142,7 +141,7 @@ public class IncrementalNativeCompiler<T extends NativeCompileSpec> implements C
         boolean deleted = cleanPreviousOutputs(spec);
         WorkResult compileResult = delegateCompiler.execute(spec);
         if (deleted && !compileResult.getDidWork()) {
-            return new SimpleWorkResult(deleted);
+            return WorkResult.didWork(deleted);
         }
         return compileResult;
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
@@ -25,6 +25,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.cache.PersistentStateCache;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -141,7 +142,7 @@ public class IncrementalNativeCompiler<T extends NativeCompileSpec> implements C
         boolean deleted = cleanPreviousOutputs(spec);
         WorkResult compileResult = delegateCompiler.execute(spec);
         if (deleted && !compileResult.getDidWork()) {
-            return WorkResult.didWork(deleted);
+            return WorkResults.didWork(deleted);
         }
         return compileResult;
     }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.changedetection.changes.DiscoveredInputRecorder
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.tasks.SimpleWorkResult
+import org.gradle.api.tasks.WorkResult
 import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.nativeplatform.toolchain.Clang
 import org.gradle.nativeplatform.toolchain.Gcc
@@ -89,7 +89,7 @@ class IncrementalNativeCompilerTest extends Specification {
         1 * spec.getObjectFileDir() >> outputFile.parentFile
         1 * outputs.previousOutputFiles >> Sets.newHashSet(outputFile)
         0 * spec._
-        1 * delegateCompiler.execute(spec) >> new SimpleWorkResult(false)
+        1 * delegateCompiler.execute(spec) >> WorkResult.didWork(false)
 
         and:
         result.didWork

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.changedetection.changes.DiscoveredInputRecorder
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.tasks.WorkResults
 import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.nativeplatform.toolchain.Clang
 import org.gradle.nativeplatform.toolchain.Gcc

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.changedetection.changes.DiscoveredInputRecorder
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.tasks.WorkResult
 import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.nativeplatform.toolchain.Clang
 import org.gradle.nativeplatform.toolchain.Gcc
@@ -89,7 +88,7 @@ class IncrementalNativeCompilerTest extends Specification {
         1 * spec.getObjectFileDir() >> outputFile.parentFile
         1 * outputs.previousOutputFiles >> Sets.newHashSet(outputFile)
         0 * spec._
-        1 * delegateCompiler.execute(spec) >> WorkResult.didWork(false)
+        1 * delegateCompiler.execute(spec) >> WorkResults.didWork(false)
 
         and:
         result.didWork

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.scala;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.internal.tasks.compile.CompilationFailedException;
 import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder;
 import org.gradle.api.logging.Logger;
@@ -104,7 +103,7 @@ public class NormalizingScalaCompiler implements Compiler<ScalaJavaJointCompileS
                 throw e;
             }
             LOGGER.debug("Ignoring compilation failure.");
-            return new SimpleWorkResult(false);
+            return WorkResult.didWork(false);
         }
     }
 }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.CollectionUtils;
 
@@ -103,7 +104,7 @@ public class NormalizingScalaCompiler implements Compiler<ScalaJavaJointCompileS
                 throw e;
             }
             LOGGER.debug("Ignoring compilation failure.");
-            return WorkResult.didWork(false);
+            return WorkResults.didWork(false);
         }
     }
 }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.time.Timer;
 import org.gradle.internal.time.Timers;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -83,7 +84,7 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec>, S
             }
             LOGGER.info("Completed Scala compilation: {}", timer.getElapsed());
 
-            return WorkResult.didWork(true);
+            return WorkResults.didWork(true);
         }
 
         private static IncOptions getIncOptions() {

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.scala;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.zinc.IncOptions;
 import com.typesafe.zinc.Inputs;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.internal.tasks.compile.CompilationFailedException;
 import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder;
 import org.gradle.api.logging.Logger;
@@ -84,7 +83,7 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec>, S
             }
             LOGGER.info("Completed Scala compilation: {}", timer.getElapsed());
 
-            return new SimpleWorkResult(true);
+            return WorkResult.didWork(true);
         }
 
         private static IncOptions getIncOptions() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractCompiler.java
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.toolchain.internal;
 
 import org.gradle.api.Action;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.logging.BuildOperationLogger;
@@ -57,7 +58,7 @@ public abstract class AbstractCompiler<T extends BinaryToolSpec> implements Comp
             }
         });
 
-        return WorkResult.didWork(true);
+        return WorkResults.didWork(true);
     }
 
     // TODO(daniel): Should support in a better way multi file invocation.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractCompiler.java
@@ -17,7 +17,6 @@
 package org.gradle.nativeplatform.toolchain.internal;
 
 import org.gradle.api.Action;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
@@ -58,7 +57,7 @@ public abstract class AbstractCompiler<T extends BinaryToolSpec> implements Comp
             }
         });
 
-        return new SimpleWorkResult(true);
+        return WorkResult.didWork(true);
     }
 
     // TODO(daniel): Should support in a better way multi file invocation.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -60,7 +59,7 @@ public abstract class NativeCompiler<T extends NativeCompileSpec> extends Abstra
 
         super.execute(spec);
 
-        return new SimpleWorkResult(!transformedSpec.getSourceFiles().isEmpty());
+        return WorkResult.didWork(!transformedSpec.getSourceFiles().isEmpty());
     }
 
     // TODO(daniel): Should support in a better way multi file invocation.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
@@ -25,6 +25,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
@@ -59,7 +60,7 @@ public abstract class NativeCompiler<T extends NativeCompileSpec> extends Abstra
 
         super.execute(spec);
 
-        return WorkResult.didWork(!transformedSpec.getSourceFiles().isEmpty());
+        return WorkResults.didWork(!transformedSpec.getSourceFiles().isEmpty());
     }
 
     // TODO(daniel): Should support in a better way multi file invocation.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompiler.java
@@ -17,6 +17,7 @@
 package org.gradle.nativeplatform.toolchain.internal;
 
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory;
 
@@ -38,7 +39,7 @@ public class OutputCleaningCompiler<T extends NativeCompileSpec> implements Comp
     public WorkResult execute(T spec) {
         boolean didRemove = deleteOutputsForRemovedSources(spec);
         boolean didCompile = compileSources(spec);
-        return WorkResult.didWork(didRemove || didCompile);
+        return WorkResults.didWork(didRemove || didCompile);
     }
 
     private boolean compileSources(T spec) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompiler.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.toolchain.internal;
 
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory;
@@ -39,7 +38,7 @@ public class OutputCleaningCompiler<T extends NativeCompileSpec> implements Comp
     public WorkResult execute(T spec) {
         boolean didRemove = deleteOutputsForRemovedSources(spec);
         boolean didCompile = compileSources(spec);
-        return new SimpleWorkResult(didRemove || didCompile);
+        return WorkResult.didWork(didRemove || didCompile);
     }
 
     private boolean compileSources(T spec) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/javascript/GoogleClosureCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/javascript/GoogleClosureCompiler.java
@@ -19,7 +19,6 @@ package org.gradle.play.internal.javascript;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.internal.file.RelativeFile;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.reflect.DirectInstantiator;
@@ -63,7 +62,7 @@ public class GoogleClosureCompiler implements Compiler<JavaScriptCompileSpec>, S
         }
 
         if (allErrors.isEmpty()) {
-            return new SimpleWorkResult(true);
+            return WorkResult.didWork(true);
         } else {
             throw new SourceTransformationException(String.format("Minification failed with the following errors:\n\t%s", StringUtils.join(allErrors, "\n\t")), null);
         }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/javascript/GoogleClosureCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/javascript/GoogleClosureCompiler.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.internal.file.RelativeFile;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.JavaMethod;
@@ -62,7 +63,7 @@ public class GoogleClosureCompiler implements Compiler<JavaScriptCompileSpec>, S
         }
 
         if (allErrors.isEmpty()) {
-            return WorkResult.didWork(true);
+            return WorkResults.didWork(true);
         } else {
             throw new SourceTransformationException(String.format("Minification failed with the following errors:\n\t%s", StringUtils.join(allErrors, "\n\t")), null);
         }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompiler.java
@@ -17,7 +17,6 @@
 package org.gradle.play.internal.routes;
 
 import com.google.common.collect.Lists;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.scala.internal.reflect.ScalaMethod;
@@ -59,7 +58,7 @@ public class RoutesCompiler implements Compiler<RoutesCompileSpec>, Serializable
             didWork = ret || didWork;
         }
 
-        return new SimpleWorkResult(didWork);
+        return WorkResult.didWork(didWork);
     }
 
     private Boolean compile(File sourceFile, RoutesCompileSpec spec) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompiler.java
@@ -18,6 +18,7 @@ package org.gradle.play.internal.routes;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.scala.internal.reflect.ScalaMethod;
 
@@ -58,7 +59,7 @@ public class RoutesCompiler implements Compiler<RoutesCompileSpec>, Serializable
             didWork = ret || didWork;
         }
 
-        return WorkResult.didWork(didWork);
+        return WorkResults.didWork(didWork);
     }
 
     private Boolean compile(File sourceFile, RoutesCompileSpec spec) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompiler.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.internal.file.RelativeFile;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.FileUtils;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.language.twirl.TwirlTemplateFormat;
@@ -64,7 +65,7 @@ public class TwirlCompiler implements Compiler<TwirlCompileSpec>, Serializable {
             }
         }
 
-        return WorkResult.didWork(!outputFiles.isEmpty());
+        return WorkResults.didWork(!outputFiles.isEmpty());
     }
 
     private ScalaMethod getCompileMethod(ClassLoader cl) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/twirl/TwirlCompiler.java
@@ -19,7 +19,6 @@ package org.gradle.play.internal.twirl;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.gradle.api.internal.file.RelativeFile;
-import org.gradle.api.internal.tasks.SimpleWorkResult;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.FileUtils;
@@ -65,7 +64,7 @@ public class TwirlCompiler implements Compiler<TwirlCompileSpec>, Serializable {
             }
         }
 
-        return new SimpleWorkResult(!outputFiles.isEmpty());
+        return WorkResult.didWork(!outputFiles.isEmpty());
     }
 
     private ScalaMethod getCompileMethod(ClassLoader cl) {


### PR DESCRIPTION
Instead of creating new ones all the time. This is take two, as #2776
failed due to SimpleWorkResult being used in third-party plugins.
