### PR TITLE
Source folders define separate output dirs in Eclipse classpath

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.eclipse.model.EclipseClasspath.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.eclipse.model.EclipseClasspath.xml
@@ -22,7 +22,7 @@
             </tr>
             <tr>
                 <td>defaultOutputDir</td>
-                <td><filename><replaceable>${project.projectDir}</replaceable>/bin</filename></td>
+                <td><filename><replaceable>${project.projectDir}</replaceable>/bin/default</filename></td>
             </tr>
             <tr>
                 <td>downloadSources</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -102,6 +102,10 @@ The JaCoCo plugin has been upgraded to use [JaCoCo version 0.7.9](http://www.jac
 
 The `eclipse` plugin now defines separate output directories for each source folders. Also, each source folders and dependencies define an additional `gradle_source_sets` classpath attribute. The attribute contains a comma-separated list of source sets which contains the element. Future [Buildship](http://eclipse.org/buildship) versions will use this information to separate source sets when launching Java applications within Eclipse.
 
+TODO (donat) add a potential breaking change: `eclipse` plugin default output location changed to `bin/default`
+
+TODO (donat) change the default output location in the eclipse plugin documentation
+
 <!--
 ### Example new and noteworthy
 -->

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -104,8 +104,6 @@ The `eclipse` plugin now defines separate output directories for each source fol
 
 TODO (donat) add a potential breaking change: `eclipse` plugin default output location changed to `bin/default`
 
-TODO (donat) change the default output location in the eclipse plugin documentation
-
 <!--
 ### Example new and noteworthy
 -->

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -98,9 +98,9 @@ or set [`org.gradle.console`](userguide/build_environment.html#sec:gradle_config
 
 The JaCoCo plugin has been upgraded to use [JaCoCo version 0.7.9](http://www.jacoco.org/jacoco/trunk/doc/changes.html) by default.
 
-### Adjustments in the `eclipse` plugin
+### Eclipse plugin separates output folders
 
-The `eclipse` plugin now defines separate output directories for each source folders. Also, each source folders and dependencies define an additional `gradle_source_sets` classpath attribute. The attribute contains a comma-separated list of source sets which contains the element. Future [Buildship](http://eclipse.org/buildship) versions will use this information to separate source sets when launching Java applications within Eclipse.
+The `eclipse` plugin now defines separate output directories for each source folders. Also, each source folder and dependency defines an additional `gradle_source_sets` classpath attribute. The attribute specifies to which sourceSet the entry belonged. Future [Buildship](http://eclipse.org/buildship) versions will use this information to separate source sets when launching Java applications within Eclipse.
 
 <!--
 ### Example new and noteworthy

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -98,6 +98,10 @@ or set [`org.gradle.console`](userguide/build_environment.html#sec:gradle_config
 
 The JaCoCo plugin has been upgraded to use [JaCoCo version 0.7.9](http://www.jacoco.org/jacoco/trunk/doc/changes.html) by default.
 
+### Adjustments in the `eclipse` plugin
+
+The `eclipse` plugin now defines separate output directories for each source folders. Also, each source folders and dependencies define an additional `gradle_source_sets` classpath attribute. The attribute contains a comma-separated list of source sets which contains the element. Future [Buildship](http://eclipse.org/buildship) versions will use this information to separate source sets when launching Java applications within Eclipse.
+
 <!--
 ### Example new and noteworthy
 -->

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -102,8 +102,6 @@ The JaCoCo plugin has been upgraded to use [JaCoCo version 0.7.9](http://www.jac
 
 The `eclipse` plugin now defines separate output directories for each source folders. Also, each source folders and dependencies define an additional `gradle_source_sets` classpath attribute. The attribute contains a comma-separated list of source sets which contains the element. Future [Buildship](http://eclipse.org/buildship) versions will use this information to separate source sets when launching Java applications within Eclipse.
 
-TODO (donat) add a potential breaking change: `eclipse` plugin default output location changed to `bin/default`
-
 <!--
 ### Example new and noteworthy
 -->
@@ -187,6 +185,10 @@ There are better ways for re-using task logic, for example by using [task depend
 - `AbstractNativeCompileTask.compilerArgs` changed type to `ListProperty<String>` from `List<String>`.
 - `AbstractNativeCompileTask.objectFileDir` changed type to `DirectoryVar` from `File`.
 - `AbstractLinkTask.linkerArgs` changed type to `ListProperty<String>` from `List<String>`.
+
+## Changes in the `eclipse` plugin
+
+The default output location in [EclipseClasspath](dsl/org.gradle.plugins.ide.eclipse.model.EclipseClasspath.html#org.gradle.plugins.ide.eclipse.model.EclipseClasspath:defaultOutputDir) changed from `${project.projectDir}/bin` to `${project.projectDir}/bin/default`.
 
 ## External contributions
 

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelOutputLocationCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelOutputLocationCrossVersionSpec.groovy
@@ -41,6 +41,7 @@ class ToolingApiEclipseModelOutputLocationCrossVersionSpec extends ToolingApiSpe
         thrown UnsupportedMethodException
     }
 
+    @TargetGradleVersion(">=1.2 <4.3")
     def "Non-Java project has default output location"() {
         when:
         EclipseProject project = loadToolingModel(EclipseProject)
@@ -50,6 +51,7 @@ class ToolingApiEclipseModelOutputLocationCrossVersionSpec extends ToolingApiSpe
         output.path == 'bin'
     }
 
+    @TargetGradleVersion(">=1.2 <4.3")
     def "Java project has default output location"() {
         setup:
         buildFile << "apply plugin: 'java'"

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec.groovy
@@ -43,6 +43,7 @@ class ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec extends Toolin
         thrown UnsupportedMethodException
     }
 
+    @TargetGradleVersion(">=1.2 <4.3")
     def "Source directory has no output specified"() {
         setup:
         settingsFile << 'rootProject.name = "root"'

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r43/ToolingApiEclipseModelOutputLocationCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r43/ToolingApiEclipseModelOutputLocationCrossVersionSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.tooling.r43
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.model.eclipse.EclipseOutputLocation
+import org.gradle.tooling.model.eclipse.EclipseProject
+
+@ToolingApiVersion('>=4.3')
+@TargetGradleVersion(">=4.3")
+class ToolingApiEclipseModelOutputLocationCrossVersionSpec extends ToolingApiSpecification {
+
+    def setup() {
+        settingsFile << 'rootProject.name = "root"'
+    }
+
+    def "Non-Java project has default output location"() {
+        when:
+        EclipseProject project = loadToolingModel(EclipseProject)
+        EclipseOutputLocation output = project.getOutputLocation()
+
+        then:
+        output.path == 'bin/default'
+    }
+
+    def "Java project has default output location"() {
+        setup:
+        buildFile << "apply plugin: 'java'"
+        EclipseProject project = loadToolingModel(EclipseProject)
+
+        when:
+        EclipseOutputLocation output = project.getOutputLocation()
+
+        then:
+        output.path == 'bin/default'
+    }
+}

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r43/ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r43/ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.tooling.r43
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.model.eclipse.EclipseProject
+
+@ToolingApiVersion('>=4.3')
+@TargetGradleVersion(">=4.3")
+class ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec extends ToolingApiSpecification {
+
+    def "Source directory has default output"() {
+        setup:
+        settingsFile << 'rootProject.name = "root"'
+        buildFile << "apply plugin: 'java'"
+        file('src/main/java').mkdirs()
+
+        when:
+        EclipseProject project = loadToolingModel(EclipseProject)
+
+        then:
+        project.sourceDirectories.size() == 1
+        project.sourceDirectories[0].output == 'output/src/main/java'
+    }
+
+    def "Source directory has custom output"() {
+        setup:
+        settingsFile << 'rootProject.name = "root"'
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+
+            eclipse.classpath.file.whenMerged {
+                entries.find { entry -> entry.path == 'src/test/java' }.output = null
+                entries.find { entry -> entry.path == 'src/test/resources' }.output = 'out/test-resources'
+            }
+        """
+
+        file('src/test/java').mkdirs()
+        file('src/test/resources').mkdirs()
+
+        when:
+        EclipseProject project = loadToolingModel(EclipseProject)
+
+        then:
+        project.sourceDirectories.size() == 2
+        project.sourceDirectories[0].output == null
+        project.sourceDirectories[1].output == 'out/test-resources'
+    }
+
+}

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r43/ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r43/ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec.groovy
@@ -25,7 +25,7 @@ import org.gradle.tooling.model.eclipse.EclipseProject
 @TargetGradleVersion(">=4.3")
 class ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec extends ToolingApiSpecification {
 
-    def "Source directory has default output"() {
+    def "Source directories have default output"() {
         setup:
         settingsFile << 'rootProject.name = "root"'
         buildFile << "apply plugin: 'java'"
@@ -36,7 +36,7 @@ class ToolingApiEclipseModelSourceDirectoryOutputCrossVersionSpec extends Toolin
 
         then:
         project.sourceDirectories.size() == 1
-        project.sourceDirectories[0].output == 'output/src/main/java'
+        project.sourceDirectories[0].output == 'bin/main'
     }
 
     def "Source directory has custom output"() {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
@@ -104,6 +104,10 @@ class EclipseClasspathFixture {
         String getPath() {
             return entry.@path
         }
+
+        void assertOutputLocation(String output) {
+            assert entry.@output == output
+        }
     }
 
     class EclipseLibrary extends EclipseClasspathEntry {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -129,7 +129,7 @@ sourceSets {
         def classpath = parseClasspathFile()
 
         def outputs = findEntries(classpath, "output")
-        assert outputs*.@path == ["bin"]
+        assert outputs*.@path == ["bin/default"]
 
         def sources = findEntries(classpath, "src")
         sources.each { assert !it.attributes().containsKey("path") }

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
@@ -1,26 +1,26 @@
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java">
+	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/resources">
+	<classpathentry kind="src" output="output/src/main/resources" path="src/main/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/test/java">
+	<classpathentry kind="src" output="output/src/test/java" path="src/test/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/test/resources">
+	<classpathentry kind="src" output="output/src/test/resources" path="src/test/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/integTest/java">
+	<classpathentry kind="src" output="output/src/integTest/java" path="src/integTest/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="integTest"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
@@ -1,26 +1,26 @@
 <classpath>
-	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
+	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/main/resources" path="src/main/resources">
+	<classpathentry kind="src" output="bin/main" path="src/main/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/test/java" path="src/test/java">
+	<classpathentry kind="src" output="bin/test" path="src/test/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/test/resources" path="src/test/resources">
+	<classpathentry kind="src" output="bin/test" path="src/test/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/integTest/java" path="src/integTest/java">
+	<classpathentry kind="src" output="bin/integTest" path="src/integTest/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="integTest"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
+	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/main/resources" path="src/main/resources">
+	<classpathentry kind="src" output="bin/main" path="src/main/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/test/java" path="src/test/java">
+	<classpathentry kind="src" output="bin/test" path="src/test/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java">
+	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/resources">
+	<classpathentry kind="src" output="output/src/main/resources" path="src/main/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/test/java">
+	<classpathentry kind="src" output="output/src/test/java" path="src/test/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
@@ -1,26 +1,26 @@
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java">
+	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/groovy">
+	<classpathentry kind="src" output="output/src/main/groovy" path="src/main/groovy">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/resources">
+	<classpathentry kind="src" output="output/src/main/resources" path="src/main/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/test/java">
+	<classpathentry kind="src" output="output/src/test/java" path="src/test/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/test/resources">
+	<classpathentry kind="src" output="output/src/test/resources" path="src/test/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
@@ -1,26 +1,26 @@
 <classpath>
-	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
+	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/main/groovy" path="src/main/groovy">
+	<classpathentry kind="src" output="bin/main" path="src/main/groovy">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/main/resources" path="src/main/resources">
+	<classpathentry kind="src" output="bin/main" path="src/main/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/test/java" path="src/test/java">
+	<classpathentry kind="src" output="bin/test" path="src/test/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="output/src/test/resources" path="src/test/resources">
+	<classpathentry kind="src" output="bin/test" path="src/test/resources">
 		<attributes>
 			<attribute name="gradle_source_sets" value="test"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/javabaseprojectClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/javabaseprojectClasspath.xml
@@ -1,4 +1,4 @@
 <classpath>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="bin/default"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 </classpath>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
@@ -1,6 +1,6 @@
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java">
+	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
@@ -1,6 +1,6 @@
 <classpath>
-	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
+	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
@@ -1,6 +1,6 @@
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java">
+	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
@@ -1,6 +1,6 @@
 <classpath>
-	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
+	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
+	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="src" path="src/main/java">
+	<classpathentry kind="src" output="output/src/main/java" path="src/main/java">
 		<attributes>
 			<attribute name="gradle_source_sets" value="main"/>
 		</attributes>

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -50,6 +50,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.plugins.ear.EarPlugin;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.eclipse.internal.AfterEvaluateHelper;
+import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.internal.LinkedResourcesCreator;
 import org.gradle.plugins.ide.eclipse.model.BuildCommand;
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
@@ -206,7 +207,7 @@ public class EclipsePlugin extends IdePlugin {
         ((IConventionAware) model.getClasspath()).getConventionMapping().map("defaultOutputDir", new Callable<File>() {
             @Override
             public File call() {
-                return new File(project.getProjectDir(), "bin/default");
+                return new File(project.getProjectDir(), EclipsePluginConstants.DEFAULT_PROJECT_OUTPUT_PATH);
             }
 
         });

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -206,7 +206,7 @@ public class EclipsePlugin extends IdePlugin {
         ((IConventionAware) model.getClasspath()).getConventionMapping().map("defaultOutputDir", new Callable<File>() {
             @Override
             public File call() {
-                return new File(project.getProjectDir(), "bin");
+                return new File(project.getProjectDir(), "bin/default");
             }
 
         });

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipsePluginConstants.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipsePluginConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.eclipse.internal;
+
+public class EclipsePluginConstants {
+
+    public static final String DEFAULT_PROJECT_OUTPUT_PATH = "bin/default";
+
+    private EclipsePluginConstants() {
+    }
+
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/LinkedResourcesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/LinkedResourcesCreator.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradle.plugins.ide.eclipse.EclipsePlugin;
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
 import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.gradle.plugins.ide.eclipse.model.Link;
@@ -34,9 +33,8 @@ import java.util.Set;
 public class LinkedResourcesCreator {
     public Set<Link> links(final Project project) {
         SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
-        // TODO (donat) there must be a better way to obtain the current/default value
         EclipseClasspath classpath = project.getExtensions().getByType(EclipseModel.class).getClasspath();
-        File defaultOutputDir = classpath == null ? project.file("bin/default") : classpath.getDefaultOutputDir();
+        File defaultOutputDir = classpath == null ? project.file(EclipsePluginConstants.DEFAULT_PROJECT_OUTPUT_PATH) : classpath.getDefaultOutputDir();
         List<SourceFolder> sourceFolders = new SourceFoldersCreator().getExternalSourceFolders(sourceSets, new Function<File, String>() {
             @Override
             public String apply(File dir) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/LinkedResourcesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/LinkedResourcesCreator.java
@@ -20,6 +20,9 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.plugins.ide.eclipse.EclipsePlugin;
+import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.gradle.plugins.ide.eclipse.model.Link;
 import org.gradle.plugins.ide.eclipse.model.SourceFolder;
 import org.gradle.plugins.ide.eclipse.model.internal.SourceFoldersCreator;
@@ -31,12 +34,15 @@ import java.util.Set;
 public class LinkedResourcesCreator {
     public Set<Link> links(final Project project) {
         SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+        // TODO (donat) there must be a better way to obtain the current/default value
+        EclipseClasspath classpath = project.getExtensions().getByType(EclipseModel.class).getClasspath();
+        File defaultOutputDir = classpath == null ? project.file("bin/default") : classpath.getDefaultOutputDir();
         List<SourceFolder> sourceFolders = new SourceFoldersCreator().getExternalSourceFolders(sourceSets, new Function<File, String>() {
             @Override
             public String apply(File dir) {
                 return project.relativePath(dir);
             }
-        });
+        }, defaultOutputDir);
         Set<Link> links = Sets.newLinkedHashSetWithExpectedSize(sourceFolders.size());
         for (SourceFolder sourceFolder : sourceFolders) {
             links.add(new Link(sourceFolder.getName(), "2", sourceFolder.getAbsolutePath(), null));

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Classpath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Classpath.java
@@ -86,7 +86,7 @@ public class Classpath extends XmlPersistableConfigurationObject {
     public Object configure(List newEntries) {
         Set<ClasspathEntry> updatedEntries = Sets.newLinkedHashSet();
         for (ClasspathEntry entry : entries) {
-            if (!isDependency(entry) && !isJreContainer(entry)) {
+            if (!isDependency(entry) && !isJreContainer(entry) && !isOutputLocation(entry)) {
                 updatedEntries.add(entry);
             }
         }
@@ -133,6 +133,10 @@ public class Classpath extends XmlPersistableConfigurationObject {
 
     private boolean isJreContainer(ClasspathEntry entry) {
         return entry instanceof Container && ((Container) entry).getPath().startsWith("org.eclipse.jdt.launching.JRE_CONTAINER");
+    }
+
+    private boolean isOutputLocation(ClasspathEntry entry) {
+        return entry instanceof Output;
     }
 
     /**

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
@@ -116,7 +116,7 @@ public class SourceFoldersCreator {
     }
 
     private List<SourceFolder> projectRelativeFolders(Iterable<SourceSet> sourceSets, Function<File, String> provideRelativePath, File defaultOutputDir) {
-        final String defaultOutputPath = provideRelativePath.apply(defaultOutputDir);
+        String defaultOutputPath = provideRelativePath.apply(defaultOutputDir);
         ArrayList<SourceFolder> entries = Lists.newArrayList();
         List<SourceSet> sortedSourceSets = sortSourceSetsAsPerUsualConvention(sourceSets);
         Map<SourceSet, String> sourceSetOutputPaths = collectSourceSetOutputPaths(sortedSourceSets, defaultOutputPath);
@@ -141,8 +141,8 @@ public class SourceFoldersCreator {
         return entries;
     }
 
-    private Map<SourceSet, String> collectSourceSetOutputPaths(List<SourceSet> sourceSets, String outputDir) {
-        Set<String> existingPaths = Sets.newHashSet(outputDir);
+    private Map<SourceSet, String> collectSourceSetOutputPaths(List<SourceSet> sourceSets, String defaultOutputPath) {
+        Set<String> existingPaths = Sets.newHashSet(defaultOutputPath);
         Map<SourceSet, String> result = Maps.newHashMap();
         for (SourceSet sourceSet : sourceSets) {
             String path = collectSourceSetOutputPath(sourceSet.getName(), existingPaths, "");

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
@@ -116,7 +116,7 @@ public class SourceFoldersCreator {
     }
 
     private List<SourceFolder> projectRelativeFolders(Iterable<SourceSet> sourceSets, Function<File, String> provideRelativePath, File defaultOutputDir) {
-        String defaultOutputPath = provideRelativePath.apply(defaultOutputDir);
+        String defaultOutputPath = PathUtil.normalizePath(provideRelativePath.apply(defaultOutputDir));
         ArrayList<SourceFolder> entries = Lists.newArrayList();
         List<SourceSet> sortedSourceSets = sortSourceSetsAsPerUsualConvention(sourceSets);
         Map<SourceSet, String> sourceSetOutputPaths = collectSourceSetOutputPaths(sortedSourceSets, defaultOutputPath);

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
@@ -43,8 +43,6 @@ import java.util.Set;
 
 public class SourceFoldersCreator {
 
-    // TODO (donat) add coverage: custom source set has name 'default'
-    // TODO (donat) add coverage: custom source sets have names 'default' and 'default_'
     // TODO (donat) test linked resources creation on non-java projects
 
     public List<ClasspathEntry> createSourceFolders(final EclipseClasspath classpath) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
@@ -126,6 +126,7 @@ public class SourceFoldersCreator {
                     folder.setName(dir.getName());
                     folder.setIncludes(getIncludesForTree(sourceSet, tree));
                     folder.setExcludes(getExcludesForTree(sourceSet, tree));
+                    folder.setOutput("output/" + relativePath.replaceAll("\\\\", "/"));
 
                     folder.getEntryAttributes().put("gradle_source_sets", sourceSet.getName().replaceAll(",", ""));
                     entries.add(folder);

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
@@ -43,8 +43,6 @@ import java.util.Set;
 
 public class SourceFoldersCreator {
 
-    // TODO (donat) test linked resources creation on non-java projects
-
     public List<ClasspathEntry> createSourceFolders(final EclipseClasspath classpath) {
         List<ClasspathEntry> entries = Lists.newArrayList();
         Function<File, String> provideRelativePath = new Function<File, String>() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
@@ -155,7 +155,7 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
         assert classpath.minusConfigurations == []
 
         assert classpath.containers == ["org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/${project.eclipse.jdt.getJavaRuntimeName()}/"] + additionalContainers as Set
-        assert classpath.defaultOutputDir == new File(project.projectDir, 'bin')
+        assert classpath.defaultOutputDir == new File(project.projectDir, 'bin/default')
     }
 
     private void checkEclipseJdt() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ClasspathTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ClasspathTest.groovy
@@ -33,6 +33,7 @@ public class ClasspathTest extends Specification {
         new Output("bin")]
     final projectDependency = [customEntries[0]]
     final jreContainer = [customEntries[1]]
+    final outputLocation = [customEntries[6]]
 
     final allDependencies = [customEntries[0], customEntries[2], customEntries[4]]
 
@@ -53,16 +54,16 @@ public class ClasspathTest extends Specification {
         classpath.entries == customEntries
     }
 
-    def "configure overwrites dependencies and jre container and appends all other entries"() {
+    def "configure overwrites output location, dependencies and jre container and appends all other entries"() {
         def constructorEntries = [createSomeLibrary()]
 
         when:
         classpath.load(customClasspathReader)
-        def newEntries = constructorEntries + projectDependency + jreContainer
+        def newEntries = constructorEntries + projectDependency + jreContainer + outputLocation
         classpath.configure(newEntries)
 
         then:
-        def entriesToBeKept = customEntries - allDependencies - jreContainer
+        def entriesToBeKept = customEntries - allDependencies - jreContainer - outputLocation
         classpath.entries == entriesToBeKept + newEntries
     }
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreatorTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreatorTest.groovy
@@ -38,6 +38,7 @@ class SourceFoldersCreatorTest extends Specification {
     DirectoryTree javaTree;
     DirectoryTree resourcesTree;
     File projectRootFolder;
+    File defaultOutputFolder;
 
     def setup() {
         sourceSet = Mock()
@@ -49,6 +50,7 @@ class SourceFoldersCreatorTest extends Specification {
         _ * sourceSet.allJava >> java
         _ * sourceSet.resources >> resources
         projectRootFolder = tempFolder.newFolder("project-root")
+        defaultOutputFolder = new File(projectRootFolder, 'bin/default')
     }
 
     def "applies excludes/includes for src folders"() {
@@ -127,7 +129,7 @@ class SourceFoldersCreatorTest extends Specification {
         _ * resources.includes >> resourcesTree.patterns.includes
         _ * resources.srcDirTrees >> [resourcesTree]
         _ * allSource.getSrcDirTrees() >> [javaTree, resourcesTree]
-        return new SourceFoldersCreator().getRegularSourceFolders([sourceSet], { File file -> file.path })
+        return new SourceFoldersCreator().getRegularSourceFolders([sourceSet], { File file -> file.path }, defaultOutputFolder)
     }
 
     private List<SourceFolder> externalSourceFolders(String... paths) {
@@ -141,7 +143,7 @@ class SourceFoldersCreatorTest extends Specification {
         _ * resources.srcDirs >> [resourcesTree.dir]
         _ * resources.srcDirTrees >> [resourcesTree]
         _ * allSource.getSrcDirTrees() >> allExtTrees + [javaTree, resourcesTree]
-        return new SourceFoldersCreator().getExternalSourceFolders([sourceSet], { File file -> file.path })
+        return new SourceFoldersCreator().getExternalSourceFolders([sourceSet], { File file -> file.path }, defaultOutputFolder)
     }
 
     private def dirTree(String sourceDirName, List excludes, List includes) {


### PR DESCRIPTION
This PR changes the eclipse classpath generation such that every source folder has different output location. This is required by Buildship to exclude test resources from the main classpath when launching a Java application from the IDE. For the details see https://github.com/eclipse/buildship/issues/354#issuecomment-331385098.

The only thing I'm not so sure about is that whether we should organize the output folders. The current change will result in two output folder per Gradle project

    |-bin
    |-output
      |-src/main
        |-java
        |-resources

I think this structure would be better because this way we would have one folder per Gradle project:

    |-bin
      |-default
      |-perSourceSet
        |-src/main
          |-java
          |-resources

Unfortunately, this means that we'd need to change the default output from `bin` to `bin/default`. I guess that's a breaking change, so we might want to do this only in Gradle 5. Is there a better option?