### PR TITLE
Recover changes about HTTP timeout handling

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.caching.http.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
+import static org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpTimeoutSettings.SOCKET_TIMEOUT_SYSTEM_PROPERTY
+
 class HttpBuildCacheServiceErrorHandlingIntegrationTest extends AbstractIntegrationSpec implements HttpBuildCacheFixture {
     def setup() {
         buildFile << """   
@@ -64,6 +66,20 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends AbstractIntegrat
         then:
         output =~ /Could not store entry .* for task ':customTask' in remote build cache/
         output =~ /Unable to store entry at .*: ${errorPattern}/
+    }
+
+    def "build cache is deactivated for the build if the connection times out"() {
+        httpBuildCacheServer.blockIncomingConnectionsForSeconds = 10
+        startServer()
+
+        when:
+        executer.withArgument("-D${SOCKET_TIMEOUT_SYSTEM_PROPERTY}=1000")
+        executer.withStacktraceDisabled()
+        withBuildCache().succeeds("customTask")
+
+        then:
+        output =~ /Could not load entry .* for task ':customTask' from remote build cache/
+        output =~ /Read timed out/
     }
 
     private void startServer() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveTimeoutIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveTimeoutIntegrationTest.groovy
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.keystore.TestKeyStore
+import org.gradle.test.fixtures.maven.MavenModule
+import org.gradle.test.fixtures.maven.MavenRepository
+import org.gradle.test.fixtures.server.http.HttpResource
+import org.gradle.test.fixtures.server.http.MavenHttpModule
+import org.gradle.test.fixtures.server.http.MavenHttpRepository
+import spock.lang.Unroll
+
+import static org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpTimeoutSettings.SOCKET_TIMEOUT_SYSTEM_PROPERTY
+
+class DependencyResolveTimeoutIntegrationTest extends AbstractHttpDependencyResolutionTest {
+
+    private static final String GROUP_ID = 'group'
+    private static final String VERSION = '1.0'
+    TestFile downloadedLibsDir
+    MavenHttpModule moduleA
+
+    def setup() {
+        moduleA = publishMavenModule(mavenHttpRepo, 'a')
+        downloadedLibsDir = file('build/libs')
+        executer.withArgument("-D${SOCKET_TIMEOUT_SYSTEM_PROPERTY}=1000")
+    }
+
+    void blockingForProtocol(String protocol, HttpResource... resources) {
+        if (protocol == 'http') {
+            resources.each { it.expectGetBlocking() }
+        } else if (protocol == 'https') {
+            // https://issues.apache.org/jira/browse/HTTPCLIENT-1478
+            def keyStore = TestKeyStore.init(temporaryFolder.file('ssl-keystore'))
+            keyStore.enableSslWithServerCert(server)
+            keyStore.configureServerCert(executer)
+            server.expectSslHandshakeBlocking()
+        } else {
+            assert false: "Unsupported protocol: ${protocol}"
+        }
+    }
+
+    @Unroll
+    def "fails single build script dependency resolution if #protocol connection exceeds timeout"() {
+        given:
+        blockingForProtocol(protocol, moduleA.pom)
+        buildFile << """
+            buildscript {
+                ${mavenRepository(mavenHttpRepo)}
+
+                dependencies {
+                    classpath '${mavenModuleCoordinates(moduleA)}'
+                }
+            }
+        """
+
+        when:
+        fails('help')
+
+        then:
+        assertDependencyReadTimeout(moduleA)
+
+        where:
+        protocol << ['http', 'https']
+    }
+
+    @Unroll
+    def "fails single application dependency resolution if #protocol connection exceeds timeout"() {
+        given:
+        blockingForProtocol(protocol, moduleA.pom)
+        buildFile << """
+            ${mavenRepository(mavenHttpRepo)}
+            ${customConfigDependencyAssignment(moduleA)}
+            ${configSyncTask()}
+        """
+
+        when:
+        fails('resolve')
+
+        then:
+        assertDependencyReadTimeout(moduleA)
+        !downloadedLibsDir.isDirectory()
+
+        where:
+        protocol << ['http', 'https']
+    }
+
+    @Unroll
+    def "fails concurrent application dependency resolution if #protocol connection exceeds timeout"() {
+        given:
+        MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')
+        MavenHttpModule moduleC = publishMavenModule(mavenHttpRepo, 'c')
+        blockingForProtocol(protocol, moduleA.pom, moduleB.pom, moduleC.pom)
+
+        buildFile << """
+            ${mavenRepository(mavenHttpRepo)}
+            ${customConfigDependencyAssignment(moduleA, moduleB, moduleC)}
+            ${configSyncTask()}
+        """
+
+        when:
+        fails('resolve', '--max-workers=3')
+
+        then:
+        assertDependencyReadTimeout(moduleA)
+        assertDependencyReadTimeout(moduleB)
+        assertDependencyReadTimeout(moduleC)
+        !downloadedLibsDir.isDirectory()
+        where:
+        protocol << ['http', 'https']
+    }
+
+    private String mavenRepository(MavenRepository repo) {
+        """
+            repositories {
+                maven { url "${repo.uri}"}
+            }
+        """
+    }
+
+    private String customConfigDependencyAssignment(MavenHttpModule... modules) {
+        """
+            configurations {
+                deps
+            }
+            
+            dependencies {
+                deps ${modules.collect { "'${mavenModuleCoordinates(it)}'" }.join(', ')}
+            }
+        """
+    }
+
+    private String configSyncTask() {
+        """
+            task resolve(type: Sync) {
+                from configurations.deps
+                into "\$buildDir/libs"
+            }
+        """
+    }
+
+    private void assertDependencyReadTimeout(MavenModule module) {
+        failure.error.contains("""> Could not resolve ${mavenModuleCoordinates(module)}.
+   > Could not get resource '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.
+      > Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.
+         > Read timed out""")
+    }
+
+    private String mavenModuleCoordinates(MavenHttpModule module) {
+        "$module.groupId:$module.artifactId:$module.version"
+    }
+
+    private String mavenModuleRepositoryPath(MavenHttpModule module) {
+        "$module.groupId/$module.artifactId/$module.artifactId-$module.version"
+    }
+
+    private MavenHttpModule publishMavenModule(MavenHttpRepository mavenHttpRepo, String artifactId) {
+        mavenHttpRepo.module(GROUP_ID, artifactId, VERSION).publish()
+    }
+}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -6,6 +6,21 @@ Here are the new features introduced in this Gradle release.
 IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
 Add-->
 
+### Timeouts for HTTP/HTTPS requests
+
+Previous versions of Gradle did not define a timeout for any HTTP/HTTPS requests. Under certain conditions e.g. network problems, unresponsive or overloaded servers this behavior could lead to hanging connections.
+Gradle now defines connection and socket timeouts for all HTTP/HTTPS requests.
+
+The timeouts are also effective for connections to an [HTTP build cache](dsl/org.gradle.caching.http.HttpBuildCache.html#org.gradle.caching.http.HttpBuildCache).
+If connections to the build cache time out then it will be disabled for the rest of the build.
+
+    :compileJava
+    Could not load entry 2b308a0ad9cbd0ad048d4ea84c186f71 for task ':compileJava' from remote build cache: Unable to load entry from 'https://example.com/cache/2b308a0ad9cbd0ad048d4ea84c186f71': Read timed out
+    
+    BUILD SUCCESSFUL in 4s
+    1 actionable task: 1 executed
+    The remote build cache was disabled during the build due to errors.
+
 ### Improvements for plugin authors
 
 In Gradle 4.1, we added APIs that allow a specific task output directory or output file to be wired in as an input for another task, in a way that allows the task dependencies to be inferred and that deals with later changes to the configured locations of those outputs. It is intended to be a more robust, performant and descriptive alternative to using `File` property types and calls to `Task.dependsOn`.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
@@ -20,6 +20,7 @@ import com.google.gson.Gson
 import com.google.gson.JsonElement
 import groovy.xml.MarkupBuilder
 import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.internal.BiAction
 import org.gradle.internal.hash.HashUtil
 import org.gradle.test.fixtures.server.ExpectOne
 import org.gradle.test.fixtures.server.ServerExpectation
@@ -27,10 +28,12 @@ import org.gradle.test.fixtures.server.ServerWithExpectations
 import org.gradle.test.matchers.UserAgentMatcher
 import org.gradle.util.GFileUtils
 import org.hamcrest.Matcher
+import org.mortbay.io.EndPoint
 import org.mortbay.jetty.Handler
 import org.mortbay.jetty.HttpHeaders
 import org.mortbay.jetty.HttpStatus
 import org.mortbay.jetty.MimeTypes
+import org.mortbay.jetty.Request
 import org.mortbay.jetty.handler.AbstractHandler
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -623,6 +626,18 @@ class HttpServer extends ServerWithExpectations implements HttpServerFixture {
 
     void addHandler(Handler handler) {
         collection.addHandler(handler)
+    }
+
+    /**
+     * Blocks on SSL handshake for 60 seconds.
+     */
+    void expectSslHandshakeBlocking() {
+        sslPreHandler = new BiAction<EndPoint, Request>() {
+            @Override
+            void execute(EndPoint endPoint, Request request) {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(60))
+            }
+        }
     }
 
     static class HttpExpectOne extends ExpectOne {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServerFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServerFixture.groovy
@@ -117,7 +117,7 @@ trait HttpServerFixture {
 
         connector = new SocketConnector()
         connector.port = portAllocatorEnabled ? FixedAvailablePortAllocator.instance.assignPort() : 0
-        server.setConnectors([connector] as Connector[])
+        server.addConnector(connector)
         server.start()
         for (int i = 0; i < 5; i++) {
             if (connector.localPort > 0) {

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/DefaultHttpSettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/DefaultHttpSettings.java
@@ -37,6 +37,7 @@ public class DefaultHttpSettings implements HttpSettings {
     private final HostnameVerifier hostnameVerifier;
     private HttpProxySettings proxySettings;
     private HttpProxySettings secureProxySettings;
+    private HttpTimeoutSettings timeoutSettings;
 
     public static DefaultHttpSettings allowUntrustedSslConnections(Collection<Authentication> authenticationSettings) {
         return new DefaultHttpSettings(authenticationSettings, ALL_TRUSTING_SSL_CONTEXT_FACTORY, ALL_TRUSTING_HOSTNAME_VERIFIER);
@@ -70,6 +71,14 @@ public class DefaultHttpSettings implements HttpSettings {
             secureProxySettings = new JavaSystemPropertiesSecureHttpProxySettings();
         }
         return secureProxySettings;
+    }
+
+    @Override
+    public HttpTimeoutSettings getTimeoutSettings() {
+        if (timeoutSettings == null) {
+            timeoutSettings = new JavaSystemPropertiesHttpTimeoutSettings();
+        }
+        return timeoutSettings;
     }
 
     @Override

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
@@ -30,11 +30,13 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.AuthSchemes;
 import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.DateUtils;
 import org.apache.http.config.RegistryBuilder;
+import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.util.PublicSuffixMatcher;
 import org.apache.http.conn.util.PublicSuffixMatcherLoader;
@@ -91,6 +93,8 @@ public class HttpClientConfigurer {
         configureProxy(builder, credentialsProvider, httpSettings);
         configureUserAgent(builder);
         configureCookieSpecRegistry(builder);
+        configureRequestConfig(builder);
+        configureSocketConfig(builder);
         builder.setDefaultCredentialsProvider(credentialsProvider);
         builder.setMaxConnTotal(MAX_HTTP_CONNECTIONS);
         builder.setMaxConnPerRoute(MAX_HTTP_CONNECTIONS);
@@ -192,6 +196,20 @@ public class HttpClientConfigurer {
             .register(CookieSpecs.IGNORE_COOKIES, new IgnoreSpecProvider())
             .build()
         );
+    }
+
+    private void configureRequestConfig(HttpClientBuilder builder) {
+        HttpTimeoutSettings timeoutSettings = httpSettings.getTimeoutSettings();
+        RequestConfig config = RequestConfig.custom()
+            .setConnectTimeout(timeoutSettings.getConnectionTimeoutMs())
+            .setSocketTimeout(timeoutSettings.getSocketTimeoutMs())
+            .build();
+        builder.setDefaultRequestConfig(config);
+    }
+
+    private void configureSocketConfig(HttpClientBuilder builder) {
+        HttpTimeoutSettings timeoutSettings = httpSettings.getTimeoutSettings();
+        builder.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeoutSettings.getSocketTimeoutMs()).build());
     }
 
     private PasswordCredentials getPasswordCredentials(Authentication authentication) {

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpTimeoutSettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpTimeoutSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,24 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.internal.resource.transport.http;
 
+public interface HttpTimeoutSettings {
 
-import org.gradle.authentication.Authentication;
+    int getConnectionTimeoutMs();
 
-import javax.net.ssl.HostnameVerifier;
-import java.util.Collection;
-
-public interface HttpSettings {
-    HttpProxySettings getProxySettings();
-
-    HttpProxySettings getSecureProxySettings();
-
-    HttpTimeoutSettings getTimeoutSettings();
-
-    Collection<Authentication> getAuthenticationSettings();
-
-    SslContextFactory getSslContextFactory();
-
-    HostnameVerifier getHostnameVerifier();
+    int getSocketTimeoutMs();
 }

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesHttpTimeoutSettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesHttpTimeoutSettings.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JavaSystemPropertiesHttpTimeoutSettings implements HttpTimeoutSettings {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaSystemPropertiesHttpTimeoutSettings.class);
+    public static final String CONNECTION_TIMEOUT_SYSTEM_PROPERTY = "http.connectionTimeout";
+    public static final String SOCKET_TIMEOUT_SYSTEM_PROPERTY = "http.socketTimeout";
+    public static final int DEFAULT_CONNECTION_TIMEOUT = 10000;
+    public static final int DEFAULT_SOCKET_TIMEOUT = 10000;
+    private final int connectionTimeoutMs;
+    private final int socketTimeoutMs;
+
+    public JavaSystemPropertiesHttpTimeoutSettings() {
+        this.connectionTimeoutMs = initTimeout(CONNECTION_TIMEOUT_SYSTEM_PROPERTY, DEFAULT_CONNECTION_TIMEOUT);
+        this.socketTimeoutMs = initTimeout(SOCKET_TIMEOUT_SYSTEM_PROPERTY, DEFAULT_SOCKET_TIMEOUT);
+    }
+
+    @Override
+    public int getConnectionTimeoutMs() {
+        return connectionTimeoutMs;
+    }
+
+    @Override
+    public int getSocketTimeoutMs() {
+        return socketTimeoutMs;
+    }
+
+    private int initTimeout(String propertyName, int defaultValue) {
+        String systemProperty = System.getProperty(propertyName);
+
+        if (!StringUtils.isBlank(systemProperty)) {
+            try {
+                return Integer.parseInt(systemProperty);
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Invalid value for java system property '{}': {}. Default timeout '{}' will be used.",
+                    propertyName, systemProperty, defaultValue);
+            }
+        }
+
+        return defaultValue;
+    }
+}

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
@@ -31,9 +31,11 @@ public class HttpClientConfigurerTest extends Specification {
     }
     HttpProxySettings proxySettings = Mock()
     HttpProxySettings secureProxySettings = Mock()
+    HttpTimeoutSettings timeoutSettings = Mock()
     HttpSettings httpSettings = Mock() {
         getProxySettings() >> proxySettings
         getSecureProxySettings() >> secureProxySettings
+        getTimeoutSettings() >> timeoutSettings
     }
     SslContextFactory sslContextFactory = Mock() {
         createSslContext() >> SSLContexts.createDefault()
@@ -109,5 +111,19 @@ public class HttpClientConfigurerTest extends Specification {
 
         then:
         httpClientBuilder.userAgent == UriTextResource.userAgentString
+    }
+
+    def "configures http client timeout"() {
+        when:
+        configurer.configure(httpClientBuilder)
+
+        then:
+        1 * httpSettings.authenticationSettings >> []
+        1 * httpSettings.proxySettings >> proxySettings
+        1 * httpSettings.sslContextFactory >> sslContextFactory
+        1 * timeoutSettings.connectionTimeoutMs >> 10000
+        2 * timeoutSettings.socketTimeoutMs >> 30000
+        httpClientBuilder.defaultRequestConfig.connectTimeout == 10000
+        httpClientBuilder.defaultRequestConfig.socketTimeout == 30000
     }
 }

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientHelperTimeoutTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientHelperTimeoutTest.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http
+
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.ssl.SSLContexts
+import org.junit.Rule
+import org.junit.rules.ExternalResource
+import org.mortbay.jetty.Server
+import org.mortbay.jetty.handler.AbstractHandler
+import spock.lang.Specification
+import spock.lang.Subject
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class HttpClientHelperTimeoutTest extends Specification {
+
+    @Rule BlockingHttpServer httpServer = new BlockingHttpServer()
+    @Subject HttpClientHelper client = new HttpClientHelper(httpSettings)
+
+    def "throws exception if socket timeout is reached"() {
+        when:
+        client.performRequest(new HttpGet(httpServer.uri), false)
+
+        then:
+        def e = thrown(HttpRequestException)
+        e.cause instanceof SocketTimeoutException
+        e.cause.message == 'Read timed out'
+    }
+
+    static class BlockingHttpServer extends ExternalResource {
+        private final Server server = new Server(0)
+        private final CountDownLatch latch = new CountDownLatch(1)
+
+        @Override
+        protected void before() {
+            server.addHandler(new AbstractHandler() {
+                void handle(String target, HttpServletRequest request, HttpServletResponse response, int dispatch) {
+                    try {
+                        latch.await(60, TimeUnit.SECONDS)
+                    } catch (InterruptedException e) {
+                        // ignore
+                    }
+                }
+            })
+            server.start()
+        }
+
+        @Override
+        protected void after() {
+            server.stop()
+        }
+
+        URI getUri() {
+            new URI("http://localhost:${server.connectors[0].localPort}/")
+        }
+    }
+
+    private HttpSettings getHttpSettings() {
+        Stub(HttpSettings) {
+            getProxySettings() >> Mock(HttpProxySettings)
+            getSecureProxySettings() >> Mock(HttpProxySettings)
+            getTimeoutSettings() >> new JavaSystemPropertiesHttpTimeoutSettings()
+            getSslContextFactory() >> Mock(SslContextFactory) {
+                createSslContext() >> SSLContexts.createDefault()
+            }
+        }
+    }
+}

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesHttpTimeoutSettingsTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesHttpTimeoutSettingsTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http
+
+import org.gradle.testing.internal.util.Specification
+import org.gradle.util.SetSystemProperties
+import org.junit.Rule
+
+import static org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpTimeoutSettings.*
+
+class JavaSystemPropertiesHttpTimeoutSettingsTest extends Specification {
+
+    @Rule SetSystemProperties setSystemProperties = new SetSystemProperties()
+
+    def "can retrieve default values"() {
+        JavaSystemPropertiesHttpTimeoutSettings settings = new JavaSystemPropertiesHttpTimeoutSettings()
+
+        expect:
+        settings.connectionTimeoutMs == DEFAULT_CONNECTION_TIMEOUT
+        settings.socketTimeoutMs == DEFAULT_SOCKET_TIMEOUT
+    }
+
+    def "can parse custom value from system property"() {
+        System.setProperty(CONNECTION_TIMEOUT_SYSTEM_PROPERTY, "111")
+        System.setProperty(SOCKET_TIMEOUT_SYSTEM_PROPERTY, "222")
+        JavaSystemPropertiesHttpTimeoutSettings settings = new JavaSystemPropertiesHttpTimeoutSettings()
+
+        expect:
+        settings.connectionTimeoutMs == 111
+        settings.socketTimeoutMs == 222
+    }
+
+    def "uses default value if provided connection timeout is not valid"() {
+        System.setProperty(CONNECTION_TIMEOUT_SYSTEM_PROPERTY, timeout)
+        JavaSystemPropertiesHttpTimeoutSettings settings = new JavaSystemPropertiesHttpTimeoutSettings()
+
+        expect:
+        settings.connectionTimeoutMs == DEFAULT_CONNECTION_TIMEOUT
+
+        where:
+        timeout << ["", "abc"]
+    }
+
+    def "uses default value if provided socket timeout is not valid"() {
+        System.setProperty(SOCKET_TIMEOUT_SYSTEM_PROPERTY, timeout)
+        JavaSystemPropertiesHttpTimeoutSettings settings = new JavaSystemPropertiesHttpTimeoutSettings()
+
+        expect:
+        settings.socketTimeoutMs == DEFAULT_SOCKET_TIMEOUT
+
+        where:
+        timeout << ["", "abc"]
+    }
+}


### PR DESCRIPTION
In #3041 , we introduced some configuration to handle HTTP timeout. However, there's a tiny issue in the implementation and it caused CI failed here: https://builds.gradle.org/viewLog.html?buildId=8466105&tab=buildResultsDiv&buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger

I reverted the change because of the CI failure yesterday, but now I fixed it and make sure all tests are OK: https://github.com/gradle/gradle/commit/4c979862e65936e78a8b358561f50fdfdb4bc8d5
