### PR TITLE
`Provider<File>` should behave the same as `File` when used with `@InputFile`

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
@@ -27,6 +27,7 @@ import org.gradle.internal.io.SkipFirstTextStream;
 import org.gradle.internal.io.StreamByteBuffer;
 import org.gradle.internal.io.WriterTextStream;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -431,6 +432,7 @@ public class GUtil {
      * @param <T> Callable's return type
      * @return The value returned by {@link Callable#call()}
      */
+    @Nullable
     public static <T> T uncheckedCall(Callable<T> callable) {
         try {
             return callable.call();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.FileTreeInternal;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.util.PatternSet;
@@ -41,6 +42,7 @@ import java.util.concurrent.Callable;
 
 import static org.gradle.util.GUtil.uncheckedCall;
 
+@SuppressWarnings("Since15")
 public class DefaultFileCollectionResolveContext implements ResolvableFileCollectionResolveContext {
     protected final PathToFileResolver fileResolver;
     private final List<Object> queue = new LinkedList<Object>();
@@ -125,6 +127,11 @@ public class DefaultFileCollectionResolveContext implements ResolvableFileCollec
                 Object callableResult = uncheckedCall(callable);
                 if (callableResult != null) {
                     queue.add(0, callableResult);
+                }
+            } else if (element instanceof Provider) {
+                Object providerResult = ((Provider<?>) element).getOrNull();
+                if (providerResult != null) {
+                    queue.add(0, providerResult);
                 }
             } else if (element instanceof Path) {
                 queue.add(0, ((Path) element).toFile());

--- a/subprojects/core/src/main/java/org/gradle/util/DeferredUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/util/DeferredUtil.java
@@ -36,7 +36,7 @@ public class DeferredUtil {
             if (current instanceof Callable) {
                 current = uncheckedCall((Callable) current);
             } else if (current instanceof Provider) {
-                return ((Provider<?>) current).get();
+                return ((Provider<?>) current).getOrNull();
             } else if (current instanceof Factory) {
                 return ((Factory) current).create();
             } else {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
@@ -223,9 +223,9 @@ The following types/formats are supported:
         def baseDir = tmpDir.testDirectory.file("base")
         def file = tmpDir.testDirectory.file("test")
         def provider1 = Stub(Provider)
-        provider1.get() >> file
+        provider1.getOrNull() >> file
         def provider2 = Stub(Provider)
-        provider2.get() >> "value"
+        provider2.getOrNull() >> "value"
 
         expect:
         normalize(provider1, baseDir) == file

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
@@ -45,7 +45,7 @@ class DefaultProjectLayoutTest extends Specification {
 
     def "can resolve directory relative to project directory"() {
         def pathProvider = Stub(Provider)
-        _ * pathProvider.get() >>> ["a", "b"]
+        _ * pathProvider.getOrNull() >>> ["a", "b"]
         _ * pathProvider.present >> true
 
         expect:
@@ -125,7 +125,7 @@ class DefaultProjectLayoutTest extends Specification {
 
     def "can create directory var"() {
         def pathProvider = Stub(Provider)
-        _ * pathProvider.get() >> { "../other-dir" }
+        _ * pathProvider.getOrNull() >> { "../other-dir" }
         _ * pathProvider.present >> true
         def otherDir = tmpDir.file("other-dir")
 
@@ -394,8 +394,8 @@ class DefaultProjectLayoutTest extends Specification {
         tree.files
 
         then:
-        def e5 = thrown(IllegalStateException)
-        e5.message == 'No value has been specified for this provider.'
+        def e5 = thrown(IllegalArgumentException)
+        e5.message == "Cannot convert path to File. path='value: null'"
     }
 
     def "cannot set the value of a directory var using incompatible type"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -210,6 +210,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         TaskWithOptionalOutputDirs                | 'output-dirs'
         TaskWithOptionalNestedBean                | 'bean'
         TaskWithOptionalNestedBeanWithPrivateType | 'private-bean'
+        TaskWithOptionalInputFileAsProvider       | 'input-file'
     }
 
     def validationActionSucceedsWhenSpecifiedOutputFileDoesNotExist() {
@@ -270,16 +271,17 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         validateException(task, e, "No value has been specified for property '$property'.")
 
         where:
-        type                | property
-        TaskWithInputFile   | 'inputFile'
-        TaskWithOutputFile  | 'outputFile'
-        TaskWithOutputFiles | 'outputFiles'
-        TaskWithInputFiles  | 'input'
-        TaskWithOutputDir   | 'outputDir'
-        TaskWithOutputDirs  | 'outputDirs'
-        TaskWithInputDir    | 'inputDir'
-        TaskWithInput       | 'inputValue'
-        TaskWithNestedBean  | 'bean.inputFile'
+        type                        | property
+        TaskWithInputFile           | 'inputFile'
+        TaskWithOutputFile          | 'outputFile'
+        TaskWithOutputFiles         | 'outputFiles'
+        TaskWithInputFiles          | 'input'
+        TaskWithOutputDir           | 'outputDir'
+        TaskWithOutputDirs          | 'outputDirs'
+        TaskWithInputDir            | 'inputDir'
+        TaskWithInput               | 'inputValue'
+        TaskWithNestedBean          | 'bean.inputFile'
+        TaskWithInputFileAsProvider | 'inputFile'
     }
 
     def validationActionFailsWhenSpecifiedOutputFileIsADirectory() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileVar;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
@@ -182,6 +183,22 @@ public class AnnotationProcessingTasks {
 
         @InputFile
         public File getInputFile() {
+            return inputFile;
+        }
+    }
+
+    public static class TaskWithInputFileAsProvider extends TaskWithAction {
+        RegularFileVar inputFile;
+
+        public TaskWithInputFileAsProvider(File inputFile) {
+            this.inputFile = newInputFile();
+            if (inputFile != null) {
+                this.inputFile.set(inputFile);
+            }
+        }
+
+        @InputFile
+        public RegularFileVar getInputFile() {
             return inputFile;
         }
     }
@@ -392,6 +409,20 @@ public class AnnotationProcessingTasks {
         @org.gradle.api.tasks.Optional
         public File getInputFile() {
             return null;
+        }
+    }
+
+    public static class TaskWithOptionalInputFileAsProvider extends TaskWithAction {
+        RegularFileVar inputFile;
+
+        public TaskWithOptionalInputFileAsProvider() {
+            inputFile = newInputFile();
+        }
+
+        @InputFile
+        @org.gradle.api.tasks.Optional
+        public RegularFileVar getInputFile() {
+            return inputFile;
         }
     }
 


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle/issues/2955.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fissue-2955)
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [x] Recognize contributor in release notes
