### PR TITLE
Add support for configurable start script directory

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.jvm.application.tasks.CreateStartScripts.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.jvm.application.tasks.CreateStartScripts.xml
@@ -10,6 +10,7 @@
             <tr><td>classpath</td></tr>
             <tr><td>defaultJvmOpts</td></tr>
             <tr><td>outputDir</td></tr>
+            <tr><td>executableDir</td></tr>
             <tr><td>optsEnvironmentVar</td></tr>
             <tr><td>unixStartScriptGenerator</td></tr>
             <tr><td>windowsStartScriptGenerator</td></tr>

--- a/subprojects/docs/src/docs/userguide/applicationPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/applicationPlugin.adoc
@@ -51,6 +51,14 @@ If your application requires a specific set of JVM settings or system properties
         </sample>
 ++++
 
+If your application's start scripts should be in a different directory than `bin`, you can configure the `executableDir` property.
+
+++++
+<sample id="configureApplicationDefaultJvmArgs" dir="application" title="Configure custom directory for start scripts">
+            <sourcefile file="build.gradle" snippet="executableDir-conf"/>
+        </sample>
+++++
+
 
 [[sec:the_distribution]]
 ==== The distribution

--- a/subprojects/docs/src/samples/application/build.gradle
+++ b/subprojects/docs/src/samples/application/build.gradle
@@ -13,6 +13,10 @@ mainClassName = "org.gradle.sample.Main"
 applicationDefaultJvmArgs = ["-Dgreeting.language=en"]
 // END SNIPPET application-defaultjvmargs
 
+// START SNIPPET executableDir-conf
+executableDir = "custom_bin_dir"
+// END SNIPPET executableDir-conf
+
 // START SNIPPET distribution-spec
 task createDocs {
     def docs = file("$buildDir/docs")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesApplicationIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesApplicationIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.ScriptExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Rule
+import spock.lang.Unroll
 
 class SamplesApplicationIntegrationTest extends AbstractIntegrationSpec {
 
@@ -33,19 +34,26 @@ class SamplesApplicationIntegrationTest extends AbstractIntegrationSpec {
         result.output.contains('Greetings from the sample application.')
     }
 
+    @Unroll
     def canBuildAndRunTheInstalledApplication() {
         when:
+        appendExecutableDir(executableDir)
         executer.inDirectory(sample.dir).withTasks('installDist').run()
 
         then:
         def installDir = sample.dir.file('build/install/application')
         installDir.assertIsDir()
 
-        checkApplicationImage(installDir)
+        checkApplicationImage(installDir, executableDir)
+
+        where:
+        executableDir << ['bin', 'customBin']
     }
 
+    @Unroll
     def canBuildAndRunTheZippedDistribution() {
         when:
+        appendExecutableDir(executableDir)
         executer.inDirectory(sample.dir).withTasks('distZip').run()
 
         then:
@@ -55,12 +63,21 @@ class SamplesApplicationIntegrationTest extends AbstractIntegrationSpec {
         def installDir = sample.dir.file('unzip')
         distFile.usingNativeTools().unzipTo(installDir)
 
-        checkApplicationImage(installDir.file('application-1.0.2'))
+        checkApplicationImage(installDir.file('application-1.0.2'), executableDir)
+
+        where:
+        executableDir << ['bin', 'customBin']
     }
 
-    private void checkApplicationImage(TestFile installDir) {
-        installDir.file('bin/application').assertIsFile()
-        installDir.file('bin/application.bat').assertIsFile()
+    private void appendExecutableDir(String executableDir) {
+        sample.dir.file('build.gradle') << """
+executableDir = '${executableDir}' 
+"""
+    }
+
+    private void checkApplicationImage(TestFile installDir, String executableDir) {
+        installDir.file("${executableDir}/application").assertIsFile()
+        installDir.file("${executableDir}/application.bat").assertIsFile()
         installDir.file('lib/application-1.0.2.jar').assertIsFile()
         installDir.file('lib/commons-collections-3.2.2.jar').assertIsFile()
 
@@ -68,7 +85,7 @@ class SamplesApplicationIntegrationTest extends AbstractIntegrationSpec {
         installDir.file('docs/readme.txt').assertIsFile()
 
         def builder = new ScriptExecuter()
-        builder.workingDir installDir.file('bin')
+        builder.workingDir installDir.file(executableDir)
         builder.executable 'application'
         builder.standardOutput = new ByteArrayOutputStream()
         builder.errorOutput = new ByteArrayOutputStream()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -258,6 +258,32 @@ dependencies {
         file('build/install/sample/lib').allDescendants() == ['sample.jar', 'compile-1.0.jar'] as Set
     }
 
+    def "executables can be placed at the root of the distribution"() {
+        given:
+        buildFile << """
+executableDir = ''
+"""
+        when:
+        run "installDist"
+
+        then:
+        file('build/install/sample/sample').exists()
+        file('build/install/sample/sample.bat').exists()
+    }
+
+    def "executables can be placed in a custom directory"() {
+        given:
+        buildFile << """
+executableDir = 'foo/bar'
+"""
+        when:
+        run "installDist"
+
+        then:
+        file('build/install/sample/foo/bar/sample').exists()
+        file('build/install/sample/foo/bar/sample.bat').exists()
+    }
+
     def "includes transitive implementation dependencies in distribution"() {
         mavenRepo.module('org.gradle.test', 'implementation', '1.0').publish()
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.plugins;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.file.CopySpec;
 
@@ -28,6 +29,7 @@ public class ApplicationPluginConvention {
     private String applicationName;
     private String mainClassName;
     private Iterable<String> applicationDefaultJvmArgs = new ArrayList<String>();
+    private String executableDir = "bin";
     private CopySpec applicationDistribution;
 
     private final Project project;
@@ -77,6 +79,24 @@ public class ApplicationPluginConvention {
      */
     public void setApplicationDefaultJvmArgs(Iterable<String> applicationDefaultJvmArgs) {
         this.applicationDefaultJvmArgs = applicationDefaultJvmArgs;
+    }
+
+    /**
+     * Directory to place executables in
+     * @since 4.5
+     */
+    @Incubating
+    public String getExecutableDir() {
+        return executableDir;
+    }
+
+    /**
+     * Directory to place executables in
+     * @since 4.5
+     */
+    @Incubating
+    public void setExecutableDir(String executableDir) {
+        this.executableDir = executableDir;
     }
 
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -84,6 +84,7 @@ import java.io.File;
  * <li>{@code optsEnvironmentVar}</li>
  * <li>{@code exitEnvironmentVar}</li>
  * <li>{@code mainClassName}</li>
+ * <li>{@code executableDir}</li>
  * <li>{@code defaultJvmOpts}</li>
  * <li>{@code appNameSystemProperty}</li>
  * <li>{@code appHomeRelativePath}</li>
@@ -101,6 +102,7 @@ import java.io.File;
 public class CreateStartScripts extends ConventionTask {
 
     private File outputDir;
+    private String executableDir = "bin";
     private String mainClassName;
     private Iterable<String> defaultJvmOpts = Lists.newLinkedList();
     private String applicationName;
@@ -170,6 +172,25 @@ public class CreateStartScripts extends ConventionTask {
 
     public void setOutputDir(File outputDir) {
         this.outputDir = outputDir;
+    }
+
+    /**
+     * The directory to write the scripts into in the distribution.
+     * @since 4.5
+     */
+    @Incubating
+    @Input
+    public String getExecutableDir() {
+        return executableDir;
+    }
+
+    /**
+     * The directory to write the scripts into in the distribution.
+     * @since 4.5
+     */
+    @Incubating
+    public void setExecutableDir(String executableDir) {
+        this.executableDir = executableDir;
     }
 
     /**
@@ -268,7 +289,7 @@ public class CreateStartScripts extends ConventionTask {
         generator.setOptsEnvironmentVar(getOptsEnvironmentVar());
         generator.setExitEnvironmentVar(getExitEnvironmentVar());
         generator.setClasspath(getRelativeClasspath());
-        generator.setScriptRelPath("bin/" + getUnixScript().getName());
+        generator.setScriptRelPath(getExecutableDir() + "/" + getUnixScript().getName());
         generator.generateUnixScript(getUnixScript());
         generator.generateWindowsScript(getWindowsScript());
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
@@ -100,6 +100,17 @@ class ApplicationPluginTest extends AbstractProjectBuilderSpec {
         distZipTask.archiveName == "SuperApp.zip"
     }
 
+    public void "executableDir is configurable"() {
+        when:
+        plugin.apply(project)
+        project.applicationName = "myApp";
+        project.executableDir = "custom_bin";
+
+        then:
+        def startScripts = project.tasks[ApplicationPlugin.TASK_START_SCRIPTS_NAME]
+        startScripts.executableDir == "custom_bin"
+    }
+
     public void "mainClassName in project delegates to main in run task"() {
         when:
         plugin.apply(project)


### PR DESCRIPTION
### Context
Allows more flexibility with respect to where the executables are placed when using the application plugin
#2323 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] [Link to Design Spec](https://github.com/gradle/gradle/tree/master/design-docs) for changes that affect more than 1 public API (that is, not in an `internal` package) or updates to > 20 files
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation including proper use of `@since` and `@Incubating` annotations for all public APIs
- [ ] Recognize contributor in release notes
