### PR TITLE
Add no source test coverage for C++ executable and library

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppExecutableIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppExecutableIntegrationTest.groovy
@@ -31,6 +31,19 @@ class CppExecutableIntegrationTest extends AbstractInstalledToolChainIntegration
         Assume.assumeTrue(toolChain.id != "mingw" && toolChain.id != "gcccygwin")
     }
 
+    def "skip compile, link and install tasks when no source"() {
+        given:
+        buildFile << """
+            apply plugin: 'cpp-executable'
+        """
+
+        expect:
+        succeeds "assemble"
+        result.assertTasksExecuted(":compileDebugCpp", ":linkDebug", ":installMain", ":assemble")
+        // TODO - should skip the task as NO-SOURCE
+        result.assertTasksSkipped(":compileDebugCpp", ":linkDebug", ":installMain", ":assemble")
+    }
+
     def "build fails when compilation fails"() {
         given:
         buildFile << """

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
@@ -29,6 +29,19 @@ class CppLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationSpe
         Assume.assumeTrue(toolChain.id != "mingw" && toolChain.id != "gcccygwin")
     }
 
+    def "skip compile and link tasks when no source"() {
+        given:
+        buildFile << """
+            apply plugin: 'cpp-library'
+        """
+
+        expect:
+        succeeds "assemble"
+        result.assertTasksExecuted(":compileDebugCpp", ":linkDebug", ":assemble")
+        // TODO - should skip the task as NO-SOURCE
+        result.assertTasksSkipped(":compileDebugCpp", ":linkDebug", ":assemble")
+    }
+
     def "build fails when compilation fails"() {
         given:
         buildFile << """

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.language.swift
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftAppWithLib
-import org.gradle.nativeplatform.fixtures.app.SwiftLib
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 


### PR DESCRIPTION
### Context
This PR adds left over test coverage for https://github.com/gradle/gradle-native/issues/3 and https://github.com/gradle/gradle-native/issues/2.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=dl%2Fno-source-coverage-cpp)
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
