### PR TITLE
Allow user to persist --console setting in gradle.properties

### DIFF
--- a/subprojects/docs/src/docs/userguide/buildEnvironment.adoc
+++ b/subprojects/docs/src/docs/userguide/buildEnvironment.adoc
@@ -50,6 +50,8 @@ When set to true, Gradle will run the build with remote debugging enabled, liste
 When set to false, Gradle will not monitor the memory usage of running daemons. See <<sec:what_can_go_wrong_with_daemon>>.
 `org.gradle.caching`::
 When set to true, Gradle will try to reuse outputs from previous builds. See <<sec:build_cache_intro>>.
+`org.gradle.console`::
+When set to plain, auto or rich, Gradle will use different type of console. See <<sec:console_build_output>>.
 
 [[sec:forked_java_processes]]
 ==== Forked Java processes

--- a/subprojects/docs/src/docs/userguide/console.adoc
+++ b/subprojects/docs/src/docs/userguide/console.adoc
@@ -54,7 +54,7 @@ Output from build script log messages, tasks, forked processes, test output and 
 
 Starting with Gradle 4.0, the volume of command-line console output has been reduced. The start and end of each task is not displayed anymore or the outcome of the task (e.g. `UP-TO-DATE`). The task's name is only displayed if some output is emitted during task execution. Gradle also groups output originating from a specific context together, e.g. all warnings from a compilation task, test execution or forked processes. Grouped output is especially useful for parallel task execution, as it prevents interleaved messages that do not clearly indicate their origin (see <<sec:parallel_execution>>).
 
-NOTE: Grouped console output and reduced console output only occurs with interactive and _rich console_ command-lines. Continuous integration servers and builds using `--console=plain` will see console output similar to pre-Gradle 4.0.
+NOTE: Grouped console output and reduced console output only occurs with interactive and _rich console_ command-lines. Continuous integration servers and builds using `--console=plain` will see console output similar to pre-Gradle 4.0. You can also set this option via `org.gradle.console` property, see <<sec:gradle_configuration_properties>>.
 
 The following console output shows grouped output for the configuration phase and the task `:compileJava`:
 

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/ConsoleTypePersistIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/ConsoleTypePersistIntegrationTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class ConsoleTypePersistIntegrationTest extends AbstractIntegrationSpec {
+
+    def "--console can be persisted in gradle.properties"() {
+        given:
+        buildFile << "task hello { print 'hello' }"
+
+        when:
+        succeeds('hello')
+
+        then:
+        !output.contains('[1m')
+
+
+        when:
+        file('gradle.properties') << 'org.gradle.console=rich'
+        succeeds('hello')
+
+        then:
+        output.contains('[1m')
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptionFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptionFactory.java
@@ -149,9 +149,10 @@ public class LoggingConfigurationBuildOptionFactory implements Factory<List<Buil
 
     public static class ConsoleOption extends StringBuildOption<LoggingConfiguration> {
         public static final String LONG_OPTION = "console";
+        public static final String GRADLE_PROPERTY = "org.gradle.console";
 
         public ConsoleOption() {
-            super(null, CommandLineOptionConfiguration.create("console", "Specifies which type of console output to generate. Values are 'plain', 'auto' (default) or 'rich'."));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create("console", "Specifies which type of console output to generate. Values are 'plain', 'auto' (default) or 'rich'."));
         }
 
         @Override


### PR DESCRIPTION
### Context

See #2744 

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
