### PR TITLE
Add annotations to account for the nullability of extra properties

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtraPropertiesExtension.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtraPropertiesExtension.java
@@ -18,6 +18,7 @@ package org.gradle.api.plugins;
 
 import org.gradle.api.InvalidUserDataException;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -118,6 +119,7 @@ public interface ExtraPropertiesExtension {
      * @return The value for the property with the given name.
      * @throws UnknownPropertyException if there is no property registered with the given name
      */
+    @Nullable
     Object get(String name) throws UnknownPropertyException;
 
     /**
@@ -139,7 +141,7 @@ public interface ExtraPropertiesExtension {
      * @param name The name of the property to update the value of or create
      * @param value The value to set for the property
      */
-    void set(String name, Object value);
+    void set(String name, @Nullable Object value);
 
     /**
      * Returns all of the registered properties and their current values as a map.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultExtraPropertiesExtension.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultExtraPropertiesExtension.java
@@ -22,6 +22,7 @@ import groovy.lang.MissingPropertyException;
 import groovy.lang.ReadOnlyPropertyException;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,6 +34,7 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
         return storage.containsKey(name);
     }
 
+    @Nullable
     public Object get(String name) {
         if (storage.containsKey(name)) {
             return storage.get(name);
@@ -41,10 +43,11 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
         }
     }
 
-    public void set(String name, Object value) {
+    public void set(String name, @Nullable Object value) {
         storage.put(name, value);
     }
 
+    @Nullable
     public Object getProperty(String name) {
         if (name.equals("properties")) {
             return getProperties();
@@ -57,7 +60,7 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
         }
     }
 
-    public void setProperty(String name, Object newValue) {
+    public void setProperty(String name, @Nullable Object newValue) {
         if (name.equals("properties")) {
             throw new ReadOnlyPropertyException("name", ExtraPropertiesExtension.class);
         }


### PR DESCRIPTION
`UnknownPropertyExtension` != existing null extra property

Already covered in `ExtraPropertiesExtensionTest`

See https://github.com/gradle/kotlin-dsl/issues/512
