### PR TITLE
Eclipse: Add build/generated-resources/test to the classpath

### DIFF
--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -15,6 +15,7 @@ allprojects {
                     classpath.entries.removeAll { it.path.contains("/subprojects") && it.kind == 'lib' }
                     // Add needed resources for running gradle as a non daemon java application
                     classpath.entries.add(new org.gradle.plugins.ide.eclipse.model.SourceFolder("build/generated-resources/main", null))
+                    classpath.entries.add(new org.gradle.plugins.ide.eclipse.model.SourceFolder("build/generated-resources/test", null))
                 }
             }
             jdt {


### PR DESCRIPTION
build/generated-resources/test needs to be added to the classpath, otherwise there is an `ExceptionInInitializerError` when looking for the resource `/org/gradle/build-receipt.properties` in `org.gradle.util.GradleVersion`

### Context
C:\Users\fandre\Documents\git\gradle>gradlew -version

------------------------------------------------------------
Gradle 4.2-20170827235721+0000
------------------------------------------------------------

Build time:   2017-08-27 23:57:21 UTC
Revision:     0f1ca60c6c878a3c5abaa3638cf35a99c592f2be

Groovy:       2.4.11
Ant:          Apache Ant(TM) version 1.9.6 compiled on June 29 2015
JVM:          1.7.0_80 (Oracle Corporation 24.80-b11)
OS:           Windows 8.1 6.3 amd64

### Contributor Checklist
- [ x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
