### PR TITLE
[Spike - do not merge] Spike polymorphic inputs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/InputPropertyRegistration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/InputPropertyRegistration.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks;
+
+import org.gradle.api.NonNullApi;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+@NonNullApi
+public interface InputPropertyRegistration {
+    /**
+     * Returns true if this task has declared the inputs that it consumes.
+     *
+     * @return true if this task has declared any inputs.
+     */
+    boolean getHasInputs();
+
+    /**
+     * Registers some input files for this task.
+     *
+     * @param paths The input files. The given paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
+     * @return a property builder to further configure the property.
+     */
+    TaskInputFilePropertyBuilder files(Object... paths);
+
+    /**
+     * Registers some input file for this task.
+     *
+     * @param path The input file. The given path is evaluated as per {@link org.gradle.api.Project#files(Object...)}.
+     * @return a property builder to further configure the property.
+     */
+    TaskInputFilePropertyBuilder file(Object path);
+
+    /**
+     * Registers an input directory hierarchy. All files found under the given directory are treated as input files for
+     * this task.
+     *
+     * @param dirPath The directory. The path is evaluated as per {@link org.gradle.api.Project#file(Object)}.
+     * @return a property builder to further configure the property.
+     */
+    TaskInputFilePropertyBuilder dir(Object dirPath);
+
+    /**
+     * <p>Registers an input property for this task. This value is persisted when the task executes, and is compared
+     * against the property value for later invocations of the task, to determine if the task is up-to-date.</p>
+     *
+     * <p>The given value for the property must be Serializable, so that it can be persisted. It should also provide a
+     * useful {@code equals()} method.</p>
+     *
+     * <p>You can specify a closure or {@code Callable} as the value of the property. In which case, the closure or
+     * {@code Callable} is executed to determine the actual property value.</p>
+     *
+     * @param name The name of the property. Must not be null.
+     * @param value The value for the property. Can be null.
+     */
+    @Nullable
+    TaskInputs property(String name, @Nullable Object value);
+
+    /**
+     * Registers a set of input properties for this task. See {@link #property(String, Object)} for details.
+     *
+     * @param properties The properties.
+     */
+    @Nullable
+    TaskInputs properties(Map<String, ?> properties);
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/InputPropertyRegistration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/InputPropertyRegistration.java
@@ -21,6 +21,9 @@ import org.gradle.api.NonNullApi;
 import javax.annotation.Nullable;
 import java.util.Map;
 
+/**
+ * Allows to register inputs.
+ */
 @NonNullApi
 public interface InputPropertyRegistration {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputPropertyRegistration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputPropertyRegistration.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks;
+
+import org.gradle.api.NonNullApi;
+
+import javax.annotation.Nullable;
+
+@NonNullApi
+public interface OutputPropertyRegistration {
+
+    /**
+     * Returns true if this task has declared any outputs. Note that a task may be able to produce output files and
+     * still have an empty set of output files.
+     *
+     * @return true if this task has declared any outputs, otherwise false.
+     */
+    boolean getHasOutput();
+
+    /**
+     * Registers some output files for this task.
+     *
+     * <p>When the given {@code paths} is a {@link java.util.Map}, then each output file
+     * will be associated with an identity. For cacheable tasks this is a requirement.
+     * The keys of the map must be <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8">valid Java identifiers</a>.
+     * The values of the map will be evaluated to individual files as per
+     * {@link org.gradle.api.Project#file(Object)}.</p>
+     *
+     * <p>Otherwise the given files will be evaluated as per {@link org.gradle.api.Project#files(Object...)},
+     * and task output caching will be disabled for the task.</p>
+     *
+     * @param paths The output files.
+     *
+     * @see CacheableTask
+     */
+    TaskOutputFilePropertyBuilder files(@Nullable Object... paths);
+
+    /**
+     * Registers some output directories for this task.
+     *
+     * <p>When the given {@code paths} is a {@link java.util.Map}, then each output directory
+     * will be associated with an identity. For cacheable tasks this is a requirement.
+     * The keys of the map must be <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8">valid Java identifiers</a>.
+     * The values of the map will be evaluated to individual directories as per
+     * {@link org.gradle.api.Project#file(Object)}.</p>
+     *
+     * <p>Otherwise the given directories will be evaluated as per {@link org.gradle.api.Project#files(Object...)},
+     * and task output caching will be disabled for the task.</p>
+     *
+     * @param paths The output files.
+     *
+     * @see CacheableTask
+     *
+     * @since 3.3
+     */
+    TaskOutputFilePropertyBuilder dirs(Object... paths);
+
+    /**
+     * Registers some output file for this task.
+     *
+     * @param path The output file. The given path is evaluated as per {@link org.gradle.api.Project#file(Object)}.
+     * @return a property builder to further configure this property.
+     */
+    TaskOutputFilePropertyBuilder file(Object path);
+
+    /**
+     * Registers an output directory for this task.
+     *
+     * @param path The output directory. The given path is evaluated as per {@link org.gradle.api.Project#file(Object)}.
+     * @return a property builder to further configure this property.
+     */
+    TaskOutputFilePropertyBuilder dir(Object path);
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputPropertyRegistration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputPropertyRegistration.java
@@ -20,6 +20,9 @@ import org.gradle.api.NonNullApi;
 
 import javax.annotation.Nullable;
 
+/**
+ * Allows to register outputs.
+ */
 @NonNullApi
 public interface OutputPropertyRegistration {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskDestroyables.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskDestroyables.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
+import org.gradle.internal.HasInternalProtocol;
 
 /**
  * Represents the files or directories that a {@link org.gradle.api.Task} destroys (removes).
@@ -25,6 +26,7 @@ import org.gradle.api.file.FileCollection;
  * @since 4.0
  */
 @Incubating
+@HasInternalProtocol
 public interface TaskDestroyables {
     /**
      * Registers some files that this task destroys.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -19,7 +19,6 @@ package org.gradle.api.tasks;
 import org.gradle.api.file.FileCollection;
 import org.gradle.internal.HasInternalProtocol;
 
-import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -28,14 +27,7 @@ import java.util.Map;
  * <p>You can obtain a {@code TaskInputs} instance using {@link org.gradle.api.Task#getInputs()}.</p>
  */
 @HasInternalProtocol
-public interface TaskInputs extends CompatibilityAdapterForTaskInputs {
-    /**
-     * Returns true if this task has declared the inputs that it consumes.
-     *
-     * @return true if this task has declared any inputs.
-     */
-    boolean getHasInputs();
-
+public interface TaskInputs extends InputPropertyRegistration, CompatibilityAdapterForTaskInputs {
     /**
      * Returns the input files of this task.
      *
@@ -44,58 +36,11 @@ public interface TaskInputs extends CompatibilityAdapterForTaskInputs {
     FileCollection getFiles();
 
     /**
-     * Registers some input files for this task.
-     *
-     * @param paths The input files. The given paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
-     * @return a property builder to further configure the property.
-     */
-    TaskInputFilePropertyBuilder files(Object... paths);
-
-    /**
-     * Registers some input file for this task.
-     *
-     * @param path The input file. The given path is evaluated as per {@link org.gradle.api.Project#files(Object...)}.
-     * @return a property builder to further configure the property.
-     */
-    TaskInputFilePropertyBuilder file(Object path);
-
-    /**
-     * Registers an input directory hierarchy. All files found under the given directory are treated as input files for
-     * this task.
-     *
-     * @param dirPath The directory. The path is evaluated as per {@link org.gradle.api.Project#file(Object)}.
-     * @return a property builder to further configure the property.
-     */
-    TaskInputFilePropertyBuilder dir(Object dirPath);
-
-    /**
      * Returns the set of input properties for this task.
      *
      * @return The properties.
      */
     Map<String, Object> getProperties();
-
-    /**
-     * <p>Registers an input property for this task. This value is persisted when the task executes, and is compared
-     * against the property value for later invocations of the task, to determine if the task is up-to-date.</p>
-     *
-     * <p>The given value for the property must be Serializable, so that it can be persisted. It should also provide a
-     * useful {@code equals()} method.</p>
-     *
-     * <p>You can specify a closure or {@code Callable} as the value of the property. In which case, the closure or
-     * {@code Callable} is executed to determine the actual property value.</p>
-     *
-     * @param name The name of the property. Must not be null.
-     * @param value The value for the property. Can be null.
-     */
-    TaskInputs property(String name, @Nullable Object value);
-
-    /**
-     * Registers a set of input properties for this task. See {@link #property(String, Object)} for details.
-     *
-     * @param properties The properties.
-     */
-    TaskInputs properties(Map<String, ?> properties);
 
     /**
      * Returns true if this task has declared that it accepts source files.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputFilePropertyBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputFilePropertyBuilder.java
@@ -23,6 +23,8 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.HasInternalProtocol;
 
+import javax.annotation.Nullable;
+
 /**
  * Describes an output property of a task that contains zero or more files.
  *
@@ -35,7 +37,7 @@ public interface TaskOutputFilePropertyBuilder extends TaskFilePropertyBuilder, 
      * {@inheritDoc}
      */
     @Override
-    TaskOutputFilePropertyBuilder withPropertyName(String propertyName);
+    TaskOutputFilePropertyBuilder withPropertyName(@Nullable String propertyName);
 
     /**
      * Marks a task property as optional. This means that a value does not have to be specified for the property, but any
@@ -92,7 +94,7 @@ public interface TaskOutputFilePropertyBuilder extends TaskFilePropertyBuilder, 
      */
     @Deprecated
     @Override
-    TaskOutputFilePropertyBuilder files(Object... paths);
+    TaskOutputFilePropertyBuilder files(@Nullable Object... paths);
 
     /**
      * Throws {@link UnsupportedOperationException}.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
@@ -29,7 +29,8 @@ import org.gradle.internal.HasInternalProtocol;
  * <p>You can obtain a {@code TaskOutputs} instance using {@link org.gradle.api.Task#getOutputs()}.</p>
  */
 @HasInternalProtocol
-public interface TaskOutputs extends CompatibilityAdapterForTaskOutputs {
+public interface TaskOutputs extends OutputPropertyRegistration, CompatibilityAdapterForTaskOutputs {
+
     /**
      * <p>Adds a predicate to determine whether the outputs of this task are up-to-date. The given closure is executed
      * at task execution time. The closure is passed the task as a parameter. If the closure returns false, the task
@@ -103,71 +104,10 @@ public interface TaskOutputs extends CompatibilityAdapterForTaskOutputs {
     void doNotCacheIf(String cachingDisabledReason, Spec<? super Task> spec);
 
     /**
-     * Returns true if this task has declared any outputs. Note that a task may be able to produce output files and
-     * still have an empty set of output files.
-     *
-     * @return true if this task has declared any outputs, otherwise false.
-     */
-    boolean getHasOutput();
-
-    /**
      * Returns the output files of this task.
      *
      * @return The output files. Returns an empty collection if this task has no output files.
      */
     FileCollection getFiles();
 
-    /**
-     * Registers some output files for this task.
-     *
-     * <p>When the given {@code paths} is a {@link java.util.Map}, then each output file
-     * will be associated with an identity. For cacheable tasks this is a requirement.
-     * The keys of the map must be <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8">valid Java identifiers</a>.
-     * The values of the map will be evaluated to individual files as per
-     * {@link org.gradle.api.Project#file(Object)}.</p>
-     *
-     * <p>Otherwise the given files will be evaluated as per {@link org.gradle.api.Project#files(Object...)},
-     * and task output caching will be disabled for the task.</p>
-     *
-     * @param paths The output files.
-     *
-     * @see CacheableTask
-     */
-    TaskOutputFilePropertyBuilder files(Object... paths);
-
-    /**
-     * Registers some output directories for this task.
-     *
-     * <p>When the given {@code paths} is a {@link java.util.Map}, then each output directory
-     * will be associated with an identity. For cacheable tasks this is a requirement.
-     * The keys of the map must be <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8">valid Java identifiers</a>.
-     * The values of the map will be evaluated to individual directories as per
-     * {@link org.gradle.api.Project#file(Object)}.</p>
-     *
-     * <p>Otherwise the given directories will be evaluated as per {@link org.gradle.api.Project#files(Object...)},
-     * and task output caching will be disabled for the task.</p>
-     *
-     * @param paths The output files.
-     *
-     * @see CacheableTask
-     *
-     * @since 3.3
-     */
-    TaskOutputFilePropertyBuilder dirs(Object... paths);
-
-    /**
-     * Registers some output file for this task.
-     *
-     * @param path The output file. The given path is evaluated as per {@link org.gradle.api.Project#file(Object)}.
-     * @return a property builder to further configure this property.
-     */
-    TaskOutputFilePropertyBuilder file(Object path);
-
-    /**
-     * Registers an output directory for this task.
-     *
-     * @param path The output directory. The given path is evaluated as per {@link org.gradle.api.Project#file(Object)}.
-     * @return a property builder to further configure this property.
-     */
-    TaskOutputFilePropertyBuilder dir(Object path);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
@@ -176,8 +176,8 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
         succeeds "test", "printMetadata"
 
         then:
-        output =~ /Input property 'input' : 'someString'/ // FIXME: That should be 'someOtherString'
-        output =~ /Input property 'bean.input' : 'someString'/ // FIXME: That should be 'otherNestedString'
+        output =~ /Input property 'input' : 'someOtherString'/
+        output =~ /Input property 'bean.input' : 'otherNestedString'/
 
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.project.taskfactory
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.ToBeImplemented
 import spock.lang.Issue
 
 class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
@@ -99,5 +100,151 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
         output.contains "Output: outputDirectory [outputs]"
         output.contains "Output: outputFile [output.txt]"
         output.contains "Output: outputFiles [output1.txt, output2.txt]"
+    }
+
+    def "nested input and output properties are discovered"() {
+        buildFile << classesForNestedProperties()
+        buildFile << """
+            task test(type: MyTask) {           
+                input = "someString"
+                bean = new NestedProperty(
+                    inputDir: file('input'),
+                    input: 'someString',
+                    outputDir: file("\$buildDir/output"),  
+                    nestedBean: new AnotherNestedProperty(inputFile: file('inputFile'))
+                )
+            }        
+
+            task printMetadata(type: PrintInputsAndOutputs) {
+                task = test
+            }
+        """
+
+        expect:
+        succeeds "test", "printMetadata"
+        output =~ /Input property 'input' : 'someString'/
+        output =~ /Input property 'bean\.class' : 'NestedProperty'/
+        output =~ /Input property 'bean\.input' : 'someString'/
+        output =~ /Input property 'bean\.nestedBean.class' : 'AnotherNestedProperty'/
+        output =~ /Input file property 'bean\.inputDir'/
+        output =~ /Input file property 'bean\.nestedBean.inputFile'/
+        output =~ /Output file property 'bean\.outputDir'/
+    }
+
+    def "nested destroyables are discovered"() {
+        buildFile << classesForNestedProperties()
+        buildFile << """
+            task destroy(type: MyDestroyer) {
+                bean = new DestroyerBean(
+                    destroyedFile: file("\$buildDir/destroyed")
+                )
+            }               
+            task printMetadata(type: PrintInputsAndOutputs) {
+                task = destroy
+            }
+        """
+
+        when:
+        succeeds "destroy", "printMetadata"
+
+        then:
+        output =~ /Destroys: '.*destroyed'/
+        output =~ /Input property 'bean\.class' : 'DestroyerBean'/
+    }
+
+    @ToBeImplemented
+    def "input properties can be overridden"() {
+        buildFile << classesForNestedProperties()
+        buildFile << """
+            task test(type: MyTask) { 
+                input = "someString"
+                bean = new NestedProperty(
+                    inputDir: file('input'),
+                    input: 'someString',
+                    outputDir: file("\$buildDir/output"),  
+                    nestedBean: new AnotherNestedProperty(inputFile: file('inputFile'))
+                )                    
+                inputs.property("input", "someOtherString") 
+                inputs.property("bean.input", "otherNestedString")
+            }                        
+            task printMetadata(type: PrintInputsAndOutputs) {
+                task = test
+            }
+        """
+
+        when:
+        succeeds "test", "printMetadata"
+
+        then:
+        output =~ /Input property 'input' : 'someString'/ // FIXME: That should be 'someOtherString'
+        output =~ /Input property 'bean.input' : 'someString'/ // FIXME: That should be 'otherNestedString'
+
+    }
+
+    String classesForNestedProperties() {
+        """
+            class MyTask extends DefaultTask {
+                @Nested
+                Object bean
+
+                @Input
+                String input
+                
+                @TaskAction
+                void doStuff() {}
+            }
+            
+            class NestedProperty {
+                @InputDirectory
+                File inputDir
+                
+                @OutputDirectory
+                File outputDir      
+                        
+                @Input
+                String input
+
+                @Nested
+                Object nestedBean
+
+                @Destroys File destroyedFile
+            }                    
+
+            class AnotherNestedProperty {
+                @InputFile
+                File inputFile
+            }     
+
+            class PrintInputsAndOutputs extends DefaultTask {
+                Task task
+
+                @TaskAction
+                void printInputsAndOutputs() {
+                    task.inputs.properties.entrySet().each {
+                        println "Input property '\${it.key}' : '\${it.value}'"
+                    }        
+                    task.inputs.fileProperties.each {
+                        println "Input file property '\${it.propertyName}'"
+                    }
+                    task.outputs.fileProperties.each {
+                        println "Output file property '\${it.propertyName}'"
+                    }
+                    task.destroyables.files.files.each {
+                        println "Destroys: '\${it}'"
+                    }
+                }
+            }      
+            
+            class MyDestroyer extends DefaultTask {
+                @TaskAction void doStuff() {}
+
+                @Nested
+                Object bean
+            }              
+
+            class DestroyerBean {
+                @Destroys File destroyedFile
+            }            
+        """
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -72,6 +72,25 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         skippedTasks.contains ":customTask"
     }
 
+    def "don't evalute output properties too often"() {
+        buildFile << """
+            class TestTask extends DefaultTask {
+                int count = 0
+                @OutputFile
+                File getOutputFile() {
+                    count++
+                    println "Evaluating outputFile \$count"
+                    return project.file("foo.bar")
+                }
+            }
+            
+            task test(type: TestTask)
+        """
+
+        expect:
+        succeeds "test"
+    }
+
     def "changing custom Groovy task implementation in buildSrc doesn't invalidate built-in task"() {
         def taskSourceFile = file("buildSrc/src/main/groovy/CustomTask.groovy")
         taskSourceFile << customGroovyTask()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -34,6 +34,7 @@ import org.gradle.api.file.RegularFileVar;
 import org.gradle.api.internal.file.TaskFileVarFactory;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.taskfactory.TaskClassValidator;
 import org.gradle.api.internal.tasks.ClassLoaderAwareTaskAction;
 import org.gradle.api.internal.tasks.ContextAwareTaskAction;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
@@ -127,6 +128,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     private ObservableList observableActionList;
     private boolean impliesSubProjects;
     private boolean hasCustomActions;
+    private boolean taskInputsAndOutputsDiscovered;
 
     private final TaskInputsInternal taskInputs;
     private final TaskOutputsInternal taskOutputs;
@@ -1015,5 +1017,17 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     @Incubating
     protected DirectoryVar newInputDirectory() {
         return getServices().get(TaskFileVarFactory.class).newInputDirectory(this);
+    }
+
+    @Override
+    public void ensureTaskInputsAndOutputsDiscovered() {
+        if (!taskInputsAndOutputsDiscovered) {
+            if (validators != null) {
+                for (TaskValidator validator : validators) {
+                    ((TaskClassValidator) validator).addInputsAndOutputs(this);
+                }
+            }
+            taskInputsAndOutputsDiscovered = true;
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -34,13 +34,10 @@ import org.gradle.api.file.RegularFileVar;
 import org.gradle.api.internal.file.TaskFileVarFactory;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.project.taskfactory.TaskClassValidator;
+import org.gradle.api.internal.project.taskfactory.SchemaExtractor;
 import org.gradle.api.internal.tasks.ClassLoaderAwareTaskAction;
 import org.gradle.api.internal.tasks.ContextAwareTaskAction;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
-import org.gradle.api.internal.tasks.DefaultTaskDestroyables;
-import org.gradle.api.internal.tasks.DefaultTaskInputs;
-import org.gradle.api.internal.tasks.DefaultTaskOutputs;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskExecuter;
@@ -128,11 +125,8 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     private ObservableList observableActionList;
     private boolean impliesSubProjects;
     private boolean hasCustomActions;
-    private boolean taskInputsAndOutputsDiscovered;
 
-    private final TaskInputsInternal taskInputs;
-    private final TaskOutputsInternal taskOutputs;
-    private final TaskDestroyables taskDestroyables;
+    private final ChangeDetection changeDetection;
     private final Class<? extends Task> publicType;
     private LoggingManagerInternal loggingManager;
 
@@ -164,9 +158,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         shouldRunAfter = new DefaultTaskDependency(tasks);
         services = project.getServices();
         taskMutator = new TaskMutator(this);
-        taskInputs = new DefaultTaskInputs(project.getFileResolver(), this, taskMutator);
-        taskOutputs = new DefaultTaskOutputs(project.getFileResolver(), this, taskMutator);
-        taskDestroyables = new DefaultTaskDestroyables(project.getFileResolver(), this, taskMutator);
+        this.changeDetection = new ChangeDetection(this, project.getServices().get(SchemaExtractor.class), project.getFileResolver(), taskMutator);
     }
 
     private void assertDynamicObject() {
@@ -534,17 +526,17 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public TaskInputsInternal getInputs() {
-        return taskInputs;
+        return changeDetection.getInputs();
     }
 
     @Override
     public TaskOutputsInternal getOutputs() {
-        return taskOutputs;
+        return changeDetection.getOutputs();
     }
 
     @Override
     public TaskDestroyables getDestroyables() {
-        return taskDestroyables;
+        return changeDetection.getDestroyables();
     }
 
     @Internal
@@ -1017,17 +1009,5 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     @Incubating
     protected DirectoryVar newInputDirectory() {
         return getServices().get(TaskFileVarFactory.class).newInputDirectory(this);
-    }
-
-    @Override
-    public void ensureTaskInputsAndOutputsDiscovered() {
-        if (!taskInputsAndOutputsDiscovered) {
-            if (validators != null) {
-                for (TaskValidator validator : validators) {
-                    ((TaskClassValidator) validator).addInputsAndOutputs(this);
-                }
-            }
-            taskInputsAndOutputsDiscovered = true;
-        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -327,6 +327,11 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     }
 
     @Override
+    public ChangeDetection getChangeDetection() {
+        return changeDetection;
+    }
+
+    @Override
     public boolean getImpliesSubProjects() {
         return impliesSubProjects;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/ChangeDetection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/ChangeDetection.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal;
+
+import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.project.taskfactory.DefaultSchemaExtractor;
+import org.gradle.api.internal.project.taskfactory.SchemaExtractor;
+import org.gradle.api.internal.tasks.DefaultTaskDestroyables;
+import org.gradle.api.internal.tasks.DefaultTaskInputs;
+import org.gradle.api.internal.tasks.DefaultTaskOutputs;
+import org.gradle.api.internal.tasks.TaskMutator;
+import org.gradle.api.tasks.TaskDestroyables;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class ChangeDetection {
+
+    private final TaskInternal task;
+    private final SchemaExtractor schemaExtractor;
+    private final TaskInputsInternal taskInputs;
+    private final TaskOutputsInternal taskOutputs;
+    private final TaskDestroyables taskDestroyables;
+    private DefaultSchemaExtractor.SchemaRoot schemaRoot;
+
+    public ChangeDetection(TaskInternal task, SchemaExtractor schemaExtractor, FileResolver fileResolver, TaskMutator taskMutator) {
+        this.task = task;
+        this.schemaExtractor = schemaExtractor;
+        this.taskInputs = new DefaultTaskInputs(fileResolver, task, taskMutator, this);
+        this.taskOutputs = new DefaultTaskOutputs(fileResolver, task, taskMutator, this);
+        this.taskDestroyables = new DefaultTaskDestroyables(fileResolver, task, taskMutator, this);
+    }
+
+    public TaskInputsInternal getInputs() {
+        return taskInputs;
+    }
+
+    public TaskOutputsInternal getOutputs() {
+        return taskOutputs;
+    }
+
+    public TaskDestroyables getDestroyables() {
+        return taskDestroyables;
+    }
+
+
+    public void ensureTaskInputsAndOutputsDiscovered() {
+        if (schemaRoot == null) {
+            schemaRoot = schemaExtractor.extractSchema(task);
+            registerInputsAndOutputs(schemaRoot);
+        }
+    }
+
+    private void registerInputsAndOutputs(DefaultSchemaExtractor.SchemaRoot schemaRoot) {
+        registerInputsAndOutputs(null, schemaRoot.getChildren());
+    }
+
+    private void registerInputsAndOutputs(@Nullable String parentPropertyName, Map<String, DefaultSchemaExtractor.SchemaNode> children) {
+        for (Map.Entry<String, DefaultSchemaExtractor.SchemaNode> entry : children.entrySet()) {
+            String propertyName = parentPropertyName == null ? entry.getKey() : parentPropertyName + "." + entry.getKey();
+            DefaultSchemaExtractor.SchemaNode node = entry.getValue();
+            updateInputsAndOutputs(node, propertyName);
+            if (node instanceof DefaultSchemaExtractor.NestedSchema) {
+                registerInputsAndOutputs(propertyName, ((DefaultSchemaExtractor.NestedSchema) node).getChildren());
+            }
+        }
+    }
+
+    private void updateInputsAndOutputs(DefaultSchemaExtractor.SchemaNode value, String propertyName) {
+        value.getConfigureAction().updateInputs(taskInputs, propertyName, value);
+        value.getConfigureAction().updateOutputs(taskOutputs, propertyName, value);
+        value.getConfigureAction().updateDestroyables(taskDestroyables, propertyName, value);
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/ChangeDetection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/ChangeDetection.java
@@ -17,8 +17,10 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.project.taskfactory.DefaultSchemaExtractor;
+import org.gradle.api.internal.project.taskfactory.NestedSchema;
 import org.gradle.api.internal.project.taskfactory.SchemaExtractor;
+import org.gradle.api.internal.project.taskfactory.SchemaNode;
+import org.gradle.api.internal.project.taskfactory.SchemaRoot;
 import org.gradle.api.internal.tasks.DefaultTaskDestroyables;
 import org.gradle.api.internal.tasks.DefaultTaskInputs;
 import org.gradle.api.internal.tasks.DefaultTaskOutputs;
@@ -35,7 +37,7 @@ public class ChangeDetection {
     private final TaskInputsInternal taskInputs;
     private final TaskOutputsInternal taskOutputs;
     private final TaskDestroyables taskDestroyables;
-    private DefaultSchemaExtractor.SchemaRoot schemaRoot;
+    private SchemaRoot schemaRoot;
 
     public ChangeDetection(TaskInternal task, SchemaExtractor schemaExtractor, FileResolver fileResolver, TaskMutator taskMutator) {
         this.task = task;
@@ -65,22 +67,22 @@ public class ChangeDetection {
         }
     }
 
-    private void registerInputsAndOutputs(DefaultSchemaExtractor.SchemaRoot schemaRoot) {
+    private void registerInputsAndOutputs(SchemaRoot schemaRoot) {
         registerInputsAndOutputs(null, schemaRoot.getChildren());
     }
 
-    private void registerInputsAndOutputs(@Nullable String parentPropertyName, Map<String, DefaultSchemaExtractor.SchemaNode> children) {
-        for (Map.Entry<String, DefaultSchemaExtractor.SchemaNode> entry : children.entrySet()) {
+    private void registerInputsAndOutputs(@Nullable String parentPropertyName, Map<String, SchemaNode> children) {
+        for (Map.Entry<String, SchemaNode> entry : children.entrySet()) {
             String propertyName = parentPropertyName == null ? entry.getKey() : parentPropertyName + "." + entry.getKey();
-            DefaultSchemaExtractor.SchemaNode node = entry.getValue();
+            SchemaNode node = entry.getValue();
             updateInputsAndOutputs(node, propertyName);
-            if (node instanceof DefaultSchemaExtractor.NestedSchema) {
-                registerInputsAndOutputs(propertyName, ((DefaultSchemaExtractor.NestedSchema) node).getChildren());
+            if (node instanceof NestedSchema) {
+                registerInputsAndOutputs(propertyName, ((NestedSchema) node).getChildren());
             }
         }
     }
 
-    private void updateInputsAndOutputs(DefaultSchemaExtractor.SchemaNode value, String propertyName) {
+    private void updateInputsAndOutputs(SchemaNode value, String propertyName) {
         value.getConfigureAction().updateInputs(taskInputs, propertyName, value);
         value.getConfigureAction().updateOutputs(taskOutputs, propertyName, value);
         value.getConfigureAction().updateDestroyables(taskDestroyables, propertyName, value);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/ChangeDetection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/ChangeDetection.java
@@ -68,14 +68,18 @@ public class ChangeDetection {
 
     public void ensureTaskInputsAndOutputsDiscovered() {
         if (schemaRoot == null) {
-            schemaRoot = schemaExtractor.extractSchema(task);
-            String taskName = task.getName();
-            DefaultInputPropertyRegistration inputPropertyRegistration = new DefaultInputPropertyRegistration(taskName, taskMutator, resolver);
-            DefaultOutputPropertyRegistration outputPropertyRegistration = new DefaultOutputPropertyRegistration(taskName, taskMutator, resolver);
-            registerInputsAndOutputs(inputPropertyRegistration, outputPropertyRegistration, schemaRoot);
-            taskInputs.setDiscoveredProperties(inputPropertyRegistration);
-            taskOutputs.setDiscoveredProperties(outputPropertyRegistration);
+            discoverTaskInputsAndOutputs();
         }
+    }
+
+    public void discoverTaskInputsAndOutputs() {
+        schemaRoot = schemaExtractor.extractSchema(task);
+        String taskName = task.getName();
+        DefaultInputPropertyRegistration inputPropertyRegistration = new DefaultInputPropertyRegistration(taskName, taskMutator, resolver);
+        DefaultOutputPropertyRegistration outputPropertyRegistration = new DefaultOutputPropertyRegistration(taskName, taskMutator, resolver);
+        registerInputsAndOutputs(inputPropertyRegistration, outputPropertyRegistration, schemaRoot);
+        taskInputs.setDiscoveredProperties(inputPropertyRegistration);
+        taskOutputs.setDiscoveredProperties(outputPropertyRegistration);
     }
 
     private void registerInputsAndOutputs(DefaultInputPropertyRegistration inputPropertyRegistration, DefaultOutputPropertyRegistration outputPropertyRegistration, SchemaRoot schemaRoot) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -91,6 +91,4 @@ public interface TaskInternal extends Task, Configurable<Task> {
 
     @Internal
     Path getIdentityPath();
-
-    void ensureTaskInputsAndOutputsDiscovered();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -91,4 +91,6 @@ public interface TaskInternal extends Task, Configurable<Task> {
 
     @Internal
     Path getIdentityPath();
+
+    void ensureTaskInputsAndOutputsDiscovered();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -69,6 +69,8 @@ public interface TaskInternal extends Task, Configurable<Task> {
     @Override
     TaskStateInternal getState();
 
+    ChangeDetection getChangeDetection();
+
     @Internal
     boolean getImpliesSubProjects();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractInputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractInputPropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInputsInternal;
+import org.gradle.api.tasks.InputPropertyRegistration;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
@@ -48,7 +48,7 @@ abstract class AbstractInputPropertyAnnotationHandler implements PropertyAnnotat
 
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
+            public void updateInputs(InputPropertyRegistration inputs, String propertyName, Callable<Object> futureValue) {
                 final TaskInputFilePropertyBuilder propertyBuilder = createPropertyBuilder(context, inputs, futureValue);
                 propertyBuilder
                     .withPropertyName(propertyName)
@@ -59,6 +59,6 @@ abstract class AbstractInputPropertyAnnotationHandler implements PropertyAnnotat
         });
     }
 
-    protected abstract TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInputsInternal inputs, Callable<Object> futureValue);
+    protected abstract TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, InputPropertyRegistration inputs, Callable<Object> futureValue);
     protected abstract void validate(String propertyName, Object value, Collection<String> messages);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractInputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractInputPropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
@@ -47,8 +47,9 @@ abstract class AbstractInputPropertyAnnotationHandler implements PropertyAnnotat
         }
 
         context.setConfigureAction(new UpdateAction() {
-            public void update(TaskInternal task, Callable<Object> futureValue) {
-                final TaskInputFilePropertyBuilder propertyBuilder = createPropertyBuilder(context, task, futureValue);
+            @Override
+            public void updateInputs(TaskInputsInternal inputs, Callable<Object> futureValue) {
+                final TaskInputFilePropertyBuilder propertyBuilder = createPropertyBuilder(context, inputs, futureValue);
                 propertyBuilder
                     .withPropertyName(context.getName())
                     .withPathSensitivity(pathSensitivity)
@@ -58,6 +59,6 @@ abstract class AbstractInputPropertyAnnotationHandler implements PropertyAnnotat
         });
     }
 
-    protected abstract TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue);
+    protected abstract TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInputsInternal inputs, Callable<Object> futureValue);
     protected abstract void validate(String propertyName, Object value, Collection<String> messages);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractInputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractInputPropertyAnnotationHandler.java
@@ -48,10 +48,10 @@ abstract class AbstractInputPropertyAnnotationHandler implements PropertyAnnotat
 
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateInputs(TaskInputsInternal inputs, Callable<Object> futureValue) {
+            public void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
                 final TaskInputFilePropertyBuilder propertyBuilder = createPropertyBuilder(context, inputs, futureValue);
                 propertyBuilder
-                    .withPropertyName(context.getName())
+                    .withPropertyName(propertyName)
                     .withPathSensitivity(pathSensitivity)
                     .skipWhenEmpty(context.isAnnotationPresent(SkipWhenEmpty.class))
                     .optional(context.isOptional());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractOutputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractOutputPropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 
 import java.util.Collection;
@@ -33,15 +33,15 @@ public abstract class AbstractOutputPropertyAnnotationHandler implements Propert
         });
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void update(TaskInternal task, final Callable<Object> futureValue) {
-                createPropertyBuilder(context, task, futureValue)
+            public void updateOutputs(TaskOutputsInternal outputs, final Callable<Object> futureValue) {
+                createPropertyBuilder(context, outputs, futureValue)
                     .withPropertyName(context.getName())
                     .optional(context.isOptional());
             }
         });
     }
 
-    protected abstract TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue);
+    protected abstract TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue);
 
     protected abstract void validate(String propertyName, Object value, Collection<String> messages);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractOutputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractOutputPropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskOutputsInternal;
+import org.gradle.api.tasks.OutputPropertyRegistration;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 
 import java.util.Collection;
@@ -33,7 +33,7 @@ public abstract class AbstractOutputPropertyAnnotationHandler implements Propert
         });
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateOutputs(TaskOutputsInternal outputs, String propertyName, final Callable<Object> futureValue) {
+            public void updateOutputs(OutputPropertyRegistration outputs, String propertyName, final Callable<Object> futureValue) {
                 createPropertyBuilder(outputs, futureValue)
                     .withPropertyName(propertyName)
                     .optional(context.isOptional());
@@ -41,7 +41,7 @@ public abstract class AbstractOutputPropertyAnnotationHandler implements Propert
         });
     }
 
-    protected abstract TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue);
+    protected abstract TaskOutputFilePropertyBuilder createPropertyBuilder(OutputPropertyRegistration outputs, Callable<Object> futureValue);
 
     protected abstract void validate(String propertyName, Object value, Collection<String> messages);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractOutputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AbstractOutputPropertyAnnotationHandler.java
@@ -33,15 +33,15 @@ public abstract class AbstractOutputPropertyAnnotationHandler implements Propert
         });
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateOutputs(TaskOutputsInternal outputs, final Callable<Object> futureValue) {
-                createPropertyBuilder(context, outputs, futureValue)
-                    .withPropertyName(context.getName())
+            public void updateOutputs(TaskOutputsInternal outputs, String propertyName, final Callable<Object> futureValue) {
+                createPropertyBuilder(outputs, futureValue)
+                    .withPropertyName(propertyName)
                     .optional(context.isOptional());
             }
         });
     }
 
-    protected abstract TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue);
+    protected abstract TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue);
 
     protected abstract void validate(String propertyName, Object value, Collection<String> messages);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -69,7 +69,7 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
 
         TaskClassValidator validator = taskClassInfo.getValidator();
         if (validator.hasAnythingToValidate()) {
-            validator.addInputsAndOutputs(task);
+            task.addValidator(validator);
         }
 
         // Enabled caching if task type is annotated with @CacheableTask

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ClasspathPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ClasspathPropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.tasks.TaskInputFilePropertyBuilderInternal;
@@ -44,8 +44,9 @@ public class ClasspathPropertyAnnotationHandler implements OverridingPropertyAnn
     @Override
     public void attachActions(final TaskPropertyActionContext context) {
         context.setConfigureAction(new UpdateAction() {
-            public void update(TaskInternal task, Callable<Object> futureValue) {
-                ((TaskInputFilePropertyBuilderInternal) task.getInputs().files(futureValue))
+            @Override
+            public void updateInputs(TaskInputsInternal inputs, Callable<Object> futureValue) {
+                ((TaskInputFilePropertyBuilderInternal) inputs.files(futureValue))
                     .withPropertyName(context.getName())
                     .withSnapshotter(getSnapshotterType())
                     .optional(context.isOptional());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ClasspathPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ClasspathPropertyAnnotationHandler.java
@@ -16,12 +16,12 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.tasks.TaskInputFilePropertyBuilderInternal;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.InputPropertyRegistration;
 
 import java.lang.annotation.Annotation;
 import java.util.concurrent.Callable;
@@ -45,7 +45,7 @@ public class ClasspathPropertyAnnotationHandler implements OverridingPropertyAnn
     public void attachActions(final TaskPropertyActionContext context) {
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
+            public void updateInputs(InputPropertyRegistration inputs, String propertyName, Callable<Object> futureValue) {
                 ((TaskInputFilePropertyBuilderInternal) inputs.files(futureValue))
                     .withPropertyName(propertyName)
                     .withSnapshotter(getSnapshotterType())

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ClasspathPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ClasspathPropertyAnnotationHandler.java
@@ -45,9 +45,9 @@ public class ClasspathPropertyAnnotationHandler implements OverridingPropertyAnn
     public void attachActions(final TaskPropertyActionContext context) {
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateInputs(TaskInputsInternal inputs, Callable<Object> futureValue) {
+            public void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
                 ((TaskInputFilePropertyBuilderInternal) inputs.files(futureValue))
-                    .withPropertyName(context.getName())
+                    .withPropertyName(propertyName)
                     .withSnapshotter(getSnapshotterType())
                     .optional(context.isOptional());
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultSchemaExtractor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultSchemaExtractor.java
@@ -1,0 +1,661 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project.taskfactory;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import groovy.lang.GroovyObject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Task;
+import org.gradle.api.internal.AbstractTask;
+import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.internal.tasks.options.OptionValues;
+import org.gradle.api.tasks.Console;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.internal.Factory;
+import org.gradle.internal.reflect.GroovyMethods;
+import org.gradle.internal.reflect.JavaReflectionUtil;
+import org.gradle.internal.reflect.PropertyAccessorType;
+import org.gradle.internal.reflect.Types;
+import org.gradle.util.DeprecationLogger;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+@NonNullApi
+public class DefaultSchemaExtractor implements SchemaExtractor {
+    // Avoid reflecting on classes we know we don't need to look at
+    private static final Collection<Class<?>> IGNORED_SUPER_CLASSES = ImmutableSet.<Class<?>>of(
+        ConventionTask.class, DefaultTask.class, AbstractTask.class, Task.class, Object.class, GroovyObject.class
+    );
+
+    private final static List<? extends PropertyAnnotationHandler> HANDLERS = Arrays.asList(
+        new InputFilePropertyAnnotationHandler(),
+        new InputDirectoryPropertyAnnotationHandler(),
+        new InputFilesPropertyAnnotationHandler(),
+        new OutputFilePropertyAnnotationHandler(),
+        new OutputFilesPropertyAnnotationHandler(),
+        new OutputDirectoryPropertyAnnotationHandler(),
+        new OutputDirectoriesPropertyAnnotationHandler(),
+        new InputPropertyAnnotationHandler(),
+        new DestroysPropertyAnnotationHandler(),
+        new NestedBeanPropertyAnnotationHandler(),
+        new NoOpPropertyAnnotationHandler(Inject.class),
+        new NoOpPropertyAnnotationHandler(Console.class),
+        new NoOpPropertyAnnotationHandler(Internal.class),
+        new NoOpPropertyAnnotationHandler(OptionValues.class)
+    );
+
+    private final Map<Class<? extends Annotation>, PropertyAnnotationHandler> annotationHandlers;
+    private final Multimap<Class<? extends Annotation>, Class<? extends Annotation>> annotationOverrides;
+    private final Set<Class<? extends Annotation>> relevantAnnotationTypes;
+
+    public DefaultSchemaExtractor(PropertyAnnotationHandler... customAnnotationHandlers) {
+        this(Arrays.asList(customAnnotationHandlers));
+    }
+
+    public DefaultSchemaExtractor(Iterable<? extends PropertyAnnotationHandler> customAnnotationHandlers) {
+        Iterable<PropertyAnnotationHandler> allAnnotationHandlers = Iterables.concat(HANDLERS, customAnnotationHandlers);
+        Map<Class<? extends Annotation>, PropertyAnnotationHandler> annotationsHandlers = Maps.uniqueIndex(allAnnotationHandlers, new Function<PropertyAnnotationHandler, Class<? extends Annotation>>() {
+            @Override
+            public Class<? extends Annotation> apply(PropertyAnnotationHandler handler) {
+                return handler.getAnnotationType();
+            }
+        });
+        this.annotationHandlers = annotationsHandlers;
+        this.annotationOverrides = collectAnnotationOverrides(allAnnotationHandlers);
+        this.relevantAnnotationTypes = collectRelevantAnnotationTypes(annotationsHandlers.keySet());
+    }
+
+    private static Multimap<Class<? extends Annotation>, Class<? extends Annotation>> collectAnnotationOverrides(Iterable<PropertyAnnotationHandler> allAnnotationHandlers) {
+        ImmutableSetMultimap.Builder<Class<? extends Annotation>, Class<? extends Annotation>> builder = ImmutableSetMultimap.builder();
+        for (PropertyAnnotationHandler handler : allAnnotationHandlers) {
+            if (handler instanceof OverridingPropertyAnnotationHandler) {
+                builder.put(((OverridingPropertyAnnotationHandler) handler).getOverriddenAnnotationType(), handler.getAnnotationType());
+            }
+        }
+        return builder.build();
+    }
+
+    private static Set<Class<? extends Annotation>> collectRelevantAnnotationTypes(Set<Class<? extends Annotation>> propertyTypeAnnotations) {
+        return ImmutableSet.<Class<? extends Annotation>>builder()
+            .addAll(propertyTypeAnnotations)
+            .add(Optional.class)
+            .add(SkipWhenEmpty.class)
+            .add(PathSensitive.class)
+            .build();
+    }
+
+    public <T> ChangeDetectionClassInfo extractClassInfo(Class<T> type) {
+        ImmutableSortedSet.Builder<ChangeDetectionProperty> annotatedPropertiesBuilder = ImmutableSortedSet.naturalOrder();
+        ImmutableList.Builder<TaskClassValidationMessage> validationMessages = ImmutableList.builder();
+        parseProperties(type, annotatedPropertiesBuilder, validationMessages);
+        return new ChangeDetectionClassInfo(annotatedPropertiesBuilder.build(), validationMessages.build());
+    }
+
+    @Override
+    public SchemaRoot extractSchema(Object instance) {
+        ChangeDetectionClassInfo classInfo = extractClassInfo(instance.getClass());
+        ImmutableMap.Builder<String, SchemaNode> children = ImmutableMap.builder();
+        for (ChangeDetectionProperty changeDetectionProperty : classInfo.getAnnotatedProperties()) {
+            String propertyName = changeDetectionProperty.getName();
+            UpdateAction configureAction = changeDetectionProperty.getConfigureAction();
+            if (changeDetectionProperty.isNested()) {
+                TaskPropertyValue value = changeDetectionProperty.getValue(instance);
+                if (value.getValue() == null) {
+                    children.put(propertyName, new SchemaProperty(changeDetectionProperty, instance, configureAction));
+                } else {
+                    children.put(propertyName, new NestedSchema(extractSchema(value.getValue()).getChildren(), value, configureAction));
+                }
+            } else {
+                children.put(propertyName, new SchemaProperty(changeDetectionProperty, instance, configureAction));
+            }
+        }
+        return new SchemaRoot(children.build(), instance);
+    }
+
+    private <T> void parseProperties(Class<T> type, ImmutableSet.Builder<ChangeDetectionProperty> annotatedProperties, final ImmutableCollection.Builder<TaskClassValidationMessage> validationMessages) {
+        final Set<Class<? extends Annotation>> propertyTypeAnnotations = annotationHandlers.keySet();
+        final Map<String, DefaultTaskPropertyActionContext> propertyContexts = Maps.newLinkedHashMap();
+        Types.walkTypeHierarchy(type, IGNORED_SUPER_CLASSES, new Types.TypeVisitor<T>() {
+            @Override
+            public void visitType(Class<? super T> type) {
+                Map<String, Field> fields = getFields(type);
+                List<Getter> getters = getGetters(type);
+                for (Getter getter : getters) {
+                    Method method = getter.getMethod();
+                    String fieldName = getter.getName();
+                    Field field = fields.get(fieldName);
+
+                    DefaultTaskPropertyActionContext propertyContext = propertyContexts.get(fieldName);
+                    if (propertyContext == null) {
+                        propertyContext = new DefaultTaskPropertyActionContext(propertyTypeAnnotations, fieldName, method, false, validationMessages);
+                        propertyContexts.put(fieldName, propertyContext);
+                    }
+
+                    if (field != null) {
+                        propertyContext.setInstanceVariableField(field);
+                    }
+                    Iterable<Annotation> declaredAnnotations = mergeDeclaredAnnotations(propertyContext, method, field);
+
+                    // Discard overridden property type annotations when an overriding annotation is also present
+                    Iterable<Annotation> overriddenAnnotations = filterOverridingAnnotations(declaredAnnotations, propertyTypeAnnotations);
+
+                    recordAnnotations(propertyContext, overriddenAnnotations, propertyTypeAnnotations);
+                }
+            }
+        });
+        for (DefaultTaskPropertyActionContext propertyContext : propertyContexts.values()) {
+            ChangeDetectionProperty property = createProperty(propertyContext);
+            if (property != null) {
+                annotatedProperties.add(property);
+            }
+        }
+    }
+
+    public static class ChangeDetectionClassInfo {
+        private final ImmutableSortedSet<ChangeDetectionProperty> annotatedProperties;
+        private final ImmutableList<TaskClassValidationMessage> validationMessages;
+
+        public ChangeDetectionClassInfo(Set<ChangeDetectionProperty> annotatedProperties, List<TaskClassValidationMessage> validationMessages) {
+            this.annotatedProperties = ImmutableSortedSet.copyOf(annotatedProperties);
+            this.validationMessages = ImmutableList.copyOf(validationMessages);
+        }
+
+        public ImmutableSortedSet<ChangeDetectionProperty> getAnnotatedProperties() {
+            return annotatedProperties;
+        }
+
+        public ImmutableList<TaskClassValidationMessage> getValidationMessages() {
+            return validationMessages;
+        }
+    }
+
+    private Iterable<Annotation> mergeDeclaredAnnotations(TaskPropertyActionContext propertyContext, Method method, Field field) {
+        Collection<Annotation> methodAnnotations = collectRelevantAnnotations(method.getDeclaredAnnotations());
+        if (field == null) {
+            return methodAnnotations;
+        }
+        Collection<Annotation> fieldAnnotations = collectRelevantAnnotations(field.getDeclaredAnnotations());
+        if (fieldAnnotations.isEmpty()) {
+            return methodAnnotations;
+        }
+        if (methodAnnotations.isEmpty()) {
+            return fieldAnnotations;
+        }
+
+        for (Annotation methodAnnotation : methodAnnotations) {
+            Iterator<Annotation> iFieldAnnotation = fieldAnnotations.iterator();
+            while (iFieldAnnotation.hasNext()) {
+                Annotation fieldAnnotation = iFieldAnnotation.next();
+                if (methodAnnotation.annotationType().equals(fieldAnnotation.annotationType())) {
+                    propertyContext.validationMessage("has both a getter and field declared with annotation @" + methodAnnotation.annotationType().getSimpleName());
+                    iFieldAnnotation.remove();
+                }
+            }
+        }
+
+        return Iterables.concat(methodAnnotations, fieldAnnotations);
+    }
+
+    private Collection<Annotation> collectRelevantAnnotations(Annotation[] annotations) {
+        List<Annotation> relevantAnnotations = Lists.newArrayListWithCapacity(annotations.length);
+        for (Annotation annotation : annotations) {
+            if (relevantAnnotationTypes.contains(annotation.annotationType())) {
+                relevantAnnotations.add(annotation);
+            }
+        }
+        return relevantAnnotations;
+    }
+
+    private Iterable<Annotation> filterOverridingAnnotations(final Iterable<Annotation> declaredAnnotations, final Set<Class<? extends Annotation>> propertyTypeAnnotations) {
+        return Iterables.filter(declaredAnnotations, new Predicate<Annotation>() {
+            @Override
+            public boolean apply(Annotation input) {
+                Class<? extends Annotation> annotationType = input.annotationType();
+                if (!propertyTypeAnnotations.contains(annotationType)) {
+                    return true;
+                }
+                for (Class<? extends Annotation> overridingAnnotation : annotationOverrides.get(annotationType)) {
+                    for (Annotation declaredAnnotation : declaredAnnotations) {
+                        if (declaredAnnotation.annotationType().equals(overridingAnnotation)) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+        });
+    }
+
+    private void recordAnnotations(TaskPropertyActionContext propertyContext, Iterable<Annotation> annotations, Set<Class<? extends Annotation>> propertyTypeAnnotations) {
+        Set<Class<? extends Annotation>> declaredPropertyTypes = Sets.newLinkedHashSet();
+        for (Annotation annotation : annotations) {
+            if (propertyTypeAnnotations.contains(annotation.annotationType())) {
+                declaredPropertyTypes.add(annotation.annotationType());
+            }
+            propertyContext.addAnnotation(annotation);
+        }
+
+        if (declaredPropertyTypes.size() > 1) {
+            propertyContext.validationMessage("has conflicting property types declared: "
+                    + Joiner.on(", ").join(Iterables.transform(declaredPropertyTypes, new Function<Class<? extends Annotation>, String>() {
+                    @Override
+                    public String apply(Class<? extends Annotation> annotationType) {
+                        return "@" + annotationType.getSimpleName();
+                    }
+                }))
+            );
+        }
+    }
+
+    @Nullable
+    private ChangeDetectionProperty createProperty(DefaultTaskPropertyActionContext propertyContext) {
+        Class<? extends Annotation> propertyType = propertyContext.getPropertyType();
+        if (propertyType != null) {
+            if (propertyContext.isAnnotationPresent(Optional.class)) {
+                propertyContext.setOptional(true);
+            }
+
+            PropertyAnnotationHandler handler = annotationHandlers.get(propertyType);
+            handler.attachActions(propertyContext);
+
+            return propertyContext.createProperty();
+        } else {
+            propertyContext.validationMessage("is not annotated with an input or output annotation");
+            return null;
+        }
+    }
+
+    private static Map<String, Field> getFields(Class<?> type) {
+        Map<String, Field> fields = Maps.newHashMap();
+        for (Field field : type.getDeclaredFields()) {
+            fields.put(field.getName(), field);
+        }
+        return fields;
+    }
+
+    private static List<Getter> getGetters(Class<?> type) {
+        Method[] methods = type.getDeclaredMethods();
+        List<Getter> getters = Lists.newArrayListWithCapacity(methods.length);
+        for (Method method : methods) {
+            PropertyAccessorType accessorType = PropertyAccessorType.of(method);
+            // We only care about getters
+            if (accessorType == null || accessorType == PropertyAccessorType.SETTER) {
+                continue;
+            }
+            // We only care about actual methods the user added
+            if (method.isBridge() || GroovyMethods.isObjectMethod(method)) {
+                continue;
+            }
+            getters.add(new DefaultSchemaExtractor.Getter(method, accessorType.propertyNameFor(method)));
+        }
+        Collections.sort(getters);
+        return getters;
+    }
+
+    private static class Getter implements Comparable<Getter> {
+        private final Method method;
+        private final String name;
+
+        public Getter(Method method, String name) {
+            this.method = method;
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Method getMethod() {
+            return method;
+        }
+
+        @Override
+        public int compareTo(Getter o) {
+            // Sort "is"-getters before "get"-getters when both are available
+            return method.getName().compareTo(o.method.getName());
+        }
+    }
+
+    private static class DefaultTaskPropertyActionContext implements TaskPropertyActionContext {
+        private final Set<Class<? extends Annotation>> propertyTypeAnnotations;
+        private final String name;
+        private final Method method;
+        private final List<Annotation> annotations = Lists.newArrayList();
+        private final boolean cacheable;
+        private final ImmutableCollection.Builder<TaskClassValidationMessage> validationMessages;
+        private Field instanceVariableField;
+        private ValidationAction validationAction;
+        private UpdateAction configureAction;
+        private boolean optional;
+        private Class<?> nestedType;
+        private Class<? extends Annotation> propertyType;
+
+        public DefaultTaskPropertyActionContext(Set<Class<? extends Annotation>> propertyTypeAnnotations, String name, Method method, boolean cacheable, ImmutableCollection.Builder<TaskClassValidationMessage> validationMessages) {
+            this.propertyTypeAnnotations = propertyTypeAnnotations;
+            this.name = name;
+            this.method = method;
+            this.cacheable = cacheable;
+            this.validationMessages = validationMessages;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public Class<? extends Annotation> getPropertyType() {
+            return propertyType;
+        }
+
+        @Override
+        public Class<?> getValueType() {
+            return instanceVariableField != null
+                ? instanceVariableField.getType()
+                : method.getReturnType();
+        }
+
+        @Override
+        public void addAnnotation(Annotation annotation) {
+            Class<? extends Annotation> annotationType = annotation.annotationType();
+            // Record the most specific property type annotation only
+            if (propertyType == null && isPropertyTypeAnnotation(annotationType)) {
+                propertyType = annotationType;
+            }
+            // Record the most specific annotation only
+            if (!isAnnotationPresent(annotation.annotationType())) {
+                annotations.add(annotation);
+            }
+        }
+
+        private boolean isPropertyTypeAnnotation(Class<? extends Annotation> annotationType) {
+            return propertyTypeAnnotations.contains(annotationType);
+        }
+
+        @Override
+        @Nullable
+        public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+            for (Annotation annotation : annotations) {
+                if (annotationType.equals(annotation.annotationType())) {
+                    return annotationType.cast(annotation);
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+            return getAnnotation(annotationType) != null;
+        }
+
+        @Override
+        public void setInstanceVariableField(@Nullable Field instanceVariableField) {
+            if (this.instanceVariableField == null && instanceVariableField != null) {
+                this.instanceVariableField = instanceVariableField;
+            }
+        }
+
+        @Override
+        public boolean isOptional() {
+            return optional;
+        }
+
+        @Override
+        public boolean isCacheable() {
+            return cacheable;
+        }
+
+        @Override
+        public void setOptional(boolean optional) {
+            this.optional = optional;
+        }
+
+        @Override
+        public void setValidationAction(ValidationAction action) {
+            this.validationAction = action;
+        }
+
+        @Override
+        public void setConfigureAction(UpdateAction action) {
+            this.configureAction = action;
+        }
+
+        @Nullable
+        public Class<?> getNestedType() {
+            return nestedType;
+        }
+
+        @Override
+        public void setNestedType(Class<?> nestedType) {
+            this.nestedType = nestedType;
+        }
+
+        @Nullable
+        public ChangeDetectionProperty createProperty() {
+            if (configureAction == null && validationAction == null) {
+                return null;
+            }
+            return new ChangeDetectionProperty(name, propertyType, method, validationAction, configureAction, optional);
+        }
+
+        @Override
+        public void validationMessage(String message) {
+            validationMessages.add(TaskClassValidationMessage.property(name, message));
+        }
+    }
+
+
+    public static class ChangeDetectionProperty implements Comparable<ChangeDetectionProperty> {
+        private static final UpdateAction NO_OP_CONFIGURATION_ACTION = new UpdateAction() {};
+
+        private static final ValidationAction NO_OP_VALIDATION_ACTION = new ValidationAction() {
+            public void validate(String propertyName, Object value, Collection<String> messages) {
+            }
+        };
+
+        private final String propertyName;
+        private final Class<? extends Annotation> propertyType;
+        private final Method method;
+        private final ValidationAction validationAction;
+        private final UpdateAction configureAction;
+        private final boolean optional;
+
+        ChangeDetectionProperty(String propertyName, Class<? extends Annotation> propertyType, Method method, @Nullable ValidationAction validationAction, @Nullable UpdateAction configureAction, boolean optional) {
+            this.propertyName = propertyName;
+            this.propertyType = propertyType;
+            this.method = method;
+            this.validationAction = validationAction == null ? NO_OP_VALIDATION_ACTION : validationAction;
+            this.configureAction = configureAction == null ? NO_OP_CONFIGURATION_ACTION : configureAction;
+            this.optional = optional;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("@%s %s", propertyType.getSimpleName(), propertyName);
+        }
+
+        public String getName() {
+            return propertyName;
+        }
+
+        public Class<? extends Annotation> getPropertyType() {
+            return propertyType;
+        }
+
+        public boolean isNested() {
+            return propertyType == Nested.class;
+        }
+
+        public UpdateAction getConfigureAction() {
+            return configureAction;
+        }
+
+        public TaskPropertyValue getValue(final Object bean) {
+
+            final Object value = DeprecationLogger.whileDisabled(new Factory<Object>() {
+                public Object create() {
+                    return JavaReflectionUtil.method(Object.class, method).invoke(bean);
+                }
+            });
+
+            return new TaskPropertyValue() {
+                @Override
+                public Object getValue() {
+                    return value;
+                }
+
+                @Override
+                @SuppressWarnings("ConstantConditions")
+                public void checkNotNull(Collection<String> messages) {
+                    if (value == null && !optional) {
+                        messages.add(String.format("No value has been specified for property '%s'.", propertyName));
+                    }
+                }
+
+                @Override
+                @SuppressWarnings("ConstantConditions")
+                public void checkValid(Collection<String> messages) {
+                    if (value != null) {
+                        validationAction.validate(propertyName, value, messages);
+                    }
+                }
+            };
+        }
+
+        @Override
+        public int compareTo(ChangeDetectionProperty o) {
+            return propertyName.compareTo(o.getName());
+        }
+    }
+
+    public interface SchemaNode extends Callable<Object> {
+        UpdateAction getConfigureAction();
+    }
+
+    private static final UpdateAction NO_OP_CONFIGURATION_ACTION = new UpdateAction() {};
+
+    public static class SchemaProperty implements SchemaNode {
+
+        private final ChangeDetectionProperty property;
+        private final Object parentValue;
+        private final Supplier<TaskPropertyValue> valueSupplier = Suppliers.memoize(new Supplier<TaskPropertyValue>() {
+            @Override
+            public TaskPropertyValue get() {
+                return property.getValue(parentValue);
+            }
+        });
+        private final UpdateAction configureAction;
+
+        SchemaProperty(ChangeDetectionProperty property, Object parentValue, @Nullable UpdateAction configureAction) {
+            this.property = property;
+            this.parentValue = parentValue;
+            this.configureAction = configureAction == null ? NO_OP_CONFIGURATION_ACTION : configureAction;
+        }
+
+        @Override
+        public UpdateAction getConfigureAction() {
+            return configureAction;
+        }
+
+        @Override
+        public Object call() throws Exception {
+            return valueSupplier.get().getValue();
+        }
+    }
+
+    public static class SchemaRoot implements SchemaNode {
+        private final Map<String, SchemaNode> children;
+        private final Object instance;
+
+        SchemaRoot(Map<String, SchemaNode> children, Object instance) {
+            this.children = children;
+            this.instance = instance;
+        }
+
+        public Map<String, SchemaNode> getChildren() {
+            return children;
+        }
+
+        @Override
+        public UpdateAction getConfigureAction() {
+            return NO_OP_CONFIGURATION_ACTION;
+        }
+
+        @Override
+        public Object call() throws Exception {
+            return instance;
+        }
+    }
+
+    public static class NestedSchema implements SchemaNode {
+        private final Map<String, SchemaNode> children;
+        private final TaskPropertyValue value;
+        private final UpdateAction configureAction;
+
+        NestedSchema(Map<String, SchemaNode> children, TaskPropertyValue value, @Nullable UpdateAction configureAction) {
+            this.children = children;
+            this.value = value;
+            this.configureAction = configureAction == null ? NO_OP_CONFIGURATION_ACTION : configureAction;
+        }
+
+        public Map<String, SchemaNode> getChildren() {
+            return children;
+        }
+
+        @Override
+        public UpdateAction getConfigureAction() {
+            return configureAction;
+        }
+
+        @Override
+        public Object call() throws Exception {
+            return value.getValue();
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultSchemaExtractor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultSchemaExtractor.java
@@ -146,7 +146,7 @@ public class DefaultSchemaExtractor implements SchemaExtractor {
                 if (value.getValue() == null) {
                     children.put(propertyName, new SchemaProperty(changeDetectionProperty, instance, configureAction));
                 } else {
-                    children.put(propertyName, new NestedSchema(extractSchema(value.getValue()).getChildren(), changeDetectionProperty, instance, value));
+                    children.put(propertyName, new NestedSchema(extractSchema(value.getValue()).getChildren(), changeDetectionProperty, value));
                 }
             } else {
                 children.put(propertyName, new SchemaProperty(changeDetectionProperty, instance, configureAction));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DestroysPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DestroysPropertyAnnotationHandler.java
@@ -32,7 +32,7 @@ public class DestroysPropertyAnnotationHandler implements PropertyAnnotationHand
     public void attachActions(TaskPropertyActionContext context) {
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateDestroyables(TaskDestroyables destroyables, Callable<Object> futureValue) {
+            public void updateDestroyables(TaskDestroyables destroyables, String propertyName, Callable<Object> futureValue) {
                 destroyables.files(futureValue);
             }
         });

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DestroysPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DestroysPropertyAnnotationHandler.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.tasks.Destroys;
+import org.gradle.api.tasks.TaskDestroyables;
 
 import java.lang.annotation.Annotation;
 import java.util.concurrent.Callable;
@@ -32,8 +32,8 @@ public class DestroysPropertyAnnotationHandler implements PropertyAnnotationHand
     public void attachActions(TaskPropertyActionContext context) {
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void update(TaskInternal task, Callable<Object> futureValue) {
-                task.getDestroyables().files(futureValue);
+            public void updateDestroyables(TaskDestroyables destroyables, Callable<Object> futureValue) {
+                destroyables.files(futureValue);
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputDirectoryPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputDirectoryPropertyAnnotationHandler.java
@@ -17,8 +17,8 @@ package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputPropertyRegistration;
 import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
 import org.gradle.util.DeferredUtil;
 
@@ -56,7 +56,7 @@ public class InputDirectoryPropertyAnnotationHandler extends AbstractInputProper
         }
     }
 
-    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInputsInternal inputs, Callable<Object> futureValue) {
+    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, InputPropertyRegistration inputs, Callable<Object> futureValue) {
         return inputs.dir(futureValue);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputDirectoryPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputDirectoryPropertyAnnotationHandler.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
 import org.gradle.util.DeferredUtil;
@@ -56,7 +56,7 @@ public class InputDirectoryPropertyAnnotationHandler extends AbstractInputProper
         }
     }
 
-    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue) {
-        return task.getInputs().dir(futureValue);
+    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInputsInternal inputs, Callable<Object> futureValue) {
+        return inputs.dir(futureValue);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputFilePropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputFilePropertyAnnotationHandler.java
@@ -16,8 +16,8 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputPropertyRegistration;
 import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
 import org.gradle.util.DeferredUtil;
 
@@ -53,7 +53,7 @@ public class InputFilePropertyAnnotationHandler extends AbstractInputPropertyAnn
         return (File) unpacked;
     }
 
-    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInputsInternal inputs, Callable<Object> futureValue) {
+    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, InputPropertyRegistration inputs, Callable<Object> futureValue) {
         return inputs.files(futureValue);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputFilePropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputFilePropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
 import org.gradle.util.DeferredUtil;
@@ -53,7 +53,7 @@ public class InputFilePropertyAnnotationHandler extends AbstractInputPropertyAnn
         return (File) unpacked;
     }
 
-    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue) {
-        return task.getInputs().files(futureValue);
+    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInputsInternal inputs, Callable<Object> futureValue) {
+        return inputs.files(futureValue);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputFilesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputFilesPropertyAnnotationHandler.java
@@ -15,8 +15,8 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.InputPropertyRegistration;
 import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
 
 import java.lang.annotation.Annotation;
@@ -33,7 +33,7 @@ public class InputFilesPropertyAnnotationHandler extends AbstractInputPropertyAn
         // no-op
     }
 
-    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInputsInternal inputs, Callable<Object> futureValue) {
+    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, InputPropertyRegistration inputs, Callable<Object> futureValue) {
         return inputs.files(futureValue);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputFilesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputFilesPropertyAnnotationHandler.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
 
@@ -33,7 +33,7 @@ public class InputFilesPropertyAnnotationHandler extends AbstractInputPropertyAn
         // no-op
     }
 
-    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue) {
-        return task.getInputs().files(futureValue);
+    protected TaskInputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInputsInternal inputs, Callable<Object> futureValue) {
+        return inputs.files(futureValue);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputOutputProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputOutputProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project.taskfactory;
+
+public class InputOutputProvider {
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputPropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.Input;
 
 import java.io.File;
@@ -31,8 +31,9 @@ public class InputPropertyAnnotationHandler implements PropertyAnnotationHandler
     @SuppressWarnings("Since15")
     public void attachActions(final TaskPropertyActionContext context) {
         context.setConfigureAction(new UpdateAction() {
-            public void update(TaskInternal task, Callable<Object> futureValue) {
-                task.getInputs().property(context.getName(), futureValue);
+            @Override
+            public void updateInputs(TaskInputsInternal inputs, Callable<Object> futureValue) {
+                inputs.property(context.getName(), futureValue);
             }
         });
         Class<?> valueType = context.getValueType();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputPropertyAnnotationHandler.java
@@ -16,8 +16,8 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputPropertyRegistration;
 
 import java.io.File;
 import java.lang.annotation.Annotation;
@@ -32,7 +32,7 @@ public class InputPropertyAnnotationHandler implements PropertyAnnotationHandler
     public void attachActions(final TaskPropertyActionContext context) {
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
+            public void updateInputs(InputPropertyRegistration inputs, String propertyName, Callable<Object> futureValue) {
                 inputs.property(propertyName, futureValue);
             }
         });

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InputPropertyAnnotationHandler.java
@@ -32,8 +32,8 @@ public class InputPropertyAnnotationHandler implements PropertyAnnotationHandler
     public void attachActions(final TaskPropertyActionContext context) {
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateInputs(TaskInputsInternal inputs, Callable<Object> futureValue) {
-                inputs.property(context.getName(), futureValue);
+            public void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
+                inputs.property(propertyName, futureValue);
             }
         });
         Class<?> valueType = context.getValueType();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedBeanPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedBeanPropertyAnnotationHandler.java
@@ -33,8 +33,8 @@ public class NestedBeanPropertyAnnotationHandler implements PropertyAnnotationHa
         context.setNestedType(context.getValueType());
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateInputs(TaskInputsInternal inputs, final Callable<Object> futureValue) {
-                inputs.property(context.getName() + ".class", new Callable<Object>() {
+            public void updateInputs(TaskInputsInternal inputs, String propertyName, final Callable<Object> futureValue) {
+                inputs.property(propertyName + ".class", new Callable<Object>() {
                     public Object call() throws Exception {
                         Object bean = futureValue.call();
                         return bean == null ? null : bean.getClass().getName();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedBeanPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedBeanPropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.tasks.Nested;
 
 import java.lang.annotation.Annotation;
@@ -32,8 +32,9 @@ public class NestedBeanPropertyAnnotationHandler implements PropertyAnnotationHa
     public void attachActions(final TaskPropertyActionContext context) {
         context.setNestedType(context.getValueType());
         context.setConfigureAction(new UpdateAction() {
-            public void update(TaskInternal task, final Callable<Object> futureValue) {
-                task.getInputs().property(context.getName() + ".class", new Callable<Object>() {
+            @Override
+            public void updateInputs(TaskInputsInternal inputs, final Callable<Object> futureValue) {
+                inputs.property(context.getName() + ".class", new Callable<Object>() {
                     public Object call() throws Exception {
                         Object bean = futureValue.call();
                         return bean == null ? null : bean.getClass().getName();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedBeanPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedBeanPropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInputsInternal;
+import org.gradle.api.tasks.InputPropertyRegistration;
 import org.gradle.api.tasks.Nested;
 
 import java.lang.annotation.Annotation;
@@ -33,7 +33,7 @@ public class NestedBeanPropertyAnnotationHandler implements PropertyAnnotationHa
         context.setNestedType(context.getValueType());
         context.setConfigureAction(new UpdateAction() {
             @Override
-            public void updateInputs(TaskInputsInternal inputs, String propertyName, final Callable<Object> futureValue) {
+            public void updateInputs(InputPropertyRegistration inputs, String propertyName, final Callable<Object> futureValue) {
                 inputs.property(propertyName + ".class", new Callable<Object>() {
                     public Object call() throws Exception {
                         Object bean = futureValue.call();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedSchema.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedSchema.java
@@ -51,9 +51,10 @@ public class NestedSchema implements SchemaNode {
     }
 
     private void checkIfConsistent() {
-        TaskPropertyValue currentValue = property.getValue(parent);
-        if (currentValue.getValue() != scannedValue.getValue()) {
-            throw new GradleException("Nested property '" + property.getName() + "' changed after first scanning from " + scannedValue.getValue() + " to " + currentValue.getValue() +"!");
+        Class<?> typeUsedForSchema = scannedValue.getValue().getClass();
+        Object currentValue = property.getValue(parent).getValue();
+        if (currentValue == null || !typeUsedForSchema.equals(currentValue.getClass())) {
+            throw new GradleException("Nested property '" + property.getName() + "' changed after first scanning from " + typeUsedForSchema + " to " + currentValue +"!");
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedSchema.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedSchema.java
@@ -16,23 +16,17 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.GradleException;
-
 import java.util.Map;
 
 public class NestedSchema implements SchemaNode {
     private final Map<String, SchemaNode> children;
-    private final DefaultSchemaExtractor.ChangeDetectionProperty property;
-    private final Object parent;
     private final UpdateAction configureAction;
-    private final TaskPropertyValue scannedValue;
+    private final Object value;
 
-    NestedSchema(Map<String, SchemaNode> children, DefaultSchemaExtractor.ChangeDetectionProperty property, Object parent, TaskPropertyValue taskPropertyValue) {
+    NestedSchema(Map<String, SchemaNode> children, DefaultSchemaExtractor.ChangeDetectionProperty property, TaskPropertyValue taskPropertyValue) {
         this.children = children;
-        this.property = property;
-        this.parent = parent;
         this.configureAction = property.getConfigureAction();
-        this.scannedValue = taskPropertyValue;
+        this.value = taskPropertyValue.getValue();
     }
 
     public Map<String, SchemaNode> getChildren() {
@@ -46,15 +40,6 @@ public class NestedSchema implements SchemaNode {
 
     @Override
     public Object call() throws Exception {
-        checkIfConsistent();
-        return property.getValue(parent).getValue();
-    }
-
-    private void checkIfConsistent() {
-        Class<?> typeUsedForSchema = scannedValue.getValue().getClass();
-        Object currentValue = property.getValue(parent).getValue();
-        if (currentValue == null || !typeUsedForSchema.equals(currentValue.getClass())) {
-            throw new GradleException("Nested property '" + property.getName() + "' changed after first scanning from " + typeUsedForSchema + " to " + currentValue +"!");
-        }
+        return value;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedSchema.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedSchema.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project.taskfactory;
+
+import org.gradle.api.GradleException;
+
+import java.util.Map;
+
+public class NestedSchema implements SchemaNode {
+    private final Map<String, SchemaNode> children;
+    private final DefaultSchemaExtractor.ChangeDetectionProperty property;
+    private final Object parent;
+    private final UpdateAction configureAction;
+    private final TaskPropertyValue scannedValue;
+
+    NestedSchema(Map<String, SchemaNode> children, DefaultSchemaExtractor.ChangeDetectionProperty property, Object parent, TaskPropertyValue taskPropertyValue) {
+        this.children = children;
+        this.property = property;
+        this.parent = parent;
+        this.configureAction = property.getConfigureAction();
+        this.scannedValue = taskPropertyValue;
+    }
+
+    public Map<String, SchemaNode> getChildren() {
+        return children;
+    }
+
+    @Override
+    public UpdateAction getConfigureAction() {
+        return configureAction;
+    }
+
+    @Override
+    public Object call() throws Exception {
+        checkIfConsistent();
+        return property.getValue(parent).getValue();
+    }
+
+    private void checkIfConsistent() {
+        TaskPropertyValue currentValue = property.getValue(parent);
+        if (currentValue != scannedValue) {
+            throw new GradleException("Nested property '" + property.getName() + "' changed after first scanning from " + scannedValue + " to " + currentValue +"!");
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedSchema.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/NestedSchema.java
@@ -52,8 +52,8 @@ public class NestedSchema implements SchemaNode {
 
     private void checkIfConsistent() {
         TaskPropertyValue currentValue = property.getValue(parent);
-        if (currentValue != scannedValue) {
-            throw new GradleException("Nested property '" + property.getName() + "' changed after first scanning from " + scannedValue + " to " + currentValue +"!");
+        if (currentValue.getValue() != scannedValue.getValue()) {
+            throw new GradleException("Nested property '" + property.getName() + "' changed after first scanning from " + scannedValue.getValue() + " to " + currentValue.getValue() +"!");
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoriesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoriesPropertyAnnotationHandler.java
@@ -15,8 +15,8 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.tasks.OutputDirectories;
+import org.gradle.api.tasks.OutputPropertyRegistration;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 
 import java.io.File;
@@ -35,7 +35,7 @@ public class OutputDirectoriesPropertyAnnotationHandler extends AbstractPluralOu
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(OutputPropertyRegistration outputs, Callable<Object> futureValue) {
         return outputs.dirs(futureValue);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoriesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoriesPropertyAnnotationHandler.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.tasks.OutputDirectories;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 
@@ -35,8 +35,8 @@ public class OutputDirectoriesPropertyAnnotationHandler extends AbstractPluralOu
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue) {
-        return task.getOutputs().dirs(futureValue);
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue) {
+        return outputs.dirs(futureValue);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoriesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoriesPropertyAnnotationHandler.java
@@ -35,7 +35,7 @@ public class OutputDirectoriesPropertyAnnotationHandler extends AbstractPluralOu
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue) {
         return outputs.dirs(futureValue);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoryPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoryPropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 import org.gradle.util.DeferredUtil;
@@ -44,8 +44,8 @@ public class OutputDirectoryPropertyAnnotationHandler extends AbstractOutputProp
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue) {
-        return task.getOutputs().dir(futureValue);
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue) {
+        return outputs.dir(futureValue);
     }
 
     private File toFile(Object value) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoryPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoryPropertyAnnotationHandler.java
@@ -44,7 +44,7 @@ public class OutputDirectoryPropertyAnnotationHandler extends AbstractOutputProp
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue) {
         return outputs.dir(futureValue);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoryPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputDirectoryPropertyAnnotationHandler.java
@@ -16,8 +16,8 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputPropertyRegistration;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 import org.gradle.util.DeferredUtil;
 
@@ -44,7 +44,7 @@ public class OutputDirectoryPropertyAnnotationHandler extends AbstractOutputProp
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(OutputPropertyRegistration outputs, Callable<Object> futureValue) {
         return outputs.dir(futureValue);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilePropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilePropertyAnnotationHandler.java
@@ -42,7 +42,7 @@ public class OutputFilePropertyAnnotationHandler extends AbstractOutputPropertyA
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue) {
         return outputs.file(futureValue);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilePropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilePropertyAnnotationHandler.java
@@ -16,8 +16,8 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.OutputPropertyRegistration;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 import org.gradle.util.DeferredUtil;
 
@@ -42,7 +42,7 @@ public class OutputFilePropertyAnnotationHandler extends AbstractOutputPropertyA
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(OutputPropertyRegistration outputs, Callable<Object> futureValue) {
         return outputs.file(futureValue);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilePropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilePropertyAnnotationHandler.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 import org.gradle.util.DeferredUtil;
@@ -42,8 +42,8 @@ public class OutputFilePropertyAnnotationHandler extends AbstractOutputPropertyA
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue) {
-        return task.getOutputs().file(futureValue);
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue) {
+        return outputs.file(futureValue);
     }
 
     private File toFile(Object value) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilesPropertyAnnotationHandler.java
@@ -34,7 +34,7 @@ public class OutputFilesPropertyAnnotationHandler extends AbstractPluralOutputPr
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue) {
         return outputs.files(futureValue);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilesPropertyAnnotationHandler.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.internal.tasks.TaskOutputsUtil;
 import org.gradle.api.tasks.OutputFiles;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
@@ -34,8 +34,8 @@ public class OutputFilesPropertyAnnotationHandler extends AbstractPluralOutputPr
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskInternal task, Callable<Object> futureValue) {
-        return task.getOutputs().files(futureValue);
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskPropertyActionContext context, TaskOutputsInternal outputs, Callable<Object> futureValue) {
+        return outputs.files(futureValue);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/OutputFilesPropertyAnnotationHandler.java
@@ -15,9 +15,9 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.internal.tasks.TaskOutputsUtil;
 import org.gradle.api.tasks.OutputFiles;
+import org.gradle.api.tasks.OutputPropertyRegistration;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 
 import java.io.File;
@@ -34,7 +34,7 @@ public class OutputFilesPropertyAnnotationHandler extends AbstractPluralOutputPr
     }
 
     @Override
-    protected TaskOutputFilePropertyBuilder createPropertyBuilder(TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    protected TaskOutputFilePropertyBuilder createPropertyBuilder(OutputPropertyRegistration outputs, Callable<Object> futureValue) {
         return outputs.files(futureValue);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaExtractor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaExtractor.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project.taskfactory;
+
+public interface SchemaExtractor {
+    DefaultSchemaExtractor.SchemaRoot extractSchema(Object instance);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaNode.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-public interface SchemaExtractor {
-    SchemaRoot extractSchema(Object instance);
+import java.util.concurrent.Callable;
+
+public interface SchemaNode extends Callable<Object> {
+    UpdateAction getConfigureAction();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaProperty.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project.taskfactory;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+import javax.annotation.Nullable;
+
+import static org.gradle.api.internal.project.taskfactory.UpdateAction.NO_OP_CONFIGURATION_ACTION;
+
+public class SchemaProperty implements SchemaNode {
+
+    private final DefaultSchemaExtractor.ChangeDetectionProperty property;
+    private final Object parentValue;
+    private final Supplier<TaskPropertyValue> valueSupplier = Suppliers.memoize(new Supplier<TaskPropertyValue>() {
+        @Override
+        public TaskPropertyValue get() {
+            return property.getValue(parentValue);
+        }
+    });
+    private final UpdateAction configureAction;
+
+    SchemaProperty(DefaultSchemaExtractor.ChangeDetectionProperty property, Object parentValue, @Nullable UpdateAction configureAction) {
+        this.property = property;
+        this.parentValue = parentValue;
+        this.configureAction = configureAction == null ? NO_OP_CONFIGURATION_ACTION : configureAction;
+    }
+
+    @Override
+    public UpdateAction getConfigureAction() {
+        return configureAction;
+    }
+
+    @Override
+    public Object call() throws Exception {
+        return valueSupplier.get().getValue();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaProperty.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 
 import javax.annotation.Nullable;
 
@@ -27,12 +26,12 @@ public class SchemaProperty implements SchemaNode {
 
     private final DefaultSchemaExtractor.ChangeDetectionProperty property;
     private final Object parentValue;
-    private final Supplier<TaskPropertyValue> valueSupplier = Suppliers.memoize(new Supplier<TaskPropertyValue>() {
+    private final Supplier<TaskPropertyValue> valueSupplier = new Supplier<TaskPropertyValue>() {
         @Override
         public TaskPropertyValue get() {
             return property.getValue(parentValue);
         }
-    });
+    };
     private final UpdateAction configureAction;
 
     SchemaProperty(DefaultSchemaExtractor.ChangeDetectionProperty property, Object parentValue, @Nullable UpdateAction configureAction) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaProperty.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 
 import javax.annotation.Nullable;
 
@@ -26,12 +27,12 @@ public class SchemaProperty implements SchemaNode {
 
     private final DefaultSchemaExtractor.ChangeDetectionProperty property;
     private final Object parentValue;
-    private final Supplier<TaskPropertyValue> valueSupplier = new Supplier<TaskPropertyValue>() {
+    private final Supplier<TaskPropertyValue> valueSupplier = Suppliers.memoize(new Supplier<TaskPropertyValue>() {
         @Override
         public TaskPropertyValue get() {
             return property.getValue(parentValue);
         }
-    };
+    });
     private final UpdateAction configureAction;
 
     SchemaProperty(DefaultSchemaExtractor.ChangeDetectionProperty property, Object parentValue, @Nullable UpdateAction configureAction) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaRoot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/SchemaRoot.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project.taskfactory;
+
+import java.util.Map;
+
+import static org.gradle.api.internal.project.taskfactory.UpdateAction.NO_OP_CONFIGURATION_ACTION;
+
+public class SchemaRoot implements SchemaNode {
+    private final Map<String, SchemaNode> children;
+    private final Object instance;
+
+    SchemaRoot(Map<String, SchemaNode> children, Object instance) {
+        this.children = children;
+        this.instance = instance;
+    }
+
+    public Map<String, SchemaNode> getChildren() {
+        return children;
+    }
+
+    @Override
+    public UpdateAction getConfigureAction() {
+        return NO_OP_CONFIGURATION_ACTION;
+    }
+
+    @Override
+    public Object call() throws Exception {
+        return instance;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.project.taskfactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.ChangeDetection;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.execution.TaskValidator;
 
@@ -40,47 +41,47 @@ public class TaskClassValidator implements TaskValidator {
         this.cacheable = cacheable;
     }
 
-    public void addInputsAndOutputs(final TaskInternal task) {
-        addInputs(task);
-        addOutputs(task);
-        addDestroyables(task);
+    public void registerInputsAndOutputs(ChangeDetection changeDetection, Object instance) {
+        addInputs(changeDetection, instance);
+        addOutputs(changeDetection, instance);
+        addDestroyables(changeDetection, instance);
     }
 
-    public void addInputs(final TaskInternal task) {
+    public void addInputs(ChangeDetection changeDetection, Object instance) {
         for (TaskPropertyInfo property : annotatedProperties) {
-            property.getConfigureAction().updateInputs(task.getInputs(), property.getName(), new FutureValue(property, task));
+            property.getConfigureAction().updateInputs(changeDetection.getInputs(), property.getName(), new FutureValue(property, instance));
         }
     }
 
-    public void addOutputs(final TaskInternal task) {
+    public void addOutputs(ChangeDetection changeDetection, Object instance) {
         for (TaskPropertyInfo property : annotatedProperties) {
-            property.getConfigureAction().updateOutputs(task.getOutputs(), property.getName(), new FutureValue(property, task));
+            property.getConfigureAction().updateOutputs(changeDetection.getOutputs(), property.getName(), new FutureValue(property, instance));
         }
     }
 
-    public void addDestroyables(final TaskInternal task) {
+    public void addDestroyables(ChangeDetection changeDetection, Object instance) {
         for (TaskPropertyInfo property : annotatedProperties) {
-            property.getConfigureAction().updateDestroyables(task.getDestroyables(), property.getName(), new FutureValue(property, task));
+            property.getConfigureAction().updateDestroyables(changeDetection.getDestroyables(), property.getName(), new FutureValue(property, instance));
         }
     }
 
     private static class FutureValue implements Callable<Object> {
         private final TaskPropertyInfo property;
-        private final TaskInternal task;
+        private final Object instance;
 
-        private FutureValue(TaskPropertyInfo property, TaskInternal task) {
+        private FutureValue(TaskPropertyInfo property, Object instance) {
             this.property = property;
-            this.task = task;
+            this.instance = instance;
         }
 
         @Override
         public Object call() throws Exception {
-            return property.getValue(task).getValue();
+            return property.getValue(instance).getValue();
         }
 
         @Override
         public String toString() {
-            return String.format("property (%s) for task '%s'", property, task.getName());
+            return String.format("property (%s) for task '%s'", property, instance);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
@@ -41,8 +41,26 @@ public class TaskClassValidator implements TaskValidator {
     }
 
     public void addInputsAndOutputs(final TaskInternal task) {
+        addInputs(task);
+        addOutputs(task);
+        addDestroyables(task);
+    }
+
+    public void addInputs(final TaskInternal task) {
         for (TaskPropertyInfo property : annotatedProperties) {
-            property.getConfigureAction().update(task, new FutureValue(property, task));
+            property.getConfigureAction().updateInputs(task.getInputs(), new FutureValue(property, task));
+        }
+    }
+
+    public void addOutputs(final TaskInternal task) {
+        for (TaskPropertyInfo property : annotatedProperties) {
+            property.getConfigureAction().updateOutputs(task.getOutputs(), new FutureValue(property, task));
+        }
+    }
+
+    public void addDestroyables(final TaskInternal task) {
+        for (TaskPropertyInfo property : annotatedProperties) {
+            property.getConfigureAction().updateDestroyables(task.getDestroyables(), new FutureValue(property, task));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
@@ -41,7 +41,6 @@ public class TaskClassValidator implements TaskValidator {
     }
 
     public void addInputsAndOutputs(final TaskInternal task) {
-        task.addValidator(this);
         for (TaskPropertyInfo property : annotatedProperties) {
             property.getConfigureAction().update(task, new FutureValue(property, task));
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassValidator.java
@@ -48,19 +48,19 @@ public class TaskClassValidator implements TaskValidator {
 
     public void addInputs(final TaskInternal task) {
         for (TaskPropertyInfo property : annotatedProperties) {
-            property.getConfigureAction().updateInputs(task.getInputs(), new FutureValue(property, task));
+            property.getConfigureAction().updateInputs(task.getInputs(), property.getName(), new FutureValue(property, task));
         }
     }
 
     public void addOutputs(final TaskInternal task) {
         for (TaskPropertyInfo property : annotatedProperties) {
-            property.getConfigureAction().updateOutputs(task.getOutputs(), new FutureValue(property, task));
+            property.getConfigureAction().updateOutputs(task.getOutputs(), property.getName(), new FutureValue(property, task));
         }
     }
 
     public void addDestroyables(final TaskInternal task) {
         for (TaskPropertyInfo property : annotatedProperties) {
-            property.getConfigureAction().updateDestroyables(task.getDestroyables(), new FutureValue(property, task));
+            property.getConfigureAction().updateDestroyables(task.getDestroyables(), property.getName(), new FutureValue(property, task));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskPropertyInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskPropertyInfo.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
 import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.gradle.util.DeprecationLogger;
@@ -24,7 +23,6 @@ import org.gradle.util.DeprecationLogger;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 public class TaskPropertyInfo implements Comparable<TaskPropertyInfo> {
     private static final ValidationAction NO_OP_VALIDATION_ACTION = new ValidationAction() {
@@ -42,10 +40,7 @@ public class TaskPropertyInfo implements Comparable<TaskPropertyInfo> {
         public void checkValid(Collection<String> messages) {
         }
     };
-    private static final UpdateAction NO_OP_CONFIGURATION_ACTION = new UpdateAction() {
-        public void update(TaskInternal task, Callable<Object> futureValue) {
-        }
-    };
+    private static final UpdateAction NO_OP_CONFIGURATION_ACTION = new UpdateAction() {};
 
     private final TaskPropertyInfo parent;
     private final String propertyName;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
@@ -22,6 +22,8 @@ import org.gradle.api.tasks.TaskDestroyables;
 import java.util.concurrent.Callable;
 
 public abstract class UpdateAction {
+    public static final UpdateAction NO_OP_CONFIGURATION_ACTION = new UpdateAction() {};
+
 
     public void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
@@ -23,12 +23,12 @@ import java.util.concurrent.Callable;
 
 public abstract class UpdateAction {
 
-    void updateInputs(TaskInputsInternal inputs, Callable<Object> futureValue) {
+    void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
     }
 
-    void updateOutputs(TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    void updateOutputs(TaskOutputsInternal outputs, String propertyName, Callable<Object> futureValue) {
     }
 
-    void updateDestroyables(TaskDestroyables destroyables, Callable<Object> futureValue) {
+    void updateDestroyables(TaskDestroyables destroyables, String propertyName, Callable<Object> futureValue) {
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
@@ -15,8 +15,8 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.tasks.InputPropertyRegistration;
+import org.gradle.api.tasks.OutputPropertyRegistration;
 import org.gradle.api.tasks.TaskDestroyables;
 
 import java.util.concurrent.Callable;
@@ -28,7 +28,7 @@ public abstract class UpdateAction {
     public void updateInputs(InputPropertyRegistration inputs, String propertyName, Callable<Object> futureValue) {
     }
 
-    public void updateOutputs(TaskOutputsInternal outputs, String propertyName, Callable<Object> futureValue) {
+    public void updateOutputs(OutputPropertyRegistration outputs, String propertyName, Callable<Object> futureValue) {
     }
 
     public void updateDestroyables(TaskDestroyables destroyables, String propertyName, Callable<Object> futureValue) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
@@ -15,10 +15,20 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.TaskInputsInternal;
+import org.gradle.api.internal.TaskOutputsInternal;
+import org.gradle.api.tasks.TaskDestroyables;
 
 import java.util.concurrent.Callable;
 
-public interface UpdateAction {
-    void update(TaskInternal task, Callable<Object> futureValue);
+public abstract class UpdateAction {
+
+    void updateInputs(TaskInputsInternal inputs, Callable<Object> futureValue) {
+    }
+
+    void updateOutputs(TaskOutputsInternal outputs, Callable<Object> futureValue) {
+    }
+
+    void updateDestroyables(TaskDestroyables destroyables, Callable<Object> futureValue) {
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
@@ -23,12 +23,12 @@ import java.util.concurrent.Callable;
 
 public abstract class UpdateAction {
 
-    void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
+    public void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
     }
 
-    void updateOutputs(TaskOutputsInternal outputs, String propertyName, Callable<Object> futureValue) {
+    public void updateOutputs(TaskOutputsInternal outputs, String propertyName, Callable<Object> futureValue) {
     }
 
-    void updateDestroyables(TaskDestroyables destroyables, String propertyName, Callable<Object> futureValue) {
+    public void updateDestroyables(TaskDestroyables destroyables, String propertyName, Callable<Object> futureValue) {
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/UpdateAction.java
@@ -15,8 +15,8 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.internal.TaskOutputsInternal;
+import org.gradle.api.tasks.InputPropertyRegistration;
 import org.gradle.api.tasks.TaskDestroyables;
 
 import java.util.concurrent.Callable;
@@ -25,7 +25,7 @@ public abstract class UpdateAction {
     public static final UpdateAction NO_OP_CONFIGURATION_ACTION = new UpdateAction() {};
 
 
-    public void updateInputs(TaskInputsInternal inputs, String propertyName, Callable<Object> futureValue) {
+    public void updateInputs(InputPropertyRegistration inputs, String propertyName, Callable<Object> futureValue) {
     }
 
     public void updateOutputs(TaskOutputsInternal outputs, String propertyName, Callable<Object> futureValue) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputsDeprecatingTaskPropertyBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskOutputsDeprecatingTaskPropertyBuilder.java
@@ -17,12 +17,16 @@
 package org.gradle.api.internal.tasks;
 
 import groovy.lang.Closure;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
 import org.gradle.api.tasks.TaskOutputs;
 
+import javax.annotation.Nullable;
+
+@NonNullApi
 abstract class AbstractTaskOutputsDeprecatingTaskPropertyBuilder extends AbstractTaskPropertyBuilder implements TaskOutputs {
     // --- See CompatibilityAdapterForTaskOutputs for an explanation for why these methods are here
 
@@ -71,13 +75,13 @@ abstract class AbstractTaskOutputsDeprecatingTaskPropertyBuilder extends Abstrac
 
     @Override
     @Deprecated
-    public TaskOutputFilePropertyBuilder files(Object... paths) {
+    public TaskOutputFilePropertyBuilder files(@Nullable Object... paths) {
         throw failWithUnsupportedMethod("files(Object...)");
     }
 
     @Override
     @Deprecated
-    public TaskOutputFilePropertyBuilder dirs(Object... paths) {
+    public TaskOutputFilePropertyBuilder dirs(@Nullable Object... paths) {
         throw failWithUnsupportedMethod("dirs(Object...)");
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultInputPropertyRegistration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultInputPropertyRegistration.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.tasks.InputPropertyRegistration;
+import org.gradle.api.tasks.TaskInputs;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+@NonNullApi
+public class DefaultInputPropertyRegistration implements InputPropertyRegistration {
+    private final String taskName;
+    private final TaskMutator taskMutator;
+    private final FileResolver resolver;
+
+    private List<TaskInputPropertySpecAndBuilder> fileProperties = Lists.newArrayList();
+    private final Map<String, Object> properties = new HashMap<String, Object>();
+
+    public DefaultInputPropertyRegistration(String taskName, TaskMutator taskMutator, FileResolver resolver) {
+        this.taskName = taskName;
+        this.taskMutator = taskMutator;
+        this.resolver = resolver;
+    }
+
+    @Override
+    public boolean getHasInputs() {
+        return !properties.isEmpty() || !fileProperties.isEmpty();
+    }
+
+    @Override
+    public TaskInputFilePropertyBuilderInternal files(final Object... paths) {
+        return taskMutator.mutate("TaskInputs.files(Object...)", new Callable<TaskInputFilePropertyBuilderInternal>() {
+            @Override
+            public TaskInputFilePropertyBuilderInternal call() {
+                return addSpec(paths);
+            }
+        });
+    }
+
+    @Override
+    public TaskInputFilePropertyBuilderInternal file(final Object path) {
+        return taskMutator.mutate("TaskInputs.file(Object)", new Callable<TaskInputFilePropertyBuilderInternal>() {
+            @Override
+            public TaskInputFilePropertyBuilderInternal call() {
+                return addSpec(path);
+            }
+        });
+    }
+
+    @Override
+    public TaskInputFilePropertyBuilderInternal dir(final Object dirPath) {
+        return taskMutator.mutate("TaskInputs.dir(Object)", new Callable<TaskInputFilePropertyBuilderInternal>() {
+            @Override
+            public TaskInputFilePropertyBuilderInternal call() {
+                return addSpec(resolver.resolveFilesAsTree(dirPath));
+            }
+        });
+    }
+
+    private TaskInputFilePropertyBuilderInternal addSpec(Object paths) {
+        DefaultTaskInputPropertySpec spec = new DefaultTaskInputPropertySpec(taskName, resolver, paths);
+        fileProperties.add(spec);
+        return spec;
+    }
+
+    @Nullable
+    public TaskInputs property(final String name, @Nullable final Object value) {
+        taskMutator.mutate("TaskInputs.property(String, Object)", new Runnable() {
+            public void run() {
+                properties.put(name, value);
+            }
+        });
+        return null;
+    }
+
+    @Nullable
+    public TaskInputs properties(final Map<String, ?> newProps) {
+        taskMutator.mutate("TaskInputs.properties(Map)", new Runnable() {
+            public void run() {
+                properties.putAll(newProps);
+            }
+        });
+        return null;
+    }
+
+
+    public List<TaskInputPropertySpecAndBuilder> getFileProperties() {
+        return fileProperties;
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultOutputPropertyRegistration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultOutputPropertyRegistration.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.tasks.OutputPropertyRegistration;
+import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+@NonNullApi
+public class DefaultOutputPropertyRegistration implements OutputPropertyRegistration{
+    private final TaskMutator taskMutator;
+    private final String taskName;
+    private final FileResolver resolver;
+
+    private final List<TaskOutputPropertySpecAndBuilder> fileProperties = Lists.newArrayList();
+
+    public DefaultOutputPropertyRegistration(String taskName, TaskMutator taskMutator, FileResolver resolver) {
+        this.taskMutator = taskMutator;
+        this.taskName = taskName;
+        this.resolver = resolver;
+    }
+
+    @Override
+    public TaskOutputFilePropertyBuilder file(final Object path) {
+        return taskMutator.mutate("TaskOutputs.file(Object)", new Callable<TaskOutputFilePropertyBuilder>() {
+            @Override
+            public TaskOutputFilePropertyBuilder call() throws Exception {
+                return addSpec(new DefaultCacheableTaskOutputFilePropertySpec(taskName, resolver, OutputType.FILE, path));
+            }
+        });
+    }
+
+    @Override
+    public TaskOutputFilePropertyBuilder dir(final Object path) {
+        return taskMutator.mutate("TaskOutputs.dir(Object)", new Callable<TaskOutputFilePropertyBuilder>() {
+            @Override
+            public TaskOutputFilePropertyBuilder call() throws Exception {
+                return addSpec(new DefaultCacheableTaskOutputFilePropertySpec(taskName, resolver, OutputType.DIRECTORY, path));
+            }
+        });
+    }
+
+    @Override
+    public boolean getHasOutput() {
+        return !fileProperties.isEmpty();
+    }
+
+    @Override
+    public TaskOutputFilePropertyBuilder files(@Nullable final Object... paths) {
+        return taskMutator.mutate("TaskOutputs.files(Object...)", new Callable<TaskOutputFilePropertyBuilder>() {
+            @Override
+            public TaskOutputFilePropertyBuilder call() throws Exception {
+                return addSpec(new CompositeTaskOutputPropertySpec(taskName, resolver, OutputType.FILE, paths));
+            }
+        });
+    }
+
+    @Override
+    public TaskOutputFilePropertyBuilder dirs(@Nullable final Object... paths) {
+        return taskMutator.mutate("TaskOutputs.dirs(Object...)", new Callable<TaskOutputFilePropertyBuilder>() {
+            @Override
+            public TaskOutputFilePropertyBuilder call() throws Exception {
+                return addSpec(new CompositeTaskOutputPropertySpec(taskName, resolver, OutputType.DIRECTORY, paths));
+            }
+        });
+    }
+
+    private TaskOutputFilePropertyBuilder addSpec(TaskOutputPropertySpecAndBuilder spec) {
+        fileProperties.add(spec);
+        return spec;
+    }
+
+    public List<TaskOutputPropertySpecAndBuilder> getFileProperties() {
+        return fileProperties;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDestroyables.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDestroyables.java
@@ -61,13 +61,14 @@ public class DefaultTaskDestroyables implements TaskDestroyables, TaskDestroyabl
     public DefaultConfigurableFileCollection getFiles() {
         if (destroyFiles == null) {
             destroyFiles = new DefaultConfigurableFileCollection(task + " destroy files", resolver, null);
-
+            task.ensureTaskInputsAndOutputsDiscovered();
         }
         return destroyFiles;
     }
 
     @Override
     public Collection<File> getFilesReadOnly() {
+        task.ensureTaskInputsAndOutputsDiscovered();
         if (destroyFiles != null) {
             return destroyFiles.getFiles();
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDestroyables.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDestroyables.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.internal.ChangeDetection;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection;
@@ -29,12 +30,14 @@ public class DefaultTaskDestroyables implements TaskDestroyables, TaskDestroyabl
     private final FileResolver resolver;
     private final TaskInternal task;
     private final TaskMutator taskMutator;
+    private final ChangeDetection changeDetection;
     private DefaultConfigurableFileCollection destroyFiles;
 
-    public DefaultTaskDestroyables(FileResolver resolver, TaskInternal task, TaskMutator taskMutator) {
+    public DefaultTaskDestroyables(FileResolver resolver, TaskInternal task, TaskMutator taskMutator, ChangeDetection changeDetection) {
         this.resolver = resolver;
         this.task = task;
         this.taskMutator = taskMutator;
+        this.changeDetection = changeDetection;
     }
 
     @Override
@@ -61,14 +64,14 @@ public class DefaultTaskDestroyables implements TaskDestroyables, TaskDestroyabl
     public DefaultConfigurableFileCollection getFiles() {
         if (destroyFiles == null) {
             destroyFiles = new DefaultConfigurableFileCollection(task + " destroy files", resolver, null);
-            task.ensureTaskInputsAndOutputsDiscovered();
+            changeDetection.ensureTaskInputsAndOutputsDiscovered();
         }
         return destroyFiles;
     }
 
     @Override
     public Collection<File> getFilesReadOnly() {
-        task.ensureTaskInputsAndOutputsDiscovered();
+        changeDetection.ensureTaskInputsAndOutputsDiscovered();
         if (destroyFiles != null) {
             return destroyFiles.getFiles();
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshotter;
 import org.gradle.api.internal.changedetection.state.GenericFileCollectionSnapshotter;
@@ -26,10 +27,12 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
 import org.gradle.api.tasks.TaskInputs;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 import static org.gradle.api.internal.changedetection.state.InputPathNormalizationStrategy.ABSOLUTE;
 
+@NonNullApi
 public class DefaultTaskInputPropertySpec extends AbstractTaskPropertyBuilder implements TaskInputPropertySpecAndBuilder {
 
     private final TaskPropertyFileCollection files;
@@ -48,7 +51,7 @@ public class DefaultTaskInputPropertySpec extends AbstractTaskPropertyBuilder im
     }
 
     @Override
-    public TaskInputFilePropertyBuilderInternal withPropertyName(String propertyName) {
+    public TaskInputFilePropertyBuilderInternal withPropertyName(@Nullable String propertyName) {
         setPropertyName(propertyName);
         return this;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -17,10 +17,12 @@ package org.gradle.api.internal.tasks;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import groovy.lang.GString;
 import org.gradle.api.Describable;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ChangeDetection;
 import org.gradle.api.internal.TaskInputsInternal;
@@ -30,47 +32,45 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.tasks.TaskInputs;
 
-import java.util.HashMap;
-import java.util.List;
+import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import static org.gradle.api.internal.tasks.TaskPropertyUtils.ensurePropertiesHaveNames;
 import static org.gradle.util.GUtil.uncheckedCall;
 
+@NonNullApi
 public class DefaultTaskInputs implements TaskInputsInternal {
     private final FileCollection allInputFiles;
     private final FileCollection allSourceFiles;
-    private final FileResolver resolver;
     private final TaskInternal task;
-    private final TaskMutator taskMutator;
     private final ChangeDetection changeDetection;
-    private final Map<String, Object> properties = new HashMap<String, Object>();
-    private List<TaskInputPropertySpecAndBuilder> filePropertiesInternal = Lists.newArrayList();
-    private final Supplier<List<TaskInputPropertySpecAndBuilder>> filePropertiesInternalSupplier = new Supplier<List<TaskInputPropertySpecAndBuilder>>() {
+    private final DefaultInputPropertyRegistration userSuppliedProperties;
+    private DefaultInputPropertyRegistration discoveredProperties;
+
+    private final Supplier<Iterable<TaskInputPropertySpecAndBuilder>> filePropertiesInternalSupplier = new Supplier<Iterable<TaskInputPropertySpecAndBuilder>>() {
 
         @Override
-        public List<TaskInputPropertySpecAndBuilder> get() {
+        public Iterable<TaskInputPropertySpecAndBuilder> get() {
             changeDetection.ensureTaskInputsAndOutputsDiscovered();
-            return filePropertiesInternal;
+            return getFilePropertiesInternal();
         }
     };
     private ImmutableSortedSet<TaskInputFilePropertySpec> fileProperties;
-
     public DefaultTaskInputs(FileResolver resolver, TaskInternal task, TaskMutator taskMutator, ChangeDetection changeDetection) {
-        this.resolver = resolver;
         this.task = task;
-        this.taskMutator = taskMutator;
         this.changeDetection = changeDetection;
         String taskName = task.getName();
         this.allInputFiles = new TaskInputUnionFileCollection(taskName, "input", false, filePropertiesInternalSupplier);
         this.allSourceFiles = new TaskInputUnionFileCollection(taskName, "source", true, filePropertiesInternalSupplier);
+        this.userSuppliedProperties = new DefaultInputPropertyRegistration(taskName, taskMutator, resolver);
     }
 
     @Override
     public boolean getHasInputs() {
         changeDetection.ensureTaskInputsAndOutputsDiscovered();
-        return !filePropertiesInternal.isEmpty() || !properties.isEmpty();
+        return userSuppliedProperties.getHasInputs() || discoveredProperties.getHasInputs();
     }
 
     @Override
@@ -82,46 +82,48 @@ public class DefaultTaskInputs implements TaskInputsInternal {
     public ImmutableSortedSet<TaskInputFilePropertySpec> getFileProperties() {
         changeDetection.ensureTaskInputsAndOutputsDiscovered();
         if (fileProperties == null) {
-            ensurePropertiesHaveNames(filePropertiesInternal);
-            fileProperties = TaskPropertyUtils.<TaskInputFilePropertySpec>collectFileProperties("input", filePropertiesInternal.iterator());
+            Iterable<TaskInputPropertySpecAndBuilder> allSpecs = getFilePropertiesInternal();
+            ensurePropertiesHaveNames(allSpecs);
+            fileProperties = TaskPropertyUtils.<TaskInputFilePropertySpec>collectFileProperties("input", allSpecs.iterator());
         }
         return fileProperties;
     }
 
-    @Override
-    public TaskInputFilePropertyBuilderInternal files(final Object... paths) {
-        return taskMutator.mutate("TaskInputs.files(Object...)", new Callable<TaskInputFilePropertyBuilderInternal>() {
-            @Override
-            public TaskInputFilePropertyBuilderInternal call() {
-                return addSpec(paths);
-            }
-        });
+    private Iterable<TaskInputPropertySpecAndBuilder> getFilePropertiesInternal() {
+        return Iterables.concat(userSuppliedProperties.getFileProperties(), discoveredProperties.getFileProperties());
     }
 
     @Override
-    public TaskInputFilePropertyBuilderInternal file(final Object path) {
-        return taskMutator.mutate("TaskInputs.file(Object)", new Callable<TaskInputFilePropertyBuilderInternal>() {
-            @Override
-            public TaskInputFilePropertyBuilderInternal call() {
-                return addSpec(path);
-            }
-        });
+    public TaskInputFilePropertyBuilderInternal files(Object... paths) {
+        return userSuppliedProperties.files(paths);
     }
 
     @Override
-    public TaskInputFilePropertyBuilderInternal dir(final Object dirPath) {
-        return taskMutator.mutate("TaskInputs.dir(Object)", new Callable<TaskInputFilePropertyBuilderInternal>() {
-            @Override
-            public TaskInputFilePropertyBuilderInternal call() {
-                return addSpec(resolver.resolveFilesAsTree(dirPath));
-            }
-        });
+    public TaskInputFilePropertyBuilderInternal file(Object path) {
+        return userSuppliedProperties.file(path);
+    }
+
+    @Override
+    public TaskInputFilePropertyBuilderInternal dir(Object dirPath) {
+        return userSuppliedProperties.dir(dirPath);
+    }
+
+    @Override
+    @Nullable
+    public TaskInputs property(String name, @Nullable Object value) {
+        return userSuppliedProperties.property(name, value);
+    }
+
+    @Override
+    @Nullable
+    public TaskInputs properties(Map<String, ?> newProps) {
+        return userSuppliedProperties.properties(newProps);
     }
 
     @Override
     public boolean getHasSourceFiles() {
         changeDetection.ensureTaskInputsAndOutputsDiscovered();
-        for (TaskInputPropertySpecAndBuilder propertySpec : filePropertiesInternal) {
+        for (TaskInputPropertySpecAndBuilder propertySpec : getFilePropertiesInternal()) {
             if (propertySpec.isSkipWhenEmpty()) {
                 return true;
             }
@@ -134,25 +136,27 @@ public class DefaultTaskInputs implements TaskInputsInternal {
         return allSourceFiles;
     }
 
-    private TaskInputFilePropertyBuilderInternal addSpec(Object paths) {
-        DefaultTaskInputPropertySpec spec = new DefaultTaskInputPropertySpec(task.getName(), resolver, paths);
-        filePropertiesInternal.add(spec);
-        return spec;
-    }
-
     public Map<String, Object> getProperties() {
         changeDetection.ensureTaskInputsAndOutputsDiscovered();
-        Map<String, Object> actualProperties = new HashMap<String, Object>();
+        Map<String, Object> result = Maps.newHashMap();
+        addResolvedProperties(result, userSuppliedProperties.getProperties(), ImmutableSortedSet.<String>of());
+        addResolvedProperties(result, discoveredProperties.getProperties(), userSuppliedProperties.getProperties().keySet());
+        return result;
+    }
+
+    private void addResolvedProperties(Map<String, Object> builder, Map<String, Object> properties, Set<String> registeredProperties) {
         for (Map.Entry<String, Object> entry : properties.entrySet()) {
             String propertyName = entry.getKey();
+            if (registeredProperties.contains(propertyName)) {
+                continue;
+            }
             try {
                 Object value = prepareValue(entry.getValue());
-                actualProperties.put(propertyName, value);
+                builder.put(propertyName, value);
             } catch (Exception ex) {
                 throw new InvalidUserDataException(String.format("Error while evaluating property '%s' of %s", propertyName, task), ex);
             }
         }
-        return actualProperties;
     }
 
     private Object prepareValue(Object value) {
@@ -173,31 +177,19 @@ public class DefaultTaskInputs implements TaskInputsInternal {
         return (value instanceof GString) ? value.toString() : value;
     }
 
-    public TaskInputs property(final String name, final Object value) {
-        taskMutator.mutate("TaskInputs.property(String, Object)", new Runnable() {
-            public void run() {
-                properties.put(name, value);
-            }
-        });
-        return this;
-    }
-
-    public TaskInputs properties(final Map<String, ?> newProps) {
-        taskMutator.mutate("TaskInputs.properties(Map)", new Runnable() {
-            public void run() {
-                properties.putAll(newProps);
-            }
-        });
-        return this;
+    public void setDiscoveredProperties(DefaultInputPropertyRegistration discoveredProperties) {
+        this.discoveredProperties = discoveredProperties;
+        this.fileProperties = null;
     }
 
     private static class TaskInputUnionFileCollection extends CompositeFileCollection implements Describable {
+
         private final boolean skipWhenEmptyOnly;
         private final String taskName;
         private final String type;
-        private final Supplier<List<TaskInputPropertySpecAndBuilder>> filePropertiesInternal;
+        private final Supplier<Iterable<TaskInputPropertySpecAndBuilder>> filePropertiesInternal;
 
-        public TaskInputUnionFileCollection(String taskName, String type, boolean skipWhenEmptyOnly, Supplier<List<TaskInputPropertySpecAndBuilder>> filePropertiesInternal) {
+        public TaskInputUnionFileCollection(String taskName, String type, boolean skipWhenEmptyOnly, Supplier<Iterable<TaskInputPropertySpecAndBuilder>> filePropertiesInternal) {
             this.taskName = taskName;
             this.type = type;
             this.skipWhenEmptyOnly = skipWhenEmptyOnly;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -177,6 +177,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
 
     @Override
     public boolean hasDeclaredOutputs() {
+        task.ensureTaskInputsAndOutputsDiscovered();
         return !filePropertiesInternal.isEmpty();
     }
 
@@ -187,6 +188,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
 
     @Override
     public ImmutableSortedSet<TaskOutputFilePropertySpec> getFileProperties() {
+        task.ensureTaskInputsAndOutputsDiscovered();
         if (fileProperties == null) {
             TaskPropertyUtils.ensurePropertiesHaveNames(filePropertiesInternal);
             Iterator<TaskOutputFilePropertySpec> flattenedProperties = Iterators.concat(Iterables.transform(filePropertiesInternal, new Function<TaskPropertySpec, Iterator<? extends TaskOutputFilePropertySpec>>() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskInputsAndOutputsExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskInputsAndOutputsExecuter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.execution;
+
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.tasks.TaskExecuter;
+import org.gradle.api.internal.tasks.TaskExecutionContext;
+import org.gradle.api.internal.tasks.TaskStateInternal;
+
+public class ResolveTaskInputsAndOutputsExecuter implements TaskExecuter {
+    private final TaskExecuter delegate;
+
+    public ResolveTaskInputsAndOutputsExecuter(TaskExecuter executer) {
+        delegate = executer;
+    }
+
+    @Override
+    public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
+        task.getChangeDetection().discoverTaskInputsAndOutputs();
+        delegate.execute(task, state, context);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -57,11 +57,13 @@ import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.internal.project.ProjectTaskLister;
 import org.gradle.api.internal.project.antbuilder.DefaultIsolatedAntBuilder;
 import org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory;
+import org.gradle.api.internal.project.taskfactory.DefaultSchemaExtractor;
 import org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore;
 import org.gradle.api.internal.project.taskfactory.DefaultTaskClassValidatorExtractor;
 import org.gradle.api.internal.project.taskfactory.DependencyAutoWireTaskFactory;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
 import org.gradle.api.internal.project.taskfactory.PropertyAnnotationHandler;
+import org.gradle.api.internal.project.taskfactory.SchemaExtractor;
 import org.gradle.api.internal.project.taskfactory.TaskClassInfoStore;
 import org.gradle.api.internal.project.taskfactory.TaskClassValidatorExtractor;
 import org.gradle.api.internal.project.taskfactory.TaskFactory;
@@ -125,6 +127,7 @@ import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.actor.internal.DefaultActorFactory;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.authentication.DefaultAuthenticationSchemeRegistry;
+import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
@@ -146,7 +149,6 @@ import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.time.Clock;
 import org.gradle.model.internal.inspect.ModelRuleSourceDetector;
 import org.gradle.plugin.repository.internal.PluginRepositoryFactory;
@@ -230,6 +232,10 @@ public class BuildScopeServices extends DefaultServiceRegistry {
 
     protected TaskClassValidatorExtractor createTaskClassValidatorExtractor(List<PropertyAnnotationHandler> annotationHandlers) {
         return new DefaultTaskClassValidatorExtractor(annotationHandlers);
+    }
+
+    protected SchemaExtractor createChangeDetectionSchemaExtractor(List<PropertyAnnotationHandler> annotationHandlers) {
+        return new DefaultSchemaExtractor(annotationHandlers);
     }
 
     protected TaskClassInfoStore createTaskClassInfoStore(TaskClassValidatorExtractor validatorExtractor) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
@@ -48,6 +48,7 @@ import org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter;
 import org.gradle.api.internal.tasks.execution.OutputDirectoryCreatingTaskExecuter;
 import org.gradle.api.internal.tasks.execution.ResolveBuildCacheKeyExecuter;
 import org.gradle.api.internal.tasks.execution.ResolveTaskArtifactStateTaskExecuter;
+import org.gradle.api.internal.tasks.execution.ResolveTaskInputsAndOutputsExecuter;
 import org.gradle.api.internal.tasks.execution.ResolveTaskOutputCachingStateExecuter;
 import org.gradle.api.internal.tasks.execution.SkipCachedTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipEmptySourceFilesTaskExecuter;
@@ -140,6 +141,7 @@ public class TaskExecutionServices {
         executer = new SkipEmptySourceFilesTaskExecuter(inputsListener, cleanupRegistry, taskOutputsGenerationListener, executer);
         executer = new CleanupStaleOutputsExecuter(cleanupRegistry, taskOutputFilesRepository, buildOperationExecutor, executer);
         executer = new ResolveTaskArtifactStateTaskExecuter(repository, executer);
+        executer = new ResolveTaskInputsAndOutputsExecuter(executer);
         executer = new SkipTaskWithNoActionsExecuter(executer);
         executer = new SkipOnlyIfTaskExecuter(executer);
         executer = new ExecuteAtMostOnceTaskExecuter(executer);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/DefaultSchemaExtractorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/DefaultSchemaExtractorTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project.taskfactory
+
+import org.gradle.api.internal.AbstractTask
+import org.gradle.api.internal.ClassGenerator
+import org.gradle.api.internal.TaskInternal
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+
+import java.util.concurrent.Callable
+
+import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.*
+
+class DefaultSchemaExtractorTest extends AbstractProjectBuilderSpec {
+
+    private Map args = new HashMap()
+    DefaultSchemaExtractor extractor = new DefaultSchemaExtractor()
+    ITaskFactory delegate
+    DefaultTaskClassInfoStore taskClassInfoStore
+    AnnotationProcessingTaskFactory factory
+
+    def setup() {
+        delegate = Mock(ITaskFactory)
+        taskClassInfoStore = new DefaultTaskClassInfoStore(new DefaultTaskClassValidatorExtractor())
+        factory = new AnnotationProcessingTaskFactory(taskClassInfoStore, delegate)
+    }
+
+    def "extract inputs and outputs from class"() {
+        when:
+        def classInfo = extractor.extractClassInfo(type)
+
+        then:
+        classInfo.annotatedProperties.collectEntries() { [(it.name): it.propertyType] } == [(propertyName): propertyType]
+
+        where:
+        type                       | propertyName | propertyType
+        TaskWithInputDir           | 'inputDir'   | InputDirectory
+        TaskWithOutputDir          | 'outputDir'  | OutputDirectory
+        TaskWithBooleanInput       | 'inputValue' | Input
+        TaskWithOptionalOutputFile | 'outputFile' | OutputFile
+        TaskWithNestedBean         | 'bean'       | Nested
+    }
+
+    def "extract schema from class"() {
+        when:
+        def schema = extractor.extractSchema(expectTaskCreated(TaskWithNestedBean))
+
+        then:
+        schema.children.size() == 1
+    }
+
+    private TaskInternal expectTaskCreated(final Class type, final Object... params) {
+        final Class decorated = project.getServices().get(ClassGenerator).generate(type)
+        TaskInternal task = (TaskInternal) AbstractTask.injectIntoNewInstance(project, "task", type, new Callable<TaskInternal>() {
+            TaskInternal call() throws Exception {
+                if (params.length > 0) {
+                    return type.cast(decorated.constructors[0].newInstance(params))
+                } else {
+                    return decorated.newInstance()
+                }
+            }
+        })
+        return expectTaskCreated(task)
+    }
+
+    private TaskInternal expectTaskCreated(final TaskInternal task) {
+        // We cannot just stub here as we want to return a different task each time.
+        1 * delegate.createTask(args) >> task
+        assert factory.createTask(args).is(task)
+        return task
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDestroyablesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDestroyablesTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks
 
+import org.gradle.api.internal.ChangeDetection
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileResolver
@@ -43,7 +44,8 @@ class DefaultTaskDestroyablesTest extends Specification {
             }
         }
     }
-    TaskDestroyables taskDestroys = new DefaultTaskDestroyables(resolver, Mock(TaskInternal), taskMutator, this)
+    def changeDetection = Mock(ChangeDetection)
+    TaskDestroyables taskDestroys = new DefaultTaskDestroyables(resolver, Mock(TaskInternal), taskMutator, changeDetection)
 
     def "empty destroys by default"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDestroyablesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDestroyablesTest.groovy
@@ -43,7 +43,7 @@ class DefaultTaskDestroyablesTest extends Specification {
             }
         }
     }
-    TaskDestroyables taskDestroys = new DefaultTaskDestroyables(resolver, Mock(TaskInternal), taskMutator)
+    TaskDestroyables taskDestroys = new DefaultTaskDestroyables(resolver, Mock(TaskInternal), taskMutator, this)
 
     def "empty destroys by default"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -50,6 +50,10 @@ class DefaultTaskInputsTest extends Specification {
     def changeDetection = Mock(ChangeDetection)
     private final DefaultTaskInputs inputs = new DefaultTaskInputs(resolver, task, taskStatusNagger, changeDetection)
 
+    def setup() {
+        inputs.discoveredProperties = new DefaultInputPropertyRegistration("task", taskStatusNagger, resolver)
+    }
+
     def "default values"() {
         expect:
         inputs.files.empty

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks
 
 import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.ChangeDetection
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.FileTreeInternal
@@ -46,7 +47,8 @@ class DefaultTaskInputsTest extends Specification {
         getName() >> "task"
         toString() >> "task 'task'"
     }
-    private final DefaultTaskInputs inputs = new DefaultTaskInputs(resolver, task, taskStatusNagger, this)
+    def changeDetection = Mock(ChangeDetection)
+    private final DefaultTaskInputs inputs = new DefaultTaskInputs(resolver, task, taskStatusNagger, changeDetection)
 
     def "default values"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -46,7 +46,7 @@ class DefaultTaskInputsTest extends Specification {
         getName() >> "task"
         toString() >> "task 'task'"
     }
-    private final DefaultTaskInputs inputs = new DefaultTaskInputs(resolver, task, taskStatusNagger)
+    private final DefaultTaskInputs inputs = new DefaultTaskInputs(resolver, task, taskStatusNagger, this)
 
     def "default values"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -48,7 +48,7 @@ class DefaultTaskOutputsTest extends Specification {
         toString() >> "task 'task'"
         getProject() >> project
     }
-    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs({new File(it)} as FileResolver, task, taskStatusNagger)
+    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs({ new File(it) } as FileResolver, task, taskStatusNagger, this)
 
     void hasNoOutputsByDefault() {
         setup:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -50,7 +50,12 @@ class DefaultTaskOutputsTest extends Specification {
         getProject() >> project
     }
     def changeDetection = Mock(ChangeDetection)
-    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs({ new File(it) } as FileResolver, task, taskStatusNagger, changeDetection)
+    private FileResolver resolver = { new File(it) } as FileResolver
+    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs(resolver, task, taskStatusNagger, changeDetection)
+
+    def setup() {
+        outputs.discoveredProperties = new DefaultOutputPropertyRegistration("task", taskStatusNagger, resolver)
+    }
 
     void hasNoOutputsByDefault() {
         setup:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks
 
 import org.gradle.api.GradleException
+import org.gradle.api.internal.ChangeDetection
 import org.gradle.api.internal.OverlappingOutputs
 import org.gradle.api.internal.TaskExecutionHistory
 import org.gradle.api.internal.TaskInternal
@@ -48,7 +49,8 @@ class DefaultTaskOutputsTest extends Specification {
         toString() >> "task 'task'"
         getProject() >> project
     }
-    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs({ new File(it) } as FileResolver, task, taskStatusNagger, this)
+    def changeDetection = Mock(ChangeDetection)
+    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs({ new File(it) } as FileResolver, task, taskStatusNagger, changeDetection)
 
     void hasNoOutputsByDefault() {
         setup:

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -106,7 +106,61 @@
             "changes": [
                 "Interface has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.tasks.InputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.InputPropertyRegistration.dir(java.lang.Object)",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.InputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.InputPropertyRegistration.file(java.lang.Object)",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.InputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.InputPropertyRegistration.files(java.lang.Object[])",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.InputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.InputPropertyRegistration.getHasInputs()",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.InputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.InputPropertyRegistration.properties(java.util.Map)",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.InputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.InputPropertyRegistration.property(java.lang.String,java.lang.Object)",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.OutputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.OutputPropertyRegistration.dir(java.lang.Object)",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.OutputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.OutputPropertyRegistration.dirs(java.lang.Object[])",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.OutputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.OutputPropertyRegistration.file(java.lang.Object)",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.OutputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.OutputPropertyRegistration.files(java.lang.Object[])",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
+        },
+        {
+            "type": "org.gradle.api.tasks.OutputPropertyRegistration",
+            "member": "Method org.gradle.api.tasks.OutputPropertyRegistration.getHasOutput()",
+            "acceptation": "Existing method was extracted into new interface -> No incubating"
         }
-
     ]
 }

--- a/subprojects/docs/src/docs/userguide/buildCache.adoc
+++ b/subprojects/docs/src/docs/userguide/buildCache.adoc
@@ -215,7 +215,7 @@ These issues may affect the correctness of your build when using the build cache
 
 | Environment variables are not tracked as inputs.
 | For tasks that fork processes (like `Test`), Gradle does not track any of the environment variables visible to the process. This can allow undeclared inputs to affect the outputs of the task.
-| Declare environment variables as inputs to the task with api:org.gradle.api.tasks.TaskInputs#property(java.lang.String,java.lang.Object)[].
+| Declare environment variables as inputs to the task with api:org.gradle.api.tasks.InputPropertyRegistration#property(java.lang.String,java.lang.Object)[].
 
 | Changes in Gradle's file encoding that affect the build script
 | Gradle can produce different task output based on the file encoding used by the JVM. Gradle will use a default file encoding based on the operating system if `file.encoding` is not explicitly set.

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -197,7 +197,7 @@ public class JavaCompile extends AbstractCompile {
 
     @Nested
     protected JavaPlatform getPlatform() {
-        return new DefaultJavaPlatform(JavaVersion.toVersion(getTargetCompatibility()));
+        return new DefaultJavaPlatform(getTargetCompatibility() == null ? JavaVersion.current() : JavaVersion.toVersion(getTargetCompatibility()));
     }
 
     private void performCompilation(JavaCompileSpec spec, Compiler<JavaCompileSpec> compiler) {


### PR DESCRIPTION
By the changes in this PR we allow `@Nested` properties to actually use the runtime type for input detection instead of using the static type class having the property.