### PR TITLE
Rebaseline performance tests

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/AbstractTaskOutputCacheJavaPerformanceTest.groovy
@@ -34,7 +34,7 @@ class AbstractTaskOutputCacheJavaPerformanceTest extends AbstractCrossVersionPer
         runner.cleanTasks = ["clean"]
         runner.args = ["-D${StartParameterBuildOptionFactory.BuildCacheOption.GRADLE_PROPERTY}=true"]
         runner.minimumVersion = "3.5"
-        runner.targetVersions = ["4.2-20170904082212+0000"]
+        runner.targetVersions = ["4.2.1"]
     }
 
     /**

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
@@ -20,6 +20,11 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import spock.lang.Unroll
 
 class NativeBuildDependentsPerformanceTest extends AbstractCrossVersionPerformanceTest {
+
+    def setup() {
+        runner.targetVersions = ["4.3-20171004093631+0000"]
+    }
+
     @Unroll
     def "#task on #testProject"() {
         given:
@@ -27,7 +32,6 @@ class NativeBuildDependentsPerformanceTest extends AbstractCrossVersionPerforman
         runner.tasksToRun = [ task ]
         runner.args += ["--parallel", "--max-workers=4"]
         runner.gradleOpts = ["-Xms3g", "-Xmx3g"]
-        runner.targetVersions = ["4.2-20170817235727+0000"]
 
         when:
         def result = runner.run()
@@ -52,7 +56,6 @@ class NativeBuildDependentsPerformanceTest extends AbstractCrossVersionPerforman
         runner.tasksToRun = [ "$subprojectPath:dependentComponents" ]
         runner.args += ["--parallel", "--max-workers=4"]
         runner.gradleOpts = ["-Xms3g", "-Xmx3g"]
-        runner.targetVersions = ["4.2-20170817235727+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
@@ -20,6 +20,11 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import spock.lang.Unroll
 
 class NativeBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
+
+    def setup() {
+        runner.targetVersions = ["4.3-20171004093631+0000"]
+    }
+
     @Unroll
     def "clean assemble on #testProject"() {
         given:
@@ -28,7 +33,6 @@ class NativeBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.gradleOpts = ["-Xms$maxMemory", "-Xmx$maxMemory"]
         runner.runs = iterations
         runner.warmUpRuns = iterations
-        runner.targetVersions = ["4.2-20170817235727+0000"]
 
         when:
         def result = runner.run()
@@ -48,7 +52,6 @@ class NativeBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
         given:
         runner.testProject = "manyProjectsNative"
         runner.tasksToRun = ["clean", "assemble"]
-        runner.targetVersions = ["4.2-20170817235727+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
@@ -27,13 +27,17 @@ import org.gradle.performance.measure.MeasuredOperation
 import spock.lang.Unroll
 
 class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionPerformanceTest {
+
+    def setup() {
+        runner.targetVersions = ["4.3-20171004093631+0000"]
+    }
+
     @Unroll
     def "build on #testProject with #parallelWorkers parallel workers"() {
         given:
         runner.testProject = testProject
         runner.tasksToRun = ['build']
         runner.gradleOpts = ["-Xms1500m", "-Xmx1500m"]
-        runner.targetVersions = ["4.2-20170817235727+0000"]
         runner.warmUpRuns = 5
         runner.runs = 10
 
@@ -64,7 +68,6 @@ class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionPerforman
         runner.gradleOpts = ["-Xms512m", "-Xmx512m"]
         runner.warmUpRuns = iterations - 1
         runner.runs = iterations
-        runner.targetVersions = ["4.2-20170817235727+0000"]
         if (runner.honestProfiler.enabled) {
             runner.honestProfiler.autoStartStop = false
         }


### PR DESCRIPTION
We want to lock in the improvements for the build cache and native compilation introduced in 4.2.