### PR TITLE
Allow for adding artifacts to mavenPlugin and ivyPlugin publications

### DIFF
--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingRules.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingRules.java
@@ -65,7 +65,7 @@ class IvyPluginPublishingRules extends RuleSource {
     }
 
     private void createIvyPluginPublication(SoftwareComponent component, PublicationContainer publications) {
-        IvyPublication publication = publications.create("pluginIvy", IvyPublication.class);
+        IvyPublication publication = publications.maybeCreate("pluginIvy", IvyPublication.class);
         publication.from(component);
     }
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishingRules.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishingRules.java
@@ -63,7 +63,7 @@ class MavenPluginPublishingRules extends RuleSource {
         }
     }
     private void createMavenPluginPublication(SoftwareComponent component, PublicationContainer publications) {
-        MavenPublication publication = publications.create("pluginMaven", MavenPublication.class);
+        MavenPublication publication = publications.maybeCreate("pluginMaven", MavenPublication.class);
         publication.from(component);
     }
 


### PR DESCRIPTION
Without requiring the use of a software model rule source.

By making the existing plugin publishing rules use `maybeCreate` instead of `create` when creating the plugin publications.

See #2612
