### PR TITLE
Add mailmap entries for anonymous commits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -12,6 +12,7 @@ Daz DeBoer <daz@gradle.com> <darrell.deboer@gradleware.com>
 Daz DeBoer <daz@gradle.com> <daz@Darrells-MacBook-Pro.local>
 Daz DeBoer <daz@gradle.com> <daz@DazBook.local>
 Daz DeBoer <daz@gradle.com> <daz@bigdaz.com>
+Derek Eskens <snekse@gmail.com> <t99982@WNN64B-5012299.nng.i.midamerican.com>
 Etienne Studer <etienne@gradle.com> <etienne.studer@gradleware.com>
 Etienne Studer <etienne@gradle.com> <etienne@studer.nu>
 Etienne Studer <etienne@gradle.com> <log>

--- a/.mailmap
+++ b/.mailmap
@@ -47,6 +47,7 @@ Rene Groeschke <rene@gradle.com> <rene.groeschke@breskeby.com>
 Rene Groeschke <rene@gradle.com> <rene.groeschke@gradleware.com>
 Rene Groeschke <rene@gradle.com> <rene@breskeby.com>
 Rene Groeschke <rene@gradle.com> <rgroeschke@builds.gradle.org>
+Ryan <codespelunker@gmail.com> <UNELSRY@.PEROOT.com>
 Rodrigo B. de Oliveira <rodrigo@gradle.com> <rbo@acm.org>
 Sebastian Schuberth <sschuberth@gmail.com> <sschuberth@users.noreply.github.com>
 Stefan Oehme <stefan@gradle.com> <st.oehme@gmail.com>


### PR DESCRIPTION
Previously, we were missing some audit history in the commit log for:
https://github.com/gradle/gradle/commit/00c77a6d98452a7157bd3524f1be944e50271ade
https://github.com/gradle/gradle/commit/015b23e8241a975c26eaef7323c1c98a09c4a212
https://github.com/gradle/gradle/commit/23ec18a6f3b95d397b38d1ff96f1409536731efe
https://github.com/gradle/gradle/commit/acc745649e5855318e2b3226c132f747a9f84710

The four commits were pulled in as the result of two pull requests:
#93
#316

The authors of those pull requests are added to the `.mailmap` file to make our git log more accurate and auditable.