### PR TITLE
Detect changes between null output file and non-existent output file

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
@@ -94,10 +94,13 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
         output.contains "Output: namedOutputDirectories.two [outputs-two]"
         output.contains "Output: namedOutputFiles.one [output-one.txt]"
         output.contains "Output: namedOutputFiles.two [output-two.txt]"
-        output.contains "Output: nested.outputFiles [output-nested-1.txt, output-nested-2.txt]"
-        output.contains "Output: outputDirectories [outputs1, outputs2]"
+        output.contains 'Output: nested.outputFiles$1 [output-nested-1.txt]'
+        output.contains 'Output: nested.outputFiles$2 [output-nested-2.txt]'
+        output.contains 'Output: outputDirectories$1 [outputs1]'
+        output.contains 'Output: outputDirectories$2 [outputs2]'
         output.contains "Output: outputDirectory [outputs]"
         output.contains "Output: outputFile [output.txt]"
-        output.contains "Output: outputFiles [output1.txt, output2.txt]"
+        output.contains 'Output: outputFiles$1 [output1.txt]'
+        output.contains 'Output: outputFiles$2 [output2.txt]'
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
@@ -138,7 +138,7 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
             @CacheableTask
             class PluralOutputs extends BaseTask {
                 @OutputFiles
-                Set<File> outputFiles = []
+                Set<File> outputFiles = ['some.txt']
                 
                 @TaskAction
                 void generate() {}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -559,21 +559,12 @@ task someTask(type: SomeTask) {
         """
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        if (expectToFail) {
-            // Singular null outputs will cause build to fail, but message should still be printed
-            fails "test"
-        } else {
-            succeeds "test"
-        }
+        succeeds "test"
         output.contains """A problem was found with the configuration of task ':test'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated and is scheduled to be removed in Gradle 5.0.
  - No value has been specified for property 'output'."""
 
         where:
-        method  | expectToFail
-        "file"  | true
-        "files" | false
-        "dir"   | true
-        "dirs"  | false
+        method << ["file", "files", "dir", "dirs"]
     }
 
     @Unroll

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultCacheableTaskOutputFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultCacheableTaskOutputFilePropertySpec.java
@@ -47,7 +47,7 @@ public class DefaultCacheableTaskOutputFilePropertySpec extends AbstractTaskOutp
     @Override
     public File getOutputFile() {
         Object unpackedOutput = DeferredUtil.unpack(value.call());
-        if (unpackedOutput == null && isOptional()) {
+        if (unpackedOutput == null) {
             return null;
         }
         return resolver.resolve(unpackedOutput);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -200,6 +200,12 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
                     if (propertySpec instanceof CompositeTaskOutputPropertySpec) {
                         return ((CompositeTaskOutputPropertySpec) propertySpec).resolveToOutputProperties();
                     } else {
+                        if (propertySpec instanceof CacheableTaskOutputFilePropertySpec) {
+                            File outputFile = ((CacheableTaskOutputFilePropertySpec) propertySpec).getOutputFile();
+                            if (outputFile == null) {
+                                return Iterators.emptyIterator();
+                            }
+                        }
                         return Iterators.singletonIterator((TaskOutputFilePropertySpec) propertySpec);
                     }
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -121,7 +121,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
                 return DefaultTaskOutputCachingState.disabled(
                     PLURAL_OUTPUTS,
                     "Declares multiple output files for the single output property '"
-                        + spec.getPropertyName()
+                        + ((NonCacheableTaskOutputPropertySpec) spec).getParent().getPropertyName()
                         + "' via `@OutputFiles`, `@OutputDirectories` or `TaskOutputs.files()`"
                 );
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -121,7 +121,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
                 return DefaultTaskOutputCachingState.disabled(
                     PLURAL_OUTPUTS,
                     "Declares multiple output files for the single output property '"
-                        + ((NonCacheableTaskOutputPropertySpec) spec).getParent().getPropertyName()
+                        + ((NonCacheableTaskOutputPropertySpec) spec).getOriginalPropertyName()
                         + "' via `@OutputFiles`, `@OutputDirectories` or `TaskOutputs.files()`"
                 );
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
@@ -40,13 +40,13 @@ public class NonCacheableTaskOutputPropertySpec extends TaskOutputsDeprecationSu
         return parent.getPropertyName() + "$" + index;
     }
 
+    public String getOriginalPropertyName() {
+        return parent.getPropertyName();
+    }
+
     @Override
     public OutputType getOutputType() {
         return parent.getOutputType();
-    }
-
-    public CompositeTaskOutputPropertySpec getParent() {
-        return parent;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/NonCacheableTaskOutputPropertySpec.java
@@ -26,21 +26,27 @@ import org.gradle.api.tasks.FileNormalizer;
 public class NonCacheableTaskOutputPropertySpec extends TaskOutputsDeprecationSupport implements TaskOutputFilePropertySpec {
 
     private final CompositeTaskOutputPropertySpec parent;
+    private final int index;
     private final FileCollection files;
 
-    public NonCacheableTaskOutputPropertySpec(String taskName, CompositeTaskOutputPropertySpec parent, FileResolver resolver, Object paths) {
+    public NonCacheableTaskOutputPropertySpec(String taskName, CompositeTaskOutputPropertySpec parent, int index, FileResolver resolver, Object paths) {
         this.parent = parent;
+        this.index = index;
         this.files = new TaskPropertyFileCollection(taskName, "output", this, resolver, paths);
     }
 
     @Override
     public String getPropertyName() {
-        return parent.getPropertyName();
+        return parent.getPropertyName() + "$" + index;
     }
 
     @Override
     public OutputType getOutputType() {
         return parent.getOutputType();
+    }
+
+    public CompositeTaskOutputPropertySpec getParent() {
+        return parent;
     }
 
     @Override
@@ -55,7 +61,7 @@ public class NonCacheableTaskOutputPropertySpec extends TaskOutputsDeprecationSu
 
     @Override
     public int compareTo(TaskPropertySpec o) {
-        return parent.compareTo(o);
+        return getPropertyName().compareTo(o.getPropertyName());
     }
 
     @Override

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -272,9 +272,15 @@ There are better ways for re-using task logic, for example by using [task depend
 - `AbstractNativeCompileTask.objectFileDir` changed type to `DirectoryVar` from `File`.
 - `AbstractLinkTask.linkerArgs` changed type to `ListProperty<String>` from `List<String>`.
 
-## Changes in the `eclipse` plugin
+### Changes in the `eclipse` plugin
 
 The default output location in [EclipseClasspath](dsl/org.gradle.plugins.ide.eclipse.model.EclipseClasspath.html#org.gradle.plugins.ide.eclipse.model.EclipseClasspath:defaultOutputDir) changed from `${project.projectDir}/bin` to `${project.projectDir}/bin/default`.
+
+### Incremental build respects order of declared output files
+
+For output properties annotated with [`@OutputFiles`](javadoc/org/gradle/api/tasks/OutputFiles.html) or [`@OutputDirectories`](javadoc/org/gradle/api/tasks/OutputDirectories.html) that evaluate to an `Iterable`, the order of the declared files is now important.
+In other words, if the property changes from `[file1, file2]` to `[file2, file1]` the task will not be up-to-date. 
+Prefer annotating individual properties with [`@OutputFile`](javadoc/org/gradle/api/tasks/OutputFile.html) and [`@OutputDirectory`](javadoc/org/gradle/api/tasks/OutputDirectory.html) if you can, or return a `Map` annotated with [`@OutputFiles`](javadoc/org/gradle/api/tasks/OutputFiles.html) or [`@OutputDirectories`](javadoc/org/gradle/api/tasks/OutputDirectories.html).
 
 ## External contributions
 


### PR DESCRIPTION
This is a fix for #3073.