### PR TITLE
Create build options only once

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/RecompileScriptsDeprecationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/RecompileScriptsDeprecationIntegrationTest.groovy
@@ -36,6 +36,6 @@ task hello {
 
         then:
         succeeds('hello')
-        outputContains(StartParameterBuildOptionFactory.RecompileScriptsOption.DEPRECATION_MESSAGE)
+        outputContains(StartParameterBuildOptions.RecompileScriptsOption.DEPRECATION_MESSAGE)
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildLayoutParametersBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildLayoutParametersBuildOptions.java
@@ -19,7 +19,6 @@ package org.gradle.initialization;
 import org.gradle.api.Transformer;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.file.BasicFileResolver;
-import org.gradle.internal.Factory;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.EnabledOnlyBooleanBuildOption;
@@ -28,21 +27,26 @@ import org.gradle.internal.buildoption.StringBuildOption;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public class BuildLayoutParametersBuildOptionFactory implements Factory<List<BuildOption<BuildLayoutParameters>>> {
+public class BuildLayoutParametersBuildOptions {
 
-    private final List<BuildOption<BuildLayoutParameters>> options = new ArrayList<BuildOption<BuildLayoutParameters>>();
+    private static List<BuildOption<BuildLayoutParameters>> options;
 
-    public BuildLayoutParametersBuildOptionFactory() {
+    static {
+        List<BuildOption<BuildLayoutParameters>> options = new ArrayList<BuildOption<BuildLayoutParameters>>();
         options.add(new GradleUserHomeOption());
         options.add(new ProjectDirOption());
         options.add(new NoSearchUpwardsOption());
+        BuildLayoutParametersBuildOptions.options = Collections.unmodifiableList(options);
     }
 
-    @Override
-    public List<BuildOption<BuildLayoutParameters>> create() {
+    public static List<BuildOption<BuildLayoutParameters>> get() {
         return options;
+    }
+
+    private BuildLayoutParametersBuildOptions() {
     }
 
     public static class GradleUserHomeOption extends StringBuildOption<BuildLayoutParameters> {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultCommandLineConverter.java
@@ -42,7 +42,7 @@ public class DefaultCommandLineConverter extends AbstractCommandLineConverter<St
     private final CommandLineConverter<ParallelismConfiguration> parallelConfigurationCommandLineConverter = new ParallelismConfigurationCommandLineConverter();
     private final SystemPropertiesCommandLineConverter systemPropertiesCommandLineConverter = new SystemPropertiesCommandLineConverter();
     private final ProjectPropertiesCommandLineConverter projectPropertiesCommandLineConverter = new ProjectPropertiesCommandLineConverter();
-    private final List<BuildOption<StartParameter>> buildOptions = new StartParameterBuildOptionFactory().create();
+    private final List<BuildOption<StartParameter>> buildOptions = StartParameterBuildOptions.get();
     private final LayoutCommandLineConverter layoutCommandLineConverter;
 
     public DefaultCommandLineConverter() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
@@ -25,7 +25,7 @@ import org.gradle.internal.buildoption.BuildOption;
 import java.util.List;
 
 public class LayoutCommandLineConverter extends AbstractCommandLineConverter<BuildLayoutParameters> {
-    private List<BuildOption<BuildLayoutParameters>> buildOptions = new BuildLayoutParametersBuildOptionFactory().create();
+    private List<BuildOption<BuildLayoutParameters>> buildOptions = BuildLayoutParametersBuildOptions.get();
 
     public BuildLayoutParameters convert(ParsedCommandLine options, BuildLayoutParameters target) throws CommandLineArgumentException {
         for (BuildOption<BuildLayoutParameters> option : buildOptions) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismBuildOptions.java
@@ -17,7 +17,6 @@
 package org.gradle.initialization;
 
 import org.gradle.concurrent.ParallelismConfiguration;
-import org.gradle.internal.Factory;
 import org.gradle.internal.buildoption.BooleanBuildOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
@@ -25,20 +24,25 @@ import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public class ParallelismBuildOptionFactory implements Factory<List<BuildOption<ParallelismConfiguration>>> {
+public class ParallelismBuildOptions {
 
-    private final List<BuildOption<ParallelismConfiguration>> options = new ArrayList<BuildOption<ParallelismConfiguration>>();
+    private static List<BuildOption<ParallelismConfiguration>> options;
 
-    public ParallelismBuildOptionFactory() {
+    static {
+        List<BuildOption<ParallelismConfiguration>> options = new ArrayList<BuildOption<ParallelismConfiguration>>();
         options.add(new ParallelOption());
         options.add(new MaxWorkersOption());
+        ParallelismBuildOptions.options = Collections.unmodifiableList(options);
     }
 
-    @Override
-    public List<BuildOption<ParallelismConfiguration>> create() {
+    public static List<BuildOption<ParallelismConfiguration>> get() {
         return options;
+    }
+
+    private ParallelismBuildOptions() {
     }
 
     public static class ParallelOption extends BooleanBuildOption<ParallelismConfiguration> {

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismConfigurationCommandLineConverter.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 public class ParallelismConfigurationCommandLineConverter extends AbstractCommandLineConverter<ParallelismConfiguration> {
 
-    private List<BuildOption<ParallelismConfiguration>> buildOptions = new ParallelismBuildOptionFactory().create();
+    private List<BuildOption<ParallelismConfiguration>> buildOptions = ParallelismBuildOptions.get();
 
     public ParallelismConfiguration convert(ParsedCommandLine options, ParallelismConfiguration target) throws CommandLineArgumentException {
         for (BuildOption<ParallelismConfiguration> option : buildOptions) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -19,24 +19,25 @@ package org.gradle.initialization;
 import org.gradle.StartParameter;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.file.BasicFileResolver;
-import org.gradle.internal.Factory;
 import org.gradle.internal.buildoption.BooleanBuildOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
-import org.gradle.internal.buildoption.ListBuildOption;
 import org.gradle.internal.buildoption.EnabledOnlyBooleanBuildOption;
+import org.gradle.internal.buildoption.ListBuildOption;
 import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public class StartParameterBuildOptionFactory implements Factory<List<BuildOption<StartParameter>>> {
+public class StartParameterBuildOptions {
 
-    private final List<BuildOption<StartParameter>> options = new ArrayList<BuildOption<StartParameter>>();
+    private static List<BuildOption<StartParameter>> options;
 
-    public StartParameterBuildOptionFactory() {
+    static {
+        List<BuildOption<StartParameter>> options = new ArrayList<BuildOption<StartParameter>>();
         options.add(new ProjectCacheDirOption());
         options.add(new RerunTasksOption());
         options.add(new RecompileScriptsOption());
@@ -55,11 +56,14 @@ public class StartParameterBuildOptionFactory implements Factory<List<BuildOptio
         options.add(new ConfigureOnDemandOption());
         options.add(new BuildCacheOption());
         options.add(new BuildScanOption());
+        StartParameterBuildOptions.options = Collections.unmodifiableList(options);
     }
 
-    @Override
-    public List<BuildOption<StartParameter>> create() {
+    public static List<BuildOption<StartParameter>> get() {
         return options;
+    }
+
+    private StartParameterBuildOptions() {
     }
 
     public static class ProjectCacheDirOption extends StringBuildOption<StartParameter> {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -25,7 +25,7 @@ import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.exceptions.FailureResolutionAware;
 import org.gradle.internal.exceptions.LocationAwareException;
-import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
 import org.gradle.internal.logging.text.BufferingStyledTextOutput;
 import org.gradle.internal.logging.text.LinePrefixingStyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutput;
@@ -188,16 +188,16 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
         }
         if (details.exceptionStyle == ExceptionStyle.NONE) {
             resolution.text("Run with ");
-            resolution.withStyle(UserInput).format("--%s", LoggingConfigurationBuildOptionFactory.StacktraceOption.STACKTRACE_LONG_OPTION);
+            resolution.withStyle(UserInput).format("--%s", LoggingConfigurationBuildOptions.StacktraceOption.STACKTRACE_LONG_OPTION);
             resolution.text(" option to get the stack trace. ");
         }
         if (loggingConfiguration.getLogLevel() != LogLevel.DEBUG) {
             resolution.text("Run with ");
             if (loggingConfiguration.getLogLevel() != LogLevel.INFO) {
-                resolution.withStyle(UserInput).format("--%s", LoggingConfigurationBuildOptionFactory.LogLevelOption.INFO_LONG_OPTION);
+                resolution.withStyle(UserInput).format("--%s", LoggingConfigurationBuildOptions.LogLevelOption.INFO_LONG_OPTION);
                 resolution.text(" or ");
             }
-            resolution.withStyle(UserInput).format("--%s", LoggingConfigurationBuildOptionFactory.LogLevelOption.DEBUG_LONG_OPTION);
+            resolution.withStyle(UserInput).format("--%s", LoggingConfigurationBuildOptions.LogLevelOption.DEBUG_LONG_OPTION);
             resolution.text(" option to get more log output.");
         }
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -47,7 +47,7 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
 import org.gradle.internal.time.Clock;
-import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory;
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 import org.gradle.process.internal.streams.SafeStreams;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
@@ -883,8 +883,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
             properties.put("user.home", getUserHomeDir().getAbsolutePath());
         }
 
-        properties.put(DaemonBuildOptionFactory.IdleTimeoutOption.GRADLE_PROPERTY, "" + (daemonIdleTimeoutSecs * 1000));
-        properties.put(DaemonBuildOptionFactory.BaseDirOption.GRADLE_PROPERTY, daemonBaseDir.getAbsolutePath());
+        properties.put(DaemonBuildOptions.IdleTimeoutOption.GRADLE_PROPERTY, "" + (daemonIdleTimeoutSecs * 1000));
+        properties.put(DaemonBuildOptions.BaseDirOption.GRADLE_PROPERTY, daemonBaseDir.getAbsolutePath());
         if (!noExplicitNativeServicesDir) {
             properties.put(NativeServices.NATIVE_DIR_OVERRIDE, buildContext.getNativeServicesDir().getAbsolutePath());
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleInvocationSpec.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleInvocationSpec.groovy
@@ -18,7 +18,7 @@ package org.gradle.performance.fixture
 
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
-import org.gradle.initialization.ParallelismBuildOptionFactory
+import org.gradle.initialization.ParallelismBuildOptions
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 
 @CompileStatic
@@ -161,7 +161,7 @@ class GradleInvocationSpec implements InvocationSpec {
         }
 
         InvocationBuilder disableParallelWorkers() {
-            gradleOpts("-D${ParallelismBuildOptionFactory.MaxWorkersOption.GRADLE_PROPERTY}=1")
+            gradleOpts("-D${ParallelismBuildOptions.MaxWorkersOption.GRADLE_PROPERTY}=1")
         }
 
         InvocationBuilder useProfiler() {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/DaemonCommandLineConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/DaemonCommandLineConverter.java
@@ -21,14 +21,14 @@ import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.internal.buildoption.BuildOption;
-import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory;
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 
 import java.util.List;
 
 public class DaemonCommandLineConverter extends AbstractCommandLineConverter<DaemonParameters> {
 
-    private List<BuildOption<DaemonParameters>> buildOptions = new DaemonBuildOptionFactory().create();
+    private List<BuildOption<DaemonParameters>> buildOptions = DaemonBuildOptions.get();
 
     public DaemonParameters convert(ParsedCommandLine args, DaemonParameters target) throws CommandLineArgumentException {
         for (BuildOption<DaemonParameters> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -20,14 +20,14 @@ import org.gradle.api.Project;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.specs.Spec;
 import org.gradle.initialization.BuildLayoutParameters;
-import org.gradle.initialization.BuildLayoutParametersBuildOptionFactory;
-import org.gradle.initialization.ParallelismBuildOptionFactory;
-import org.gradle.initialization.StartParameterBuildOptionFactory;
+import org.gradle.initialization.BuildLayoutParametersBuildOptions;
+import org.gradle.initialization.ParallelismBuildOptions;
+import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.buildoption.BuildOption;
-import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
-import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
 import org.gradle.util.CollectionUtils;
 
 import java.io.File;
@@ -44,11 +44,11 @@ public class LayoutToPropertiesConverter {
     private final List<BuildOption<?>> allBuildOptions = new ArrayList<BuildOption<?>>();
 
     public LayoutToPropertiesConverter() {
-        allBuildOptions.addAll(new BuildLayoutParametersBuildOptionFactory().create());
-        allBuildOptions.addAll(new StartParameterBuildOptionFactory().create());
-        allBuildOptions.addAll(new LoggingConfigurationBuildOptionFactory().create());
-        allBuildOptions.addAll(new DaemonBuildOptionFactory().create());
-        allBuildOptions.addAll(new ParallelismBuildOptionFactory().create());
+        allBuildOptions.addAll(BuildLayoutParametersBuildOptions.get());
+        allBuildOptions.addAll(StartParameterBuildOptions.get());
+        allBuildOptions.addAll(LoggingConfigurationBuildOptions.get());
+        allBuildOptions.addAll(DaemonBuildOptions.get());
+        allBuildOptions.addAll(ParallelismBuildOptions.get());
     }
 
     public Map<String, String> convert(BuildLayoutParameters layout, Map<String, String> properties) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverter.java
@@ -17,14 +17,14 @@
 package org.gradle.launcher.cli.converter;
 
 import org.gradle.internal.buildoption.BuildOption;
-import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory;
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 
 import java.util.List;
 import java.util.Map;
 
 public class PropertiesToDaemonParametersConverter {
-    private List<BuildOption<DaemonParameters>> buildOptions = new DaemonBuildOptionFactory().create();
+    private List<BuildOption<DaemonParameters>> buildOptions = DaemonBuildOptions.get();
 
     public void convert(Map<String, String> properties, DaemonParameters target) {
         for (BuildOption<DaemonParameters> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToLogLevelConfigurationConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToLogLevelConfigurationConverter.java
@@ -18,13 +18,13 @@ package org.gradle.launcher.cli.converter;
 
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.internal.buildoption.BuildOption;
-import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
 
 import java.util.List;
 import java.util.Map;
 
 public class PropertiesToLogLevelConfigurationConverter {
-    private final List<BuildOption<LoggingConfiguration>> buildOptions = new LoggingConfigurationBuildOptionFactory().create();
+    private final List<BuildOption<LoggingConfiguration>> buildOptions = LoggingConfigurationBuildOptions.get();
 
     public LoggingConfiguration convert(Map<String, String> properties, LoggingConfiguration loggingConfiguration) {
         for (BuildOption<LoggingConfiguration> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToParallelismConfigurationConverter.java
@@ -17,7 +17,7 @@
 package org.gradle.launcher.cli.converter;
 
 import org.gradle.concurrent.ParallelismConfiguration;
-import org.gradle.initialization.ParallelismBuildOptionFactory;
+import org.gradle.initialization.ParallelismBuildOptions;
 import org.gradle.internal.buildoption.BuildOption;
 
 import java.util.List;
@@ -25,7 +25,7 @@ import java.util.Map;
 
 public class PropertiesToParallelismConfigurationConverter {
 
-    private List<BuildOption<ParallelismConfiguration>> buildOptions = new ParallelismBuildOptionFactory().create();
+    private List<BuildOption<ParallelismConfiguration>> buildOptions = ParallelismBuildOptions.get();
 
     public ParallelismConfiguration convert(Map<String, String> properties, ParallelismConfiguration parallelismConfiguration) {
         for (BuildOption<ParallelismConfiguration> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverter.java
@@ -17,7 +17,7 @@
 package org.gradle.launcher.cli.converter;
 
 import org.gradle.StartParameter;
-import org.gradle.initialization.StartParameterBuildOptionFactory;
+import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.internal.buildoption.BuildOption;
 
 import java.util.List;
@@ -26,7 +26,7 @@ import java.util.Map;
 public class PropertiesToStartParameterConverter {
     private final PropertiesToParallelismConfigurationConverter propertiesToParallelismConfigurationConverter = new PropertiesToParallelismConfigurationConverter();
     private final PropertiesToLogLevelConfigurationConverter propertiesToLogLevelConfigurationConverter = new PropertiesToLogLevelConfigurationConverter();
-    private final List<BuildOption<StartParameter>> buildOptions = new StartParameterBuildOptionFactory().create();
+    private final List<BuildOption<StartParameter>> buildOptions = StartParameterBuildOptions.get();
 
     public StartParameter convert(Map<String, String> properties, StartParameter startParameter) {
         for (BuildOption<StartParameter> option : buildOptions) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -16,7 +16,6 @@
 
 package org.gradle.launcher.daemon.configuration;
 
-import org.gradle.internal.Factory;
 import org.gradle.internal.buildoption.BooleanBuildOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
@@ -30,13 +29,15 @@ import org.gradle.process.internal.JvmOptions;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public class DaemonBuildOptionFactory implements Factory<List<BuildOption<DaemonParameters>>> {
+public class DaemonBuildOptions {
 
-    private final List<BuildOption<DaemonParameters>> options = new ArrayList<BuildOption<DaemonParameters>>();
+    private static List<BuildOption<DaemonParameters>> options;
 
-    public DaemonBuildOptionFactory() {
+    static {
+        List<BuildOption<DaemonParameters>> options = new ArrayList<BuildOption<DaemonParameters>>();
         options.add(new IdleTimeoutOption());
         options.add(new HealthCheckOption());
         options.add(new BaseDirOption());
@@ -47,11 +48,15 @@ public class DaemonBuildOptionFactory implements Factory<List<BuildOption<Daemon
         options.add(new ForegroundOption());
         options.add(new StopOption());
         options.add(new StatusOption());
+        DaemonBuildOptions.options = Collections.unmodifiableList(options);
     }
 
-    @Override
-    public List<BuildOption<DaemonParameters>> create() {
+    public static List<BuildOption<DaemonParameters>> get() {
         return options;
+    }
+
+    private DaemonBuildOptions() {
+
     }
 
     public static class IdleTimeoutOption extends StringBuildOption<DaemonParameters> {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.launcher.cli.converter
 
 import org.gradle.initialization.BuildLayoutParameters
-import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
@@ -48,47 +48,47 @@ class LayoutToPropertiesConverterTest extends Specification {
 
     def "configures from gradle home dir"() {
         when:
-        temp.file("gradleHome/gradle.properties") << "$DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY=-Xmx1024m -Dprop=value"
+        temp.file("gradleHome/gradle.properties") << "$DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY=-Xmx1024m -Dprop=value"
 
         then:
-        converter.convert(layout, props).get(DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY) == '-Xmx1024m -Dprop=value'
+        converter.convert(layout, props).get(DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY) == '-Xmx1024m -Dprop=value'
     }
 
     def "configures from project dir"() {
         when:
-        temp.file("projectDir/gradle.properties") << "$DaemonBuildOptionFactory.IdleTimeoutOption.GRADLE_PROPERTY=125"
+        temp.file("projectDir/gradle.properties") << "$DaemonBuildOptions.IdleTimeoutOption.GRADLE_PROPERTY=125"
 
         then:
-        converter.convert(layout, props).get(DaemonBuildOptionFactory.IdleTimeoutOption.GRADLE_PROPERTY) == "125"
+        converter.convert(layout, props).get(DaemonBuildOptions.IdleTimeoutOption.GRADLE_PROPERTY) == "125"
     }
 
     def "configures from root dir in a multiproject build"() {
         when:
         temp.file("projectDir/settings.gradle") << "include 'foo'"
-        temp.file("projectDir/gradle.properties") << "$DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY=-Xmx128m"
+        temp.file("projectDir/gradle.properties") << "$DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY=-Xmx128m"
         layout.setProjectDir(temp.file("projectDir/foo"))
         layout.searchUpwards = true
 
         then:
-        converter.convert(layout, props).get(DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY) == '-Xmx128m'
+        converter.convert(layout, props).get(DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY) == '-Xmx128m'
     }
 
     def "gradle home properties take precedence over project dir properties"() {
         when:
-        temp.file("gradleHome/gradle.properties") << "$DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY=-Xmx1024m"
-        temp.file("projectDir/gradle.properties") << "$DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY=-Xmx512m"
+        temp.file("gradleHome/gradle.properties") << "$DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY=-Xmx1024m"
+        temp.file("projectDir/gradle.properties") << "$DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY=-Xmx512m"
 
         then:
-        converter.convert(layout, props).get(DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY) == '-Xmx1024m'
+        converter.convert(layout, props).get(DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY) == '-Xmx1024m'
     }
 
     def "system property takes precedence over gradle home"() {
         when:
-        temp.file("gradleHome/gradle.properties") << "$DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY=-Xmx1024m"
-        System.setProperty(DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY, '-Xmx2048m')
+        temp.file("gradleHome/gradle.properties") << "$DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY=-Xmx1024m"
+        System.setProperty(DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY, '-Xmx2048m')
 
         then:
-        converter.convert(layout, props).get(DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY) == '-Xmx2048m'
+        converter.convert(layout, props).get(DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY) == '-Xmx2048m'
     }
 
     def "non-serializable system properties are ignored"() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.launcher.cli.converter
 
 import org.gradle.initialization.BuildLayoutParameters
 import org.gradle.internal.jvm.Jvm
-import org.gradle.launcher.daemon.configuration.DaemonBuildOptionFactory
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptions
 import org.gradle.launcher.daemon.configuration.DaemonParameters
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.UsesNativeServices
@@ -36,14 +36,14 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
 
     def "allows whitespace around boolean properties"() {
         when:
-        converter.convert([ (DaemonBuildOptionFactory.DaemonOption.GRADLE_PROPERTY): 'false ' ], params)
+        converter.convert([ (DaemonBuildOptions.DaemonOption.GRADLE_PROPERTY): 'false ' ], params)
         then:
         !params.enabled
     }
 
     def "can configure jvm args combined with a system property"() {
         when:
-        converter.convert([(DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY): '-Xmx512m -Dprop=value'], params)
+        converter.convert([(DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY): '-Xmx512m -Dprop=value'], params)
 
         then:
         params.effectiveJvmArgs.contains('-Xmx512m')
@@ -54,7 +54,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
 
     def "supports 'empty' system properties"() {
         when:
-        converter.convert([(DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY): "-Dfoo= -Dbar"], params)
+        converter.convert([(DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY): "-Dfoo= -Dbar"], params)
 
         then:
         params.systemProperties == [foo: '', bar: '']
@@ -63,13 +63,13 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
     def "configures from gradle properties"() {
         when:
         converter.convert([
-            (DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY)     : '-Xmx256m',
-            (DaemonBuildOptionFactory.JavaHomeOption.GRADLE_PROPERTY)    : Jvm.current().javaHome.absolutePath,
-            (DaemonBuildOptionFactory.DaemonOption.GRADLE_PROPERTY)      : "false",
-            (DaemonBuildOptionFactory.BaseDirOption.GRADLE_PROPERTY)     : new File("baseDir").absolutePath,
-            (DaemonBuildOptionFactory.IdleTimeoutOption.GRADLE_PROPERTY) : "115",
-            (DaemonBuildOptionFactory.HealthCheckOption.GRADLE_PROPERTY) : "42",
-            (DaemonBuildOptionFactory.DebugOption.GRADLE_PROPERTY)       : "true",
+            (DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY)     : '-Xmx256m',
+            (DaemonBuildOptions.JavaHomeOption.GRADLE_PROPERTY)    : Jvm.current().javaHome.absolutePath,
+            (DaemonBuildOptions.DaemonOption.GRADLE_PROPERTY)      : "false",
+            (DaemonBuildOptions.BaseDirOption.GRADLE_PROPERTY)     : new File("baseDir").absolutePath,
+            (DaemonBuildOptions.IdleTimeoutOption.GRADLE_PROPERTY) : "115",
+            (DaemonBuildOptions.HealthCheckOption.GRADLE_PROPERTY) : "42",
+            (DaemonBuildOptions.DebugOption.GRADLE_PROPERTY)       : "true",
         ], params)
 
         then:
@@ -84,7 +84,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
 
     def "shows nice message for dummy java home"() {
         when:
-        converter.convert([(DaemonBuildOptionFactory.JavaHomeOption.GRADLE_PROPERTY): "/invalid/path"], params)
+        converter.convert([(DaemonBuildOptions.JavaHomeOption.GRADLE_PROPERTY): "/invalid/path"], params)
 
         then:
         def ex = thrown(IllegalArgumentException)
@@ -95,7 +95,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
     def "shows nice message for invalid java home"() {
         def dummyDir = temp.createDir("foobar")
         when:
-        converter.convert([(DaemonBuildOptionFactory.JavaHomeOption.GRADLE_PROPERTY): dummyDir.absolutePath], params)
+        converter.convert([(DaemonBuildOptions.JavaHomeOption.GRADLE_PROPERTY): dummyDir.absolutePath], params)
 
         then:
         def ex = thrown(IllegalArgumentException)
@@ -105,7 +105,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
 
     def "shows nice message for invalid idle timeout"() {
         when:
-        converter.convert((DaemonBuildOptionFactory.IdleTimeoutOption.GRADLE_PROPERTY): 'asdf', params)
+        converter.convert((DaemonBuildOptions.IdleTimeoutOption.GRADLE_PROPERTY): 'asdf', params)
 
         then:
         def ex = thrown(IllegalArgumentException)
@@ -115,7 +115,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
 
     def "shows nice message for invalid periodic check interval"() {
         when:
-        converter.convert((DaemonBuildOptionFactory.HealthCheckOption.GRADLE_PROPERTY): 'bogus', params)
+        converter.convert((DaemonBuildOptions.HealthCheckOption.GRADLE_PROPERTY): 'bogus', params)
 
         then:
         def ex = thrown(IllegalArgumentException)
@@ -126,7 +126,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
     @Unroll
     def "explicitly sets daemon usage if daemon system property is specified"() {
         when:
-        converter.convert((DaemonBuildOptionFactory.DaemonOption.GRADLE_PROPERTY): enabled.toString(), params)
+        converter.convert((DaemonBuildOptions.DaemonOption.GRADLE_PROPERTY): enabled.toString(), params)
 
         then:
         params.enabled == propertyValue
@@ -140,7 +140,7 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
     def "enable debug mode from JVM args when default debug argument is used"() {
         when:
         converter.convert([
-            (DaemonBuildOptionFactory.JvmArgsOption.GRADLE_PROPERTY)                 : "-Xmx256m $debugArgs".toString(),
+            (DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY)                 : "-Xmx256m $debugArgs".toString(),
         ], params)
 
         then:

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToStartParameterConverterTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.launcher.cli.converter
 
 import org.gradle.StartParameter
 import org.gradle.api.logging.LogLevel
-import org.gradle.initialization.ParallelismBuildOptionFactory
-import org.gradle.initialization.StartParameterBuildOptionFactory
-import org.gradle.internal.logging.LoggingConfigurationBuildOptionFactory
+import org.gradle.initialization.ParallelismBuildOptions
+import org.gradle.initialization.StartParameterBuildOptions
+import org.gradle.internal.logging.LoggingConfigurationBuildOptions
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -30,16 +30,16 @@ class PropertiesToStartParameterConverterTest extends Specification {
 
     def "converts"() {
         expect:
-        converter.convert([(ParallelismBuildOptionFactory.MaxWorkersOption.GRADLE_PROPERTY): "37"], new StartParameter()).maxWorkerCount == 37
-        converter.convert([(ParallelismBuildOptionFactory.ParallelOption.GRADLE_PROPERTY): "true"], new StartParameter()).parallelProjectExecutionEnabled
-        converter.convert([(StartParameterBuildOptionFactory.BuildCacheOption.GRADLE_PROPERTY): "true"], new StartParameter()).buildCacheEnabled
-        converter.convert([(StartParameterBuildOptionFactory.ConfigureOnDemandOption.GRADLE_PROPERTY): "TRUE"], new StartParameter()).configureOnDemand
-        !converter.convert([(StartParameterBuildOptionFactory.ConfigureOnDemandOption.GRADLE_PROPERTY): "xxx"], new StartParameter()).configureOnDemand
+        converter.convert([(ParallelismBuildOptions.MaxWorkersOption.GRADLE_PROPERTY): "37"], new StartParameter()).maxWorkerCount == 37
+        converter.convert([(ParallelismBuildOptions.ParallelOption.GRADLE_PROPERTY): "true"], new StartParameter()).parallelProjectExecutionEnabled
+        converter.convert([(StartParameterBuildOptions.BuildCacheOption.GRADLE_PROPERTY): "true"], new StartParameter()).buildCacheEnabled
+        converter.convert([(StartParameterBuildOptions.ConfigureOnDemandOption.GRADLE_PROPERTY): "TRUE"], new StartParameter()).configureOnDemand
+        !converter.convert([(StartParameterBuildOptions.ConfigureOnDemandOption.GRADLE_PROPERTY): "xxx"], new StartParameter()).configureOnDemand
     }
 
     def invalidMaxWorkersProperty() {
         when:
-        converter.convert([(ParallelismBuildOptionFactory.MaxWorkersOption.GRADLE_PROPERTY): "invalid"], new StartParameter())
+        converter.convert([(ParallelismBuildOptions.MaxWorkersOption.GRADLE_PROPERTY): "invalid"], new StartParameter())
         then:
         thrown(IllegalArgumentException)
     }
@@ -47,7 +47,7 @@ class PropertiesToStartParameterConverterTest extends Specification {
     @Unroll
     def "converts log levels"() {
         expect:
-        converter.convert([(LoggingConfigurationBuildOptionFactory.LogLevelOption.GRADLE_PROPERTY): level], new StartParameter()).logLevel == logLevel
+        converter.convert([(LoggingConfigurationBuildOptions.LogLevelOption.GRADLE_PROPERTY): level], new StartParameter()).logLevel == logLevel
 
         where:
         level       | logLevel
@@ -60,11 +60,11 @@ class PropertiesToStartParameterConverterTest extends Specification {
 
     def "throws exception for invalid log level"() {
         when:
-        converter.convert([(LoggingConfigurationBuildOptionFactory.LogLevelOption.GRADLE_PROPERTY): "fakeLevel"], new StartParameter())
+        converter.convert([(LoggingConfigurationBuildOptions.LogLevelOption.GRADLE_PROPERTY): "fakeLevel"], new StartParameter())
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.getMessage().contains(LoggingConfigurationBuildOptionFactory.LogLevelOption.GRADLE_PROPERTY)
+        ex.getMessage().contains(LoggingConfigurationBuildOptions.LogLevelOption.GRADLE_PROPERTY)
         LogLevel.values().each { level ->
             if(level != LogLevel.ERROR) {
                 ex.getMessage().contains(level.toString())

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
@@ -16,7 +16,7 @@
 package org.gradle.tooling.internal.provider
 
 import org.gradle.TaskExecutionRequest
-import org.gradle.initialization.StartParameterBuildOptionFactory
+import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.tooling.internal.protocol.InternalLaunchable
 import org.gradle.tooling.internal.provider.connection.ProviderOperationParameters
@@ -92,7 +92,7 @@ class ProviderStartParameterConverterTest extends Specification {
     def "the start parameter is configured from properties"() {
         when:
         def properties = [
-            (StartParameterBuildOptionFactory.ConfigureOnDemandOption.GRADLE_PROPERTY): "true",
+            (StartParameterBuildOptions.ConfigureOnDemandOption.GRADLE_PROPERTY): "true",
         ]
 
         def start = new ProviderStartParameterConverter().toStartParameter(params, properties)

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingCommandLineConverter.java
@@ -32,11 +32,11 @@ import java.util.List;
 import java.util.Set;
 
 public class LoggingCommandLineConverter extends AbstractCommandLineConverter<LoggingConfiguration> {
-    private final List<BuildOption<LoggingConfiguration>> buildOptions = new LoggingConfigurationBuildOptionFactory().create();
-    public static final String DEBUG = LoggingConfigurationBuildOptionFactory.LogLevelOption.DEBUG_SHORT_OPTION;
-    public static final String WARN = LoggingConfigurationBuildOptionFactory.LogLevelOption.WARN_SHORT_OPTION;
-    public static final String INFO = LoggingConfigurationBuildOptionFactory.LogLevelOption.INFO_SHORT_OPTION;
-    public static final String QUIET = LoggingConfigurationBuildOptionFactory.LogLevelOption.QUIET_SHORT_OPTION;
+    private final List<BuildOption<LoggingConfiguration>> buildOptions = LoggingConfigurationBuildOptions.get();
+    public static final String DEBUG = LoggingConfigurationBuildOptions.LogLevelOption.DEBUG_SHORT_OPTION;
+    public static final String WARN = LoggingConfigurationBuildOptions.LogLevelOption.WARN_SHORT_OPTION;
+    public static final String INFO = LoggingConfigurationBuildOptions.LogLevelOption.INFO_SHORT_OPTION;
+    public static final String QUIET = LoggingConfigurationBuildOptions.LogLevelOption.QUIET_SHORT_OPTION;
     private final BiMap<String, LogLevel> logLevelMap = HashBiMap.create();
 
     public LoggingCommandLineConverter() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -23,7 +23,6 @@ import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
-import org.gradle.internal.Factory;
 import org.gradle.internal.buildoption.AbstractBuildOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
@@ -31,23 +30,28 @@ import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-public class LoggingConfigurationBuildOptionFactory implements Factory<List<BuildOption<LoggingConfiguration>>> {
+public class LoggingConfigurationBuildOptions {
 
-    private final List<BuildOption<LoggingConfiguration>> options = new ArrayList<BuildOption<LoggingConfiguration>>();
+    private static List<BuildOption<LoggingConfiguration>> options;
 
-    public LoggingConfigurationBuildOptionFactory() {
+    static {
+        List<BuildOption<LoggingConfiguration>> options = new ArrayList<BuildOption<LoggingConfiguration>>();
         options.add(new LogLevelOption());
         options.add(new StacktraceOption());
         options.add(new ConsoleOption());
+        LoggingConfigurationBuildOptions.options = Collections.unmodifiableList(options);
     }
 
-    @Override
-    public List<BuildOption<LoggingConfiguration>> create() {
+    public static List<BuildOption<LoggingConfiguration>> get() {
         return options;
+    }
+
+    private LoggingConfigurationBuildOptions() {
     }
 
     public static class LogLevelOption extends AbstractBuildOption<LoggingConfiguration> {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.performance.regression.buildcache
 
-import org.gradle.initialization.StartParameterBuildOptionFactory
+import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
 
@@ -32,7 +32,7 @@ class AbstractTaskOutputCacheJavaPerformanceTest extends AbstractCrossVersionPer
         runner.warmUpRuns = 5
         runner.runs = 13
         runner.cleanTasks = ["clean"]
-        runner.args = ["-D${StartParameterBuildOptionFactory.BuildCacheOption.GRADLE_PROPERTY}=true"]
+        runner.args = ["-D${StartParameterBuildOptions.BuildCacheOption.GRADLE_PROPERTY}=true"]
         runner.minimumVersion = "3.5"
         runner.targetVersions = ["4.2.1"]
     }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerCacheIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerCacheIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.testkit.runner
 
-import org.gradle.initialization.StartParameterBuildOptionFactory
+import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.testkit.runner.fixtures.NonCrossVersion
 import org.gradle.util.TextUtil
 
@@ -61,7 +61,7 @@ class GradleRunnerCacheIntegrationTest extends BaseGradleRunnerIntegrationTest {
             }
         """
         file("gradle.properties") << """
-            ${StartParameterBuildOptionFactory.BuildCacheOption.GRADLE_PROPERTY}=true
+            ${StartParameterBuildOptions.BuildCacheOption.GRADLE_PROPERTY}=true
         """
         file("input").text = "input file"
 


### PR DESCRIPTION
They are effectively immutable constants, so no need to
create them again and again in sevaral different places.