### PR TITLE
Cache performance templates for JavaExecProjectGeneratorTask

### DIFF
--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -26,6 +26,11 @@ import org.gradle.testing.performance.generator.tasks.RemoteProject
  'smallJavaMultiProject'].each { template ->
     tasks.create(template, JavaExec) {
         outputs.dir new File(buildDir, template)
+        outputs.cacheIf { true }
+        inputs.property('template', template)
+        inputs.property('args') { // Arguments are covered by the testProjectName and the outputs. We don't want them to contain the absolute path
+            return []
+        }
         classpath = sourceSets.performanceTest.runtimeClasspath
         main = 'org.gradle.performance.generator.TestProjectGenerator'
         args name, buildDir.absolutePath


### PR DESCRIPTION
Generating perfomance projects seems to be expensive. Let's just use the build cache for it!
For `largeJavaMultiProject` we have [2 minutes](https://e.grdev.net/s/uocrnkdra62f2/performance/build) vs [20 seconds](https://e.grdev.net/s/452tqko7vas2w/performance/build).