### PR TITLE
Make CompileOptions.sourcepath work with daemon executer

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
@@ -29,7 +30,6 @@ import org.codehaus.groovy.tools.javac.JavaAwareCompilationUnit;
 import org.codehaus.groovy.tools.javac.JavaCompiler;
 import org.codehaus.groovy.tools.javac.JavaCompilerFactory;
 import org.gradle.api.GradleException;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.classloading.GroovySystemLoader;
 import org.gradle.api.internal.classloading.GroovySystemLoaderFactory;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
@@ -147,11 +147,12 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
                         } else {
                             // When annotation processing isn't required, it's better to add the Groovy stubs as part of the source path.
                             // This allows compilations to complete faster, because only the Groovy stubs that are needed by the java source are compiled.
-                            FileCollection sourcepath = new SimpleFileCollection(stubDir);
+                            ImmutableList.Builder<File> sourcepathBuilder = ImmutableList.builder();
+                            sourcepathBuilder.add(stubDir);
                             if (spec.getCompileOptions().getSourcepath() != null) {
-                                sourcepath = spec.getCompileOptions().getSourcepath().plus(sourcepath);
+                                sourcepathBuilder.addAll(spec.getCompileOptions().getSourcepath());
                             }
-                            spec.getCompileOptions().setSourcepath(sourcepath);
+                            spec.getCompileOptions().setSourcepath(sourcepathBuilder.build());
                         }
 
                         spec.setSource(spec.getSource().filter(new Spec<File>() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -19,16 +19,17 @@ package org.gradle.api.internal.tasks.compile;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.internal.Factory;
 import org.gradle.util.DeprecationLogger;
+import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -174,11 +175,11 @@ public class JavaCompilerArgumentsBuilder {
             args.add("-g:none");
         }
 
-        FileCollection sourcepath = compileOptions.getSourcepath();
+        Collection<File> sourcepath = compileOptions.getSourcepath();
         String userProvidedSourcepath = extractSourcepathFrom(compilerArgs, false);
         if (allowEmptySourcePath || sourcepath != null && !sourcepath.isEmpty() || !userProvidedSourcepath.isEmpty()) {
             args.add("-sourcepath");
-            args.add(sourcepath == null ? userProvidedSourcepath : Joiner.on(File.pathSeparator).skipNulls().join(sourcepath.getAsPath(), userProvidedSourcepath.isEmpty() ? null : userProvidedSourcepath));
+            args.add(sourcepath == null ? userProvidedSourcepath : Joiner.on(File.pathSeparator).skipNulls().join(GUtil.asPath(sourcepath), userProvidedSourcepath.isEmpty() ? null : userProvidedSourcepath));
         }
 
         if (spec.getSourceCompatibility() == null || JavaVersion.toVersion(spec.getSourceCompatibility()).compareTo(JavaVersion.VERSION_1_6) >= 0) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompileOptions.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.compile.CompileOptions;
@@ -30,7 +31,7 @@ import java.io.Serializable;
 import java.util.List;
 
 public class MinimalJavaCompileOptions implements Serializable {
-    private FileCollection sourcepath;
+    private List<File> sourcepath;
     private List<String> compilerArgs;
     private String encoding;
     private String bootClasspath;
@@ -46,7 +47,8 @@ public class MinimalJavaCompileOptions implements Serializable {
     private File annotationProcessorGeneratedSourcesDirectory;
 
     public MinimalJavaCompileOptions(final CompileOptions compileOptions) {
-        this.sourcepath = compileOptions.getSourcepath();
+        FileCollection sourcepath = compileOptions.getSourcepath();
+        this.sourcepath = sourcepath == null ? null : ImmutableList.copyOf(sourcepath.getFiles());
         this.compilerArgs = Lists.newArrayList(compileOptions.getCompilerArgs());
         this.encoding = compileOptions.getEncoding();
         this.bootClasspath = DeprecationLogger.whileDisabled(new Factory<String>() {
@@ -69,11 +71,11 @@ public class MinimalJavaCompileOptions implements Serializable {
         this.annotationProcessorGeneratedSourcesDirectory = compileOptions.getAnnotationProcessorGeneratedSourcesDirectory();
     }
 
-    public FileCollection getSourcepath() {
+    public List<File> getSourcepath() {
         return sourcepath;
     }
 
-    public void setSourcepath(FileCollection sourcepath) {
+    public void setSourcepath(List<File> sourcepath) {
         this.sourcepath = sourcepath;
     }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.file.collections.SimpleFileCollection
 import org.gradle.api.internal.provider.DefaultProviderFactory
 import org.gradle.api.tasks.compile.CompileOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.GUtil
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -338,9 +339,9 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
     def "generates -sourcepath option"() {
         def file1 = new File("/lib/lib1.jar")
         def file2 = new File("/lib/lib2.jar")
-        def fc = new SimpleFileCollection(file1, file2)
+        def fc = [file1, file2]
         spec.compileOptions.sourcepath = fc
-        def expected = ["-g", "-sourcepath", fc.asPath, "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
+        def expected = ["-g", "-sourcepath", GUtil.asPath(fc), "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
 
         expect:
         builder.build() == expected
@@ -351,11 +352,11 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         given:
         def file1 = new File('/libs/lib1.jar')
         def file2 = new File('/libs/lib2.jar')
-        def fc = new SimpleFileCollection(file1, file2)
+        def fc = [file1, file2]
         def userProvidedPath = ['/libs/lib3.jar', '/libs/lib4.jar'].join(File.pathSeparator)
         spec.compileOptions.sourcepath = fc
         spec.compileOptions.compilerArgs = ['-sourcepath', userProvidedPath]
-        def expected = ["-g", "-sourcepath", [fc.asPath, userProvidedPath].join(File.pathSeparator), "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
+        def expected = ["-g", "-sourcepath", [GUtil.asPath(fc), userProvidedPath].join(File.pathSeparator), "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
 
         expect:
         builder.build() == expected


### PR DESCRIPTION
Fixes #3098. Added a test for `-bootclasspath` to also work with the daemon.