### PR TITLE
Ignore DescriptiveChange in ChangesOnlyIncrementalTaskInputs.outOfDate(#1224)

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1264,4 +1264,34 @@ task generate(type: TransformerTask) {
         skipped(':taskWithInputs')
     }
 
+    @Issue('https://github.com/gradle/gradle/issues/1224')
+    def 'can change input properties dynamically'() {
+        given:
+        file('inputDir1').createDir()
+        file('inputDir2').createDir()
+        buildFile << '''
+    class MyTask extends DefaultTask{
+        @TaskAction
+        void processFiles(IncrementalTaskInputs inputs) {
+            inputs.outOfDate { }
+        }
+    }
+    
+    task myTask (type: MyTask){
+        project.ext.inputDirs.split(',').each { inputs.dir(it) }
+    }
+'''
+
+        when:
+        args('-PinputDirs=inputDir1,inputDir2')
+
+        then:
+        succeeds('myTask')
+
+        when:
+        args('-PinputDirs=inputDir1')
+
+        then:
+        succeeds('myTask')
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ChangesOnlyIncrementalTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/ChangesOnlyIncrementalTaskInputs.java
@@ -39,6 +39,9 @@ public class ChangesOnlyIncrementalTaskInputs extends StatefulIncrementalTaskInp
     @Override
     protected void doOutOfDate(final Action<? super InputFileDetails> outOfDateAction) {
         for (TaskStateChange change : inputFilesState) {
+            if (!(change instanceof InputFileDetails)) {
+                continue;
+            }
             InputFileDetails fileChange = (InputFileDetails) change;
             if (fileChange.isRemoved()) {
                 removedFiles.add(fileChange);


### PR DESCRIPTION
Fix https://github.com/gradle/gradle/issues/1224

In current InputFilesTaskStateChanges implementation, file properties
changes and file changes are not separated. This would result in that
DescriptiveChange are added into inputFileChanges and ClassCastException
in ChangesOnlyIncrementalTaskInputs.doOutOfDate (#1224).

This PR separate file changes and file properties changes, and put the
file properties changes into `inputPropertiesState`.

@lptr , looks like you're the best person to review this, could you please take a look?
