### PR TITLE
Simplify contribution instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,24 +16,14 @@ git config user.email user@example.com
 
 You can generate the IntelliJ project by running
 ```
-./gradlew idea       # *nix-based systems
-gradlew idea         # Windows
+./gradlew idea
 ```
 then "Open" it with IntelliJ.
 
 You can generate the Eclipse projects by running
 ```
-./gradlew eclipse   # *nix-based systems
-gradlew eclipse     # Windows
+./gradlew eclipse
 ```
-
-### Running or debugging gradle under Eclipse
-1. Create a `Java Application Run/Debug configuration as`
-2. Right click on `launcher/src/main/java/org.gradle.launcher.Main` and select `Run as->Run configuration`
-3. In the Arguments tab, enter: `--no-daemon -Dorg.gradle.appname=gradle`
-4. In the Working Directory tab: `enter you project's root directory`
-5. Apply/Run/Close as needed
-
 
 ## Choosing Tasks
 If you'd like to contribute to Gradle but aren't sure where, please look for issues [labelled help-wanted](https://github.com/gradle/gradle/labels/help-wanted). We have designated these issues as good candidates for easy contribution.
@@ -41,7 +31,7 @@ If you'd like to contribute to Gradle but aren't sure where, please look for iss
 ## Making Changes
 
 ### Larger Changes (features or enhancements)
-Before starting to work on a feature or a fix, please open a discussion about your proposed changes on the [Gradle Developer List](https://groups.google.com/forum/#!forum/gradle-dev).
+Before starting to work on a feature or a fix, please open an issue to discuss the use case or bug with us.
 Doing so helps to ensure that:
 * You understand how your proposed changes fit with the strategic goals of the Gradle project.
 * You can get early feedback on your proposed changes, and suggestions as to the best approach to implementation.
@@ -55,12 +45,9 @@ All code contributions should contain the following:
 * Documentation in the User Guide and DSL Reference (under `subprojects/docs/src/docs`). You can generate docs by running `./gradlew :docs:docs`.
 * Javadoc `@author` tags and committer names are not used in the codebase (contributions are recognised in the commit history and release notes)
 
-If you're not sure where to start, ask on the developer list. There's likely a number of existing examples to help get you going.
+Your code needs to run on all supported Java versions and operationg systems. The [Gradle CI](http://builds.gradle.org/) will verify this, but here are some pointers that will avoid surprises:
 
-Try to ensure that your code & tests will run successfully on Java 6, and on both *nix and Windows platforms.
-The [Gradle CI](http://builds.gradle.org/) will verify this, but it helps if things work first time.
-
-* Avoid using features introduced in Java 1.7 or later
+* Avoid using features introduced in Java 1.7 or later. Several parts of Gradle still need to run on Java 6.
 * Be careful to normalise file paths in tests. The `org.gradle.util.TextUtil` class has some useful utility functions for this purpose.
 
 ### Development Workflow
@@ -73,10 +60,7 @@ To try out a change in behavior manually, install Gradle source locally and use 
 /any/path/bin/gradle taskName
 ```
 
-You can debug Gradle by adding `-Dorg.gradle.debug=true` when executing. Gradle will wait for you to attach at debugger at `localhost:5005` by default. We recommend disabling the Gradle Daemon when debugging (`--no-daemon`).
-
-### Getting Help
-If you run into any trouble, please reach out to us on the [help/discuss forum](https://discuss.gradle.org/c/help-discuss) or [tweet @Gradle](https://twitter.com/gradle).
+You can debug Gradle by adding `-Dorg.gradle.debug=true` when executing. Gradle will wait for you to attach at debugger at `localhost:5005` by default.
 
 ### Creating Commits And Writing Commit Messages
 The commit messages that accompany your code changes are an important piece of documentation, and help make your contribution easier to review.
@@ -92,11 +76,10 @@ Before we can accept any code contributions, you must complete and electronicall
 
 All code contributions should be submitted via a [pull request](https://help.github.com/articles/using-pull-requests) from a [forked GitHub repository](https://help.github.com/articles/fork-a-repo).
 
-Once received, the pull request will be reviewed by a Gradle core developer. Your pull request will be given higher priority if you:
-* Have first discussed the change on the Gradle Developer list.
-* Have followed all of the Contribution Guidelines here.
+Once received, the pull request will be reviewed and eventually merged by a Gradle core developer. It is normal that this takes several iterations, so don't get discouraged by change requests. They ensure the high quality that we all enjoy.
 
-After review, and usually after a number of iterations of development, your pull request may be merged into the Gradle distribution.
+### Getting Help
+If you run into any trouble, please reach out to us on the [help/discuss forum](https://discuss.gradle.org/c/help-discuss) or on the issue you are working on.
 
 ## Our Thanks
 We deeply appreciate your effort toward improving Gradle. For any contribution, large or small, you will be immortalized in the release notes for the version you've contributed to. 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,9 @@
-<!--- Provide a brief summary of the issue in the title above -->
+<!--- Please follow the instructions below. We receive dozens of issues every week, -->
+<!--- so to stay productive, we will close issues that don't provide enough information. -->
+
 <!--- We kindly ask you to open any issues related to the Gradle Android plugin or Android Studio on the Android Issue Tracker at `https://source.android.com/source/report-bugs` -->
+
+<!--- Provide a brief summary of the issue in the title above -->
 
 ### Expected Behavior
 <!--- If you're describing a bug, tell us what should happen -->
@@ -14,8 +18,8 @@
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
 
 ### Steps to Reproduce (for bugs)
-<!--- Provide a link to a build scan, example project, or an unambiguous -->
-<!--- set of steps to reproduce this bug. Include code to reproduce, if relevant -->
+<!--- Provide a self-contained example project (as an attached archive or a Github project). -->
+<!--- In the rare cases where this is infeasible, we will also accept a detailed set of instructions. -->
 
 ### Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->

--- a/README.md
+++ b/README.md
@@ -8,27 +8,13 @@ For more information about Gradle, please visit: https://gradle.org
 
 You can download released versions and nightly build artifacts from: https://gradle.org/downloads
 
-## Building
-
-Naturally, Gradle builds itself with Gradle. Gradle provides an innovative [wrapper](https://gradle.org/docs/current/userguide/gradle_wrapper.html) that allows you to work with a Gradle build without having to manually install Gradle. The wrapper is a batch script on Windows and a shell script on other operating systems.
-
-You should use the wrapper to build the gradle project. Generally, you should use the wrapper for any wrapper-enabled project because it guarantees building with the Gradle version that the build was intended to use.
-
-To build the entire Gradle project, you should run the following in the root of the checkout.
-
-    ./gradlew build
-
-This will compile all the code, generate all the documentation and run all the tests. It can take several hours because we have thousands of tests, including integration tests that exercise virtually every Gradle feature. Among the things we test are: compatibility across versions, validity of samples and Javadoc snippets, daemon process capabilities, etc.
-
-In order for this build to pass, you will need a supported native tool chain installed. See the [Gradle userguide](https://docs.gradle.org/current/userguide/native_software.html#native-binaries:tool-chain-support) for a list of supported tool chains.
-
 ### Installing from source
 
 To create an install from the source tree you can run either of the following:
 
     ./gradlew install -Pgradle_installPath=/usr/local/gradle-source-build
 
-This will create a minimal installation; just what's needed to run Gradle (i.e. no docs). Note that the `-Pgradle_installPath` denotes where to install to.
+This will create a minimal installation; just what's needed to run Gradle (i.e. no docs).
 
 You can then build a Gradle based project with this installation:
 
@@ -38,58 +24,6 @@ To create a full installation (includes docs):
 
     ./gradlew installAll -Pgradle_installPath=/usr/local/gradle-source-build
 
-### Working with subprojects
-
-The Gradle build uses Gradle's ability to customize the logical structure of a multiproject build. All of the build's subprojects are in the `subprojects/` directory and are mapped to top level children in [settings.gradle](https://github.com/gradle/gradle/blob/master/settings.gradle).
-
-This means that to build just the `core` subproject (that lives in `subprojects/core`) you would run:
-
-    ./gradlew core:build
-
-Or to build the docs:
-
-    ./gradlew docs:build
-
-And so on.
-
 ## Contributing
 
 If you're looking to contribute to Gradle or provide a patch/pull request, you can find more info [here](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md).
-
-### Contributing Code
-
-This is a complicated topic and the Gradle development team are happy to help anybody get started working with the Gradle code base, so don't hesitate to get in touch with the developers if you need help working with the finer points of the build.
-
-If you are simply wanting to fix something or adding a small minor feature, it is usually good enough to simply make your change to the code and then run the `check` task for that subproject. So if the patch was to the `launcher` package for example, you can run:
-
-    ./gradlew launcher:check
-
-To run all of the tests and code quality checks for that module.
-
-### Contributing Documentation
-
-Please see the readme in the [docs subproject](https://github.com/gradle/gradle/tree/master/subprojects/docs).
-
-## Opening in your IDE
-
-### IntelliJ IDEA
-
-To open the Gradle project in IDEA, simply run the following task from the root:
-
-    ./gradlew idea
-
-This will generate appropriate IDEA metadata so that the project can be opened from within IDEA. Note that you should open the generated `.ipr` file, not `build.gradle`. Also, IntelliJ Run Configurations will be generated, which allow you to run/debug Gradle or run pre-commit tests.
-
-Note that due to an IDEA glitch, the first build of Gradle from IDEA will fail. Launching a second build fixes the compilation error.
-
-### Eclipse
-
-Building the Gradle project with Eclipse is currently limited due to Eclipse's lacking Groovy support.
-We recommend using IntelliJ IDEA.
-
-1. You will need Eclipse 4.5 (Mars)
-2. Install the Groovy Eclipse plugin from http://dist.springsource.org/snapshot/GRECLIPSE/e4.5/
-3. Make sure you have a Java 8 compatible JRE configured in your workspace
-4. In `Window->Preferences->Groovy->Compiler`, check `Enable Script folder support` and add `**/*.gradle`
-5. Run `./gradlew eclipse` from the root directory
-6. Import all projects using the "Import Existing Projects into Workspace" wizard


### PR DESCRIPTION
This is aimed to make our README a bit more digestible. It also clarifies that we absolutely expect users to follow our guidelines or we'll close issues to stay productive.