### PR TITLE
Use PortAllocator in http script tests

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ExternalScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ExternalScriptExecutionIntegrationTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.matchers.UserAgentMatcher
 import org.gradle.util.GradleVersion
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -34,6 +35,11 @@ import static org.junit.Assert.assertThat
 public class ExternalScriptExecutionIntegrationTest extends AbstractIntegrationTest {
     @Rule
     public final HttpServer server = new HttpServer()
+
+    @Before
+    void setUp(){
+        server.enablePortAllocator()
+    }
 
     @Test
     public void executesExternalScriptAgainstAProjectWithCorrectEnvironment() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/HttpProxyScriptPluginIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/HttpProxyScriptPluginIntegrationSpec.groovy
@@ -34,6 +34,7 @@ class HttpProxyScriptPluginIntegrationSpec extends AbstractIntegrationSpec {
     def setup() {
         settingsFile << "rootProject.name = 'project'"
         server.expectUserAgent(UserAgentMatcher.matchesNameAndVersion("Gradle", GradleVersion.current().getVersion()))
+        server.enablePortAllocator()
         server.start()
     }
 
@@ -68,7 +69,7 @@ class HttpProxyScriptPluginIntegrationSpec extends AbstractIntegrationSpec {
         "configured"    | null        | null
         "authenticated" | "proxyUser" | "proxyPassword"
     }
-    
+
     def "uses authenticated proxy to access remote settings script plugin"() {
         given:
         testProxyServer.start("proxyUser", "proxyPassword")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServerFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServerFixture.groovy
@@ -42,7 +42,7 @@ trait HttpServerFixture {
     private boolean logRequests = true
     private final Set<String> authenticationAttempts = Sets.newLinkedHashSet()
     private boolean configured
-    private boolean enablePortAllocator
+    private boolean portAllocatorEnabled
 
     Server getServer() {
         server
@@ -91,7 +91,7 @@ trait HttpServerFixture {
     }
 
     void enablePortAllocator() {
-        this.enablePortAllocator = true
+        this.portAllocatorEnabled = true
     }
 
     void start() {
@@ -105,7 +105,7 @@ trait HttpServerFixture {
         }
 
         connector = new SocketConnector()
-        connector.port = enablePortAllocator ? FixedAvailablePortAllocator.instance.assignPort() : 0
+        connector.port = portAllocatorEnabled ? FixedAvailablePortAllocator.instance.assignPort() : 0
         server.addConnector(connector)
         server.start()
         for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
### Context

Although attempt to fix https://github.com/gradle/gradle-private/issues/948 has been made in #3025 , the issue still exists after it was merged into `master`.

According to https://github.com/gradle/gradle-private/issues/966 , there're at least two failures observed after #3025 are merged. I was trying to use `BlockingHttpServer` to replace `HttpServer` but it looks like `BlockingHttpServer` doesn't support some features of `HttpServer`, for example [SSL](https://github.com/gradle/gradle/blob/25625363319836e74aea4abed4c52f14b2597f13/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServerFixture.groovy#L165). Therefore, I enable `PortAllocator` in all places where https://github.com/gradle/gradle-private/issues/948 potentially happens. Let's make this change first and see if it could improve the situation.

### Gradle Core Team Checklist
- [x] Verify test coverage and CI build status
