### PR TITLE
Add no source test coverage for swift executable and library

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftExecutableIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftExecutableIntegrationTest.groovy
@@ -27,6 +27,19 @@ import static org.gradle.util.Matchers.containsText
 
 @Requires(TestPrecondition.SWIFT_SUPPORT)
 class SwiftExecutableIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+    def "skip compile, link and install tasks when no source"() {
+        given:
+        buildFile << """
+            apply plugin: 'swift-executable'
+        """
+
+        expect:
+        succeeds "assemble"
+        result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":installMain", ":assemble")
+        // TODO - should skip the task as NO-SOURCE
+        result.assertTasksSkipped(":compileDebugSwift", ":linkDebug", ":installMain", ":assemble")
+    }
+
     def "build fails when compilation fails"() {
         given:
         buildFile << """

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.language.swift
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftAppWithLib
+import org.gradle.nativeplatform.fixtures.app.SwiftLib
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryIntegrationTest.groovy
@@ -26,6 +26,19 @@ import static org.gradle.util.Matchers.containsText
 
 @Requires(TestPrecondition.SWIFT_SUPPORT)
 class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+    def "skip compile and link tasks when no source"() {
+        given:
+        buildFile << """
+            apply plugin: 'swift-library'
+        """
+
+        expect:
+        succeeds "assemble"
+        result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":assemble")
+        // TODO - should skip the task as NO-SOURCE
+        result.assertTasksSkipped(":compileDebugSwift", ":linkDebug", ":assemble")
+    }
+
     def "build fails when compilation fails"() {
         given:
         buildFile << """


### PR DESCRIPTION
### Context
This PR adds left over test coverage for https://github.com/gradle/gradle-native/issues/27 and https://github.com/gradle/gradle-native/issues/28.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=dl%2Fno-source-coverage-swift)
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
