### PR TITLE
Use partial Gradle distributions for tests to increase cache hits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ archivesBaseName = 'gradle'
 
 buildTypes {
     sanityCheck {
-        tasks "intTestImage", "doc:checkstyleApi", "codeQuality", "docs:check", "distribution:checkBinaryCompatibility", "javadocAll"
+        tasks "classes", "doc:checkstyleApi", "codeQuality", "docs:check", "distribution:checkBinaryCompatibility", "javadocAll"
     }
 
     // Used by the first phase of the build pipeline, running only last version on multiversion - tests
@@ -224,6 +224,9 @@ configurations {
     coreRuntime {
         visible = false
     }
+    coreRuntimeExtensions {
+        visible = false
+    }
     externalModules {
         visible = false
     }
@@ -252,8 +255,8 @@ def patchedExternalModules = files({ -> fileTree(patchedExternalModulesDir).file
 patchedExternalModules.builtBy 'patchExternalModules'
 
 dependencies {
-    externalModules 'org.gradle:gradle-kotlin-dsl:0.11.1'
-    externalModules 'org.gradle:gradle-kotlin-dsl-tooling-builders:0.11.1'
+    externalModules "org.gradle:gradle-kotlin-dsl:${versions.gradle_kotlin_dsl}"
+    externalModules "org.gradle:gradle-kotlin-dsl-tooling-builders:${versions.gradle_kotlin_dsl}"
     coreRuntime project(':launcher')
     coreRuntime project(':runtimeApiInfo')
     runtime project(':wrapper')
@@ -264,6 +267,11 @@ dependencies {
     gradlePlugins project(':workers')
     gradlePlugins project(':dependencyManagement')
     gradlePlugins project(':testKit')
+
+    coreRuntimeExtensions project(':dependencyManagement') //See: DynamicModulesClassPathProvider.GRADLE_EXTENSION_MODULES
+    coreRuntimeExtensions project(':pluginUse')
+    coreRuntimeExtensions project(':workers')
+    coreRuntimeExtensions patchedExternalModules
 }
 
 import org.gradle.modules.PatchExternalModules
@@ -311,8 +319,6 @@ task installAll(type: Install) {
     with project(":distributions").allDistImage
     installDirPropertyName = 'gradle_installPath'
 }
-
-apply from: "gradle/intTestImage.gradle"
 
 // Generate a report showing which tests in a subproject are leaving
 // files around.

--- a/gradle/crossVersionTest.gradle
+++ b/gradle/crossVersionTest.gradle
@@ -14,6 +14,7 @@ configurations {
     crossVersionTestImplementation.extendsFrom testImplementation
     crossVersionTestRuntime.extendsFrom testRuntime
     crossVersionTestRuntimeOnly.extendsFrom testRuntimeOnly
+    partialDistribution.extendsFrom crossVersionTestRuntimeClasspath
 }
 
 dependencies {
@@ -37,7 +38,6 @@ crossVersionTestTasks.all { CrossVersionTest task ->
     group = "verification"
     testClassesDirs = sourceSets.crossVersionTest.output.classesDirs
     classpath = sourceSets.crossVersionTest.runtimeClasspath
-    requiresBinZip = true
     requiresLibsRepo = true
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,6 +19,8 @@ ext {
     libraries = [:]
 }
 
+versions.gradle_kotlin_dsl = '0.11.1'
+
 versions.commons_io = 'commons-io:commons-io:2.2'
 
 versions.groovy = "2.4.11"

--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -20,7 +20,6 @@ import org.gradle.testing.DistributionTest
 ext.distributionTestTasks = tasks.withType(DistributionTest)
 
 distributionTestTasks.all { DistributionTest task ->
-    dependsOn ':intTestImage'
     dependsOn ':toolingApi:toolingApiShadedJar'
     dependsOn ':cleanUpCaches'
     finalizedBy ':cleanUpDaemons'
@@ -50,7 +49,7 @@ distributionTestTasks.all { DistributionTest task ->
         doLast {
             configure(task) {
                 reports.html.destination = file("${project.reporting.baseDir}/$name")
-                gradleHomeDir = rootProject.intTestImage.destinationDir
+                gradleHomeDir = intTestImage.destinationDir
                 gradleUserHomeDir = rootProject.file('intTestHomeDir')
                 toolingApiShadedJarDir = rootProject.project(':toolingApi').toolingApiShadedJar.destinationDir
 

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -86,8 +86,6 @@ ext.useTestFixtures = { params = [:] ->
     }
 }
 
-apply from: "$rootDir/gradle/distributionTesting.gradle"
-
 if (file("src/testFixtures").exists()) {
     apply from: "$rootDir/gradle/testFixtures.gradle"
 }
@@ -107,6 +105,9 @@ if (file("src/performanceTest").exists()) {
 if (file("src/jmh").exists()) {
     apply from: "$rootDir/gradle/jmh.gradle"
 }
+
+apply from: "$rootDir/gradle/distributionTesting.gradle"
+apply from: "$rootDir/gradle/intTestImage.gradle"
 
 task compileAll {
     dependsOn tasks.matching { it instanceof JavaCompile || it instanceof GroovyCompile }

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -190,7 +190,7 @@ idea {
         def defaultTestVmParams = [
                 "-Dorg.gradle.docs.releasenotes.source=${docsProject.releaseNotesMarkdown.markdownFile}",
                 "-Dorg.gradle.docs.releasenotes.rendered=${new File(docsProject.releaseNotes.destinationDir, docsProject.releaseNotes.fileName)}",
-                "-DintegTest.gradleHomeDir=${rootProject.intTestImage.destinationDir.absolutePath}",
+                "-DintegTest.gradleHomeDir=\$MODULE_DIR\$/build/integ test",
                 "-DintegTest.gradleUserHomeDir=${rootProject.file('intTestHomeDir').absolutePath}",
                 "-DintegTest.libsRepo=${rootProject.file('build/repo').absolutePath}",
                 "-Dorg.gradle.integtest.daemon.registry=${rootProject.file('build/daemon').absolutePath}",

--- a/gradle/intTestImage.gradle
+++ b/gradle/intTestImage.gradle
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
-evaluationDependsOn ":distributions"
-evaluationDependsOn ":docs"
-
 task intTestImage(type: Sync) {
     group = "Verification"
     into file("$buildDir/integ test")
 }
 
+distributionTestTasks.all {
+    dependsOn intTestImage
+}
+
+configurations {
+    partialDistribution
+}
+
 if (useAllDistribution) {
-    def allZip = tasks.getByPath(':distributions:allZip')
     task unpackAllDistribution(type: Sync) {
-        dependsOn allZip
-        from { zipTree(allZip.archivePath) }
+        dependsOn ':distributions:allZip'
+        from { zipTree(tasks.getByPath(':distributions:allZip').archivePath) }
         into "$buildDir/tmp/unpacked-all-distribution"
     }
 
@@ -38,13 +42,37 @@ if (useAllDistribution) {
         from(unpackedPath)
     }
 } else {
-    intTestImage {
-        with project(":distributions").binDistImage
-        into "samples", {
-            from { project(":docs").outputs.samples }
+    configurations { selfRuntime }
+
+    afterEvaluate {
+        if (project.tasks.findByName("jar")) {
+            dependencies { selfRuntime project }
         }
-        doLast { task ->
-            ant.chmod(dir: "$destinationDir/bin", perm: "ugo+rx", includes: "**/*")
+
+        intTestImage {
+            into('bin') {
+                from { project(':launcher').startScripts.outputs.files }
+                fileMode = 0755
+            }
+
+            def runtimeClasspathConfigurations = (rootProject.configurations.coreRuntime
+                    + rootProject.configurations.coreRuntimeExtensions
+                    + project.configurations.selfRuntime
+                    + project.configurations.partialDistribution)
+            def libsThisProjectDoesNotUse = (rootProject.configurations.runtime + rootProject.configurations.gradlePlugins) - runtimeClasspathConfigurations
+
+            into 'lib', {
+                from rootProject.configurations.runtime - libsThisProjectDoesNotUse
+                into('plugins') {
+                    from rootProject.configurations.gradlePlugins - rootProject.configurations.runtime - libsThisProjectDoesNotUse
+                }
+            }
+            into 'samples', {
+                from { project(":docs").outputs.samples }
+            }
+            doLast {
+                ant.chmod(dir: "$destinationDir/bin", perm: "ugo+rx", includes: "**/*")
+            }
         }
     }
 }

--- a/gradle/integTest.gradle
+++ b/gradle/integTest.gradle
@@ -13,6 +13,7 @@ configurations {
     integTestCompile.extendsFrom testCompile
     integTestImplementation.extendsFrom testImplementation
     integTestRuntime.extendsFrom testRuntime
+    partialDistribution.extendsFrom integTestRuntimeClasspath
 }
 
 dependencies {

--- a/gradle/performanceTest.gradle
+++ b/gradle/performanceTest.gradle
@@ -34,6 +34,7 @@ sourceSets {
 configurations {
     performanceTestCompile.extendsFrom testCompile
     performanceTestRuntime.extendsFrom testRuntime
+    partialDistribution.extendsFrom performanceTestRuntimeClasspath
     junit
 }
 
@@ -43,9 +44,13 @@ dependencies {
     //so that implicit help tasks are available:
     performanceTestRuntime project(':diagnostics')
 
-    //So that the wrapper and init task are added when performanceTests are run via commandline
-    //above can be removed when we implement the auto-apply plugins
     performanceTestRuntime project(':buildInit')
+    performanceTestRuntime project(':buildCacheHttp')
+    performanceTestRuntime project(':codeQuality')
+    performanceTestRuntime project(':ide')
+    performanceTestRuntime project(':maven')
+    performanceTestRuntime project(':testingNative')
+    performanceTestRuntime project(':toolingApiBuilders')
 
     junit 'junit:junit:4.12'
 }

--- a/subprojects/build-comparison/build-comparison.gradle
+++ b/subprojects/build-comparison/build-comparison.gradle
@@ -27,6 +27,8 @@ dependencies {
     compile libraries.slf4j_api
 
     testCompile libraries.jsoup
+
+    integTestRuntime project(":toolingApiBuilders")
 }
 
 processResources {

--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -77,6 +77,7 @@ dependencies {
     integTestImplementation project(":internalIntegTesting")
 
     integTestRuntimeOnly project(":plugins")
+    integTestRuntimeOnly project(':maven')
 }
 
 useTestFixtures()

--- a/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
@@ -67,8 +67,6 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
     @Ignore
     @Issue("GRADLE-3578")
     def "java compiler uses a different version of Jansi than initialized by Gradle's native services"() {
-        requireGradleDistribution()
-
         when:
         AnnotationProcessorPublisher annotationProcessorPublisher = new AnnotationProcessorPublisher()
         annotationProcessorPublisher.writeSourceFiles()
@@ -98,8 +96,6 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "groovy compiler uses a different version of Jansi than initialized by Gradle's native services"() {
-        requireGradleDistribution()
-
         when:
         AnnotationProcessorPublisher annotationProcessorPublisher = new AnnotationProcessorPublisher()
         annotationProcessorPublisher.writeSourceFiles()

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
@@ -89,7 +89,9 @@ public class BuildProgressLogger implements LoggerProvider {
     }
 
     public void beforeComplete() {
-        buildProgress.completed(WAITING_PHASE_DESCRIPTION, false);
+        if (buildProgress != null) {
+            buildProgress.completed(WAITING_PHASE_DESCRIPTION, false);
+        }
         buildProgress = null;
     }
 

--- a/subprojects/dependency-management/dependency-management.gradle
+++ b/subprojects/dependency-management/dependency-management.gradle
@@ -38,8 +38,7 @@ dependencies {
     integTestRuntime project(":maven")
     integTestRuntime project(":resourcesS3")
     integTestRuntime project(":resourcesSftp")
-    //this dependency is necessary to run IvySFtpResolverIntegrationTest on ibm jdk
-    //integTestRuntime "org.bouncycastle:bcprov-jdk15:1.46@jar"
+    integTestRuntime project(":testKit")
 
     testFixturesCompile project(":internalIntegTesting")
 }

--- a/subprojects/plugin-development/plugin-development.gradle
+++ b/subprojects/plugin-development/plugin-development.gradle
@@ -24,6 +24,7 @@ dependencies {
     testRuntime project(':toolingApi')
     testRuntime project(':launcher')
     testRuntime project(':testKit')
+    integTestRuntime project(':toolingApiBuilders')
 }
 
 useTestFixtures()

--- a/subprojects/scala/scala.gradle
+++ b/subprojects/scala/scala.gradle
@@ -28,6 +28,7 @@ dependencies {
     testCompile libraries.slf4j_api
 
     integTestRuntime project(":ide")
+    integTestRuntime project(':maven')
 }
 
 useTestFixtures(project: ":plugins") // includes core test fixtures

--- a/subprojects/smoke-test/smoke-test.gradle
+++ b/subprojects/smoke-test/smoke-test.gradle
@@ -12,12 +12,22 @@ sourceSets {
 configurations {
     smokeTestCompile.extendsFrom testCompile
     smokeTestRuntime.extendsFrom testRuntime
+    partialDistribution.extendsFrom smokeTestRuntimeClasspath
 }
 
 dependencies {
     smokeTestCompile project(':testKit')
     smokeTestCompile project(":internalIntegTesting")
     smokeTestCompile libraries.spock
+
+    smokeTestRuntimeOnly "org.gradle:gradle-kotlin-dsl:${versions.gradle_kotlin_dsl}"
+    smokeTestRuntimeOnly project(':codeQuality')
+    smokeTestRuntimeOnly project(':ide')
+    smokeTestRuntimeOnly project(':ivy')
+    smokeTestRuntimeOnly project(':jacoco')
+    smokeTestRuntimeOnly project(':maven')
+    smokeTestRuntimeOnly project(':plugins')
+    smokeTestRuntimeOnly project(':toolingApiBuilders')
 }
 
 processSmokeTestResources {

--- a/subprojects/soak/soak.gradle
+++ b/subprojects/soak/soak.gradle
@@ -19,6 +19,4 @@ task('soakTest', type: org.gradle.testing.SoakTest) {
     options {
         includeCategories 'org.gradle.soak.categories.SoakTest'
     }
-    requiresBinZip = true
-    requiresLibsRepo = true
 }

--- a/subprojects/test-kit/test-kit.gradle
+++ b/subprojects/test-kit/test-kit.gradle
@@ -3,6 +3,8 @@ dependencies {
     compile project(':toolingApi')
     compile libraries.commons_io
     runtime project(':native')
+    integTestRuntime project(':toolingApiBuilders')
+    integTestRuntime project(':pluginDevelopment')
 }
 
 task crossVersionTests(type: org.gradle.testing.IntegrationTest) {

--- a/subprojects/tooling-api/tooling-api.gradle
+++ b/subprojects/tooling-api/tooling-api.gradle
@@ -17,17 +17,12 @@ dependencies {
     testFixturesCompile project(':internalIntegTesting')
 
     integTestRuntime project(":toolingApiBuilders")
-    integTestRuntime rootProject.configurations.testRuntime.allDependencies
+    integTestRuntime project(":ivy")
 
-    // Need these to be loaded into the crossVersionTestRuntime, so that the modules are available on the classpath and the services can be registered
-    // I think this is only really required for the TAPI tests in embedded mode, where we use `GradleConnector.useClasspathDistribution()`.
-    crossVersionTestRuntime project(':ide')
-    crossVersionTestRuntime project(':buildInit')
+    crossVersionTestRuntime "org.gradle:gradle-kotlin-dsl:${versions.gradle_kotlin_dsl}"
     crossVersionTestRuntime project(':buildComparison')
     crossVersionTestRuntime project(":ivy")
     crossVersionTestRuntime project(":maven")
-    crossVersionTestRuntime project(":compositeBuilds")
-    crossVersionTestRuntime rootProject.configurations.testRuntime.allDependencies
 }
 
 useTestFixtures()

--- a/subprojects/wrapper/wrapper.gradle
+++ b/subprojects/wrapper/wrapper.gradle
@@ -21,8 +21,6 @@ dependencies {
     compile project(":cli")
 
     testCompile libraries.ant
-
-    integTestRuntime rootProject.configurations.testRuntime.allDependencies
 }
 
 ext {


### PR DESCRIPTION
This is a follow up PR to #2847 

The main change is that instead of building one `intTestImage` in the root project's build folder, we now build an `intTestImage` for each subproject. The image only contains what the test runtime configurations, if present, require (integTestRuntime, crossVersionTestRuntime, smokeTestRuntime, performanceTestRuntime).

For this to work, we add missing dependencies to test runtime configurations that were not declared before because some tests always ran against a full distribution.


I was considering to add functionality that allows a project to declare that it always requires a full distribution. I was thinking about using that for the `performance` subproject. But it would add more complexity to the build scripts for a feature we might not necessarily need/want. If a project, like the performance test, should run against a "full distribution", it should also depend on everything in the runtime configurations. We could consider doing that for `performance`.

There is still the option to run agains a full distribution with `-PuseAllDistribution=true` (see #2847).

