### PR TITLE
Make build cache performance tests fair

### DIFF
--- a/subprojects/performance/performance.gradle
+++ b/subprojects/performance/performance.gradle
@@ -15,3 +15,7 @@
  */
 
 apply from: 'templates.gradle'
+
+dependencies {
+    performanceTestImplementation libraries.commons_compress
+}


### PR DESCRIPTION
We used to restore file dates when loading from cache, which in turn
allowed performance tests to reuse some file snapshots from earlier rounds.
This however does not reflect real life situations most of the time,
and made the results look quicker. We stopped restoring file dates in 4.2,
and hence the performance tests became fair for this version. However,
now the comparison is skewed in favor of the older versions.

To compensate, we change the file dates in every cached artifact after each
round. This makes sure that we never reuse a file snapshot.
