### PR TITLE
Add source set information to dependencies in Eclipse model

### DIFF
--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec.groovy
@@ -52,6 +52,7 @@ class ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec exte
         thrown UnsupportedMethodException
     }
 
+    @TargetGradleVersion(">=1.2 <4.3")
     def "Source folder doesn't define classpath attributes"() {
         setup:
         settingsFile << 'rootProject.name = "root"'
@@ -65,6 +66,7 @@ class ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec exte
         project.sourceDirectories.find {it.path == 'src/main/java' }.classpathAttributes.isEmpty()
     }
 
+    @TargetGradleVersion(">=1.2 <4.3")
     def "Source folder defines one classpath attribute"() {
         settingsFile << 'rootProject.name = "root"'
         buildFile <<
@@ -92,6 +94,7 @@ class ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec exte
         project.sourceDirectories[0].classpathAttributes[0].value == 'customValue'
     }
 
+    @TargetGradleVersion(">=1.2 <4.3")
     def "Source folder defines multiple classpath attributes"() {
         settingsFile << 'rootProject.name = "root"'
         buildFile <<

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r43/ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r43/ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.tooling.r43
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.model.eclipse.EclipseProject
+
+@ToolingApiVersion('>=4.3')
+@TargetGradleVersion(">=4.3")
+class ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec extends ToolingApiSpecification {
+
+    def "Source folder contains source set information in classpath attributes"() {
+        setup:
+        buildFile << "apply plugin: 'java'"
+        file('src/main/java').mkdirs()
+        file('src/test/java').mkdirs()
+
+        when:
+        EclipseProject project = loadToolingModel(EclipseProject)
+        def mainDirAttributes = project.sourceDirectories.find { it.path == 'src/main/java' }.classpathAttributes
+        def testDirAttributes = project.sourceDirectories.find { it.path == 'src/test/java' }.classpathAttributes
+
+        then:
+        mainDirAttributes.size() == 1
+        mainDirAttributes[0].name == 'gradle_source_sets'
+        mainDirAttributes[0].value == 'main'
+
+        testDirAttributes.size() == 1
+        testDirAttributes[0].name == 'gradle_source_sets'
+        testDirAttributes[0].value == 'test'
+    }
+
+    def "Source folder defines additional classpath attributes"() {
+        buildFile <<
+            """apply plugin: 'java'
+           apply plugin: 'eclipse'
+           eclipse {
+               classpath {
+                   file {
+                       whenMerged { classpath ->
+                           classpath.entries.find { it.kind == 'src' && it.path == 'src/main/java' }.entryAttributes.key1 = 'value1'
+                           classpath.entries.find { it.kind == 'src' && it.path == 'src/main/java' }.entryAttributes.key2 = 'value2'
+                       }
+                   }
+               }
+           }
+        """
+        file('src/main/java').mkdirs()
+
+        when:
+        EclipseProject project = loadToolingModel(EclipseProject)
+
+        then:
+        project.sourceDirectories.size() == 1
+        project.sourceDirectories[0].classpathAttributes.size() == 3
+        project.sourceDirectories[0].classpathAttributes.find { it.name == 'gradle_source_sets' && it.value == 'main'}
+        project.sourceDirectories[0].classpathAttributes.find { it.name == 'key1' && it.value == 'value1'}
+        project.sourceDirectories[0].classpathAttributes.find { it.name == 'key2' && it.value == 'value2'}
+    }
+
+
+    def "Source dir information can be modified in whenMerged block"() {
+        buildFile <<
+            """apply plugin: 'java'
+           apply plugin: 'eclipse'
+           eclipse {
+               classpath {
+                   file {
+                       whenMerged { classpath ->
+                           classpath.entries.find { it.kind == 'src' && it.path == 'src/main/java' }.entryAttributes['gradle_source_sets'] = 'main,test'
+                       }
+                   }
+               }
+           }
+        """
+        file('src/main/java').mkdirs()
+
+        when:
+        EclipseProject project = loadToolingModel(EclipseProject)
+
+        then:
+        project.sourceDirectories.size() == 1
+        project.sourceDirectories[0].classpathAttributes.size() == 1
+        project.sourceDirectories[0].classpathAttributes.find { it.name == 'gradle_source_sets' && it.value == 'main,test'}
+    }
+}

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourceSetIntegrationSpec.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourceSetIntegrationSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.eclipse
+
+import org.gradle.integtests.fixtures.TestResources
+import org.junit.Rule
+
+class EclipseSourceSetIntegrationSpec extends AbstractEclipseIntegrationSpec {
+
+    @Rule
+    public final TestResources testResources = new TestResources(testDirectoryProvider)
+
+    def "Source set defined on dependencies"() {
+        setup:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+
+            ${jcenterRepository()}
+
+            dependencies {
+                compile 'com.google.guava:guava:18.0'
+                testCompile 'junit:junit:4.12'
+            }
+        """
+
+        when:
+        run 'eclipse'
+
+        then:
+        EclipseClasspathFixture classpath = classpath('.')
+        classpath.lib('guava-18.0.jar').assertHasAttribute('gradle_source_sets', 'main,test')
+        classpath.lib('junit-4.12.jar').assertHasAttribute('gradle_source_sets', 'test')
+    }
+
+    def "Source sets defined on source folders"() {
+        setup:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+        """
+        file('src/main/java').mkdirs()
+        file('src/test/java').mkdirs()
+
+        when:
+        run 'eclipse'
+
+        then:
+        EclipseClasspathFixture classpath = classpath('.')
+        classpath.sourceDir('src/main/java').assertHasAttribute('gradle_source_sets', 'main')
+        classpath.sourceDir('src/test/java').assertHasAttribute('gradle_source_sets', 'test')
+    }
+
+    def "Source set information is customizable in whenMerged block"() {
+        setup:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+
+            ${jcenterRepository()}
+
+            dependencies {
+                compile 'com.google.guava:guava:18.0'
+                testCompile 'junit:junit:4.12'
+            }
+
+            eclipse.classpath.file.whenMerged {
+                def testDir = entries.find { entry -> entry.path == 'src/test/java' }
+                def guavaDep = entries.find { entry -> entry.path.contains 'guava-18.0.jar' }
+                testDir.entryAttributes['gradle_source_sets'] = 'test,integTest'
+                guavaDep.entryAttributes['gradle_source_sets'] = 'main,test,integTest'
+            }
+        """
+        file('src/test/java').mkdirs()
+
+        when:
+        run 'eclipse'
+
+        then:
+        EclipseClasspathFixture classpath = classpath('.')
+        classpath.sourceDir('src/test/java').assertHasAttribute('gradle_source_sets', 'test,integTest')
+        classpath.lib('junit-4.12.jar').assertHasAttribute('gradle_source_sets', 'test')
+        classpath.lib('guava-18.0.jar').assertHasAttribute('gradle_source_sets', 'main,test,integTest')
+    }
+}

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
@@ -1,19 +1,41 @@
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="src" path="src/main/resources"/>
-	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="src" path="src/integTest/java"/>
+	<classpathentry kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/main/resources">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/test/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/test/resources">
+		<attributes>
+			<attribute name="gradle_source_sets" value="test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/integTest/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="integTest"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar">
 		<attributes>
+			<attribute name="gradle_source_sets" value="test"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="src" path="src/main/resources"/>
-	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/main/resources">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/test/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="test"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry kind="src" path="/api">
 		<attributes>
@@ -13,30 +25,35 @@
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-sources.jar" kind="var"  path="GRADLE_USER_HOME/@CACHE@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/junit/junit/4.12/@SHA1@/junit-4.12-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/junit/junit/4.12/@SHA1@/junit-4.12.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="gradle_source_sets" value="test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/junit/junit/4.12/@SHA1@/junit-4.12-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/org.hamcrest/hamcrest-core/1.3/@SHA1@/hamcrest-core-1.3-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/org.hamcrest/hamcrest-core/1.3/@SHA1@/hamcrest-core-1.3.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="gradle_source_sets" value="test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/org.hamcrest/hamcrest-core/1.3/@SHA1@/hamcrest-core-1.3-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
@@ -1,15 +1,40 @@
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="src" path="src/main/groovy"/>
-	<classpathentry kind="src" path="src/main/resources"/>
-	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry kind="src" path="src/test/resources"/>
+	<classpathentry kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/main/groovy">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/main/resources">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/test/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src/test/resources">
+		<attributes>
+			<attribute name="gradle_source_sets" value="test"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar"/>
+	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar">
+		<attributes>
+			<attribute name="gradle_source_sets" value="test"/>
+		</attributes>
+	</classpathentry>
 </classpath>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
@@ -1,6 +1,10 @@
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="src" path="/common">
@@ -16,18 +20,21 @@
 	<classpathentry sourcepath="@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-sources.jar" kind="lib" path="@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-sources.jar" kind="lib" path="@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
@@ -1,17 +1,23 @@
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-sources.jar" kind="var"
 					path="GRADLE_USER_HOME/@CACHE@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/junit/junit/4.7/@SHA1@/junit-4.7.jar">
 		<attributes>
+			<attribute name="gradle_source_sets" value="test"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_source_sets" value="main"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="src" path="/api">
@@ -11,28 +15,33 @@
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8-sources.jar" kind="lib" path="@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8.jar">
 		<attributes>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-sources.jar" kind="lib" path="@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar">
 		<attributes>
+			<attribute name="gradle_source_sets" value="test"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
+			<attribute name="gradle_source_sets" value="main,test"/>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
 		</attributes>

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -19,9 +19,8 @@ package org.gradle.plugins.ide.eclipse.model.internal;
 import com.google.common.base.Joiner;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;/**/
+import com.google.common.collect.Multimap;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.SourceSet;
@@ -114,10 +113,11 @@ public class EclipseDependenciesCreator {
         try {
             for (SourceSet sourceSet : sourceSets) {
                 String name = sourceSet.getName().replace(",", "");
-                FileCollection classpath = sourceSet.getRuntimeClasspath();
-                for (File f : classpath) {
-                    String path = f.getAbsolutePath();
-                    pathToSourceSetNames.put(path, name);
+                for (File f : sourceSet.getCompileClasspath()) {
+                    pathToSourceSetNames.put(f.getAbsolutePath(), name);
+                }
+                for (File f : sourceSet.getRuntimeClasspath()) {
+                    pathToSourceSetNames.put(f.getAbsolutePath(), name);
                 }
             }
         } catch (Exception e) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -88,7 +88,7 @@ public class EclipseDependenciesCreator {
         boolean downloadSources = classpath.isDownloadSources();
         boolean downloadJavadoc = classpath.isDownloadJavadoc();
 
-        Multimap<String, String> pathToSourceSets = collectRuntimeClasspathPathSourceSets();
+        Multimap<String, String> pathToSourceSets = collectLibraryToSourceSetMapping();
 
         Collection<IdeExtendedRepoFileDependency> repoFileDependencies = dependenciesExtractor.extractRepoFileDependencies(classpath.getProject().getDependencies(), classpath.getPlusConfigurations(), classpath.getMinusConfigurations(), downloadSources, downloadJavadoc);
         for (IdeExtendedRepoFileDependency dependency : repoFileDependencies) {
@@ -102,7 +102,7 @@ public class EclipseDependenciesCreator {
         return libraries;
     }
 
-    private Multimap<String, String> collectRuntimeClasspathPathSourceSets() {
+    private Multimap<String, String> collectLibraryToSourceSetMapping() {
         Multimap<String, String> pathToSourceSetNames = LinkedHashMultimap.create();
         Iterable<SourceSet> sourceSets = classpath.getSourceSets();
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -16,10 +16,15 @@
 
 package org.gradle.plugins.ide.eclipse.model.internal;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry;
 import org.gradle.plugins.ide.eclipse.model.AbstractLibrary;
@@ -32,13 +37,19 @@ import org.gradle.plugins.ide.internal.resolver.model.IdeExtendedRepoFileDepende
 import org.gradle.plugins.ide.internal.resolver.model.IdeLocalFileDependency;
 import org.gradle.plugins.ide.internal.resolver.model.IdeProjectDependency;
 import org.gradle.plugins.ide.internal.resolver.model.UnresolvedIdeRepoFileDependency;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class EclipseDependenciesCreator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EclipseDependenciesCreator.class);
 
     private final IdeDependenciesExtractor dependenciesExtractor;
     private final EclipseClasspath classpath;
@@ -79,19 +90,50 @@ public class EclipseDependenciesCreator {
         boolean downloadSources = classpath.isDownloadSources();
         boolean downloadJavadoc = classpath.isDownloadJavadoc();
 
+        Map<String, Set<String>> pathToSourceSets = collectRuntimeClasspathPathSourceSets();
+
         Collection<IdeExtendedRepoFileDependency> repoFileDependencies = dependenciesExtractor.extractRepoFileDependencies(classpath.getProject().getDependencies(), classpath.getPlusConfigurations(), classpath.getMinusConfigurations(), downloadSources, downloadJavadoc);
         for (IdeExtendedRepoFileDependency dependency : repoFileDependencies) {
-            libraries.add(createLibraryEntry(dependency.getFile(), dependency.getSourceFile(), dependency.getJavadocFile(), classpath, dependency.getId()));
+            libraries.add(createLibraryEntry(dependency.getFile(), dependency.getSourceFile(), dependency.getJavadocFile(), classpath, dependency.getId(), pathToSourceSets));
         }
 
         Collection<IdeLocalFileDependency> localFileDependencies = dependenciesExtractor.extractLocalFileDependencies(classpath.getPlusConfigurations(), classpath.getMinusConfigurations());
         for (IdeLocalFileDependency it : localFileDependencies) {
-            libraries.add(createLibraryEntry(it.getFile(), null, null, classpath, null));
+            libraries.add(createLibraryEntry(it.getFile(), null, null, classpath, null, pathToSourceSets));
         }
         return libraries;
     }
 
-    private static AbstractLibrary createLibraryEntry(File binary, File source, File javadoc, EclipseClasspath classpath, ModuleVersionIdentifier id) {
+    private Map<String, Set<String>> collectRuntimeClasspathPathSourceSets() {
+        Map<String, Set<String>> pathToSourceSetNames = Maps.newHashMap();
+        Iterable<SourceSet> sourceSets = classpath.getSourceSets();
+
+        // for non-java projects there are no source sets configured
+        if (sourceSets == null) {
+            return pathToSourceSetNames;
+        }
+
+        try {
+            for (SourceSet sourceSet : sourceSets) {
+                String name = sourceSet.getName().replace(",", "");
+                FileCollection classpath = sourceSet.getRuntimeClasspath();
+                for (File f : classpath) {
+                    String path = f.getAbsolutePath();
+                    Set<String> names = pathToSourceSetNames.get(path);
+                    if (names == null) {
+                        names = Sets.newLinkedHashSet();
+                    }
+                    names.add(name);
+                    pathToSourceSetNames.put(path, names);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Failed to collect source sets for Eclipse dependencies", e);
+        }
+        return pathToSourceSetNames;
+    }
+
+    private static AbstractLibrary createLibraryEntry(File binary, File source, File javadoc, EclipseClasspath classpath, ModuleVersionIdentifier id, Map<String, Set<String>> pathToSourceSets) {
         FileReferenceFactory referenceFactory = classpath.getFileReferenceFactory();
 
         FileReference binaryRef = referenceFactory.fromFile(binary);
@@ -104,6 +146,11 @@ public class EclipseDependenciesCreator {
         out.setSourcePath(sourceRef);
         out.setExported(false);
         out.setModuleVersion(id);
+
+        Set<String> sourceSets = pathToSourceSets.get(binary.getAbsolutePath());
+        if (sourceSets != null) {
+            out.getEntryAttributes().put("gradle_source_sets", Joiner.on(',').join(sourceSets));
+        }
         return out;
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
@@ -126,6 +126,8 @@ public class SourceFoldersCreator {
                     folder.setName(dir.getName());
                     folder.setIncludes(getIncludesForTree(sourceSet, tree));
                     folder.setExcludes(getExcludesForTree(sourceSet, tree));
+
+                    folder.getEntryAttributes().put("gradle_source_sets", sourceSet.getName().replaceAll(",", ""));
                     entries.add(folder);
                 }
             }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreatorTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreatorTest.groovy
@@ -44,6 +44,7 @@ class SourceFoldersCreatorTest extends Specification {
         java = Mock()
         resources = Mock()
         allSource = Mock()
+        _ * sourceSet.name >> 'source_set'
         _ * sourceSet.allSource >> allSource
         _ * sourceSet.allJava >> java
         _ * sourceSet.resources >> resources


### PR DESCRIPTION
This pull request adds source set information to the source directories and to the dependencies in the Eclipse model. Using this information, Buildship will be able to separate dependencies when running a Java application in Eclipse. 

More elaboration on the motivation and design is available here: https://github.com/eclipse/buildship/issues/354