### PR TITLE
 Add Java 6/7 cross compilation guide in Java plugin user guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/groovyPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/groovyPlugin.adoc
@@ -268,9 +268,9 @@ The Groovy plugin adds a api:org.gradle.api.tasks.compile.GroovyCompile[] task f
 
 
 [[sec:groovy_cross_compilation]]
-=== Compiling and testing for Java 6
+=== Compiling and testing for Java 6/7
 
-The Groovy compiler will always be executed with the same version of Java that was used to start Gradle. You should set `sourceCompatibility` and `targetCompatibility` to `1.6`. If you also have Java sources, you can follow the same steps as for the <<sec:java_cross_compilation,Java plugin>> to ensure the correct Java compiler is used.
+The Groovy compiler will always be executed with the same version of Java that was used to start Gradle. You should set `sourceCompatibility` and `targetCompatibility` to `1.6` or `1.7`. If you also have Java sources, you can follow the same steps as for the <<sec:java_cross_compilation,Java plugin>> to ensure the correct Java compiler is used.
 ++++
 <sample xmlns:xi="http://www.w3.org/2001/XInclude" id="groovyCrossCompilation" dir="groovy/crossCompilation" title="Configure Java 6 build for Groovy">
                 <sourcefile file="gradle.properties"/>

--- a/subprojects/docs/src/docs/userguide/groovyPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/groovyPlugin.adoc
@@ -268,7 +268,7 @@ The Groovy plugin adds a api:org.gradle.api.tasks.compile.GroovyCompile[] task f
 
 
 [[sec:groovy_cross_compilation]]
-=== Compiling and testing for Java 6/7
+=== Compiling and testing for Java 6 or Java 7
 
 The Groovy compiler will always be executed with the same version of Java that was used to start Gradle. You should set `sourceCompatibility` and `targetCompatibility` to `1.6` or `1.7`. If you also have Java sources, you can follow the same steps as for the <<sec:java_cross_compilation,Java plugin>> to ensure the correct Java compiler is used.
 ++++

--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -1005,17 +1005,17 @@ You can easily write a manifest to disk.
 How to upload your archives is described in <<artifact_management>>.
 
 [[sec:java_cross_compilation]]
-=== Compiling and testing for Java 6
+=== Compiling and testing for Java 6/7
 
-Gradle can only run on Java version 7 or higher. Gradle 3.x still supports compiling, testing, generating Javadoc and executing applications for Java 6. Java 5 is not supported.
+Support for running Gradle on Java 7 has been deprecated and is scheduled to be removed in Gradle 5.0. However, it still supports compiling, testing, generating Javadoc and executing applications for Java 6 and Java 7. Java 5 is not supported.
 
-To use Java 6 the following tasks need to be configured:
+To use Java 6 or Java 7, the following tasks need to be configured:
 
 * `JavaCompile` task to fork and use the correct Java home
 * `Javadoc` task to use the correct `javadoc` executable
 * `Test` and the `JavaExec` task to use the correct `java` executable.
 
-The following sample shows how the `build.gradle` needs to be adjusted. In order to be able to make the build machine-independent, the location of the Java 6 home should be configured in `GRADLE_USER_HOME/gradle.properties` footnote:[For more details on `gradle.properties` see <<sec:gradle_configuration_properties>> ] in the users home directory on each developer machine, as shown in the example.
+The following sample shows how the `build.gradle` needs to be adjusted. In order to be able to make the build machine-independent, the location of the old Java home and target version should be configured in `GRADLE_USER_HOME/gradle.properties` footnote:[For more details on `gradle.properties` see <<sec:gradle_configuration_properties>> ] in the user's home directory on each developer machine, as shown in the example.
 
 ++++
 <sample xmlns:xi="http://www.w3.org/2001/XInclude" id="javaCrossCompilation" dir="java/crossCompilation" title="Configure Java 6 build">

--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -1005,9 +1005,9 @@ You can easily write a manifest to disk.
 How to upload your archives is described in <<artifact_management>>.
 
 [[sec:java_cross_compilation]]
-=== Compiling and testing for Java 6/7
+=== Compiling and testing for Java 6 or Java7
 
-Support for running Gradle on Java 7 has been deprecated and is scheduled to be removed in Gradle 5.0. However, it still supports compiling, testing, generating Javadoc and executing applications for Java 6 and Java 7. Java 5 is not supported.
+Gradle can only run on Java version 7 or higher. However, support for running Gradle on Java 7 has been deprecated and is scheduled to be removed in Gradle 5.0. Gradle still supports compiling, testing, generating Javadoc and executing applications for Java 6 and Java 7. Java 5 is not supported.
 
 To use Java 6 or Java 7, the following tasks need to be configured:
 

--- a/subprojects/docs/src/docs/userguide/scalaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/scalaPlugin.adoc
@@ -290,7 +290,7 @@ Incremental compilation requires dependency analysis of the source code. The res
 Note that Zinc's Nailgun based daemon mode is not supported. Instead, we plan to enhance Gradle's own compiler daemon to stay alive across Gradle invocations, reusing the same Scala compiler. This is expected to yield another significant speedup for Scala compilation.
 
 [[sec:scala_cross_compilation]]
-=== Compiling and testing for Java 6
+=== Compiling and testing for Java 6/7
 
 The Scala compiler ignores Gradle's `targetCompatibility` and `sourceCompatibility` settings. In Scala 2.11, the Scala compiler always compiles to Java 6 compatible bytecode. In Scala 2.12, the Scala compiler always compiles to Java 8 compatible bytecode. If you also have Java sources, you can follow the same steps as for the <<sec:java_cross_compilation,Java plugin>> to ensure the correct Java compiler is used.
 ++++

--- a/subprojects/docs/src/docs/userguide/scalaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/scalaPlugin.adoc
@@ -290,7 +290,7 @@ Incremental compilation requires dependency analysis of the source code. The res
 Note that Zinc's Nailgun based daemon mode is not supported. Instead, we plan to enhance Gradle's own compiler daemon to stay alive across Gradle invocations, reusing the same Scala compiler. This is expected to yield another significant speedup for Scala compilation.
 
 [[sec:scala_cross_compilation]]
-=== Compiling and testing for Java 6/7
+=== Compiling and testing for Java 6 or Java 7
 
 The Scala compiler ignores Gradle's `targetCompatibility` and `sourceCompatibility` settings. In Scala 2.11, the Scala compiler always compiles to Java 6 compatible bytecode. In Scala 2.12, the Scala compiler always compiles to Java 8 compatible bytecode. If you also have Java sources, you can follow the same steps as for the <<sec:java_cross_compilation,Java plugin>> to ensure the correct Java compiler is used.
 ++++

--- a/subprojects/docs/src/samples/java/crossCompilation/build.gradle
+++ b/subprojects/docs/src/samples/java/crossCompilation/build.gradle
@@ -7,24 +7,26 @@ repositories {
 }
 
 dependencies {
-    compile group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
     testCompile group: 'junit', name: 'junit', version: '4.+'
 }
 
 // START SNIPPET java-cross-compilation
-sourceCompatibility = 1.6
+assert hasProperty('javaHome'): "Set the property 'javaHome' in your your gradle.properties pointing to a Java 6 or 7 installation"
+assert hasProperty('targetJavaVersion'): "Set the property 'targetJavaVersion' in your your gradle.properties to '1.6' or '1.7'"
 
-assert hasProperty('java6Home') : "Set the property 'java6Home' in your your gradle.properties pointing to a Java 6 installation"
-def javaExecutablesPath = new File(java6Home, 'bin')
+sourceCompatibility = targetJavaVersion
+
+def javaExecutablesPath = new File(javaHome, 'bin')
 def javaExecutables = [:].withDefault { execName ->
     def executable = new File(javaExecutablesPath, execName)
-    assert executable.exists() : "There is no ${execName} executable in ${javaExecutablesPath}"
+    assert executable.exists(): "There is no ${execName} executable in ${javaExecutablesPath}"
     executable
 }
 tasks.withType(AbstractCompile) {
     options.with {
         fork = true
-        forkOptions.javaHome = file(java6Home)
+        forkOptions.javaHome = file(javaHome)
     }
 }
 tasks.withType(Javadoc) {
@@ -37,3 +39,17 @@ tasks.withType(JavaExec) {
     executable = javaExecutables.java
 }
 // END SNIPPET java-cross-compilation
+
+tasks.withType(Test) {
+    systemProperty 'targetJavaVersion', targetJavaVersion
+}
+
+task checkJavadocOutput {
+    dependsOn javadoc
+    doLast {
+        assert new File(docsDir, 'javadoc/org/gradle/Person.html').text.contains('<p>Represents a person.</p>')
+    }
+}
+
+build.dependsOn checkJavadocOutput
+

--- a/subprojects/docs/src/samples/java/crossCompilation/build.gradle
+++ b/subprojects/docs/src/samples/java/crossCompilation/build.gradle
@@ -7,7 +7,8 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
+    // We should use a legacy version to support running on jdk6
+    compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testCompile group: 'junit', name: 'junit', version: '4.+'
 }
 

--- a/subprojects/docs/src/samples/java/crossCompilation/gradle.properties
+++ b/subprojects/docs/src/samples/java/crossCompilation/gradle.properties
@@ -1,2 +1,3 @@
 # in $HOME/.gradle/gradle.properties
-java6Home=/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
+javaHome=/Library/Java/JavaVirtualMachines/1.7.0.jdk/Contents/Home
+targetJavaVersion=1.7

--- a/subprojects/docs/src/samples/java/crossCompilation/src/main/java/org/gradle/Person.java
+++ b/subprojects/docs/src/samples/java/crossCompilation/src/main/java/org/gradle/Person.java
@@ -1,15 +1,25 @@
 package org.gradle;
 
-import org.apache.commons.collections.list.GrowthList;
+import org.apache.commons.lang3.StringUtils;
 
+/**
+ * <p>Represents a person.</p>
+ */
 public class Person {
     private final String name;
 
     public Person(String name) {
+        if (StringUtils.isEmpty(name)) {
+            throw new IllegalArgumentException();
+        }
         this.name = name;
-        new GrowthList();
     }
 
+    /**
+     * Get the person's name
+     *
+     * @return the name
+     */
     public String getName() {
         return name;
     }

--- a/subprojects/docs/src/samples/java/crossCompilation/src/main/java/org/gradle/Person.java
+++ b/subprojects/docs/src/samples/java/crossCompilation/src/main/java/org/gradle/Person.java
@@ -1,6 +1,6 @@
 package org.gradle;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * <p>Represents a person.</p>

--- a/subprojects/docs/src/samples/java/crossCompilation/src/test/java/org/gradle/PersonTest.java
+++ b/subprojects/docs/src/samples/java/crossCompilation/src/test/java/org/gradle/PersonTest.java
@@ -27,8 +27,14 @@ public class PersonTest {
         assertEquals("Larry", person.getName());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void cannotConstructAPersonWithEmptyName() {
+        Person person = new Person("");
+        person.getName();
+    }
+
     @Test
     public void testJavaVersion() {
-        assertEquals(System.getProperty("java.version").substring(0, 3), "1.6");
+        assertEquals(System.getProperty("java.version").substring(0, 3), System.getProperty("targetJavaVersion"));
     }
 }


### PR DESCRIPTION
Add Java 7 cross compilation guide in Java plugin user guide as a preparation for Java 7 deprecation.
