### PR TITLE
Fix failed tests which need non-root permission

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyErrorIntegrationTest.groovy
@@ -75,7 +75,7 @@ The following types/formats are supported:
     }
 
     @Test
-    @Requires(TestPrecondition.FILE_PERMISSIONS)
+    @Requires([TestPrecondition.FILE_PERMISSIONS, TestPrecondition.WITHOUT_ROOT_PERMISSION])
     public void reportsUnreadableSourceDir() {
         TestFile dir = testFile('src').createDir()
         def oldPermissions = dir.permissions

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/jdk7/Jdk7UnauthorizedDirectoryWalkerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/jdk7/Jdk7UnauthorizedDirectoryWalkerTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Issue
 
 import java.nio.file.AccessDeniedException
 
-@Requires(TestPrecondition.FILE_PERMISSIONS)
+@Requires([TestPrecondition.FILE_PERMISSIONS, TestPrecondition.WITHOUT_ROOT_PERMISSION])
 @Issue('https://github.com/gradle/gradle/issues/2639')
 class Jdk7UnauthorizedDirectoryWalkerTest extends Specification {
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -45,6 +45,12 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     NO_FILE_PERMISSIONS({
         !FILE_PERMISSIONS.fulfilled
     }),
+    WITH_ROOT_PERMISSION({
+        'root' == System.getProperty('user.name')
+    }),
+    WITHOUT_ROOT_PERMISSION({
+        !WITH_ROOT_PERMISSION.fulfilled
+    }),
     SET_ENV_VARIABLE({
         !UNKNOWN_OS.fulfilled && JavaVersion.current() < JavaVersion.VERSION_1_9
     }),


### PR DESCRIPTION
### Context

There're 2 tests failing on `ubuntu14-agent1`, see https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Check_Quick_Java8_Oracle_Linux_core&tab=buildTypeHistoryList .

https://builds.gradle.org/viewLog.html?buildId=8120875&tab=buildResultsDiv&buildTypeId=Gradle_Check_Quick_Java8_Oracle_Linux_core

The reason is that these tests require to be run under non-root user to do some permission-related tests, but looks like that agent is running as root user.

This PR adds a test precondition `WITH_ROOT_PERMISSION` which checks if current user is `root`. This is not absolutely accurate, though.
