### PR TITLE
Enable parallel snapshotting of files

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -381,10 +381,10 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
 
         @Override
         public void run() {
-            try {
-                delegate = new RegularFileSnapshot(internPath(details.getFile()), details.getRelativePath(), false, fileSnapshot(details));
-            } finally {
-                synchronized (lock) {
+            synchronized (lock) {
+                try {
+                    delegate = new RegularFileSnapshot(internPath(details.getFile()), details.getRelativePath(), false, fileSnapshot(details));
+                } finally {
                     lock.notifyAll();
                 }
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -227,7 +227,7 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
         private final ArrayList<FileSnapshot> fileTreeElements;
         private final Runnable[] buffer;
         private int bufferSize;
-        private boolean completed = false;
+        private boolean completed;
 
         FileVisitorImpl() {
             this.fileTreeElements = Lists.newArrayList();
@@ -273,6 +273,7 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
                 }
                 i++;
             }
+            completed = true;
             return fileTreeElements;
 
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -65,9 +65,9 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
     private final FileSystem fileSystem;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
     private final FileSystemMirror fileSystemMirror;
-    private final ProducerGuard<String> producingSelfSnapshots = ProducerGuard.striped();
-    private final ProducerGuard<String> producingTrees = ProducerGuard.striped();
-    private final ProducerGuard<String> producingAllSnapshots = ProducerGuard.striped();
+    private final ProducerGuard<String> producingSelfSnapshots = ProducerGuard.adaptive();
+    private final ProducerGuard<String> producingTrees = ProducerGuard.adaptive();
+    private final ProducerGuard<String> producingAllSnapshots = ProducerGuard.adaptive();
     private final DefaultGenericFileCollectionSnapshotter snapshotter;
     private final ExecutorService executorService;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -253,7 +253,12 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
             Runnable task = new Runnable() {
                 @Override
                 public void run() {
-                    deferred.setResult(new RegularFileSnapshot(getPath(fileDetails.getFile()), fileDetails.getRelativePath(), false, fileSnapshot(fileDetails)));
+                    RegularFileSnapshot snapshot = null;
+                    try {
+                        snapshot = new RegularFileSnapshot(getPath(fileDetails.getFile()), fileDetails.getRelativePath(), false, fileSnapshot(fileDetails));
+                    } finally {
+                        deferred.setResult(snapshot);
+                    }
                 }
             };
             buffer[bufferSize++] = task;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -348,8 +348,8 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
         }
 
         private FileSnapshot getResult() {
-            while (delegate == null) {
-                synchronized (lock) {
+            synchronized (lock) {
+                while (delegate == null) {
                     try {
                         lock.wait();
                     } catch (InterruptedException e) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -223,6 +223,10 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
         }
     }
 
+    private RegularFileSnapshot createRegularFileSnapshot(FileVisitDetails fileDetails) {
+        return new RegularFileSnapshot(internPath(fileDetails.getFile()), fileDetails.getRelativePath(), false, fileSnapshot(fileDetails));
+    }
+
     private class FileVisitorImpl implements FileVisitor {
         private final static int BATCH_SIZE = 32;
         private final ArrayList<FileSnapshot> fileTreeElements;
@@ -242,11 +246,7 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
 
         @Override
         public void visitFile(final FileVisitDetails fileDetails) {
-            if (buffer != null) {
-                visitFileBuffered(fileDetails);
-            } else {
-                visitFileDirect(fileDetails);
-            }
+            visitFileBuffered(fileDetails);
         }
 
         private void visitFileBuffered(final FileVisitDetails fileDetails) {
@@ -256,10 +256,6 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
             if (bufferSize == BATCH_SIZE) {
                 flush();
             }
-        }
-
-        private void visitFileDirect(final FileVisitDetails fileDetails) {
-            fileTreeElements.add(new RegularFileSnapshot(internPath(fileDetails.getFile()), fileDetails.getRelativePath(), false, fileSnapshot(fileDetails)));
         }
 
         public List<FileSnapshot> getElements() {
@@ -403,7 +399,7 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter, Clos
         public void run() {
             synchronized (lock) {
                 try {
-                    delegate = new RegularFileSnapshot(internPath(details.getFile()), details.getRelativePath(), false, fileSnapshot(details));
+                    delegate = createRegularFileSnapshot(details);
                 } finally {
                     lock.notifyAll();
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
@@ -53,6 +53,10 @@ class DefaultClasspathSnapshotterTest extends Specification {
         fileSystemSnapshotter,
         stringInterner)
 
+    def tearDown() {
+        fileSystemSnapshotter.close()
+    }
+
     def "directories and missing files are ignored"() {
         def emptyDir = file('root/emptyDir').createDir()
         def missingFile = file('some').createDir().file('does-not-exist')

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotterTest.groovy
@@ -31,6 +31,10 @@ class DefaultFileSystemSnapshotterTest extends Specification {
     def fileSystemMirror = new DefaultFileSystemMirror([])
     def snapshotter = new DefaultFileSystemSnapshotter(fileHasher, new StringInterner(), TestFiles.fileSystem(), TestFiles.directoryFileTreeFactory(), fileSystemMirror)
 
+    def tearDown() {
+        snapshotter.close()
+    }
+
     def "fetches details of a file and caches the result"() {
         def f = tmpDir.createFile("f")
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
@@ -35,11 +35,16 @@ import static InputPathNormalizationStrategy.ABSOLUTE
 class DefaultGenericFileCollectionSnapshotterTest extends Specification {
     def stringInterner = new StringInterner()
     def fileSystemMirror = new DefaultFileSystemMirror([])
-    def snapshotter = new DefaultGenericFileCollectionSnapshotter(stringInterner, TestFiles.directoryFileTreeFactory(), new DefaultFileSystemSnapshotter(new TestFileHasher(), stringInterner, TestFiles.fileSystem(), TestFiles.directoryFileTreeFactory(), fileSystemMirror))
+    def snapshotter = new DefaultGenericFileCollectionSnapshotter(stringInterner, TestFiles.directoryFileTreeFactory(), fileSystemSnapshotter)
     def listener = Mock(ChangeListener)
     def normalizationStrategy = InputNormalizationStrategy.NOT_CONFIGURED
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    private DefaultFileSystemSnapshotter fileSystemSnapshotter = new DefaultFileSystemSnapshotter(new TestFileHasher(), stringInterner, TestFiles.fileSystem(), TestFiles.directoryFileTreeFactory(), fileSystemMirror)
+
+    def tearDown() {
+        fileSystemSnapshotter.close()
+    }
 
     def getFilesReturnsOnlyTheFilesWhichExisted() {
         given:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
@@ -35,12 +35,13 @@ import static InputPathNormalizationStrategy.ABSOLUTE
 class DefaultGenericFileCollectionSnapshotterTest extends Specification {
     def stringInterner = new StringInterner()
     def fileSystemMirror = new DefaultFileSystemMirror([])
-    def snapshotter = new DefaultGenericFileCollectionSnapshotter(stringInterner, TestFiles.directoryFileTreeFactory(), fileSystemSnapshotter)
     def listener = Mock(ChangeListener)
     def normalizationStrategy = InputNormalizationStrategy.NOT_CONFIGURED
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     private DefaultFileSystemSnapshotter fileSystemSnapshotter = new DefaultFileSystemSnapshotter(new TestFileHasher(), stringInterner, TestFiles.fileSystem(), TestFiles.directoryFileTreeFactory(), fileSystemMirror)
+    def snapshotter = new DefaultGenericFileCollectionSnapshotter(stringInterner, TestFiles.directoryFileTreeFactory(), fileSystemSnapshotter)
+
 
     def tearDown() {
         fileSystemSnapshotter.close()


### PR DESCRIPTION
### Context

So far, when snapshotting a file tree (typically input/output snapshotting), Gradle was walking the file directory and snapshotting each file serially. In practice, it means that when the file walker returns a file, this file is immediately, synchronously, snapshotted, and the walker has to wait for snapshotting to complete before moving to the next file.

However, profiling has shown that walking a file tree is I/O expensive, and already time consuming. So we investigated ways to perform snapshotting _concurrently to_ walking the file tree. This pull request is the result of the experiment.

Implementation-wise, it uses a fixed thread pool for snapshotting. It doesn't use the build operation processor, because it turned out to add too much overhead and synchronization for this to be worth doing, even with batching of files.

So this implementation uses a fixed thread pool executor, and each thread is provided with a _batch_ of files to snapshot.

Local performance improvements on the `up-to-date assemble on largeMonolithicJavaProject` ranged from 6% (measured by me using performance tests) to 20% (measured by @wolfs using Gradle Profiler). However, results on CI turned out to be very different: https://builds.gradle.org/viewLog.html?buildId=7979216&buildTypeId=Gradle_Check_PerformanceTestCoordinator&tab=report_project944_Performance

We can see that there's little to no improvement for most scenarios, but some are on the other hand very impressive:

- 55% faster for [clean assemble on manyProjectsNative](https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/7979216:id/report-performance-performance-tests.zip%21/report/tests/clean-assemble-on-manyProjectsNative.html)
- 36% faster for [visiting gzip file trees](https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/7979216:id/report-performance-performance-tests.zip%21/report/tests/visiting-gzip-tar-trees.html)
- 41% faster for [visiting tar trees](https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/7979216:id/report-performance-performance-tests.zip%21/report/tests/visiting-tar-trees.html)
- 55% faster for [visiting zip trees](https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/7979216:id/report-performance-performance-tests.zip%21/report/tests/visiting-zip-trees.html)

The visit compressed archives improvements kind of make sense because we can expect that walking the trees is even more expensive, so snapshotting the entries concurrently really help.

However I'm surprised not to see as much improvement as locally for other use cases.

Things I noticed, profiling after those improvements, is that interning the file paths (absolute path, and constructing `RelativePath` entries) now clearly dominate snapshotting. I tried to implement a faster interner, without success. At this point I think it would be better to _avoid_ interning at all, which, in order to keep the memory usage low, probably means not storing absolute paths at all.

See gradle/build-cache#768
