### PR TITLE
Relocatable -bootclasspath for Java compilation

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -147,6 +147,16 @@
             "type": "org.gradle.api.specs.AndSpec",
             "member": "Method org.gradle.api.specs.AndSpec.and(org.gradle.api.specs.Spec)",
             "acceptation": "Added overload to help with generics"
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.CompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.CompileOptions.getBootstrapClasspath()",
+            "acceptation": "Replaces bootClasspath property"
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.CompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.CompileOptions.setBootstrapClasspath(org.gradle.api.file.FileCollection)",
+            "acceptation": "Replaces bootClasspath property"
         }
     ]
 }

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.CompileOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.CompileOptions.xml
@@ -53,6 +53,10 @@
                 <td><literal>null</literal></td>
             </tr>
             <tr>
+                <td>bootstrapClasspath</td>
+                <td><literal>null</literal></td>
+            </tr>
+            <tr>
                 <td>extensionDirs</td>
                 <td><literal>null</literal></td>
             </tr>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -129,6 +129,10 @@ task myTask {
 In this release we deprecate calling `TaskInternal.execute()`. Calling `task.execute()` should never be necessary.
 There are better ways for re-using task logic, for example by using [task dependencies](userguide/more_about_tasks.html#sec:adding_dependencies_to_tasks), [task rules](userguide/more_about_tasks.html#sec:task_rules), extracting a re-usable piece of logic from your task which can be called on its own (e.g. `project.copy` vs. the `Copy` task) or using the [worker API](userguide/custom_tasks.html#worker_api).
 
+### Other deprecations
+
+* `CompileOptions.bootClasspath` is deprecated in favor of the new `bootstrapClasspath` property.
+
 ## Potential breaking changes
 
 ### Changes to incubating native compile and link tasks

--- a/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
+++ b/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.compile
 import org.gradle.api.tasks.compile.CompileOptions
 import spock.lang.Specification
 
-
 class DefaultGroovyJavaJointCompileSpecFactoryTest extends Specification {
     def "produces correct spec type" () {
         CompileOptions options = new CompileOptions()

--- a/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
+++ b/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.gradle.api.internal.tasks.compile
+
 import groovy.transform.InheritConstructors
 import org.gradle.api.internal.file.collections.SimpleFileCollection
 import org.gradle.api.tasks.compile.CompileOptions

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -18,10 +18,10 @@ package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.integtests.tooling.fixture.TextUtil
 import org.gradle.util.Requires
 import org.gradle.util.Resources
 import org.gradle.util.TestPrecondition
+import org.gradle.util.TextUtil
 import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -843,5 +843,23 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         executer.withJavaHome jdk7.javaHome
         succeeds "-Pjava8", "clean", "compileJava"
+    }
+
+    def "CompileOptions.bootclasspath is deprecated"() {
+        def jre = AvailableJavaHomes.getBestJre()
+        def bootClasspath = TextUtil.escapeString(jre.absolutePath) + "/lib/rt.jar"
+        buildFile << """
+            apply plugin: 'java'
+            
+            compileJava {
+                options.bootClasspath = "$bootClasspath"
+            }
+        """
+        file('src/main/java/Main.java') << "public class Main {}"
+
+        expect:
+        executer.withFullDeprecationStackTraceDisabled()
+        executer.expectDeprecationWarning()
+        succeeds "compileJava"
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.TextUtil
 import org.gradle.util.Requires
 import org.gradle.util.Resources
 import org.gradle.util.TestPrecondition
@@ -796,5 +798,50 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         file('build/classes/java/main/Rectangle.class').exists()
         file('build/classes/java/main/Shape.class').exists()
         result.output.contains("Specifying the source path in the CompilerOptions compilerArgs property has been deprecated")
+    }
+
+    @Requires(adhoc = { AvailableJavaHomes.getJdks("1.7", "1.8") })
+    def "bootclasspath can be set"() {
+        def jdk7 = AvailableJavaHomes.getJdk7()
+        def jdk7bootClasspath = TextUtil.escapeString(jdk7.jre.homeDir.absolutePath) + "/lib/rt.jar"
+        def jdk8 = AvailableJavaHomes.getJdk8()
+        def jdk8bootClasspath = TextUtil.escapeString(jdk8.jre.homeDir.absolutePath) + "/lib/rt.jar"
+        buildFile << """
+            apply plugin: 'java'
+            
+            compileJava {
+                if (project.hasProperty("java7")) {
+                    options.bootstrapClasspath = files("$jdk7bootClasspath")
+                } else if (project.hasProperty("java8")) {
+                    options.bootstrapClasspath = files("$jdk8bootClasspath")
+                } 
+            }
+        """
+        file('src/main/java/Main.java') << """
+            import java.nio.file.Files;
+            import java.nio.file.Paths;
+
+            public class Main {
+                public static void main(String... args) throws Exception {
+                    // Use Files.lines() method introduced in Java 8
+                    System.out.println("Line count: " + Files.lines(Paths.get(args[0])));
+                }
+            }
+        """
+
+        expect:
+        executer.withJavaHome jdk8.javaHome
+        succeeds "clean", "compileJava"
+
+        executer.withJavaHome jdk8.javaHome
+        executer.withStacktraceDisabled()
+        fails "-Pjava7", "clean", "compileJava"
+        errorOutput.contains "Main.java:8: error: cannot find symbol"
+
+        executer.withJavaHome jdk8.javaHome
+        succeeds "-Pjava8", "clean", "compileJava"
+
+        executer.withJavaHome jdk7.javaHome
+        succeeds "-Pjava8", "clean", "compileJava"
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -861,5 +861,6 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         executer.withFullDeprecationStackTraceDisabled()
         executer.expectDeprecationWarning()
         succeeds "compileJava"
+        output.contains "The CompileOptions.bootClasspath property has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the CompileOptions.bootstrapClasspath property instead."
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -24,8 +24,10 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
+import org.gradle.internal.Factory;
 import org.gradle.util.DeprecationLogger;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -111,7 +113,7 @@ public class JavaCompilerArgumentsBuilder {
             return;
         }
 
-        CompileOptions compileOptions = spec.getCompileOptions();
+        final CompileOptions compileOptions = spec.getCompileOptions();
         if (!releaseOptionIsSet(compilerArgs)) {
             String sourceCompatibility = spec.getSourceCompatibility();
             if (sourceCompatibility != null) {
@@ -142,9 +144,17 @@ public class JavaCompilerArgumentsBuilder {
             args.add("-encoding");
             args.add(compileOptions.getEncoding());
         }
-        if (compileOptions.getBootClasspath() != null) { //TODO: move bootclasspath to platform
+        String bootClasspath = DeprecationLogger.whileDisabled(new Factory<String>() {
+            @Nullable
+            @Override
+            @SuppressWarnings("deprecation")
+            public String create() {
+                return compileOptions.getBootClasspath();
+            }
+        });
+        if (bootClasspath != null) { //TODO: move bootclasspath to platform
             args.add("-bootclasspath");
-            args.add(compileOptions.getBootClasspath());
+            args.add(bootClasspath);
         }
         if (compileOptions.getExtensionDirs() != null) {
             args.add("-extdirs");

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -63,6 +64,8 @@ public class CompileOptions extends AbstractOptions {
     private ForkOptions forkOptions = new ForkOptions();
 
     private String bootClasspath;
+
+    private FileCollection bootstrapClasspath;
 
     private String extensionDirs;
 
@@ -235,18 +238,49 @@ public class CompileOptions extends AbstractOptions {
 
     /**
      * Returns the bootstrap classpath to be used for the compiler process. Defaults to {@code null}.
+     *
+     * @deprecated Use {@link #getBootstrapClasspath()} instead.
      */
-    @Input
-    @Optional
+    @Deprecated
+    @Internal
     public String getBootClasspath() {
+        if (bootClasspath == null && bootstrapClasspath != null) {
+            return bootstrapClasspath.getAsPath();
+        }
         return bootClasspath;
     }
 
     /**
      * Sets the bootstrap classpath to be used for the compiler process. Defaults to {@code null}.
+     *
+     * @deprecated Use {@link #setBootstrapClasspath(FileCollection)} instead.
      */
+    @Deprecated
     public void setBootClasspath(String bootClasspath) {
         this.bootClasspath = bootClasspath;
+        this.bootstrapClasspath = null;
+    }
+
+    /**
+     * Returns the bootstrap classpath to be used for the compiler process. Defaults to {@code null}.
+     *
+     * @since 4.3
+     */
+    // TODO This could be a @CompileClasspath, but that would require a lot of processing
+    @Optional
+    @Classpath
+    public FileCollection getBootstrapClasspath() {
+        return bootstrapClasspath;
+    }
+
+    /**
+     * Sets the bootstrap classpath to be used for the compiler process. Defaults to {@code null}.
+     *
+     * @since 4.3
+     */
+    public void setBootstrapClasspath(FileCollection bootstrapClasspath) {
+        this.bootClasspath = null;
+        this.bootstrapClasspath = bootstrapClasspath;
     }
 
     /**

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -267,7 +267,9 @@ public class CompileOptions extends AbstractOptions {
      *
      * @since 4.3
      */
-    // TODO This could be a @CompileClasspath, but that would require a lot of processing
+    // The bootstrap classpath is actually a `@CompileClasspath`, but declaring it so adds a significant amount
+    // of processing time the first time a full Java runtime is encountered. We decided to declare it as
+    // `@Classpath` instead, because the benefits would be sparse anyway.
     @Optional
     @Classpath
     public FileCollection getBootstrapClasspath() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -244,7 +245,9 @@ public class CompileOptions extends AbstractOptions {
      */
     @Deprecated
     @Internal
+    @SuppressWarnings("DeprecatedIsStillUsed")
     public String getBootClasspath() {
+        DeprecationLogger.nagUserOfReplacedProperty("CompileOptions.bootClasspath", "CompileOptions.bootstrapClasspath");
         if (bootClasspath == null && bootstrapClasspath != null) {
             return bootstrapClasspath.getAsPath();
         }
@@ -258,6 +261,7 @@ public class CompileOptions extends AbstractOptions {
      */
     @Deprecated
     public void setBootClasspath(String bootClasspath) {
+        DeprecationLogger.nagUserOfReplacedProperty("CompileOptions.bootClasspath", "CompileOptions.bootstrapClasspath");
         this.bootClasspath = bootClasspath;
         this.bootstrapClasspath = null;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.compile;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Classpath;
@@ -270,6 +271,9 @@ public class CompileOptions extends AbstractOptions {
     @Optional
     @Classpath
     public FileCollection getBootstrapClasspath() {
+        if (bootClasspath != null) {
+            throw new GradleException("Deprecated property CompileOptions.bootClasspath was set, but replacement property CompileOptions.bootstrapClasspath was queried");
+        }
         return bootstrapClasspath;
     }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/AnnotationProcessorDetectorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/AnnotationProcessorDetectorTest.groovy
@@ -18,10 +18,10 @@ package org.gradle.api.internal.tasks.compile
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.FileCollection
-import org.gradle.cache.internal.TestFileContentCacheFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.SimpleFileCollection
 import org.gradle.api.tasks.compile.CompileOptions
+import org.gradle.cache.internal.TestFileContentCacheFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.JarUtils
 import org.junit.Rule

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -45,7 +45,7 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
     }
 
     def "generates -source option when current Jvm Version is used"() {
-        spec.sourceCompatibility = JavaVersion.current().toString();
+        spec.sourceCompatibility = JavaVersion.current().toString()
 
         expect:
         builder.build() == ["-source", JavaVersion.current().toString()] + defaultOptions
@@ -66,7 +66,7 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
     }
 
     def "generates -target option when current Jvm Version is used"() {
-        spec.targetCompatibility = JavaVersion.current().toString();
+        spec.targetCompatibility = JavaVersion.current().toString()
 
         expect:
         builder.build() == ["-target", JavaVersion.current().toString()] + defaultOptions
@@ -167,10 +167,20 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
     }
 
     def "generates -bootclasspath option"() {
-        spec.compileOptions.bootClasspath = "/lib/lib1.jar:/lib/lib2.jar"
+        spec.compileOptions.bootstrapClasspath = new SimpleFileCollection([new File("/lib/lib1.jar"), new File("/lib/lib2.jar")])
 
         expect:
-        builder.build() == ["-bootclasspath", "/lib/lib1.jar:/lib/lib2.jar"] + defaultOptions
+        builder.build() == ["-bootclasspath", "/lib/lib1.jar${File.pathSeparator}/lib/lib2.jar"] + defaultOptions
+    }
+
+    @SuppressWarnings("GrDeprecatedAPIUsage")
+    def "generates -bootclasspath option via deprecated property"() {
+        when:
+        spec.compileOptions.bootClasspath = "/lib/lib1.jar${File.pathSeparator}/lib/lib2.jar"
+        def options = builder.build()
+
+        then:
+        options == ["-bootclasspath", "/lib/lib1.jar${File.pathSeparator}/lib/lib2.jar"] + defaultOptions
     }
 
     def "generates -extdirs option"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -167,10 +167,10 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
     }
 
     def "generates -bootclasspath option"() {
-        spec.compileOptions.bootstrapClasspath = new SimpleFileCollection([new File("/lib/lib1.jar"), new File("/lib/lib2.jar")])
+        spec.compileOptions.bootstrapClasspath = new SimpleFileCollection([new File("lib1.jar"), new File("lib2.jar")])
 
         expect:
-        builder.build() == ["-bootclasspath", "/lib/lib1.jar${File.pathSeparator}/lib/lib2.jar"] + defaultOptions
+        builder.build() == ["-bootclasspath", "lib1.jar${File.pathSeparator}lib2.jar"] + defaultOptions
     }
 
     @SuppressWarnings("GrDeprecatedAPIUsage")

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -180,7 +180,7 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         def options = builder.build()
 
         then:
-        options == ["-bootclasspath", "/lib/lib1.jar${File.pathSeparator}/lib/lib2.jar"] + defaultOptions
+        options == ["-bootclasspath", new File("/lib/lib1.jar").path + File.pathSeparator + new File("/lib/lib2.jar").path] + defaultOptions
     }
 
     def "generates -extdirs option"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks.compile
 
-import org.gradle.api.GradleException
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.collections.SimpleFileCollection
 import spock.lang.Specification
@@ -194,20 +193,16 @@ class CompileOptionsTest extends Specification {
     }
 
     @SuppressWarnings("GrDeprecatedAPIUsage")
-    def "querying bootstrapClasspath when deprecated bootClasspath is set fails"() {
+    def "setting deprecated bootClasspath sets bootstrapClasspath"() {
         given:
         compileOptions.bootClasspath = "lib2.jar"
 
-        when:
-        compileOptions.bootstrapClasspath
-
-        then:
-        def ex = thrown GradleException
-        ex.message == "Deprecated property CompileOptions.bootClasspath was set, but replacement property CompileOptions.bootstrapClasspath was queried"
+        expect:
+        compileOptions.bootstrapClasspath.files as List == [new File("lib2.jar")]
     }
 
     @SuppressWarnings("GrDeprecatedAPIUsage")
-    def "setting bootstrapClasspath resets deprecated bootClasspath"() {
+    def "setting bootstrapClasspath sets deprecated bootClasspath"() {
         given:
         compileOptions.bootClasspath = "lib1.jar"
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
@@ -16,135 +16,164 @@
 
 package org.gradle.api.tasks.compile
 
-import org.junit.Before
-import org.junit.Test
+import org.gradle.api.internal.file.FileCollectionInternal
+import spock.lang.Specification
+import spock.lang.Unroll
 
-import static org.gradle.util.Matchers.isEmpty
-import static org.junit.Assert.*
-
-class CompileOptionsTest {
-    static final Map TEST_DEBUG_OPTION_MAP = [someDebugOption: 'someDebugOptionValue']
-    static final Map TEST_FORK_OPTION_MAP = [someForkOption: 'someForkOptionValue']
+class CompileOptionsTest extends Specification {
+    static final TEST_DEBUG_OPTION_MAP = [someDebugOption: 'someDebugOptionValue']
+    static final TEST_FORK_OPTION_MAP = [someForkOption: 'someForkOptionValue']
 
     CompileOptions compileOptions
 
-    @Before public void setUp()  {
+    def setup()  {
         compileOptions = new CompileOptions()
         compileOptions.debugOptions = [optionMap: {TEST_DEBUG_OPTION_MAP}] as DebugOptions
         compileOptions.forkOptions = [optionMap: {TEST_FORK_OPTION_MAP}] as ForkOptions
     }
 
-    @Test public void testCompileOptions() {
-        assertTrue(compileOptions.debug)
-        assertTrue(compileOptions.failOnError)
-        assertTrue(compileOptions.warnings)
+    @SuppressWarnings("GrDeprecatedAPIUsage")
+    def "default compile options"() {
+        expect:
+        compileOptions.debug
+        compileOptions.failOnError
+        compileOptions.warnings
 
-        assertFalse(compileOptions.deprecation)
-        assertFalse(compileOptions.listFiles)
-        assertFalse(compileOptions.verbose)
-        assertFalse(compileOptions.fork)
+        !compileOptions.deprecation
+        !compileOptions.listFiles
+        !compileOptions.verbose
+        !compileOptions.fork
 
-        assertThat(compileOptions.compilerArgs, isEmpty())
-        assertNull(compileOptions.encoding)
-        assertNull(compileOptions.bootClasspath)
-        assertNull(compileOptions.extensionDirs)
+        compileOptions.compilerArgs.empty
+        compileOptions.encoding == null
+        compileOptions.bootClasspath == null
+        compileOptions.bootstrapClasspath == null
+        compileOptions.extensionDirs == null
 
-        assertNotNull(compileOptions.forkOptions)
-        assertNotNull(compileOptions.debugOptions)
+        compileOptions.forkOptions != null
+        compileOptions.debugOptions != null
     }
 
-    @Test public void testOptionMapForDebugOptions() {
+    def "option map for debug options"() {
         Map optionMap = compileOptions.optionMap()
-        assertEquals(optionMap.subMap(TEST_DEBUG_OPTION_MAP.keySet()), TEST_DEBUG_OPTION_MAP)
-        assertEquals(optionMap.subMap(TEST_FORK_OPTION_MAP.keySet()), TEST_FORK_OPTION_MAP)
+        expect:
+        optionMap.subMap(TEST_DEBUG_OPTION_MAP.keySet()) == TEST_DEBUG_OPTION_MAP
+        optionMap.subMap(TEST_FORK_OPTION_MAP.keySet()) == TEST_FORK_OPTION_MAP
     }
 
-    @Test public void testOptionMapWithNullables() {
-        Map optionMap = compileOptions.optionMap()
-        Map nullables = [
-                encoding: 'encoding',
-                bootClasspath: 'bootClasspath',
-                extensionDirs: 'extdirs'
-        ]
-        nullables.each {String field, String antProperty ->
-            assertFalse(optionMap.keySet().contains(antProperty))
-        }
+    @Unroll
+    def "option map with nullable #option"() {
+        expect:
+        !compileOptions.optionMap().keySet().contains(option)
 
-        nullables.keySet().each {compileOptions."$it" = "${it}Value"}
+        when:
+        compileOptions."$property" = "${property}Value"
+
+        then:
+        compileOptions.optionMap()[option] == "${property}Value"
+
+        where:
+        property             | option
+        "encoding"           | "encoding"
+        "extensionDirs"      | "extdirs"
+    }
+
+    @Unroll
+    def "option map with true/false #property"() {
+        when:
+        compileOptions."$property" = true
+        Map optionMap = compileOptions.optionMap()
+
+        then:
+        optionMap[option] == !(option == "nowarn")
+
+        when:
+        compileOptions."$property" = false
         optionMap = compileOptions.optionMap()
-        nullables.each {String field, String antProperty ->
-            assertEquals("${field}Value" as String, optionMap[antProperty])
-        }
+
+        then:
+        optionMap[option] == (option == "nowarn")
+
+        where:
+        property      | option
+        "failOnError" | "failOnError"
+        "verbose"     | "verbose"
+        "listFiles"   | "listFiles"
+        "deprecation" | "deprecation"
+        "warnings"    | "nowarn"
+        "debug"       | "debug"
+
     }
 
-    @Test public void testOptionMapWithTrueFalseValues() {
-        Map booleans = [
-                failOnError: 'failOnError',
-                verbose: 'verbose',
-                listFiles: 'listFiles',
-                deprecation: 'deprecation',
-                warnings: 'nowarn',
-                debug: 'debug'
-        ]
-        booleans.keySet().each {compileOptions."$it" = true}
-        Map optionMap = compileOptions.optionMap()
-        booleans.values().each {
-            if (it.equals('nowarn')) {
-                assertEquals(false, optionMap[it])
-            } else {
-                assertEquals(true, optionMap[it])
-            }
-        }
-        booleans.keySet().each {compileOptions."$it" = false}
-        optionMap = compileOptions.optionMap()
-        booleans.values().each {
-            if (it.equals('nowarn')) {
-                assertEquals(true, optionMap[it])
-            } else {
-                assertEquals(false, optionMap[it])
-            }
-        }
+    @Unroll
+    def "with exclude #option from option map"() {
+        compileOptions.compilerArgs = ["-value=something"]
+
+        expect:
+        !compileOptions.optionMap().containsKey(option)
+
+        where:
+        option << ['debugOptions', 'forkOptions', 'compilerArgs']
     }
 
-    @Test public void testWithExcludeFieldsFromOptionMap() {
-      compileOptions.compilerArgs = [[value: 'something']]
-        Map optionMap = compileOptions.optionMap()
-        ['debugOptions', 'forkOptions', 'compilerArgs'].each {
-            assertFalse(optionMap.containsKey(it))
-        }
-    }
-
-    @Test public void testFork() {
+    def "fork"() {
         compileOptions.fork = false
         boolean forkUseCalled = false
+
         compileOptions.forkOptions = [define: {Map args ->
             forkUseCalled = true
-            assertEquals(TEST_FORK_OPTION_MAP, args)
+            assert args == TEST_FORK_OPTION_MAP
         }] as ForkOptions
-        assert compileOptions.fork(TEST_FORK_OPTION_MAP).is(compileOptions)
-        assertTrue(compileOptions.fork)
-        assertTrue(forkUseCalled)
+
+        expect:
+        compileOptions.fork(TEST_FORK_OPTION_MAP).is(compileOptions)
+        compileOptions.fork
+        forkUseCalled
     }
 
-    @Test public void testDebug() {
+    def "debug"() {
         compileOptions.debug = false
         boolean debugUseCalled = false
+
         compileOptions.debugOptions = [define: {Map args ->
             debugUseCalled = true
-            assertEquals(TEST_DEBUG_OPTION_MAP, args)
+            args == TEST_DEBUG_OPTION_MAP
         }] as DebugOptions
+
+        expect:
         assert compileOptions.debug(TEST_DEBUG_OPTION_MAP).is(compileOptions)
-        assertTrue(compileOptions.debug)
-        assertTrue(debugUseCalled)
+        compileOptions.debug
+        debugUseCalled
     }
 
-    @Test public void testDefine() {
+    @SuppressWarnings("GrDeprecatedAPIUsage")
+    def "define"() {
         compileOptions.debug = false
         compileOptions.bootClasspath = 'xxxx'
         compileOptions.fork = false
         compileOptions.define(debug: true, bootClasspath: null)
-        assertTrue(compileOptions.debug)
-        assertNull(compileOptions.bootClasspath)
-        assertFalse(compileOptions.fork)
+        compileOptions.debug
+        compileOptions.bootClasspath == null
+        compileOptions.bootstrapClasspath == null
+        !compileOptions.fork
+    }
+
+    @SuppressWarnings("GrDeprecatedAPIUsage")
+    def "boot classpath is reflected via deprecated property"() {
+        def bootstrapClasspath = Mock(FileCollectionInternal)
+
+        when:
+        compileOptions.bootstrapClasspath = bootstrapClasspath
+
+        then:
+        compileOptions.bootstrapClasspath == bootstrapClasspath
+
+        when:
+        def deprecatedPath = compileOptions.bootClasspath
+
+        then:
+        deprecatedPath == "resolved"
+        1 * bootstrapClasspath.getAsPath() >> "resolved"
+        0 * _
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.api.tasks.compile
 
+import org.gradle.api.GradleException
 import org.gradle.api.internal.file.FileCollectionInternal
+import org.gradle.api.internal.file.collections.SimpleFileCollection
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -152,6 +154,8 @@ class CompileOptionsTest extends Specification {
         compileOptions.bootClasspath = 'xxxx'
         compileOptions.fork = false
         compileOptions.define(debug: true, bootClasspath: null)
+
+        expect:
         compileOptions.debug
         compileOptions.bootClasspath == null
         compileOptions.bootstrapClasspath == null
@@ -175,5 +179,42 @@ class CompileOptionsTest extends Specification {
         deprecatedPath == "resolved"
         1 * bootstrapClasspath.getAsPath() >> "resolved"
         0 * _
+    }
+
+    @SuppressWarnings("GrDeprecatedAPIUsage")
+    def "setting deprecated bootClasspath resets bootstrapClasspath"() {
+        given:
+        compileOptions.bootstrapClasspath = new SimpleFileCollection(new File("lib1.jar"))
+
+        when:
+        compileOptions.bootClasspath = "lib2.jar"
+
+        then:
+        compileOptions.bootClasspath == "lib2.jar"
+    }
+
+    @SuppressWarnings("GrDeprecatedAPIUsage")
+    def "querying bootstrapClasspath when deprecated bootClasspath is set fails"() {
+        given:
+        compileOptions.bootClasspath = "lib2.jar"
+
+        when:
+        compileOptions.bootstrapClasspath
+
+        then:
+        def ex = thrown GradleException
+        ex.message == "Deprecated property CompileOptions.bootClasspath was set, but replacement property CompileOptions.bootstrapClasspath was queried"
+    }
+
+    @SuppressWarnings("GrDeprecatedAPIUsage")
+    def "setting bootstrapClasspath resets deprecated bootClasspath"() {
+        given:
+        compileOptions.bootClasspath = "lib1.jar"
+
+        when:
+        compileOptions.bootstrapClasspath = new SimpleFileCollection(new File("lib2.jar"))
+
+        then:
+        compileOptions.bootClasspath == "lib2.jar"
     }
 }

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractOptions.java
@@ -87,6 +87,7 @@ public abstract class AbstractOptions implements Serializable {
     private boolean isOptionField(Field field) {
         return ((field.getModifiers() & Modifier.STATIC) == 0)
                 && (!field.getName().equals("metaClass"))
+                && (!field.getName().equals("fileResolver"))
                 && (!excludeFromAntProperties(field.getName()));
     }
 }


### PR DESCRIPTION
Deprecate the single string valued `CompileOptions.bootClasspath` and introduce a `FileCollection` property instead called `bootstrapClasspath`.