### PR TITLE
Spike an basic API for requesting User input (do not merge)

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/UserInputHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/UserInputHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks;
+
+import org.apache.commons.lang.StringUtils;
+import org.gradle.internal.logging.sink.OutputEventRenderer;
+
+import java.util.Scanner;
+
+// TODO:DAZ Sanity check input
+// TODO:DAZ Handle ctrl-D to cancel build during input
+// TODO:DAZ Provide a way for plugins to see if user-input handling is unsupported (TAPI, CI, etc)
+// TODO:DAZ Fail gracefully when user-input handling is unsupported
+public class UserInputHandler {
+    private final OutputEventRenderer outputEventRenderer;
+
+    public UserInputHandler(OutputEventRenderer outputEventRenderer) {
+        this.outputEventRenderer = outputEventRenderer;
+    }
+
+    public String getUserResponse(String prompt) {
+        outputEventRenderer.onOutput(new org.gradle.internal.logging.events.UserInputRequestEvent(prompt));
+        try {
+            return StringUtils.trim(readInput());
+        } finally {
+            outputEventRenderer.onOutput(new org.gradle.internal.logging.events.UserInputResumeEvent());
+        }
+    }
+
+    private String readInput() {
+        Scanner scanner = new Scanner(System.in);
+        return scanner.nextLine();
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -65,6 +65,7 @@ import org.gradle.api.internal.project.taskfactory.PropertyAnnotationHandler;
 import org.gradle.api.internal.project.taskfactory.TaskClassInfoStore;
 import org.gradle.api.internal.project.taskfactory.TaskClassValidatorExtractor;
 import org.gradle.api.internal.project.taskfactory.TaskFactory;
+import org.gradle.api.internal.tasks.UserInputHandler;
 import org.gradle.api.internal.tasks.execution.statistics.TaskExecutionStatisticsEventAdapter;
 import org.gradle.api.internal.tasks.execution.statistics.TaskExecutionStatisticsListener;
 import org.gradle.api.provider.ProviderFactory;
@@ -136,6 +137,7 @@ import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.logging.sink.OutputEventRenderer;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.logging.BuildOperationLoggerFactory;
 import org.gradle.internal.operations.logging.DefaultBuildOperationLoggerFactory;
@@ -438,5 +440,9 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             registryAction.execute(registry);
         }
         return registry;
+    }
+
+    protected UserInputHandler createUserInputHandler(OutputEventRenderer outputEventRenderer) {
+        return new UserInputHandler(outputEventRenderer);
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
@@ -20,17 +20,21 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.logging.events.LogEvent;
 import org.gradle.internal.logging.events.LogLevelChangeEvent;
 import org.gradle.internal.logging.events.OutputEvent;
+import org.gradle.internal.logging.events.UserInputRequestEvent;
 import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
 import org.gradle.internal.logging.events.StyledTextOutputEvent;
+import org.gradle.internal.logging.events.UserInputResumeEvent;
 import org.gradle.internal.logging.serializer.LogEventSerializer;
 import org.gradle.internal.logging.serializer.LogLevelChangeEventSerializer;
+import org.gradle.internal.logging.serializer.UserInputRequestEventSerializer;
 import org.gradle.internal.logging.serializer.ProgressCompleteEventSerializer;
 import org.gradle.internal.logging.serializer.ProgressEventSerializer;
 import org.gradle.internal.logging.serializer.ProgressStartEventSerializer;
 import org.gradle.internal.logging.serializer.SpanSerializer;
 import org.gradle.internal.logging.serializer.StyledTextOutputEventSerializer;
+import org.gradle.internal.logging.serializer.UserInputResumeEventSerializer;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.serialize.BaseSerializerFactory;
 import org.gradle.internal.serialize.Decoder;
@@ -56,6 +60,8 @@ public class DaemonMessageSerializer {
 
         // Output events
         registry.register(LogEvent.class, new LogEventSerializer(logLevelSerializer, throwableSerializer));
+        registry.register(UserInputRequestEvent.class, new UserInputRequestEventSerializer());
+        registry.register(UserInputResumeEvent.class, new UserInputResumeEventSerializer());
         registry.register(StyledTextOutputEvent.class, new StyledTextOutputEventSerializer(logLevelSerializer, new ListSerializer<StyledTextOutputEvent.Span>(new SpanSerializer(factory.getSerializerFor(StyledTextOutput.Style.class)))));
         registry.register(ProgressStartEvent.class, new ProgressStartEventSerializer());
         registry.register(ProgressCompleteEvent.class, new ProgressCompleteEventSerializer());

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/UserInputRequestEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/UserInputRequestEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.logging.events;
+
+import org.gradle.api.logging.LogLevel;
+
+import javax.annotation.Nullable;
+
+public class UserInputRequestEvent extends OutputEvent {
+    private final String prompt;
+
+    public UserInputRequestEvent(String prompt) {
+        this.prompt = prompt;
+    }
+
+    public String getPrompt() {
+        return prompt;
+    }
+
+    @Nullable
+    @Override
+    public LogLevel getLogLevel() {
+        return LogLevel.QUIET;
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/UserInputResumeEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/UserInputResumeEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.logging.events;
+
+import org.gradle.api.logging.LogLevel;
+
+import javax.annotation.Nullable;
+
+public class UserInputResumeEvent extends OutputEvent {
+    @Nullable
+    @Override
+    public LogLevel getLogLevel() {
+        return LogLevel.QUIET;
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/UserInputRequestEventSerializer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/UserInputRequestEventSerializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.serializer;
+
+import org.gradle.internal.logging.events.UserInputRequestEvent;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.serialize.Serializer;
+
+public class UserInputRequestEventSerializer implements Serializer<UserInputRequestEvent> {
+
+    @Override
+    public void write(Encoder encoder, UserInputRequestEvent event) throws Exception {
+        encoder.writeString(event.getPrompt());
+    }
+
+    @Override
+    public UserInputRequestEvent read(Decoder decoder) throws Exception {
+        String prompt = decoder.readString();
+        return new UserInputRequestEvent(prompt);
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/UserInputResumeEventSerializer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/serializer/UserInputResumeEventSerializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.serializer;
+
+import org.gradle.internal.logging.events.UserInputResumeEvent;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.serialize.Serializer;
+
+public class UserInputResumeEventSerializer implements Serializer<UserInputResumeEvent> {
+
+    @Override
+    public void write(Encoder encoder, UserInputResumeEvent event) throws Exception {
+        encoder.writeBoolean(true);
+    }
+
+    @Override
+    public UserInputResumeEvent read(Decoder decoder) throws Exception {
+        decoder.readBoolean();
+        return new UserInputResumeEvent();
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class GroupingProgressLogEventGenerator implements OutputEventListener {
 
-    private static final long LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT = TimeUnit.SECONDS.toMillis(5);
+    private static final long LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT = TimeUnit.SECONDS.toMillis(2);
     private final OutputEventListener listener;
     private final TimeProvider timeProvider;
     private final LogHeaderFormatter headerFormatter;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.logging.sink;
 
+import com.google.common.collect.Lists;
 import net.jcip.annotations.ThreadSafe;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.StandardOutputListener;
@@ -41,6 +42,8 @@ import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
+import org.gradle.internal.logging.events.UserInputRequestEvent;
+import org.gradle.internal.logging.events.UserInputResumeEvent;
 import org.gradle.internal.logging.format.PrettyPrefixedLogHeaderFormatter;
 import org.gradle.internal.logging.text.StreamBackedStandardOutputListener;
 import org.gradle.internal.logging.text.StreamingStyledTextOutput;
@@ -50,6 +53,8 @@ import org.gradle.internal.time.TimeProvider;
 
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -210,12 +215,14 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     public OutputEventRenderer addConsole(Console console, boolean stdout, boolean stderr, ConsoleMetaData consoleMetaData) {
         final OutputEventListener consoleChain = new ThrottlingOutputEventListener(
-            new BuildStatusRenderer(
-                new WorkInProgressRenderer(
-                    new BuildLogLevelFilterRenderer(
-                        new GroupingProgressLogEventGenerator(new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), timeProvider, new PrettyPrefixedLogHeaderFormatter(), false)),
-                    console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
-                console.getStatusBar(), console, consoleMetaData, timeProvider),
+            new UserInputPromptRenderer(
+                new BuildStatusRenderer(
+                    new WorkInProgressRenderer(
+                        new BuildLogLevelFilterRenderer(
+                            new GroupingProgressLogEventGenerator(new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), timeProvider, new PrettyPrefixedLogHeaderFormatter(), false)),
+                        console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
+                    console.getStatusBar(), console, consoleMetaData, timeProvider),
+                console),
             timeProvider);
         synchronized (lock) {
             if (stdout && stderr) {
@@ -340,5 +347,63 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
             }
             delegate.onOutput(event);
         }
+    }
+
+    private class UserInputPromptRenderer implements OutputEventListener {
+        private final OutputEventListener delegate;
+        private final Console console;
+        private final List<OutputEvent> eventQueue = Lists.newArrayList();
+        private boolean paused;
+
+        public UserInputPromptRenderer(OutputEventListener delegate, Console console) {
+            this.delegate = delegate;
+            this.console = console;
+        }
+
+        @Override
+        public void onOutput(OutputEvent event) {
+            if (event instanceof UserInputRequestEvent) {
+                String prompt = ((UserInputRequestEvent) event).getPrompt();
+                console.getBuildProgressArea().setVisible(false);
+                console.flush();
+                console.getBuildOutputArea().println(prompt);
+                console.flush();
+                paused = true;
+                return;
+            }
+            if (event instanceof UserInputResumeEvent) {
+                if (!paused) {
+                    throw new RuntimeException("UnPause when not paused");
+                }
+                paused = false;
+                console.getBuildProgressArea().setVisible(true);
+                console.flush();
+
+                replayEvents();
+
+                return;
+            }
+
+            if (paused) {
+                eventQueue.add(event);
+                return;
+            }
+
+            delegate.onOutput(event);
+        }
+
+        private void replayEvents() {
+            for (OutputEvent outputEvent : eventQueue) {
+                delegate.onOutput(outputEvent);
+            }
+            eventQueue.clear();
+        }
+    }
+
+    private PrintStream getSystemOut() {
+        if (originalStdOut != null) {
+            return (PrintStream) originalStdOut;
+        }
+        return System.out;
     }
 }


### PR DESCRIPTION
This spike demonstrates a possible mechanism to ask for (and receive) user input from a task or plugin, in a way that works in the daemon, with both the rich and plain console.

The API is deliberately very basic, and will not support any form of interaction beyond a single request and response. (Sequential requests will be interspersed by other logging).

The implementation pauses logging while waiting for a user response, spooling all events to be replayed after the response has been received. There's no timeout, and a build could quite easily run out of memory while spooling messages waiting for input. (This is probably OK for the build-scan plugin, since it will likely ask for license agreement in a `buildFinished` hook, when little other logging is going on).

You can see this API in action with the following basic example:
```
import org.gradle.api.internal.tasks.UserInputHandler

task ask {
    doLast {
        def userInputHandler = project.services.get(UserInputHandler)
        def response = userInputHandler.getUserResponse("Enter your response:")

        println("You entered '${response}'")
    }
}
```