### PR TITLE
Revert change that broke Android testing

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/reporting/DurationFormatter.java
+++ b/subprojects/core/src/main/java/org/gradle/reporting/DurationFormatter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.reporting;
+
+import java.math.BigDecimal;
+
+/**
+ * This internal detail is used by the Android plugin < 3.0. It will be removed in Gradle 5.0.
+ */
+@Deprecated
+public class DurationFormatter {
+    public static final int MILLIS_PER_SECOND = 1000;
+    public static final int MILLIS_PER_MINUTE = 60 * MILLIS_PER_SECOND;
+    public static final int MILLIS_PER_HOUR = 60 * MILLIS_PER_MINUTE;
+    public static final int MILLIS_PER_DAY = 24 * MILLIS_PER_HOUR;
+
+    public String format(long duration) {
+        if (duration == 0) {
+            return "0s";
+        }
+
+        StringBuilder result = new StringBuilder();
+
+        long days = duration / MILLIS_PER_DAY;
+        duration = duration % MILLIS_PER_DAY;
+        if (days > 0) {
+            result.append(days);
+            result.append("d");
+        }
+        long hours = duration / MILLIS_PER_HOUR;
+        duration = duration % MILLIS_PER_HOUR;
+        if (hours > 0 || result.length() > 0) {
+            result.append(hours);
+            result.append("h");
+        }
+        long minutes = duration / MILLIS_PER_MINUTE;
+        duration = duration % MILLIS_PER_MINUTE;
+        if (minutes > 0 || result.length() > 0) {
+            result.append(minutes);
+            result.append("m");
+        }
+        int secondsScale = result.length() > 0 ? 2 : 3;
+        result.append(BigDecimal.valueOf(duration).divide(BigDecimal.valueOf(MILLIS_PER_SECOND)).setScale(secondsScale, BigDecimal.ROUND_HALF_UP));
+        result.append("s");
+        return result.toString();
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -29,6 +29,10 @@ class RepoScriptBlockUtil {
         return "repositories { ${mavenCentralRepositoryDefinition()} }"
     }
 
+    static String googleRepository() {
+        return "repositories { google() }"
+    }
+
     static String jcenterRepositoryDefinition() {
         String repoUrl = System.getProperty('org.gradle.integtest.mirrors.jcenter')
         if (repoUrl) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -80,4 +80,8 @@ abstract class AbstractSmokeTest extends Specification {
     protected static String mavenCentralRepository() {
         RepoScriptBlockUtil.mavenCentralRepository()
     }
+
+    protected static String googleRepository() {
+        RepoScriptBlockUtil.googleRepository()
+    }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -17,13 +17,16 @@
 package org.gradle.smoketests
 
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
 
 /**
  * For these tests to run you need to set ANDROID_HOME to your Android SDK directory
  */
 class AndroidPluginsSmokeTest extends AbstractSmokeTest {
-    public static final ANDROID_PLUGIN_VERSION = '2.3.1'
     public static final ANDROID_BUILD_TOOLS_VERSION = '25.0.0'
+    public static final String STABLE_ANDROID_VERSION = '2.3.3'
+    public static final String EXPERIMENTAL_ANDROID_VERSION = '3.0.0-beta6'
+    public static final TESTED_ANDROID_PLUGIN_VERSIONS = [STABLE_ANDROID_VERSION, EXPERIMENTAL_ANDROID_VERSION]
 
     def setup() {
         assertAndroidHomeSet()
@@ -37,7 +40,8 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
         '''.stripIndent()
     }
 
-    def "android application plugin"() {
+    @Unroll
+    def "android application plugin #pluginVersion"(String pluginVersion) {
         given:
 
         def basedir='.'
@@ -69,23 +73,28 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
 
             </manifest>""".stripIndent()
 
-        buildFile << buildscript() << """
+        buildFile << buildscript(pluginVersion) << """
             apply plugin: 'com.android.application'
 
            ${jcenterRepository()}
+           ${googleRepository()}
 
             android.defaultConfig.applicationId "org.gradle.android.myapplication"
         """.stripIndent() << androidPluginConfiguration() << activityDependency()
 
         when:
-        def result = runner('androidDependencies', 'build', '-x', 'lint').build()
+        def result = runner('androidDependencies', 'build', 'connectedAndroidTest', '-x', 'lint').build()
 
         then:
         result.task(':assemble').outcome == TaskOutcome.SUCCESS
         result.task(':compileReleaseJavaWithJavac').outcome == TaskOutcome.SUCCESS
+
+        where:
+        pluginVersion << TESTED_ANDROID_PLUGIN_VERSIONS
     }
 
-    def "android library plugin"() {
+    @Unroll
+    def "android library plugin #pluginVersion"(String pluginVersion) {
         given:
 
         def app = 'app'
@@ -132,7 +141,7 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
             include ':${library}'
         """
 
-        file('build.gradle') << buildscript() << """
+        file('build.gradle') << buildscript(pluginVersion) << """
             subprojects {
                 ${jcenterRepository()}
             }
@@ -161,6 +170,9 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
         result.task(':app:assemble').outcome == TaskOutcome.SUCCESS
         result.task(':library:assemble').outcome == TaskOutcome.SUCCESS
         result.task(':app:compileReleaseJavaWithJavac').outcome == TaskOutcome.SUCCESS
+
+        where:
+        pluginVersion << TESTED_ANDROID_PLUGIN_VERSIONS
     }
 
     private String activityDependency() {
@@ -171,14 +183,14 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
         """
     }
 
-    private String buildscript() {
+    private String buildscript(String pluginVersion) {
         """
             buildscript {
                 ${jcenterRepository()}
-
+                ${googleRepository()}
 
                 dependencies {
-                    classpath 'com.android.tools.build:gradle:${ANDROID_PLUGIN_VERSION}'
+                    classpath 'com.android.tools.build:gradle:${pluginVersion}'
                 }
             }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -21,7 +21,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class KotlinPluginSmokeTest extends AbstractSmokeTest {
     private kotlinVersion = '1.1.1'
-    private androidPluginVersion = AndroidPluginsSmokeTest.ANDROID_PLUGIN_VERSION
+    private androidPluginVersion = AndroidPluginsSmokeTest.STABLE_ANDROID_VERSION
     private androidBuildToolsVersion = AndroidPluginsSmokeTest.ANDROID_BUILD_TOOLS_VERSION
 
     def 'kotlin plugin'() {


### PR DESCRIPTION
Android 2.3 uses the internal DurationFormatter class for its
test reporting. This has been fixed in Android 3.0, but we want
to keep Android 2.3 working a while longer. We will remove this
class in Android 5.0

This adds coverage for reporting on connected tests (the scenario that
broke). It does not add coverage for actually running the tests, since
that would require additional setup like an emulator.

This also adds coverage for Android 3.0 to ensure we don't break the
latest beta.