### PR TITLE
Do not persist declared output paths

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractTaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractTaskExecution.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.internal.id.UniqueId;
@@ -28,21 +27,18 @@ public abstract class AbstractTaskExecution implements TaskExecution {
     private final ImmutableList<ImplementationSnapshot> taskActionImplementations;
     private final ImmutableSortedMap<String, ValueSnapshot> inputProperties;
     private final ImmutableSortedSet<String> outputPropertyNamesForCacheKey;
-    private final ImmutableSet<String> declaredOutputFilePaths;
 
     public AbstractTaskExecution(
         UniqueId buildInvocationId,
         ImplementationSnapshot taskImplementation,
         ImmutableList<ImplementationSnapshot> taskActionImplementations,
         ImmutableSortedMap<String, ValueSnapshot> inputProperties,
-        ImmutableSortedSet<String> outputPropertyNames,
-        ImmutableSet<String> declaredOutputFilePaths) {
+        ImmutableSortedSet<String> outputPropertyNames) {
         this.buildInvocationId = buildInvocationId;
         this.taskImplementation = taskImplementation;
         this.taskActionImplementations = taskActionImplementations;
         this.inputProperties = inputProperties;
         this.outputPropertyNamesForCacheKey = outputPropertyNames;
-        this.declaredOutputFilePaths = declaredOutputFilePaths;
     }
 
     @Override
@@ -53,11 +49,6 @@ public abstract class AbstractTaskExecution implements TaskExecution {
     @Override
     public ImmutableSortedSet<String> getOutputPropertyNamesForCacheKey() {
         return ImmutableSortedSet.copyOf(outputPropertyNamesForCacheKey);
-    }
-
-    @Override
-    public ImmutableSet<String> getDeclaredOutputFilePaths() {
-        return declaredOutputFilePaths;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CurrentTaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CurrentTaskExecution.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 
 @NonNullApi
 public class CurrentTaskExecution extends AbstractTaskExecution {
+    private final ImmutableSet<String> declaredOutputFilePaths;
     private ImmutableSortedMap<String, FileCollectionSnapshot> outputFilesSnapshot;
     private final ImmutableSortedMap<String, FileCollectionSnapshot> inputFilesSnapshot;
     private FileCollectionSnapshot discoveredInputFilesSnapshot;
@@ -46,13 +47,24 @@ public class CurrentTaskExecution extends AbstractTaskExecution {
         ImmutableSortedMap<String, FileCollectionSnapshot> outputFilesSnapshot,
         @Nullable OverlappingOutputs detectedOverlappingOutputs
     ) {
-        super(buildInvocationId, taskImplementation, taskActionImplementations, inputProperties, outputPropertyNames, declaredOutputFilePaths);
+        super(buildInvocationId, taskImplementation, taskActionImplementations, inputProperties, outputPropertyNames);
+        this.declaredOutputFilePaths = declaredOutputFilePaths;
         this.outputFilesSnapshot = outputFilesSnapshot;
         this.inputFilesSnapshot = inputFilesSnapshot;
         this.discoveredInputFilesSnapshot = discoveredInputFilesSnapshot;
         this.detectedOverlappingOutputs = detectedOverlappingOutputs;
     }
 
+    /**
+     * Returns the absolute path of every declared output file and directory.
+     * The returned set includes potentially missing files as well, and does
+     * not include the resolved contents of directories.
+     */
+    public ImmutableSet<String> getDeclaredOutputFilePaths() {
+        return declaredOutputFilePaths;
+    }
+
+    @Override
     public boolean isSuccessful() {
         return successful;
     }
@@ -96,7 +108,6 @@ public class CurrentTaskExecution extends AbstractTaskExecution {
             getTaskActionImplementations(),
             getInputProperties(),
             getOutputPropertyNamesForCacheKey(),
-            getDeclaredOutputFilePaths(),
             inputFilesSnapshot,
             discoveredInputFilesSnapshot,
             outputFilesSnapshot,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/HistoricalTaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/HistoricalTaskExecution.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.api.NonNullApi;
@@ -39,13 +38,12 @@ public class HistoricalTaskExecution extends AbstractTaskExecution {
         ImmutableList<ImplementationSnapshot> taskActionsImplementations,
         ImmutableSortedMap<String, ValueSnapshot> inputProperties,
         ImmutableSortedSet<String> outputPropertyNames,
-        ImmutableSet<String> declaredOutputFilePaths,
         ImmutableSortedMap<String, FileCollectionSnapshot> inputFilesSnapshot,
         FileCollectionSnapshot discoveredInputFilesSnapshot,
         ImmutableSortedMap<String, FileCollectionSnapshot> outputFilesSnapshot,
         boolean successful
     ) {
-        super(buildInvocationId, taskImplementation, taskActionsImplementations, inputProperties, outputPropertyNames, declaredOutputFilePaths);
+        super(buildInvocationId, taskImplementation, taskActionsImplementations, inputProperties, outputPropertyNames);
         this.inputFilesSnapshot = inputFilesSnapshot;
         this.discoveredInputFilesSnapshot = discoveredInputFilesSnapshot;
         this.outputFilesSnapshot = outputFilesSnapshot;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecution.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.internal.id.UniqueId;
@@ -35,13 +34,6 @@ public interface TaskExecution {
      * cacheable, it returns an empty collection.
      */
     ImmutableSortedSet<String> getOutputPropertyNamesForCacheKey();
-
-    /**
-     * Returns the absolute path of every declared output file and directory.
-     * The returned set includes potentially missing files as well, and does
-     * not include the resolved contents of directories.
-     */
-    ImmutableSet<String> getDeclaredOutputFilePaths();
 
     ImplementationSnapshot getTaskImplementation();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecutionSnapshotSerializer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskExecutionSnapshotSerializer.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.api.internal.cache.StringInterner;
@@ -69,13 +68,6 @@ public class TaskExecutionSnapshotSerializer extends AbstractSerializer<Historic
         }
         ImmutableSortedSet<String> cacheableOutputProperties = cacheableOutputPropertiesBuilder.build();
 
-        int outputFilesCount = decoder.readSmallInt();
-        ImmutableSet.Builder<String> declaredOutputFilePathsBuilder = ImmutableSet.builder();
-        for (int j = 0; j < outputFilesCount; j++) {
-            declaredOutputFilePathsBuilder.add(stringInterner.intern(decoder.readString()));
-        }
-        ImmutableSet<String> declaredOutputFilePaths = declaredOutputFilePathsBuilder.build();
-
         ImmutableSortedMap<String, ValueSnapshot> inputProperties = inputPropertiesSerializer.read(decoder);
 
         return new HistoricalTaskExecution(
@@ -84,7 +76,6 @@ public class TaskExecutionSnapshotSerializer extends AbstractSerializer<Historic
             taskActionImplementations,
             inputProperties,
             cacheableOutputProperties,
-            declaredOutputFilePaths,
             inputFilesSnapshots,
             discoveredFilesSnapshot,
             outputFilesSnapshots,
@@ -105,10 +96,6 @@ public class TaskExecutionSnapshotSerializer extends AbstractSerializer<Historic
         }
         encoder.writeSmallInt(execution.getOutputPropertyNamesForCacheKey().size());
         for (String outputFile : execution.getOutputPropertyNamesForCacheKey()) {
-            encoder.writeString(outputFile);
-        }
-        encoder.writeSmallInt(execution.getDeclaredOutputFilePaths().size());
-        for (String outputFile : execution.getDeclaredOutputFilePaths()) {
             encoder.writeString(outputFile);
         }
         inputPropertiesSerializer.write(encoder, execution.getInputProperties());


### PR DESCRIPTION
We do not need this information any more in the task history.
