### PR TITLE
Creates build option factories in service

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
@@ -42,12 +42,13 @@ public class DefaultCommandLineConverter extends AbstractCommandLineConverter<St
     private final CommandLineConverter<ParallelismConfiguration> parallelConfigurationCommandLineConverter;
     private final SystemPropertiesCommandLineConverter systemPropertiesCommandLineConverter = new SystemPropertiesCommandLineConverter();
     private final ProjectPropertiesCommandLineConverter projectPropertiesCommandLineConverter = new ProjectPropertiesCommandLineConverter();
-    private final List<BuildOption<StartParameter>> buildOptions = new StartParameterBuildOptionFactory().create();
+    private final List<BuildOption<StartParameter>> buildOptions;
     private final LayoutCommandLineConverter layoutCommandLineConverter;
 
-    public DefaultCommandLineConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public DefaultCommandLineConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
         parallelConfigurationCommandLineConverter = new ParallelismConfigurationCommandLineConverter(parallelismBuildOptionFactory);
         layoutCommandLineConverter = new LayoutCommandLineConverter();
+        buildOptions = startParameterBuildOptionFactory.create();
     }
 
     public void configure(CommandLineParser parser) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
@@ -39,13 +39,14 @@ import static org.gradle.StartParameter.GRADLE_USER_HOME_PROPERTY_KEY;
 
 public class DefaultCommandLineConverter extends AbstractCommandLineConverter<StartParameter> {
     private final CommandLineConverter<LoggingConfiguration> loggingConfigurationCommandLineConverter = new LoggingCommandLineConverter();
-    private final CommandLineConverter<ParallelismConfiguration> parallelConfigurationCommandLineConverter = new ParallelismConfigurationCommandLineConverter();
+    private final CommandLineConverter<ParallelismConfiguration> parallelConfigurationCommandLineConverter;
     private final SystemPropertiesCommandLineConverter systemPropertiesCommandLineConverter = new SystemPropertiesCommandLineConverter();
     private final ProjectPropertiesCommandLineConverter projectPropertiesCommandLineConverter = new ProjectPropertiesCommandLineConverter();
     private final List<BuildOption<StartParameter>> buildOptions = new StartParameterBuildOptionFactory().create();
     private final LayoutCommandLineConverter layoutCommandLineConverter;
 
-    public DefaultCommandLineConverter() {
+    public DefaultCommandLineConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        parallelConfigurationCommandLineConverter = new ParallelismConfigurationCommandLineConverter(parallelismBuildOptionFactory);
         layoutCommandLineConverter = new LayoutCommandLineConverter();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
@@ -45,9 +45,9 @@ public class DefaultCommandLineConverter extends AbstractCommandLineConverter<St
     private final List<BuildOption<StartParameter>> buildOptions;
     private final LayoutCommandLineConverter layoutCommandLineConverter;
 
-    public DefaultCommandLineConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public DefaultCommandLineConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
         parallelConfigurationCommandLineConverter = new ParallelismConfigurationCommandLineConverter(parallelismBuildOptionFactory);
-        layoutCommandLineConverter = new LayoutCommandLineConverter();
+        layoutCommandLineConverter = new LayoutCommandLineConverter(buildLayoutParametersBuildOptionFactory);
         buildOptions = startParameterBuildOptionFactory.create();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
@@ -29,6 +29,7 @@ import org.gradle.cli.SystemPropertiesCommandLineConverter;
 import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.logging.LoggingCommandLineConverter;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 
 import java.io.File;
 import java.util.HashMap;
@@ -38,15 +39,16 @@ import java.util.Map;
 import static org.gradle.StartParameter.GRADLE_USER_HOME_PROPERTY_KEY;
 
 public class DefaultCommandLineConverter extends AbstractCommandLineConverter<StartParameter> {
-    private final CommandLineConverter<LoggingConfiguration> loggingConfigurationCommandLineConverter = new LoggingCommandLineConverter();
+    private final CommandLineConverter<LoggingConfiguration> loggingConfigurationCommandLineConverter;
     private final CommandLineConverter<ParallelismConfiguration> parallelConfigurationCommandLineConverter;
     private final SystemPropertiesCommandLineConverter systemPropertiesCommandLineConverter = new SystemPropertiesCommandLineConverter();
     private final ProjectPropertiesCommandLineConverter projectPropertiesCommandLineConverter = new ProjectPropertiesCommandLineConverter();
     private final List<BuildOption<StartParameter>> buildOptions;
     private final LayoutCommandLineConverter layoutCommandLineConverter;
 
-    public DefaultCommandLineConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public DefaultCommandLineConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
         parallelConfigurationCommandLineConverter = new ParallelismConfigurationCommandLineConverter(parallelismBuildOptionFactory);
+        loggingConfigurationCommandLineConverter = new LoggingCommandLineConverter(loggingConfigurationBuildOptionFactory);
         layoutCommandLineConverter = new LayoutCommandLineConverter(buildLayoutParametersBuildOptionFactory);
         buildOptions = startParameterBuildOptionFactory.create();
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
@@ -25,7 +25,11 @@ import org.gradle.internal.buildoption.BuildOption;
 import java.util.List;
 
 public class LayoutCommandLineConverter extends AbstractCommandLineConverter<BuildLayoutParameters> {
-    private List<BuildOption<BuildLayoutParameters>> buildOptions = new BuildLayoutParametersBuildOptionFactory().create();
+    private List<BuildOption<BuildLayoutParameters>> buildOptions;
+
+    public LayoutCommandLineConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory) {
+        buildOptions = buildLayoutParametersBuildOptionFactory.create();
+    }
 
     public BuildLayoutParameters convert(ParsedCommandLine options, BuildLayoutParameters target) throws CommandLineArgumentException {
         for (BuildOption<BuildLayoutParameters> option : buildOptions) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
@@ -27,7 +27,11 @@ import java.util.List;
 
 public class ParallelismConfigurationCommandLineConverter extends AbstractCommandLineConverter<ParallelismConfiguration> {
 
-    private List<BuildOption<ParallelismConfiguration>> buildOptions = new ParallelismBuildOptionFactory().create();
+    private List<BuildOption<ParallelismConfiguration>> buildOptions;
+
+    public ParallelismConfigurationCommandLineConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        buildOptions = parallelismBuildOptionFactory.create();
+    }
 
     public ParallelismConfiguration convert(ParsedCommandLine options, ParallelismConfiguration target) throws CommandLineArgumentException {
         for (BuildOption<ParallelismConfiguration> option : buildOptions) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -55,6 +55,7 @@ import org.gradle.cache.internal.DefaultCacheFactory;
 import org.gradle.cli.CommandLineConverter;
 import org.gradle.configuration.DefaultImportsReader;
 import org.gradle.configuration.ImportsReader;
+import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.initialization.DefaultClassLoaderRegistry;
 import org.gradle.initialization.DefaultCommandLineConverter;
@@ -172,6 +173,10 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return environment;
     }
 
+    BuildLayoutParametersBuildOptionFactory createBuildLayoutParametersBuildOptionFactory() {
+        return new BuildLayoutParametersBuildOptionFactory();
+    }
+
     StartParameterBuildOptionFactory createStartParameterBuildOptionFactory() {
         return new StartParameterBuildOptionFactory();
     }
@@ -180,8 +185,8 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return new ParallelismBuildOptionFactory();
     }
 
-    CommandLineConverter<StartParameter> createCommandLine2StartParameterConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
-        return new DefaultCommandLineConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory);
+    CommandLineConverter<StartParameter> createCommandLine2StartParameterConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        return new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory);
     }
 
     ClassPathRegistry createClassPathRegistry(ModuleRegistry moduleRegistry, PluginModuleRegistry pluginModuleRegistry) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -84,6 +84,7 @@ import org.gradle.internal.hash.DefaultStreamHasher;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.installation.GradleRuntimeShadedJarDetector;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
@@ -185,8 +186,12 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return new ParallelismBuildOptionFactory();
     }
 
-    CommandLineConverter<StartParameter> createCommandLine2StartParameterConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
-        return new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory);
+    LoggingConfigurationBuildOptionFactory createLoggingConfigurationBuildOptionFactory() {
+        return new LoggingConfigurationBuildOptionFactory();
+    }
+
+    CommandLineConverter<StartParameter> createCommandLine2StartParameterConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
+        return new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory);
     }
 
     ClassPathRegistry createClassPathRegistry(ModuleRegistry moduleRegistry, PluginModuleRegistry pluginModuleRegistry) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -66,6 +66,7 @@ import org.gradle.initialization.FlatClassLoaderRegistry;
 import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.initialization.JdkToolsInitializer;
 import org.gradle.initialization.LegacyTypesSupport;
+import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.DefaultClassLoaderFactory;
 import org.gradle.internal.classpath.ClassPath;
@@ -170,8 +171,12 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return environment;
     }
 
-    CommandLineConverter<StartParameter> createCommandLine2StartParameterConverter() {
-        return new DefaultCommandLineConverter();
+    ParallelismBuildOptionFactory createParallelismBuildOptionFactory() {
+        return new ParallelismBuildOptionFactory();
+    }
+
+    CommandLineConverter<StartParameter> createCommandLine2StartParameterConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        return new DefaultCommandLineConverter(parallelismBuildOptionFactory);
     }
 
     ClassPathRegistry createClassPathRegistry(ModuleRegistry moduleRegistry, PluginModuleRegistry pluginModuleRegistry) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -67,6 +67,7 @@ import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.initialization.JdkToolsInitializer;
 import org.gradle.initialization.LegacyTypesSupport;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
+import org.gradle.initialization.StartParameterBuildOptionFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.DefaultClassLoaderFactory;
 import org.gradle.internal.classpath.ClassPath;
@@ -171,12 +172,16 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return environment;
     }
 
+    StartParameterBuildOptionFactory createStartParameterBuildOptionFactory() {
+        return new StartParameterBuildOptionFactory();
+    }
+
     ParallelismBuildOptionFactory createParallelismBuildOptionFactory() {
         return new ParallelismBuildOptionFactory();
     }
 
-    CommandLineConverter<StartParameter> createCommandLine2StartParameterConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
-        return new DefaultCommandLineConverter(parallelismBuildOptionFactory);
+    CommandLineConverter<StartParameter> createCommandLine2StartParameterConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        return new DefaultCommandLineConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory);
     }
 
     ClassPathRegistry createClassPathRegistry(ModuleRegistry moduleRegistry, PluginModuleRegistry pluginModuleRegistry) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
@@ -56,7 +56,7 @@ public class CommandLineConverterTestSupport {
     protected File expectedProjectCacheDir;
     protected boolean expectedRefreshDependencies;
     protected boolean expectedRerunTasks;
-    protected final DefaultCommandLineConverter commandLineConverter = new DefaultCommandLineConverter(new ParallelismBuildOptionFactory());
+    protected final DefaultCommandLineConverter commandLineConverter = new DefaultCommandLineConverter(new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory());
     protected boolean expectedContinue;
     protected boolean expectedOffline;
     protected boolean expectedRecompileScripts;

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
@@ -56,7 +56,7 @@ public class CommandLineConverterTestSupport {
     protected File expectedProjectCacheDir;
     protected boolean expectedRefreshDependencies;
     protected boolean expectedRerunTasks;
-    protected final DefaultCommandLineConverter commandLineConverter = new DefaultCommandLineConverter(new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory());
+    protected final DefaultCommandLineConverter commandLineConverter = new DefaultCommandLineConverter(new BuildLayoutParametersBuildOptionFactory(), new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory());
     protected boolean expectedContinue;
     protected boolean expectedOffline;
     protected boolean expectedRecompileScripts;

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
@@ -20,6 +20,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.ShowStacktrace;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.util.WrapUtil;
 
@@ -56,7 +57,7 @@ public class CommandLineConverterTestSupport {
     protected File expectedProjectCacheDir;
     protected boolean expectedRefreshDependencies;
     protected boolean expectedRerunTasks;
-    protected final DefaultCommandLineConverter commandLineConverter = new DefaultCommandLineConverter(new BuildLayoutParametersBuildOptionFactory(), new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory());
+    protected final DefaultCommandLineConverter commandLineConverter = new DefaultCommandLineConverter(new BuildLayoutParametersBuildOptionFactory(), new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory(), new LoggingConfigurationBuildOptionFactory());
     protected boolean expectedContinue;
     protected boolean expectedOffline;
     protected boolean expectedRecompileScripts;

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
@@ -56,7 +56,7 @@ public class CommandLineConverterTestSupport {
     protected File expectedProjectCacheDir;
     protected boolean expectedRefreshDependencies;
     protected boolean expectedRerunTasks;
-    protected final DefaultCommandLineConverter commandLineConverter = new DefaultCommandLineConverter();
+    protected final DefaultCommandLineConverter commandLineConverter = new DefaultCommandLineConverter(new ParallelismBuildOptionFactory());
     protected boolean expectedContinue;
     protected boolean expectedOffline;
     protected boolean expectedRecompileScripts;

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
@@ -20,12 +20,13 @@ import org.gradle.internal.SystemProperties
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
+import spock.lang.Subject
 
 import static org.gradle.internal.FileUtils.canonicalize
 
 class LayoutCommandLineConverterTest extends Specification {
 
-    def converter = new LayoutCommandLineConverter()
+    @Subject def converter = new LayoutCommandLineConverter(new BuildLayoutParametersBuildOptionFactory())
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
 
     def convert(String... args) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
@@ -20,10 +20,11 @@ import org.gradle.concurrent.ParallelismConfiguration
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.util.ToBeImplemented
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.lang.Unroll
 
 class ParallelismConfigurationCommandLineConverterTest extends Specification {
-    final def converter = new ParallelismConfigurationCommandLineConverter()
+    @Subject def converter = new ParallelismConfigurationCommandLineConverter(new ParallelismBuildOptionFactory())
 
     def "converts parallel executor"() {
         when:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.TaskState;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.configuration.GradleLauncherMetaData;
 import org.gradle.execution.MultipleBuildFailures;
+import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.DefaultBuildCancellationToken;
 import org.gradle.initialization.DefaultBuildRequestContext;
@@ -264,10 +265,11 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
         // TODO: Reuse more of CommandlineActionFactory
         CommandLineParser parser = new CommandLineParser();
+        BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = GLOBAL_SERVICES.get(BuildLayoutParametersBuildOptionFactory.class);
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = GLOBAL_SERVICES.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = GLOBAL_SERVICES.get(ParallelismBuildOptionFactory.class);
-        DaemonBuildOptionFactory daemonBuildOptionFactory = GLOBAL_SERVICES.get(DaemonBuildOptionFactory.class);
-        ParametersConverter parametersConverter = new ParametersConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory);
+        DaemonBuildOptionFactory daemonBuildOptionFactory = new DaemonBuildOptionFactory();
+        ParametersConverter parametersConverter = new ParametersConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);
         parametersConverter.convert(parser.parse(getAllArgs()), parameters);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -55,6 +55,7 @@ import org.gradle.launcher.Main;
 import org.gradle.launcher.cli.ExecuteBuildAction;
 import org.gradle.launcher.cli.Parameters;
 import org.gradle.launcher.cli.ParametersConverter;
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory;
 import org.gradle.launcher.exec.BuildActionExecuter;
 import org.gradle.launcher.exec.BuildActionParameters;
 import org.gradle.launcher.exec.DefaultBuildActionParameters;
@@ -265,7 +266,8 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
         CommandLineParser parser = new CommandLineParser();
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = GLOBAL_SERVICES.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = GLOBAL_SERVICES.get(ParallelismBuildOptionFactory.class);
-        ParametersConverter parametersConverter = new ParametersConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory);
+        DaemonBuildOptionFactory daemonBuildOptionFactory = GLOBAL_SERVICES.get(DaemonBuildOptionFactory.class);
+        ParametersConverter parametersConverter = new ParametersConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);
         parametersConverter.convert(parser.parse(getAllArgs()), parameters);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -36,6 +36,7 @@ import org.gradle.initialization.DefaultBuildCancellationToken;
 import org.gradle.initialization.DefaultBuildRequestContext;
 import org.gradle.initialization.DefaultBuildRequestMetaData;
 import org.gradle.initialization.NoOpBuildEventConsumer;
+import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.initialization.ReportedException;
 import org.gradle.integtests.fixtures.logging.GroupedOutputFixture;
 import org.gradle.internal.Factory;
@@ -261,7 +262,7 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
         // TODO: Reuse more of CommandlineActionFactory
         CommandLineParser parser = new CommandLineParser();
-        ParametersConverter parametersConverter = new ParametersConverter();
+        ParametersConverter parametersConverter = new ParametersConverter(GLOBAL_SERVICES.get(ParallelismBuildOptionFactory.class));
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);
         parametersConverter.convert(parser.parse(getAllArgs()), parameters);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -38,6 +38,7 @@ import org.gradle.initialization.DefaultBuildRequestMetaData;
 import org.gradle.initialization.NoOpBuildEventConsumer;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.initialization.ReportedException;
+import org.gradle.initialization.StartParameterBuildOptionFactory;
 import org.gradle.integtests.fixtures.logging.GroupedOutputFixture;
 import org.gradle.internal.Factory;
 import org.gradle.internal.SystemProperties;
@@ -262,7 +263,9 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
         // TODO: Reuse more of CommandlineActionFactory
         CommandLineParser parser = new CommandLineParser();
-        ParametersConverter parametersConverter = new ParametersConverter(GLOBAL_SERVICES.get(ParallelismBuildOptionFactory.class));
+        StartParameterBuildOptionFactory startParameterBuildOptionFactory = GLOBAL_SERVICES.get(StartParameterBuildOptionFactory.class);
+        ParallelismBuildOptionFactory parallelismBuildOptionFactory = GLOBAL_SERVICES.get(ParallelismBuildOptionFactory.class);
+        ParametersConverter parametersConverter = new ParametersConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);
         parametersConverter.convert(parser.parse(getAllArgs()), parameters);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -50,6 +50,7 @@ import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.io.LineBufferingOutputStream;
 import org.gradle.internal.io.TextStream;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.launcher.Main;
@@ -268,8 +269,9 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
         BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = GLOBAL_SERVICES.get(BuildLayoutParametersBuildOptionFactory.class);
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = GLOBAL_SERVICES.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = GLOBAL_SERVICES.get(ParallelismBuildOptionFactory.class);
+        LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory = GLOBAL_SERVICES.get(LoggingConfigurationBuildOptionFactory.class);
         DaemonBuildOptionFactory daemonBuildOptionFactory = new DaemonBuildOptionFactory();
-        ParametersConverter parametersConverter = new ParametersConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory);
+        ParametersConverter parametersConverter = new ParametersConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory, loggingConfigurationBuildOptionFactory);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);
         parametersConverter.convert(parser.parse(getAllArgs()), parameters);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
@@ -29,6 +29,7 @@ import org.gradle.launcher.cli.converter.DaemonCommandLineConverter;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
 import org.gradle.launcher.cli.converter.PropertiesToStartParameterConverter;
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 
 import java.util.HashMap;
@@ -63,14 +64,14 @@ public class ParametersConverter extends AbstractCommandLineConverter<Parameters
         this.propertiesToDaemonParametersConverter = propertiesToDaemonParametersConverter;
     }
 
-    public ParametersConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public ParametersConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory) {
         this(new LayoutCommandLineConverter(),
             new SystemPropertiesCommandLineConverter(),
-            new LayoutToPropertiesConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory),
+            new LayoutToPropertiesConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory),
             new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory),
             new DefaultCommandLineConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory),
-            new DaemonCommandLineConverter(),
-            new PropertiesToDaemonParametersConverter());
+            new DaemonCommandLineConverter(daemonBuildOptionFactory),
+            new PropertiesToDaemonParametersConverter(daemonBuildOptionFactory));
     }
 
     @Override

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
@@ -24,6 +24,7 @@ import org.gradle.cli.SystemPropertiesCommandLineConverter;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.LayoutCommandLineConverter;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
+import org.gradle.initialization.StartParameterBuildOptionFactory;
 import org.gradle.launcher.cli.converter.DaemonCommandLineConverter;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
@@ -62,12 +63,12 @@ public class ParametersConverter extends AbstractCommandLineConverter<Parameters
         this.propertiesToDaemonParametersConverter = propertiesToDaemonParametersConverter;
     }
 
-    public ParametersConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public ParametersConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
         this(new LayoutCommandLineConverter(),
             new SystemPropertiesCommandLineConverter(),
-            new LayoutToPropertiesConverter(parallelismBuildOptionFactory),
-            new PropertiesToStartParameterConverter(parallelismBuildOptionFactory),
-            new DefaultCommandLineConverter(parallelismBuildOptionFactory),
+            new LayoutToPropertiesConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory),
+            new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory),
+            new DefaultCommandLineConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory),
             new DaemonCommandLineConverter(),
             new PropertiesToDaemonParametersConverter());
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
@@ -26,6 +26,7 @@ import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.LayoutCommandLineConverter;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.initialization.StartParameterBuildOptionFactory;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 import org.gradle.launcher.cli.converter.DaemonCommandLineConverter;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
@@ -65,12 +66,12 @@ public class ParametersConverter extends AbstractCommandLineConverter<Parameters
         this.propertiesToDaemonParametersConverter = propertiesToDaemonParametersConverter;
     }
 
-    public ParametersConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory) {
+    public ParametersConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory, LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
         this(new LayoutCommandLineConverter(buildLayoutParametersBuildOptionFactory),
             new SystemPropertiesCommandLineConverter(),
-            new LayoutToPropertiesConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory),
-            new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory),
-            new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory),
+            new LayoutToPropertiesConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory, loggingConfigurationBuildOptionFactory),
+            new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory),
+            new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory),
             new DaemonCommandLineConverter(daemonBuildOptionFactory),
             new PropertiesToDaemonParametersConverter(daemonBuildOptionFactory));
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
@@ -21,6 +21,7 @@ import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.cli.SystemPropertiesCommandLineConverter;
+import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.LayoutCommandLineConverter;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
@@ -64,12 +65,12 @@ public class ParametersConverter extends AbstractCommandLineConverter<Parameters
         this.propertiesToDaemonParametersConverter = propertiesToDaemonParametersConverter;
     }
 
-    public ParametersConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory) {
-        this(new LayoutCommandLineConverter(),
+    public ParametersConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory) {
+        this(new LayoutCommandLineConverter(buildLayoutParametersBuildOptionFactory),
             new SystemPropertiesCommandLineConverter(),
-            new LayoutToPropertiesConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory),
+            new LayoutToPropertiesConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory),
             new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory),
-            new DefaultCommandLineConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory),
+            new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory),
             new DaemonCommandLineConverter(daemonBuildOptionFactory),
             new PropertiesToDaemonParametersConverter(daemonBuildOptionFactory));
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
@@ -16,9 +16,14 @@
 
 package org.gradle.launcher.cli;
 
-import org.gradle.cli.*;
+import org.gradle.cli.AbstractCommandLineConverter;
+import org.gradle.cli.CommandLineArgumentException;
+import org.gradle.cli.CommandLineParser;
+import org.gradle.cli.ParsedCommandLine;
+import org.gradle.cli.SystemPropertiesCommandLineConverter;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.LayoutCommandLineConverter;
+import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.launcher.cli.converter.DaemonCommandLineConverter;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
@@ -57,12 +62,12 @@ public class ParametersConverter extends AbstractCommandLineConverter<Parameters
         this.propertiesToDaemonParametersConverter = propertiesToDaemonParametersConverter;
     }
 
-    public ParametersConverter() {
+    public ParametersConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
         this(new LayoutCommandLineConverter(),
             new SystemPropertiesCommandLineConverter(),
-            new LayoutToPropertiesConverter(),
-            new PropertiesToStartParameterConverter(),
-            new DefaultCommandLineConverter(),
+            new LayoutToPropertiesConverter(parallelismBuildOptionFactory),
+            new PropertiesToStartParameterConverter(parallelismBuildOptionFactory),
+            new DefaultCommandLineConverter(parallelismBuildOptionFactory),
             new DaemonCommandLineConverter(),
             new PropertiesToDaemonParametersConverter());
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/DaemonCommandLineConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/DaemonCommandLineConverter.java
@@ -28,7 +28,11 @@ import java.util.List;
 
 public class DaemonCommandLineConverter extends AbstractCommandLineConverter<DaemonParameters> {
 
-    private List<BuildOption<DaemonParameters>> buildOptions = new DaemonBuildOptionFactory().create();
+    private List<BuildOption<DaemonParameters>> buildOptions;
+
+    public DaemonCommandLineConverter(DaemonBuildOptionFactory daemonBuildOptionFactory) {
+        buildOptions = daemonBuildOptionFactory.create();
+    }
 
     public DaemonParameters convert(ParsedCommandLine args, DaemonParameters target) throws CommandLineArgumentException {
         for (BuildOption<DaemonParameters> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -43,9 +43,9 @@ public class LayoutToPropertiesConverter {
 
     private final List<BuildOption<?>> allBuildOptions = new ArrayList<BuildOption<?>>();
 
-    public LayoutToPropertiesConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public LayoutToPropertiesConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
         allBuildOptions.addAll(new BuildLayoutParametersBuildOptionFactory().create());
-        allBuildOptions.addAll(new StartParameterBuildOptionFactory().create());
+        allBuildOptions.addAll(startParameterBuildOptionFactory.create());
         allBuildOptions.addAll(new LoggingConfigurationBuildOptionFactory().create());
         allBuildOptions.addAll(new DaemonBuildOptionFactory().create());
         allBuildOptions.addAll(parallelismBuildOptionFactory.create());

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -43,12 +43,12 @@ public class LayoutToPropertiesConverter {
 
     private final List<BuildOption<?>> allBuildOptions = new ArrayList<BuildOption<?>>();
 
-    public LayoutToPropertiesConverter() {
+    public LayoutToPropertiesConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
         allBuildOptions.addAll(new BuildLayoutParametersBuildOptionFactory().create());
         allBuildOptions.addAll(new StartParameterBuildOptionFactory().create());
         allBuildOptions.addAll(new LoggingConfigurationBuildOptionFactory().create());
         allBuildOptions.addAll(new DaemonBuildOptionFactory().create());
-        allBuildOptions.addAll(new ParallelismBuildOptionFactory().create());
+        allBuildOptions.addAll(parallelismBuildOptionFactory.create());
     }
 
     public Map<String, String> convert(BuildLayoutParameters layout, Map<String, String> properties) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -43,8 +43,8 @@ public class LayoutToPropertiesConverter {
 
     private final List<BuildOption<?>> allBuildOptions = new ArrayList<BuildOption<?>>();
 
-    public LayoutToPropertiesConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory) {
-        allBuildOptions.addAll(new BuildLayoutParametersBuildOptionFactory().create());
+    public LayoutToPropertiesConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory) {
+        allBuildOptions.addAll(buildLayoutParametersBuildOptionFactory.create());
         allBuildOptions.addAll(startParameterBuildOptionFactory.create());
         allBuildOptions.addAll(new LoggingConfigurationBuildOptionFactory().create());
         allBuildOptions.addAll(daemonBuildOptionFactory.create());

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -43,12 +43,12 @@ public class LayoutToPropertiesConverter {
 
     private final List<BuildOption<?>> allBuildOptions = new ArrayList<BuildOption<?>>();
 
-    public LayoutToPropertiesConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory) {
+    public LayoutToPropertiesConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory, LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
         allBuildOptions.addAll(buildLayoutParametersBuildOptionFactory.create());
         allBuildOptions.addAll(startParameterBuildOptionFactory.create());
-        allBuildOptions.addAll(new LoggingConfigurationBuildOptionFactory().create());
         allBuildOptions.addAll(daemonBuildOptionFactory.create());
         allBuildOptions.addAll(parallelismBuildOptionFactory.create());
+        allBuildOptions.addAll(loggingConfigurationBuildOptionFactory.create());
     }
 
     public Map<String, String> convert(BuildLayoutParameters layout, Map<String, String> properties) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -43,11 +43,11 @@ public class LayoutToPropertiesConverter {
 
     private final List<BuildOption<?>> allBuildOptions = new ArrayList<BuildOption<?>>();
 
-    public LayoutToPropertiesConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public LayoutToPropertiesConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, DaemonBuildOptionFactory daemonBuildOptionFactory) {
         allBuildOptions.addAll(new BuildLayoutParametersBuildOptionFactory().create());
         allBuildOptions.addAll(startParameterBuildOptionFactory.create());
         allBuildOptions.addAll(new LoggingConfigurationBuildOptionFactory().create());
-        allBuildOptions.addAll(new DaemonBuildOptionFactory().create());
+        allBuildOptions.addAll(daemonBuildOptionFactory.create());
         allBuildOptions.addAll(parallelismBuildOptionFactory.create());
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverter.java
@@ -24,7 +24,11 @@ import java.util.List;
 import java.util.Map;
 
 public class PropertiesToDaemonParametersConverter {
-    private List<BuildOption<DaemonParameters>> buildOptions = new DaemonBuildOptionFactory().create();
+    private List<BuildOption<DaemonParameters>> buildOptions;
+
+    public PropertiesToDaemonParametersConverter(DaemonBuildOptionFactory daemonBuildOptionFactory) {
+        buildOptions = daemonBuildOptionFactory.create();
+    }
 
     public void convert(Map<String, String> properties, DaemonParameters target) {
         for (BuildOption<DaemonParameters> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToLogLevelConfigurationConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToLogLevelConfigurationConverter.java
@@ -24,7 +24,11 @@ import java.util.List;
 import java.util.Map;
 
 public class PropertiesToLogLevelConfigurationConverter {
-    private final List<BuildOption<LoggingConfiguration>> buildOptions = new LoggingConfigurationBuildOptionFactory().create();
+    private final List<BuildOption<LoggingConfiguration>> buildOptions;
+
+    public PropertiesToLogLevelConfigurationConverter(LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
+        buildOptions = loggingConfigurationBuildOptionFactory.create();
+    }
 
     public LoggingConfiguration convert(Map<String, String> properties, LoggingConfiguration loggingConfiguration) {
         for (BuildOption<LoggingConfiguration> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
@@ -25,7 +25,11 @@ import java.util.Map;
 
 public class PropertiesToParallelismConfigurationConverter {
 
-    private List<BuildOption<ParallelismConfiguration>> buildOptions = new ParallelismBuildOptionFactory().create();
+    private final List<BuildOption<ParallelismConfiguration>> buildOptions;
+
+    public PropertiesToParallelismConfigurationConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        buildOptions = parallelismBuildOptionFactory.create();
+    }
 
     public ParallelismConfiguration convert(Map<String, String> properties, ParallelismConfiguration parallelismConfiguration) {
         for (BuildOption<ParallelismConfiguration> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
@@ -17,6 +17,7 @@
 package org.gradle.launcher.cli.converter;
 
 import org.gradle.StartParameter;
+import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.initialization.StartParameterBuildOptionFactory;
 import org.gradle.internal.buildoption.BuildOption;
 
@@ -24,9 +25,13 @@ import java.util.List;
 import java.util.Map;
 
 public class PropertiesToStartParameterConverter {
-    private final PropertiesToParallelismConfigurationConverter propertiesToParallelismConfigurationConverter = new PropertiesToParallelismConfigurationConverter();
+    private final PropertiesToParallelismConfigurationConverter propertiesToParallelismConfigurationConverter;
     private final PropertiesToLogLevelConfigurationConverter propertiesToLogLevelConfigurationConverter = new PropertiesToLogLevelConfigurationConverter();
     private final List<BuildOption<StartParameter>> buildOptions = new StartParameterBuildOptionFactory().create();
+
+    public PropertiesToStartParameterConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        propertiesToParallelismConfigurationConverter = new PropertiesToParallelismConfigurationConverter(parallelismBuildOptionFactory);
+    }
 
     public StartParameter convert(Map<String, String> properties, StartParameter startParameter) {
         for (BuildOption<StartParameter> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
@@ -20,18 +20,20 @@ import org.gradle.StartParameter;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.initialization.StartParameterBuildOptionFactory;
 import org.gradle.internal.buildoption.BuildOption;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 
 import java.util.List;
 import java.util.Map;
 
 public class PropertiesToStartParameterConverter {
     private final PropertiesToParallelismConfigurationConverter propertiesToParallelismConfigurationConverter;
-    private final PropertiesToLogLevelConfigurationConverter propertiesToLogLevelConfigurationConverter = new PropertiesToLogLevelConfigurationConverter();
+    private final PropertiesToLogLevelConfigurationConverter propertiesToLogLevelConfigurationConverter;
     private final List<BuildOption<StartParameter>> buildOptions;
 
-    public PropertiesToStartParameterConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public PropertiesToStartParameterConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
         buildOptions = startParameterBuildOptionFactory.create();
         propertiesToParallelismConfigurationConverter = new PropertiesToParallelismConfigurationConverter(parallelismBuildOptionFactory);
+        propertiesToLogLevelConfigurationConverter = new PropertiesToLogLevelConfigurationConverter(loggingConfigurationBuildOptionFactory);
     }
 
     public StartParameter convert(Map<String, String> properties, StartParameter startParameter) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
@@ -27,9 +27,10 @@ import java.util.Map;
 public class PropertiesToStartParameterConverter {
     private final PropertiesToParallelismConfigurationConverter propertiesToParallelismConfigurationConverter;
     private final PropertiesToLogLevelConfigurationConverter propertiesToLogLevelConfigurationConverter = new PropertiesToLogLevelConfigurationConverter();
-    private final List<BuildOption<StartParameter>> buildOptions = new StartParameterBuildOptionFactory().create();
+    private final List<BuildOption<StartParameter>> buildOptions;
 
-    public PropertiesToStartParameterConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public PropertiesToStartParameterConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        buildOptions = startParameterBuildOptionFactory.create();
         propertiesToParallelismConfigurationConverter = new PropertiesToParallelismConfigurationConverter(parallelismBuildOptionFactory);
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonClientGlobalServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonClientGlobalServices.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.daemon.bootstrap.DaemonGreeter;
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory;
 
 /**
  * Global services shared by all Gradle daemon clients in a given process.
@@ -35,5 +36,9 @@ public class DaemonClientGlobalServices {
 
     DaemonClientFactory createClientFactory(ServiceRegistry sharedServices) {
         return new DaemonClientFactory(sharedServices);
+    }
+
+    DaemonBuildOptionFactory createDaemonBuildOptionFactory() {
+        return new DaemonBuildOptionFactory();
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -25,6 +25,7 @@ import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.DefaultBuildRequestContext;
 import org.gradle.initialization.DefaultBuildRequestMetaData;
 import org.gradle.initialization.NoOpBuildEventConsumer;
+import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
@@ -112,7 +113,8 @@ public class ProviderConnection {
                     params.daemonParams.getEffectiveJvmArgs());
         }
 
-        StartParameter startParameter = new ProviderStartParameterConverter().toStartParameter(providerParameters, params.properties);
+        ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
+        StartParameter startParameter = new ProviderStartParameterConverter(parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         BuildAction action = new BuildModelAction(startParameter, modelName, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -122,7 +124,8 @@ public class ProviderConnection {
         List<String> tasks = providerParameters.getTasks();
         SerializedPayload serializedAction = payloadSerializer.serialize(clientAction);
         Parameters params = initParams(providerParameters);
-        StartParameter startParameter = new ProviderStartParameterConverter().toStartParameter(providerParameters, params.properties);
+        ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
+        StartParameter startParameter = new ProviderStartParameterConverter(parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         BuildAction action = new ClientProvidedBuildAction(startParameter, serializedAction, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -130,7 +133,8 @@ public class ProviderConnection {
 
     public Object runTests(ProviderInternalTestExecutionRequest testExecutionRequest, BuildCancellationToken cancellationToken, ProviderOperationParameters providerParameters) {
         Parameters params = initParams(providerParameters);
-        StartParameter startParameter = new ProviderStartParameterConverter().toStartParameter(providerParameters, params.properties);
+        ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
+        StartParameter startParameter = new ProviderStartParameterConverter(parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         TestExecutionRequestAction action = TestExecutionRequestAction.create(listenerConfig.clientSubscriptions, startParameter, testExecutionRequest);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -176,7 +180,8 @@ public class ProviderConnection {
         layout.setProjectDir(operationParameters.getProjectDir());
 
         Map<String, String> properties = new HashMap<String, String>();
-        new LayoutToPropertiesConverter().convert(layout, properties);
+        ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
+        new LayoutToPropertiesConverter(parallelismBuildOptionFactory).convert(layout, properties);
 
         DaemonParameters daemonParams = new DaemonParameters(layout);
         new PropertiesToDaemonParametersConverter().convert(properties, daemonParams);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -38,6 +38,7 @@ import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
 import org.gradle.launcher.daemon.client.DaemonClient;
 import org.gradle.launcher.daemon.client.DaemonClientFactory;
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 import org.gradle.launcher.exec.BuildActionExecuter;
 import org.gradle.launcher.exec.BuildActionParameters;
@@ -186,10 +187,11 @@ public class ProviderConnection {
         Map<String, String> properties = new HashMap<String, String>();
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        new LayoutToPropertiesConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).convert(layout, properties);
+        DaemonBuildOptionFactory daemonBuildOptionFactory = sharedServices.get(DaemonBuildOptionFactory.class);
+        new LayoutToPropertiesConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory).convert(layout, properties);
 
         DaemonParameters daemonParams = new DaemonParameters(layout);
-        new PropertiesToDaemonParametersConverter().convert(properties, daemonParams);
+        new PropertiesToDaemonParametersConverter(daemonBuildOptionFactory).convert(properties, daemonParams);
         if (operationParameters.getDaemonBaseDir(null) != null) {
             daemonParams.setBaseDir(operationParameters.getDaemonBaseDir(null));
         }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -26,6 +26,7 @@ import org.gradle.initialization.DefaultBuildRequestContext;
 import org.gradle.initialization.DefaultBuildRequestMetaData;
 import org.gradle.initialization.NoOpBuildEventConsumer;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
+import org.gradle.initialization.StartParameterBuildOptionFactory;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
@@ -113,8 +114,9 @@ public class ProviderConnection {
                     params.daemonParams.getEffectiveJvmArgs());
         }
 
+        StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        StartParameter startParameter = new ProviderStartParameterConverter(parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
+        StartParameter startParameter = new ProviderStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         BuildAction action = new BuildModelAction(startParameter, modelName, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -124,8 +126,9 @@ public class ProviderConnection {
         List<String> tasks = providerParameters.getTasks();
         SerializedPayload serializedAction = payloadSerializer.serialize(clientAction);
         Parameters params = initParams(providerParameters);
+        StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        StartParameter startParameter = new ProviderStartParameterConverter(parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
+        StartParameter startParameter = new ProviderStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         BuildAction action = new ClientProvidedBuildAction(startParameter, serializedAction, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -133,8 +136,9 @@ public class ProviderConnection {
 
     public Object runTests(ProviderInternalTestExecutionRequest testExecutionRequest, BuildCancellationToken cancellationToken, ProviderOperationParameters providerParameters) {
         Parameters params = initParams(providerParameters);
+        StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        StartParameter startParameter = new ProviderStartParameterConverter(parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
+        StartParameter startParameter = new ProviderStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         TestExecutionRequestAction action = TestExecutionRequestAction.create(listenerConfig.clientSubscriptions, startParameter, testExecutionRequest);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -180,8 +184,9 @@ public class ProviderConnection {
         layout.setProjectDir(operationParameters.getProjectDir());
 
         Map<String, String> properties = new HashMap<String, String>();
+        StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        new LayoutToPropertiesConverter(parallelismBuildOptionFactory).convert(layout, properties);
+        new LayoutToPropertiesConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).convert(layout, properties);
 
         DaemonParameters daemonParams = new DaemonParameters(layout);
         new PropertiesToDaemonParametersConverter().convert(properties, daemonParams);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -31,6 +31,7 @@ import org.gradle.initialization.StartParameterBuildOptionFactory;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
@@ -119,7 +120,8 @@ public class ProviderConnection {
         BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = sharedServices.get(BuildLayoutParametersBuildOptionFactory.class);
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        StartParameter startParameter = new ProviderStartParameterConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
+        LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory = sharedServices.get(LoggingConfigurationBuildOptionFactory.class);
+        StartParameter startParameter = new ProviderStartParameterConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         BuildAction action = new BuildModelAction(startParameter, modelName, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -132,7 +134,8 @@ public class ProviderConnection {
         BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = sharedServices.get(BuildLayoutParametersBuildOptionFactory.class);
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        StartParameter startParameter = new ProviderStartParameterConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
+        LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory = sharedServices.get(LoggingConfigurationBuildOptionFactory.class);
+        StartParameter startParameter = new ProviderStartParameterConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         BuildAction action = new ClientProvidedBuildAction(startParameter, serializedAction, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -143,7 +146,8 @@ public class ProviderConnection {
         BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = sharedServices.get(BuildLayoutParametersBuildOptionFactory.class);
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        StartParameter startParameter = new ProviderStartParameterConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
+        LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory = sharedServices.get(LoggingConfigurationBuildOptionFactory.class);
+        StartParameter startParameter = new ProviderStartParameterConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         TestExecutionRequestAction action = TestExecutionRequestAction.create(listenerConfig.clientSubscriptions, startParameter, testExecutionRequest);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -193,7 +197,8 @@ public class ProviderConnection {
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
         DaemonBuildOptionFactory daemonBuildOptionFactory = sharedServices.get(DaemonBuildOptionFactory.class);
-        new LayoutToPropertiesConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory).convert(layout, properties);
+        LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory = sharedServices.get(LoggingConfigurationBuildOptionFactory.class);
+        new LayoutToPropertiesConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory, loggingConfigurationBuildOptionFactory).convert(layout, properties);
 
         DaemonParameters daemonParams = new DaemonParameters(layout);
         new PropertiesToDaemonParametersConverter(daemonBuildOptionFactory).convert(properties, daemonParams);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -21,6 +21,7 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.initialization.BuildLayoutParameters;
+import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.DefaultBuildRequestContext;
 import org.gradle.initialization.DefaultBuildRequestMetaData;
@@ -115,9 +116,10 @@ public class ProviderConnection {
                     params.daemonParams.getEffectiveJvmArgs());
         }
 
+        BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = sharedServices.get(BuildLayoutParametersBuildOptionFactory.class);
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        StartParameter startParameter = new ProviderStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
+        StartParameter startParameter = new ProviderStartParameterConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         BuildAction action = new BuildModelAction(startParameter, modelName, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -127,9 +129,10 @@ public class ProviderConnection {
         List<String> tasks = providerParameters.getTasks();
         SerializedPayload serializedAction = payloadSerializer.serialize(clientAction);
         Parameters params = initParams(providerParameters);
+        BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = sharedServices.get(BuildLayoutParametersBuildOptionFactory.class);
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        StartParameter startParameter = new ProviderStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
+        StartParameter startParameter = new ProviderStartParameterConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         BuildAction action = new ClientProvidedBuildAction(startParameter, serializedAction, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -137,9 +140,10 @@ public class ProviderConnection {
 
     public Object runTests(ProviderInternalTestExecutionRequest testExecutionRequest, BuildCancellationToken cancellationToken, ProviderOperationParameters providerParameters) {
         Parameters params = initParams(providerParameters);
+        BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = sharedServices.get(BuildLayoutParametersBuildOptionFactory.class);
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
-        StartParameter startParameter = new ProviderStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
+        StartParameter startParameter = new ProviderStartParameterConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory).toStartParameter(providerParameters, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters);
         TestExecutionRequestAction action = TestExecutionRequestAction.create(listenerConfig.clientSubscriptions, startParameter, testExecutionRequest);
         return run(action, cancellationToken, listenerConfig, providerParameters, params);
@@ -185,10 +189,11 @@ public class ProviderConnection {
         layout.setProjectDir(operationParameters.getProjectDir());
 
         Map<String, String> properties = new HashMap<String, String>();
+        BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = sharedServices.get(BuildLayoutParametersBuildOptionFactory.class);
         StartParameterBuildOptionFactory startParameterBuildOptionFactory = sharedServices.get(StartParameterBuildOptionFactory.class);
         ParallelismBuildOptionFactory parallelismBuildOptionFactory = sharedServices.get(ParallelismBuildOptionFactory.class);
         DaemonBuildOptionFactory daemonBuildOptionFactory = sharedServices.get(DaemonBuildOptionFactory.class);
-        new LayoutToPropertiesConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory).convert(layout, properties);
+        new LayoutToPropertiesConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, daemonBuildOptionFactory).convert(layout, properties);
 
         DaemonParameters daemonParams = new DaemonParameters(layout);
         new PropertiesToDaemonParametersConverter(daemonBuildOptionFactory).convert(properties, daemonParams);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderStartParameterConverter.java
@@ -18,6 +18,7 @@ package org.gradle.tooling.internal.provider;
 import org.gradle.StartParameter;
 import org.gradle.TaskExecutionRequest;
 import org.gradle.cli.CommandLineArgumentException;
+import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.initialization.StartParameterBuildOptionFactory;
@@ -34,10 +35,12 @@ import java.util.Map;
 
 class ProviderStartParameterConverter {
 
+    private final BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory;
     private final StartParameterBuildOptionFactory startParameterBuildOptionFactory;
     private final ParallelismBuildOptionFactory parallelismBuildOptionFactory;
 
-    public ProviderStartParameterConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public ProviderStartParameterConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        this.buildLayoutParametersBuildOptionFactory = buildLayoutParametersBuildOptionFactory;
         this.startParameterBuildOptionFactory = startParameterBuildOptionFactory;
         this.parallelismBuildOptionFactory = parallelismBuildOptionFactory;
     }
@@ -82,7 +85,7 @@ class ProviderStartParameterConverter {
 
         List<String> arguments = parameters.getArguments();
         if (arguments != null) {
-            DefaultCommandLineConverter converter = new DefaultCommandLineConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory);
+            DefaultCommandLineConverter converter = new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory);
             try {
                 converter.convert(arguments, startParameter);
             } catch (CommandLineArgumentException e) {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderStartParameterConverter.java
@@ -19,6 +19,7 @@ import org.gradle.StartParameter;
 import org.gradle.TaskExecutionRequest;
 import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.initialization.DefaultCommandLineConverter;
+import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.launcher.cli.converter.PropertiesToStartParameterConverter;
 import org.gradle.tooling.internal.protocol.InternalLaunchable;
@@ -31,6 +32,12 @@ import java.util.List;
 import java.util.Map;
 
 class ProviderStartParameterConverter {
+
+    private final ParallelismBuildOptionFactory parallelismBuildOptionFactory;
+
+    public ProviderStartParameterConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        this.parallelismBuildOptionFactory = parallelismBuildOptionFactory;
+    }
 
     private List<TaskExecutionRequest> unpack(final List<InternalLaunchable> launchables, File projectDir) {
         // Important that the launchables are unpacked on the client side, to avoid sending back any additional internal state that
@@ -68,11 +75,11 @@ class ProviderStartParameterConverter {
             startParameter.setTaskNames(parameters.getTasks());
         }
 
-        new PropertiesToStartParameterConverter().convert(properties, startParameter);
+        new PropertiesToStartParameterConverter(parallelismBuildOptionFactory).convert(properties, startParameter);
 
         List<String> arguments = parameters.getArguments();
         if (arguments != null) {
-            DefaultCommandLineConverter converter = new DefaultCommandLineConverter();
+            DefaultCommandLineConverter converter = new DefaultCommandLineConverter(parallelismBuildOptionFactory);
             try {
                 converter.convert(arguments, startParameter);
             } catch (CommandLineArgumentException e) {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderStartParameterConverter.java
@@ -23,6 +23,7 @@ import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
 import org.gradle.initialization.StartParameterBuildOptionFactory;
 import org.gradle.internal.DefaultTaskExecutionRequest;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 import org.gradle.launcher.cli.converter.PropertiesToStartParameterConverter;
 import org.gradle.tooling.internal.protocol.InternalLaunchable;
 import org.gradle.tooling.internal.protocol.exceptions.InternalUnsupportedBuildArgumentException;
@@ -38,11 +39,13 @@ class ProviderStartParameterConverter {
     private final BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory;
     private final StartParameterBuildOptionFactory startParameterBuildOptionFactory;
     private final ParallelismBuildOptionFactory parallelismBuildOptionFactory;
+    private final LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory;
 
-    public ProviderStartParameterConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public ProviderStartParameterConverter(BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory, StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory, LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
         this.buildLayoutParametersBuildOptionFactory = buildLayoutParametersBuildOptionFactory;
         this.startParameterBuildOptionFactory = startParameterBuildOptionFactory;
         this.parallelismBuildOptionFactory = parallelismBuildOptionFactory;
+        this.loggingConfigurationBuildOptionFactory = loggingConfigurationBuildOptionFactory;
     }
 
     private List<TaskExecutionRequest> unpack(final List<InternalLaunchable> launchables, File projectDir) {
@@ -81,11 +84,11 @@ class ProviderStartParameterConverter {
             startParameter.setTaskNames(parameters.getTasks());
         }
 
-        new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).convert(properties, startParameter);
+        new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory).convert(properties, startParameter);
 
         List<String> arguments = parameters.getArguments();
         if (arguments != null) {
-            DefaultCommandLineConverter converter = new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory);
+            DefaultCommandLineConverter converter = new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory);
             try {
                 converter.convert(arguments, startParameter);
             } catch (CommandLineArgumentException e) {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderStartParameterConverter.java
@@ -20,6 +20,7 @@ import org.gradle.TaskExecutionRequest;
 import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.ParallelismBuildOptionFactory;
+import org.gradle.initialization.StartParameterBuildOptionFactory;
 import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.launcher.cli.converter.PropertiesToStartParameterConverter;
 import org.gradle.tooling.internal.protocol.InternalLaunchable;
@@ -33,9 +34,11 @@ import java.util.Map;
 
 class ProviderStartParameterConverter {
 
+    private final StartParameterBuildOptionFactory startParameterBuildOptionFactory;
     private final ParallelismBuildOptionFactory parallelismBuildOptionFactory;
 
-    public ProviderStartParameterConverter(ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+    public ProviderStartParameterConverter(StartParameterBuildOptionFactory startParameterBuildOptionFactory, ParallelismBuildOptionFactory parallelismBuildOptionFactory) {
+        this.startParameterBuildOptionFactory = startParameterBuildOptionFactory;
         this.parallelismBuildOptionFactory = parallelismBuildOptionFactory;
     }
 
@@ -75,11 +78,11 @@ class ProviderStartParameterConverter {
             startParameter.setTaskNames(parameters.getTasks());
         }
 
-        new PropertiesToStartParameterConverter(parallelismBuildOptionFactory).convert(properties, startParameter);
+        new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory).convert(properties, startParameter);
 
         List<String> arguments = parameters.getArguments();
         if (arguments != null) {
-            DefaultCommandLineConverter converter = new DefaultCommandLineConverter(parallelismBuildOptionFactory);
+            DefaultCommandLineConverter converter = new DefaultCommandLineConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory);
             try {
                 converter.convert(arguments, startParameter);
             } catch (CommandLineArgumentException e) {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixIn.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixIn.java
@@ -17,24 +17,27 @@
 package org.gradle.tooling.internal.provider.connection;
 
 import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.internal.logging.DefaultLoggingConfiguration;
-import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.internal.logging.LoggingCommandLineConverter;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 
 import java.util.Collections;
 import java.util.List;
 
 public class BuildLogLevelMixIn {
     private final ProviderOperationParameters parameters;
+    private final LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory;
 
-    public BuildLogLevelMixIn(ProviderOperationParameters parameters) {
+    public BuildLogLevelMixIn(ProviderOperationParameters parameters, LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
         this.parameters = parameters;
+        this.loggingConfigurationBuildOptionFactory = loggingConfigurationBuildOptionFactory;
     }
 
     public LogLevel getBuildLogLevel() {
-        LoggingCommandLineConverter converter = new LoggingCommandLineConverter();
+        LoggingCommandLineConverter converter = new LoggingCommandLineConverter(loggingConfigurationBuildOptionFactory);
         CommandLineParser parser = new CommandLineParser().allowUnknownOptions().allowMixedSubcommandsAndOptions();
         converter.configure(parser);
         List<String> arguments = parameters.getArguments();

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixIn.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixIn.java
@@ -29,15 +29,13 @@ import java.util.List;
 
 public class BuildLogLevelMixIn {
     private final ProviderOperationParameters parameters;
-    private final LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory;
 
-    public BuildLogLevelMixIn(ProviderOperationParameters parameters, LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
+    public BuildLogLevelMixIn(ProviderOperationParameters parameters) {
         this.parameters = parameters;
-        this.loggingConfigurationBuildOptionFactory = loggingConfigurationBuildOptionFactory;
     }
 
     public LogLevel getBuildLogLevel() {
-        LoggingCommandLineConverter converter = new LoggingCommandLineConverter(loggingConfigurationBuildOptionFactory);
+        LoggingCommandLineConverter converter = new LoggingCommandLineConverter(new LoggingConfigurationBuildOptionFactory());
         CommandLineParser parser = new CommandLineParser().allowUnknownOptions().allowMixedSubcommandsAndOptions();
         converter.configure(parser);
         List<String> arguments = parameters.getArguments();

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.internal.Factory
 import org.gradle.internal.invocation.BuildActionRunner
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.jvm.inspection.JvmVersionDetector
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
@@ -61,13 +62,14 @@ class BuildActionsFactoryTest extends Specification {
     StartParameterBuildOptionFactory startParameterBuildOptionFactory = new StartParameterBuildOptionFactory()
     ParallelismBuildOptionFactory parallelismBuildOptionFactory = new ParallelismBuildOptionFactory()
     DaemonBuildOptionFactory daemonBuildOptionFactory = new DaemonBuildOptionFactory()
+    LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory = new LoggingConfigurationBuildOptionFactory()
     PropertiesToDaemonParametersConverter propertiesToDaemonParametersConverter = Stub()
-    PropertiesToStartParameterConverter propertiesToStartParameterConverter = new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory)
+    PropertiesToStartParameterConverter propertiesToStartParameterConverter = new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory)
     JvmVersionDetector jvmVersionDetector = Stub()
     ParametersConverter parametersConverter = new ParametersConverter(
             Stub(LayoutCommandLineConverter), Stub(SystemPropertiesCommandLineConverter),
             Stub(LayoutToPropertiesConverter), propertiesToStartParameterConverter,
-            new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory), new DaemonCommandLineConverter(daemonBuildOptionFactory),
+            new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory, loggingConfigurationBuildOptionFactory), new DaemonCommandLineConverter(daemonBuildOptionFactory),
             propertiesToDaemonParametersConverter)
 
     BuildActionsFactory factory = new BuildActionsFactory(loggingServices, parametersConverter, jvmVersionDetector)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.cli.CommandLineParser
 import org.gradle.cli.SystemPropertiesCommandLineConverter
 import org.gradle.initialization.DefaultCommandLineConverter
 import org.gradle.initialization.LayoutCommandLineConverter
+import org.gradle.initialization.ParallelismBuildOptionFactory
+import org.gradle.initialization.StartParameterBuildOptionFactory
 import org.gradle.internal.Factory
 import org.gradle.internal.invocation.BuildActionRunner
 import org.gradle.internal.jvm.Jvm
@@ -53,13 +55,15 @@ class BuildActionsFactoryTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
     ServiceRegistry loggingServices = Mock()
+    StartParameterBuildOptionFactory startParameterBuildOptionFactory = new StartParameterBuildOptionFactory()
+    ParallelismBuildOptionFactory parallelismBuildOptionFactory = new ParallelismBuildOptionFactory()
     PropertiesToDaemonParametersConverter propertiesToDaemonParametersConverter = Stub()
-    PropertiesToStartParameterConverter propertiesToStartParameterConverter = Stub()
+    PropertiesToStartParameterConverter propertiesToStartParameterConverter = new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory)
     JvmVersionDetector jvmVersionDetector = Stub()
     ParametersConverter parametersConverter = new ParametersConverter(
             Stub(LayoutCommandLineConverter), Stub(SystemPropertiesCommandLineConverter),
             Stub(LayoutToPropertiesConverter), propertiesToStartParameterConverter,
-            new DefaultCommandLineConverter(), new DaemonCommandLineConverter(),
+            new DefaultCommandLineConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory), new DaemonCommandLineConverter(),
             propertiesToDaemonParametersConverter)
 
     BuildActionsFactory factory = new BuildActionsFactory(loggingServices, parametersConverter, jvmVersionDetector)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.launcher.cli
 import org.gradle.StartParameter
 import org.gradle.cli.CommandLineParser
 import org.gradle.cli.SystemPropertiesCommandLineConverter
+import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory
 import org.gradle.initialization.DefaultCommandLineConverter
 import org.gradle.initialization.LayoutCommandLineConverter
 import org.gradle.initialization.ParallelismBuildOptionFactory
@@ -55,6 +56,7 @@ class BuildActionsFactoryTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
     ServiceRegistry loggingServices = Mock()
+    BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = new BuildLayoutParametersBuildOptionFactory()
     StartParameterBuildOptionFactory startParameterBuildOptionFactory = new StartParameterBuildOptionFactory()
     ParallelismBuildOptionFactory parallelismBuildOptionFactory = new ParallelismBuildOptionFactory()
     PropertiesToDaemonParametersConverter propertiesToDaemonParametersConverter = Stub()
@@ -63,7 +65,7 @@ class BuildActionsFactoryTest extends Specification {
     ParametersConverter parametersConverter = new ParametersConverter(
             Stub(LayoutCommandLineConverter), Stub(SystemPropertiesCommandLineConverter),
             Stub(LayoutToPropertiesConverter), propertiesToStartParameterConverter,
-            new DefaultCommandLineConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory), new DaemonCommandLineConverter(),
+            new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory), new DaemonCommandLineConverter(),
             propertiesToDaemonParametersConverter)
 
     BuildActionsFactory factory = new BuildActionsFactory(loggingServices, parametersConverter, jvmVersionDetector)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -41,6 +41,7 @@ import org.gradle.launcher.cli.converter.PropertiesToStartParameterConverter
 import org.gradle.launcher.daemon.bootstrap.ForegroundDaemonAction
 import org.gradle.launcher.daemon.client.DaemonClient
 import org.gradle.launcher.daemon.client.SingleUseDaemonClient
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory
 import org.gradle.launcher.daemon.configuration.DaemonParameters
 import org.gradle.launcher.exec.InProcessBuildActionExecuter
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -59,13 +60,14 @@ class BuildActionsFactoryTest extends Specification {
     BuildLayoutParametersBuildOptionFactory buildLayoutParametersBuildOptionFactory = new BuildLayoutParametersBuildOptionFactory()
     StartParameterBuildOptionFactory startParameterBuildOptionFactory = new StartParameterBuildOptionFactory()
     ParallelismBuildOptionFactory parallelismBuildOptionFactory = new ParallelismBuildOptionFactory()
+    DaemonBuildOptionFactory daemonBuildOptionFactory = new DaemonBuildOptionFactory()
     PropertiesToDaemonParametersConverter propertiesToDaemonParametersConverter = Stub()
     PropertiesToStartParameterConverter propertiesToStartParameterConverter = new PropertiesToStartParameterConverter(startParameterBuildOptionFactory, parallelismBuildOptionFactory)
     JvmVersionDetector jvmVersionDetector = Stub()
     ParametersConverter parametersConverter = new ParametersConverter(
             Stub(LayoutCommandLineConverter), Stub(SystemPropertiesCommandLineConverter),
             Stub(LayoutToPropertiesConverter), propertiesToStartParameterConverter,
-            new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory), new DaemonCommandLineConverter(),
+            new DefaultCommandLineConverter(buildLayoutParametersBuildOptionFactory, startParameterBuildOptionFactory, parallelismBuildOptionFactory), new DaemonCommandLineConverter(daemonBuildOptionFactory),
             propertiesToDaemonParametersConverter)
 
     BuildActionsFactory factory = new BuildActionsFactory(loggingServices, parametersConverter, jvmVersionDetector)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/DaemonCommandLineConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/DaemonCommandLineConverterTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.launcher.cli.converter
 
 import org.gradle.cli.CommandLineParser
 import org.gradle.initialization.BuildLayoutParameters
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory
 import org.gradle.launcher.daemon.configuration.DaemonParameters
 import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
@@ -89,7 +90,7 @@ class DaemonCommandLineConverterTest extends Specification {
 
     private DaemonParameters convert(Iterable args) {
         CommandLineParser parser = new CommandLineParser()
-        def converter = new DaemonCommandLineConverter()
+        def converter = new DaemonCommandLineConverter(new DaemonBuildOptionFactory())
         converter.configure(parser)
         converter.convert(args, new DaemonParameters(new BuildLayoutParameters()))
     }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.initialization.BuildLayoutParameters
 import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory
 import org.gradle.initialization.ParallelismBuildOptionFactory
 import org.gradle.initialization.StartParameterBuildOptionFactory
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.SetSystemProperties
@@ -31,7 +32,7 @@ class LayoutToPropertiesConverterTest extends Specification {
 
     @Rule SetSystemProperties sysProperties = new SetSystemProperties()
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
-    @Subject def converter = new LayoutToPropertiesConverter(new BuildLayoutParametersBuildOptionFactory(), new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory(), new DaemonBuildOptionFactory())
+    @Subject def converter = new LayoutToPropertiesConverter(new BuildLayoutParametersBuildOptionFactory(), new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory(), new DaemonBuildOptionFactory(), new LoggingConfigurationBuildOptionFactory())
     BuildLayoutParameters layout
     Map<String, String> props = new HashMap<String, String>()
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -17,17 +17,19 @@
 package org.gradle.launcher.cli.converter
 
 import org.gradle.initialization.BuildLayoutParameters
+import org.gradle.initialization.ParallelismBuildOptionFactory
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 import spock.lang.Specification
+import spock.lang.Subject
 
 class LayoutToPropertiesConverterTest extends Specification {
 
     @Rule SetSystemProperties sysProperties = new SetSystemProperties()
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
-    def converter = new LayoutToPropertiesConverter()
+    @Subject def converter = new LayoutToPropertiesConverter(new ParallelismBuildOptionFactory())
     BuildLayoutParameters layout
     Map<String, String> props = new HashMap<String, String>()
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.launcher.cli.converter
 
 import org.gradle.initialization.BuildLayoutParameters
+import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory
 import org.gradle.initialization.ParallelismBuildOptionFactory
 import org.gradle.initialization.StartParameterBuildOptionFactory
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory
@@ -30,7 +31,7 @@ class LayoutToPropertiesConverterTest extends Specification {
 
     @Rule SetSystemProperties sysProperties = new SetSystemProperties()
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
-    @Subject def converter = new LayoutToPropertiesConverter(new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory(), new DaemonBuildOptionFactory())
+    @Subject def converter = new LayoutToPropertiesConverter(new BuildLayoutParametersBuildOptionFactory(), new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory(), new DaemonBuildOptionFactory())
     BuildLayoutParameters layout
     Map<String, String> props = new HashMap<String, String>()
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.launcher.cli.converter
 
 import org.gradle.initialization.BuildLayoutParameters
 import org.gradle.initialization.ParallelismBuildOptionFactory
+import org.gradle.initialization.StartParameterBuildOptionFactory
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.SetSystemProperties
@@ -29,7 +30,7 @@ class LayoutToPropertiesConverterTest extends Specification {
 
     @Rule SetSystemProperties sysProperties = new SetSystemProperties()
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
-    @Subject def converter = new LayoutToPropertiesConverter(new ParallelismBuildOptionFactory())
+    @Subject def converter = new LayoutToPropertiesConverter(new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory(), new DaemonBuildOptionFactory())
     BuildLayoutParameters layout
     Map<String, String> props = new HashMap<String, String>()
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
@@ -32,7 +32,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
 
-    def converter = new PropertiesToDaemonParametersConverter()
+    def converter = new PropertiesToDaemonParametersConverter(new DaemonBuildOptionFactory())
     def params = new DaemonParameters(new BuildLayoutParameters())
 
     def "allows whitespace around boolean properties"() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
@@ -22,11 +22,12 @@ import org.gradle.initialization.ParallelismBuildOptionFactory
 import org.gradle.initialization.StartParameterBuildOptionFactory
 import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.lang.Unroll
 
 class PropertiesToStartParameterConverterTest extends Specification {
 
-    def converter = new PropertiesToStartParameterConverter()
+    @Subject def converter = new PropertiesToStartParameterConverter(new ParallelismBuildOptionFactory())
 
     def "converts"() {
         expect:

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Unroll
 
 class PropertiesToStartParameterConverterTest extends Specification {
 
-    @Subject def converter = new PropertiesToStartParameterConverter(new ParallelismBuildOptionFactory())
+    @Subject def converter = new PropertiesToStartParameterConverter(new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory())
 
     def "converts"() {
         expect:

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Unroll
 
 class PropertiesToStartParameterConverterTest extends Specification {
 
-    @Subject def converter = new PropertiesToStartParameterConverter(new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory())
+    @Subject def converter = new PropertiesToStartParameterConverter(new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory(), new LoggingConfigurationBuildOptionFactory())
 
     def "converts"() {
         expect:

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
@@ -16,22 +16,25 @@
 package org.gradle.tooling.internal.provider
 
 import org.gradle.TaskExecutionRequest
+import org.gradle.initialization.ParallelismBuildOptionFactory
 import org.gradle.initialization.StartParameterBuildOptionFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.tooling.internal.protocol.InternalLaunchable
 import org.gradle.tooling.internal.provider.connection.ProviderOperationParameters
 import org.junit.Rule
 import spock.lang.Specification
+import spock.lang.Subject
 
 class ProviderStartParameterConverterTest extends Specification {
     @Rule TestNameTestDirectoryProvider temp
     def params = Stub(ProviderOperationParameters)
+    @Subject def providerStartParameterConverter = new ProviderStartParameterConverter(new ParallelismBuildOptionFactory())
 
     def "allows configuring the start parameter with build arguments"() {
         params.getArguments() >> ['-PextraProperty=foo', '-m']
 
         when:
-        def start = new ProviderStartParameterConverter().toStartParameter(params, [:])
+        def start = providerStartParameterConverter.toStartParameter(params, [:])
 
         then:
         start.projectProperties['extraProperty'] == 'foo'
@@ -45,7 +48,7 @@ class ProviderStartParameterConverterTest extends Specification {
         params.getArguments() >> ['-p', 'otherDir']
 
         when:
-        def start = new ProviderStartParameterConverter().toStartParameter(params, [:])
+        def start = providerStartParameterConverter.toStartParameter(params, [:])
 
         then:
         start.projectDir == new File(projectDir, "otherDir")
@@ -60,7 +63,7 @@ class ProviderStartParameterConverterTest extends Specification {
         params.getArguments() >> ['-g', 'otherDir']
 
         when:
-        def start = new ProviderStartParameterConverter().toStartParameter(params, [:])
+        def start = providerStartParameterConverter.toStartParameter(params, [:])
 
         then:
         start.gradleUserHomeDir == new File(projectDir, "otherDir")
@@ -71,7 +74,7 @@ class ProviderStartParameterConverterTest extends Specification {
         params.getArguments() >> ['-u']
 
         when:
-        def start = new ProviderStartParameterConverter().toStartParameter(params, [:])
+        def start = providerStartParameterConverter.toStartParameter(params, [:])
 
         then:
         !start.searchUpwards
@@ -83,7 +86,7 @@ class ProviderStartParameterConverterTest extends Specification {
         params.isSearchUpwards() >> true
 
         when:
-        def start = new ProviderStartParameterConverter().toStartParameter(params, [:])
+        def start = providerStartParameterConverter.toStartParameter(params, [:])
 
         then:
         start.searchUpwards
@@ -95,7 +98,7 @@ class ProviderStartParameterConverterTest extends Specification {
             (StartParameterBuildOptionFactory.ConfigureOnDemandOption.GRADLE_PROPERTY): "true",
         ]
 
-        def start = new ProviderStartParameterConverter().toStartParameter(params, properties)
+        def start = providerStartParameterConverter.toStartParameter(params, properties)
 
         then:
         start.configureOnDemand
@@ -112,7 +115,7 @@ class ProviderStartParameterConverterTest extends Specification {
         params.getLaunchables(_) >> [selector]
 
         when:
-        def start = new ProviderStartParameterConverter().toStartParameter(params, [:])
+        def start = providerStartParameterConverter.toStartParameter(params, [:])
 
         then:
         start.taskRequests.size() == 1

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.tooling.internal.provider
 
 import org.gradle.TaskExecutionRequest
+import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory
 import org.gradle.initialization.ParallelismBuildOptionFactory
 import org.gradle.initialization.StartParameterBuildOptionFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -28,7 +29,7 @@ import spock.lang.Subject
 class ProviderStartParameterConverterTest extends Specification {
     @Rule TestNameTestDirectoryProvider temp
     def params = Stub(ProviderOperationParameters)
-    @Subject def providerStartParameterConverter = new ProviderStartParameterConverter(new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory())
+    @Subject def providerStartParameterConverter = new ProviderStartParameterConverter(new BuildLayoutParametersBuildOptionFactory(), new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory())
 
     def "allows configuring the start parameter with build arguments"() {
         params.getArguments() >> ['-PextraProperty=foo', '-m']

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.TaskExecutionRequest
 import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory
 import org.gradle.initialization.ParallelismBuildOptionFactory
 import org.gradle.initialization.StartParameterBuildOptionFactory
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.tooling.internal.protocol.InternalLaunchable
 import org.gradle.tooling.internal.provider.connection.ProviderOperationParameters
@@ -29,7 +30,7 @@ import spock.lang.Subject
 class ProviderStartParameterConverterTest extends Specification {
     @Rule TestNameTestDirectoryProvider temp
     def params = Stub(ProviderOperationParameters)
-    @Subject def providerStartParameterConverter = new ProviderStartParameterConverter(new BuildLayoutParametersBuildOptionFactory(), new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory())
+    @Subject def providerStartParameterConverter = new ProviderStartParameterConverter(new BuildLayoutParametersBuildOptionFactory(), new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory(), new LoggingConfigurationBuildOptionFactory())
 
     def "allows configuring the start parameter with build arguments"() {
         params.getArguments() >> ['-PextraProperty=foo', '-m']

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Subject
 class ProviderStartParameterConverterTest extends Specification {
     @Rule TestNameTestDirectoryProvider temp
     def params = Stub(ProviderOperationParameters)
-    @Subject def providerStartParameterConverter = new ProviderStartParameterConverter(new ParallelismBuildOptionFactory())
+    @Subject def providerStartParameterConverter = new ProviderStartParameterConverter(new StartParameterBuildOptionFactory(), new ParallelismBuildOptionFactory())
 
     def "allows configuring the start parameter with build arguments"() {
         params.getArguments() >> ['-PextraProperty=foo', '-m']

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
@@ -17,13 +17,12 @@
 package org.gradle.tooling.internal.provider.connection
 
 import org.gradle.api.logging.LogLevel
-import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory
 import spock.lang.Specification
 
 class BuildLogLevelMixInTest extends Specification {
 
     final parameters = Mock(ProviderOperationParameters)
-    final mixin = new BuildLogLevelMixIn(parameters, new LoggingConfigurationBuildOptionFactory())
+    final mixin = new BuildLogLevelMixIn(parameters)
 
     def "knows build log level for mixed set of arguments"() {
         when:

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
@@ -17,12 +17,13 @@
 package org.gradle.tooling.internal.provider.connection
 
 import org.gradle.api.logging.LogLevel
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory
 import spock.lang.Specification
 
 class BuildLogLevelMixInTest extends Specification {
 
     final parameters = Mock(ProviderOperationParameters)
-    final mixin = new BuildLogLevelMixIn(parameters)
+    final mixin = new BuildLogLevelMixIn(parameters, new LoggingConfigurationBuildOptionFactory())
 
     def "knows build log level for mixed set of arguments"() {
         when:

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
@@ -32,14 +32,15 @@ import java.util.List;
 import java.util.Set;
 
 public class LoggingCommandLineConverter extends AbstractCommandLineConverter<LoggingConfiguration> {
-    private final List<BuildOption<LoggingConfiguration>> buildOptions = new LoggingConfigurationBuildOptionFactory().create();
+    private final List<BuildOption<LoggingConfiguration>> buildOptions;
     public static final String DEBUG = LoggingConfigurationBuildOptionFactory.LogLevelOption.DEBUG_SHORT_OPTION;
     public static final String WARN = LoggingConfigurationBuildOptionFactory.LogLevelOption.WARN_SHORT_OPTION;
     public static final String INFO = LoggingConfigurationBuildOptionFactory.LogLevelOption.INFO_SHORT_OPTION;
     public static final String QUIET = LoggingConfigurationBuildOptionFactory.LogLevelOption.QUIET_SHORT_OPTION;
     private final BiMap<String, LogLevel> logLevelMap = HashBiMap.create();
 
-    public LoggingCommandLineConverter() {
+    public LoggingCommandLineConverter(LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
+        buildOptions = loggingConfigurationBuildOptionFactory.create();
         logLevelMap.put(QUIET, LogLevel.QUIET);
         logLevelMap.put(WARN, LogLevel.WARN);
         logLevelMap.put(INFO, LogLevel.INFO);

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
@@ -106,8 +106,8 @@ public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
         return new NestedLogging();
     }
 
-    protected CommandLineConverter<LoggingConfiguration> createCommandLineConverter(LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
-        return new LoggingCommandLineConverter(loggingConfigurationBuildOptionFactory);
+    protected CommandLineConverter<LoggingConfiguration> createCommandLineConverter() {
+        return new LoggingCommandLineConverter(new LoggingConfigurationBuildOptionFactory());
     }
 
     protected Clock createTimeProvider() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
@@ -20,6 +20,7 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.cli.CommandLineConverter;
 import org.gradle.internal.logging.LoggingCommandLineConverter;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.config.LoggingSourceSystem;
 import org.gradle.internal.logging.config.LoggingSystemAdapter;
@@ -105,8 +106,8 @@ public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
         return new NestedLogging();
     }
 
-    protected CommandLineConverter<LoggingConfiguration> createCommandLineConverter() {
-        return new LoggingCommandLineConverter();
+    protected CommandLineConverter<LoggingConfiguration> createCommandLineConverter(LoggingConfigurationBuildOptionFactory loggingConfigurationBuildOptionFactory) {
+        return new LoggingCommandLineConverter(loggingConfigurationBuildOptionFactory);
     }
 
     protected Clock createTimeProvider() {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.cli.CommandLineArgumentException
 import spock.lang.Specification
 
 class LoggingCommandLineConverterTest extends Specification {
-    final LoggingCommandLineConverter converter = new LoggingCommandLineConverter()
+    final LoggingCommandLineConverter converter = new LoggingCommandLineConverter(new LoggingConfigurationBuildOptionFactory())
     final LoggingConfiguration expectedConfig = new DefaultLoggingConfiguration()
 
     def convertsEmptyArgs() {


### PR DESCRIPTION
### Context

Creates build option factories in service to passes it along to where it is needed. Reduces the overhead of having to create the same build options in multiple places. Aims to minimize the impact on performance.

Had some trouble with creating a central `LoggingConfigurationBuildOptionFactory` instance. Got some weird errors when running integration tests but didn't track them down yet.

Branch build: https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger&branch_Gradle_Check=bm%2Fcentralized-build-option-factory&tab=buildTypeStatusDiv
