### PR TITLE
Make CheckStyle plugin work by default for multi-project builds

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginMultiProjectTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/CheckstylePluginMultiProjectTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins.quality
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
+
+    def "configures checkstyle extension to read config from root project"() {
+        given:
+        def rootProject = multiProjectBuild('rootCheckStyle', ['child']) {
+            settingsFile << """
+include 'child:grand'
+"""
+        }
+        rootProject.file("child/grand/build.gradle") << """
+apply plugin: "java"
+apply plugin: "checkstyle"
+
+${mavenCentralRepository()}
+"""
+        rootProject.file('child/grand/src/main/java/Dummy.java') << "public class Dummy {}\n"
+        rootProject.file('child/grand', 'config/checkstyle/checkstyle.xml') << "INVALID AND SHOULD NEVER BE READ"
+        rootProject.file('config/checkstyle/checkstyle.xml') << simpleCheckStyleConfig()
+
+        expect:
+        succeeds(":child:grand:checkstyleMain")
+        checkStyleReportFile(rootProject.file('child/grand')).text.contains('Dummy.java')
+    }
+
+    private static String simpleCheckStyleConfig() {
+        """
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+    <module name="NewlineAtEndOfFile"/>
+</module>
+        """
+    }
+
+    private static File checkStyleReportFile(File projectDir) {
+        new File(projectDir, 'build/reports/checkstyle/main.html')
+    }
+}

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -52,7 +52,7 @@ public class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
         extension = project.getExtensions().create("checkstyle", CheckstyleExtension.class, project);
         extension.setToolVersion(DEFAULT_CHECKSTYLE_VERSION);
 
-        extension.setConfigDir(project.file("config/checkstyle"));
+        extension.setConfigDir(project.getRootProject().file("config/checkstyle"));
         extension.setConfig(project.getResources().getText().fromFile(new Callable<File>() {
             @Override
             public File call() throws Exception {

--- a/subprojects/docs/src/docs/userguide/checkstylePlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/checkstylePlugin.adoc
@@ -77,9 +77,9 @@ The Checkstyle plugin adds the following dependencies to tasks defined by the Ja
 [[sec:checkstyle_project_layout]]
 === Project layout
 
-By default, the Checkstyle plugin expects the following project layout, but this can be changed:
+By default, the Checkstyle plugin expects configuration files to be placed in the root project, but this can be changed. With default settings of the plugin, CheckStyle configuration files used for checking all subprojects are kept in a single place.
 
-.Checkstyle plugin - project layout
+.Checkstyle plugin - root project layout
 [cols="a,a", options="header"]
 |===
 | File


### PR DESCRIPTION
Fixes #2765

### Context
Will speed up setting CheckStyle for multi-project builds.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
