### PR TITLE
Fix flaky tests caused by accidental cache hit with PortAllocator

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
@@ -31,6 +31,7 @@ class HttpScriptPluginIntegrationSpec extends AbstractIntegrationSpec {
     def setup() {
         settingsFile << "rootProject.name = 'project'"
         server.expectUserAgent(UserAgentMatcher.matchesNameAndVersion("Gradle", GradleVersion.current().getVersion()))
+        server.enablePortAllocator()
         server.start()
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServerFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServerFixture.groovy
@@ -17,6 +17,7 @@
 package org.gradle.test.fixtures.server.http
 
 import com.google.common.collect.Sets
+import org.gradle.util.ports.FixedAvailablePortAllocator
 import org.mortbay.jetty.Connector
 import org.mortbay.jetty.Handler
 import org.mortbay.jetty.HttpHeaders
@@ -41,6 +42,7 @@ trait HttpServerFixture {
     private boolean logRequests = true
     private final Set<String> authenticationAttempts = Sets.newLinkedHashSet()
     private boolean configured
+    private boolean enablePortAllocator
 
     Server getServer() {
         server
@@ -88,6 +90,10 @@ trait HttpServerFixture {
         this.authenticationScheme = authenticationScheme
     }
 
+    void enablePortAllocator() {
+        this.enablePortAllocator = true
+    }
+
     void start() {
         if (!configured) {
             HandlerCollection handlers = new HandlerCollection()
@@ -99,7 +105,7 @@ trait HttpServerFixture {
         }
 
         connector = new SocketConnector()
-        connector.port = 0
+        connector.port = enablePortAllocator ? FixedAvailablePortAllocator.instance.assignPort() : 0
         server.addConnector(connector)
         server.start()
         for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
gradle/gradle-private#948
When two tests happen to be assigned the same port number, the cache
 is hit by accident. This result in different control flows and flaky tests

### Context

See https://github.com/gradle/gradle-private/issues/948

This PR uses `PortAllocator` to avoid different tests are assigned same port number accidentally. By default, `PortAllocator` is disabled because ports number is limited and very easy to be exhausted .
