### PR TITLE
Add back the empty cycles list guard that was removed in 869916

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -480,7 +480,11 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
             }
         });
         graphWalker.add(entryTasks);
-        final List<TaskInfo> firstCycle = new ArrayList<TaskInfo>(graphWalker.findCycles().get(0));
+        List<Set<TaskInfo>> cycles = graphWalker.findCycles();
+        if (cycles.isEmpty()) {
+            return;
+        }
+        final List<TaskInfo> firstCycle = new ArrayList<TaskInfo>(cycles.get(0));
         Collections.sort(firstCycle);
 
         DirectedGraphRenderer<TaskInfo> graphRenderer = new DirectedGraphRenderer<TaskInfo>(new GraphNodeRenderer<TaskInfo>() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/AntTaskExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/AntTaskExecutionPlanTest.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.taskgraph
+
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.project.DefaultAntBuilder
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ant.AntLoggingAdapter
+import org.gradle.initialization.BuildCancellationToken
+import org.gradle.internal.resources.ResourceLockCoordinationService
+import org.gradle.internal.work.WorkerLeaseService
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+import spock.lang.Issue
+
+import static org.gradle.util.TestUtil.createRootProject
+
+class AntTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
+
+    DefaultTaskExecutionPlan executionPlan
+    ProjectInternal root
+    def cancellationToken = Mock(BuildCancellationToken)
+    def coordinationService = Mock(ResourceLockCoordinationService)
+    def leaseService = Mock(WorkerLeaseService)
+    def internal = Mock(GradleInternal)
+    private final AntLoggingAdapter loggingAdapter = Mock(AntLoggingAdapter)
+    def ant
+
+    def setup() {
+        root = createRootProject(temporaryFolder.testDirectory)
+        executionPlan = new DefaultTaskExecutionPlan(cancellationToken, coordinationService, leaseService, internal)
+        ant = new DefaultAntBuilder(project, loggingAdapter)
+    }
+
+    private void addToGraphAndPopulate(List tasks) {
+        executionPlan.addToTaskGraph(tasks)
+        executionPlan.determineExecutionPlan()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/2293")
+    def "determining execution plan for an imported ant project should not fail on empty cycles list"() {
+        /*
+            The following is a minimal test case for the problem described in the issue 2293.
+            Have to provide actual xml contents of the Ant build script, since an integrated
+            test wouldn't allow to create the actual runtime data structure that triggers the bug.
+
+            The Ant project contains 5 targets corresponding to gradle tasks. Here's the initial
+            dependencies graph defined by the xml contents:
+
+            x--+->d+-------+
+               |           |
+               +->c+-+--+  |
+               |     |  |  |
+               +->b<-+  |  |
+               |        |  |
+               +->a<----+--+
+
+            The Ant project importer adds several additional edges, called "shouldRunAfter", as per
+            https://github.com/gradle/gradle/pull/224. These only impose an ordering among tasks that
+            are othewise independent.
+
+            a--->c
+            |    |
+            |    v
+            +--->b-->d
+
+            As one can see, these two graphs, when combined, produce a cycle. For example, between "a" and "c".
+
+            Now, DefaultTaskExecutionPlan treats the two kinds of edges the same when building a plan,
+            see addSuccessorsInReverseOrder() method. But since a "shouldRunAfter" edge doesn't really
+            constitute a dependency, these are rightfully ignored by the graphWalker in onOrderingCycle().
+            Thus, a cycle is not detected, and this condition must be checked.
+         */
+
+        // integrated test wouldn't allow to reproduce the problem
+        File buildFile = new File(project.projectDir, 'build.xml')
+        buildFile.withWriter {Writer wr ->
+            def contents =
+                '''
+                <project name="fubar" default="x">
+                <target name="x" depends="d, b, c, a"/>
+                <target name="a"/>
+                <target name="b"/>
+                <target name="c" depends="b, a"/>
+                <target name="d" depends="a"/>
+                </project>
+                '''
+            wr.write(contents)
+        }
+
+        when:
+        ant.importBuild(buildFile)
+        def taskList = project.getAllTasks(true)[project].asList()
+        addToGraphAndPopulate(taskList)
+
+        then:
+        notThrown(IndexOutOfBoundsException)
+    }
+
+}


### PR DESCRIPTION
Add back the empty cycles list guard that was removed in 869916c5dc081a75af10548e76e2d1ccbc7687a9

Issue #2293.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

This issue affects all users of JetBrains MPS who make use of the feature that generates Ant build script, which should be possible to import into a gradle build. 

Also, this issue may affect other users who may accidentally create "cycles" by listing dependencies in the ant target definitions in a specific order. Note that the order the dependencies are listed should not affect the validity of a build script. 

Detailed information about the issue and the fix follows.
```
            The Ant project contains 5 targets corresponding to gradle tasks. Here's the initial
            dependencies graph defined by the xml contents:

            x--+->d+-------+
               |           |
               +->c+-+--+  |
               |     |  |  |
               +->b<-+  |  |
               |        |  |
               +->a<----+--+

            The Ant project importer adds several additional edges, called "shouldRunAfter", as per
            https://github.com/gradle/gradle/pull/224. These only impose an ordering among tasks that
            are othewise independent.

            a--->c
            |    |
            |    v
            +--->b-->d

            As one can see, these two graphs, when combined, produce a cycle. For example, between "a" and "c".

            Now, DefaultTaskExecutionPlan treats the two kinds of edges the same when building a plan,
            see addSuccessorsInReverseOrder() method. But since a "shouldRunAfter" edge doesn't really
            constitute a dependency, these are rightfully ignored by the graphWalker in onOrderingCycle().
            Thus, a cycle is not detected, and this condition must be checked.
```



### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
