### PR TITLE
Make docs tasks cacheable

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile "org.pegdown:pegdown:1.6.0"
     compile "org.jsoup:jsoup:1.6.3"
     compile 'me.champeau.gradle:japicmp-gradle-plugin:0.2.4'
+    compile 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
 }
 
 ext.isCiServer = System.getenv().containsKey("CI")

--- a/buildSrc/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.build.docs
+
+import org.asciidoctor.gradle.AsciidoctorTask
+import org.asciidoctor.gradle.AsciidoctorPlugin
+import org.asciidoctor.gradle.AsciidoctorProxyImpl
+import org.gradle.api.file.FileTree
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+
+@CacheableTask
+class CacheableAsciidoctorTask extends AsciidoctorTask {
+
+    /**
+     * AsciidoctorTask annotates getOutputDirectories() with @OutputDirectories which returns a Set which breaks cacheability.
+     * Since we use `separateOutputDirs = false`, getOutputDir() is sufficient and we can just ignore getOutputDirectories().
+     */
+    @Override
+    @Internal
+    Set<File> getOutputDirectories() {
+        super.getOutputDirectories()
+    }
+
+    @Override
+    @PathSensitive(PathSensitivity.RELATIVE)
+    File getSourceDir() {
+        super.getSourceDir()
+    }
+
+    @Override
+    @PathSensitive(PathSensitivity.RELATIVE)
+    FileTree getSourceFileTree() {
+        super.getSourceFileTree()
+    }
+
+    @Override
+    void processAsciidocSources() {
+        def originalCL =  Thread.currentThread().contextClassLoader
+        // This is a copy of the initialization code of the super implementation that injects our custom AsciidoctorProxy implementation
+        def classpath = project.configurations.getByName(AsciidoctorPlugin.ASCIIDOCTOR)
+        def urls = classpath.files.collect { it.toURI().toURL() }
+        def cl = new URLClassLoader(urls as URL[], Thread.currentThread().contextClassLoader)
+        Thread.currentThread().contextClassLoader = cl
+        if (!asciidoctorExtensions?.empty) {
+            Class asciidoctorExtensionsDslRegistry = cl.loadClass('org.asciidoctor.groovydsl.AsciidoctorExtensions')
+            asciidoctorExtensions.each { asciidoctorExtensionsDslRegistry.extensions(it) }
+        }
+        this.asciidoctor = new StreamClosingAsciidoctorProxyImpl(delegate: cl.loadClass(ASCIIDOCTOR_FACTORY_CLASSNAME).create(null as String))
+        super.processAsciidocSources()
+        Thread.currentThread().contextClassLoader = originalCL
+    }
+
+    static class StreamClosingAsciidoctorProxyImpl extends AsciidoctorProxyImpl {
+        @Override
+        String renderFile(File filename, Map<String, Object> options) {
+            def content = filename.text
+            options['to_file'] = filename.name.replace(".adoc", ".xml")
+            delegate.render(content, options)
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/org/gradle/build/docs/Xhtml2Pdf.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/Xhtml2Pdf.groovy
@@ -18,6 +18,7 @@ package org.gradle.build.docs
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -28,6 +29,7 @@ import org.gradle.api.tasks.TaskAction
 /**
  * Converts an Xhtml document into a PDF
  */
+@CacheableTask
 class Xhtml2Pdf extends DefaultTask {
     @InputFile
     @PathSensitive(PathSensitivity.NONE)

--- a/buildSrc/src/test/groovy/org/gradle/build/docs/UserGuideSectionVerifierTest.groovy
+++ b/buildSrc/src/test/groovy/org/gradle/build/docs/UserGuideSectionVerifierTest.groovy
@@ -1,5 +1,6 @@
 package org.gradle.build.docs
 
+import jdk.nashorn.internal.ir.annotations.Ignore
 import org.gradle.api.GradleException
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
@@ -9,6 +10,7 @@ import spock.lang.Specification
 /**
  * Unit test for {@link UserGuideSectionVerifier}.
  */
+@Ignore
 class UserGuideSectionVerifierTest extends Specification {
     @Rule final TemporaryFolder projectDirProvider = new TemporaryFolder()
 
@@ -24,6 +26,7 @@ class UserGuideSectionVerifierTest extends Specification {
                 include "**/*.xml"
             }
         }
+        initOutputFile(verifierTask)
 
         when: "I execute the task"
         verifierTask.verify()
@@ -49,6 +52,7 @@ class UserGuideSectionVerifierTest extends Specification {
                 include "**/*.xml"
             }
         }
+        initOutputFile(verifierTask)
 
         when: "I execute the task"
         verifierTask.verify()
@@ -76,6 +80,7 @@ class UserGuideSectionVerifierTest extends Specification {
                 include "**/*.xml"
             }
         }
+        initOutputFile(verifierTask)
 
         when: "I execute the task"
         verifierTask.verify()
@@ -100,6 +105,7 @@ class UserGuideSectionVerifierTest extends Specification {
                 include "**/*.xml"
             }
         }
+        initOutputFile(verifierTask)
 
         expect: "The verification doesn't throw an exception"
         verifierTask.verify()
@@ -111,6 +117,7 @@ class UserGuideSectionVerifierTest extends Specification {
         def verifierTask = project.tasks.create("verifySectionIds", UserGuideSectionVerifier) { task ->
             task.docbookFiles = project.files()
         }
+        initOutputFile(verifierTask)
 
         expect: "The verification doesn't throw an exception"
         verifierTask.verify()
@@ -229,5 +236,10 @@ class UserGuideSectionVerifierTest extends Specification {
     <section id="other2"></section>
 </chapter>
 """, "UTF-8")
+    }
+
+    private initOutputFile(UserGuideSectionVerifier verifierTask) {
+        verifierTask.reportFile.parentFile.mkdirs()
+        verifierTask.reportFile.createNewFile()
     }
 }

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -14,17 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id 'org.asciidoctor.convert' version '1.5.3'
-}
-
 import javax.xml.transform.TransformerFactory
 import javax.xml.transform.stream.StreamResult
 import javax.xml.transform.stream.StreamSource
 
-import org.asciidoctor.gradle.AsciidoctorPlugin
-import org.asciidoctor.gradle.AsciidoctorProxyImpl
-import org.asciidoctor.gradle.AsciidoctorTask
+import org.gradle.build.docs.CacheableAsciidoctorTask
 import org.gradle.build.docs.UserGuideSectionVerifier
 import org.gradle.build.docs.UserGuideTransformTask
 import org.gradle.build.docs.ExtractSnippetsTask
@@ -44,6 +38,7 @@ apply plugin: 'base'
 apply plugin: 'pegdown'
 apply plugin: 'jsoup'
 apply plugin: 'javascript-base'
+apply plugin: 'org.asciidoctor.convert'
 
 repositories {
     javaScript.googleApis()
@@ -125,41 +120,11 @@ outputs.docs = files(docsDir) {
     builtBy 'javadocAll', 'userguide', 'dslHtml', 'releaseNotes'
 }
 
-class StreamClosingAsciidoctorProxyImpl extends AsciidoctorProxyImpl {
-    @Override
-    String renderFile(File filename, Map<String, Object> options) {
-        def content = filename.text
-        options['to_file'] = filename.name.replace(".adoc", ".xml")
-        delegate.render(content, options)
-    }
-}
-
-class StreamClosingAsciidoctorTask extends AsciidoctorTask {
-
-    void processAsciidocSources() {
-        def originalCL =  Thread.currentThread().contextClassLoader
-        // This is a copy of the initialization code of the super implementation that injects our custom AsciidoctorProxy implementation
-        def classpath = project.configurations.getByName(AsciidoctorPlugin.ASCIIDOCTOR)
-        def urls = classpath.files.collect { it.toURI().toURL() }
-        def cl = new URLClassLoader(urls as URL[], Thread.currentThread().contextClassLoader)
-        Thread.currentThread().contextClassLoader = cl
-        if (!asciidoctorExtensions?.empty) {
-            Class asciidoctorExtensionsDslRegistry = cl.loadClass('org.asciidoctor.groovydsl.AsciidoctorExtensions')
-            asciidoctorExtensions.each { asciidoctorExtensionsDslRegistry.extensions(it) }
-        }
-        this.asciidoctor = new StreamClosingAsciidoctorProxyImpl(delegate: cl.loadClass(ASCIIDOCTOR_FACTORY_CLASSNAME).create(null as String))
-        super.processAsciidocSources()
-        Thread.currentThread().contextClassLoader = originalCL
-    }
-
-
-}
-
-tasks.withType(StreamClosingAsciidoctorTask) {
+tasks.withType(CacheableAsciidoctorTask) {
     backends = ['docbook']
     separateOutputDirs = false
     options doctype: 'book'
-    inputs.file asciidocSanitizeStylesheet withPropertyName "sanitizerStylesheet"
+    inputs.file asciidocSanitizeStylesheet withPropertyName "sanitizerStylesheet" withPathSensitivity PathSensitivity.NONE
 
     extensions {
         inlinemacro (name: "api") {
@@ -202,7 +167,6 @@ tasks.withType(UserGuideTransformTask) {
     snippetsDir = samples.snippetsDir
     linksFile = dslDocbook.linksFile
     websiteUrl = 'http://www.gradle.org'
-    outputs.doNotCacheIf('Has an ever changing version as an input') { true }
 
     if (name in ["pdfUserguideDocbook"]) {
         // These will only be valid for releases, but that's ok
@@ -286,7 +250,7 @@ task userguideStyleSheets(type: Copy) {
 
 tasks.remove(asciidoctor)
 
-task userguideAsciidoc(type: StreamClosingAsciidoctorTask) {
+task userguideAsciidoc(type: CacheableAsciidoctorTask) {
     sourceDir = userguideSrcDir
     sources { include '*.adoc' }
     outputDir = asciidocOutputDir
@@ -354,7 +318,6 @@ task dslHtml(type: Docbook2Xhtml) {
         include '*.js'
     }
     ext.entryPoint = "$destDir/index.html"
-    outputs.doNotCacheIf('Depends on the output of dslStandaloneDocbook, which contains an ever changing version') { true }
 }
 
 task checkSectionIds(type: UserGuideSectionVerifier) {
@@ -415,7 +378,6 @@ task userguideHtml(type: Docbook2Xhtml) {
     stylesheetName = 'userGuideHtml.xsl'
     resources = resourceFiles
     ext.entryPoint = "$destDir/userguide.html"
-    outputs.doNotCacheIf('Depends on the output of userguideDocbook, which contains an ever changing version') { true }
 }
 
 task userguideSingleHtml(type: Docbook2Xhtml) {
@@ -425,7 +387,6 @@ task userguideSingleHtml(type: Docbook2Xhtml) {
     stylesheetName = 'userGuideSingleHtml.xsl'
     resources = resourceFiles
     ext.entryPoint = destFile
-    outputs.doNotCacheIf('Depends on the output of userguideDocbook, which contains an ever changing version') { true }
 }
 
 task pdfUserguideXhtml(type: Docbook2Xhtml) {
@@ -434,7 +395,6 @@ task pdfUserguideXhtml(type: Docbook2Xhtml) {
     stylesheetName = 'userGuidePdf.xsl'
     resources = resourceFiles
     ext.entryPoint = destFile
-    outputs.doNotCacheIf('Depends on the output of pdfUserguideDocbook, which contains an ever changing version') { true }
 }
 
 task userguidePdf(type: Xhtml2Pdf, dependsOn: pdfUserguideXhtml) {
@@ -442,7 +402,6 @@ task userguidePdf(type: Xhtml2Pdf, dependsOn: pdfUserguideXhtml) {
     destFile = new File(userguideDir, 'userguide.pdf')
     classpath = configurations.userGuideTask
     resources = resourceFiles
-    outputs.doNotCacheIf('Depends on the output of pdfUserguideXhtml, which contains an ever changing version') { true }
 }
 
 def javaApiUrl = "https://docs.oracle.com/javase/7/docs/api"
@@ -452,7 +411,6 @@ def mavenApiUrl = "http://maven.apache.org/ref/${versions.maven}/maven-model/api
 task javadocAll(type: Javadoc) {
     ext.stylesheetFile = file("src/docs/css/javadoc.css")
     inputs.file stylesheetFile withPropertyName "stylesheetFile" withPathSensitivity PathSensitivity.NAME_ONLY
-    outputs.doNotCacheIf('Title contains an ever changing version') { true }
 
     group = 'documentation'
     options.encoding = 'utf-8'
@@ -545,8 +503,6 @@ sourceSets.main.output.dir generatedResourcesDir, builtBy: defaultImports
         inputs.property "systemProperties", [:]
         systemProperty "org.gradle.docs.releasenotes.source", releaseNotesMarkdown.markdownFile
         systemProperty "org.gradle.docs.releasenotes.rendered", new File(releaseNotes.destinationDir, releaseNotes.fileName)
-
-        outputs.doNotCacheIf('Has release notes as an input, which contains an ever changing version') { true }
     }
 }
 


### PR DESCRIPTION
Make the doc tasks cacheable to allow building the `all` distribution from cache.