### PR TITLE
Add stale object file test coverage for `CppCompile` task

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -16,6 +16,7 @@
 
 package org.gradle.test.fixtures.file;
 
+import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -499,19 +500,12 @@ public class TestFile extends File {
     /**
      * Convenience method for {@link #assertHasDescendants(String...)}.
      */
-    public TestFile assertHasDescendants(List<String> descendants) {
-        return assertHasDescendants(descendants.toArray(new String[0]));
-    }
-
-    /**
-     * Asserts that this file contains the given set of descendants (and possibly other files).
-     */
-    public TestFile assertContainsDescendants(String... descendants) {
+    public TestFile assertHasDescendants(Iterable<String> descendants) {
         assertIsDir();
         Set<String> actual = new TreeSet<String>();
         visit(actual, "", this);
 
-        Set<String> expected = new TreeSet<String>(Arrays.asList(descendants));
+        Set<String> expected = new TreeSet<String>(Lists.newArrayList(descendants));
 
         Set<String> missing = new TreeSet<String>(expected);
         missing.removeAll(actual);
@@ -519,6 +513,14 @@ public class TestFile extends File {
         assertTrue(String.format("For dir: %s, missing files: %s, expected: %s, actual: %s", this, missing, expected, actual), missing.isEmpty());
 
         return this;
+
+    }
+
+    /**
+     * Asserts that this file contains the given set of descendants (and possibly other files).
+     */
+    public TestFile assertContainsDescendants(String... descendants) {
+        return assertHasDescendants(Arrays.asList(descendants));
     }
 
     public TestFile assertIsEmptyDir() {
@@ -711,6 +713,13 @@ public class TestFile extends File {
 
     public ExecOutput execute(List args, List env) {
         return new TestFileHelper(this).execute(args, env);
+    }
+
+    /**
+     * Relativizes the URI of this file according to the base directory.
+     */
+    public URI relativizeFrom(TestFile baseDir) {
+        return baseDir.toURI().relativize(toURI());
     }
 
     public class Snapshot {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
@@ -44,7 +44,7 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
         result.assertTasksNotSkipped(":compileDebugCpp", ":linkDebug", ":installDebug", ":assemble")
 
         files("build/obj/main")*.name as Set == app.expectedAlternateIntermediateFilenames
-        executable("build/exe/main/debug/App").assertExists()
+        executable("build/exe/main/debug/app").assertExists()
         installation("build/install/main/debug").exec().out == app.expectedOutput
     }
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import groovy.io.FileType
+import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.app.IncrementalCppStaleCompileOutputApp
+import org.gradle.nativeplatform.fixtures.app.IncrementalCppStaleCompileOutputLib
+
+class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+    def "removes stale object files for executable"() {
+        settingsFile << "rootProject.name = 'app'"
+        def app = new IncrementalCppStaleCompileOutputApp()
+
+        given:
+        app.writeToProject(testDirectory)
+
+        and:
+        buildFile << """
+            apply plugin: 'cpp-executable'
+         """
+
+        and:
+        succeeds "assemble"
+        app.applyChangesToProject(testDirectory)
+
+        expect:
+        succeeds "assemble"
+        result.assertTasksExecuted(":compileDebugCpp", ":linkDebug", ":installDebug", ":assemble")
+        result.assertTasksNotSkipped(":compileDebugCpp", ":linkDebug", ":installDebug", ":assemble")
+
+        files("build/obj/main")*.name as Set == app.expectedAlternateIntermediateFilenames
+        executable("build/exe/main/debug/App").assertExists()
+        installation("build/install/main/debug").exec().out == app.expectedOutput
+    }
+
+    def "removes stale object files for library"() {
+        def lib = new IncrementalCppStaleCompileOutputLib()
+        settingsFile << "rootProject.name = 'hello'"
+
+        given:
+        lib.writeToProject(testDirectory)
+
+        and:
+        buildFile << """
+            apply plugin: 'cpp-library'
+         """
+
+        and:
+        succeeds "assemble"
+        lib.applyChangesToProject(testDirectory)
+
+        expect:
+        succeeds "assemble"
+        result.assertTasksExecuted(":compileDebugCpp", ":linkDebug", ":assemble")
+        result.assertTasksNotSkipped(":compileDebugCpp", ":linkDebug", ":assemble")
+
+        files("build/obj/main")*.name as Set == lib.expectedAlternateIntermediateFilenames
+        sharedLibrary("build/lib/main/debug/hello").assertExists()
+    }
+
+
+    private Set<File> files(Object path) {
+        File directory = file(path)
+        directory.assertIsDir()
+
+        def result = [] as Set
+        directory.eachFileRecurse(FileType.FILES) {
+            result += it
+        }
+
+        return result
+    }
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -78,10 +78,14 @@ allprojects { p ->
     }
 
     def objectFileFor(File sourceFile, String rootObjectFilesDir = "build/objs/main/main${sourceType}") {
+        return intermediateFileFor(sourceFile, rootObjectFilesDir, OperatingSystem.current().isWindows() ? ".obj" : ".o")
+    }
+
+    def intermediateFileFor(File sourceFile, String intermediateFilesDir, String intermediateFileSuffix) {
         File objectFile = new CompilerOutputFileNamingSchemeFactory(new BaseDirFileResolver(TestFiles.fileSystem(), testDirectory, TestFiles.getPatternSetFactory())).create()
-                        .withObjectFileNameSuffix(OperatingSystem.current().isWindows() ? ".obj" : ".o")
-                        .withOutputBaseFolder(file(rootObjectFilesDir))
-                        .map(file(sourceFile))
+            .withObjectFileNameSuffix(intermediateFileSuffix)
+            .withOutputBaseFolder(file(intermediateFilesDir))
+            .map(file(sourceFile))
         return file(getTestDirectory().toURI().relativize(objectFile.toURI()))
     }
 

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/CppMultiply.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/CppMultiply.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+import static org.gradle.nativeplatform.fixtures.app.SourceFileElement.ofFile
+
+class CppMultiply extends CppSourceFileElement implements MultiplyElement {
+    final SourceFileElement header = ofFile(sourceFile("headers", "multiply.h", """
+#ifdef _WIN32
+#define EXPORT_FUNC __declspec(dllexport)
+#else
+#define EXPORT_FUNC
+#endif
+
+class Multiply {
+public:
+    int EXPORT_FUNC multiply(int a, int b);
+};
+"""))
+
+    final SourceFileElement source = ofFile(sourceFile("cpp", "multiply.cpp", """
+#include "multiply.h"
+
+int Multiply::multiply(int a, int b) {
+    return a * b;
+}
+"""))
+
+    final SourceElement privateHeaders = header
+    final SourceElement publicHeaders = empty()
+
+    @Override
+    int multiply(int a, int b) {
+        return a * b
+    }
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppApp.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppApp.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app;
+
+public abstract class IncrementalCppApp extends IncrementalCppElement implements AppElement {
+    public abstract String getExpectedAlternateOutput();
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
@@ -16,21 +16,24 @@
 
 package org.gradle.nativeplatform.fixtures.app;
 
-import com.google.common.collect.Sets;
 import org.gradle.integtests.fixtures.SourceFile;
+import org.gradle.internal.os.OperatingSystem;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 public abstract class IncrementalCppElement extends IncrementalElement {
     @Override
-    protected Set<String> intermediateFilenames(SourceFile sourceFile) {
-        if (sourceFile.getName().endsWith(".h")) {
-            return Collections.emptySet();
+    protected List<String> toExpectedIntermediateDescendants(SourceElement sourceElement) {
+        List<String> result = new ArrayList<String>();
+
+        String sourceSetName = sourceElement.getSourceSetName();
+        for (SourceFile sourceFile : sourceElement.getFiles()) {
+            if (!sourceFile.getName().endsWith(".h")) {
+                result.add(getIntermediateRelativeFilePath(sourceSetName, sourceFile, OperatingSystem.current().isWindows() ? ".obj" : ".o"));
+            }
         }
-        return Sets.newHashSet(sourceFile.getName().replace(".cpp", ".o"));
+        return result;
     }
 
     /**

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
@@ -17,25 +17,11 @@
 package org.gradle.nativeplatform.fixtures.app;
 
 import org.gradle.integtests.fixtures.SourceFile;
-import org.gradle.internal.os.OperatingSystem;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class IncrementalCppElement extends IncrementalElement {
-    @Override
-    protected List<String> toExpectedIntermediateDescendants(SourceElement sourceElement) {
-        List<String> result = new ArrayList<String>();
-
-        String sourceSetName = sourceElement.getSourceSetName();
-        for (SourceFile sourceFile : sourceElement.getFiles()) {
-            if (!sourceFile.getName().endsWith(".h")) {
-                result.add(getIntermediateRelativeFilePath(sourceSetName, sourceFile, OperatingSystem.current().isWindows() ? ".obj" : ".o"));
-            }
-        }
-        return result;
-    }
-
     /**
      * Returns a transform that rename the before element to {@code renamed-} followed by the original name.
      */

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
@@ -18,7 +18,6 @@ package org.gradle.nativeplatform.fixtures.app;
 
 import com.google.common.collect.Sets;
 import org.gradle.integtests.fixtures.SourceFile;
-import org.gradle.test.fixtures.file.TestFile;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,34 +37,33 @@ public abstract class IncrementalCppElement extends IncrementalElement {
      * Returns a transform that rename the before element to {@code renamed-} followed by the original name.
      */
     protected static Transform rename(CppSourceFileElement beforeElement) {
-        return rename(beforeElement, "renamed-");
+        return rename(beforeElement, AbstractRenameTransform.DEFAULT_RENAME_PREFIX);
     }
 
     protected static Transform rename(final CppSourceFileElement beforeElement, String renamePrefix) {
-        final String sourceSetName = beforeElement.getSourceSetName();
         final SourceFile beforeFile = beforeElement.getSource().getSourceFile();
         final SourceFile afterFile = new SourceFile(beforeFile.getPath(), renamePrefix + beforeFile.getName(), beforeFile.getContent());
 
-        return new Transform() {
+        return new AbstractRenameTransform() {
             @Override
-            public void applyChangesToProject(TestFile projectDir) {
-                TestFile file = projectDir.file(beforeFile.withPath("src/" + sourceSetName));
-
-                file.assertExists();
-
-                file.renameTo(projectDir.file(afterFile.withPath("src/" + sourceSetName)));
+            SourceFile getSourceFile() {
+                return beforeFile;
             }
 
             @Override
-            public List<SourceFile> getBeforeFiles() {
-                return beforeElement.getFiles();
+            SourceFile getDestinationFile() {
+                return afterFile;
+            }
+
+            @Override
+            SourceElement getBeforeElement() {
+                return beforeElement;
             }
 
             @Override
             public List<SourceFile> getAfterFiles() {
                 List<SourceFile> result = new ArrayList<SourceFile>();
-                result.addAll(beforeElement.getPublicHeaders().getFiles());
-                result.addAll(beforeElement.getPrivateHeaders().getFiles());
+                result.addAll(beforeElement.getHeaders().getFiles());
                 result.add(afterFile);
                 return result;
             }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app;
+
+import com.google.common.collect.Sets;
+import org.gradle.integtests.fixtures.SourceFile;
+import org.gradle.test.fixtures.file.TestFile;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public abstract class IncrementalCppElement extends IncrementalElement {
+    @Override
+    protected Set<String> intermediateFilenames(SourceFile sourceFile) {
+        if (sourceFile.getName().endsWith(".h")) {
+            return Collections.emptySet();
+        }
+        return Sets.newHashSet(sourceFile.getName().replace(".cpp", ".o"));
+    }
+
+    /**
+     * Returns a transform that rename the before element to {@code renamed-} followed by the original name.
+     */
+    protected static Transform rename(CppSourceFileElement beforeElement) {
+        return rename(beforeElement, "renamed-");
+    }
+
+    protected static Transform rename(final CppSourceFileElement beforeElement, String renamePrefix) {
+        final String sourceSetName = beforeElement.getSourceSetName();
+        final SourceFile beforeFile = beforeElement.getSource().getSourceFile();
+        final SourceFile afterFile = new SourceFile(beforeFile.getPath(), renamePrefix + beforeFile.getName(), beforeFile.getContent());
+
+        return new Transform() {
+            @Override
+            public void applyChangesToProject(TestFile projectDir) {
+                TestFile file = projectDir.file(beforeFile.withPath("src/" + sourceSetName));
+
+                file.assertExists();
+
+                file.renameTo(projectDir.file(afterFile.withPath("src/" + sourceSetName)));
+            }
+
+            @Override
+            public List<SourceFile> getBeforeFiles() {
+                return beforeElement.getFiles();
+            }
+
+            @Override
+            public List<SourceFile> getAfterFiles() {
+                List<SourceFile> result = new ArrayList<SourceFile>();
+                result.addAll(beforeElement.getPublicHeaders().getFiles());
+                result.addAll(beforeElement.getPrivateHeaders().getFiles());
+                result.add(afterFile);
+                return result;
+            }
+        };
+    }
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppElement.java
@@ -41,25 +41,10 @@ public abstract class IncrementalCppElement extends IncrementalElement {
     }
 
     protected static Transform rename(final CppSourceFileElement beforeElement, String renamePrefix) {
-        final SourceFile beforeFile = beforeElement.getSource().getSourceFile();
+        SourceFile beforeFile = beforeElement.getSource().getSourceFile();
         final SourceFile afterFile = new SourceFile(beforeFile.getPath(), renamePrefix + beforeFile.getName(), beforeFile.getContent());
 
-        return new AbstractRenameTransform() {
-            @Override
-            SourceFile getSourceFile() {
-                return beforeFile;
-            }
-
-            @Override
-            SourceFile getDestinationFile() {
-                return afterFile;
-            }
-
-            @Override
-            SourceElement getBeforeElement() {
-                return beforeElement;
-            }
-
+        return new AbstractRenameTransform(beforeFile, afterFile, beforeElement) {
             @Override
             public List<SourceFile> getAfterFiles() {
                 List<SourceFile> result = new ArrayList<SourceFile>();

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleCompileOutputApp.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleCompileOutputApp.groovy
@@ -30,4 +30,6 @@ class IncrementalCppStaleCompileOutputApp extends IncrementalCppApp {
     ]
     final String expectedOutput = main.expectedOutput
     final String expectedAlternateOutput = main.expectedOutput
+
+
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleCompileOutputApp.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleCompileOutputApp.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+class IncrementalCppStaleCompileOutputApp extends IncrementalCppApp {
+    private final greeter = new CppGreeter()
+    private final sum = new CppSum()
+    private final multiply = new CppMultiply()
+    private final main = new CppMain(greeter, sum)
+
+    final List<IncrementalElement.Transform> incrementalChanges = [
+        preserve(greeter),
+        rename(sum),
+        delete(multiply),
+        preserve(main)
+    ]
+    final String expectedOutput = main.expectedOutput
+    final String expectedAlternateOutput = main.expectedOutput
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleCompileOutputLib.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleCompileOutputLib.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+class IncrementalCppStaleCompileOutputLib extends IncrementalCppElement {
+    final greeter = new CppGreeter()
+    final sum = new CppSum()
+    final multiply = new CppMultiply()
+
+    final List<IncrementalElement.Transform> incrementalChanges = [
+        preserve(greeter),
+        rename(sum),
+        delete(multiply)
+    ]
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalElement.java
@@ -23,7 +23,7 @@ import org.gradle.test.fixtures.file.TestFile;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -79,21 +79,19 @@ public abstract class IncrementalElement {
     /**
      * Returns a transform that keep the before element intact.
      */
-    protected static Transform preserve(final SourceFileElement element) {
-        assert element.getFiles().size() == 1;
-
+    protected static Transform preserve(final SourceElement element) {
         return new Transform() {
             @Override
             public void applyChangesToProject(TestFile projectDir) {}
 
             @Override
             public List<SourceFile> getBeforeFiles() {
-                return Arrays.asList(element.getSourceFile());
+                return element.getFiles();
             }
 
             @Override
             public List<SourceFile> getAfterFiles() {
-                return Arrays.asList(element.getSourceFile());
+                return element.getFiles();
             }
         };
     }
@@ -102,58 +100,71 @@ public abstract class IncrementalElement {
      * Returns a transform that replace the content of the before element with the content of the after element.
      * Both elements must have the same location.
      */
-    protected static Transform modify(final SourceFileElement beforeElement, SourceFileElement afterElement) {
-        assert beforeElement.getFiles().size() == 1;
-        assert afterElement.getFiles().size() == 1;
+    protected static Transform modify(final SourceElement beforeElement, final SourceElement afterElement) {
+        assert hasSameFiles(beforeElement.getFiles(), afterElement.getFiles());
         assert beforeElement.getSourceSetName().equals(afterElement.getSourceSetName());
-        final String sourceSetName = beforeElement.getSourceSetName();
-        final SourceFile beforeFile = beforeElement.getSourceFile();
-        final SourceFile afterFile = afterElement.getSourceFile();
-        assert beforeFile.getPath().equals(afterFile.getPath());
-        assert beforeFile.getName().equals(afterFile.getName());
-        assert !beforeFile.getContent().equals(afterFile.getContent());
 
         return new Transform() {
             @Override
             public void applyChangesToProject(TestFile projectDir) {
-                TestFile file = projectDir.file(beforeFile.withPath("src/" + sourceSetName));
-                file.assertExists();
-
-                file.write(afterFile.getContent());
+                afterElement.writeToProject(projectDir);
             }
 
             @Override
             public List<SourceFile> getBeforeFiles() {
-                return Arrays.asList(beforeFile);
+                return beforeElement.getFiles();
             }
 
             @Override
             public List<SourceFile> getAfterFiles() {
-                return Arrays.asList(afterFile);
+                return afterElement.getFiles();
             }
         };
+    }
+
+    private static boolean hasSameFiles(Collection<SourceFile> beforeFiles, Collection<SourceFile> afterFiles)  {
+        if (beforeFiles.size() != afterFiles.size()) {
+            return false;
+        }
+
+        for (SourceFile beforeFile : beforeFiles) {
+            boolean found = false;
+            for (SourceFile afterFile : afterFiles) {
+                if (beforeFile.getName().equals(afterFile.getName()) && beforeFile.getPath().equals(afterFile.getPath())) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
      * Returns a transform that delete the before element.
      */
-    protected static Transform delete(SourceFileElement beforeElement) {
-        assert beforeElement.getFiles().size() == 1;
+    protected static Transform delete(final SourceElement beforeElement) {
         final String sourceSetName = beforeElement.getSourceSetName();
-        final SourceFile beforeFile = beforeElement.getSourceFile();
+        final List<SourceFile> beforeFiles = beforeElement.getFiles();
 
         return new Transform() {
             @Override
             public void applyChangesToProject(TestFile projectDir) {
-                TestFile file = projectDir.file(beforeFile.withPath("src/" + sourceSetName));
-                file.assertExists();
+                for (SourceFile beforeFile : beforeFiles) {
+                    TestFile file = projectDir.file(beforeFile.withPath("src/" + sourceSetName));
+                    file.assertExists();
 
-                file.delete();
+                    file.delete();
+                }
             }
 
             @Override
             public List<SourceFile> getBeforeFiles() {
-                return Arrays.asList(beforeFile);
+                return beforeElement.getFiles();
             }
 
             @Override
@@ -166,20 +177,11 @@ public abstract class IncrementalElement {
     /**
      * Returns a transform that add the after element.
      */
-    protected static Transform add(SourceFileElement afterElement) {
-        assert afterElement.getFiles().size() == 1;
-        final String sourceSetName = afterElement.getSourceSetName();
-        final SourceFile afterFile = afterElement.getSourceFile();
-
-
+    protected static Transform add(final SourceElement afterElement) {
         return new Transform() {
             @Override
             public void applyChangesToProject(TestFile projectDir) {
-                TestFile file = projectDir.file(afterFile.withPath("src/" + sourceSetName));
-
-                file.assertDoesNotExist();
-
-                afterFile.writeToDir(projectDir);
+                afterElement.writeToProject(projectDir);
             }
 
             @Override
@@ -189,42 +191,7 @@ public abstract class IncrementalElement {
 
             @Override
             public List<SourceFile> getAfterFiles() {
-                return Arrays.asList(afterFile);
-            }
-        };
-    }
-
-    /**
-     * Returns a transform that rename the before element to {@code renamed-} followed by the original name.
-     */
-    protected static Transform rename(SourceFileElement beforeElement) {
-        return rename(beforeElement, "renamed-");
-    }
-
-    protected static Transform rename(SourceFileElement beforeElement, String renamePrefix) {
-        assert beforeElement.getFiles().size() == 1;
-        final String sourceSetName = beforeElement.getSourceSetName();
-        final SourceFile beforeFile = beforeElement.getSourceFile();
-        final SourceFile afterFile = new SourceFile(beforeFile.getPath(), renamePrefix + beforeFile.getName(), beforeFile.getContent());
-
-        return new Transform() {
-            @Override
-            public void applyChangesToProject(TestFile projectDir) {
-                TestFile file = projectDir.file(beforeFile.withPath("src/" + sourceSetName));
-
-                file.assertExists();
-
-                file.renameTo(projectDir.file(afterFile.withPath("src/" + sourceSetName)));
-            }
-
-            @Override
-            public List<SourceFile> getBeforeFiles() {
-                return Arrays.asList(beforeFile);
-            }
-
-            @Override
-            public List<SourceFile> getAfterFiles() {
-                return Arrays.asList(afterFile);
+                return afterElement.getFiles();
             }
         };
     }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalElement.java
@@ -16,12 +16,9 @@
 
 package org.gradle.nativeplatform.fixtures.app;
 
-import org.gradle.api.internal.file.TestFiles;
 import org.gradle.integtests.fixtures.SourceFile;
-import org.gradle.nativeplatform.internal.CompilerOutputFileNamingScheme;
 import org.gradle.test.fixtures.file.TestFile;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -47,25 +44,6 @@ public abstract class IncrementalElement {
      */
     public void writeToProject(TestFile projectDir) {
         original.writeToProject(projectDir);
-    }
-
-    public List<String> getExpectedIntermediateDescendants() {
-        return toExpectedIntermediateDescendants(original);
-    }
-
-    public List<String> getExpectedAlternateIntermediateDescendants() {
-        return toExpectedIntermediateDescendants(alternate);
-    }
-
-    protected abstract List<String> toExpectedIntermediateDescendants(SourceElement sourceElement);
-
-    protected String getIntermediateRelativeFilePath(String sourceSetName, SourceFile sourceFile, String fileSuffix) {
-        File baseDir = TestFile.listRoots()[0];  // Pick the first root as the virtual base for the source file
-        File outputFile = new CompilerOutputFileNamingScheme(TestFiles.resolver(baseDir))
-            .withObjectFileNameSuffix(fileSuffix)
-            .withOutputBaseFolder(new File(""))
-            .map(new File(baseDir, "src/" + sourceSetName + "/" + sourceFile.getPath() + "/" + sourceFile.getName()));
-        return outputFile.getPath().substring(baseDir.getPath().length());
     }
 
     public interface Transform {
@@ -236,10 +214,6 @@ public abstract class IncrementalElement {
             }
             return result;
         }
-
-        public List<String> getExpectedIntermediateDescendants() {
-            return IncrementalElement.this.getExpectedIntermediateDescendants();
-        }
     }
 
     private class AlternateElement extends SourceElement {
@@ -250,10 +224,6 @@ public abstract class IncrementalElement {
                 result.addAll(transform.getAfterFiles());
             }
             return result;
-        }
-
-        public List<String> getExpectedIntermediateDescendants() {
-            return IncrementalElement.this.getExpectedAlternateIntermediateDescendants();
         }
     }
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalElement.java
@@ -196,6 +196,32 @@ public abstract class IncrementalElement {
         };
     }
 
+    /**
+     * Generic transform class that rename the source of the before element.
+     */
+    protected static abstract class AbstractRenameTransform implements Transform {
+        public static final String DEFAULT_RENAME_PREFIX = "renamed-";
+
+        abstract SourceFile getSourceFile();
+        abstract SourceFile getDestinationFile();
+        abstract SourceElement getBeforeElement();
+
+        @Override
+        public void applyChangesToProject(TestFile projectDir) {
+            String sourceSetName = getBeforeElement().getSourceSetName();
+            TestFile file = projectDir.file(getSourceFile().withPath("src/" + sourceSetName));
+
+            file.assertExists();
+
+            file.renameTo(projectDir.file(getDestinationFile().withPath("src/" + sourceSetName)));
+        }
+
+        @Override
+        public List<SourceFile> getBeforeFiles() {
+            return getBeforeElement().getFiles();
+        }
+    }
+
     private class OriginalElement extends SourceElement {
         @Override
         public List<SourceFile> getFiles() {

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalElement.java
@@ -201,24 +201,29 @@ public abstract class IncrementalElement {
      */
     protected static abstract class AbstractRenameTransform implements Transform {
         public static final String DEFAULT_RENAME_PREFIX = "renamed-";
+        private final SourceFile sourceFile;
+        private final SourceFile destinationFile;
+        private final SourceElement beforeElement;
 
-        abstract SourceFile getSourceFile();
-        abstract SourceFile getDestinationFile();
-        abstract SourceElement getBeforeElement();
+        AbstractRenameTransform(SourceFile sourceFile, SourceFile destinationFile, SourceElement beforeElement) {
+            this.sourceFile = sourceFile;
+            this.destinationFile = destinationFile;
+            this.beforeElement = beforeElement;
+        }
 
         @Override
         public void applyChangesToProject(TestFile projectDir) {
-            String sourceSetName = getBeforeElement().getSourceSetName();
-            TestFile file = projectDir.file(getSourceFile().withPath("src/" + sourceSetName));
+            String sourceSetName = beforeElement.getSourceSetName();
+            TestFile file = projectDir.file(sourceFile.withPath("src/" + sourceSetName));
 
             file.assertExists();
 
-            file.renameTo(projectDir.file(getDestinationFile().withPath("src/" + sourceSetName)));
+            file.renameTo(projectDir.file(destinationFile.withPath("src/" + sourceSetName)));
         }
 
         @Override
         public List<SourceFile> getBeforeFiles() {
-            return getBeforeElement().getFiles();
+            return beforeElement.getFiles();
         }
     }
 

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftElement.java
@@ -96,28 +96,28 @@ public abstract class IncrementalSwiftElement extends IncrementalElement {
      * Returns a transform that rename the before element to {@code renamed-} followed by the original name.
      */
     protected static Transform rename(SourceFileElement beforeElement) {
-        return rename(beforeElement, "renamed-");
+        return rename(beforeElement, AbstractRenameTransform.DEFAULT_RENAME_PREFIX);
     }
 
-    protected static Transform rename(SourceFileElement beforeElement, String renamePrefix) {
+    protected static Transform rename(final SourceFileElement beforeElement, String renamePrefix) {
         assert beforeElement.getFiles().size() == 1;
-        final String sourceSetName = beforeElement.getSourceSetName();
         final SourceFile beforeFile = beforeElement.getSourceFile();
         final SourceFile afterFile = new SourceFile(beforeFile.getPath(), renamePrefix + beforeFile.getName(), beforeFile.getContent());
 
-        return new Transform() {
+        return new AbstractRenameTransform() {
             @Override
-            public void applyChangesToProject(TestFile projectDir) {
-                TestFile file = projectDir.file(beforeFile.withPath("src/" + sourceSetName));
-
-                file.assertExists();
-
-                file.renameTo(projectDir.file(afterFile.withPath("src/" + sourceSetName)));
+            SourceFile getSourceFile() {
+                return beforeFile;
             }
 
             @Override
-            public List<SourceFile> getBeforeFiles() {
-                return Arrays.asList(beforeFile);
+            SourceFile getDestinationFile() {
+                return afterFile;
+            }
+
+            @Override
+            SourceElement getBeforeElement() {
+                return beforeElement;
             }
 
             @Override

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftElement.java
@@ -99,27 +99,12 @@ public abstract class IncrementalSwiftElement extends IncrementalElement {
         return rename(beforeElement, AbstractRenameTransform.DEFAULT_RENAME_PREFIX);
     }
 
-    protected static Transform rename(final SourceFileElement beforeElement, String renamePrefix) {
+    protected static Transform rename(SourceFileElement beforeElement, String renamePrefix) {
         assert beforeElement.getFiles().size() == 1;
-        final SourceFile beforeFile = beforeElement.getSourceFile();
+        SourceFile beforeFile = beforeElement.getSourceFile();
         final SourceFile afterFile = new SourceFile(beforeFile.getPath(), renamePrefix + beforeFile.getName(), beforeFile.getContent());
 
-        return new AbstractRenameTransform() {
-            @Override
-            SourceFile getSourceFile() {
-                return beforeFile;
-            }
-
-            @Override
-            SourceFile getDestinationFile() {
-                return afterFile;
-            }
-
-            @Override
-            SourceElement getBeforeElement() {
-                return beforeElement;
-            }
-
+        return new AbstractRenameTransform(beforeFile, afterFile, beforeElement) {
             @Override
             public List<SourceFile> getAfterFiles() {
                 return Arrays.asList(afterFile);

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftElement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftElement.java
@@ -19,41 +19,10 @@ package org.gradle.nativeplatform.fixtures.app;
 import org.gradle.integtests.fixtures.SourceFile;
 import org.gradle.test.fixtures.file.TestFile;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public abstract class IncrementalSwiftElement extends IncrementalElement {
-    @Override
-    protected List<String> toExpectedIntermediateDescendants(SourceElement sourceElement) {
-        List<String> result = new ArrayList<String>();
-
-        String sourceSetName = sourceElement.getSourceSetName();
-        for (SourceFile sourceFile : sourceElement.getFiles()) {
-            result.add(getIntermediateRelativeFilePath(sourceSetName, sourceFile, ".o"));
-            result.add(getIntermediateRelativeFilePath(sourceSetName, sourceFile, "~partial.swiftdoc"));
-            result.add(getIntermediateRelativeFilePath(sourceSetName, sourceFile, "~partial.swiftmodule"));
-        }
-        return result;
-    }
-
-    @Override
-    public List<String> getExpectedIntermediateDescendants() {
-        return appendGenericExpectedIntermediateDescendants(super.getExpectedIntermediateDescendants());
-    }
-
-    @Override
-    public List<String> getExpectedAlternateIntermediateDescendants() {
-        return appendGenericExpectedIntermediateDescendants(super.getExpectedAlternateIntermediateDescendants());
-    }
-
-    private List<String> appendGenericExpectedIntermediateDescendants(List<String> delegate) {
-        delegate.add("output-file-map.json");
-        delegate.add(getModuleName() + ".swiftmodule");
-        delegate.add(getModuleName() + ".swiftdoc");
-        return delegate;
-    }
-
     public abstract String getModuleName();
 
     /**


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle-native/issues/95

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=dl%2Fcpp-stale-object-coverage)
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
