### PR TITLE
Make bootclasspath a compile classpath

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
-import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -276,11 +276,8 @@ public class CompileOptions extends AbstractOptions {
      *
      * @since 4.3
      */
-    // The bootstrap classpath is actually a `@CompileClasspath`, but declaring it so adds a significant amount
-    // of processing time the first time a full Java runtime is encountered. We decided to declare it as
-    // `@Classpath` instead, because the benefits would be sparse anyway.
     @Optional
-    @Classpath
+    @CompileClasspath
     public FileCollection getBootstrapClasspath() {
         return bootstrapClasspath;
     }


### PR DESCRIPTION
Originally we used `@Classpath` because of performance considerations, but that would prevent different OS versions of the same ABI-compatible JARs to be successfully recognized as compatible.
