### PR TITLE
Support zulu9 version number(#2992)

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -54,10 +54,10 @@ public enum JavaVersion {
         }
 
         String name = value.toString();
-        Matcher matcher = Pattern.compile("(\\d{1,2})(-.+)?").matcher(name);
+        Matcher matcher = Pattern.compile("(\\d{1,2})(\\D.+)?").matcher(name);
         if (matcher.matches()) {
             int index = Integer.parseInt(matcher.group(1)) - 1;
-            if (index < values().length && values()[index].hasMajorVersion) {
+            if (index > 0 && index < values().length && values()[index].hasMajorVersion) {
                 return values()[index];
             }
         }
@@ -98,7 +98,7 @@ public enum JavaVersion {
     }
 
     public static JavaVersion forClass(byte[] classData) {
-        if (classData.length<8) {
+        if (classData.length < 8) {
             throw new IllegalArgumentException("Invalid class format. Should contain at least 8 bytes");
         }
         return forClassVersion(classData[7] & 0xFF);

--- a/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
@@ -63,7 +63,12 @@ public class JavaVersionSpec extends Specification {
         JavaVersion.toVersion("1.9.0-internal") == JavaVersion.VERSION_1_9
         JavaVersion.toVersion("1.9.0-ea") == JavaVersion.VERSION_1_9
         JavaVersion.toVersion("9-ea") == JavaVersion.VERSION_1_9
+        JavaVersion.toVersion("9.0.0.15") == JavaVersion.VERSION_1_9
+        JavaVersion.toVersion("9.0.1") == JavaVersion.VERSION_1_9
+        JavaVersion.toVersion("9.1") == JavaVersion.VERSION_1_9
 
+        JavaVersion.toVersion("10.1") == JavaVersion.VERSION_1_10
+        JavaVersion.toVersion("10.1.2") == JavaVersion.VERSION_1_10
         JavaVersion.toVersion("10-ea") == JavaVersion.VERSION_1_10
         JavaVersion.toVersion("10-internal") == JavaVersion.VERSION_1_10
     }
@@ -98,10 +103,6 @@ public class JavaVersionSpec extends Specification {
         conversionFails("1.54");
         conversionFails("2.0");
         conversionFails("1_4");
-        conversionFails("8.1");
-        conversionFails("9.1");
-        conversionFails("9.0.0");
-        conversionFails("10.1.2");
 
         conversionFails("9-");
         conversionFails("11-ea");


### PR DESCRIPTION
See https://github.com/gradle/gradle/issues/2992

zulu JDK 9 introduces version number format '9.0.0.15' which
can't be recognized by Gradle. This fix adjusts the recognition
pattern.