### PR TITLE
Improve `JacocoPluginExtension#applyTo` type signature

### DIFF
--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -164,8 +164,8 @@ public class JacocoPluginExtension {
      *
      * @param tasks the tasks to apply Jacoco to
      */
-    public <T extends Task & JavaForkOptions> void applyTo(TaskCollection tasks) {
-        tasks.withType(JavaForkOptions.class, new Action<JavaForkOptions>() {
+    public <T extends Task & JavaForkOptions> void applyTo(TaskCollection<T> tasks) {
+        ((TaskCollection) tasks).withType(JavaForkOptions.class, new Action<JavaForkOptions>() {
             @Override
             public void execute(JavaForkOptions task) {
                 applyTo(Cast.<T>uncheckedCast(task));

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -26,7 +26,6 @@ import org.gradle.api.provider.PropertyState;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskCollection;
-import org.gradle.internal.Cast;
 import org.gradle.internal.jacoco.JacocoAgentJar;
 import org.gradle.process.JavaForkOptions;
 
@@ -165,10 +164,10 @@ public class JacocoPluginExtension {
      * @param tasks the tasks to apply Jacoco to
      */
     public <T extends Task & JavaForkOptions> void applyTo(TaskCollection<T> tasks) {
-        ((TaskCollection) tasks).withType(JavaForkOptions.class, new Action<JavaForkOptions>() {
+        ((TaskCollection) tasks).withType(JavaForkOptions.class, new Action<T>() {
             @Override
-            public void execute(JavaForkOptions task) {
-                applyTo(Cast.<T>uncheckedCast(task));
+            public void execute(T task) {
+                applyTo(task);
             }
         });
     }


### PR DESCRIPTION
By mentioning the type parameter `T` in the parameter list so it can be inferred by a capable compiler.

See https://github.com/gradle/kotlin-dsl/issues/458