### PR TITLE
Document default exclusion pattern for ConfigurableFileTree (#1348)

### DIFF
--- a/subprojects/docs/src/docs/userguide/workingWithFiles.xml
+++ b/subprojects/docs/src/docs/userguide/workingWithFiles.xml
@@ -147,6 +147,12 @@
         <sample id="fileTrees" dir="userguide/files/fileTrees" title="Using a file tree">
             <sourcefile file="build.gradle" snippet="use"/>
         </sample>
+        <note>
+            <para>
+                By default, the <literal>FileTree</literal> instance <literal>fileTree()</literal> returns will apply some Ant-style default exclude patterns for convenience.
+                For the complete default exclusion list, see <ulink url="http://ant.apache.org/manual/dirtasks.html#defaultexcludes">Default Excludes</ulink>.
+            </para>
+        </note>
     </section>
 
     <section id="sec:archive_contents">


### PR DESCRIPTION
### Context

See #1348 
