### PR TITLE
Native plugins use configurations.maybeCreate(name) instead of .create()

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
@@ -68,17 +68,17 @@ public class DefaultCppBinary implements CppBinary {
         Names names = Names.of(name);
 
         // TODO - reduce duplication with Swift binary
-        Configuration includePathConfig = configurations.create(names.withPrefix("cppCompile"));
+        Configuration includePathConfig = configurations.maybeCreate(names.withPrefix("cppCompile"));
         includePathConfig.setCanBeConsumed(false);
         includePathConfig.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.C_PLUS_PLUS_API));
         includePathConfig.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
 
-        Configuration nativeLink = configurations.create(names.withPrefix("nativeLink"));
+        Configuration nativeLink = configurations.maybeCreate(names.withPrefix("nativeLink"));
         nativeLink.setCanBeConsumed(false);
         nativeLink.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.NATIVE_LINK));
         nativeLink.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
 
-        Configuration nativeRuntime = configurations.create(names.withPrefix("nativeRuntime"));
+        Configuration nativeRuntime = configurations.maybeCreate(names.withPrefix("nativeRuntime"));
         nativeRuntime.setCanBeConsumed(false);
         nativeRuntime.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.NATIVE_RUNTIME));
         nativeRuntime.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -55,7 +55,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
         baseName = providerFactory.property(String.class);
 
         names = Names.of(name);
-        implementation = configurations.create(names.withSuffix("implementation"));
+        implementation = configurations.maybeCreate(names.withSuffix("implementation"));
         implementation.setCanBeConsumed(false);
         implementation.setCanBeResolved(false);
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
@@ -46,7 +46,7 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
         debug = objectFactory.newInstance(DefaultCppSharedLibrary.class, name + "Debug", objectFactory, getBaseName(), true, getCppSource(), getAllHeaderDirs(), configurations, getImplementationDependencies());
         release = objectFactory.newInstance(DefaultCppSharedLibrary.class, name + "Release", objectFactory, getBaseName(), false, getCppSource(), getAllHeaderDirs(), configurations, getImplementationDependencies());
 
-        api = configurations.create(getNames().withSuffix("api"));
+        api = configurations.maybeCreate(getNames().withSuffix("api"));
         api.setCanBeConsumed(false);
         api.setCanBeResolved(false);
         getImplementationDependencies().extendsFrom(api);

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppExecutablePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppExecutablePlugin.java
@@ -95,14 +95,14 @@ public class CppExecutablePlugin implements Plugin<ProjectInternal> {
 
         final Usage runtimeUsage = objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME);
 
-        final Configuration debugRuntimeElements = configurations.create("debugRuntimeElements");
+        final Configuration debugRuntimeElements = configurations.maybeCreate("debugRuntimeElements");
         debugRuntimeElements.extendsFrom(application.getImplementationDependencies());
         debugRuntimeElements.setCanBeResolved(false);
         debugRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
         debugRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, true);
         debugRuntimeElements.getOutgoing().artifact(linkDebug.getBinaryFile());
 
-        final Configuration releaseRuntimeElements = configurations.create("releaseRuntimeElements");
+        final Configuration releaseRuntimeElements = configurations.maybeCreate("releaseRuntimeElements");
         releaseRuntimeElements.extendsFrom(application.getImplementationDependencies());
         releaseRuntimeElements.setCanBeResolved(false);
         releaseRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
@@ -125,7 +125,7 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
         // TODO - extract some common code to setup the configurations
 
         final Usage apiUsage = objectFactory.named(Usage.class, Usage.C_PLUS_PLUS_API);
-        final Configuration apiElements = configurations.create("cppApiElements");
+        final Configuration apiElements = configurations.maybeCreate("cppApiElements");
         apiElements.extendsFrom(library.getApiDependencies());
         apiElements.setCanBeResolved(false);
         apiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, apiUsage);
@@ -147,7 +147,7 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
         final Usage linkUsage = objectFactory.named(Usage.class, Usage.NATIVE_LINK);
         final Usage runtimeUsage = objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME);
 
-        final Configuration debugLinkElements = configurations.create("debugLinkElements");
+        final Configuration debugLinkElements = configurations.maybeCreate("debugLinkElements");
         debugLinkElements.extendsFrom(implementation);
         debugLinkElements.setCanBeResolved(false);
         debugLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, linkUsage);
@@ -160,14 +160,14 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
             }
         });
 
-        final Configuration debugRuntimeElements = configurations.create("debugRuntimeElements");
+        final Configuration debugRuntimeElements = configurations.maybeCreate("debugRuntimeElements");
         debugRuntimeElements.extendsFrom(implementation);
         debugRuntimeElements.setCanBeResolved(false);
         debugRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
         debugRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, true);
         debugRuntimeElements.getOutgoing().artifact(linkDebug.getBinaryFile());
 
-        final Configuration releaseLinkElements = configurations.create("releaseLinkElements");
+        final Configuration releaseLinkElements = configurations.maybeCreate("releaseLinkElements");
         releaseLinkElements.extendsFrom(implementation);
         releaseLinkElements.setCanBeResolved(false);
         releaseLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, linkUsage);
@@ -180,7 +180,7 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
             }
         });
 
-        final Configuration releaseRuntimeElements = configurations.create("releaseRuntimeElements");
+        final Configuration releaseRuntimeElements = configurations.maybeCreate("releaseRuntimeElements");
         releaseRuntimeElements.extendsFrom(implementation);
         releaseRuntimeElements.setCanBeResolved(false);
         releaseRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
@@ -45,19 +45,19 @@ public class DefaultSwiftBinary implements SwiftBinary {
         Names names = Names.of(name);
 
         // TODO - reduce duplication with C++ binary
-        Configuration importPathConfig = configurations.create(names.withPrefix("swiftImport"));
+        Configuration importPathConfig = configurations.maybeCreate(names.withPrefix("swiftImport"));
         importPathConfig.extendsFrom(implementation);
         importPathConfig.setCanBeConsumed(false);
         importPathConfig.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));
         importPathConfig.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
 
-        Configuration nativeLink = configurations.create(names.withPrefix("nativeLink"));
+        Configuration nativeLink = configurations.maybeCreate(names.withPrefix("nativeLink"));
         nativeLink.extendsFrom(implementation);
         nativeLink.setCanBeConsumed(false);
         nativeLink.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_LINK));
         nativeLink.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
 
-        Configuration nativeRuntime = configurations.create(names.withPrefix("nativeRuntime"));
+        Configuration nativeRuntime = configurations.maybeCreate(names.withPrefix("nativeRuntime"));
         nativeRuntime.extendsFrom(implementation);
         nativeRuntime.setCanBeConsumed(false);
         nativeRuntime.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME));

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
@@ -42,7 +42,7 @@ public abstract class DefaultSwiftComponent extends DefaultNativeComponent imple
         module = providerFactory.property(String.class);
 
         names = Names.of(name);
-        implementation = configurations.create(names.withSuffix("implementation"));
+        implementation = configurations.maybeCreate(names.withSuffix("implementation"));
         implementation.setCanBeConsumed(false);
         implementation.setCanBeResolved(false);
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftLibrary.java
@@ -37,7 +37,7 @@ public class DefaultSwiftLibrary extends DefaultSwiftComponent implements SwiftL
         debug = objectFactory.newInstance(DefaultSwiftSharedLibrary.class, name + "Debug", objectFactory, getModule(), true, getSwiftSource(), configurations, getImplementationDependencies());
         release = objectFactory.newInstance(DefaultSwiftSharedLibrary.class, name + "Release", objectFactory, getModule(), false, getSwiftSource(), configurations, getImplementationDependencies());
 
-        api = configurations.create(getNames().withSuffix("api"));
+        api = configurations.maybeCreate(getNames().withSuffix("api"));
         api.setCanBeConsumed(false);
         api.setCanBeResolved(false);
         getImplementationDependencies().extendsFrom(api);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
@@ -104,14 +104,14 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
         Configuration implementation = library.getImplementationDependencies();
         Configuration api = library.getApiDependencies();
 
-        Configuration debugApiElements = configurations.create("debugSwiftApiElements");
+        Configuration debugApiElements = configurations.maybeCreate("debugSwiftApiElements");
         debugApiElements.extendsFrom(api);
         debugApiElements.setCanBeResolved(false);
         debugApiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));
         debugApiElements.getAttributes().attribute(CppBinary.DEBUGGABLE_ATTRIBUTE, true);
         debugApiElements.getOutgoing().artifact(compileDebug.getObjectFileDir());
 
-        Configuration debugLinkElements = configurations.create("debugLinkElements");
+        Configuration debugLinkElements = configurations.maybeCreate("debugLinkElements");
         debugLinkElements.extendsFrom(implementation);
         debugLinkElements.setCanBeResolved(false);
         debugLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_LINK));
@@ -119,7 +119,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
         debugLinkElements.getAttributes().attribute(CppBinary.DEBUGGABLE_ATTRIBUTE, true);
         debugLinkElements.getOutgoing().artifact(linkDebug.getBinaryFile());
 
-        Configuration debugRuntimeElements = configurations.create("debugRuntimeElements");
+        Configuration debugRuntimeElements = configurations.maybeCreate("debugRuntimeElements");
         debugRuntimeElements.extendsFrom(implementation);
         debugRuntimeElements.setCanBeResolved(false);
         debugRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME));
@@ -127,14 +127,14 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
         // TODO - should distinguish between link-time and runtime files
         debugRuntimeElements.getOutgoing().artifact(linkDebug.getBinaryFile());
 
-        Configuration releaseApiElements = configurations.create("releaseSwiftApiElements");
+        Configuration releaseApiElements = configurations.maybeCreate("releaseSwiftApiElements");
         releaseApiElements.extendsFrom(api);
         releaseApiElements.setCanBeResolved(false);
         releaseApiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));
         releaseApiElements.getAttributes().attribute(CppBinary.DEBUGGABLE_ATTRIBUTE, false);
         releaseApiElements.getOutgoing().artifact(compileRelease.getObjectFileDir());
 
-        Configuration releaseLinkElements = configurations.create("releaseLinkElements");
+        Configuration releaseLinkElements = configurations.maybeCreate("releaseLinkElements");
         releaseLinkElements.extendsFrom(implementation);
         releaseLinkElements.setCanBeResolved(false);
         releaseLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_LINK));
@@ -142,7 +142,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
         // TODO - should distinguish between link-time and runtime files
         releaseLinkElements.getOutgoing().artifact(linkRelease.getBinaryFile());
 
-        Configuration releaseRuntimeElements = configurations.create("releaseRuntimeElements");
+        Configuration releaseRuntimeElements = configurations.maybeCreate("releaseRuntimeElements");
         releaseRuntimeElements.extendsFrom(implementation);
         releaseRuntimeElements.setCanBeResolved(false);
         releaseRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME));

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
@@ -37,7 +37,7 @@ class DefaultCppComponentTest extends Specification {
     DefaultCppComponent component
 
     def setup() {
-        _ * configurations.create("implementation") >> implementation
+        _ * configurations.maybeCreate("implementation") >> implementation
         component = new TestComponent("main", fileOperations, providerFactory, configurations)
     }
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
@@ -36,8 +36,8 @@ class DefaultCppLibraryTest extends Specification {
     DefaultCppLibrary library
 
     def setup() {
-        _ * configurations.create("api") >> api
-        _ * configurations.create(_) >> Stub(TestConfiguration)
+        _ * configurations.maybeCreate("api") >> api
+        _ * configurations.maybeCreate(_) >> Stub(TestConfiguration)
         library = new DefaultCppLibrary("main", TestUtil.objectFactory(), fileOperations, providerFactory, configurations)
     }
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
@@ -32,9 +32,9 @@ class DefaultSwiftBinaryTest extends Specification {
     DefaultSwiftBinary binary
 
     def setup() {
-        _ * configurations.create("swiftImportDebug") >> compile
-        _ * configurations.create("nativeLinkDebug") >> link
-        _ * configurations.create("nativeRuntimeDebug") >> runtime
+        _ * configurations.maybeCreate("swiftImportDebug") >> compile
+        _ * configurations.maybeCreate("nativeLinkDebug") >> link
+        _ * configurations.maybeCreate("nativeRuntimeDebug") >> runtime
 
         binary = new DefaultSwiftBinary("mainDebug", TestUtil.objectFactory(), Stub(Provider), true, Stub(FileCollection),  configurations, implementation)
     }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftComponentTest.groovy
@@ -37,7 +37,7 @@ class DefaultSwiftComponentTest extends Specification {
     DefaultSwiftComponent component
 
     def setup() {
-        _ * configurations.create("implementation") >> implementation
+        _ * configurations.maybeCreate("implementation") >> implementation
         component = new TestComponent("main", fileOperations, providerFactory, configurations)
     }
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
@@ -31,8 +31,8 @@ class DefaultSwiftLibraryTest extends Specification {
     DefaultSwiftLibrary library
 
     def setup() {
-        _ * configurations.create("api") >> api
-        _ * configurations.create(_) >> Stub(TestConfiguration)
+        _ * configurations.maybeCreate("api") >> api
+        _ * configurations.maybeCreate(_) >> Stub(TestConfiguration)
         library = new DefaultSwiftLibrary("main", TestUtil.objectFactory(), Stub(FileOperations), Stub(ProviderFactory), configurations)
     }
 


### PR DESCRIPTION
So that their application don't fail the build at configuration time
if a configuration with the same name happen to already exist.
