### PR TITLE
Add test coverage for Xcode via `xcodebuild`

### DIFF
--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeIntegrationTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.ide.xcode
+
+import org.gradle.ide.xcode.fixtures.AbstractXcodeIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
+import static org.gradle.util.Matchers.containsText
+
+class XcodeIntegrationTest extends AbstractXcodeIntegrationSpec {
+    @Requires(TestPrecondition.XCODE)
+    def "fails to build when project code is broken"() {
+        executer.requireGradleDistribution()
+
+        given:
+        buildFile << """
+            apply plugin: 'swift-executable'
+         """
+
+        and:
+        file("src/main/swift/broken.swift") << "broken!"
+
+        and:
+        succeeds("xcode")
+
+        expect:
+        def failure = xcodebuild()
+            .withProject(rootXcodeProjectFile)
+            .withScheme("App Executable")
+            .fails()
+        failure.assertHasDescription("Execution failed for task ':compileDebugSwift'.")
+        failure.assertHasCause("A build operation failed.")
+        failure.assertThatCause(containsText("Swift compiler failed while compiling swift file(s)"))
+    }
+}

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
@@ -59,15 +59,15 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
             ":greeter:xcodeProject", ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeSchemeGreeterSharedLibrary", ":greeter:xcode",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        xcodeWorkspace("${rootProjectName}.xcworkspace")
-            .contentFile.assertHasProjects([file("${rootProjectName}.xcodeproj"), file('app/app.xcodeproj'), file('greeter/greeter.xcodeproj')]*.absolutePath)
+        rootXcodeWorkspace().contentFile
+            .assertHasProjects([rootXcodeProjectFile, file('app/app.xcodeproj'), file('greeter/greeter.xcodeproj')]*.absolutePath)
 
         def project = xcodeProject("app/app.xcodeproj").projectFile
         project.indexTarget.getBuildSettings().HEADER_SEARCH_PATHS == toSpaceSeparatedList(file("app/src/main/headers"), file("greeter/src/main/public"))
 
         when:
         def resultDebugApp = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('App Executable')
             .succeeds()
 
@@ -77,7 +77,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
 
         when:
         def resultReleaseApp = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('App Executable')
             .withConfiguration('Release')
             .succeeds()
@@ -125,8 +125,8 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
             ":hello:xcodeProject", ":hello:xcodeProjectWorkspaceSettings", ":hello:xcodeSchemeHelloSharedLibrary", ":hello:xcode",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        xcodeWorkspace("${rootProjectName}.xcworkspace")
-            .contentFile.assertHasProjects([file("${rootProjectName}.xcodeproj"), file('app/app.xcodeproj'), file('log/log.xcodeproj'), file('hello/hello.xcodeproj')]*.absolutePath)
+        rootXcodeWorkspace().contentFile
+            .assertHasProjects([rootXcodeProjectFile, file('app/app.xcodeproj'), file('log/log.xcodeproj'), file('hello/hello.xcodeproj')]*.absolutePath)
 
         def appProject = xcodeProject("app/app.xcodeproj").projectFile
         appProject.indexTarget.getBuildSettings().HEADER_SEARCH_PATHS == toSpaceSeparatedList(file("app/src/main/headers"), file("hello/src/main/public"))
@@ -135,7 +135,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
 
         when:
         def resultDebugApp = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('App Executable')
             .succeeds()
 
@@ -146,7 +146,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
 
         when:
         def resultReleaseHello = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('Hello SharedLibrary')
             .withConfiguration('Release')
             .succeeds()
@@ -190,15 +190,15 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
         executedAndNotSkipped(":greeter:xcodeProject", ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeSchemeGreeterSharedLibrary",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        xcodeWorkspace("${rootProjectName}.xcworkspace")
-            .contentFile.assertHasProjects([file("${rootProjectName}.xcodeproj"), file('greeter/greeter.xcodeproj')]*.absolutePath)
+        rootXcodeWorkspace().contentFile
+            .assertHasProjects([rootXcodeProjectFile, file('greeter/greeter.xcodeproj')]*.absolutePath)
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.indexTarget.getBuildSettings().HEADER_SEARCH_PATHS == toSpaceSeparatedList(file("src/main/headers"), file("greeter/src/main/public"))
 
         when:
         def resultDebugApp = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('App Executable')
             .succeeds()
 
@@ -207,7 +207,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
 
         when:
         def resultReleaseGreeter = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('Greeter SharedLibrary')
             .withConfiguration('Release')
             .succeeds()

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
@@ -66,7 +66,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
         project.indexTarget.getBuildSettings().HEADER_SEARCH_PATHS == toSpaceSeparatedList(file("app/src/main/headers"), file("greeter/src/main/public"))
 
         when:
-        def resultDebugApp = newXcodebuildExecuter()
+        def resultDebugApp = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('App Executable')
             .succeeds()
@@ -76,7 +76,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
             ':app:compileDebugCpp', ':app:linkDebug')
 
         when:
-        def resultReleaseApp = newXcodebuildExecuter()
+        def resultReleaseApp = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('App Executable')
             .withConfiguration('Release')
@@ -134,7 +134,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
         helloProject.indexTarget.getBuildSettings().HEADER_SEARCH_PATHS == toSpaceSeparatedList(file("hello/src/main/public"), file("hello/src/main/headers"), file("log/src/main/public"))
 
         when:
-        def resultDebugApp = newXcodebuildExecuter()
+        def resultDebugApp = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('App Executable')
             .succeeds()
@@ -145,7 +145,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
             ':app:compileDebugCpp', ':app:linkDebug')
 
         when:
-        def resultReleaseHello = newXcodebuildExecuter()
+        def resultReleaseHello = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('Hello SharedLibrary')
             .withConfiguration('Release')
@@ -197,7 +197,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
         project.indexTarget.getBuildSettings().HEADER_SEARCH_PATHS == toSpaceSeparatedList(file("src/main/headers"), file("greeter/src/main/public"))
 
         when:
-        def resultDebugApp = newXcodebuildExecuter()
+        def resultDebugApp = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('App Executable')
             .succeeds()
@@ -206,7 +206,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
         resultDebugApp.assertTasksExecuted(':greeter:compileDebugCpp', ':greeter:linkDebug', ':compileDebugCpp', ':linkDebug')
 
         when:
-        def resultReleaseGreeter = newXcodebuildExecuter()
+        def resultReleaseGreeter = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('Greeter SharedLibrary')
             .withConfiguration('Release')

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
@@ -17,22 +17,21 @@
 package org.gradle.ide.xcode
 
 import org.gradle.ide.xcode.fixtures.AbstractXcodeIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibrary
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 
 import static org.gradle.ide.xcode.internal.XcodeUtils.toSpaceSeparatedList
 
 @Requires(TestPrecondition.XCODE)
-@IgnoreIf({GradleContextualExecuter.embedded})
 class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
     def setup() {
         settingsFile << """
             include 'app', 'greeter'
         """
+
+        executer.requireGradleDistribution()
     }
 
     def "create xcode project C++ executable"() {

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
@@ -66,7 +66,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
         project.indexTarget.getBuildSettings().SWIFT_INCLUDE_PATHS == toSpaceSeparatedList(file("greeter/build/obj/main/debug"))
 
         when:
-        def resultDebugApp = newXcodebuildExecuter()
+        def resultDebugApp = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('App Executable')
             .succeeds()
@@ -76,7 +76,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             ':app:compileDebugSwift', ':app:linkDebug')
 
         when:
-        def resultReleaseApp = newXcodebuildExecuter()
+        def resultReleaseApp = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('App Executable')
             .withConfiguration('Release')
@@ -134,7 +134,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
         helloProject.indexTarget.getBuildSettings().SWIFT_INCLUDE_PATHS == toSpaceSeparatedList(file("log/build/obj/main/debug"))
 
         when:
-        def resultDebugApp = newXcodebuildExecuter()
+        def resultDebugApp = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('App Executable')
             .succeeds()
@@ -145,7 +145,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             ':app:compileDebugSwift', ':app:linkDebug')
 
         when:
-        def resultReleaseHello = newXcodebuildExecuter()
+        def resultReleaseHello = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('Hello SharedLibrary')
             .withConfiguration('Release')
@@ -197,7 +197,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
         project.indexTarget.getBuildSettings().SWIFT_INCLUDE_PATHS == toSpaceSeparatedList(file("greeter/build/obj/main/debug"))
 
         when:
-        def resultDebugApp = newXcodebuildExecuter()
+        def resultDebugApp = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('App Executable')
             .succeeds()
@@ -206,7 +206,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
         resultDebugApp.assertTasksExecuted(':greeter:compileDebugSwift', ':greeter:linkDebug', ':compileDebugSwift', ':linkDebug')
 
         when:
-        def resultReleaseGreeter = newXcodebuildExecuter()
+        def resultReleaseGreeter = xcodebuild()
             .withWorkspace("${rootProjectName}.xcworkspace")
             .withScheme('Greeter SharedLibrary')
             .withConfiguration('Release')

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
@@ -59,15 +59,15 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             ":greeter:xcodeProject", ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeSchemeGreeterSharedLibrary", ":greeter:xcode",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        xcodeWorkspace("${rootProjectName}.xcworkspace")
-            .contentFile.assertHasProjects([file("${rootProjectName}.xcodeproj"), file('app/app.xcodeproj'), file('greeter/greeter.xcodeproj')]*.absolutePath)
+        rootXcodeWorkspace().contentFile
+            .assertHasProjects([rootXcodeProjectFile, file('app/app.xcodeproj'), file('greeter/greeter.xcodeproj')]*.absolutePath)
 
         def project = xcodeProject("app/app.xcodeproj").projectFile
         project.indexTarget.getBuildSettings().SWIFT_INCLUDE_PATHS == toSpaceSeparatedList(file("greeter/build/obj/main/debug"))
 
         when:
         def resultDebugApp = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('App Executable')
             .succeeds()
 
@@ -77,7 +77,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
 
         when:
         def resultReleaseApp = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('App Executable')
             .withConfiguration('Release')
             .succeeds()
@@ -125,8 +125,8 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             ":hello:xcodeProject", ":hello:xcodeProjectWorkspaceSettings", ":hello:xcodeSchemeHelloSharedLibrary", ":hello:xcode",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        xcodeWorkspace("${rootProjectName}.xcworkspace")
-            .contentFile.assertHasProjects([file("${rootProjectName}.xcodeproj"), file('app/app.xcodeproj'), file('log/log.xcodeproj'), file('hello/hello.xcodeproj')]*.absolutePath)
+        rootXcodeWorkspace().contentFile
+            .assertHasProjects([rootXcodeProjectFile, file('app/app.xcodeproj'), file('log/log.xcodeproj'), file('hello/hello.xcodeproj')]*.absolutePath)
 
         def appProject = xcodeProject("app/app.xcodeproj").projectFile
         appProject.indexTarget.getBuildSettings().SWIFT_INCLUDE_PATHS == toSpaceSeparatedList(file("hello/build/obj/main/debug"), file("log/build/obj/main/debug"))
@@ -135,7 +135,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
 
         when:
         def resultDebugApp = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('App Executable')
             .succeeds()
 
@@ -146,7 +146,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
 
         when:
         def resultReleaseHello = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('Hello SharedLibrary')
             .withConfiguration('Release')
             .succeeds()
@@ -190,15 +190,15 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
         executedAndNotSkipped(":greeter:xcodeProject", ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeSchemeGreeterSharedLibrary",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        xcodeWorkspace("${rootProjectName}.xcworkspace")
-            .contentFile.assertHasProjects([file("${rootProjectName}.xcodeproj"), file('greeter/greeter.xcodeproj')]*.absolutePath)
+        rootXcodeWorkspace().contentFile
+            .assertHasProjects([rootXcodeProjectFile, file('greeter/greeter.xcodeproj')]*.absolutePath)
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.indexTarget.getBuildSettings().SWIFT_INCLUDE_PATHS == toSpaceSeparatedList(file("greeter/build/obj/main/debug"))
 
         when:
         def resultDebugApp = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('App Executable')
             .succeeds()
 
@@ -207,7 +207,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
 
         when:
         def resultReleaseGreeter = xcodebuild()
-            .withWorkspace("${rootProjectName}.xcworkspace")
+            .withWorkspace(rootXcodeWorkspaceFile)
             .withScheme('Greeter SharedLibrary')
             .withConfiguration('Release')
             .succeeds()

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
@@ -17,22 +17,21 @@
 package org.gradle.ide.xcode
 
 import org.gradle.ide.xcode.fixtures.AbstractXcodeIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibrary
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 
 import static org.gradle.ide.xcode.internal.XcodeUtils.toSpaceSeparatedList
 
 @Requires(TestPrecondition.XCODE)
-@IgnoreIf({GradleContextualExecuter.embedded})
 class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
     def setup() {
         settingsFile << """
             include 'app', 'greeter'
         """
+
+        executer.requireGradleDistribution()
     }
 
     def "create xcode project Swift executable"() {

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
@@ -46,7 +46,7 @@ apply plugin: 'cpp-executable'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeSchemeAppExecutable", ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
         project.buildConfigurationList.buildConfigurations.name == ["Debug", "Release"]
         project.targets.size() == 2
@@ -68,7 +68,7 @@ apply plugin: 'cpp-executable'
 
         when:
         def resultDebug = xcodebuild()
-            .withProject("${rootProjectName}.xcodeproj")
+            .withProject(rootXcodeProjectFile)
             .withScheme('App Executable')
             .succeeds()
 
@@ -77,7 +77,7 @@ apply plugin: 'cpp-executable'
 
         when:
         def resultRelease = xcodebuild()
-            .withProject("${rootProjectName}.xcodeproj")
+            .withProject(rootXcodeProjectFile)
             .withScheme('App Executable')
             .withConfiguration('Release')
             .succeeds()
@@ -108,7 +108,7 @@ apply plugin: 'cpp-library'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeSchemeAppSharedLibrary", ":xcodeProjectWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.mainGroup.assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
         project.buildConfigurationList.buildConfigurations.name == ["Debug", "Release"]
         project.targets.size() == 2
@@ -130,7 +130,7 @@ apply plugin: 'cpp-library'
 
         when:
         def resultDebug = xcodebuild()
-            .withProject("${rootProjectName}.xcodeproj")
+            .withProject(rootXcodeProjectFile)
             .withScheme('App SharedLibrary')
             .succeeds()
 
@@ -139,7 +139,7 @@ apply plugin: 'cpp-library'
 
         when:
         def resultRelease = xcodebuild()
-            .withProject("${rootProjectName}.xcodeproj")
+            .withProject(rootXcodeProjectFile)
             .withScheme('App SharedLibrary')
             .withConfiguration('Release')
             .succeeds()
@@ -160,16 +160,16 @@ apply plugin: 'cpp-executable'
         succeeds("xcode")
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
 
         when:
         file("src/main/cpp/new.cpp") << "include <iostream>\n"
         succeeds('xcode')
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle', 'new.cpp'] + app.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle', 'new.cpp'] + app.files*.name)
     }
 
     def "deleted source files are not included in the project"() {
@@ -185,16 +185,16 @@ apply plugin: 'cpp-executable'
         succeeds("xcode")
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle', 'old.cpp'] + app.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle', 'old.cpp'] + app.files*.name)
 
         when:
         file('src/main/cpp/old.cpp').delete()
         succeeds('xcode')
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
     }
 
     def "executable source files in a non-default location are included in the project"() {
@@ -217,8 +217,8 @@ executable {
         succeeds("xcode")
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
     }
 
     def "library source files in a non-default location are included in the project"() {
@@ -244,8 +244,8 @@ library {
         succeeds("xcode")
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
     }
 
     def "honors changes to executable output locations"() {
@@ -265,7 +265,7 @@ executable.baseName = 'test_app'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeSchemeAppExecutable", ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.targets.size() == 2
 
         project.targets[0].name == 'App Executable'
@@ -295,7 +295,7 @@ library.baseName = 'test_lib'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeSchemeAppSharedLibrary", ":xcodeProjectWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.targets.size() == 2
 
         project.targets[0].name == 'App SharedLibrary'

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
@@ -68,7 +68,7 @@ apply plugin: 'cpp-executable'
 
         when:
         def resultDebug = newXcodebuildExecuter()
-            .withProject(file("${rootProjectName}.xcodeproj"))
+            .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App Executable')
             .succeeds()
 
@@ -77,7 +77,7 @@ apply plugin: 'cpp-executable'
 
         when:
         def resultRelease = newXcodebuildExecuter()
-            .withProject(file("${rootProjectName}.xcodeproj"))
+            .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App Executable')
             .withConfiguration('Release')
             .succeeds()

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
@@ -17,19 +17,18 @@
 package org.gradle.ide.xcode
 
 import org.gradle.ide.xcode.fixtures.AbstractXcodeIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.nativeplatform.fixtures.app.CppApp
 import org.gradle.nativeplatform.fixtures.app.CppLib
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 
 import static org.gradle.ide.xcode.internal.XcodeUtils.toSpaceSeparatedList
 
 class XcodeSingleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
     @Requires(TestPrecondition.XCODE)
-    @IgnoreIf({GradleContextualExecuter.embedded})
     def "create xcode project C++ executable"() {
+        executer.requireGradleDistribution()
+
         given:
         buildFile << """
 apply plugin: 'cpp-executable'
@@ -88,8 +87,9 @@ apply plugin: 'cpp-executable'
     }
 
     @Requires(TestPrecondition.XCODE)
-    @IgnoreIf({GradleContextualExecuter.embedded})
     def "create xcode project C++ library"() {
+        executer.requireGradleDistribution()
+
         given:
         buildFile << """
 apply plugin: 'cpp-library'
@@ -135,7 +135,7 @@ apply plugin: 'cpp-library'
             .succeeds()
 
         then:
-        resultDebug.assertTasksExecuted(':compileDebugSwift', ':linkDebug')
+        resultDebug.assertTasksExecuted(':compileDebugCpp', ':linkDebug')
 
         when:
         def resultRelease = newXcodebuildExecuter()
@@ -145,7 +145,7 @@ apply plugin: 'cpp-library'
             .succeeds()
 
         then:
-        resultRelease.assertTasksExecuted(':compileReleaseSwift', ':linkRelease')
+        resultRelease.assertTasksExecuted(':compileReleaseCpp', ':linkRelease')
     }
 
     def "new source files are included in the project"() {

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
@@ -67,7 +67,7 @@ apply plugin: 'cpp-executable'
         project.products.children[0].path == exe("build/exe/main/debug/app").absolutePath
 
         when:
-        def resultDebug = newXcodebuildExecuter()
+        def resultDebug = xcodebuild()
             .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App Executable')
             .succeeds()
@@ -76,7 +76,7 @@ apply plugin: 'cpp-executable'
         resultDebug.assertTasksExecuted(':compileDebugCpp', ':linkDebug')
 
         when:
-        def resultRelease = newXcodebuildExecuter()
+        def resultRelease = xcodebuild()
             .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App Executable')
             .withConfiguration('Release')
@@ -129,7 +129,7 @@ apply plugin: 'cpp-library'
         project.products.children[0].path == sharedLib("build/lib/main/debug/app").absolutePath
 
         when:
-        def resultDebug = newXcodebuildExecuter()
+        def resultDebug = xcodebuild()
             .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App SharedLibrary')
             .succeeds()
@@ -138,7 +138,7 @@ apply plugin: 'cpp-library'
         resultDebug.assertTasksExecuted(':compileDebugCpp', ':linkDebug')
 
         when:
-        def resultRelease = newXcodebuildExecuter()
+        def resultRelease = xcodebuild()
             .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App SharedLibrary')
             .withConfiguration('Release')

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -62,7 +62,7 @@ apply plugin: 'swift-executable'
         project.products.children[0].path == exe("build/exe/main/debug/App").absolutePath
 
         when:
-        def resultDebug = newXcodebuildExecuter()
+        def resultDebug = xcodebuild()
             .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App Executable')
             .succeeds()
@@ -71,7 +71,7 @@ apply plugin: 'swift-executable'
         resultDebug.assertTasksExecuted(':compileDebugSwift', ':linkDebug')
 
         when:
-        def resultRelease = newXcodebuildExecuter()
+        def resultRelease = xcodebuild()
             .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App Executable')
             .withConfiguration('Release')
@@ -119,7 +119,7 @@ apply plugin: 'swift-library'
         project.products.children[0].path == sharedLib("build/lib/main/debug/App").absolutePath
 
         when:
-        def resultDebug = newXcodebuildExecuter()
+        def resultDebug = xcodebuild()
             .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App SharedLibrary')
             .succeeds()
@@ -128,7 +128,7 @@ apply plugin: 'swift-library'
         resultDebug.assertTasksExecuted(':compileDebugSwift', ':linkDebug')
 
         when:
-        def resultRelease = newXcodebuildExecuter()
+        def resultRelease = xcodebuild()
             .withProject("${rootProjectName}.xcodeproj")
             .withScheme('App SharedLibrary')
             .withConfiguration('Release')

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -41,7 +41,7 @@ apply plugin: 'swift-executable'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeSchemeAppExecutable", ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
         project.buildConfigurationList.buildConfigurations.name == ["Debug", "Release"]
         project.targets.size() == 2
@@ -63,7 +63,7 @@ apply plugin: 'swift-executable'
 
         when:
         def resultDebug = xcodebuild()
-            .withProject("${rootProjectName}.xcodeproj")
+            .withProject(rootXcodeProjectFile)
             .withScheme('App Executable')
             .succeeds()
 
@@ -72,7 +72,7 @@ apply plugin: 'swift-executable'
 
         when:
         def resultRelease = xcodebuild()
-            .withProject("${rootProjectName}.xcodeproj")
+            .withProject(rootXcodeProjectFile)
             .withScheme('App Executable')
             .withConfiguration('Release')
             .succeeds()
@@ -98,7 +98,7 @@ apply plugin: 'swift-library'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeSchemeAppSharedLibrary", ":xcodeProjectWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.mainGroup.assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
         project.buildConfigurationList.buildConfigurations.name == ["Debug", "Release"]
         project.targets.size() == 2
@@ -120,7 +120,7 @@ apply plugin: 'swift-library'
 
         when:
         def resultDebug = xcodebuild()
-            .withProject("${rootProjectName}.xcodeproj")
+            .withProject(rootXcodeProjectFile)
             .withScheme('App SharedLibrary')
             .succeeds()
 
@@ -129,7 +129,7 @@ apply plugin: 'swift-library'
 
         when:
         def resultRelease = xcodebuild()
-            .withProject("${rootProjectName}.xcodeproj")
+            .withProject(rootXcodeProjectFile)
             .withScheme('App SharedLibrary')
             .withConfiguration('Release')
             .succeeds()
@@ -150,8 +150,8 @@ apply plugin: 'swift-executable'
         succeeds("xcode")
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
 
         when:
         def app = new SwiftApp()
@@ -159,8 +159,8 @@ apply plugin: 'swift-executable'
         succeeds('xcode')
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
     }
 
     def "deleted source files are not included in the project"() {
@@ -175,8 +175,8 @@ apply plugin: 'swift-executable'
         succeeds("xcode")
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
 
         when:
         file('src/main').deleteDir()
@@ -185,8 +185,8 @@ apply plugin: 'swift-executable'
         succeeds('xcode')
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
     }
 
     def "executable source files in a non-default location are included in the project"() {
@@ -206,8 +206,8 @@ executable {
         succeeds("xcode")
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
     }
 
     def "library source files in a non-default location are included in the project"() {
@@ -227,8 +227,8 @@ library {
         succeeds("xcode")
 
         then:
-        xcodeProject("${rootProjectName}.xcodeproj").projectFile
-            .mainGroup.assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
+        rootXcodeProject().projectFile.mainGroup
+            .assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
     }
 
     def "honors changes to executable output file locations"() {
@@ -248,7 +248,7 @@ executable.module = 'TestApp'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeSchemeAppExecutable", ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.targets.size() == 2
         project.targets.every { it.productName == 'App' }
         project.targets[0].name == 'App Executable'
@@ -276,7 +276,7 @@ library.module = 'TestLib'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeSchemeAppSharedLibrary", ":xcodeProjectWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
+        def project = rootXcodeProject().projectFile
         project.targets.size() == 2
         project.targets.every { it.productName == "App" }
         project.targets[0].name == 'App SharedLibrary'

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -17,17 +17,16 @@
 package org.gradle.ide.xcode
 
 import org.gradle.ide.xcode.fixtures.AbstractXcodeIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.nativeplatform.fixtures.app.SwiftApp
 import org.gradle.nativeplatform.fixtures.app.SwiftLib
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 
 class XcodeSingleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
     @Requires(TestPrecondition.XCODE)
-    @IgnoreIf({GradleContextualExecuter.embedded})
     def "create xcode project executable"() {
+        executer.requireGradleDistribution()
+
         given:
         buildFile << """
 apply plugin: 'swift-executable'
@@ -83,8 +82,9 @@ apply plugin: 'swift-executable'
     }
 
     @Requires(TestPrecondition.XCODE)
-    @IgnoreIf({GradleContextualExecuter.embedded})
     def "create xcode project library"() {
+        executer.requireGradleDistribution()
+
         given:
         buildFile << """
 apply plugin: 'swift-library'

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -41,7 +41,7 @@ apply plugin: 'swift-executable'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeSchemeAppExecutable", ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("app.xcodeproj").projectFile
+        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
         project.mainGroup.assertHasChildren(['Products', 'build.gradle'] + app.files*.name)
         project.buildConfigurationList.buildConfigurations.name == ["Debug", "Release"]
         project.targets.size() == 2
@@ -98,7 +98,7 @@ apply plugin: 'swift-library'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeSchemeAppSharedLibrary", ":xcodeProjectWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("app.xcodeproj").projectFile
+        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
         project.mainGroup.assertHasChildren(['Products', 'build.gradle'] + lib.files*.name)
         project.buildConfigurationList.buildConfigurations.name == ["Debug", "Release"]
         project.targets.size() == 2
@@ -248,7 +248,7 @@ executable.module = 'TestApp'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeSchemeAppExecutable", ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("app.xcodeproj").projectFile
+        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
         project.targets.size() == 2
         project.targets.every { it.productName == 'App' }
         project.targets[0].name == 'App Executable'
@@ -276,7 +276,7 @@ library.module = 'TestLib'
         then:
         executedAndNotSkipped(":xcodeProject", ":xcodeSchemeAppSharedLibrary", ":xcodeProjectWorkspaceSettings", ":xcode")
 
-        def project = xcodeProject("app.xcodeproj").projectFile
+        def project = xcodeProject("${rootProjectName}.xcodeproj").projectFile
         project.targets.size() == 2
         project.targets.every { it.productName == "App" }
         project.targets[0].name == 'App SharedLibrary'

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
@@ -51,4 +51,8 @@ rootProject.name = "${rootProjectName}"
     protected XcodeWorkspacePackage xcodeWorkspace(String path) {
         new XcodeWorkspacePackage(file(path))
     }
+
+    protected XcodebuildExecuter newXcodebuildExecuter() {
+        new XcodebuildExecuter(testDirectory)
+    }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
@@ -44,12 +44,36 @@ rootProject.name = "${rootProjectName}"
         file(OperatingSystem.current().getSharedLibraryName(str))
     }
 
+    protected TestFile getRootXcodeProjectFile() {
+        file("${rootProjectName}.xcodeproj")
+    }
+
+    protected TestFile getRootXcodeWorkspaceFile() {
+        file("${rootProjectName}.xcworkspace")
+    }
+
     protected XcodeProjectPackage xcodeProject(String path) {
-        new XcodeProjectPackage(file(path))
+        xcodeProject(file(path))
+    }
+
+    protected XcodeProjectPackage xcodeProject(TestFile bundle) {
+        new XcodeProjectPackage(bundle)
+    }
+
+    protected XcodeProjectPackage rootXcodeProject() {
+        xcodeProject(rootXcodeProjectFile)
     }
 
     protected XcodeWorkspacePackage xcodeWorkspace(String path) {
-        new XcodeWorkspacePackage(file(path))
+        xcodeWorkspace(file(path))
+    }
+
+    protected XcodeWorkspacePackage xcodeWorkspace(TestFile bundle) {
+        new XcodeWorkspacePackage(bundle)
+    }
+
+    protected XcodeWorkspacePackage rootXcodeWorkspace() {
+        xcodeWorkspace(rootXcodeWorkspaceFile)
     }
 
     protected XcodebuildExecuter xcodebuild() {

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
@@ -52,7 +52,7 @@ rootProject.name = "${rootProjectName}"
         new XcodeWorkspacePackage(file(path))
     }
 
-    protected XcodebuildExecuter newXcodebuildExecuter() {
+    protected XcodebuildExecuter xcodebuild() {
         new XcodebuildExecuter(testDirectory)
     }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/XcodebuildExecuter.java
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/XcodebuildExecuter.java
@@ -17,7 +17,9 @@
 package org.gradle.ide.xcode.fixtures;
 
 import com.google.common.collect.Lists;
+import org.gradle.integtests.fixtures.executer.ExecutionFailure;
 import org.gradle.integtests.fixtures.executer.ExecutionResult;
+import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionFailure;
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult;
 import org.gradle.test.fixtures.file.ExecOutput;
 import org.gradle.test.fixtures.file.TestFile;
@@ -80,19 +82,16 @@ public class XcodebuildExecuter {
         return this;
     }
 
-    public ExecutionResult run(String action) {
-        args.add(action);
-        return run();
-    }
-
-    public ExecutionResult run() {
-        ExecOutput result = findXcodeBuild().exec(args.toArray());
-        return new OutputScrapingExecutionResult(result.getOut(), result.getError());
-    }
-
     public ExecutionResult succeeds() {
         ExecOutput result = findXcodeBuild().exec(args.toArray());
         return new OutputScrapingExecutionResult(result.getOut(), result.getError());
+    }
+
+    public ExecutionFailure fails() {
+        ExecOutput result = findXcodeBuild().execWithFailure(args.toArray());
+        // stderr of Gradle is redirected to stdout of xcodebuild tool. To work around, we consider xcodebuild stdout and stderr as
+        // the error output only if xcodebuild failed most likely due to Gradle.
+        return new OutputScrapingExecutionFailure(result.getOut(), result.getOut() + "\n" + result.getError());
     }
 
     private TestFile findXcodeBuild() {

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/XcodebuildExecuter.java
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/XcodebuildExecuter.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.testng.Assert.assertTrue;
+
 public class XcodebuildExecuter {
     private final TestFile baseDir;
     private final List<String> args = new ArrayList<String>();
@@ -84,12 +86,18 @@ public class XcodebuildExecuter {
     }
 
     public ExecutionResult run() {
-        ExecOutput result = new TestFile("/usr/bin/xcodebuild").exec(args.toArray());
+        ExecOutput result = findXcodeBuild().exec(args.toArray());
         return new OutputScrapingExecutionResult(result.getOut(), result.getError());
     }
 
     public ExecutionResult succeeds() {
-        ExecOutput result = new TestFile("/usr/bin/xcodebuild").exec(args.toArray());
+        ExecOutput result = findXcodeBuild().exec(args.toArray());
         return new OutputScrapingExecutionResult(result.getOut(), result.getError());
+    }
+
+    private TestFile findXcodeBuild() {
+        TestFile xcodebuild = new TestFile("/usr/bin/xcodebuild");
+        assertTrue(xcodebuild.exists(), "This test requires xcode to be installed in " + xcodebuild.getAbsolutePath());
+        return xcodebuild;
     }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/XcodebuildExecuter.java
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/XcodebuildExecuter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.ide.xcode.fixtures;
+
+import com.google.common.collect.Lists;
+import org.gradle.integtests.fixtures.executer.ExecutionResult;
+import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult;
+import org.gradle.test.fixtures.file.ExecOutput;
+import org.gradle.test.fixtures.file.TestFile;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class XcodebuildExecuter {
+    private final TestFile baseDir;
+    private final List<String> args = new ArrayList<String>();
+    public XcodebuildExecuter(TestFile baseDir) {
+        this.baseDir = baseDir;
+    }
+
+    public XcodebuildExecuter withProject(String pathToBundle) {
+        return withProject(baseDir.file(pathToBundle));
+    }
+
+    public XcodebuildExecuter withProject(File xcodeProjectBundle) {
+        new TestFile(xcodeProjectBundle).assertIsDir();
+        return withArguments("-project", xcodeProjectBundle.getAbsolutePath());
+    }
+
+    public XcodebuildExecuter withWorkspace(String pathToBundle) {
+        return withWorkspace(baseDir.file(pathToBundle));
+    }
+
+    public XcodebuildExecuter withWorkspace(File bundle) {
+        new TestFile(bundle).assertIsDir();
+        return withArguments("-workspace", bundle.getAbsolutePath());
+    }
+
+    public XcodebuildExecuter withScheme(String schemeName) {
+        withArgument("-scheme");
+        withArgument(schemeName);
+        return this;
+    }
+
+    public XcodebuildExecuter withConfiguration(String configurationName) {
+        withArgument("-configuration");
+        withArgument(configurationName);
+        return this;
+    }
+
+    public XcodebuildExecuter withArguments(String... args) {
+        return withArguments(Lists.newArrayList(args));
+    }
+
+    public XcodebuildExecuter withArguments(List<String> args) {
+        this.args.clear();
+        this.args.addAll(args);
+        return this;
+    }
+
+    public XcodebuildExecuter withArgument(String arg) {
+        this.args.add(arg);
+        return this;
+    }
+
+    public ExecutionResult run(String action) {
+        args.add(action);
+        return run();
+    }
+
+    public ExecutionResult run() {
+        ExecOutput result = new TestFile("/usr/bin/xcodebuild").exec(args.toArray());
+        return new OutputScrapingExecutionResult(result.getOut(), result.getError());
+    }
+
+    public ExecutionResult succeeds() {
+        ExecOutput result = new TestFile("/usr/bin/xcodebuild").exec(args.toArray());
+        return new OutputScrapingExecutionResult(result.getOut(), result.getError());
+    }
+}

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/ExecOutput.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/ExecOutput.groovy
@@ -17,12 +17,14 @@
 package org.gradle.test.fixtures.file
 
 class ExecOutput {
-    ExecOutput(String rawOutput, String error) {
+    ExecOutput(int exitCode, String rawOutput, String error) {
+        this.exitCode = exitCode
         this.rawOutput = rawOutput
         this.out = rawOutput.replaceAll("\r\n|\r", "\n")
         this.error = error
     }
 
+    int exitCode
     String rawOutput
     String out
     String error

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -708,11 +708,15 @@ public class TestFile extends File {
     }
 
     public ExecOutput exec(Object... args) {
-        return new TestFileHelper(this).execute(Arrays.asList(args), null);
+        return new TestFileHelper(this).executeSuccess(Arrays.asList(args), null);
+    }
+
+    public ExecOutput execWithFailure(Object... args) {
+        return new TestFileHelper(this).executeFailure(Arrays.asList(args), null);
     }
 
     public ExecOutput execute(List args, List env) {
-        return new TestFileHelper(this).execute(args, env);
+        return new TestFileHelper(this).executeSuccess(args, env);
     }
 
     /**

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
@@ -184,12 +184,26 @@ class TestFileHelper {
 
     ExecOutput execute(List args, List env) {
         def process = ([file.absolutePath] + args).execute(env, null)
+        int exitCode = process.waitFor()
         String output = process.inputStream.text
         String error = process.errorStream.text
-        if (process.waitFor() != 0) {
-            throw new RuntimeException("Could not execute $file. Error: $error, Output: $output")
+        return new ExecOutput(exitCode, output, error)
+    }
+
+    ExecOutput executeSuccess(List args, List env) {
+        def result = execute(args, env)
+        if (result.exitCode != 0) {
+            throw new RuntimeException("Could not execute $file. Error: ${result.error}, Output: ${result.out}")
         }
-        return new ExecOutput(output, error)
+        return result
+    }
+
+    ExecOutput executeFailure(List args, List env) {
+        def result = execute(args, env)
+        if (result.exitCode == 0) {
+            throw new RuntimeException("Unexpected success, executing $file. Error: ${result.error}, Output: ${result.out}")
+        }
+        return result
     }
 
     public void zipTo(TestFile zipFile, boolean nativeTools, boolean readOnly) {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -154,6 +154,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     }),
     KOTLIN_SCRIPT({
         JDK8_OR_LATER.fulfilled && FIX_TO_WORK_ON_JAVA9.fulfilled && NOT_JDK_IBM.fulfilled
+    }),
+    XCODE({
+        MAC_OS_X.fulfilled
     })
 
     /**

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.gradle.util
+
 import org.gradle.api.JavaVersion
 import org.gradle.internal.os.OperatingSystem
 
@@ -156,6 +157,7 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
         JDK8_OR_LATER.fulfilled && FIX_TO_WORK_ON_JAVA9.fulfilled && NOT_JDK_IBM.fulfilled
     }),
     XCODE({
+        // Simplistic approach at detecting Xcode by assuming macOS imply Xcode is present
         MAC_OS_X.fulfilled
     })
 


### PR DESCRIPTION
### Context
Assert Xcode IDE can parse and make sense of the generated files.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=dl%2Fxcode-coverage)
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
