### PR TITLE
More realistic build cache performance tests

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/AbstractFileChangeMutator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/AbstractFileChangeMutator.groovy
@@ -25,7 +25,7 @@ abstract class AbstractFileChangeMutator extends BuildExperimentListenerAdapter 
     protected final String sourceFilePath
     private String originalText
     private long timestamp
-    protected int counter
+    private int counter
 
     protected AbstractFileChangeMutator(String sourceFilePath) {
         this.sourceFilePath = sourceFilePath
@@ -36,12 +36,16 @@ abstract class AbstractFileChangeMutator extends BuildExperimentListenerAdapter 
         this.timestamp = timestamp
     }
 
+    protected int getCounter() {
+        return counter
+    }
+
     /**
      * Returns some text that is unlikely to have been included in any previous version of the target source file.
      * The string can be used as a Java identifier.
      */
     protected String getUniqueText() {
-        return "_" + String.valueOf(timestamp) + "_" + counter
+        return "_" + String.valueOf(timestamp) + "_" + getCounter()
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/ApplyAlternatingAbiChangeToJavaSourceFileMutator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/ApplyAlternatingAbiChangeToJavaSourceFileMutator.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.mutator
+
+class ApplyAlternatingAbiChangeToJavaSourceFileMutator extends ApplyAbiChangeToJavaSourceFileMutator {
+    ApplyAlternatingAbiChangeToJavaSourceFileMutator(String sourceFilePath) {
+        super(sourceFilePath)
+    }
+
+    @Override
+    protected int getCounter() {
+        return super.counter % 2
+    }
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
@@ -43,8 +43,8 @@ class AbstractTaskOutputCacheJavaPerformanceTest extends AbstractCrossVersionPer
      */
     def getScenarios() {
         [
-            [LARGE_MONOLITHIC_JAVA_PROJECT, 'assemble'],
-            [LARGE_JAVA_MULTI_PROJECT, 'assemble']
+            [LARGE_MONOLITHIC_JAVA_PROJECT, 'compileJava'],
+            [LARGE_JAVA_MULTI_PROJECT, 'compileJava']
         ]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
@@ -25,7 +25,7 @@ import static org.gradle.performance.fixture.BuildExperimentRunner.Phase.WARMUP
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 
-class AbstractTaskOutputCacheJavaPerformanceTest extends AbstractCrossVersionPerformanceTest{
+class AbstractTaskOutputCacheJavaPerformanceTest extends AbstractCrossVersionPerformanceTest {
     int firstWarmupWithCache = 1
 
     def setup() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.performance.fixture.InvocationSpec
 import org.gradle.performance.generator.JavaTestProject
 import org.gradle.performance.measure.MeasuredOperation
 import org.gradle.performance.mutator.ApplyAbiChangeToJavaSourceFileMutator
+import org.gradle.performance.mutator.ApplyAlternatingAbiChangeToJavaSourceFileMutator
 import org.gradle.performance.mutator.ApplyNonAbiChangeToJavaSourceFileMutator
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.keystore.TestKeyStore
@@ -268,6 +269,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = tasks.split(' ') as List
         runner.cleanTasks = ["clean"]
+        runner.addBuildExperimentListener(new ApplyAlternatingAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario[tasks]))
     }
 
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -269,7 +269,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = tasks.split(' ') as List
         runner.cleanTasks = ["clean"]
-        runner.addBuildExperimentListener(new ApplyAlternatingAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario[tasks]))
+        runner.addBuildExperimentListener(new ApplyAlternatingAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario["assemble"]))
     }
 
 }


### PR DESCRIPTION
In this way, the outputs will need to be re-snapshotted anyway and
the use case is closer to the branch switching case.
