### PR TITLE
Clean stale object files from `SwiftCompile` task

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -107,7 +107,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
         result.assertTasksSkipped(":greeter:compileDebugSwift", ":greeter:linkDebug", ":app:compileDebugSwift", ":app:linkDebug", ":app:installDebug", ":app:assemble")
     }
 
-    def "stale object files are removed for executable"() {
+    def "removes stale object files for executable"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new IncrementalSwiftStaleCompileOutputApp()
 
@@ -133,7 +133,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
         installation("build/install/main/debug").exec().out == app.expectedAlternateOutput
     }
 
-    def "stale object files are removed library"() {
+    def "removes stale object files for library"() {
         def lib = new IncrementalSwiftStaleCompileOutputLib()
         settingsFile << "rootProject.name = 'hello'"
 
@@ -153,7 +153,6 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
         succeeds "assemble"
         result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":assemble")
         result.assertTasksNotSkipped(":compileDebugSwift", ":linkDebug", ":assemble")
-
 
         file("build/obj/main/debug").assertHasDescendants(lib.alternate.expectedIntermediateDescendants as String[])
         sharedLibrary("build/lib/main/debug/Hello").assertExists()

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift
 
-import groovy.io.FileType
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftModifyExpectedOutputApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftModifyExpectedOutputAppWithLib
@@ -129,7 +128,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
         result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":installDebug", ":assemble")
         result.assertTasksNotSkipped(":compileDebugSwift", ":linkDebug", ":installDebug", ":assemble")
 
-        files("build/obj/main")*.name as Set == app.alternate.expectedIntermediateFilenames
+        file("build/obj/main/debug").assertHasDescendants(app.alternate.expectedIntermediateDescendants as String[])
         executable("build/exe/main/debug/App").assertExists()
         installation("build/install/main/debug").exec().out == app.expectedAlternateOutput
     }
@@ -156,19 +155,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
         result.assertTasksNotSkipped(":compileDebugSwift", ":linkDebug", ":assemble")
 
 
-        files("build/obj/main")*.name as Set == lib.alternate.expectedIntermediateFilenames
+        file("build/obj/main/debug").assertHasDescendants(lib.alternate.expectedIntermediateDescendants as String[])
         sharedLibrary("build/lib/main/debug/Hello").assertExists()
-    }
-
-    private Set<File> files(Object path) {
-        File directory = file(path)
-        directory.assertIsDir()
-
-        def result = [] as Set
-        directory.eachFileRecurse(FileType.FILES) {
-            result += it
-        }
-
-        return result
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -22,7 +22,9 @@ import org.gradle.api.provider.PropertyState;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.language.base.internal.compile.Compiler;
+import org.gradle.language.base.internal.tasks.SimpleStaleClassCleaner;
 import org.gradle.language.nativeplatform.internal.incremental.IncrementalCompilerBuilder;
 import org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask;
 import org.gradle.language.swift.internal.DefaultSwiftCompileSpec;
@@ -77,5 +79,19 @@ public class SwiftCompile extends AbstractNativeCompileTask {
      */
     public void setModuleName(Provider<String> moduleName) {
         this.moduleName.set(moduleName);
+    }
+
+    @Override
+    public void compile(IncrementalTaskInputs inputs) {
+        SimpleStaleClassCleaner cleaner = new SimpleStaleClassCleaner(getOutputs());
+        cleaner.setDestinationDir(getObjectFileDir().getAsFile().get());
+        cleaner.execute();
+
+        if (getSource().isEmpty()) {
+            setDidWork(cleaner.getDidWork());
+            return;
+        }
+
+        super.compile(inputs);
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -87,11 +87,6 @@ public class SwiftCompile extends AbstractNativeCompileTask {
         cleaner.setDestinationDir(getObjectFileDir().getAsFile().get());
         cleaner.execute();
 
-        if (getSource().isEmpty()) {
-            setDidWork(cleaner.getDidWork());
-            return;
-        }
-
         super.compile(inputs);
     }
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftElement.java
@@ -16,36 +16,36 @@
 
 package org.gradle.nativeplatform.fixtures.app;
 
-import com.google.common.collect.Sets;
-import org.gradle.api.Transformer;
 import org.gradle.integtests.fixtures.SourceFile;
-import org.gradle.util.CollectionUtils;
 
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class IncrementalSwiftElement extends IncrementalElement {
     @Override
-    protected Set<String> intermediateFilenames(SourceFile sourceFile) {
-        final String name = sourceFile.getName().replace(".swift", "");
-        return CollectionUtils.collect(Sets.newHashSet(".o", "~partial.swiftdoc", "~partial.swiftmodule"), new Transformer<String, String>() {
-            @Override
-            public String transform(String suffix) {
-                return name + suffix;
-            }
-        });
+    protected List<String> toExpectedIntermediateDescendants(SourceElement sourceElement) {
+        List<String> result = new ArrayList<String>();
+
+        String sourceSetName = sourceElement.getSourceSetName();
+        for (SourceFile sourceFile : sourceElement.getFiles()) {
+            result.add(getIntermediateRelativeFilePath(sourceSetName, sourceFile, ".o"));
+            result.add(getIntermediateRelativeFilePath(sourceSetName, sourceFile, "~partial.swiftdoc"));
+            result.add(getIntermediateRelativeFilePath(sourceSetName, sourceFile, "~partial.swiftmodule"));
+        }
+        return result;
     }
 
     @Override
-    public Set<String> getExpectedIntermediateFilenames() {
-        return appendGenericExpectedIntermediateFilenames(super.getExpectedIntermediateFilenames());
+    public List<String> getExpectedIntermediateDescendants() {
+        return appendGenericExpectedIntermediateDescendants(super.getExpectedIntermediateDescendants());
     }
 
     @Override
-    public Set<String> getExpectedAlternateIntermediateFilenames() {
-        return appendGenericExpectedIntermediateFilenames(super.getExpectedAlternateIntermediateFilenames());
+    public List<String> getExpectedAlternateIntermediateDescendants() {
+        return appendGenericExpectedIntermediateDescendants(super.getExpectedAlternateIntermediateDescendants());
     }
 
-    private Set<String> appendGenericExpectedIntermediateFilenames(Set<String> delegate) {
+    private List<String> appendGenericExpectedIntermediateDescendants(List<String> delegate) {
         delegate.add("output-file-map.json");
         delegate.add(getModuleName() + ".swiftmodule");
         delegate.add(getModuleName() + ".swiftdoc");

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleCompileOutputApp.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleCompileOutputApp.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+class IncrementalSwiftStaleCompileOutputApp extends IncrementalSwiftApp {
+    private final greeter = new SwiftGreeter()
+    private final sum = new SwiftSum()
+    private final multiply = new SwiftMultiply()
+    private final main = new SwiftMain(greeter, sum)
+
+    final List<IncrementalElement.Transform> incrementalChanges = [
+        preserve(greeter),
+        rename(sum),
+        delete(multiply),
+        preserve(main)
+    ]
+    final String expectedOutput = main.expectedOutput
+    final String expectedAlternateOutput = main.expectedOutput
+    final String moduleName = "App"
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleCompileOutputLib.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleCompileOutputLib.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+class IncrementalSwiftStaleCompileOutputLib extends IncrementalSwiftElement {
+    final greeter = new SwiftGreeter()
+    final sum = new SwiftSum()
+    final multiply = new SwiftMultiply()
+
+    final List<IncrementalElement.Transform> incrementalChanges = [
+        preserve(greeter),
+        rename(sum),
+        delete(multiply)
+    ]
+    final String moduleName = "Hello"
+}

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.nativeplatform.fixtures.app.SwiftXcTestTestApp
 import org.gradle.nativeplatform.fixtures.app.TestElement
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.nativeplatform.fixtures.app.SourceTestElement.newTestCase
@@ -105,7 +104,6 @@ apply plugin: 'xctest'
         task << ["test", "check", "build"]
     }
 
-    @Ignore("https://github.com/gradle/gradle-native/issues/94")
     def "doesn't execute removed test suite and case"() {
         def oldTestApp = new SwiftXcTestTestApp([
             newTestSuite("FooTestSuite", [


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle-native/issues/94.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=dl%2Fswift-stale-object-coverage)
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
