### PR TITLE
Fix URI-quoted chars in cached outputs bug

### DIFF
--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TarTaskOutputPackerTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TarTaskOutputPackerTest.groovy
@@ -31,6 +31,8 @@ import org.gradle.internal.nativeplatform.filesystem.FileSystem
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -182,6 +184,7 @@ class TarTaskOutputPackerTest extends Specification {
         "unicode" | "prop-dezső"
     }
 
+    @Requires(TestPrecondition.UNIX_DERIVATIVE)
     @Unroll
     def "can pack output directory with files having #type characters in name"() {
         def sourceOutputDir = temporaryFolder.file("source").createDir()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
@@ -647,6 +648,35 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         withBuildCache().succeeds "consumer"
         then:
         skippedTasks.sort() == [":consumer", ":producer"]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/3043")
+    def "URL-quoted characters in file names are handled properly"() {
+        def weirdOutputPath = 'build/bad&dir/bad! <Dezső> %20.txt'
+        def expectedOutput = file(weirdOutputPath)
+        buildFile << """
+            task weirdOutput {
+                outputs.dir("build")
+                outputs.cacheIf { true }
+                doLast {
+                    mkdir file('$weirdOutputPath').parentFile
+                    file('$weirdOutputPath').text = "Data"
+                }
+            }
+        """
+
+        when:
+        withBuildCache().succeeds "weirdOutput"
+        then:
+        executedAndNotSkipped ":weirdOutput"
+        expectedOutput.file
+
+        when:
+        cleanBuildDir()
+        withBuildCache().succeeds "weirdOutput"
+        then:
+        skipped ":weirdOutput"
+        expectedOutput.file
     }
 
     private static String defineProducerTask() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -652,7 +652,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
 
     @Issue("https://github.com/gradle/gradle/issues/3043")
     def "URL-quoted characters in file names are handled properly"() {
-        def weirdOutputPath = 'build/bad&dir/bad! <Dezső> %20.txt'
+        def weirdOutputPath = 'build/bad&dir/bad! Dezső %20.txt'
         def expectedOutput = file(weirdOutputPath)
         buildFile << """
             task weirdOutput {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TarTaskOutputPacker.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TarTaskOutputPacker.java
@@ -55,7 +55,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 import java.util.SortedSet;
@@ -68,6 +68,7 @@ import static org.gradle.caching.internal.tasks.TaskOutputPackerUtils.makeDirect
 /**
  * Packages task output to a POSIX TAR file.
  */
+@SuppressWarnings("Since15")
 public class TarTaskOutputPacker implements TaskOutputPacker {
     private static final String METADATA_PATH = "METADATA";
     private static final Pattern PROPERTY_PATH = Pattern.compile("(missing-)?property-([^/]+)(?:/(.*))?");
@@ -169,7 +170,7 @@ public class TarTaskOutputPacker implements TaskOutputPacker {
         entries++;
 
         String rootAbsolutePath = directory.getAbsolutePath();
-        URI rootUri = directory.toURI();
+        Path rootPath = directory.toPath();
 
         for (Map.Entry<String, FileContentSnapshot> entry : outputSnapshots.entrySet()) {
             String absolutePath = entry.getKey();
@@ -178,7 +179,7 @@ public class TarTaskOutputPacker implements TaskOutputPacker {
                 continue;
             }
             File file = new File(absolutePath);
-            String relativePath = rootUri.relativize(file.toURI()).toString();
+            String relativePath = rootPath.relativize(file.toPath()).toString();
             String targetPath = propertyRoot + relativePath;
             int mode = fileSystem.getUnixMode(file);
             switch (entry.getValue().getType()) {


### PR DESCRIPTION
Fixes #3043

Since using `URI.relativize()` we don't seem to be handling task output file names with URI-quoted characters in them.