### PR TITLE
Refactor populate to return working directory

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/vcs/VersionControlSystem.java
+++ b/subprojects/core-api/src/main/java/org/gradle/vcs/VersionControlSystem.java
@@ -36,9 +36,10 @@ public interface VersionControlSystem {
     Set<VersionRef> getAvailableVersions(VersionControlSpec spec);
 
     /**
-     * Populates the {@code workingDir} with the latest state of the
-     * version control repostory from the {@code spec}.
+     * Populates a working directory under {@code versionDir} with the latest
+     * state of the version control repository from the {@code spec} and
+     * returns the working directory.
      */
-    void populate(File workingDir, VersionRef ref, VersionControlSpec spec);
+    File populate(File versionDir, VersionRef ref, VersionControlSpec spec);
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -115,9 +115,8 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
 
     private File populateWorkingDirectory(File baseWorkingDir, VersionControlSpec spec, VersionControlSystem versionControlSystem, VersionRef selectedVersion) {
         String repositoryId = HashUtil.createCompactMD5(versionControlSystem.getClass().getCanonicalName() + spec.getUniqueId());
-        File dependencyWorkingDir = new File(baseWorkingDir, repositoryId + "/" + selectedVersion.getCanonicalId() + "/" + spec.getRepoName());
-        versionControlSystem.populate(dependencyWorkingDir, selectedVersion, spec);
-        return dependencyWorkingDir;
+        File versionDirectory = new File(baseWorkingDir, repositoryId + "/" + selectedVersion.getCanonicalId());
+        return versionControlSystem.populate(versionDirectory, selectedVersion, spec);
     }
 
     private VersionRef selectVersionFromRepository(VersionControlSpec spec, VersionControlSystem versionControlSystem) {

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Rule
 
 class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
     @Rule
-    GitRepository repo = new GitRepository("dep", temporaryFolder)
+    GitRepository repo = new GitRepository("dep", temporaryFolder.getTestDirectory())
 
     def "can define and use source repositories"() {
         def commit = repo.commit("initial commit", GFileUtils.listFiles(file("dep"), null, true))

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
@@ -44,8 +44,9 @@ import java.util.Set;
  */
 public class GitVersionControlSystem implements VersionControlSystem {
     @Override
-    public void populate(File workingDir, VersionRef ref, VersionControlSpec spec) {
+    public File populate(File versionDir, VersionRef ref, VersionControlSpec spec) {
         GitVersionControlSpec gitSpec = cast(spec);
+        File workingDir = new File(versionDir, gitSpec.getRepoName());
 
         // TODO: Assuming the default branch for the repository
         File dbDir = new File(workingDir, ".git");
@@ -54,6 +55,7 @@ public class GitVersionControlSystem implements VersionControlSystem {
         } else {
             cloneRepo(workingDir, gitSpec);
         }
+        return workingDir;
     }
 
     @Override

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/SimpleVersionControlSystem.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/SimpleVersionControlSystem.java
@@ -34,13 +34,15 @@ public class SimpleVersionControlSystem implements VersionControlSystem {
     }
 
     @Override
-    public void populate(File workingDir, VersionRef ref, VersionControlSpec spec) {
+    public File populate(File versionDir, VersionRef ref, VersionControlSpec spec) {
         File sourceDir = ((DirectoryRepositorySpec)spec).getSourceDir();
+        File workingDir = new File(versionDir, sourceDir.getName());
         try {
             GFileUtils.copyDirectory(sourceDir, workingDir);
             new File(workingDir, "checkedout").createNewFile();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        return workingDir;
     }
 }

--- a/subprojects/version-control/src/testFixtures/groovy/org/gradle/vcs/fixtures/GitRepository.java
+++ b/subprojects/version-control/src/testFixtures/groovy/org/gradle/vcs/fixtures/GitRepository.java
@@ -22,7 +22,6 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.gradle.internal.UncheckedException;
-import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.test.fixtures.file.TestFile;
 import org.junit.rules.ExternalResource;
 
@@ -35,21 +34,21 @@ import java.util.Collection;
 
 public class GitRepository extends ExternalResource {
     private final String repoName;
-    private final TestDirectoryProvider temporaryFolder;
+    private final TestFile parentDirectory;
     private Git git;
 
-    public GitRepository(String repoName, TestDirectoryProvider temporaryFolder) {
+    public GitRepository(String repoName, TestFile parentDirectory) {
         this.repoName = repoName;
-        this.temporaryFolder = temporaryFolder;
+        this.parentDirectory = parentDirectory;
     }
 
-    public GitRepository(TestDirectoryProvider temporaryFolder) {
-        this("repo", temporaryFolder);
+    public GitRepository(TestFile parentDirectory) {
+        this("repo", parentDirectory);
     }
 
     @Override
     protected void before() throws Throwable {
-        git = Git.init().setDirectory(temporaryFolder.getTestDirectory().file(repoName)).call();
+        git = Git.init().setDirectory(parentDirectory.file(repoName)).call();
     }
 
     @Override


### PR DESCRIPTION
In an attempt to implement locking of the git clone directory in
gradle/gradle-native#146, we realized that the directory locking
mechanism writes a lock file into the directory being locked. That
lock file prevents jGit from cloning into the directory because it
expects directories to be empty when they are the target of a clone
operation.

This change moves the responsibility for calculating the path to the
working directory into the VersionControlSystem and provides the
populate method with a parent directory which can be the target of
locking.

Part of gradle/gradle-native#146

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation