### PR TITLE
Create directories when registering outputs via the runtime API, too

### DIFF
--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheConfigurationIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheConfigurationIntegrationTest.groovy
@@ -254,7 +254,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.assertOutputContains("Task output caching is enabled, but no build caches are configured or enabled.")
         and:
-        file("local-cache").assertIsEmptyDir()
+        file("local-cache").assertDoesNotExist()
     }
 
     def "does not populate the build cache when we cannot push to it"() {

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TarTaskOutputPackerTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TarTaskOutputPackerTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.changedetection.state.DirContentSnapshot
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshot
 import org.gradle.api.internal.changedetection.state.FileHashSnapshot
-import org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType
+import org.gradle.api.internal.tasks.OutputType
 import org.gradle.api.internal.tasks.ResolvedTaskOutputFilePropertySpec
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginReader
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginWriter
@@ -37,8 +37,8 @@ import spock.lang.Unroll
 
 import java.util.concurrent.Callable
 
-import static org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType.DIRECTORY
-import static org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType.FILE
+import static OutputType.DIRECTORY
+import static OutputType.FILE
 
 @CleanupTestDirectory
 class TarTaskOutputPackerTest extends Specification {

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TaskOutputCacheCommandFactoryTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TaskOutputCacheCommandFactoryTest.groovy
@@ -28,7 +28,7 @@ import org.gradle.api.internal.changedetection.state.FileCollectionSnapshot
 import org.gradle.api.internal.changedetection.state.FileHashSnapshot
 import org.gradle.api.internal.changedetection.state.FileSystemMirror
 import org.gradle.api.internal.changedetection.state.RegularFileSnapshot
-import org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType
+import org.gradle.api.internal.tasks.OutputType
 import org.gradle.api.internal.tasks.ResolvedTaskOutputFilePropertySpec
 import org.gradle.api.internal.tasks.execution.TaskOutputsGenerationListener
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginFactory
@@ -40,8 +40,8 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testing.internal.util.Specification
 import org.junit.Rule
 
-import static org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType.DIRECTORY
-import static org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType.FILE
+import static OutputType.DIRECTORY
+import static OutputType.FILE
 
 @CleanupTestDirectory
 class TaskOutputCacheCommandFactoryTest extends Specification {

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TaskOutputPackerUtilsTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TaskOutputPackerUtilsTest.groovy
@@ -21,8 +21,8 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType.DIRECTORY
-import static org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType.FILE
+import static org.gradle.api.internal.tasks.OutputType.DIRECTORY
+import static org.gradle.api.internal.tasks.OutputType.FILE
 import static org.gradle.caching.internal.tasks.TaskOutputPackerUtils.ensureDirectoryForProperty
 
 @CleanupTestDirectory

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -399,9 +399,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         then:
         nonSkippedTasks.contains ":customTask"
         file("build/output.txt").text == "data"
-        // TODO: The runtime API doesn't automatically create output file paths
-        // This should really exist and behave the same as annotations.
-        file("build/output").assertDoesNotExist()
+        file("build/output").assertIsDir()
         file("build/output/missing").assertDoesNotExist()
 
         when:
@@ -497,6 +495,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
                 outputs.$expected "build/output" withPropertyName "output"
                 outputs.cacheIf { true }
                 doLast {
+                    delete('build')
                     ${
                         actual == "file" ?
                             "mkdir('build'); file('build/output').text = file('input.txt').text"

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractOutputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractOutputPropertyAnnotationHandler.java
@@ -16,9 +16,6 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.Action;
-import org.gradle.api.Describable;
-import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 
@@ -40,34 +37,11 @@ public abstract class AbstractOutputPropertyAnnotationHandler implements Propert
                 createPropertyBuilder(context, task, futureValue)
                     .withPropertyName(context.getName())
                     .optional(context.isOptional());
-                task.prependParallelSafeAction(new CreateOutputDirectoryTaskAction(context.getName(), futureValue));
             }
         });
     }
 
     protected abstract TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue);
 
-    protected abstract void beforeTask(Callable<Object> futureValue);
-
     protected abstract void validate(String propertyName, Object value, Collection<String> messages);
-
-    private class CreateOutputDirectoryTaskAction implements Action<Task>, Describable {
-        private final String propertyName;
-        private final Callable<Object> futureValue;
-
-        public CreateOutputDirectoryTaskAction(String propertyName, Callable<Object> futureValue) {
-            this.propertyName = propertyName;
-            this.futureValue = futureValue;
-        }
-
-        @Override
-        public void execute(Task task) {
-            beforeTask(futureValue);
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "Create " + propertyName + " output directory";
-        }
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractPluralOutputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractPluralOutputPropertyAnnotationHandler.java
@@ -20,10 +20,8 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 import static org.gradle.internal.Cast.uncheckedCast;
-import static org.gradle.util.GUtil.uncheckedCall;
 
 public abstract class AbstractPluralOutputPropertyAnnotationHandler extends AbstractOutputPropertyAnnotationHandler {
 
@@ -35,15 +33,6 @@ public abstract class AbstractPluralOutputPropertyAnnotationHandler extends Abst
     }
 
     protected abstract void doValidate(String propertyName, File file, Collection<String> messages);
-
-    @Override
-    protected void beforeTask(final Callable<Object> futureValue) {
-        for (File file : toFiles(uncheckedCall(futureValue))) {
-            doEnsureExists(file);
-        }
-    }
-
-    protected abstract void doEnsureExists(File file);
 
     private static Iterable<File> toFiles(Object value) {
         if (value == null) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoriesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoriesPropertyAnnotationHandler.java
@@ -24,7 +24,6 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.internal.tasks.TaskOutputsUtil.ensureDirectoryExists;
 import static org.gradle.api.internal.tasks.TaskOutputsUtil.validateDirectory;
 
 @SuppressWarnings("deprecation")
@@ -43,10 +42,5 @@ public class OutputDirectoriesPropertyAnnotationHandler extends AbstractPluralOu
     @Override
     protected void doValidate(String propertyName, File directory, Collection<String> messages) {
         validateDirectory(propertyName, directory, messages);
-    }
-
-    @Override
-    protected void doEnsureExists(File directory) {
-        ensureDirectoryExists(directory);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoryPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoryPropertyAnnotationHandler.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.internal.tasks.TaskOutputsUtil.ensureDirectoryExists;
 import static org.gradle.api.internal.tasks.TaskOutputsUtil.validateDirectory;
 
 public class OutputDirectoryPropertyAnnotationHandler extends AbstractOutputPropertyAnnotationHandler {
@@ -47,14 +46,6 @@ public class OutputDirectoryPropertyAnnotationHandler extends AbstractOutputProp
     @Override
     protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue) {
         return task.getOutputs().dir(futureValue);
-    }
-
-    @Override
-    protected void beforeTask(final Callable<Object> futureValue) {
-        File directory = toFile(futureValue);
-        if (directory != null) {
-            ensureDirectoryExists(directory);
-        }
     }
 
     private File toFile(Object value) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilePropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilePropertyAnnotationHandler.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.internal.tasks.TaskOutputsUtil.ensureParentDirectoryExists;
 import static org.gradle.api.internal.tasks.TaskOutputsUtil.validateFile;
 
 public class OutputFilePropertyAnnotationHandler extends AbstractOutputPropertyAnnotationHandler {
@@ -45,14 +44,6 @@ public class OutputFilePropertyAnnotationHandler extends AbstractOutputPropertyA
     @Override
     protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue) {
         return task.getOutputs().file(futureValue);
-    }
-
-    @Override
-    protected void beforeTask(final Callable<Object> futureValue) {
-        File file = toFile(futureValue);
-        if (file != null) {
-            ensureParentDirectoryExists(file);
-        }
     }
 
     private File toFile(Object value) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilesPropertyAnnotationHandler.java
@@ -25,8 +25,6 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.internal.tasks.TaskOutputsUtil.ensureParentDirectoryExists;
-
 @SuppressWarnings("deprecation")
 public class OutputFilesPropertyAnnotationHandler extends AbstractPluralOutputPropertyAnnotationHandler {
 
@@ -43,10 +41,5 @@ public class OutputFilesPropertyAnnotationHandler extends AbstractPluralOutputPr
     @Override
     protected void doValidate(String propertyName, File file, Collection<String> messages) {
         TaskOutputsUtil.validateFile(propertyName, file, messages);
-    }
-
-    @Override
-    protected void doEnsureExists(File file) {
-        ensureParentDirectoryExists(file);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CompositeTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CompositeTaskOutputPropertySpec.java
@@ -27,12 +27,12 @@ import java.util.Map;
 
 public class CompositeTaskOutputPropertySpec extends AbstractTaskOutputPropertySpec {
 
-    private final CacheableTaskOutputFilePropertySpec.OutputType outputType;
+    private final OutputType outputType;
     private final Object paths;
     private final String taskName;
     private final FileResolver resolver;
 
-    public CompositeTaskOutputPropertySpec(String taskName, FileResolver resolver, CacheableTaskOutputFilePropertySpec.OutputType outputType, Object[] paths) {
+    public CompositeTaskOutputPropertySpec(String taskName, FileResolver resolver, OutputType outputType, Object[] paths) {
         this.taskName = taskName;
         this.resolver = resolver;
         this.outputType = outputType;
@@ -41,7 +41,7 @@ public class CompositeTaskOutputPropertySpec extends AbstractTaskOutputPropertyS
             : paths;
     }
 
-    public CacheableTaskOutputFilePropertySpec.OutputType getOutputType() {
+    public OutputType getOutputType() {
         return outputType;
     }
 
@@ -69,7 +69,7 @@ public class CompositeTaskOutputPropertySpec extends AbstractTaskOutputPropertyS
             };
         } else {
             return Iterators.<TaskOutputFilePropertySpec>singletonIterator(
-                new NonCacheableTaskOutputPropertySpec(taskName, this, resolver, unpackedPaths)
+                new NonCacheableTaskOutputPropertySpec(taskName, this, resolver, outputType, unpackedPaths)
             );
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -33,7 +33,6 @@ import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.internal.file.CompositeFileCollection;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
-import org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType;
 import org.gradle.api.internal.tasks.execution.SelfDescribingSpec;
 import org.gradle.api.specs.AndSpec;
 import org.gradle.api.specs.Spec;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
@@ -25,10 +25,12 @@ import org.gradle.api.tasks.TaskPropertyBuilder;
 public class NonCacheableTaskOutputPropertySpec extends AbstractTaskOutputsDeprecatingTaskPropertyBuilder implements TaskOutputFilePropertySpec {
 
     private final CompositeTaskOutputPropertySpec parent;
+    private final OutputType outputType;
     private final FileCollection files;
 
-    public NonCacheableTaskOutputPropertySpec(String taskName, CompositeTaskOutputPropertySpec parent, FileResolver resolver, Object paths) {
+    public NonCacheableTaskOutputPropertySpec(String taskName, CompositeTaskOutputPropertySpec parent, FileResolver resolver, OutputType outputType, Object paths) {
         this.parent = parent;
+        this.outputType = outputType;
         this.files = new TaskPropertyFileCollection(taskName, "output", this, resolver, paths);
     }
 
@@ -40,6 +42,11 @@ public class NonCacheableTaskOutputPropertySpec extends AbstractTaskOutputsDepre
     @Override
     public String getPropertyName() {
         return parent.getPropertyName();
+    }
+
+    @Override
+    public OutputType getOutputType() {
+        return outputType;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/OutputType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/OutputType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,6 @@
 
 package org.gradle.api.internal.tasks;
 
-import javax.annotation.Nullable;
-import java.io.File;
-
-public interface CacheableTaskOutputFilePropertySpec extends TaskOutputFilePropertySpec {
-    @Nullable
-    File getOutputFile();
+public enum OutputType {
+    FILE, DIRECTORY
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputFilePropertySpec.java
@@ -17,4 +17,5 @@
 package org.gradle.api.internal.tasks;
 
 public interface TaskOutputFilePropertySpec extends TaskFilePropertySpec {
+    OutputType getOutputType();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputsUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputsUtil.java
@@ -19,9 +19,6 @@ package org.gradle.api.internal.tasks;
 import java.io.File;
 import java.util.Collection;
 
-import static org.gradle.internal.FileUtils.canonicalize;
-import static org.gradle.util.GFileUtils.mkdirs;
-
 public class TaskOutputsUtil {
     public static void validateFile(String propertyName, File file, Collection<String> messages) {
         if (file.exists()) {
@@ -52,13 +49,5 @@ public class TaskOutputsUtil {
                 }
             }
         }
-    }
-
-    public static void ensureDirectoryExists(File directory) {
-        mkdirs(canonicalize(directory));
-    }
-
-    public static void ensureParentDirectoryExists(File file) {
-        mkdirs(canonicalize(file).getParentFile());
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/OutputDirectoryCreatingTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/OutputDirectoryCreatingTaskExecuter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.execution;
+
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec;
+import org.gradle.api.internal.tasks.OutputType;
+import org.gradle.api.internal.tasks.TaskExecuter;
+import org.gradle.api.internal.tasks.TaskExecutionContext;
+import org.gradle.api.internal.tasks.TaskOutputFilePropertySpec;
+import org.gradle.api.internal.tasks.TaskStateInternal;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+import java.io.File;
+
+import static org.gradle.internal.FileUtils.canonicalize;
+import static org.gradle.util.GFileUtils.mkdirs;
+
+/**
+ * A {@link TaskExecuter} which creates directories for task outputs.
+ */
+public class OutputDirectoryCreatingTaskExecuter implements TaskExecuter {
+    private static final Logger LOGGER = Logging.getLogger(OutputDirectoryCreatingTaskExecuter.class);
+    private final TaskExecuter executer;
+
+    public OutputDirectoryCreatingTaskExecuter(TaskExecuter executer) {
+        this.executer = executer;
+    }
+
+    public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
+        for (TaskOutputFilePropertySpec outputProperty : task.getOutputs().getFileProperties()) {
+            OutputType type = outputProperty.getOutputType();
+            if (outputProperty instanceof CacheableTaskOutputFilePropertySpec) {
+                CacheableTaskOutputFilePropertySpec cacheableProperty = (CacheableTaskOutputFilePropertySpec) outputProperty;
+                File output = cacheableProperty.getOutputFile();
+                ensureOutput(outputProperty, output, type);
+            } else {
+                for (File output : outputProperty.getPropertyFiles()) {
+                    ensureOutput(outputProperty, output, type);
+                }
+            }
+        }
+
+        executer.execute(task, state, context);
+    }
+
+    private void ensureOutput(TaskOutputFilePropertySpec outputProperty, File output, OutputType type) {
+        if (output == null) {
+            LOGGER.debug("Not ensuring directory exists for property {}, because value is null", outputProperty);
+            return;
+        }
+        switch (type) {
+            case DIRECTORY:
+                LOGGER.debug("Ensuring directory exists for property {} at {}", outputProperty, output);
+                mkdirs(canonicalize(output));
+                break;
+            case FILE:
+                LOGGER.debug("Ensuring parent directory exists for property {} at {}", outputProperty, output);
+                mkdirs(canonicalize(output).getParentFile());
+                break;
+            default:
+                throw new AssertionError();
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TarTaskOutputPacker.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TarTaskOutputPacker.java
@@ -37,7 +37,7 @@ import org.gradle.api.internal.changedetection.state.FileHashSnapshot;
 import org.gradle.api.internal.changedetection.state.FileSnapshot;
 import org.gradle.api.internal.changedetection.state.RegularFileSnapshot;
 import org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec;
-import org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType;
+import org.gradle.api.internal.tasks.OutputType;
 import org.gradle.api.internal.tasks.ResolvedTaskOutputFilePropertySpec;
 import org.gradle.api.internal.tasks.TaskFilePropertySpec;
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginMetadata;

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputPackerUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputPackerUtils.java
@@ -17,7 +17,7 @@
 package org.gradle.caching.internal.tasks;
 
 import org.apache.commons.io.FileUtils;
-import org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType;
+import org.gradle.api.internal.tasks.OutputType;
 
 import java.io.File;
 import java.io.IOException;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
@@ -45,6 +45,7 @@ import org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter;
 import org.gradle.api.internal.tasks.execution.CleanupStaleOutputsExecuter;
 import org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter;
 import org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter;
+import org.gradle.api.internal.tasks.execution.OutputDirectoryCreatingTaskExecuter;
 import org.gradle.api.internal.tasks.execution.ResolveBuildCacheKeyExecuter;
 import org.gradle.api.internal.tasks.execution.ResolveTaskArtifactStateTaskExecuter;
 import org.gradle.api.internal.tasks.execution.ResolveTaskOutputCachingStateExecuter;
@@ -121,6 +122,7 @@ public class TaskExecutionServices {
         if (verifyInputsEnabled) {
             executer = new VerifyNoInputChangesTaskExecuter(repository, executer);
         }
+        executer = new OutputDirectoryCreatingTaskExecuter(executer);
         if (taskOutputCacheEnabled) {
             executer = new SkipCachedTaskExecuter(
                 buildCacheController,

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -27,8 +27,8 @@ import spock.lang.Unroll
 
 import java.util.concurrent.Callable
 
-import static org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType.DIRECTORY
-import static org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec.OutputType.FILE
+import static OutputType.DIRECTORY
+import static OutputType.FILE
 
 @UsesNativeServices
 class DefaultTaskOutputsTest extends Specification {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
@@ -94,14 +94,14 @@ task retrieve(type: Copy, dependsOn: deleteDir) {
         run 'retrieve'
 
         then:
-        file('libs').assertIsEmptyDir()
+        file('libs').assertDoesNotExist()
 
         when:
         server.resetExpectations()
         run 'retrieve'
 
         then: // Uses cached artifacts
-        file('libs').assertIsEmptyDir()
+        file('libs').assertDoesNotExist()
     }
 
     def "for a snapshot module with packaging of type 'pom', will check for jar artifact that was previously missing on cache expiry"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -727,13 +727,13 @@ class FileSizer extends ArtifactTransform {
         output.count("Transforming") == 2
         output.count("Transforming test-1.3.jar") == 1
         output.count("Transforming test2-2.3.jar") == 1
-        file("build/libs").assertIsEmptyDir()
+        file("build/libs").assertDoesNotExist()
 
         when:
         run "resolve"
 
         then:
-        file("build/libs").assertIsEmptyDir()
+        file("build/libs").assertDoesNotExist()
 
         and:
         output.count("Transforming") == 0

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -19,6 +19,21 @@ TBD: `ListProperty<T>`
 TBD: `Provider.map()`
 TBD: `PropertyState<Directory>` and `PropertyState<RegularFile>` can be set using `File` in DSL.
 
+### Directories are created for task outputs declared via the runtime API
+
+For task outputs declared via annotations like `@OutputDirectory` and `@OutputFile`, Gradle always ensured that the necessary directory exists before executing the task. Starting with version 4.3 Gradle will also create directories for outputs that were registered via the runtime API (e.g. by calling methods like `task.outputs.file()` and `dir()`).
+
+```
+task customTask {
+    inputs.file "input.txt"
+    outputs.file "output-dir/output.txt"
+    doLast {
+        mkdir "output-dir" // <-- This is now unnecessary
+        file("output-dir/output.txt") << file("input.txt")
+    }
+}
+```
+
 <!--
 ### Example new and noteworthy
 -->

--- a/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
+++ b/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.plugins.ear
 import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.internal.TaskInternal
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin
@@ -324,13 +325,9 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
 
     private static void execute(Task task) {
         for (Task dep : task.taskDependencies.getDependencies(task)) {
-            for (Action action : dep.actions) {
-                action.execute(dep)
-            }
+            ((TaskInternal) dep).execute()
         }
-        for (Action action : task.actions) {
-            action.execute(task)
-        }
+        ((TaskInternal) task).execute()
     }
 
     File inEar(path) {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -398,7 +398,7 @@ class Main {
                 outputs.dir docs
 
                 doLast {
-                    assert docs.mkdirs()
+                    assert docs.directory
                     new File(docs, "readme.txt") << "Read me!!!"
                 }
             }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -128,13 +128,14 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
             }
         """
         def dirInBuildDir = file("build/dir").createDir()
+        file("build/dir/stale-file.txt").touch()
         def customFile = file("customFile").touch()
         def myTaskDir = file("external/output").createDir()
 
         when:
         succeeds("myTask")
         then:
-        dirInBuildDir.assertIsDir()
+        dirInBuildDir.assertIsEmptyDir()
         customFile.assertDoesNotExist()
         buildFile.assertExists()
         // We should improve this eventually.  We currently don't delete _all_ outputs from every task
@@ -153,11 +154,13 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
                 doLast {
                     assert !file("build/file").exists()
                     file("build/file").text = "Created"
-                    assert file("build/dir").directory 
+                    assert file("build/dir").directory
+                    assert file("build/dir").list().length == 0
                 }
             }
         """
         def dirInBuildDir = file("build/dir").createDir()
+        def staleFileInDir = file("build/dir/stale-file.txt").touch()
         def fileInBuildDir = file("build/file").touch()
 
         expect:
@@ -171,6 +174,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         """
         // recreate the output
         dirInBuildDir.createDir()
+        staleFileInDir.touch()
         fileInBuildDir.touch()
         then:
         succeeds("myTask")
@@ -474,6 +478,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
             if (project.findProperty('assertRemoved')) {
                 ${taskName}.doFirst {
                     assert file('${outputDirPath}').directory
+                    assert file('${outputDirPath}').list().length == 0
                     assert !file('${outputFilePath}').exists()
                 }
             }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -134,7 +134,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         when:
         succeeds("myTask")
         then:
-        dirInBuildDir.assertDoesNotExist()
+        dirInBuildDir.assertIsDir()
         customFile.assertDoesNotExist()
         buildFile.assertExists()
         // We should improve this eventually.  We currently don't delete _all_ outputs from every task
@@ -153,8 +153,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
                 doLast {
                     assert !file("build/file").exists()
                     file("build/file").text = "Created"
-                    assert !file("build/dir").exists() 
-                    assert file("build/dir").mkdirs()
+                    assert file("build/dir").directory 
                 }
             }
         """
@@ -474,7 +473,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
 
             if (project.findProperty('assertRemoved')) {
                 ${taskName}.doFirst {
-                    assert !file('${outputDirPath}').exists()
+                    assert file('${outputDirPath}').directory
                     assert !file('${outputFilePath}').exists()
                 }
             }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -524,10 +524,8 @@ public class TestFile extends File {
     }
 
     public TestFile assertIsEmptyDir() {
-        if (exists()) {
-            assertIsDir();
-            assertHasDescendants();
-        }
+        assertIsDir();
+        assertHasDescendants();
         return this;
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
@@ -72,33 +72,6 @@ class BuildProgressTaskActionsCrossVersionSpec extends ToolingApiSpecification {
         task.child('Snapshot task inputs for :custom')
     }
 
-    //This is the current behavior. The behavior of creating each output directory in a separate action might change in the future.
-    def "create output directories actions have informative names"() {
-        given:
-        buildFile << """
-        task custom(type: CustomTask) {
-            customInString = ""
-            customOut1 = file("\$buildDir/out1")
-            customOut2 = file("\$buildDir/out2")
-        }
-        
-        class CustomTask extends DefaultTask {
-            @OutputDirectory File customOut1
-            @OutputDirectory File customOut2
-            @Input String customInString
-            @TaskAction void doSomething() { }
-        }    
-        """
-
-        when:
-        runCustomTask()
-
-        then:
-        def task = events.operation("Task :custom")
-        task.child('Create customOut1 output directory for :custom')
-        task.child('Create customOut2 output directory for :custom')
-    }
-
     def "task actions implemented in annotated methods are named after the method"() {
         given:
         buildFile << """


### PR DESCRIPTION
Previously we were creating output directories only for outputs registered via task property annotations.