### PR TITLE
Add test coverage for `xctest` component

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileProvidersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileProvidersIntegrationTest.groovy
@@ -344,4 +344,75 @@ task useDirProvider {
         file("output/merged.txt").text == 'new-file1,file2,dir1'
     }
 
+    def "can wire the output directory of a task as input directory to another task"() {
+        buildFile << """
+            class DirOutputTask extends DefaultTask {
+                @InputFile
+                final RegularFileVar inputFile = newInputFile()
+
+                @OutputDirectory
+                final DirectoryVar outputDir = newOutputDirectory()
+
+                @TaskAction
+                void go() {
+                    def dir = outputDir.asFile.get()
+                    new File(dir, "file.txt").text = inputFile.asFile.get().text
+                }
+            }
+
+            class MergeTask extends DefaultTask {
+                @InputDirectory
+                final DirectoryVar inputDir1 = newInputDirectory()
+                @InputDirectory
+                final DirectoryVar inputDir2 = newInputDirectory()
+                @OutputFile
+                final RegularFileVar outputFile = newOutputFile()
+
+                @TaskAction
+                void go() {
+                    def file = outputFile.asFile.get()
+                    file.text = [inputDir1, inputDir2]*.asFile*.get()*.listFiles().flatten()*.text.join(',')
+                }
+            }
+
+            task createDir1(type: DirOutputTask)
+            task createDir2(type: DirOutputTask)
+            task merge(type: MergeTask) {
+                outputFile = layout.buildDirectory.file("merged.txt")
+                inputDir1 = createDir1.outputDir
+                inputDir2 = createDir2.outputDir
+            }
+
+            // Set values lazily
+            createDir1.inputFile = layout.projectDirectory.file("dir1-source.txt")
+            createDir1.outputDir = layout.buildDirectory.dir("dir1")
+            createDir2.inputFile = layout.projectDirectory.file("dir2-source.txt")
+            createDir2.outputDir = layout.buildDirectory.dir("dir2")
+
+            buildDir = "output"
+"""
+        file("dir1-source.txt").text = "dir1"
+        file("dir2-source.txt").text = "dir2"
+
+        when:
+        run("merge")
+
+        then:
+        result.assertTasksExecuted(":createDir1", ":createDir2", ":merge")
+        file("output/merged.txt").text == 'dir1,dir2'
+
+        when:
+        run("merge")
+
+        then:
+        result.assertTasksNotSkipped()
+
+        when:
+        file("dir1-source.txt").text = "new-dir1"
+        run("merge")
+
+        then:
+        result.assertTasksNotSkipped(":createDir1", ":merge")
+        file("output/merged.txt").text == 'new-dir1,dir2'
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -1005,4 +1005,15 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     protected RegularFileVar newInputFile() {
         return getServices().get(TaskFileVarFactory.class).newInputFile(this);
     }
+
+    /**
+     * Creates a new input directory property for this task.
+     *
+     * @return The property.
+     * @since 4.3
+     */
+    @Incubating
+    protected DirectoryVar newInputDirectory() {
+        return getServices().get(TaskFileVarFactory.class).newInputDirectory(this);
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -91,6 +91,18 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
     }
 
     @Override
+    public DirectoryVar newInputDirectory(final Task consumer) {
+        final DefaultDirectoryVar directoryVar = new DefaultDirectoryVar(projectDir.fileResolver);
+        consumer.dependsOn(new AbstractTaskDependency() {
+            @Override
+            public void visitDependencies(TaskDependencyResolveContext context) {
+                directoryVar.visitDependencies(context);
+            }
+        });
+        return directoryVar;
+    }
+
+    @Override
     public Provider<RegularFile> file(Provider<File> provider) {
         return new AbstractMappingProvider<RegularFile, File>(RegularFile.class, provider) {
             @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/TaskFileVarFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/TaskFileVarFactory.java
@@ -26,4 +26,6 @@ public interface TaskFileVarFactory {
     RegularFileVar newOutputFile(Task producer);
 
     RegularFileVar newInputFile(Task consumer);
+
+    DirectoryVar newInputDirectory(Task consumer);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputDirectoryPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputDirectoryPropertyAnnotationHandler.java
@@ -16,9 +16,11 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
+import org.gradle.util.DeferredUtil;
 
 import java.io.File;
 import java.lang.annotation.Annotation;
@@ -42,12 +44,15 @@ public class InputDirectoryPropertyAnnotationHandler extends AbstractInputProper
     }
 
     private File toFile(Object value) {
-        if (value instanceof ConfigurableFileTree) {
-            return ((ConfigurableFileTree) value).getDir();
-        } else if (value instanceof Path) {
-            return ((Path) value).toFile();
+        Object unpacked = DeferredUtil.unpack(value);
+        if (unpacked instanceof ConfigurableFileTree) {
+            return ((ConfigurableFileTree) unpacked).getDir();
+        } else if (unpacked instanceof Path) {
+            return ((Path) unpacked).toFile();
+        } else if (unpacked instanceof FileSystemLocation) {
+            return ((FileSystemLocation) unpacked).getAsFile();
         } else {
-            return (File) value;
+            return (File) unpacked;
         }
     }
 

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -42,6 +42,70 @@
             "changes": [
                 "Method has been removed in superclass"
             ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.test.xctest.plugins.XCTestConventionPlugin",
+            "member": "Constructor XCTestConventionPlugin",
+            "acceptation": "Injectable constructor, shouldn't be used directly by users",
+            "changes": [
+                "Constructor has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle",
+            "member": "Constructor CreateXcTestBundle",
+            "acceptation": "The incubating task was moved and renamed",
+            "changes": [
+                "Constructor has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle",
+            "member": "Implemented interface org.gradle.api.Task",
+            "acceptation": "The incubating task was moved and renamed",
+            "changes": [
+                "Interface has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle",
+            "member": "Implemented interface org.gradle.util.Configurable",
+            "acceptation": "The incubating task was moved and renamed",
+            "changes": [
+                "Interface has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle",
+            "member": "Implemented interface org.gradle.api.internal.TaskInternal",
+            "acceptation": "The incubating task was moved and renamed",
+            "changes": [
+                "Interface has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle",
+            "member": "Implemented interface org.gradle.api.plugins.ExtensionAware",
+            "acceptation": "The incubating task was moved and renamed",
+            "changes": [
+                "Interface has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle",
+            "member": "Implemented interface java.lang.Comparable",
+            "acceptation": "The incubating task was moved and renamed",
+            "changes": [
+                "Interface has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle",
+            "member": "Implemented interface org.gradle.api.internal.DynamicObjectAware",
+            "acceptation": "The incubating task was moved and renamed",
+            "changes": [
+                "Interface has been removed"
+            ]
         }
 
     ]

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -8,10 +8,20 @@ Add-->
 
 ### Improvements for plugin authors
 
+In Gradle 4.1, we added APIs that allow a specific task output directory or output file to be wired in as an input for another task, in a way that allows the task dependencies to be inferred and that deals with later changes to the configured locations of those outputs. It is intended to be a more robust, performant and descriptive alternative to using `File` property types and calls to `Task.dependsOn`.
+
+It added factory methods on `DefaultTask` - i.e. `newInputFile()`, `newOutputFile()`, and `newOutputDirectory()` - to allow a task implementation class to create `DirectoryVar` instances that represent an output directory, and `RegularFileVar` instances that represent an output file or directory. When used as an output directory or file property, these instances carry dependency information about the producing task. When used as an input file property, the producing task is tracked as a dependency of the consuming task. Similar support for input files is done using `ConfigurableFileCollection` and friends, as has been possible for quite a while.
+
+In Gradle 4.3, we added a new factory method on `DefaultTask` - i.e. `newInputDirectory()` - to allow a task implementation class to create `DirectoryVar` instances that represent an input directory.
+
 TBD: `Provider<T>` and `PropertyState<T>` can be used with `@Input` properties.
 TBD: `ListProperty<T>`
 TBD: `Provider.map()`
 TBD: `PropertyState<Directory>` and `PropertyState<RegularFile>` can be set using `File` in DSL.
+
+<!--
+### Example new and noteworthy
+-->
 
 ## Promoted features
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Names.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Names.java
@@ -22,11 +22,11 @@ public abstract class Names {
 
     public static Names of(String name) {
         // Assume that names that end with 'Exe' represent the 'main' variant of the parent thing
-        if (name.equals("main") || name.equals("mainExe")) {
+        if (name.equals("main") || name.equals("mainBundle")) {
             return new Main();
         }
-        if (name.endsWith("Exe")) {
-            return new Other(name.substring(0, name.length() - 3));
+        if (name.endsWith("Bundle")) {
+            return new Other(name.substring(0, name.length() - 6));
         }
         return new Other(name);
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/registry/NativeLanguageServices.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/registry/NativeLanguageServices.java
@@ -20,6 +20,7 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.language.nativeplatform.internal.incremental.DefaultCompilationStateCacheFactory;
 import org.gradle.language.nativeplatform.internal.incremental.DefaultIncrementalCompilerBuilder;
+import org.gradle.language.swift.internal.SwiftStdlibToolLocator;
 
 public class NativeLanguageServices extends AbstractPluginServiceRegistry {
     @Override
@@ -30,5 +31,10 @@ public class NativeLanguageServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerProjectServices(ServiceRegistration registration) {
         registration.add(DefaultIncrementalCompilerBuilder.class);
+    }
+
+    @Override
+    public void registerBuildSessionServices(ServiceRegistration registration) {
+        registration.add(SwiftStdlibToolLocator.class);
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBundle.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBundle.java
@@ -14,29 +14,21 @@
  * limitations under the License.
  */
 
-package org.gradle.nativeplatform.test.xctest;
+package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.file.DirectoryVar;
-import org.gradle.language.swift.SwiftBundle;
-import org.gradle.language.swift.SwiftComponent;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
 
 /**
- * An XCTest suite, implemented in Swift.
+ * An bundle built from Swift source.
  *
- * @since 4.2
+ * @since 4.3
  */
 @Incubating
-public interface SwiftXCTestSuite extends SwiftComponent {
+public interface SwiftBundle extends SwiftBinary {
     /**
-     * Returns the executable that is built to run this test suite.
+     * Defines the location of Info.plist.
      */
-    SwiftBundle getExecutable();
-
-    /**
-     * Returns the resource directory for this component.
-     *
-     * <p>{@code src/test/resources} is used by default.
-     */
-    DirectoryVar getResourceDir();
+    Provider<RegularFile> getInformationPropertyList();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/AbstractLocator.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/AbstractLocator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.nativeplatform.test.xctest.internal;
+package org.gradle.language.swift.internal;
 
 import org.gradle.process.internal.ExecAction;
 import org.gradle.process.internal.ExecActionFactory;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBundle.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBundle.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.swift.internal;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.DirectoryVar;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
+import org.gradle.language.swift.SwiftBundle;
+
+public class DefaultSwiftBundle extends DefaultSwiftBinary implements SwiftBundle {
+    private final Provider<RegularFile> informationPropertyList;
+
+    public DefaultSwiftBundle(String name, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, DirectoryVar resourceDirectory) {
+        super(name, objectFactory, module, debuggable, source, configurations, implementation);
+
+        informationPropertyList = resourceDirectory.file("Info.plist");
+    }
+
+    @Override
+    public Provider<RegularFile> getInformationPropertyList() {
+        return informationPropertyList;
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/SwiftStdlibToolLocator.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/SwiftStdlibToolLocator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.nativeplatform.test.xctest.internal;
+package org.gradle.language.swift.internal;
 
 import org.gradle.process.internal.ExecActionFactory;
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -35,12 +35,12 @@ import org.gradle.language.swift.SwiftBinary;
 import org.gradle.language.swift.SwiftBundle;
 import org.gradle.language.swift.SwiftExecutable;
 import org.gradle.language.swift.SwiftSharedLibrary;
-import org.gradle.language.swift.tasks.CreateBundle;
+import org.gradle.language.swift.tasks.CreateSwiftBundle;
 import org.gradle.language.swift.tasks.SwiftCompile;
 import org.gradle.model.internal.registry.ModelRegistry;
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
-import org.gradle.nativeplatform.tasks.LinkBundle;
+import org.gradle.nativeplatform.tasks.LinkMachOBundle;
 import org.gradle.nativeplatform.tasks.LinkExecutable;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
@@ -143,7 +143,7 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     link.setDebuggable(binary.isDebuggable());
                 } else if (binary instanceof SwiftBundle) {
                     // Add a link task
-                    LinkBundle link = tasks.create(names.getTaskName("link"), LinkBundle.class);
+                    LinkMachOBundle link = tasks.create(names.getTaskName("link"), LinkMachOBundle.class);
                     link.source(compile.getObjectFileDir().getAsFileTree().matching(new PatternSet().include("**/*.obj", "**/*.o")));
                     link.lib(binary.getLinkLibraries());
                     final PlatformToolProvider toolProvider = ((NativeToolChainInternal) toolChain).select(currentPlatform);
@@ -158,7 +158,7 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     link.setToolChain(toolChain);
                     link.setDebuggable(binary.isDebuggable());
 
-                    final CreateBundle bundle = tasks.create(names.getTaskName("bundle"), CreateBundle.class);
+                    final CreateSwiftBundle bundle = tasks.create(names.getTaskName("bundle"), CreateSwiftBundle.class);
                     bundle.getExecutableFile().set(link.getBinaryFile());
                     bundle.getInformationFile().set(((SwiftBundle) binary).getInformationPropertyList());
                     Provider<Directory> bundleLocation = buildDirectory.dir(providers.provider(new Callable<String>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -158,7 +158,7 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     link.setToolChain(toolChain);
                     link.setDebuggable(binary.isDebuggable());
 
-                    final CreateSwiftBundle bundle = tasks.create(names.getTaskName("bundle"), CreateSwiftBundle.class);
+                    final CreateSwiftBundle bundle = tasks.create(names.getTaskName("bundleSwift"), CreateSwiftBundle.class);
                     bundle.getExecutableFile().set(link.getBinaryFile());
                     bundle.getInformationFile().set(((SwiftBundle) binary).getInformationPropertyList());
                     Provider<Directory> bundleLocation = buildDirectory.dir(providers.provider(new Callable<String>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/CreateBundle.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/CreateBundle.java
@@ -14,40 +14,36 @@
  * limitations under the License.
  */
 
-package org.gradle.nativeplatform.test.xctest.tasks;
+package org.gradle.language.swift.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.CopySpec;
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryVar;
-import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileVar;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.nativeplatform.test.xctest.internal.SwiftStdlibToolLocator;
+import org.gradle.language.swift.internal.SwiftStdlibToolLocator;
 import org.gradle.process.ExecSpec;
 
 import javax.inject.Inject;
-import java.io.File;
 
 /**
- * Creates XCTest bundle for execution.
+ * Creates Apple bundle.
  *
- * @since 4.2
+ * @since 4.3
  */
 @Incubating
-public class CreateXcTestBundle extends DefaultTask {
+public class CreateBundle extends DefaultTask {
     private final RegularFileVar informationFile;
     private final RegularFileVar executableFile;
     private final DirectoryVar outputDir;
     private final SwiftStdlibToolLocator swiftStdlibToolLocator;
 
     @Inject
-    public CreateXcTestBundle(SwiftStdlibToolLocator swiftStdlibToolLocator) {
+    public CreateBundle(SwiftStdlibToolLocator swiftStdlibToolLocator) {
         this.informationFile = newInputFile();
         this.executableFile = newInputFile();
         this.outputDir = newOutputDirectory();
@@ -84,7 +80,7 @@ public class CreateXcTestBundle extends DefaultTask {
                 execSpec.executable(swiftStdlibToolLocator.find());
                 execSpec.args(
                     "--copy",
-                    "--scan-executable", getExecutableFile().getAbsolutePath(),
+                    "--scan-executable", executableFile.getAsFile().get().getAbsolutePath(),
                     "--destination", outputDir.dir("Contents/Frameworks").get().getAsFile().getAbsolutePath(),
                     "--platform", "macosx",
                     "--resource-destination", outputDir.dir("Contents/Resources").get().getAsFile().getAbsolutePath(),
@@ -95,41 +91,17 @@ public class CreateXcTestBundle extends DefaultTask {
     }
 
     @OutputDirectory
-    public File getOutputDir() {
-        return outputDir.getAsFile().getOrNull();
-    }
-
-    public void setOutputDir(File outputDir) {
-        this.outputDir.set(outputDir);
-    }
-
-    public void setOutputDir(Provider<? extends Directory> outputDir) {
-        this.outputDir.set(outputDir);
+    public DirectoryVar getOutputDir() {
+        return outputDir;
     }
 
     @InputFile
-    public File getExecutableFile() {
-        return executableFile.getAsFile().getOrNull();
-    }
-
-    public void setExecutableFile(File executableFile) {
-        this.executableFile.set(executableFile);
-    }
-
-    public void setExecutableFile(Provider<? extends RegularFile> executableFile) {
-        this.executableFile.set(executableFile);
+    public RegularFileVar getExecutableFile() {
+        return executableFile;
     }
 
     @InputFile
-    public File getInformationFile() {
-        return informationFile.getAsFile().getOrNull();
-    }
-
-    public void setInformationFile(File informationFile) {
-        this.informationFile.set(informationFile);
-    }
-
-    public void setInformationFile(Provider<? extends RegularFile> informationFile) {
-        this.informationFile.set(informationFile);
+    public RegularFileVar getInformationFile() {
+        return informationFile;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/CreateSwiftBundle.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/CreateSwiftBundle.java
@@ -31,7 +31,7 @@ import org.gradle.process.ExecSpec;
 import javax.inject.Inject;
 
 /**
- * Creates Apple bundle.
+ * Creates Apple bundle from compiled Swift code.
  *
  * @since 4.3
  */

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/CreateSwiftBundle.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/CreateSwiftBundle.java
@@ -36,14 +36,14 @@ import javax.inject.Inject;
  * @since 4.3
  */
 @Incubating
-public class CreateBundle extends DefaultTask {
+public class CreateSwiftBundle extends DefaultTask {
     private final RegularFileVar informationFile;
     private final RegularFileVar executableFile;
     private final DirectoryVar outputDir;
     private final SwiftStdlibToolLocator swiftStdlibToolLocator;
 
     @Inject
-    public CreateBundle(SwiftStdlibToolLocator swiftStdlibToolLocator) {
+    public CreateSwiftBundle(SwiftStdlibToolLocator swiftStdlibToolLocator) {
         this.informationFile = newInputFile();
         this.executableFile = newInputFile();
         this.outputDir = newOutputDirectory();

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/NamesTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/NamesTest.groovy
@@ -41,7 +41,7 @@ class NamesTest extends Specification {
 
     def "names for main variant of main"() {
         expect:
-        def name = Names.of("mainExe")
+        def name = Names.of("mainBundle")
         name.getCompileTaskName("cpp") == "compileCpp"
         name.getTaskName("link") == "link"
         name.getDirName() == "main/"
@@ -71,7 +71,7 @@ class NamesTest extends Specification {
 
     def "names for main variants of custom"() {
         expect:
-        def name = Names.of("customExe")
+        def name = Names.of("customBundle")
         name.getCompileTaskName("cpp") == "compileCustomCpp"
         name.getTaskName("link") == "linkCustom"
         name.getDirName() == "custom/"

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBundleTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBundleTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.swift.internal
+
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.file.DefaultProjectLayout
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.provider.Provider
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
+import org.junit.Rule
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(DefaultSwiftBundle)
+class DefaultSwiftBundleTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+
+    def resourceDirectory
+    DefaultSwiftBundle binary
+
+    def setup() {
+        def projectLayout = new DefaultProjectLayout(tmpDir.testDirectory, TestFiles.resolver(tmpDir.testDirectory))
+        resourceDirectory = projectLayout.newDirectoryVar()
+        resourceDirectory.set(tmpDir.file("resources"))
+
+        binary = new DefaultSwiftBundle("mainDebug", TestUtil.objectFactory(), Stub(Provider), true, Stub(FileCollection),  Stub(ConfigurationContainer), Stub(Configuration), resourceDirectory)
+    }
+
+    def "honor changes to resource directory for the location of Info.plist"() {
+        def file = tmpDir.file("Tests")
+
+        expect:
+        resourceDirectory.set(file)
+        binary.informationPropertyList.get().asFile == tmpDir.file("Tests/Info.plist")
+    }
+
+    def "base the location of Info.plist on the resource directory"() {
+        expect:
+        binary.informationPropertyList.get().asFile == new File(resourceDirectory.asFile.get(), "Info.plist")
+    }
+}

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -18,10 +18,12 @@ package org.gradle.language.swift.plugins
 
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.language.swift.SwiftBinary
+import org.gradle.language.swift.SwiftBundle
 import org.gradle.language.swift.SwiftExecutable
 import org.gradle.language.swift.SwiftSharedLibrary
 import org.gradle.language.swift.tasks.SwiftCompile
 import org.gradle.nativeplatform.tasks.InstallExecutable
+import org.gradle.nativeplatform.tasks.LinkBundle
 import org.gradle.nativeplatform.tasks.LinkExecutable
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -103,6 +105,30 @@ class SwiftBasePluginTest extends Specification {
 
         where:
         name        | taskName        | libDir
+        "main"      | "link"          | "main/"
+        "mainDebug" | "linkDebug"     | "main/debug/"
+        "test"      | "linkTest"      | "test/"
+        "testDebug" | "linkTestDebug" | "test/debug/"
+    }
+
+    def "adds link task for bundle"() {
+        def module = project.providers.property(String)
+        module.set("TestBundle")
+        def bundle = Stub(SwiftBundle)
+        bundle.name >> name
+        bundle.module >> module
+
+        when:
+        project.pluginManager.apply(SwiftBasePlugin)
+        project.components.add(bundle)
+
+        then:
+        def link = project.tasks[taskName]
+        link instanceof LinkBundle
+        link.binaryFile.get().asFile == projectDir.file("build/exe/${bundleDir}" + OperatingSystem.current().getExecutableName("TestBundle"))
+
+        where:
+        name        | taskName        | bundleDir
         "main"      | "link"          | "main/"
         "mainDebug" | "linkDebug"     | "main/debug/"
         "test"      | "linkTest"      | "test/"

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -22,10 +22,10 @@ import org.gradle.language.swift.SwiftBinary
 import org.gradle.language.swift.SwiftBundle
 import org.gradle.language.swift.SwiftExecutable
 import org.gradle.language.swift.SwiftSharedLibrary
-import org.gradle.language.swift.tasks.CreateBundle
+import org.gradle.language.swift.tasks.CreateSwiftBundle
 import org.gradle.language.swift.tasks.SwiftCompile
 import org.gradle.nativeplatform.tasks.InstallExecutable
-import org.gradle.nativeplatform.tasks.LinkBundle
+import org.gradle.nativeplatform.tasks.LinkMachOBundle
 import org.gradle.nativeplatform.tasks.LinkExecutable
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -128,12 +128,12 @@ class SwiftBasePluginTest extends Specification {
 
         then:
         def link = project.tasks[linkTaskName]
-        link instanceof LinkBundle
+        link instanceof LinkMachOBundle
         link.binaryFile.get().asFile == projectDir.file("build/exe/${bundleDir}" + OperatingSystem.current().getExecutableName("TestBundle"))
 
         and:
         def bundleTask = project.tasks[bundleTaskName]
-        bundleTask instanceof CreateBundle
+        bundleTask instanceof CreateSwiftBundle
         bundleTask.outputDir.get().asFile == projectDir.file("build/bundle/${bundleDir}TestBundle.xctest")
 
         where:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -137,10 +137,10 @@ class SwiftBasePluginTest extends Specification {
         bundleTask.outputDir.get().asFile == projectDir.file("build/bundle/${bundleDir}TestBundle.xctest")
 
         where:
-        name        | linkTaskName    | bundleTaskName    | bundleDir
-        "main"      | "link"          | "bundle"          | "main/"
-        "mainDebug" | "linkDebug"     | "bundleDebug"     | "main/debug/"
-        "test"      | "linkTest"      | "bundleTest"      | "test/"
-        "testDebug" | "linkTestDebug" | "bundleTestDebug" | "test/debug/"
+        name        | linkTaskName    | bundleTaskName         | bundleDir
+        "main"      | "link"          | "bundleSwift"          | "main/"
+        "mainDebug" | "linkDebug"     | "bundleSwiftDebug"     | "main/debug/"
+        "test"      | "linkTest"      | "bundleSwiftTest"      | "test/"
+        "testDebug" | "linkTestDebug" | "bundleSwiftTestDebug" | "test/debug/"
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/BundleLinkerSpec.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/BundleLinkerSpec.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.internal;
+
+public interface BundleLinkerSpec extends LinkerSpec {
+}

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkBundle.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkBundle.java
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-package org.gradle.nativeplatform.test.xctest;
+package org.gradle.nativeplatform.tasks;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.file.DirectoryVar;
-import org.gradle.language.swift.SwiftBundle;
-import org.gradle.language.swift.SwiftComponent;
+import org.gradle.nativeplatform.internal.BundleLinkerSpec;
+import org.gradle.nativeplatform.internal.DefaultLinkerSpec;
+import org.gradle.nativeplatform.internal.LinkerSpec;
 
 /**
- * An XCTest suite, implemented in Swift.
+ * Links a binary bundle from object files and imported libraries.
  *
- * @since 4.2
+ * @since 4.3
  */
 @Incubating
-public interface SwiftXCTestSuite extends SwiftComponent {
-    /**
-     * Returns the executable that is built to run this test suite.
-     */
-    SwiftBundle getExecutable();
+public class LinkBundle extends AbstractLinkTask {
+    @Override
+    protected LinkerSpec createLinkerSpec() {
+        return new LinkBundle.Spec();
+    }
 
-    /**
-     * Returns the resource directory for this component.
-     *
-     * <p>{@code src/test/resources} is used by default.
-     */
-    DirectoryVar getResourceDir();
+    private static class Spec extends DefaultLinkerSpec implements BundleLinkerSpec {
+    }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkMachOBundle.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkMachOBundle.java
@@ -27,10 +27,10 @@ import org.gradle.nativeplatform.internal.LinkerSpec;
  * @since 4.3
  */
 @Incubating
-public class LinkBundle extends AbstractLinkTask {
+public class LinkMachOBundle extends AbstractLinkTask {
     @Override
     protected LinkerSpec createLinkerSpec() {
-        return new LinkBundle.Spec();
+        return new LinkMachOBundle.Spec();
     }
 
     private static class Spec extends DefaultLinkerSpec implements BundleLinkerSpec {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
@@ -67,7 +67,8 @@ class SwiftLinker extends AbstractCompiler<LinkerSpec> {
             if (spec instanceof SharedLibraryLinkerSpec) {
                 args.add("-emit-library");
             } else if (spec instanceof BundleLinkerSpec) {
-                args.add("-Wl,-bundle");
+                args.add("-Xlinker");
+                args.add("-bundle");
             } else {
                 args.add("-emit-executable");
             }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
@@ -67,8 +67,7 @@ class SwiftLinker extends AbstractCompiler<LinkerSpec> {
             if (spec instanceof SharedLibraryLinkerSpec) {
                 args.add("-emit-library");
             } else if (spec instanceof BundleLinkerSpec) {
-                args.add("-Xlinker");
-                args.add("-bundle");
+                args.add("-Wl,-bundle");
             } else {
                 args.add("-emit-executable");
             }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.work.WorkerLeaseService;
+import org.gradle.nativeplatform.internal.BundleLinkerSpec;
 import org.gradle.nativeplatform.internal.LinkerSpec;
 import org.gradle.nativeplatform.internal.SharedLibraryLinkerSpec;
 import org.gradle.nativeplatform.toolchain.internal.AbstractCompiler;
@@ -65,6 +66,9 @@ class SwiftLinker extends AbstractCompiler<LinkerSpec> {
 
             if (spec instanceof SharedLibraryLinkerSpec) {
                 args.add("-emit-library");
+            } else if (spec instanceof BundleLinkerSpec) {
+                args.add("-Xlinker");
+                args.add("-bundle");
             } else {
                 args.add("-emit-executable");
             }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinkerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinkerTest.groovy
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.toolchain.internal.swift
+
+import org.gradle.internal.Actions
+import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.BuildOperationQueue
+import org.gradle.internal.operations.logging.BuildOperationLogger
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.internal.work.WorkerLeaseService
+import org.gradle.nativeplatform.internal.BundleLinkerSpec
+import org.gradle.nativeplatform.internal.LinkerSpec
+import org.gradle.nativeplatform.internal.SharedLibraryLinkerSpec
+import org.gradle.nativeplatform.platform.NativePlatform
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+import org.gradle.nativeplatform.platform.internal.DefaultOperatingSystem
+import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext
+import org.gradle.nativeplatform.toolchain.internal.CommandLineToolInvocation
+import org.gradle.nativeplatform.toolchain.internal.CommandLineToolInvocationWorker
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.test.fixtures.work.TestWorkerLeaseService
+import org.gradle.util.UsesNativeServices
+import org.junit.Rule
+import spock.lang.Specification
+
+@UsesNativeServices
+class SwiftLinkerTest extends Specification {
+    public static final String LOG_LOCATION = "<log location>"
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+
+    def operationLogger =  Mock(BuildOperationLogger)
+    def executable = new File("executable")
+    def invocationContext = Mock(CommandLineToolContext)
+    def invocation = Mock(CommandLineToolInvocation)
+    CommandLineToolInvocationWorker commandLineTool = Mock(CommandLineToolInvocationWorker)
+    BuildOperationExecutor buildOperationExecutor = Mock(BuildOperationExecutor)
+    BuildOperationQueue queue = Mock(BuildOperationQueue)
+    WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
+
+    SwiftLinker linker = new SwiftLinker(buildOperationExecutor, commandLineTool, invocationContext, workerLeaseService)
+
+    def "ignores install name for all major operating system"() {
+        given:
+        def testDir = tmpDirProvider.testDirectory
+        def outputFile = testDir.file("output/lib")
+
+        final expectedArgs = [
+            "-emit-library",
+            "-o", outputFile.absolutePath,
+            testDir.file("one.o").absolutePath].flatten()
+
+        when:
+        NativePlatform platform = Mock(NativePlatform)
+        platform.getOperatingSystem() >> new DefaultOperatingSystem(operatingSystem.name, operatingSystem)
+
+        LinkerSpec spec = Mock(SharedLibraryLinkerSpec)
+        spec.getSystemArgs() >> []
+        spec.getArgs() >> []
+        spec.getOutputFile() >> outputFile
+        spec.getLibraries() >> []
+        spec.getLibraryPath() >> []
+        spec.getInstallName() >> "installName"
+        spec.getTargetPlatform() >> platform
+        spec.getObjectFiles() >> [testDir.file("one.o")]
+        spec.getOperationLogger() >> operationLogger
+
+        and:
+        linker.execute(spec)
+
+        then:
+        1 * operationLogger.getLogLocation() >> LOG_LOCATION
+        1 * buildOperationExecutor.runAll(commandLineTool, _) >> { worker, action -> action.execute(queue) }
+        1 * invocationContext.getArgAction() >> Actions.doNothing()
+        1 * invocationContext.createInvocation("linking lib", outputFile.parentFile, expectedArgs, operationLogger) >> invocation
+        1 * queue.add(invocation)
+        1 * queue.setLogLocation(LOG_LOCATION)
+        0 * _
+
+        where:
+        operatingSystem << [OperatingSystem.WINDOWS, OperatingSystem.MAC_OS, OperatingSystem.LINUX]
+    }
+
+    def "links all object files in a single execution"() {
+        given:
+        def testDir = tmpDirProvider.testDirectory
+        def outputFile = testDir.file("output/lib")
+
+        final expectedArgs = [
+                "-sys1", "-sys2",
+                "-emit-library",
+                "-o", outputFile.absolutePath,
+                testDir.file("one.o").absolutePath,
+                testDir.file("two.o").absolutePath,
+                "-arg1", "-arg2"].flatten()
+
+        when:
+        LinkerSpec spec = Mock(SharedLibraryLinkerSpec)
+        spec.getSystemArgs() >> ['-sys1', '-sys2']
+        spec.getArgs() >> ['-arg1', '-arg2']
+        spec.getOutputFile() >> outputFile
+        spec.getLibraries() >> []
+        spec.getLibraryPath() >> []
+        spec.getTargetPlatform() >> new DefaultNativePlatform("default")
+        spec.getObjectFiles() >> [testDir.file("one.o"), testDir.file("two.o")]
+        spec.getOperationLogger() >> operationLogger
+
+        and:
+        linker.execute(spec)
+
+        then:
+        1 * operationLogger.getLogLocation() >> LOG_LOCATION
+        1 * buildOperationExecutor.runAll(commandLineTool, _) >> { worker, action -> action.execute(queue) }
+        1 * invocationContext.getArgAction() >> Actions.doNothing()
+        1 * invocationContext.createInvocation("linking lib", outputFile.parentFile, expectedArgs, operationLogger) >> invocation
+        1 * queue.add(invocation)
+        1 * queue.setLogLocation(LOG_LOCATION)
+        0 * _
+    }
+
+    def "use the emit-library flag when linking shared library"() {
+        given:
+        def testDir = tmpDirProvider.testDirectory
+        def outputFile = testDir.file("output/lib")
+
+        final expectedArgs = [
+            "-emit-library",
+            "-o", outputFile.absolutePath,
+            testDir.file("one.o").absolutePath].flatten()
+
+        when:
+        LinkerSpec spec = mockLinkerSpec(SharedLibraryLinkerSpec, outputFile, [testDir.file("one.o")])
+        linker.execute(spec)
+
+        then:
+        1 * operationLogger.getLogLocation() >> LOG_LOCATION
+        1 * buildOperationExecutor.runAll(commandLineTool, _) >> { worker, action -> action.execute(queue) }
+        1 * invocationContext.getArgAction() >> Actions.doNothing()
+        1 * invocationContext.createInvocation("linking lib", outputFile.parentFile, expectedArgs, operationLogger) >> invocation
+        1 * queue.add(invocation)
+        1 * queue.setLogLocation(LOG_LOCATION)
+        0 * _
+    }
+
+    def "use the emit-executable flag when linking executable"() {
+        given:
+        def testDir = tmpDirProvider.testDirectory
+        def outputFile = testDir.file("output/lib")
+
+        final expectedArgs = [
+            "-emit-executable",
+            "-o", outputFile.absolutePath,
+            testDir.file("one.o").absolutePath].flatten()
+
+        when:
+        LinkerSpec spec = mockLinkerSpec(LinkerSpec, outputFile, [testDir.file("one.o")])
+        linker.execute(spec)
+
+        then:
+        1 * operationLogger.getLogLocation() >> LOG_LOCATION
+        1 * buildOperationExecutor.runAll(commandLineTool, _) >> { worker, action -> action.execute(queue) }
+        1 * invocationContext.getArgAction() >> Actions.doNothing()
+        1 * invocationContext.createInvocation("linking lib", outputFile.parentFile, expectedArgs, operationLogger) >> invocation
+        1 * queue.add(invocation)
+        1 * queue.setLogLocation(LOG_LOCATION)
+        0 * _
+    }
+
+    def "pass the bundle flag to the linker when linking bundle"() {
+        given:
+        def testDir = tmpDirProvider.testDirectory
+        def outputFile = testDir.file("output/lib")
+
+        final expectedArgs = [
+            "-Wl,-bundle",
+            "-o", outputFile.absolutePath,
+            testDir.file("one.o").absolutePath].flatten()
+
+        when:
+        LinkerSpec spec = mockLinkerSpec(BundleLinkerSpec, outputFile, [testDir.file("one.o")])
+        linker.execute(spec)
+
+        then:
+        1 * operationLogger.getLogLocation() >> LOG_LOCATION
+        1 * buildOperationExecutor.runAll(commandLineTool, _) >> { worker, action -> action.execute(queue) }
+        1 * invocationContext.getArgAction() >> Actions.doNothing()
+        1 * invocationContext.createInvocation("linking lib", outputFile.parentFile, expectedArgs, operationLogger) >> invocation
+        1 * queue.add(invocation)
+        1 * queue.setLogLocation(LOG_LOCATION)
+        0 * _
+    }
+
+    private LinkerSpec mockLinkerSpec(Class<? extends LinkerSpec> cls, File outputFile, List<File> objectFiles) {
+        LinkerSpec spec = Mock(cls)
+        spec.getSystemArgs() >> []
+        spec.getArgs() >> []
+        spec.getOutputFile() >> outputFile
+        spec.getLibraries() >> []
+        spec.getLibraryPath() >> []
+        spec.getTargetPlatform() >> new DefaultNativePlatform("default")
+        spec.getObjectFiles() >> objectFiles
+        spec.getOperationLogger() >> operationLogger
+
+        return spec
+    }
+}

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinkerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinkerTest.groovy
@@ -185,7 +185,7 @@ class SwiftLinkerTest extends Specification {
         def outputFile = testDir.file("output/lib")
 
         final expectedArgs = [
-            "-Wl,-bundle",
+            "-Xlinker", "-bundle",
             "-o", outputFile.absolutePath,
             testDir.file("one.o").absolutePath].flatten()
 

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
@@ -24,8 +24,8 @@ import org.gradle.nativeplatform.fixtures.app.TestElement
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
-import static org.gradle.nativeplatform.fixtures.app.SourceTestElement.newTestSuite
 import static org.gradle.nativeplatform.fixtures.app.SourceTestElement.newTestCase
+import static org.gradle.nativeplatform.fixtures.app.SourceTestElement.newTestSuite
 
 @Requires([TestPrecondition.SWIFT_SUPPORT, TestPrecondition.MAC_OS_X])
 class SwiftXCTestIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
@@ -45,8 +45,8 @@ apply plugin: 'swift-library'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
-        result.assertTasksSkipped(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksSkipped(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
     }
 
     def "xctest plugin can test public and internal feature of a Swift library"() {
@@ -74,7 +74,7 @@ apply plugin: 'swift-library'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
         test.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -88,8 +88,8 @@ apply plugin: 'swift-executable'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
-        result.assertTasksSkipped(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksSkipped(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
     }
 
     def "xctest plugin can test public and internal feature of a Swift executable"() {
@@ -117,6 +117,6 @@ linkTest.source = project.files(new HashSet(linkTest.source.from)).filter { !it.
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
     }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
@@ -45,8 +45,8 @@ apply plugin: 'swift-library'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
-        result.assertTasksSkipped(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
+        result.assertTasksSkipped(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
     }
 
     def "xctest plugin can test public and internal feature of a Swift library"() {
@@ -74,7 +74,7 @@ apply plugin: 'swift-library'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
         test.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -88,8 +88,8 @@ apply plugin: 'swift-executable'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
-        result.assertTasksSkipped(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
+        result.assertTasksSkipped(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
     }
 
     def "xctest plugin can test public and internal feature of a Swift executable"() {
@@ -117,6 +117,6 @@ linkTest.source = project.files(new HashSet(linkTest.source.from)).filter { !it.
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
     }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestIntegrationTest.groovy
@@ -43,8 +43,8 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
-        result.assertTasksSkipped(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
+        result.assertTasksSkipped(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
     }
 
     def "test task fail when test cases fail"() {
@@ -61,7 +61,7 @@ apply plugin: 'xctest'
         fails("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest")
         testApp.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -79,7 +79,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
         testApp.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -130,7 +130,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
         oldTestApp.expectedSummaryOutputPattern.matcher(output).find()
 
         when:
@@ -139,7 +139,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
         newTestApp.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -167,7 +167,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
         oldTestApp.expectedSummaryOutputPattern.matcher(output).find()
 
         when:
@@ -176,7 +176,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
         newTestApp.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -195,8 +195,8 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
-        result.assertTasksSkipped(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
+        result.assertTasksSkipped(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
     }
 
     def "xctest component can specify a dependency on another library"() {
@@ -227,7 +227,7 @@ dependencies {
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":greeter:compileDebugSwift", ":greeter:linkDebug", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":greeter:compileDebugSwift", ":greeter:linkDebug", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
     }
 
     def "assemble task doesn't build or run any of the tests"() {
@@ -269,7 +269,7 @@ dependencies {
 
         expect:
         succeeds "test"
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
 
         file("build/obj/test").assertIsDir()
         executable("build/exe/test/AppTest").assertExists()

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestIntegrationTest.groovy
@@ -43,8 +43,8 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
-        result.assertTasksSkipped(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksSkipped(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
     }
 
     def "test task fail when test cases fail"() {
@@ -61,7 +61,7 @@ apply plugin: 'xctest'
         fails("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest")
         testApp.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -79,7 +79,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
         testApp.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -130,7 +130,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
         oldTestApp.expectedSummaryOutputPattern.matcher(output).find()
 
         when:
@@ -139,7 +139,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
         newTestApp.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -167,7 +167,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
         oldTestApp.expectedSummaryOutputPattern.matcher(output).find()
 
         when:
@@ -176,7 +176,7 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
         newTestApp.expectedSummaryOutputPattern.matcher(output).find()
     }
 
@@ -195,8 +195,8 @@ apply plugin: 'xctest'
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
-        result.assertTasksSkipped(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
+        result.assertTasksSkipped(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
     }
 
     def "xctest component can specify a dependency on another library"() {
@@ -227,7 +227,7 @@ dependencies {
         succeeds("test")
 
         then:
-        result.assertTasksExecuted(":greeter:compileDebugSwift", ":greeter:linkDebug", ":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":greeter:compileDebugSwift", ":greeter:linkDebug", ":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
     }
 
     def "assemble task doesn't build or run any of the tests"() {
@@ -269,7 +269,7 @@ dependencies {
 
         expect:
         succeeds "test"
-        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":createXcTestBundle", ":xcTest", ":test")
+        result.assertTasksExecuted(":compileTestSwift", ":linkTest", ":bundleTest", ":xcTest", ":test")
 
         file("build/obj/test").assertIsDir()
         executable("build/exe/test/AppTest").assertExists()

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestSuite.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestSuite.java
@@ -29,9 +29,9 @@ import org.gradle.language.swift.SwiftComponent;
 @Incubating
 public interface SwiftXCTestSuite extends SwiftComponent {
     /**
-     * Returns the executable that is built to run this test suite.
+     * Returns the bundle that is built to run this test suite.
      */
-    SwiftBundle getExecutable();
+    SwiftBundle getBundle();
 
     /**
      * Returns the resource directory for this component.

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuite.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuite.java
@@ -30,7 +30,7 @@ import org.gradle.nativeplatform.test.xctest.SwiftXCTestSuite;
 import javax.inject.Inject;
 
 public class DefaultSwiftXCTestSuite extends DefaultSwiftComponent implements SwiftXCTestSuite {
-    private final DefaultSwiftBundle executable;
+    private final DefaultSwiftBundle bundle;
     private final DirectoryVar resourceDirectory;
 
     @Inject
@@ -39,7 +39,7 @@ public class DefaultSwiftXCTestSuite extends DefaultSwiftComponent implements Sw
 
         resourceDirectory = projectLayout.newDirectoryVar();
         resourceDirectory.set(projectLayout.getProjectDirectory().dir("src/" + name + "/resources"));
-        executable = new DefaultSwiftBundle(name + "Exe", objectFactory, getModule(), true, getSwiftSource(), configurations, getImplementationDependencies(), getResourceDir());
+        bundle = new DefaultSwiftBundle(name + "Bundle", objectFactory, getModule(), true, getSwiftSource(), configurations, getImplementationDependencies(), getResourceDir());
     }
 
     @Override
@@ -49,11 +49,11 @@ public class DefaultSwiftXCTestSuite extends DefaultSwiftComponent implements Sw
 
     @Override
     public SwiftBundle getDevelopmentBinary() {
-        return executable;
+        return bundle;
     }
 
     @Override
-    public SwiftBundle getExecutable() {
-        return executable;
+    public SwiftBundle getBundle() {
+        return bundle;
     }
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuite.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuite.java
@@ -17,29 +17,43 @@
 package org.gradle.nativeplatform.test.xctest.internal;
 
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.DirectoryVar;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
-import org.gradle.language.swift.SwiftBinary;
-import org.gradle.language.swift.internal.DefaultSwiftBinary;
+import org.gradle.language.swift.SwiftBundle;
+import org.gradle.language.swift.internal.DefaultSwiftBundle;
 import org.gradle.language.swift.internal.DefaultSwiftComponent;
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestSuite;
 
-public class DefaultSwiftXCTestSuite extends DefaultSwiftComponent implements SwiftXCTestSuite {
-    private final DefaultSwiftBinary executable;
+import javax.inject.Inject;
 
-    public DefaultSwiftXCTestSuite(String name, ObjectFactory objectFactory, FileOperations fileOperations, ProviderFactory providerFactory, ConfigurationContainer configurations) {
+public class DefaultSwiftXCTestSuite extends DefaultSwiftComponent implements SwiftXCTestSuite {
+    private final DefaultSwiftBundle executable;
+    private final DirectoryVar resourceDirectory;
+
+    @Inject
+    public DefaultSwiftXCTestSuite(String name, ObjectFactory objectFactory, FileOperations fileOperations, ProviderFactory providerFactory, ConfigurationContainer configurations, ProjectLayout projectLayout) {
         super(name, fileOperations, providerFactory, configurations);
-        executable = new DefaultSwiftBinary(name + "Exe", objectFactory, getModule(), true, getSwiftSource(), configurations, getImplementationDependencies());
+
+        resourceDirectory = projectLayout.newDirectoryVar();
+        resourceDirectory.set(projectLayout.getProjectDirectory().dir("src/" + name + "/resources"));
+        executable = new DefaultSwiftBundle(name + "Exe", objectFactory, getModule(), true, getSwiftSource(), configurations, getImplementationDependencies(), getResourceDir());
     }
 
     @Override
-    public SwiftBinary getDevelopmentBinary() {
+    public DirectoryVar getResourceDir() {
+        return resourceDirectory;
+    }
+
+    @Override
+    public SwiftBundle getDevelopmentBinary() {
         return executable;
     }
 
     @Override
-    public SwiftBinary getExecutable() {
+    public SwiftBundle getExecutable() {
         return executable;
     }
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/MacOSSdkPlatformPathLocator.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/MacOSSdkPlatformPathLocator.java
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.test.xctest.internal;
 
+import org.gradle.language.swift.internal.AbstractLocator;
 import org.gradle.process.internal.ExecActionFactory;
 
 import javax.inject.Inject;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/MacOSXCTestLocator.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/MacOSXCTestLocator.java
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.test.xctest.internal;
 
+import org.gradle.language.swift.internal.AbstractLocator;
 import org.gradle.process.internal.ExecActionFactory;
 
 import javax.inject.Inject;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/services/XCTestTestingServices.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/services/XCTestTestingServices.java
@@ -20,13 +20,11 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.nativeplatform.test.xctest.internal.MacOSSdkPlatformPathLocator;
 import org.gradle.nativeplatform.test.xctest.internal.MacOSXCTestLocator;
-import org.gradle.nativeplatform.test.xctest.internal.SwiftStdlibToolLocator;
 
 public class XCTestTestingServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerBuildSessionServices(ServiceRegistration registration) {
         registration.add(MacOSSdkPlatformPathLocator.class);
         registration.add(MacOSXCTestLocator.class);
-        registration.add(SwiftStdlibToolLocator.class);
     }
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -104,13 +104,13 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
 
         configureTestedComponent(project);
 
-        CreateSwiftBundle bundle = (CreateSwiftBundle) tasks.getByName("bundleTest");
+        CreateSwiftBundle bundle = (CreateSwiftBundle) tasks.getByName("bundleSwiftTest");
 
         final XcTest xcTest = tasks.create("xcTest", XcTest.class);
         // TODO - should respect changes to build directory
         xcTest.setBinResultsDir(project.file("build/results/test/bin"));
         xcTest.setTestBundleDir(bundle.getOutputDir());
-        xcTest.setWorkingDir(buildDirectory.dir("bundle"));
+        xcTest.setWorkingDir(buildDirectory.dir("bundle/test"));
         // TODO - should respect changes to reports dir
         xcTest.getReports().getHtml().setDestination(buildDirectory.dir("reports/test").map(new Transformer<File, Directory>() {
             @Override

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -36,10 +36,10 @@ import org.gradle.internal.os.OperatingSystem;
 import org.gradle.language.swift.plugins.SwiftBasePlugin;
 import org.gradle.language.swift.plugins.SwiftExecutablePlugin;
 import org.gradle.language.swift.plugins.SwiftLibraryPlugin;
-import org.gradle.language.swift.tasks.CreateBundle;
+import org.gradle.language.swift.tasks.CreateSwiftBundle;
 import org.gradle.language.swift.tasks.SwiftCompile;
 import org.gradle.nativeplatform.tasks.AbstractLinkTask;
-import org.gradle.nativeplatform.tasks.LinkBundle;
+import org.gradle.nativeplatform.tasks.LinkMachOBundle;
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestSuite;
 import org.gradle.nativeplatform.test.xctest.internal.DefaultSwiftXCTestSuite;
 import org.gradle.nativeplatform.test.xctest.internal.MacOSSdkPlatformPathLocator;
@@ -99,12 +99,12 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
         compile.setModuleName(project.getName() + "Test");
 
         // Add a link task
-        LinkBundle link = (LinkBundle) tasks.getByName("linkTest");
+        LinkMachOBundle link = (LinkMachOBundle) tasks.getByName("linkTest");
         link.getLinkerArgs().set(Lists.newArrayList("-F" + frameworkDir.getAbsolutePath(), "-framework", "XCTest", "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks", "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks"));
 
         configureTestedComponent(project);
 
-        CreateBundle bundle = (CreateBundle) tasks.getByName("bundleTest");
+        CreateSwiftBundle bundle = (CreateSwiftBundle) tasks.getByName("bundleTest");
 
         final XcTest xcTest = tasks.create("xcTest", XcTest.class);
         // TODO - should respect changes to build directory

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -26,34 +26,33 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryVar;
-import org.gradle.api.file.RegularFile;
-import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.PropertyState;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.language.nativeplatform.internal.Names;
+import org.gradle.language.swift.SwiftBinary;
 import org.gradle.language.swift.plugins.SwiftBasePlugin;
 import org.gradle.language.swift.plugins.SwiftExecutablePlugin;
 import org.gradle.language.swift.plugins.SwiftLibraryPlugin;
 import org.gradle.language.swift.tasks.SwiftCompile;
-import org.gradle.nativeplatform.platform.NativePlatform;
-import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
 import org.gradle.nativeplatform.tasks.AbstractLinkTask;
-import org.gradle.nativeplatform.tasks.LinkExecutable;
+import org.gradle.nativeplatform.tasks.LinkBundle;
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestSuite;
 import org.gradle.nativeplatform.test.xctest.internal.DefaultSwiftXCTestSuite;
 import org.gradle.nativeplatform.test.xctest.internal.MacOSSdkPlatformPathLocator;
 import org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle;
 import org.gradle.nativeplatform.test.xctest.tasks.XcTest;
-import org.gradle.nativeplatform.toolchain.NativeToolChain;
-import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
-import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.concurrent.Callable;
 
 /**
  * A plugin that sets up the infrastructure for testing native binaries with XCTest test framework. It also adds conventions on top of it.
@@ -62,13 +61,13 @@ import java.io.File;
  */
 @Incubating
 public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
-    private final FileOperations fileOperations;
     private final MacOSSdkPlatformPathLocator sdkPlatformPathLocator;
+    private final ObjectFactory objectFactory;
 
     @Inject
-    public XCTestConventionPlugin(FileOperations fileOperations, MacOSSdkPlatformPathLocator sdkPlatformPathLocator) {
-        this.fileOperations = fileOperations;
+    public XCTestConventionPlugin(MacOSSdkPlatformPathLocator sdkPlatformPathLocator, ObjectFactory objectFactory) {
         this.sdkPlatformPathLocator = sdkPlatformPathLocator;
+        this.objectFactory = objectFactory;
     }
 
     @Override
@@ -90,9 +89,14 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
         // TODO - component name and extension name aren't the same
         // TODO - should use `src/xctext/swift` as the convention?
         // Add the component extension
-        SwiftXCTestSuite component = project.getExtensions().create(SwiftXCTestSuite.class, "xctest", DefaultSwiftXCTestSuite.class, "test", project.getObjects(), fileOperations, providers, configurations);
+        SwiftXCTestSuite component = objectFactory.newInstance(DefaultSwiftXCTestSuite.class, "test", configurations);
+        project.getExtensions().add(SwiftXCTestSuite.class, "xctest", component);
         project.getComponents().add(component);
         project.getComponents().add(component.getExecutable());
+
+        // Setup component
+        final PropertyState<String> module = component.getModule();
+        module.set(GUtil.toCamelCase(project.getName() + "Test"));
 
         // Configure compile task
         SwiftCompile compile = (SwiftCompile) tasks.getByName("compileTestSwift");
@@ -100,31 +104,25 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
         compile.getCompilerArgs().set(Lists.newArrayList("-g", "-F" + frameworkDir.getAbsolutePath()));
         compile.setModuleName(project.getName() + "Test");
 
-        NativeToolChain toolChain = compile.getToolChain();
-        NativePlatform targetPlatform = compile.getTargetPlatform();
-
-        // TODO - move up to base plugin
         // Add a link task
-        LinkExecutable link = tasks.create("linkTest", LinkExecutable.class);
-        // TODO - need to set basename from component
-        link.source(compile.getObjectFileDir().getAsFileTree().matching(new PatternSet().include("**/*.obj", "**/*.o")));
-        link.lib(component.getExecutable().getLinkLibraries());
+        LinkBundle link = (LinkBundle) tasks.getByName("linkTest");
         link.getLinkerArgs().set(Lists.newArrayList("-Xlinker", "-bundle", "-F" + frameworkDir.getAbsolutePath(), "-framework", "XCTest", "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks", "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks"));
-        PlatformToolProvider toolProvider = ((NativeToolChainInternal) toolChain).select((NativePlatformInternal) targetPlatform);
-        Provider<RegularFile> exeLocation = buildDirectory.file(toolProvider.getExecutableName("exe/" + project.getName() + "Test"));
-        link.setOutputFile(exeLocation);
-        link.setTargetPlatform(targetPlatform);
-        link.setToolChain(toolChain);
-        link.setDebuggable(true);
 
         configureTestedComponent(project);
 
-        // TODO - need to set basename from component
-        Provider<Directory> testBundleDir = buildDirectory.dir("bundle/" + project.getName() + "Test.xctest");
+        final SwiftBinary binary = component.getExecutable();
+        final Names names = Names.of(binary.getName());
+        Provider<Directory> testBundleDir = buildDirectory.dir(providers.provider(new Callable<String>() {
+            @Override
+            public String call() {
+                return "bundle/" + names.getDirName() + binary.getModule().get() + ".xctest";
+            }
+        }));
+
         final CreateXcTestBundle testBundle = tasks.create("createXcTestBundle", CreateXcTestBundle.class);
         testBundle.setExecutableFile(link.getBinaryFile());
         // TODO - should be defined on the component
-        testBundle.setInformationFile(project.file("src/test/resources/Info.plist"));
+        testBundle.setInformationFile(component.getExecutable().getInformationPropertyList());
         testBundle.setOutputDir(testBundleDir);
         testBundle.onlyIf(new Spec<Task>() {
             @Override

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -106,7 +106,7 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
 
         // Add a link task
         LinkBundle link = (LinkBundle) tasks.getByName("linkTest");
-        link.getLinkerArgs().set(Lists.newArrayList("-Xlinker", "-bundle", "-F" + frameworkDir.getAbsolutePath(), "-framework", "XCTest", "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks", "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks"));
+        link.getLinkerArgs().set(Lists.newArrayList("-F" + frameworkDir.getAbsolutePath(), "-framework", "XCTest", "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks", "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks"));
 
         configureTestedComponent(project);
 

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/XcTest.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/XcTest.java
@@ -40,7 +40,7 @@ public class XcTest extends Test {
     public XcTest(ObjectFactory objectFactory) {
         setTestExecuter(objectFactory.newInstance(NativeTestExecuter.class));
 
-        getExtensions().getExtraProperties().set("testBundleDir", newOutputDirectory());
+        getExtensions().getExtraProperties().set("testBundleDir", newInputDirectory());
         getExtensions().getExtraProperties().set("workingDir", newOutputDirectory());
         setExecutable("java");
         setTestClassesDirs(getProject().files());

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
@@ -42,7 +42,7 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
         testSuite.developmentBinary == testSuite.executable
     }
 
-    def "can change location of Info.plist"() {
+    def "can change location of Info.plist by changing the test suite resource directory location"() {
         def file = tmpDir.createFile("Tests")
 
         expect:

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
@@ -35,11 +35,11 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
     def projectLayout = new DefaultProjectLayout(tmpDir.testDirectory, TestFiles.resolver(tmpDir.testDirectory))
     def testSuite = new DefaultSwiftXCTestSuite("test", TestUtil.objectFactory(), fileOperations, providerFactory, Stub(ConfigurationContainer), projectLayout)
 
-    def "has an executable"() {
+    def "has a bundle"() {
         expect:
-        testSuite.executable.name == "testExe"
-        testSuite.executable.debuggable
-        testSuite.developmentBinary == testSuite.executable
+        testSuite.bundle.name == "testBundle"
+        testSuite.bundle.debuggable
+        testSuite.developmentBinary == testSuite.bundle
     }
 
     def "can change location of Info.plist by changing the test suite resource directory location"() {
@@ -47,11 +47,11 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
 
         expect:
         testSuite.resourceDir.set(file)
-        testSuite.executable.informationPropertyList.get().asFile == tmpDir.file("Tests/Info.plist")
+        testSuite.bundle.informationPropertyList.get().asFile == tmpDir.file("Tests/Info.plist")
     }
 
     def "uses source layout convention when Info.plist not set"() {
         expect:
-        testSuite.executable.informationPropertyList.get().asFile == tmpDir.file("src/test/resources/Info.plist")
+        testSuite.bundle.informationPropertyList.get().asFile == tmpDir.file("src/test/resources/Info.plist")
     }
 }

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.nativeplatform.test.xctest.plugins
 
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.language.swift.tasks.SwiftCompile
-import org.gradle.nativeplatform.tasks.LinkExecutable
+import org.gradle.nativeplatform.tasks.LinkBundle
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestSuite
 import org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle
 import org.gradle.nativeplatform.test.xctest.tasks.XcTest
@@ -73,8 +73,8 @@ class XCTestConventionPluginTest extends Specification {
         !compileSwift.optimized
 
         def link = project.tasks.linkTest
-        link instanceof LinkExecutable
-        link.binaryFile.get().asFile == projectDir.file("build/exe/" + OperatingSystem.current().getExecutableName("testAppTest"))
+        link instanceof LinkBundle
+        link.binaryFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
         link.debuggable
 
         def bundle = project.tasks.createXcTestBundle

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.nativeplatform.test.xctest.plugins
 
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.language.swift.tasks.CreateBundle
+import org.gradle.language.swift.tasks.CreateSwiftBundle
 import org.gradle.language.swift.tasks.SwiftCompile
-import org.gradle.nativeplatform.tasks.LinkBundle
+import org.gradle.nativeplatform.tasks.LinkMachOBundle
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestSuite
 import org.gradle.nativeplatform.test.xctest.tasks.XcTest
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -73,12 +73,12 @@ class XCTestConventionPluginTest extends Specification {
         !compileSwift.optimized
 
         def link = project.tasks.linkTest
-        link instanceof LinkBundle
+        link instanceof LinkMachOBundle
         link.binaryFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
         link.debuggable
 
         def bundle = project.tasks.createXcTestBundle
-        bundle instanceof CreateBundle
+        bundle instanceof CreateSwiftBundle
         bundle.outputDir == project.file("build/bundle/testAppTest.xctest")
 
         def test = project.tasks.xcTest

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
@@ -77,13 +77,13 @@ class XCTestConventionPluginTest extends Specification {
         link.binaryFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
         link.debuggable
 
-        def bundle = project.tasks.createXcTestBundle
+        def bundle = project.tasks.bundleSwiftTest
         bundle instanceof CreateSwiftBundle
-        bundle.outputDir == project.file("build/bundle/testAppTest.xctest")
+        bundle.outputDir.get().asFile == project.file("build/bundle/test/TestAppTest.xctest")
 
         def test = project.tasks.xcTest
         test instanceof XcTest
-        test.workingDir == projectDir
+        test.workingDir == projectDir.file("build/bundle/test")
         test.binResultsDir == projectDir.file("build/results/test/bin")
         test.reports.html.destination == projectDir.file("build/reports/test")
         test.reports.junitXml.destination == projectDir.file("build/reports/test/xml")
@@ -99,13 +99,13 @@ class XCTestConventionPluginTest extends Specification {
         compileSwift.objectFileDir.get().asFile == projectDir.file("output/obj/test")
 
         def link = project.tasks.linkTest
-        link.binaryFile.get().asFile == projectDir.file("output/exe/" + OperatingSystem.current().getExecutableName("testAppTest"))
+        link.binaryFile.get().asFile == projectDir.file("output/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
 
-        def bundle = project.tasks.createXcTestBundle
-        bundle.outputDir == project.file("output/bundle/testAppTest.xctest")
+        def bundle = project.tasks.bundleSwiftTest
+        bundle.outputDir.get().asFile == project.file("output/bundle/test/TestAppTest.xctest")
 
         def test = project.tasks.xcTest
-        test.workingDir == projectDir
+        test.workingDir == projectDir.file("output/bundle/test")
         test.reports.html.destination == projectDir.file("output/reports/test")
         test.reports.junitXml.destination == projectDir.file("output/reports/test/xml")
     }

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
@@ -17,10 +17,10 @@
 package org.gradle.nativeplatform.test.xctest.plugins
 
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.language.swift.tasks.CreateBundle
 import org.gradle.language.swift.tasks.SwiftCompile
 import org.gradle.nativeplatform.tasks.LinkBundle
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestSuite
-import org.gradle.nativeplatform.test.xctest.tasks.CreateXcTestBundle
 import org.gradle.nativeplatform.test.xctest.tasks.XcTest
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.ProjectBuilder
@@ -54,7 +54,7 @@ class XCTestConventionPluginTest extends Specification {
 
         then:
         project.components.test == project.xctest
-        project.components.testExe == project.xctest.executable
+        project.components.testBundle == project.xctest.bundle
     }
 
     def "adds compile, link and install tasks"() {
@@ -78,7 +78,7 @@ class XCTestConventionPluginTest extends Specification {
         link.debuggable
 
         def bundle = project.tasks.createXcTestBundle
-        bundle instanceof CreateXcTestBundle
+        bundle instanceof CreateBundle
         bundle.outputDir == project.file("build/bundle/testAppTest.xctest")
 
         def test = project.tasks.xcTest


### PR DESCRIPTION
### Context
This PR adds test coverage around the `xctest` component and remove some technical debt for https://github.com/gradle/gradle-native/issues/78.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=dl%2Fxctest-component-coverage)
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
