### PR TITLE
Adjust Java execution environment name for JRE 9+ versions in Eclipse plugin

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
@@ -42,6 +42,7 @@ class EclipseJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
         '1.6'   | 'JavaSE-1.6'
         '1.7'   | 'JavaSE-1.7'
         '1.8'   | 'JavaSE-1.8'
-        '1.9'   | 'JavaSE-1.9'
+        '1.9'   | 'JavaSE-9'
+        '1.10'  | 'JavaSE-10'
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -364,8 +364,12 @@ public class EclipsePlugin extends IdePlugin {
             case VERSION_1_4:
             case VERSION_1_5:
                 return "J2SE-" + version;
-            default:
+            case VERSION_1_6:
+            case VERSION_1_7:
+            case VERSION_1_8:
                 return "JavaSE-" + version;
+            default:
+                return "JavaSE-" + version.getMajorVersion();
         }
     }
 


### PR DESCRIPTION
Following the version scheme change in Java 9, Eclipse also changed
the execution environment name from JavaSE-1.9 to JavaSE-9. This
commit adjusts the Eclipse `.classpath` file generation according
to this change.

This PR fixes #3046 