### PR TITLE
Add logic to pull if working directory is a repo

### DIFF
--- a/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
@@ -19,6 +19,8 @@ package org.gradle.vcs.git.internal;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.JGitInternalException;
+import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.vcs.VersionControlSpec;
@@ -27,6 +29,7 @@ import org.gradle.vcs.git.GitVersionControlSpec;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 
 /**
  * A Git {@link VersionControlSystem} implementation.
@@ -54,7 +57,9 @@ public class GitVersionControlSystem implements VersionControlSystem {
         try {
             git = clone.call();
         } catch (GitAPIException e) {
-            LOGGER.error("Could not clone: {} to {} because {}", gitSpec.getUrl(), workingDir, e.getStackTrace());
+            throw wrapGitCommandException("clone", gitSpec.getUrl(), workingDir, e);
+        } catch (JGitInternalException e) {
+            throw wrapGitCommandException("clone", gitSpec.getUrl(), workingDir, e);
         } finally {
             if (git != null) {
                 git.close();
@@ -68,13 +73,19 @@ public class GitVersionControlSystem implements VersionControlSystem {
             git = Git.open(workingDir);
             git.pull().call();
         } catch (IOException e) {
-            LOGGER.error("Could not update: {} from {} because {}", workingDir, gitSpec.getUrl(), e.getStackTrace());
+            throw wrapGitCommandException("update", gitSpec.getUrl(), workingDir, e);
         } catch (GitAPIException e) {
-            LOGGER.error("Could not update: {} from {} because {}", workingDir, gitSpec.getUrl(), e.getStackTrace());
+            throw wrapGitCommandException("update", gitSpec.getUrl(), workingDir, e);
+        } catch (JGitInternalException e) {
+            throw wrapGitCommandException("update", gitSpec.getUrl(), workingDir, e);
         } finally {
             if (git != null) {
                 git.close();
             }
         }
+    }
+
+    private GradleException wrapGitCommandException(String commandName, URI repoUrl, File workingDir, Exception e) {
+        return new GradleException(String.format("Could not {}: {} from {}", commandName, repoUrl, workingDir), e);
     }
 }

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
@@ -71,7 +71,7 @@ public class GitVersionControlSystem implements VersionControlSystem {
         Git git = null;
         try {
             git = Git.open(workingDir);
-            git.pull().call();
+            git.pull().setRemote(gitSpec.getUrl().toString()).call();
         } catch (IOException e) {
             throw wrapGitCommandException("update", gitSpec.getUrl(), workingDir, e);
         } catch (GitAPIException e) {

--- a/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
+++ b/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
@@ -32,6 +32,9 @@ class GitVersionControlSystemSpec extends Specification {
     @Rule
     TemporaryGitRepository repo = new TemporaryGitRepository(tmpDir)
 
+    @Rule
+    TemporaryGitRepository repo2 = new TemporaryGitRepository("otherRepo", tmpDir)
+
     def setup() {
         gitVcs = new GitVersionControlSystem()
 
@@ -47,7 +50,7 @@ class GitVersionControlSystemSpec extends Specification {
         given:
         def target = tmpDir.file("workingDir")
         GitVersionControlSpec spec = new GitVersionControlSpec()
-        spec.url = repo.getUrl()
+        spec.url = repo.url
 
         when:
         gitVcs.populate(target, spec)
@@ -63,7 +66,7 @@ class GitVersionControlSystemSpec extends Specification {
         def target = tmpDir.file("workingDir")
         target.mkdir()
         GitVersionControlSpec spec = new GitVersionControlSpec()
-        spec.url = repo.getUrl()
+        spec.url = repo.url
 
         when:
         gitVcs.populate(target, spec)
@@ -78,7 +81,7 @@ class GitVersionControlSystemSpec extends Specification {
         given:
         def target = tmpDir.file("workingDir")
         GitVersionControlSpec spec = new GitVersionControlSpec()
-        spec.url = repo.getUrl()
+        spec.url = repo.url
         gitVcs.populate(target, spec)
         def newFile = repo.workTree.file("newFile.txt")
         newFile << "I'm new!"
@@ -98,7 +101,7 @@ class GitVersionControlSystemSpec extends Specification {
         given:
         def target = tmpDir.file("workingdir")
         GitVersionControlSpec spec = new GitVersionControlSpec()
-        spec.url = repo.getUrl()
+        spec.url = repo.url
         target.mkdirs()
         target.file("child.txt").createNewFile()
 
@@ -110,6 +113,26 @@ class GitVersionControlSystemSpec extends Specification {
 
         when:
         target.file(".git").mkdir()
+        gitVcs.populate(target, spec)
+
+        then:
+        thrown GradleException
+    }
+
+    def "error if working dir repo is missing the remote"() {
+        given:
+        def target = tmpDir.file("workingDir")
+        GitVersionControlSpec spec = new GitVersionControlSpec()
+        spec.url = repo.url
+        gitVcs.populate(target, spec)
+
+        // Commit a file to the repository
+        def textFile = repo2.workTree.file("other.txt")
+        textFile << "Hello world!"
+        repo2.commit("Initial Commit", textFile)
+        spec.url = repo2.url
+
+        when:
         gitVcs.populate(target, spec)
 
         then:

--- a/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
+++ b/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
@@ -56,4 +56,24 @@ class GitVersionControlSystemSpec extends Specification {
         target.file( "source.txt").text == "Hello world!"
         target.file( "dir/another.txt").text == "Goodbye world!"
     }
+
+    def "update a cloned repository"() {
+        given:
+        def target = tmpDir.file("workingDir")
+        GitVersionControlSpec spec = new GitVersionControlSpec()
+        spec.url = repo.getUrl()
+        gitVcs.populate(target, spec)
+        def newFile = repo.workTree.file("newFile.txt")
+        newFile << "I'm new!"
+        repo.commit("Add newFile.txt", newFile)
+
+        expect:
+        !target.file("newFile.txt").exists()
+
+        when:
+        gitVcs.populate(target, spec)
+
+        then:
+        target.file("newFile.txt").exists()
+    }
 }


### PR DESCRIPTION
Tests cover:
  * Can populate a working directory that is a repo already.
  * Populating a working directory that is a repo already pulls from the
     remote from the spec.
  * Can clone into an empty working directory that already exists.
  * Cannot populate a non-reposioty working directory with a file in it.
  * Cannot populate a non-reposioty working directory, even with a
    `.git` subdirectory.

Part of gradle/gradle-native#107