### PR TITLE
Recover from corrupt task history entry

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/TaskArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/TaskArtifactState.java
@@ -90,4 +90,6 @@ public interface TaskArtifactState {
      */
     @Nullable
     UniqueId getOriginBuildInvocationId();
+
+    void removeExecutionHistoryIfCorrupted();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepository.java
@@ -181,6 +181,11 @@ public class DefaultTaskArtifactStateRepository implements TaskArtifactStateRepo
             snapshotAfterOutputsWereGenerated(history, null);
         }
 
+        @Override
+        public void removeExecutionHistoryIfCorrupted() {
+            history.removePreviousExecutionIfCorrupted();
+        }
+
         private void snapshotAfterOutputsWereGenerated(TaskHistoryRepository.History history, Throwable failure) {
             // Only persist task history if there was no failure, or some output files have been changed
             if (failure == null || getStates().hasAnyOutputFileChanges()) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/NoHistoryArtifactState.java
@@ -114,6 +114,10 @@ class NoHistoryArtifactState implements TaskArtifactState, TaskExecutionHistory 
     }
 
     @Override
+    public void removeExecutionHistoryIfCorrupted() {
+    }
+
+    @Override
     public void ensureSnapshotBeforeTask() {
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ShortCircuitTaskArtifactStateRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ShortCircuitTaskArtifactStateRepository.java
@@ -115,6 +115,11 @@ public class ShortCircuitTaskArtifactStateRepository implements TaskArtifactStat
         }
 
         @Override
+        public void removeExecutionHistoryIfCorrupted() {
+            delegate.removeExecutionHistoryIfCorrupted();
+        }
+
+        @Override
         public void ensureSnapshotBeforeTask() {
             delegate.ensureSnapshotBeforeTask();
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedFileSnapshotRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedFileSnapshotRepository.java
@@ -36,11 +36,7 @@ public class CacheBackedFileSnapshotRepository implements FileSnapshotRepository
     }
 
     public FileCollectionSnapshot get(Long id) {
-        FileCollectionSnapshot snapshot = cache.get(id);
-        if (snapshot == null) {
-            throw new IllegalArgumentException("Cannot find snapshot for id: " + id);
-        }
-        return snapshot;
+        return cache.get(id);
     }
 
     public void remove(Long id) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
@@ -141,6 +141,14 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
                 currentExecution.storeSnapshots();
                 taskHistoryCache.put(task.getPath(), currentExecution.snapshot());
             }
+
+            @Override
+            public void removePreviousExecutionIfCorrupted() {
+                if (previousExecution != null && previousExecution.isCorrupted()) {
+                    LOGGER.warn("Task history for {} has been corrupted - removing", task);
+                    taskHistoryCache.remove(task.getPath());
+                }
+            }
         };
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecution.java
@@ -110,4 +110,6 @@ public abstract class TaskExecution {
     public OverlappingOutputs getDetectedOverlappingOutputs() {
         return detectedOverlappingOutputs;
     }
+
+    public abstract boolean isCorrupted();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskHistoryRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskHistoryRepository.java
@@ -35,5 +35,7 @@ public interface TaskHistoryRepository {
         void updateCurrentExecutionWithOutputs(IncrementalTaskInputsInternal taskInputs, ImmutableSortedMap<String, FileCollectionSnapshot> newOutputSnapshot);
 
         void persist();
+
+        void removePreviousExecutionIfCorrupted();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskArtifactStateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskArtifactStateTaskExecuter.java
@@ -51,6 +51,7 @@ public class ResolveTaskArtifactStateTaskExecuter implements TaskExecuter {
         try {
             executer.execute(task, state, context);
         } finally {
+            taskArtifactState.removeExecutionHistoryIfCorrupted();
             outputs.setHistory(null);
             context.setTaskArtifactState(null);
             LOGGER.debug("Removed task artifact state for {} from context.");


### PR DESCRIPTION
This would make errors as occured in #2827 less permanent - i.e. we would have just one failing build per corrupted task history entry instead of never recovering from the error at all.