### PR TITLE
Explain why Java 7 support has been deprecated

### DIFF
--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -1007,7 +1007,12 @@ How to upload your archives is described in <<artifact_management>>.
 [[sec:java_cross_compilation]]
 === Compiling and testing for Java 6 or Java7
 
-Gradle can only run on Java version 7 or higher. However, support for running Gradle on Java 7 has been deprecated and is scheduled to be removed in Gradle 5.0. Gradle still supports compiling, testing, generating Javadoc and executing applications for Java 6 and Java 7. Java 5 is not supported.
+Gradle can only run on Java version 7 or higher. However, support for running Gradle on Java 7 has been deprecated and is scheduled to be removed in Gradle 5.0. There are two reasons for deprecating support for Java 7:
+
+* Java 7 reached link:http://www.oracle.com/technetwork/java/javase/eol-135779.html[end of life]. Therefore, Oracle ceased public availability of security fixes and upgrades for Java 7 as of April 2015.
+* Once support for Java 7 has ceased (likely with Gradle 5.0), Gradle's implementation can start to use Java 8 APIs optimized for performance and usability.
+
+Gradle still supports compiling, testing, generating Javadoc and executing applications for Java 6 and Java 7. Java 5 is not supported.
 
 To use Java 6 or Java 7, the following tasks need to be configured:
 


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle-private/issues/935#issuecomment-324648508
