### PR TITLE
Remove Action from TaskClassValidator

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1245,4 +1245,23 @@ task generate(type: TransformerTask) {
         skippedTasks.contains(':myTask')
     }
 
+    def "task with no actions is skipped even if it has inputs"() {
+        buildFile << """
+            task taskWithInputs(type: TaskWithInputs) {
+                input = 'some-name'
+            }
+
+            class TaskWithInputs extends DefaultTask {
+                @Input
+                String input
+            }            
+        """
+
+        when:
+        succeeds 'taskWithInputs'
+
+        then:
+        skipped(':taskWithInputs')
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -69,7 +69,6 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
 
         TaskClassValidator validator = taskClassInfo.getValidator();
         if (validator.hasAnythingToValidate()) {
-            task.prependParallelSafeAction(validator);
             validator.addInputsAndOutputs(task);
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
@@ -18,9 +18,7 @@ package org.gradle.api.internal.project.taskfactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
-import org.gradle.api.Action;
-import org.gradle.api.Describable;
-import org.gradle.api.Task;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.execution.TaskValidator;
 
@@ -30,7 +28,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-public class TaskClassValidator implements TaskValidator, Action<Task>, Describable {
+@NonNullApi
+public class TaskClassValidator implements TaskValidator {
     private final ImmutableSortedSet<TaskPropertyInfo> annotatedProperties;
     private final ImmutableList<TaskClassValidationMessage> validationMessages;
     private final boolean cacheable;
@@ -41,20 +40,11 @@ public class TaskClassValidator implements TaskValidator, Action<Task>, Describa
         this.cacheable = cacheable;
     }
 
-    @Override
-    public void execute(Task task) {
-    }
-
     public void addInputsAndOutputs(final TaskInternal task) {
         task.addValidator(this);
         for (TaskPropertyInfo property : annotatedProperties) {
             property.getConfigureAction().update(task, new FutureValue(property, task));
         }
-    }
-
-    @Override
-    public String getDisplayName() {
-        return "Validate task inputs";
     }
 
     private static class FutureValue implements Callable<Object> {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskValidator.java
@@ -15,10 +15,12 @@
  */
 package org.gradle.api.internal.tasks.execution;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.TaskInternal;
 
 import java.util.Collection;
 
+@NonNullApi
 public interface TaskValidator {
     /**
      * Validates this task, adding violations to the given collections.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -98,11 +98,11 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
 
     def cachesClassMetaInfo() {
         given:
-        def task = expectTaskCreated(TaskWithInputFile, existingFile)
-        def task2 = expectTaskCreated(TaskWithInputFile, missingFile)
+        def taskInfo1 = taskClassInfoStore.getTaskClassInfo(TaskWithInputFile)
+        def taskInfo2 = taskClassInfoStore.getTaskClassInfo(TaskWithInputFile)
 
         expect:
-        task.actions[0].action.is(task2.actions[0].action)
+        taskInfo1.is(taskInfo2)
     }
 
     @Unroll

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
@@ -109,6 +109,11 @@ public class AnnotationProcessingTasks {
         }
     }
 
+    public static class TaskWithAction extends DefaultTask {
+        @TaskAction
+        public void doStuff() {}
+    }
+
     public static class TaskWithIncrementalAction extends DefaultTask {
         private final Action<IncrementalTaskInputs> action;
 
@@ -145,7 +150,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithInputFile extends DefaultTask {
+    public static class TaskWithInputFile extends TaskWithAction {
         File inputFile;
 
         public TaskWithInputFile(File inputFile) {
@@ -158,7 +163,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithInputDir extends DefaultTask {
+    public static class TaskWithInputDir extends TaskWithAction {
         File inputDir;
 
         public TaskWithInputDir(File inputDir) {
@@ -171,7 +176,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithInput extends DefaultTask {
+    public static class TaskWithInput extends TaskWithAction {
         String inputValue;
 
         public TaskWithInput(String inputValue) {
@@ -184,7 +189,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithBooleanInput extends DefaultTask {
+    public static class TaskWithBooleanInput extends TaskWithAction {
         boolean inputValue;
 
         public TaskWithBooleanInput(boolean inputValue) {
@@ -216,7 +221,7 @@ public class AnnotationProcessingTasks {
 
     }
 
-    public static class TaskWithOutputFile extends DefaultTask {
+    public static class TaskWithOutputFile extends TaskWithAction {
         File outputFile;
 
         public TaskWithOutputFile(File outputFile) {
@@ -229,7 +234,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOutputFiles extends DefaultTask {
+    public static class TaskWithOutputFiles extends TaskWithAction {
         List<File> outputFiles;
 
         public TaskWithOutputFiles(List<File> outputFiles) {
@@ -243,7 +248,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithBridgeMethod extends DefaultTask implements WithProperty<SpecificProperty> {
+    public static class TaskWithBridgeMethod extends TaskWithAction implements WithProperty<SpecificProperty> {
         @org.gradle.api.tasks.Nested
         private SpecificProperty nestedProperty = new SpecificProperty();
         public int traversedOutputsCount;
@@ -268,7 +273,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOptionalOutputFile extends DefaultTask {
+    public static class TaskWithOptionalOutputFile extends TaskWithAction {
         @OutputFile
         @org.gradle.api.tasks.Optional
         public File getOutputFile() {
@@ -276,7 +281,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOptionalOutputFiles extends DefaultTask {
+    public static class TaskWithOptionalOutputFiles extends TaskWithAction {
         @SuppressWarnings("deprecation")
         @OutputFiles
         @org.gradle.api.tasks.Optional
@@ -285,7 +290,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOutputDir extends DefaultTask {
+    public static class TaskWithOutputDir extends TaskWithAction {
         File outputDir;
 
         public TaskWithOutputDir(File outputDir) {
@@ -298,7 +303,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOutputDirs extends DefaultTask {
+    public static class TaskWithOutputDirs extends TaskWithAction {
         List<File> outputDirs;
 
         public TaskWithOutputDirs(List<File> outputDirs) {
@@ -312,7 +317,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOptionalOutputDir extends DefaultTask {
+    public static class TaskWithOptionalOutputDir extends TaskWithAction {
         @OutputDirectory
         @org.gradle.api.tasks.Optional
         public File getOutputDir() {
@@ -320,7 +325,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOptionalOutputDirs extends DefaultTask {
+    public static class TaskWithOptionalOutputDirs extends TaskWithAction {
         @SuppressWarnings("deprecation")
         @OutputDirectories
         @org.gradle.api.tasks.Optional
@@ -329,7 +334,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithInputFiles extends DefaultTask {
+    public static class TaskWithInputFiles extends TaskWithAction {
         Iterable<? extends File> input;
 
         public TaskWithInputFiles(Iterable<? extends File> input) {
@@ -359,7 +364,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOptionalInputFile extends DefaultTask {
+    public static class TaskWithOptionalInputFile extends TaskWithAction {
         @InputFile
         @org.gradle.api.tasks.Optional
         public File getInputFile() {
@@ -367,7 +372,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithNestedBean extends DefaultTask {
+    public static class TaskWithNestedBean extends TaskWithAction {
         Bean bean = new Bean();
 
         public TaskWithNestedBean(File inputFile) {
@@ -385,7 +390,7 @@ public class AnnotationProcessingTasks {
     }
 
 
-    public static class TaskWithNestedBeanWithPrivateClass extends DefaultTask {
+    public static class TaskWithNestedBeanWithPrivateClass extends TaskWithAction {
         Bean2 bean = new Bean2();
 
         public TaskWithNestedBeanWithPrivateClass(File inputFile, File inputFile2) {
@@ -414,7 +419,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOptionalNestedBean extends DefaultTask {
+    public static class TaskWithOptionalNestedBean extends TaskWithAction {
         @Nested
         @org.gradle.api.tasks.Optional
         public Bean getBean() {
@@ -422,7 +427,7 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOptionalNestedBeanWithPrivateType extends DefaultTask {
+    public static class TaskWithOptionalNestedBeanWithPrivateType extends TaskWithAction {
         Bean2 bean = new Bean2();
 
         @Nested
@@ -451,7 +456,7 @@ public class AnnotationProcessingTasks {
     }
 
     //CHECKSTYLE:OFF
-    public static class TaskWithJavaBeanCornerCaseProperties extends DefaultTask {
+    public static class TaskWithJavaBeanCornerCaseProperties extends TaskWithAction {
         private String cCompiler;
         private String CFlags;
         private String dns;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/InputFileTask.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/InputFileTask.groovy
@@ -17,8 +17,12 @@ package org.gradle.api.internal.project.taskfactory
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
 
 class InputFileTask extends DefaultTask {
     @InputFile
     File srcFile
+
+    @TaskAction
+    void doStuff() {}
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
@@ -72,32 +72,6 @@ class BuildProgressTaskActionsCrossVersionSpec extends ToolingApiSpecification {
         task.child('Snapshot task inputs for :custom')
     }
 
-    //This is the current behavior. Validating input might become not-a-task-action in the future.
-    def "validate task inputs action has an informative name"() {
-        given:
-        buildFile << """
-        task custom(type: CustomTask) {
-            customInString1 = "1"
-            customInString2 = "2"
-            customOut = file("\$buildDir/out")
-        }
-        
-        class CustomTask extends DefaultTask {
-            @OutputDirectory File customOut
-            @Input String customInString1
-            @Input String customInString2
-            @TaskAction void doSomthing() { }
-        }    
-        """
-
-        when:
-        runCustomTask()
-
-        then:
-        def task = events.operation("Task :custom")
-        task.child('Validate task inputs for :custom')
-    }
-
     //This is the current behavior. The behavior of creating each output directory in a separate action might change in the future.
     def "create output directories actions have informative names"() {
         given:


### PR DESCRIPTION
The validation action is prepended to the task but the action itself
is a no-op.
