### PR TITLE
Move the vcsWorkingDirs to .gradle instead of build

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/AbstractVcsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/AbstractVcsIntegrationTest.groovy
@@ -47,6 +47,6 @@ abstract class AbstractVcsIntegrationTest extends AbstractIntegrationSpec {
 
     TestFile checkoutDir(String repoName, String versionId, String repoId) {
         def hashedRepo = HashUtil.createCompactMD5(repoId)
-        file("build/vcsWorkingDirs/${hashedRepo}/${versionId}/${repoName}")
+        file(".gradle/vcsWorkingDirs/${hashedRepo}/${versionId}/${repoName}")
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -108,7 +108,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
         ProjectInternal rootProject = projectRegistry.getRootProject();
         File baseWorkingDir = null;
         if (rootProject!=null) {
-            baseWorkingDir = new File(rootProject.getBuildDir(), "vcsWorkingDirs");
+            baseWorkingDir = new File(rootProject.getRootDir(), ".gradle/vcsWorkingDirs");
         }
         return baseWorkingDir;
     }


### PR DESCRIPTION
They are still relative to the root project's root directory. But,
now, when a clean task is running in parallel with dependency
resolution for some other task, they won't interfere with each other.

Fixes gradle/gradle-native#207
