### PR TITLE
Add test for http build cache timeout

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
@@ -69,12 +69,11 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends AbstractIntegrat
     }
 
     def "build cache is deactivated for the build if the connection times out"() {
-        httpBuildCacheServer.blockIncomingConnections = true
+        httpBuildCacheServer.blockIncomingConnectionsForSeconds = 10
         startServer()
 
         when:
-        executer.withArgument("-D${SOCKET_TIMEOUT_SYSTEM_PROPERTY}=2000")
-        executer.withStackTraceChecksDisabled()
+        executer.withArgument("-D${SOCKET_TIMEOUT_SYSTEM_PROPERTY}=1000")
         executer.withStacktraceDisabled()
         withBuildCache().succeeds("customTask")
 

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/HttpBuildCacheService.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/HttpBuildCacheService.java
@@ -67,7 +67,6 @@ public class HttpBuildCacheService implements BuildCacheService {
     );
 
     private final URI root;
-    private final URI safeUri;
     private final HttpClientHelper httpClientHelper;
 
     public HttpBuildCacheService(HttpClientHelper httpClientHelper, URI url) {
@@ -75,7 +74,6 @@ public class HttpBuildCacheService implements BuildCacheService {
             throw new IncompleteArgumentException("HTTP cache root URI must end with '/'");
         }
         this.root = url;
-        this.safeUri = safeUri(url);
         this.httpClientHelper = httpClientHelper;
     }
 

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/HttpBuildCacheService.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/HttpBuildCacheService.java
@@ -107,7 +107,7 @@ public class HttpBuildCacheService implements BuildCacheService {
         } catch (IOException e) {
             // TODO: We should consider different types of exceptions as fatal/recoverable.
             // Right now, everything is considered recoverable.
-            throw new BuildCacheException(String.format("Unable to load entry from '%s'", safeUri(uri)), e);
+            throw new BuildCacheException(String.format("Unable to load entry from '%s': %s", safeUri(uri), e.getMessage()), e);
         } finally {
             HttpClientUtils.closeQuietly(response);
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockFilter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.server.http;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class BlockFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        CountDownLatch latch = new CountDownLatch(1);
+        try {
+            latch.await(60, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // ignore
+        }
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockFilter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockFilter.java
@@ -28,6 +28,12 @@ import java.util.concurrent.TimeUnit;
 
 public class BlockFilter implements Filter {
 
+    private final int blockForSeconds;
+
+    public BlockFilter(int blockForSeconds) {
+        this.blockForSeconds = blockForSeconds;
+    }
+
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
     }
@@ -36,7 +42,7 @@ public class BlockFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         CountDownLatch latch = new CountDownLatch(1);
         try {
-            latch.await(60, TimeUnit.SECONDS);
+            latch.await(blockForSeconds, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             // ignore
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpBuildCacheServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpBuildCacheServer.groovy
@@ -30,7 +30,7 @@ class HttpBuildCacheServer extends ExternalResource implements HttpServerFixture
     private final WebAppContext webapp
     private TestFile cacheDir
     private long dropConnectionForPutBytes = -1
-    boolean blockIncomingConnections
+    private int blockIncomingConnectionsForSeconds = 0
 
     HttpBuildCacheServer(TestDirectoryProvider provider) {
         this.provider = provider
@@ -50,8 +50,8 @@ class HttpBuildCacheServer extends ExternalResource implements HttpServerFixture
         if (dropConnectionForPutBytes > -1) {
             this.webapp.addFilter(new FilterHolder(new DropConnectionFilter(dropConnectionForPutBytes, this)), "/*", 1)
         }
-        if (blockIncomingConnections) {
-            this.webapp.addFilter(new FilterHolder(new BlockFilter()), "/*", 1)
+        if (blockIncomingConnectionsForSeconds > 0) {
+            this.webapp.addFilter(new FilterHolder(new BlockFilter(blockIncomingConnectionsForSeconds)), "/*", 1)
         }
         this.webapp.addFilter(RestFilter, "/*", 1)
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpBuildCacheServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpBuildCacheServer.groovy
@@ -30,6 +30,7 @@ class HttpBuildCacheServer extends ExternalResource implements HttpServerFixture
     private final WebAppContext webapp
     private TestFile cacheDir
     private long dropConnectionForPutBytes = -1
+    boolean blockIncomingConnections
 
     HttpBuildCacheServer(TestDirectoryProvider provider) {
         this.provider = provider
@@ -47,7 +48,10 @@ class HttpBuildCacheServer extends ExternalResource implements HttpServerFixture
 
     private void addFilters() {
         if (dropConnectionForPutBytes > -1) {
-            this.webapp.addFilter(new FilterHolder(new DropConnectionFilter(dropConnectionForPutBytes, this)),"/*", 1)
+            this.webapp.addFilter(new FilterHolder(new DropConnectionFilter(dropConnectionForPutBytes, this)), "/*", 1)
+        }
+        if (blockIncomingConnections) {
+            this.webapp.addFilter(new FilterHolder(new BlockFilter()), "/*", 1)
         }
         this.webapp.addFilter(RestFilter, "/*", 1)
     }


### PR DESCRIPTION
Fixing #868 via #2757 also introduces timeouts for connecting to an
HTTP build cache. We just add a test to verify this.
While writing the test I realized that we do not print the real cause
for failing with the HTTP backend when not printing the stack trace,
so I fixed that, too.
