### PR TITLE
Print task result in verbose console type (#2642)

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -85,9 +85,14 @@ task customTask {
 }
 ```
 
-### Force rich or plain console with `org.gradle.console`
+### Force console type with `org.gradle.console`
 
-You may now force Gradle to use rich or plain [build output](userguide/console.html#sec:console_build_output) by setting [`org.gradle.console`](userguide/build_environment.html#sec:gradle_configuration_properties) in your `gradle.properties`.
+You may now force Gradle to use specific console type in [build output](userguide/console.html#sec:console_build_output) by setting [`org.gradle.console`](userguide/build_environment.html#sec:gradle_configuration_properties) in your `gradle.properties`.
+
+### New `verbose` console type
+
+Since Gradle 4.0, task header and outcome won't be displayed by default, which may be confusing. Now you can use `--console=verbose` command line argument 
+or set [`org.gradle.console`](userguide/build_environment.html#sec:gradle_configuration_properties) in your `gradle.properties` to enable task header and outcome output.
 
 ### Plugin library upgrades
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -35,7 +35,7 @@ public class GroupedOutputFixture {
     /**
      * All tasks will start with > Task, captures everything starting with : and going until a control char
      */
-    private final static String TASK_HEADER = "> Task (:[\\w:]*)\\n?";
+    private final static String TASK_HEADER = "> Task (:[\\w:]*) ?(FAILED|FROM-CACHE|UP-TO-DATE|SKIPPED|NO-SOURCE)?\\n?";
 
     private final static String EMBEDDED_BUILD_START = "> :\\w* > root project";
     private final static String BUILD_STATUS_FOOTER = "BUILD SUCCESSFUL";
@@ -55,14 +55,14 @@ public class GroupedOutputFixture {
     /**
      * Pattern to extract task output.
      */
-    private static final String TASK_OUTPUT_PATTERN;
+    private static final Pattern TASK_OUTPUT_PATTERN;
 
     static {
         String pattern = "(?ms)";
         pattern += TASK_HEADER;
         // Capture all output, lazily up until two new lines and an END_OF_TASK designation
         pattern += "([\\s\\S]*?(?=[^\\n]*?" + END_OF_TASK_OUTPUT + "))";
-        TASK_OUTPUT_PATTERN = pattern;
+        TASK_OUTPUT_PATTERN = Pattern.compile(pattern);
     }
 
 
@@ -79,18 +79,20 @@ public class GroupedOutputFixture {
         tasks = new HashMap<String, GroupedTaskFixture>();
 
         String strippedOutput = stripAnsiCodes(stripWorkInProgressArea(output));
-        Matcher matcher = Pattern.compile(TASK_OUTPUT_PATTERN).matcher(strippedOutput);
+        Matcher matcher = TASK_OUTPUT_PATTERN.matcher(strippedOutput);
         while (matcher.find()) {
             String taskName = matcher.group(1);
-            String taskOutput = matcher.group(2);
-            taskOutput = taskOutput.trim();
-            if (tasks.containsKey(taskName)) {
-                tasks.get(taskName).addOutput(taskOutput);
-            } else {
-                GroupedTaskFixture task = new GroupedTaskFixture(taskName);
-                task.addOutput(taskOutput);
+            String taskOutcome = matcher.group(2);
+            String taskOutput = matcher.group(3).trim();
+
+            GroupedTaskFixture task = tasks.get(taskName);
+            if (task == null) {
+                task = new GroupedTaskFixture(taskName);
                 tasks.put(taskName, task);
             }
+
+            task.addOutput(taskOutput);
+            task.setOutcome(taskOutcome);
         }
 
         return strippedOutput;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTaskFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTaskFixture.java
@@ -25,6 +25,8 @@ public class GroupedTaskFixture {
 
     private final String taskName;
 
+    private String taskOutcome;
+
     private final List<String> outputs = new ArrayList<String>(1);
 
     public GroupedTaskFixture(String taskName) {
@@ -33,6 +35,17 @@ public class GroupedTaskFixture {
 
     protected void addOutput(String output) {
         outputs.add(output);
+    }
+
+    public void setOutcome(String taskOutcome) {
+        if (this.taskOutcome != null) {
+            throw new AssertionError(taskName + " task's outcome is set twice!");
+        }
+        this.taskOutcome = taskOutcome;
+    }
+
+    public String getOutcome(){
+        return taskOutcome;
     }
 
     public String getName() {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/BasicGroupedTaskLoggingFunctionalSpec.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/BasicGroupedTaskLoggingFunctionalSpec.groovy
@@ -133,6 +133,7 @@ class BasicGroupedTaskLoggingFunctionalSpec extends AbstractConsoleGroupedTaskFu
                         lock.release()
                         project(':b').lock.acquire()
                         logger.quiet 'After'
+                        assert false
                     }
                 }
             }
@@ -166,11 +167,13 @@ class BasicGroupedTaskLoggingFunctionalSpec extends AbstractConsoleGroupedTaskFu
         """
 
         when:
-        succeeds('run')
+        fails('run')
 
         then:
         result.groupedOutput.task(':a:log').outputs == ['Before', 'After']
+        result.groupedOutput.task(':a:log').outcome == 'FAILED'
         result.groupedOutput.task(':b:log').output == 'Interrupting output'
+        result.groupedOutput.task(':b:log').outcome == null
     }
 
     def "long running task output are flushed after delay"() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatter.java
@@ -20,6 +20,7 @@ import org.gradle.internal.logging.events.StyledTextOutputEvent;
 import org.gradle.internal.logging.text.StyledTextOutput;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 
 public class PrettyPrefixedLogHeaderFormatter implements LogHeaderFormatter {
@@ -27,11 +28,24 @@ public class PrettyPrefixedLogHeaderFormatter implements LogHeaderFormatter {
     public List<StyledTextOutputEvent.Span> format(@Nullable String header, String description, @Nullable String shortDescription, @Nullable String status, boolean failed) {
         final String message = header != null ? header : description;
         if (message != null) {
-            StyledTextOutput.Style messageStyle = failed ? StyledTextOutput.Style.FailureHeader : StyledTextOutput.Style.Header;
             // Visually indicate group by adding surrounding lines
-            return Lists.newArrayList(new StyledTextOutputEvent.Span(EOL), new StyledTextOutputEvent.Span(messageStyle, "> " + message), new StyledTextOutputEvent.Span(EOL));
+            return Lists.newArrayList(eol(), header(message, failed), status(status, failed), eol());
         } else {
-            return Lists.newArrayList();
+            return Collections.emptyList();
         }
+    }
+
+    private StyledTextOutputEvent.Span eol() {
+        return new StyledTextOutputEvent.Span(EOL);
+    }
+
+    private StyledTextOutputEvent.Span header(String message, boolean failed) {
+        StyledTextOutput.Style messageStyle = failed ? StyledTextOutput.Style.FailureHeader : StyledTextOutput.Style.Header;
+        return new StyledTextOutputEvent.Span(messageStyle, "> " + message);
+    }
+
+    private StyledTextOutputEvent.Span status(String status, boolean failed) {
+        StyledTextOutput.Style statusStyle = failed ? StyledTextOutput.Style.Failure : StyledTextOutput.Style.Info;
+        return new StyledTextOutputEvent.Span(statusStyle, " " + status);
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
@@ -51,7 +51,7 @@ public class GroupingProgressLogEventGenerator implements OutputEventListener {
     private final OutputEventListener listener;
     private final Clock clock;
     private final LogHeaderFormatter headerFormatter;
-    private final boolean alwaysRenderTasks;
+    private final boolean verbose;
 
     // Maintain a hierarchy of all build operation ids — heads up: this is a *forest*, not just 1 tree
     private final Map<Object, Object> buildOpIdHierarchy = new HashMap<Object, Object>();
@@ -60,11 +60,11 @@ public class GroupingProgressLogEventGenerator implements OutputEventListener {
 
     private Object lastRenderedBuildOpId;
 
-    public GroupingProgressLogEventGenerator(OutputEventListener listener, Clock clock, LogHeaderFormatter headerFormatter, boolean alwaysRenderTasks) {
+    public GroupingProgressLogEventGenerator(OutputEventListener listener, Clock clock, LogHeaderFormatter headerFormatter, boolean verbose) {
         this.listener = listener;
         this.clock = clock;
         this.headerFormatter = headerFormatter;
-        this.alwaysRenderTasks = alwaysRenderTasks;
+        this.verbose = verbose;
     }
 
     public void onOutput(OutputEvent event) {
@@ -233,7 +233,7 @@ public class GroupingProgressLogEventGenerator implements OutputEventListener {
         }
 
         private boolean shouldForward() {
-            return !bufferedLogs.isEmpty() || (alwaysRenderTasks && buildOperationCategory == BuildOperationCategory.TASK);
+            return !bufferedLogs.isEmpty() || (verbose && buildOperationCategory == BuildOperationCategory.TASK);
         }
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
@@ -266,7 +266,7 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.restore(snapshot) // close console to flush
 
         then:
-        console.buildOutputArea.toString().readLines() == ['', '{header}> description{normal}', 'info', '{error}error', '{normal}']
+        console.buildOutputArea.toString().readLines() == ['', '{header}> description{info} status{normal}', 'info', '{error}error', '{normal}']
     }
 
     def rendersLogEventsWhenOnlyStdOutIsConsole() {
@@ -281,7 +281,7 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.restore(snapshot) // close console to flush
 
         then:
-        console.buildOutputArea.toString().readLines() == ['', '{header}> description{normal}', 'info']
+        console.buildOutputArea.toString().readLines() == ['', '{header}> description{info} status{normal}', 'info']
     }
 
     def rendersLogEventsWhenOnlyStdErrIsConsole() {


### PR DESCRIPTION
Fix https://github.com/gradle/gradle/issues/2642

Under verbose console type, print task result status (e.g. UP-TO-DATE)
in task header.
