### PR TITLE
Add test coverage when deleting all sources for both Swift and Cpp

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -482,10 +482,17 @@ public class TestFile extends File {
      * Asserts that this file contains exactly the given set of descendants.
      */
     public TestFile assertHasDescendants(String... descendants) {
+        return assertHasDescendants(Arrays.asList(descendants));
+    }
+
+    /**
+     * Convenience method for {@link #assertHasDescendants(String...)}.
+     */
+    public TestFile assertHasDescendants(Iterable<String> descendants) {
         Set<String> actual = new TreeSet<String>();
         assertIsDir();
         visit(actual, "", this);
-        Set<String> expected = new TreeSet<String>(Arrays.asList(descendants));
+        Set<String> expected = new TreeSet<String>(Lists.<String>newArrayList(descendants));
 
         Set<String> extras = new TreeSet<String>(actual);
         extras.removeAll(expected);
@@ -495,12 +502,13 @@ public class TestFile extends File {
         assertEquals(String.format("For dir: %s, extra files: %s, missing files: %s, expected: %s", this, extras, missing, expected), expected, actual);
 
         return this;
+
     }
 
     /**
-     * Convenience method for {@link #assertHasDescendants(String...)}.
+     * Asserts that this file contains the given set of descendants (and possibly other files).
      */
-    public TestFile assertHasDescendants(Iterable<String> descendants) {
+    public TestFile assertContainsDescendants(String... descendants) {
         assertIsDir();
         Set<String> actual = new TreeSet<String>();
         visit(actual, "", this);
@@ -513,14 +521,6 @@ public class TestFile extends File {
         assertTrue(String.format("For dir: %s, missing files: %s, expected: %s, actual: %s", this, missing, expected, actual), missing.isEmpty());
 
         return this;
-
-    }
-
-    /**
-     * Asserts that this file contains the given set of descendants (and possibly other files).
-     */
-    public TestFile assertContainsDescendants(String... descendants) {
-        return assertHasDescendants(Arrays.asList(descendants));
     }
 
     public TestFile assertIsEmptyDir() {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
@@ -151,13 +151,23 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
         app.library.writeToProject(file("greeter"))
         app.executable.writeToProject(file("app"))
 
-        and:
+        when:
         succeeds "assemble"
+
+        then:
+        executable("app/build/exe/main/debug/app").assertExists()
+        file("app/build/obj/main/debug").assertHasDescendants(expectIntermediateDescendants(app.executable.original))
+        installation("app/build/install/main/debug").assertInstalled()
+
+        sharedLibrary("greeter/build/lib/main/debug/greeter").assertExists()
+        file("greeter/build/obj/main/debug").assertHasDescendants(expectIntermediateDescendants(app.library.original))
+
+        when:
         app.library.applyChangesToProject(file('greeter'))
         app.executable.applyChangesToProject(file('app'))
-
-        expect:
         succeeds "assemble"
+
+        then:
         result.assertTasksExecuted(":greeter:compileDebugCpp", ":greeter:linkDebug", ":greeter:assemble",
             ":app:compileDebugCpp", ":app:linkDebug", ":app:installDebug", ":app:assemble",
             ":assemble")
@@ -185,12 +195,19 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
             apply plugin: 'cpp-executable'
          """
 
-        and:
+        when:
         succeeds "assemble"
-        app.applyChangesToProject(testDirectory)
 
-        expect:
+        then:
+        executable("build/exe/main/debug/app").assertExists()
+        file("build/obj/main/debug").assertHasDescendants(expectIntermediateDescendants(app.original))
+        installation("build/install/main/debug").assertInstalled()
+
+        when:
+        app.applyChangesToProject(testDirectory)
         succeeds "assemble"
+
+        then:
         result.assertTasksExecuted(":compileDebugCpp", ":linkDebug", ":installDebug", ":assemble")
         result.assertTasksNotSkipped(":compileDebugCpp", ":linkDebug", ":installDebug", ":assemble")
 
@@ -212,12 +229,18 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
             apply plugin: 'cpp-library'
          """
 
-        and:
+        when:
         succeeds "assemble"
-        lib.applyChangesToProject(testDirectory)
 
-        expect:
+        then:
+        sharedLibrary("build/lib/main/debug/hello").assertExists()
+        file("build/obj/main/debug").assertHasDescendants(expectIntermediateDescendants(lib.original))
+
+        when:
+        lib.applyChangesToProject(testDirectory)
         succeeds "assemble"
+
+        then:
         result.assertTasksExecuted(":compileDebugCpp", ":linkDebug", ":assemble")
         result.assertTasksNotSkipped(":compileDebugCpp", ":linkDebug", ":assemble")
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
@@ -176,7 +176,7 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
 
         executable("app/build/exe/main/debug/app").assertDoesNotExist()
         file("app/build/exe/main/debug").assertHasDescendants()
-        file("app/build/obj/main/debug").assertHasDescendants()
+        file("app/build/obj/main/debug").assertDoesNotExist()
         installation("app/build/install/main/debug").assertNotInstalled()
 
         sharedLibrary("greeter/build/lib/main/debug/greeter").assertExists()
@@ -213,7 +213,7 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
 
         executable("build/exe/main/debug/app").assertDoesNotExist()
         file("build/exe/main/debug").assertHasDescendants()
-        file("build/obj/main/debug").assertHasDescendants()
+        file("build/obj/main/debug").assertDoesNotExist()
         installation("build/install/main/debug").assertNotInstalled()
     }
 
@@ -246,7 +246,7 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
 
         sharedLibrary("build/lib/main/debug/hello").assertDoesNotExist()
         file("build/lib/main/debug").assertHasDescendants()
-        file("build/obj/main/debug").assertHasDescendants()
+        file("build/obj/main/debug").assertDoesNotExist()
     }
 
     private List<String> expectIntermediateDescendants(SourceElement sourceElement) {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
@@ -176,7 +176,7 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
 
         executable("app/build/exe/main/debug/app").assertDoesNotExist()
         file("app/build/exe/main/debug").assertHasDescendants()
-        file("app/build/obj/main/debug").assertDoesNotExist()
+        file("app/build/obj/main/debug").assertHasDescendants()
         installation("app/build/install/main/debug").assertNotInstalled()
 
         sharedLibrary("greeter/build/lib/main/debug/greeter").assertExists()
@@ -213,7 +213,7 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
 
         executable("build/exe/main/debug/app").assertDoesNotExist()
         file("build/exe/main/debug").assertHasDescendants()
-        file("build/obj/main/debug").assertDoesNotExist()
+        file("build/obj/main/debug").assertHasDescendants()
         installation("build/install/main/debug").assertNotInstalled()
     }
 
@@ -246,7 +246,7 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
 
         sharedLibrary("build/lib/main/debug/hello").assertDoesNotExist()
         file("build/lib/main/debug").assertHasDescendants()
-        file("build/obj/main/debug").assertDoesNotExist()
+        file("build/obj/main/debug").assertHasDescendants()
     }
 
     private List<String> expectIntermediateDescendants(SourceElement sourceElement) {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -256,7 +256,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
 
         executable("app/build/exe/main/debug/App").assertDoesNotExist()
         file("app/build/exe/main/debug").assertHasDescendants()
-        file("app/build/obj/main/debug").assertDoesNotExist()
+        file("app/build/obj/main/debug").assertHasDescendants()
         installation("app/build/install/main/debug").assertNotInstalled()
 
         sharedLibrary("greeter/build/lib/main/debug/Greeter").assertExists()
@@ -291,7 +291,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
 
         executable("build/exe/main/debug/App").assertDoesNotExist()
         file("build/exe/main/debug").assertHasDescendants()
-        file("build/obj/main/debug").assertDoesNotExist()
+        file("build/obj/main/debug").assertHasDescendants()
         installation("build/install/main/debug").assertNotInstalled()
     }
 
@@ -324,7 +324,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
 
         sharedLibrary("build/lib/main/debug/Hello").assertDoesNotExist()
         file("build/lib/main/debug").assertHasDescendants()
-        file("build/obj/main/debug").assertDoesNotExist()
+        file("build/obj/main/debug").assertHasDescendants()
     }
 
     private List<String> expectIntermediateDescendants(SourceElement sourceElement, String moduleName) {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -256,7 +256,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
 
         executable("app/build/exe/main/debug/App").assertDoesNotExist()
         file("app/build/exe/main/debug").assertHasDescendants()
-        file("app/build/obj/main/debug").assertHasDescendants()
+        file("app/build/obj/main/debug").assertDoesNotExist()
         installation("app/build/install/main/debug").assertNotInstalled()
 
         sharedLibrary("greeter/build/lib/main/debug/Greeter").assertExists()
@@ -291,7 +291,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
 
         executable("build/exe/main/debug/App").assertDoesNotExist()
         file("build/exe/main/debug").assertHasDescendants()
-        file("build/obj/main/debug").assertHasDescendants()
+        file("build/obj/main/debug").assertDoesNotExist()
         installation("build/install/main/debug").assertNotInstalled()
     }
 
@@ -324,7 +324,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
 
         sharedLibrary("build/lib/main/debug/Hello").assertDoesNotExist()
         file("build/lib/main/debug").assertHasDescendants()
-        file("build/obj/main/debug").assertHasDescendants()
+        file("build/obj/main/debug").assertDoesNotExist()
     }
 
     private List<String> expectIntermediateDescendants(SourceElement sourceElement, String moduleName) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -19,14 +19,12 @@ package org.gradle.language.cpp.plugins;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
-import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryVar;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.cpp.CppBinary;
@@ -109,13 +107,6 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
                     install.setToolChain(link.getToolChain());
                     install.setDestinationDir(buildDirectory.dir("install/" + names.getDirName()));
                     install.setExecutable(link.getBinaryFile());
-                    // TODO - infer this
-                    install.onlyIf(new Spec<Task>() {
-                        @Override
-                        public boolean isSatisfiedBy(Task element) {
-                            return install.getExecutable().exists();
-                        }
-                    });
                     install.lib(binary.getRuntimeLibraries());
                 } else if (binary instanceof CppSharedLibrary) {
                     final PlatformToolProvider toolProvider = ((NativeToolChainInternal) toolChain).select(currentPlatform);

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -27,7 +27,6 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
@@ -235,7 +234,6 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     /**
      * Returns the source files to be compiled.
      */
-    @SkipWhenEmpty
     @InputFiles
     public ConfigurableFileCollection getSource() {
         return source;

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
@@ -234,6 +235,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     /**
      * Returns the source files to be compiled.
      */
+    @SkipWhenEmpty
     @InputFiles
     public ConfigurableFileCollection getSource() {
         return source;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -116,13 +116,6 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     install.setToolChain(link.getToolChain());
                     install.setDestinationDir(buildDirectory.dir("install/" + names.getDirName()));
                     install.setExecutable(link.getBinaryFile());
-                    // TODO - infer this
-                    install.onlyIf(new Spec<Task>() {
-                        @Override
-                        public boolean isSatisfiedBy(Task element) {
-                            return install.getExecutable().exists();
-                        }
-                    });
                     install.lib(binary.getRuntimeLibraries());
                 } else if (binary instanceof SwiftSharedLibrary) {
                     // Add a link task

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -87,6 +87,11 @@ public class SwiftCompile extends AbstractNativeCompileTask {
         cleaner.setDestinationDir(getObjectFileDir().getAsFile().get());
         cleaner.execute();
 
+        if (getSource().isEmpty()) {
+            setDidWork(cleaner.getDidWork());
+            return;
+        }
+
         super.compile(inputs);
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -209,7 +209,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
         cleaner.execute();
 
         if (getSource().isEmpty()) {
-            setDidWork(false);
+            setDidWork(cleaner.getDidWork());
             return;
         }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -31,7 +31,9 @@ import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.os.OperatingSystem;
@@ -128,12 +130,12 @@ public class InstallExecutable extends DefaultTask {
      *
      * @since 4.1
      */
-    @InputFile
+    @Internal("Covered by inputFileIfExists")
     public RegularFileVar getSourceFile() {
         return executable;
     }
 
-    @Internal
+    @Internal("Covered by inputFileIfExists")
     public File getExecutable() {
         return executable.getAsFile().getOrNull();
     }
@@ -151,6 +153,19 @@ public class InstallExecutable extends DefaultTask {
      */
     public void setExecutable(Provider<? extends RegularFile> executable) {
         this.executable.set(executable);
+    }
+
+    // Workaround for when the task is given an input file that doesn't exist
+    @SkipWhenEmpty
+    @Optional
+    @InputFile
+    protected File getInputFileIfExists() {
+        File inputFile = getExecutable();
+        if (inputFile != null && inputFile.exists()) {
+            return inputFile;
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompiler.java
@@ -53,6 +53,10 @@ public class OutputCleaningCompiler<T extends NativeCompileSpec> implements Comp
         boolean didRemove = false;
         for (File removedSource : spec.getRemovedSourceFiles()) {
             File objectFile = getObjectFile(spec.getObjectFileDir(), removedSource);
+
+            // Remove .pdb file if present
+            new File(objectFile.getParentFile(), objectFile.getName() + ".pdb").delete();
+
             if (objectFile.delete()) {
                 didRemove = true;
                 objectFile.getParentFile().delete();

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/NativeInstallationFixture.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/NativeInstallationFixture.groovy
@@ -56,6 +56,11 @@ class NativeInstallationFixture {
         this
     }
 
+    NativeInstallationFixture assertNotInstalled() {
+        installDir.assertDoesNotExist()
+        this
+    }
+
     NativeInstallationFixture assertIncludesLibraries(String... names) {
         def expected = names.collect { os.getSharedLibraryName(it) } as Set
         assert libraryFiles.collect { it.name } as Set == expected as Set

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleLinkOutputApp.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleLinkOutputApp.groovy
@@ -17,17 +17,14 @@
 package org.gradle.nativeplatform.fixtures.app
 
 /**
- * A Swift app with a changed source file
+ * A Cpp app that remove all sources.
  */
-class IncrementalSwiftModifyExpectedOutputApp extends IncrementalSwiftElement {
-    private final greeter = new SwiftGreeter()
-    private final sum = new SwiftSum()
-    private final main = new SwiftMain(greeter, sum)
-    private final alternateMain = new SwiftAlternateMain(greeter)
+class IncrementalCppStaleLinkOutputApp extends IncrementalCppElement implements AppElement {
+    private final greeter = new CppGreeter()
+    private final sum = new CppSum()
+    private final main = new CppMain(greeter, sum)
 
     final List<IncrementalElement.Transform> incrementalChanges = [
-        preserve(greeter), preserve(sum), modify(main, alternateMain)]
+        delete(greeter), delete(sum), delete(main)]
     final String expectedOutput = main.expectedOutput
-    final String expectedAlternateOutput = alternateMain.expectedOutput
-    final String moduleName = "App"
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleLinkOutputAppWithLib.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleLinkOutputAppWithLib.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+/**
+ * A Cpp app depending on a library that remove all sources.
+ */
+class IncrementalCppStaleLinkOutputAppWithLib {
+    final lib = new IncrementalCppLib()
+    final main = new IncrementalCppAppWithDep(lib)
+
+    IncrementalCppAppWithDep getExecutable() {
+        return main
+    }
+
+    String getExpectedOutput() {
+        return main.expectedOutput
+    }
+
+    IncrementalCppLib getLibrary() {
+        return lib
+    }
+
+    class IncrementalCppLib extends IncrementalCppElement {
+        final greeter = new CppGreeter()
+        final sum = new CppSum()
+
+        final List<IncrementalElement.Transform> incrementalChanges = [preserve(greeter.asLib()), preserve(sum.asLib())]
+    }
+
+    class IncrementalCppAppWithDep extends IncrementalCppElement implements AppElement {
+        final CppMain main
+
+        IncrementalCppAppWithDep(IncrementalCppLib library) {
+            main = new CppMain(library.greeter, library.sum)
+        }
+
+        @Override
+        final List<IncrementalElement.Transform> getIncrementalChanges() {
+            [delete(main)]
+        }
+
+        @Override
+        final String getExpectedOutput() {
+            main.expectedOutput
+        }
+    }
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleLinkOutputLib.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalCppStaleLinkOutputLib.groovy
@@ -17,17 +17,12 @@
 package org.gradle.nativeplatform.fixtures.app
 
 /**
- * A Swift app with a changed source file
+ * A Cpp library that removes all sources.
  */
-class IncrementalSwiftModifyExpectedOutputApp extends IncrementalSwiftElement {
-    private final greeter = new SwiftGreeter()
-    private final sum = new SwiftSum()
-    private final main = new SwiftMain(greeter, sum)
-    private final alternateMain = new SwiftAlternateMain(greeter)
+class IncrementalCppStaleLinkOutputLib extends IncrementalCppElement {
+    private final greeter = new CppGreeter()
+    private final sum = new CppSum()
 
     final List<IncrementalElement.Transform> incrementalChanges = [
-        preserve(greeter), preserve(sum), modify(main, alternateMain)]
-    final String expectedOutput = main.expectedOutput
-    final String expectedAlternateOutput = alternateMain.expectedOutput
-    final String moduleName = "App"
+        delete(greeter.asLib()), delete(sum.asLib())]
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleLinkOutputApp.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleLinkOutputApp.groovy
@@ -17,17 +17,15 @@
 package org.gradle.nativeplatform.fixtures.app
 
 /**
- * A Swift app with a changed source file
+ * A Swift app that remove all sources.
  */
-class IncrementalSwiftModifyExpectedOutputApp extends IncrementalSwiftElement {
+class IncrementalSwiftStaleLinkOutputApp extends IncrementalSwiftElement implements AppElement {
     private final greeter = new SwiftGreeter()
     private final sum = new SwiftSum()
     private final main = new SwiftMain(greeter, sum)
-    private final alternateMain = new SwiftAlternateMain(greeter)
 
     final List<IncrementalElement.Transform> incrementalChanges = [
-        preserve(greeter), preserve(sum), modify(main, alternateMain)]
+        delete(greeter), delete(sum), delete(main)]
     final String expectedOutput = main.expectedOutput
-    final String expectedAlternateOutput = alternateMain.expectedOutput
     final String moduleName = "App"
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleLinkOutputAppWithLib.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleLinkOutputAppWithLib.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+/**
+ * A Swift app depending on a library that remove all sources.
+ */
+class IncrementalSwiftStaleLinkOutputAppWithLib {
+    final lib = new IncrementalSwiftLib()
+    final main = new IncrementalSwiftAppWithDep(lib)
+
+    IncrementalSwiftAppWithDep getExecutable() {
+        return main
+    }
+
+    String getExpectedOutput() {
+        return main.expectedOutput
+    }
+
+    IncrementalSwiftLib getLibrary() {
+        return lib
+    }
+
+    class IncrementalSwiftLib extends IncrementalSwiftElement {
+        final greeter = new SwiftGreeter()
+        final sum = new SwiftSum()
+
+        final String moduleName = "Greeter"
+        final List<IncrementalElement.Transform> incrementalChanges = [preserve(greeter), preserve(sum)]
+    }
+
+    class IncrementalSwiftAppWithDep extends IncrementalSwiftElement implements AppElement {
+        final SwiftMain main
+
+        IncrementalSwiftAppWithDep(IncrementalSwiftLib library) {
+            main = new SwiftMainWithDep(library.greeter, library.sum)
+        }
+
+        @Override
+        final List<IncrementalElement.Transform> getIncrementalChanges() {
+            [delete(main)]
+        }
+
+        final String moduleName = "App"
+
+        @Override
+        final String getExpectedOutput() {
+            main.expectedOutput
+        }
+    }
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleLinkOutputLib.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/IncrementalSwiftStaleLinkOutputLib.groovy
@@ -17,17 +17,13 @@
 package org.gradle.nativeplatform.fixtures.app
 
 /**
- * A Swift app with a changed source file
+ * A Swift app that remove all sources.
  */
-class IncrementalSwiftModifyExpectedOutputApp extends IncrementalSwiftElement {
+class IncrementalSwiftStaleLinkOutputLib extends IncrementalSwiftElement {
     private final greeter = new SwiftGreeter()
     private final sum = new SwiftSum()
-    private final main = new SwiftMain(greeter, sum)
-    private final alternateMain = new SwiftAlternateMain(greeter)
 
     final List<IncrementalElement.Transform> incrementalChanges = [
-        preserve(greeter), preserve(sum), modify(main, alternateMain)]
-    final String expectedOutput = main.expectedOutput
-    final String expectedAlternateOutput = alternateMain.expectedOutput
-    final String moduleName = "App"
+        delete(greeter), delete(sum)]
+    final String moduleName = "Greeter"
 }


### PR DESCRIPTION
It also fix the InstallExecutable task to correctly clean the output
when the input is missing.

### Context
Add coverage for https://github.com/gradle/gradle-native/issues/3 and https://github.com/gradle/gradle-native/issues/27.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=dl%2Fstale-lib-exe-coverage)
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
