### PR TITLE
Unify error messages for Gradle build options 

### DIFF
--- a/subprojects/build-option/build-option.gradle
+++ b/subprojects/build-option/build-option.gradle
@@ -5,6 +5,7 @@ sourceCompatibility = javaVersion.java9Compatible ? 1.6 : 1.5
 dependencies {
     api project(':cli')
     api libraries.jsr305
+    implementation 'commons-lang:commons-lang:2.6'
 }
 
 useClassycle()

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BooleanBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BooleanBuildOption.java
@@ -43,7 +43,7 @@ public abstract class BooleanBuildOption<T> extends AbstractBuildOption<T> {
         String value = properties.get(gradleProperty);
 
         if (value != null) {
-            applyTo(isTrue(properties.get(gradleProperty)), settings, Origin.GRADLE_PROPERTY);
+            applyTo(isTrue(properties.get(gradleProperty)), settings, Origin.withGradleProperty(gradleProperty));
         }
     }
 
@@ -61,11 +61,11 @@ public abstract class BooleanBuildOption<T> extends AbstractBuildOption<T> {
     public void applyFromCommandLine(ParsedCommandLine options, T settings) {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
             if (options.hasOption(config.getLongOption())) {
-                applyTo(true, settings, Origin.COMMAND_LINE);
+                applyTo(true, settings, Origin.withCommandLine(config.getLongOption()));
             }
 
             if (options.hasOption(getDisabledCommandLineOption(config))) {
-                applyTo(false, settings, Origin.COMMAND_LINE);
+                applyTo(false, settings, Origin.withCommandLine(getDisabledCommandLineOption(config)));
             }
         }
     }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BooleanBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BooleanBuildOption.java
@@ -43,7 +43,7 @@ public abstract class BooleanBuildOption<T> extends AbstractBuildOption<T> {
         String value = properties.get(gradleProperty);
 
         if (value != null) {
-            applyTo(isTrue(properties.get(gradleProperty)), settings, Origin.withGradleProperty(gradleProperty));
+            applyTo(isTrue(properties.get(gradleProperty)), settings, Origin.forGradleProperty(gradleProperty));
         }
     }
 
@@ -61,11 +61,11 @@ public abstract class BooleanBuildOption<T> extends AbstractBuildOption<T> {
     public void applyFromCommandLine(ParsedCommandLine options, T settings) {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
             if (options.hasOption(config.getLongOption())) {
-                applyTo(true, settings, Origin.withCommandLine(config.getLongOption()));
+                applyTo(true, settings, Origin.forCommandLine(config.getLongOption()));
             }
 
             if (options.hasOption(getDisabledCommandLineOption(config))) {
-                applyTo(false, settings, Origin.withCommandLine(getDisabledCommandLineOption(config)));
+                applyTo(false, settings, Origin.forCommandLine(getDisabledCommandLineOption(config)));
             }
         }
     }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BuildOption.java
@@ -30,19 +30,31 @@ import java.util.Map;
  */
 public interface BuildOption<T> {
 
-    @Nullable String getGradleProperty();
+    @Nullable
+    String getGradleProperty();
+
     void applyFromProperty(Map<String, String> properties, T settings);
+
     void configure(CommandLineParser parser);
+
     void applyFromCommandLine(ParsedCommandLine options, T settings);
 
     enum Origin {
-        GRADLE_PROPERTY, COMMAND_LINE;
-
-        public void handleInvalidValue(String gradlePropertyFailureMessage, String commandLineFailureMessage) {
-            switch (this) {
-                case GRADLE_PROPERTY: throw new IllegalArgumentException(gradlePropertyFailureMessage);
-                case COMMAND_LINE: throw new CommandLineArgumentException(commandLineFailureMessage);
+        GRADLE_PROPERTY {
+            @Override
+            public void handleInvalidValue(String property, String option, String value, String hint) {
+                String message = String.format("Value '%s' given for %s Gradle property is invalid (%s)", value, property, hint);
+                throw new IllegalArgumentException(message);
             }
-        }
+        },
+        COMMAND_LINE {
+            @Override
+            public void handleInvalidValue(String property, String option, String value, String hint) {
+                String message = String.format("Argument value '%s' given for --%s option is invalid (%s)", value, option, hint);
+                throw new CommandLineArgumentException(message);
+            }
+        };
+
+        public abstract void handleInvalidValue(String property, String option, String value, String hint);
     }
 }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BuildOption.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.buildoption;
 
-import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 
@@ -39,22 +38,4 @@ public interface BuildOption<T> {
 
     void applyFromCommandLine(ParsedCommandLine options, T settings);
 
-    enum Origin {
-        GRADLE_PROPERTY {
-            @Override
-            public void handleInvalidValue(String property, String option, String value, String hint) {
-                String message = String.format("Value '%s' given for %s Gradle property is invalid (%s)", value, property, hint);
-                throw new IllegalArgumentException(message);
-            }
-        },
-        COMMAND_LINE {
-            @Override
-            public void handleInvalidValue(String property, String option, String value, String hint) {
-                String message = String.format("Argument value '%s' given for --%s option is invalid (%s)", value, option, hint);
-                throw new CommandLineArgumentException(message);
-            }
-        };
-
-        public abstract void handleInvalidValue(String property, String option, String value, String hint);
-    }
 }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOption.java
@@ -39,7 +39,7 @@ public abstract class EnabledOnlyBooleanBuildOption<T> extends AbstractBuildOpti
     @Override
     public void applyFromProperty(Map<String, String> properties, T settings) {
         if (properties.get(gradleProperty) != null) {
-            applyTo(settings, Origin.withGradleProperty(gradleProperty));
+            applyTo(settings, Origin.forGradleProperty(gradleProperty));
         }
     }
 
@@ -54,7 +54,7 @@ public abstract class EnabledOnlyBooleanBuildOption<T> extends AbstractBuildOpti
     public void applyFromCommandLine(ParsedCommandLine options, T settings) {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
             if (options.hasOption(config.getLongOption())) {
-                applyTo(settings, Origin.withCommandLine(config.getLongOption()));
+                applyTo(settings, Origin.forCommandLine(config.getLongOption()));
             }
         }
     }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOption.java
@@ -39,7 +39,7 @@ public abstract class EnabledOnlyBooleanBuildOption<T> extends AbstractBuildOpti
     @Override
     public void applyFromProperty(Map<String, String> properties, T settings) {
         if (properties.get(gradleProperty) != null) {
-            applyTo(settings, Origin.GRADLE_PROPERTY);
+            applyTo(settings, Origin.withGradleProperty(gradleProperty));
         }
     }
 
@@ -54,7 +54,7 @@ public abstract class EnabledOnlyBooleanBuildOption<T> extends AbstractBuildOpti
     public void applyFromCommandLine(ParsedCommandLine options, T settings) {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
             if (options.hasOption(config.getLongOption())) {
-                applyTo(settings, Origin.COMMAND_LINE);
+                applyTo(settings, Origin.withCommandLine(config.getLongOption()));
             }
         }
     }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/ListBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/ListBuildOption.java
@@ -44,7 +44,7 @@ public abstract class ListBuildOption<T> extends AbstractBuildOption<T> {
 
         if (value != null) {
             String[] splitValues = value.split("\\s*,\\s*");
-            applyTo(Arrays.asList(splitValues), settings, Origin.withGradleProperty(gradleProperty));
+            applyTo(Arrays.asList(splitValues), settings, Origin.forGradleProperty(gradleProperty));
         }
     }
 
@@ -60,7 +60,7 @@ public abstract class ListBuildOption<T> extends AbstractBuildOption<T> {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
             if (options.hasOption(config.getLongOption())) {
                 List<String> value = options.option(config.getLongOption()).getValues();
-                applyTo(value, settings, Origin.withCommandLine(config.getLongOption()));
+                applyTo(value, settings, Origin.forCommandLine(config.getLongOption()));
             }
         }
     }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/ListBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/ListBuildOption.java
@@ -44,7 +44,7 @@ public abstract class ListBuildOption<T> extends AbstractBuildOption<T> {
 
         if (value != null) {
             String[] splitValues = value.split("\\s*,\\s*");
-            applyTo(Arrays.asList(splitValues), settings, Origin.GRADLE_PROPERTY);
+            applyTo(Arrays.asList(splitValues), settings, Origin.withGradleProperty(gradleProperty));
         }
     }
 
@@ -60,7 +60,7 @@ public abstract class ListBuildOption<T> extends AbstractBuildOption<T> {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
             if (options.hasOption(config.getLongOption())) {
                 List<String> value = options.option(config.getLongOption()).getValues();
-                applyTo(value, settings, Origin.COMMAND_LINE);
+                applyTo(value, settings, Origin.withCommandLine(config.getLongOption()));
             }
         }
     }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/Origin.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/Origin.java
@@ -22,11 +22,11 @@ import org.gradle.cli.CommandLineArgumentException;
 public abstract class Origin {
     protected String source;
 
-    public static Origin withGradleProperty(String gradleProperty) {
+    public static Origin forGradleProperty(String gradleProperty) {
         return new GradlePropertyOrigin(gradleProperty);
     }
 
-    public static Origin withCommandLine(String commandLineOption) {
+    public static Origin forCommandLine(String commandLineOption) {
         return new CommandLineOrigin(commandLineOption);
     }
 

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/Origin.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/Origin.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildoption;
+
+import org.apache.commons.lang.StringUtils;
+import org.gradle.cli.CommandLineArgumentException;
+
+public abstract class Origin {
+    protected String source;
+
+    public static Origin withGradleProperty(String gradleProperty) {
+        return new GradlePropertyOrigin(gradleProperty);
+    }
+
+    public static Origin withCommandLine(String commandLineOption) {
+        return new CommandLineOrigin(commandLineOption);
+    }
+
+    private Origin(String source) {
+        this.source = source;
+    }
+
+    public abstract void handleInvalidValue(String value, String hint);
+
+    public void handleInvalidValue(String value) {
+        handleInvalidValue(value, null);
+    }
+
+    String hintMessage(String hint) {
+        if (StringUtils.isBlank(hint)) {
+            return "";
+        } else {
+            return String.format(" (%s)", hint);
+        }
+    }
+
+    private static class GradlePropertyOrigin extends Origin {
+        public GradlePropertyOrigin(String value) {
+            super(value);
+        }
+
+        @Override
+        public void handleInvalidValue(String value, String hint) {
+            String message = String.format("Value '%s' given for %s Gradle property is invalid%s", value, source, hintMessage(hint));
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    private static class CommandLineOrigin extends Origin {
+        public CommandLineOrigin(String value) {
+            super(value);
+        }
+
+        @Override
+        public void handleInvalidValue(String value, String hint) {
+            String message = String.format("Argument value '%s' given for --%s option is invalid%s", value, source, hintMessage(hint));
+            throw new CommandLineArgumentException(message);
+        }
+    }
+}

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/Origin.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/Origin.java
@@ -43,9 +43,8 @@ public abstract class Origin {
     String hintMessage(String hint) {
         if (StringUtils.isBlank(hint)) {
             return "";
-        } else {
-            return String.format(" (%s)", hint);
         }
+        return String.format(" (%s)", hint);
     }
 
     private static class GradlePropertyOrigin extends Origin {

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/StringBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/StringBuildOption.java
@@ -41,7 +41,7 @@ public abstract class StringBuildOption<T> extends AbstractBuildOption<T> {
         String value = properties.get(gradleProperty);
 
         if (value != null) {
-            applyTo(value, settings, Origin.withGradleProperty(gradleProperty));
+            applyTo(value, settings, Origin.forGradleProperty(gradleProperty));
         }
     }
 
@@ -57,7 +57,7 @@ public abstract class StringBuildOption<T> extends AbstractBuildOption<T> {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
             if (options.hasOption(config.getLongOption())) {
                 String value = options.option(config.getLongOption()).getValue();
-                applyTo(value, settings, Origin.withCommandLine(config.getLongOption()));
+                applyTo(value, settings, Origin.forCommandLine(config.getLongOption()));
             }
         }
     }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/StringBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/StringBuildOption.java
@@ -41,7 +41,7 @@ public abstract class StringBuildOption<T> extends AbstractBuildOption<T> {
         String value = properties.get(gradleProperty);
 
         if (value != null) {
-            applyTo(value, settings, Origin.GRADLE_PROPERTY);
+            applyTo(value, settings, Origin.withGradleProperty(gradleProperty));
         }
     }
 
@@ -57,7 +57,7 @@ public abstract class StringBuildOption<T> extends AbstractBuildOption<T> {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
             if (options.hasOption(config.getLongOption())) {
                 String value = options.option(config.getLongOption()).getValue();
-                applyTo(value, settings, Origin.COMMAND_LINE);
+                applyTo(value, settings, Origin.withCommandLine(config.getLongOption()));
             }
         }
     }

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BooleanBuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BooleanBuildOptionTest.groovy
@@ -45,7 +45,8 @@ class BooleanBuildOptionTest extends Specification {
 
         then:
         testSettings.value
-        testSettings.origin == BuildOption.Origin.GRADLE_PROPERTY
+        testSettings.origin instanceof Origin.GradlePropertyOrigin
+        testSettings.origin.source == GRADLE_PROPERTY
     }
 
     def "can configure command line parser"() {
@@ -128,7 +129,8 @@ class BooleanBuildOptionTest extends Specification {
 
         then:
         testSettings.value
-        testSettings.origin == BuildOption.Origin.COMMAND_LINE
+        testSettings.origin instanceof Origin.CommandLineOrigin
+        testSettings.origin.source == LONG_OPTION
 
         when:
         parsedCommandLine.addOption(DISABLED_LONG_OPTION, disabledOption)
@@ -136,7 +138,8 @@ class BooleanBuildOptionTest extends Specification {
 
         then:
         !testSettings.value
-        testSettings.origin == BuildOption.Origin.COMMAND_LINE
+        testSettings.origin instanceof Origin.CommandLineOrigin
+        testSettings.origin.source == DISABLED_LONG_OPTION
     }
 
     static class TestOption extends BooleanBuildOption<TestSettings> {
@@ -150,7 +153,7 @@ class BooleanBuildOptionTest extends Specification {
         }
 
         @Override
-        void applyTo(boolean value, TestSettings settings, BuildOption.Origin origin) {
+        void applyTo(boolean value, TestSettings settings, Origin origin) {
             settings.value = value
             settings.origin = origin
         }
@@ -158,7 +161,7 @@ class BooleanBuildOptionTest extends Specification {
 
     static class TestSettings {
         boolean value
-        BuildOption.Origin origin
+        Origin origin
     }
 }
 

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BuildOptionTest.groovy
@@ -20,24 +20,21 @@ import org.gradle.cli.CommandLineArgumentException
 import spock.lang.Specification
 
 class BuildOptionTest extends Specification {
-    private static final String GRADLE_PROPERTY_FAILURE_MESSAGE = 'Invalid Gradle property value'
-    private static final String COMMAND_LINE_FAILUE_MESSAGE = 'Invalid command line option value'
-
     def "can handle invalid value for Gradle property"() {
         when:
-        BuildOption.Origin.GRADLE_PROPERTY.handleInvalidValue(GRADLE_PROPERTY_FAILURE_MESSAGE, COMMAND_LINE_FAILUE_MESSAGE)
+        BuildOption.Origin.GRADLE_PROPERTY.handleInvalidValue('property', 'option', 'value', 'hint')
 
         then:
         Throwable t = thrown(IllegalArgumentException)
-        t.message == GRADLE_PROPERTY_FAILURE_MESSAGE
+        t.message == "Value 'value' given for property Gradle property is invalid (hint)"
     }
 
     def "can handle invalid value for command line option"() {
         when:
-        BuildOption.Origin.COMMAND_LINE.handleInvalidValue(GRADLE_PROPERTY_FAILURE_MESSAGE, COMMAND_LINE_FAILUE_MESSAGE)
+        BuildOption.Origin.COMMAND_LINE.handleInvalidValue('property', 'option', 'value', 'hint')
 
         then:
         Throwable t = thrown(CommandLineArgumentException)
-        t.message == COMMAND_LINE_FAILUE_MESSAGE
+        t.message == "Argument value 'value' given for --option option is invalid (hint)"
     }
 }

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BuildOptionTest.groovy
@@ -18,23 +18,42 @@ package org.gradle.internal.buildoption
 
 import org.gradle.cli.CommandLineArgumentException
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class BuildOptionTest extends Specification {
-    def "can handle invalid value for Gradle property"() {
+    private static final String VALUE = '0'
+    private static final String HINT = 'must be positive'
+    private static final String GRADLE_PROPERTY = 'org.gradle.property'
+    private static final String OPTION = 'option'
+
+    @Unroll
+    def "can handle invalid value for Gradle property with empty #hint"() {
         when:
-        BuildOption.Origin.GRADLE_PROPERTY.handleInvalidValue('property', 'option', 'value', 'hint')
+        Origin.withGradleProperty(GRADLE_PROPERTY).handleInvalidValue(VALUE, hint)
 
         then:
         Throwable t = thrown(IllegalArgumentException)
-        t.message == "Value 'value' given for property Gradle property is invalid (hint)"
+        t.message == "Value '0' given for org.gradle.property Gradle property is invalid"
+
+        where:
+        hint << ['', ' ', null]
     }
 
-    def "can handle invalid value for command line option"() {
+    def "can handle invalid value for Gradle property with concrete hint"() {
         when:
-        BuildOption.Origin.COMMAND_LINE.handleInvalidValue('property', 'option', 'value', 'hint')
+        Origin.withGradleProperty(GRADLE_PROPERTY).handleInvalidValue(VALUE, HINT)
+
+        then:
+        Throwable t = thrown(IllegalArgumentException)
+        t.message == "Value '0' given for org.gradle.property Gradle property is invalid (must be positive)"
+    }
+
+    def "can handle invalid value for command line option with concrete hint"() {
+        when:
+        Origin.withCommandLine(OPTION).handleInvalidValue(VALUE, HINT)
 
         then:
         Throwable t = thrown(CommandLineArgumentException)
-        t.message == "Argument value 'value' given for --option option is invalid (hint)"
+        t.message == "Argument value '0' given for --option option is invalid (must be positive)"
     }
 }

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BuildOptionTest.groovy
@@ -29,7 +29,7 @@ class BuildOptionTest extends Specification {
     @Unroll
     def "can handle invalid value for Gradle property with empty #hint"() {
         when:
-        Origin.withGradleProperty(GRADLE_PROPERTY).handleInvalidValue(VALUE, hint)
+        Origin.forGradleProperty(GRADLE_PROPERTY).handleInvalidValue(VALUE, hint)
 
         then:
         Throwable t = thrown(IllegalArgumentException)
@@ -41,7 +41,7 @@ class BuildOptionTest extends Specification {
 
     def "can handle invalid value for Gradle property with concrete hint"() {
         when:
-        Origin.withGradleProperty(GRADLE_PROPERTY).handleInvalidValue(VALUE, HINT)
+        Origin.forGradleProperty(GRADLE_PROPERTY).handleInvalidValue(VALUE, HINT)
 
         then:
         Throwable t = thrown(IllegalArgumentException)
@@ -50,7 +50,7 @@ class BuildOptionTest extends Specification {
 
     def "can handle invalid value for command line option with concrete hint"() {
         when:
-        Origin.withCommandLine(OPTION).handleInvalidValue(VALUE, HINT)
+        Origin.forCommandLine(OPTION).handleInvalidValue(VALUE, HINT)
 
         then:
         Throwable t = thrown(CommandLineArgumentException)

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOptionTest.groovy
@@ -44,7 +44,8 @@ class EnabledOnlyBooleanBuildOptionTest extends Specification {
 
         then:
         testSettings.flag
-        testSettings.origin == BuildOption.Origin.GRADLE_PROPERTY
+        testSettings.origin instanceof Origin.GradlePropertyOrigin
+        testSettings.origin.source == GRADLE_PROPERTY
     }
 
     def "can configure command line parser"() {
@@ -125,7 +126,8 @@ class EnabledOnlyBooleanBuildOptionTest extends Specification {
 
         then:
         testSettings.flag
-        testSettings.origin == BuildOption.Origin.COMMAND_LINE
+        testSettings.origin instanceof Origin.CommandLineOrigin
+        testSettings.origin.source == LONG_OPTION
     }
 
     static class TestOption extends EnabledOnlyBooleanBuildOption<TestSettings> {
@@ -139,7 +141,7 @@ class EnabledOnlyBooleanBuildOptionTest extends Specification {
         }
 
         @Override
-        void applyTo(TestSettings settings, BuildOption.Origin origin) {
+        void applyTo(TestSettings settings, Origin origin) {
             settings.flag = true
             settings.origin = origin
         }
@@ -147,6 +149,6 @@ class EnabledOnlyBooleanBuildOptionTest extends Specification {
 
     static class TestSettings {
         boolean flag
-        BuildOption.Origin origin
+        Origin origin
     }
 }

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/ListBuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/ListBuildOptionTest.groovy
@@ -46,7 +46,8 @@ class ListBuildOptionTest extends Specification {
 
         then:
         testSettings.values == SAMPLE_VALUES
-        testSettings.origin == BuildOption.Origin.GRADLE_PROPERTY
+        testSettings.origin instanceof Origin.GradlePropertyOrigin
+        testSettings.origin.source == GRADLE_PROPERTY
     }
 
     def "can configure command line parser"() {
@@ -130,7 +131,8 @@ class ListBuildOptionTest extends Specification {
 
         then:
         testSettings.values == SAMPLE_VALUES
-        testSettings.origin == BuildOption.Origin.COMMAND_LINE
+        testSettings.origin instanceof Origin.CommandLineOrigin
+        testSettings.origin.source == LONG_OPTION
     }
 
     static class TestOption extends ListBuildOption<TestSettings> {
@@ -144,7 +146,7 @@ class ListBuildOptionTest extends Specification {
         }
 
         @Override
-        void applyTo(List<String> values, TestSettings settings, BuildOption.Origin origin) {
+        void applyTo(List<String> values, TestSettings settings, Origin origin) {
             settings.values.addAll(values)
             settings.origin = origin
         }
@@ -152,7 +154,7 @@ class ListBuildOptionTest extends Specification {
 
     static class TestSettings {
         List<String> values = []
-        BuildOption.Origin origin
+        Origin origin
     }
 }
 

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/StringBuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/StringBuildOptionTest.groovy
@@ -46,7 +46,7 @@ class StringBuildOptionTest extends Specification {
 
         then:
         testSettings.value == SAMPLE_VALUE
-        testSettings.origin == BuildOption.Origin.GRADLE_PROPERTY
+        testSettings.origin instanceof Origin.GradlePropertyOrigin
     }
 
     def "can configure command line parser"() {
@@ -128,7 +128,8 @@ class StringBuildOptionTest extends Specification {
 
         then:
         testSettings.value == SAMPLE_VALUE
-        testSettings.origin == BuildOption.Origin.COMMAND_LINE
+        testSettings.origin instanceof Origin.CommandLineOrigin
+        testSettings.origin.source == LONG_OPTION
     }
 
     static class TestOption extends StringBuildOption<TestSettings> {
@@ -142,7 +143,7 @@ class StringBuildOptionTest extends Specification {
         }
 
         @Override
-        void applyTo(String value, TestSettings settings, BuildOption.Origin origin) {
+        void applyTo(String value, TestSettings settings, Origin origin) {
             settings.value = value
             settings.origin = origin
         }
@@ -150,6 +151,6 @@ class StringBuildOptionTest extends Specification {
 
     static class TestSettings {
         String value
-        BuildOption.Origin origin
+        Origin origin
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildLayoutParametersBuildOptionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildLayoutParametersBuildOptionFactory.java
@@ -23,6 +23,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.EnabledOnlyBooleanBuildOption;
+import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
 import java.io.File;

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismBuildOptionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismBuildOptionFactory.java
@@ -21,6 +21,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.buildoption.BooleanBuildOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
+import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
 import java.util.ArrayList;
@@ -67,11 +68,11 @@ public class ParallelismBuildOptionFactory implements Factory<List<BuildOption<P
             try {
                 int workerCount = Integer.parseInt(value);
                 if (workerCount < 1) {
-                    origin.handleInvalidValue(GRADLE_PROPERTY, LONG_OPTION, value, HINT);
+                    origin.handleInvalidValue(value, HINT);
                 }
                 settings.setMaxWorkerCount(workerCount);
             } catch (NumberFormatException e) {
-                origin.handleInvalidValue(GRADLE_PROPERTY, LONG_OPTION, value, HINT);
+                origin.handleInvalidValue(value, HINT);
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismBuildOptionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismBuildOptionFactory.java
@@ -56,9 +56,10 @@ public class ParallelismBuildOptionFactory implements Factory<List<BuildOption<P
     public static class MaxWorkersOption extends StringBuildOption<ParallelismConfiguration> {
         public static final String GRADLE_PROPERTY = "org.gradle.workers.max";
         public static final String LONG_OPTION = "max-workers";
+        public static final String HINT = "must be a positive, non-zero, integer";
 
         public MaxWorkersOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create("max-workers", "Configure the number of concurrent workers Gradle is allowed to use.").incubating());
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Configure the number of concurrent workers Gradle is allowed to use.").incubating());
         }
 
         @Override
@@ -66,24 +67,12 @@ public class ParallelismBuildOptionFactory implements Factory<List<BuildOption<P
             try {
                 int workerCount = Integer.parseInt(value);
                 if (workerCount < 1) {
-                    handleInvalidValue(origin, value);
+                    origin.handleInvalidValue(GRADLE_PROPERTY, LONG_OPTION, value, HINT);
                 }
                 settings.setMaxWorkerCount(workerCount);
             } catch (NumberFormatException e) {
-                handleInvalidValue(origin, value);
+                origin.handleInvalidValue(GRADLE_PROPERTY, LONG_OPTION, value, HINT);
             }
-        }
-
-        private void handleInvalidValue(Origin origin, String value) {
-            origin.handleInvalidValue(createGradlePropertyFailureMessage(value), createCommandLineFailureMessage(value));
-        }
-
-        private String createGradlePropertyFailureMessage(String value) {
-            return String.format(String.format("Value '%s' given for %s Gradle property is invalid (must be a positive, non-zero, integer)", value, gradleProperty));
-        }
-
-        private String createCommandLineFailureMessage(String value) {
-            return String.format("Argument value '%s' given for --%s option is invalid (must be a positive, non-zero, integer)", value, LONG_OPTION);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptionFactory.java
@@ -25,6 +25,7 @@ import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.ListBuildOption;
 import org.gradle.internal.buildoption.EnabledOnlyBooleanBuildOption;
+import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
 import java.io.File;

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/GradleConfigurabilityIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/GradleConfigurabilityIntegrationSpec.groovy
@@ -52,7 +52,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
         fails()
 
         and:
-        failure.assertHasDescription("Java home supplied via 'org.gradle.java.home' seems to be invalid: ${dummyJdk.absolutePath}")
+        failure.assertHasDescription("Value '${dummyJdk.absolutePath}' given for org.gradle.java.home Gradle property is invalid (Java home supplied seems to be invalid)")
     }
 
     @Requires(TestPrecondition.SYMLINKS)

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptionFactory.java
@@ -16,12 +16,12 @@
 
 package org.gradle.launcher.daemon.configuration;
 
-import org.gradle.api.GradleException;
 import org.gradle.internal.Factory;
 import org.gradle.internal.buildoption.BooleanBuildOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.EnabledOnlyBooleanBuildOption;
+import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 import org.gradle.internal.jvm.JavaHomeException;
 import org.gradle.internal.jvm.JavaInfo;
@@ -66,7 +66,7 @@ public class DaemonBuildOptionFactory implements Factory<List<BuildOption<Daemon
             try {
                 settings.setIdleTimeout(new Integer(value));
             } catch (NumberFormatException e) {
-                throw new GradleException(String.format("Unable to parse %s property. The value should be an int but is: %s", gradleProperty, value));
+                origin.handleInvalidValue(value, "the value should be an int");
             }
         }
     }
@@ -83,7 +83,7 @@ public class DaemonBuildOptionFactory implements Factory<List<BuildOption<Daemon
             try {
                 settings.setPeriodicCheckInterval(new Integer(value));
             } catch (NumberFormatException e) {
-                throw new GradleException(String.format("Unable to parse %s property. Expected an int but got: %s", gradleProperty, value), e);
+                origin.handleInvalidValue(value, "the value should be an int");
             }
         }
     }
@@ -125,15 +125,15 @@ public class DaemonBuildOptionFactory implements Factory<List<BuildOption<Daemon
         public void applyTo(String value, DaemonParameters settings, Origin origin) {
             File javaHome = new File(value);
             if (!javaHome.isDirectory()) {
-                throw new GradleException(String.format("Java home supplied via '%s' is invalid. Invalid directory: %s", gradleProperty, value));
+                origin.handleInvalidValue(value, "Java home supplied is invalid");
             }
             JavaInfo jvm;
             try {
                 jvm = Jvm.forHome(javaHome);
+                settings.setJvm(jvm);
             } catch (JavaHomeException e) {
-                throw new GradleException(String.format("Java home supplied via '%s' seems to be invalid: %s", gradleProperty, value));
+                origin.handleInvalidValue(value, "Java home supplied seems to be invalid");
             }
-            settings.setJvm(jvm);
         }
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.launcher.cli.converter
 
-import org.gradle.api.GradleException
 import org.gradle.initialization.BuildLayoutParameters
 import org.gradle.internal.jvm.Jvm
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory
@@ -88,7 +87,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
         converter.convert([(DaemonBuildOptionFactory.JavaHomeOption.GRADLE_PROPERTY): "/invalid/path"], params)
 
         then:
-        def ex = thrown(GradleException)
+        def ex = thrown(IllegalArgumentException)
         ex.message.contains 'org.gradle.java.home'
         ex.message.contains '/invalid/path'
     }
@@ -99,7 +98,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
         converter.convert([(DaemonBuildOptionFactory.JavaHomeOption.GRADLE_PROPERTY): dummyDir.absolutePath], params)
 
         then:
-        def ex = thrown(GradleException)
+        def ex = thrown(IllegalArgumentException)
         ex.message.contains 'org.gradle.java.home'
         ex.message.contains 'foobar'
     }
@@ -109,7 +108,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
         converter.convert((DaemonBuildOptionFactory.IdleTimeoutOption.GRADLE_PROPERTY): 'asdf', params)
 
         then:
-        def ex = thrown(GradleException)
+        def ex = thrown(IllegalArgumentException)
         ex.message.contains 'org.gradle.daemon.idletimeout'
         ex.message.contains 'asdf'
     }
@@ -119,7 +118,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
         converter.convert((DaemonBuildOptionFactory.HealthCheckOption.GRADLE_PROPERTY): 'bogus', params)
 
         then:
-        def ex = thrown(GradleException)
+        def ex = thrown(IllegalArgumentException)
         ex.message.contains 'org.gradle.daemon.healthcheckinterval'
         ex.message.contains 'bogus'
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptionFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptionFactory.java
@@ -106,7 +106,7 @@ public class LoggingConfigurationBuildOptionFactory implements Factory<List<Buil
                     throw new IllegalArgumentException("Log level cannot be set to 'ERROR'.");
                 }
             } catch (IllegalArgumentException e) {
-                Origin.withGradleProperty(GRADLE_PROPERTY).handleInvalidValue(value, "must be one of quiet, warn, lifecycle, info, or debug)");
+                Origin.forGradleProperty(GRADLE_PROPERTY).handleInvalidValue(value, "must be one of quiet, warn, lifecycle, info, or debug)");
             }
             return logLevel;
         }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptionFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptionFactory.java
@@ -21,13 +21,13 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
-import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.internal.Factory;
 import org.gradle.internal.buildoption.AbstractBuildOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
+import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
 import java.util.ArrayList;
@@ -99,16 +99,16 @@ public class LoggingConfigurationBuildOptionFactory implements Factory<List<Buil
         }
 
         private LogLevel parseLogLevel(String value) {
+            LogLevel logLevel = null;
             try {
-                LogLevel logLevel = LogLevel.valueOf(value.toUpperCase());
+                logLevel = LogLevel.valueOf(value.toUpperCase());
                 if (logLevel == LogLevel.ERROR) {
                     throw new IllegalArgumentException("Log level cannot be set to 'ERROR'.");
                 }
-                return logLevel;
             } catch (IllegalArgumentException e) {
-                String message = String.format("Value '%s' given for %s system property is invalid.  (must be one of quiet, warn, lifecycle, info, or debug)", value, gradleProperty);
-                throw new IllegalArgumentException(message, e);
+                Origin.withGradleProperty(GRADLE_PROPERTY).handleInvalidValue(value, "must be one of quiet, warn, lifecycle, info, or debug)");
             }
+            return logLevel;
         }
     }
 
@@ -152,7 +152,7 @@ public class LoggingConfigurationBuildOptionFactory implements Factory<List<Buil
         public static final String GRADLE_PROPERTY = "org.gradle.console";
 
         public ConsoleOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create("console", "Specifies which type of console output to generate. Values are 'plain', 'auto' (default) or 'rich'."));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which type of console output to generate. Values are 'plain', 'auto' (default) or 'rich'."));
         }
 
         @Override
@@ -162,7 +162,7 @@ public class LoggingConfigurationBuildOptionFactory implements Factory<List<Buil
                 ConsoleOutput consoleOutput = ConsoleOutput.valueOf(consoleValue);
                 settings.setConsoleOutput(consoleOutput);
             } catch (IllegalArgumentException e) {
-                throw new CommandLineArgumentException(String.format("Unrecognized value '%s' for %s.", value, LONG_OPTION));
+                origin.handleInvalidValue(value);
             }
         }
     }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
@@ -83,7 +83,7 @@ class LoggingCommandLineConverterTest extends Specification {
 
         then:
         CommandLineArgumentException e = thrown()
-        e.message == /Unrecognized value 'unknown' for console./
+        e.message == /Argument value 'unknown' given for --console option is invalid/
     }
 
     def convertsShowStacktrace() {


### PR DESCRIPTION
### Context

See #2917

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
