### PR TITLE
Fix GCS resource list operation correctness and performance

### DIFF
--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/fixtures/GcsServer.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/fixtures/GcsServer.groovy
@@ -290,6 +290,9 @@ class GcsServer extends HttpServer implements RepositoryServer {
             request {
                 method = 'GET'
                 path = "/b/${bucketName}/o"
+                params = [
+                    'prefix' : [prefix] as String[]
+                ]
                 headers = [
                     'Content-Type': 'application/json; charset=utf-8',
                     'Connection'  : 'Keep-Alive'

--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/fixtures/MavenGcsRepository.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/fixtures/MavenGcsRepository.groovy
@@ -41,4 +41,8 @@ class MavenGcsRepository implements MavenRepository {
     MavenGcsModule module(String organisation, String module, String version = "1.0") {
         new MavenGcsModule(server, backingRepository.module(organisation, module, version), repositoryPath, bucket)
     }
+
+    GcsDirectoryResource directoryList(String organisation, String module) {
+        return new GcsDirectoryResource(server, bucket, this.module(organisation, module).backingModule.moduleDir.parentFile)
+    }
 }

--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenGcsRepoResolveIntegrationTest.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenGcsRepoResolveIntegrationTest.groovy
@@ -29,7 +29,7 @@ class MavenGcsRepoResolveIntegrationTest extends AbstractGcsDependencyResolution
         return '/maven/release/'
     }
 
-    def setup(){
+    def setup() {
         module = getMavenGcsRepo().module("org.gradle", "test", artifactVersion)
     }
 

--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenGcsSnapshotRepoIntegrationTest.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenGcsSnapshotRepoIntegrationTest.groovy
@@ -146,7 +146,7 @@ buildscript {
 }
 """
         and:
-        module.mavenRootMetaData.expectDownloadMissing()
+        module.rootMetaData.expectDownloadMissing()
         mavenGcsRepo.directoryList("org.gradle", "test").expectDownload()
         module.metaData.expectDownload()
         module.pom.expectDownload()

--- a/subprojects/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/GcsClient.java
+++ b/subprojects/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/GcsClient.java
@@ -123,8 +123,9 @@ public class GcsClient {
     public List<String> list(URI uri) throws ResourceException {
         List<StorageObject> results = new ArrayList<StorageObject>();
 
+        String path = cleanResourcePath(uri);
         try {
-            Storage.Objects.List listRequest = storage.objects().list(uri.getHost());
+            Storage.Objects.List listRequest = storage.objects().list(uri.getHost()).setPrefix(path);
             Objects objects;
 
             // Iterate through each page of results, and add them to our results list.
@@ -141,7 +142,7 @@ public class GcsClient {
         }
 
         List<String> resultStrings = new ArrayList<String>();
-        for(StorageObject result : results) {
+        for (StorageObject result : results) {
             resultStrings.add(result.getName());
         }
 

--- a/subprojects/resources-gcs/src/test/groovy/org/gradle/internal/resource/transport/gcp/gcs/GcsClientTest.groovy
+++ b/subprojects/resources-gcs/src/test/groovy/org/gradle/internal/resource/transport/gcp/gcs/GcsClientTest.groovy
@@ -60,8 +60,13 @@ class GcsClientTest extends Specification {
         1 * gcsStorageClient.objects(*_) >> Mock(Storage.Objects) {
             1 * list(uri.getHost()) >> {
                 return Mock(Storage.Objects.List) {
+                    def self = it
                     int page = 0
                     int maxPages = 2
+                    setPrefix(*_) >> { args ->
+                        assert args.get(0).startsWith(uri.getPath().replaceAll("^/+", ''))
+                        return self
+                    }
                     maxPages * execute() >> {
                         Objects objects = new Objects()
                         objects.setItems(Collections.singletonList(new StorageObject()))


### PR DESCRIPTION
### Context
The GCS support added through https://github.com/gradle/gradle/pull/2258 has a severe performance/liveness bug that manifests when using large GCS repositories. When `ExternalResourceLister` performs a "list" action the internal `GcsClient` will always try to read the full list of GCS bucket objects starting from the root. `ExternalResourceLister` expects to receive children of the `URI` parent that is provided however `GcsClient` fails to fulfil the contract by fetching and returning full list of objects for a bucket.

When using the google json API we can specify a "prefix" when listing objects on a bucket. This "prefix" can be extracted as the path from an `URI` that is provided to the `GcsClient#list` method. This fix allows us to correctly list objects for a specified bucket sub-path and gets rid of the performance issue.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
