### PR TITLE
Fix corner case happening in nested closure scenario (#2888/#2794)

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/invocation/NestedClosureIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/invocation/NestedClosureIntegrationTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.invocation
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+class NestedClosureIntegrationTest extends AbstractIntegrationSpec {
+
+    @Issue('https://github.com/gradle/gradle/issues/2888')
+    def 'can handle nested closure during initialization'() {
+        given:
+        settingsFile << '''
+gradle.projectsLoaded { g ->
+    println 'projectsLoaded' 
+    g.rootProject {
+        println 'rootProject'
+        beforeEvaluate { project ->
+            println 'beforeEvaluate'
+        }
+    }
+}
+'''
+        when:
+        succeeds('help')
+
+        then:
+        output.count('projectsLoaded') == 1
+        output.count('rootProject') == 1
+        output.count('beforeEvaluate') == 1
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -71,6 +71,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     private final ListenerBroadcast<ProjectEvaluationListener> projectEvaluationListenerBroadcast;
     private final Collection<IncludedBuild> includedBuilds = Lists.newArrayList();
     private MutableActionSet<Project> rootProjectActions = new MutableActionSet<Project>();
+    private boolean projectsLoaded;
     private Path identityPath;
     private final ClassLoaderScope classLoaderScope;
     private BuildOperationState operation;
@@ -88,8 +89,8 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
             public void projectsLoaded(Gradle gradle) {
                 if (!rootProjectActions.isEmpty()) {
                     services.get(CrossProjectConfigurator.class).rootProject(rootProject, rootProjectActions);
-                    rootProjectActions = null;
                 }
+                projectsLoaded = true;
             }
         });
 
@@ -209,11 +210,11 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void rootProject(Action<? super Project> action) {
-        if (rootProjectActions != null) {
-            rootProjectActions.add(action);
-        } else {
+        if (projectsLoaded) {
             assert rootProject != null;
             action.execute(rootProject);
+        } else {
+            rootProjectActions.add(action);
         }
     }
 


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/2888
As a flag to indicate the rootProject has been loaded,
DefaultGradle's rootProjectActions would be set to null after
projects are loaded, this is not clear enough. However, there's even
a bug: setting rootProjectActions to null should always happen,
no matter if rootProjectActions is empty. This PR fixes the
issue and adds a new boolean property projectsLoaded.

### Context

See #2888 #2794 