### PR TITLE
Add an entry to fix two commits by unknown

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -54,4 +54,5 @@ Sterling Greene <sterling@gradle.com> <big-guy@users.noreply.github.com>
 Sterling Greene <sterling@gradle.com> <sterling.greene@gmail.com>
 Szczepan Faber <szczepiq@gmail.com>
 Szczepan Faber <szczepiq@gmail.com> <szczepiq@builds.gradle.org>
+Szczepan Faber <szczepiq@gmail.com> <Administrator@szczepan-66b9bf.(none)>
 Tom Eyckmans <teyckmans@gmail.com>


### PR DESCRIPTION
Specfically:
c9a049ae7ab10dd84d15468072b126c190532c2f
1216e902866da245dd3b8c09c482e1da67003f06

I assume these belong to Szczepan Faber as his rather unique first
name is embedded in the email address used to commit them.
