### PR TITLE
Fix special case of drive-relative Windows path #2843

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
@@ -48,7 +48,12 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
         try {
             String repoPath = parseLocalRepoPathFromMavenSettings();
             if (repoPath != null) {
-                return new File(resolvePlaceholders(repoPath.trim()));
+                File file = new File(resolvePlaceholders(repoPath.trim()));
+                if (isDriveRelativeWindowsPath(file)) {
+                    return file.getAbsoluteFile();
+                } else {
+                    return file;
+                }
             } else {
                 File defaultLocation = new File(system.getProperty("user.home"), "/.m2/repository").getAbsoluteFile();
                 LOGGER.debug("No local repository in Settings file defined. Using default path: {}", defaultLocation);
@@ -57,6 +62,10 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
         } catch (SettingsBuildingException e) {
             throw new CannotLocateLocalMavenRepositoryException("Unable to parse local Maven settings.", e);
         }
+    }
+
+    private boolean isDriveRelativeWindowsPath(File file) {
+        return !file.isAbsolute() && file.getPath().startsWith(File.separator);
     }
 
     // We only cache the result of parsing the Maven settings files, but allow this value to be updated in-flight

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
@@ -18,7 +18,10 @@ package org.gradle.api.internal.artifacts.mvnsettings
 import org.apache.maven.settings.io.SettingsParseException
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -206,10 +209,18 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
         'env.unknown.ENV_VAR' |   "environment variable"
     }
 
+    @Requires(TestPrecondition.WINDOWS)
+    @Issue('https://github.com/gradle/gradle/issues/2843')
+    def "handle the case of absolute path on Windows"() {
+        when:
+        writeSettingsFile(locations.globalSettingsFile, "<localRepository>/absolute</localRepository>")
+        then:
+        locator.localMavenRepository == new File('/absolute').absoluteFile
+    }
+
     private static void writeSettingsFile(File settings, File repo) {
         writeSettingsFile(settings, "<localRepository>${repo.absolutePath}</localRepository>")
     }
-
 
     private static void writeSettingsFile(File settings, String localRepositoryElement) {
         settings.text = """


### PR DESCRIPTION

https://github.com/gradle/gradle/issues/2843
On Windows, there's a special case to be handled in Maven localRepository element:
/absolute-path is a drive-relative path. This PR fixed this issue.

### Context

See #2843 

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
