### PR TITLE
Avoid implicit `_main` symbols for Swift libraries and XCTest bundle

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -49,6 +49,7 @@ import org.gradle.nativeplatform.toolchain.internal.NativeToolChainRegistryInter
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 import org.gradle.nativeplatform.toolchain.plugins.SwiftCompilerPlugin;
 
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 
 /**
@@ -118,6 +119,9 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     install.setExecutable(link.getBinaryFile());
                     install.lib(binary.getRuntimeLibraries());
                 } else if (binary instanceof SwiftSharedLibrary) {
+                    // Specific compiler arguments
+                    compile.getCompilerArgs().set(Arrays.asList("-parse-as-library"));
+
                     // Add a link task
                     final LinkSharedLibrary link = tasks.create(names.getTaskName("link"), LinkSharedLibrary.class);
                     link.source(compile.getObjectFileDir().getAsFileTree().matching(new PatternSet().include("**/*.obj", "**/*.o")));
@@ -135,6 +139,9 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     link.setToolChain(toolChain);
                     link.setDebuggable(binary.isDebuggable());
                 } else if (binary instanceof SwiftBundle) {
+                    // Specific compiler arguments
+                    compile.getCompilerArgs().set(Arrays.asList("-parse-as-library"));
+
                     // Add a link task
                     LinkMachOBundle link = tasks.create(names.getTaskName("link"), LinkMachOBundle.class);
                     link.source(compile.getObjectFileDir().getAsFileTree().matching(new PatternSet().include("**/*.obj", "**/*.o")));

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
@@ -16,6 +16,7 @@
 
 package org.gradle.language.swift.plugins;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
@@ -37,6 +38,11 @@ import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
 
 /**
  * <p>A plugin that produces a shared library from Swift source.</p>
@@ -75,7 +81,16 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 
         // Configure compile task
         SwiftCompile compileDebug = (SwiftCompile) tasks.getByName("compileDebugSwift");
-        compileDebug.getCompilerArgs().set(Lists.newArrayList("-enable-testing"));
+        // TODO - Avoid evaluating the arguments here
+        final List<String> currentCompilerArguments = compileDebug.getCompilerArgs().getOrElse(Collections.<String>emptyList());
+        compileDebug.getCompilerArgs().set(project.provider(new Callable<List<String>>() {
+            @Override
+            public List<String> call() throws Exception {
+                return Lists.newArrayList(Iterables.concat(
+                    Arrays.asList("-enable-testing"),
+                    currentCompilerArguments));
+            }
+        }));
         SwiftCompile compileRelease = (SwiftCompile) tasks.getByName("compileReleaseSwift");
 
         LinkSharedLibrary linkDebug = (LinkSharedLibrary) tasks.getByName("linkDebug");

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
@@ -38,7 +38,6 @@ import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -22,11 +22,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.SourceFile
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.time.Time
-import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.runner.RunWith
-
 /**
  * Runs a test separately for each installed tool chain.
  */
@@ -129,7 +127,7 @@ allprojects { p ->
         return file(getTestDirectory().toURI().relativize(intermediateFile.toURI()))
     }
 
-    List<NativeBinaryFixture> objectFiles(SourceElement sourceElement, String rootObjectFilesDir = "build/obj/${sourceElement.sourceSetName}/debug") {
+    List<NativeBinaryFixture> objectFiles(def sourceElement, String rootObjectFilesDir = "build/obj/${sourceElement.sourceSetName}/debug") {
         List<NativeBinaryFixture> result = new ArrayList<NativeBinaryFixture>()
 
         String sourceSetName = sourceElement.getSourceSetName()

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftAppWithSingleXCTestSuite.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftAppWithSingleXCTestSuite.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+import org.gradle.integtests.fixtures.SourceFile
+import org.gradle.test.fixtures.file.TestFile
+
+class SwiftAppWithSingleXCTestSuite extends XCTestSourceElement implements AppElement {
+    final app = new SwiftApp()
+    final test = new XCTestSourceFileElement() {
+        final delegate = new SwiftAppTest(app.greeter, app.sum, app.multiply)
+
+        @Override
+        String getTestSuiteName() {
+            return "CombinedTests"
+        }
+
+        @Override
+        List<XCTestCaseElement> getTestCases() {
+            return delegate.sumTest.testCases + delegate.greeterTest.testCases + delegate.multiplyTest.testCases
+        }
+
+        @Override
+        String getModuleName() {
+            return delegate.sumTest.moduleName
+        }
+    }.withTestableImport("App")
+
+    List<SourceFile> files = app.files + test.files
+    List<XCTestSourceFileElement> testSuites = [test]
+
+    String expectedOutput = app.expectedOutput
+
+    @Override
+    void writeToProject(TestFile projectDir) {
+        app.writeToProject(projectDir)
+        test.writeToProject(projectDir)
+    }
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftSingleFileLib.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftSingleFileLib.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+import org.gradle.integtests.fixtures.SourceFile
+
+/**
+ * A Swift library with 3 source files.
+ */
+class SwiftSingleFileLib extends SourceElement implements GreeterElement, SumElement, MultiplyElement {
+    private final delegate = new SwiftLib()
+    final greeter = delegate.greeter
+    final sum = delegate.sum
+    final multiply = delegate.multiply
+
+    @Override
+    List<SourceFile> getFiles() {
+        def content = delegate.files.collect { it.content }.join('\n')
+        return [sourceFile("swift", "combined.swift", content)]
+    }
+
+    @Override
+    String getExpectedOutput() {
+        return greeter.expectedOutput
+    }
+
+    @Override
+    int sum(int a, int b) {
+        return sum.sum(a, b)
+    }
+
+    @Override
+    int multiply(int a, int b) {
+        return multiply.multiply(a, b)
+    }
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftSingleFileLibWithSingleXCTestSuite.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftSingleFileLibWithSingleXCTestSuite.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+import org.gradle.integtests.fixtures.SourceFile
+import org.gradle.test.fixtures.file.TestFile
+
+class SwiftSingleFileLibWithSingleXCTestSuite extends XCTestSourceElement {
+    final main = new SwiftSingleFileLib()
+    final test = new XCTestSourceFileElement() {
+        final delegate = new SwiftLibTest(main.greeter, main.sum, main.multiply)
+
+        @Override
+        String getTestSuiteName() {
+            return "CombinedTests"
+        }
+
+        @Override
+        List<XCTestCaseElement> getTestCases() {
+            return delegate.sumTest.testCases + delegate.greeterTest.testCases + delegate.multiplyTest.testCases
+        }
+
+        @Override
+        String getModuleName() {
+            return delegate.sumTest.moduleName
+        }
+    }.withTestableImport("Greeter")
+
+    List<XCTestSourceFileElement> testSuites = [test]
+
+    List<SourceFile> files = main.files + test.files
+
+    @Override
+    void writeToProject(TestFile projectDir) {
+        main.writeToProject(projectDir)
+        test.writeToProject(projectDir)
+    }
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/BinaryInfo.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/BinaryInfo.java
@@ -24,5 +24,6 @@ public interface BinaryInfo {
     ArchitectureInternal getArch();
     List<String> listObjectFiles();
     List<String> listLinkedLibraries();
+    List<String> listSymbols();
     String getSoName();
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/DumpbinBinaryInfo.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/DumpbinBinaryInfo.groovy
@@ -99,6 +99,10 @@ class DumpbinBinaryInfo implements BinaryInfo {
         return process.inputStream.readLines()
     }
 
+    List<String> listSymbols() {
+        throw new UnsupportedOperationException("Not yet implemented")
+    }
+
     String getSoName() {
         throw new UnsupportedOperationException("soname is not relevant on windows")
     }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/FileArchOnlyBinaryInfo.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/FileArchOnlyBinaryInfo.groovy
@@ -45,6 +45,11 @@ class FileArchOnlyBinaryInfo implements BinaryInfo {
     }
 
     @Override
+    List<String> listSymbols() {
+        throw new UnsupportedOperationException("Only getting the architecture is supported using the file utility")
+    }
+
+    @Override
     String getSoName() {
         throw new UnsupportedOperationException("Only getting the architecture is supported using the file utility")
     }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/OtoolBinaryInfo.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/OtoolBinaryInfo.groovy
@@ -52,6 +52,12 @@ class OtoolBinaryInfo implements BinaryInfo {
         return lines
     }
 
+    List<String> listSymbols() {
+        def process = ['nm', binaryFile.absolutePath].execute()
+        def lines = process.inputStream.readLines()
+        return lines.collect { it.split(' ').last() }
+    }
+
     String getSoName() {
         def process = ['otool', '-D', binaryFile.absolutePath].execute()
         def lines = process.inputStream.readLines()

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/ReadelfBinaryInfo.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/ReadelfBinaryInfo.groovy
@@ -52,6 +52,12 @@ class ReadelfBinaryInfo implements BinaryInfo {
         return lines
     }
 
+    List<String> listSymbols() {
+        def process = ['nm', binaryFile.absolutePath].execute()
+        def lines = process.inputStream.readLines()
+        return lines.collect { it.split(' ').last() }
+    }
+
     String getSoName() {
         def process = ['readelf', '-d', binaryFile.absolutePath].execute()
         List<String> lines = process.inputStream.readLines()

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
@@ -17,8 +17,11 @@
 package org.gradle.nativeplatform.test.xctest
 
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.NativeBinaryFixture
+import org.gradle.nativeplatform.fixtures.app.SwiftAppWithSingleXCTestSuite
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithXCTest
 import org.gradle.nativeplatform.fixtures.app.SwiftLibWithXCTestWithInfoPlist
+import org.gradle.nativeplatform.fixtures.app.SwiftSingleFileLibWithSingleXCTestSuite
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
@@ -83,8 +86,6 @@ apply plugin: 'swift-executable'
         settingsFile << "rootProject.name = 'app'"
         buildFile << """
 apply plugin: 'swift-executable'
-
-linkTest.source = project.files(new HashSet(linkTest.source.from)).filter { !it.name.equals("main.o") }
 """
         app.writeToProject(testDirectory)
 
@@ -93,5 +94,53 @@ linkTest.source = project.files(new HashSet(linkTest.source.from)).filter { !it.
 
         then:
         result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
+    }
+
+    def "can test features of a Swift executable using a single test source file"() {
+        def app = new SwiftAppWithSingleXCTestSuite()
+
+        given:
+        settingsFile << "rootProject.name = 'app'"
+        buildFile << """
+apply plugin: 'swift-executable'
+"""
+        app.writeToProject(testDirectory)
+
+        when:
+        succeeds("test")
+
+        then:
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
+        assertMainSymbolIsAbsent(objectFiles(app.test, "build/obj/test"))
+        assertMainSymbolIsAbsent(machOBundle("build/bundle/main/debug/App"))
+    }
+
+    def "can test features of a single file Swift library using a single test source file"() {
+        def lib = new SwiftSingleFileLibWithSingleXCTestSuite()
+
+        given:
+        settingsFile << "rootProject.name = 'greeter'"
+        buildFile << """
+apply plugin: 'swift-library'
+"""
+        lib.writeToProject(testDirectory)
+
+        when:
+        succeeds("test")
+
+        then:
+        result.assertTasksExecuted(":compileDebugSwift", ":compileTestSwift", ":linkTest", ":bundleSwiftTest", ":xcTest", ":test")
+        assertMainSymbolIsAbsent(objectFiles(lib.test, "build/obj/test"))
+        assertMainSymbolIsAbsent(machOBundle("build/bundle/main/debug/Greeter"))
+    }
+
+    private void assertMainSymbolIsAbsent(List<NativeBinaryFixture> binaries) {
+        binaries.each {
+            assertMainSymbolIsAbsent(it)
+        }
+    }
+
+    private void assertMainSymbolIsAbsent(NativeBinaryFixture binary) {
+        assert !binary.binaryInfo.listSymbols().contains('_main')
     }
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.test.xctest.plugins;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
@@ -48,6 +49,8 @@ import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -92,11 +95,15 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
 
         // Configure compile task
         SwiftCompile compile = (SwiftCompile) tasks.getByName("compileTestSwift");
+        // TODO - Avoid evaluating the arguments here
+        final List<String> currentCompilerArguments = compile.getCompilerArgs().getOrElse(Collections.<String>emptyList());
         compile.getCompilerArgs().set(project.provider(new Callable<List<String>>() {
             @Override
             public List<String> call() throws Exception {
                 File frameworkDir = new File(sdkPlatformPathLocator.find(), "Developer/Library/Frameworks");
-                return Lists.newArrayList("-g", "-F" + frameworkDir.getAbsolutePath());
+                return Lists.newArrayList(Iterables.concat(
+                    Arrays.asList("-g", "-F" + frameworkDir.getAbsolutePath()),
+                    currentCompilerArguments));
             }
         }));
 


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle-native/issues/159

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fissue-138-parse-as-lib)
- [x] Verify documentation
- [x] Recognize contributor in release notes
