### PR TITLE
Retain classifier when transforming artifacts

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
@@ -281,17 +281,23 @@ public class DefaultArtifactTransforms implements ArtifactTransforms {
                 return;
             }
 
+            ResolvedArtifact sourceArtifact = artifact.toPublicView();
             List<File> transformedFiles = operation.result;
-
             TaskDependency buildDependencies = ((Buildable) artifact).getBuildDependencies();
+
             for (File output : transformedFiles) {
-                ResolvedArtifact sourceArtifact = artifact.toPublicView();
-                ComponentArtifactIdentifier newId = new ComponentFileArtifactIdentifier(sourceArtifact.getId().getComponentIdentifier(), output.getName());
-                String extension = Files.getFileExtension(output.getName());
-                IvyArtifactName artifactName = new DefaultIvyArtifactName(output.getName(), extension, extension);
+                IvyArtifactName artifactName = getArtifactName(sourceArtifact, output);
+                ComponentArtifactIdentifier newId = new ComponentFileArtifactIdentifier(sourceArtifact.getId().getComponentIdentifier(), artifactName.toString());
                 DefaultResolvedArtifact resolvedArtifact = new DefaultResolvedArtifact(sourceArtifact.getModuleVersion().getId(), artifactName, newId, buildDependencies, output);
                 visitor.visitArtifact(target, resolvedArtifact);
             }
+        }
+
+        private IvyArtifactName getArtifactName(ResolvedArtifact sourceArtifact, File output) {
+            String name = Files.getNameWithoutExtension(output.getName());
+            String extension = Files.getFileExtension(output.getName());
+            String classifier = sourceArtifact.getClassifier();
+            return new DefaultIvyArtifactName(name, extension, extension, classifier);
         }
 
         @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -87,6 +87,10 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     public TestFile getArtifactFile() {
         return backingModule.getArtifactFile();
     }
+    @Override
+    public TestFile getArtifactFile(Map options) {
+        return backingModule.getArtifactFile(options);
+    }
 
     @Override
     public String getArtifactId() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -95,6 +95,8 @@ interface MavenModule extends Module {
 
     TestFile getArtifactFile()
 
+    TestFile getArtifactFile(Map options)
+
     TestFile getMetaDataFile()
 
     MavenPom getParsedPom()


### PR DESCRIPTION
Two artifacts coming from the same component, but
with different classifiers should result in two
distinguishable artifact identifiers after applying
an artifact transformation.