### PR TITLE
Defer picking between Vcs and Project DependencyResolvers

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -50,6 +50,7 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
     def 'can define and use source repositories with initscript resolution present'() {
         given:
         using m2
+        requireOwnGradleUserHomeDir()
         m2.mavenRepo().module('group', 'projectA', '1.2').publish()
         def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
         temporaryFolder.file('initialize.gradle') << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -25,11 +25,8 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
     @Rule
     GitRepository repo = new GitRepository('dep', temporaryFolder.getTestDirectory())
 
-    def setup() {
-        requireOwnGradleUserHomeDir()
-    }
-
     def 'can define and use source repositories'() {
+        given:
         def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
 
         settingsFile << """
@@ -53,17 +50,11 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
     @Issue('gradle/gradle-native#206')
     def 'can define and use source repositories with initscript resolution present'() {
         given:
-        using m2
-        m2.mavenRepo().module('group', 'projectA', '1.2').publish()
         def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
         temporaryFolder.file('initialize.gradle') << """
-        initscript {
-            repositories {
-                maven { url = '${m2.mavenRepo().uri}' }
-            }
-            
+        initscript {            
             dependencies {
-                classpath 'group:projectA:1.2'
+                classpath files('classpath.file')
             }
         }
         allprojects { p ->

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -25,6 +25,10 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
     @Rule
     GitRepository repo = new GitRepository('dep', temporaryFolder.getTestDirectory())
 
+    def setup() {
+        requireOwnGradleUserHomeDir()
+    }
+
     def 'can define and use source repositories'() {
         def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
 
@@ -50,13 +54,12 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
     def 'can define and use source repositories with initscript resolution present'() {
         given:
         using m2
-        requireOwnGradleUserHomeDir()
         m2.mavenRepo().module('group', 'projectA', '1.2').publish()
         def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
         temporaryFolder.file('initialize.gradle') << """
         initscript {
             repositories {
-                mavenLocal()
+                maven { url = '${m2.mavenRepo().uri}' }
             }
             
             dependencies {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -327,11 +327,15 @@ class DependencyManagementBuildScopeServices {
         return new ProjectDependencyResolver(localComponentRegistry, componentIdentifierFactory);
     }
 
-    private static class DefaultResolverProviderFactory implements ResolverProviderFactory {
-        private final ComponentResolvers resolvers;
+    private static class VcsOrProjectResolverProviderFactory implements ResolverProviderFactory {
+        private final VcsDependencyResolver vcsDependencyResolver;
+        private final ProjectDependencyResolver projectDependencyResolver;
+        private final VcsMappingsInternal vcsMappingsInternal;
 
-        private DefaultResolverProviderFactory(ComponentResolvers resolvers) {
-            this.resolvers = resolvers;
+        private VcsOrProjectResolverProviderFactory(VcsDependencyResolver vcsDependencyResolver, ProjectDependencyResolver projectDependencyResolver, VcsMappingsInternal vcsMappingsInternal) {
+            this.vcsDependencyResolver = vcsDependencyResolver;
+            this.projectDependencyResolver = projectDependencyResolver;
+            this.vcsMappingsInternal = vcsMappingsInternal;
         }
 
         @Override
@@ -341,7 +345,7 @@ class DependencyManagementBuildScopeServices {
 
         @Override
         public ComponentResolvers create(ResolveContext context) {
-            return resolvers;
+            return vcsMappingsInternal.hasRules() ? vcsDependencyResolver : projectDependencyResolver;
         }
     }
 
@@ -350,10 +354,6 @@ class DependencyManagementBuildScopeServices {
     }
 
     ResolverProviderFactory createVcsResolverProviderFactory(VcsDependencyResolver vcsDependencyResolver, ProjectDependencyResolver projectDependencyResolver, VcsMappingsInternal vcsMappingsInternal) {
-        if (vcsMappingsInternal.hasRules()) {
-            return new DefaultResolverProviderFactory(vcsDependencyResolver);
-        } else {
-            return new DefaultResolverProviderFactory(projectDependencyResolver);
-        }
+        return new VcsOrProjectResolverProviderFactory(vcsDependencyResolver, projectDependencyResolver, vcsMappingsInternal);
     }
 }


### PR DESCRIPTION
We need to make this decision only after the `VcsMappingsInternal` has
actually been configured by running the settings.gradle script. Before
this change, the `vcsMappingsInternal` always responded `false` to
`hasRules()` because the `sourceControl` block hadn't been executed
yet.

Fixes gradle/gradle-native#206