### PR TITLE
Compress Gradle runtime jars

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
@@ -127,9 +127,7 @@ class RuntimeShadedJarCreator {
 
     private ZipOutputStream openJarOutputStream(File outputJar) {
         try {
-            ZipOutputStream outputStream = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(outputJar), BUFFER_SIZE));
-            outputStream.setLevel(0);
-            return outputStream;
+            return new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(outputJar), BUFFER_SIZE));
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
@@ -160,7 +160,7 @@ org.gradle.api.internal.tasks.CompileServices
                 'META-INF/services/org.gradle.internal.other.Service',
                 'META-INF/.gradle-runtime-shaded']
         }
-        outputJar.md5Hash == "8eb7b9c992e83362a1445585b00a4fd0"
+        outputJar.md5Hash == "e1d4b5e36f581ae20d5465806c925246"
     }
 
     def "excludes module-info.class from jar"() {


### PR DESCRIPTION
### Context

There's no good reason I can think of why we should turn off compression for the runtime JARs. This change enables default compression which creates JARs with roughly half the size as before. It will also save some disk spaces for users of multiple Gradle versions in parallel or in an upgrade scenario.

__Before change:__

gradle-api JAR: 99.1MB
gradle-testkit JAR: 86KB

__After change:__

gradle-api JAR: 41MB
gradle-testkit JAR: 41KB

Branch build: https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger&branch_Gradle_Check=bm%2Fcompress-runtime-jars&tab=buildTypeStatusDiv

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
