### PR TITLE
Make build cache performance tests fair

### DIFF
--- a/subprojects/performance/performance.gradle
+++ b/subprojects/performance/performance.gradle
@@ -15,3 +15,7 @@
  */
 
 apply from: 'templates.gradle'
+
+dependencies {
+    performanceTestImplementation libraries.commons_compress
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -85,6 +85,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         protocol = "http"
         pushToRemote = true
         runner.addBuildExperimentListener(cleanLocalCache())
+        runner.addBuildExperimentListener(touchCacheArtifacts())
 
         when:
         def result = runner.run()
@@ -102,6 +103,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         protocol = "https"
         pushToRemote = true
         runner.addBuildExperimentListener(cleanLocalCache())
+        runner.addBuildExperimentListener(touchCacheArtifacts())
 
         def keyStore = TestKeyStore.init(temporaryFolder.file('ssl-keystore'))
         keyStore.enableSslWithServerCert(buildCacheServer)
@@ -261,7 +263,9 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
             @Override
             void beforeInvocation(BuildExperimentInvocationInfo invocationInfo) {
                 touchCacheArtifacts(cacheDir)
-                touchCacheArtifacts(buildCacheServer.cacheDir)
+                if (buildCacheServer.running) {
+                    touchCacheArtifacts(buildCacheServer.cacheDir)
+                }
             }
         }
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -273,12 +273,12 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
         int count = 0
         dir.eachFile { File cacheArchiveFile ->
             if (cacheArchiveFile.name ==~ /[a-z0-9]{32}/) {
-                def tempFile = temporaryFolder.file("re-tar-temp");
+                def tempFile = temporaryFolder.file("re-tar-temp")
                 tempFile.withOutputStream { outputStream ->
                     def tarOutput = new TarArchiveOutputStream(new GZIPOutputStream(outputStream))
-                    tarOutput.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-                    tarOutput.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
-                    tarOutput.setAddPaxHeadersForNonAsciiNames(true);
+                    tarOutput.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX)
+                    tarOutput.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX)
+                    tarOutput.setAddPaxHeadersForNonAsciiNames(true)
                     cacheArchiveFile.withInputStream { inputStream ->
                         def tarInput = new TarArchiveInputStream(new GZIPInputStream(inputStream))
                         while (true) {
@@ -289,14 +289,16 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCacheJavaPe
 
                             tarEntry.setModTime(tarEntry.modTime + 3743)
                             tarOutput.putArchiveEntry(tarEntry)
-                            tarOutput << tarInput
+                            if (!tarEntry.directory) {
+                                tarOutput << tarInput
+                            }
                             tarOutput.closeArchiveEntry()
                         }
                     }
                     tarOutput.close()
                 }
-                cacheArchiveFile.delete()
-                tempFile.renameTo(cacheArchiveFile)
+                assert cacheArchiveFile.delete()
+                assert tempFile.renameTo(cacheArchiveFile)
             }
             count++
         }


### PR DESCRIPTION
This PR replaces #2835.

We used to restore file dates when loading from cache, which in turn allowed performance tests to reuse some file snapshots from earlier rounds. This however does not reflect real life situations most of the time, and made the results look quicker. We stopped restoring file dates in 4.2, and hence the performance tests became fair for this version. However, now the comparison is skewed in favor of the older versions.

To compensate, we change the file dates in every cached artifact after each round. This makes sure that we never reuse a file snapshot.