### PR TITLE
Add {small|medium|big}CppLibrary performance tests

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/tasks/CppProjectGeneratorTask.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/tasks/CppProjectGeneratorTask.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.performance.generator.tasks
+
+import org.gradle.testing.performance.generator.TestProject
+
+class CppProjectGeneratorTask extends AbstractProjectGeneratorTask {
+    @Override
+    void generateProjectSource(File projectDir, TestProject testProject, Map args) {
+        testProject.sourceFiles.times { s ->
+            Map classArgs = args + [functionName: "lib${s + 1}"]
+            generateWithTemplate(projectDir, "src/main/cpp/${classArgs.functionName}.cpp", 'src.cpp', classArgs)
+            generateWithTemplate(projectDir, "src/main/public/${classArgs.functionName}.h", 'src.h', classArgs)
+        }
+    }
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
@@ -41,11 +41,14 @@ class NativeBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject    | maxMemory    | iterations
-        "smallNative"  | '256m'       | 40
-        "mediumNative" | '256m'       | null
-        "bigNative"    | '1g'         | null
-        "multiNative"  | '256m'       | null
+        testProject        | maxMemory    | iterations
+        "smallNative"      | '256m'       | 40
+        "mediumNative"     | '256m'       | null
+        "bigNative"        | '1g'         | null
+        "multiNative"      | '256m'       | null
+        "smallCppLibrary"  | '256m'       | 40
+        "mediumCppLibrary" | '256m'       | null
+        "bigCppLibrary"    | '256m'       | null
     }
 
     def "clean assemble on manyProjectsNative"() {

--- a/subprojects/performance/src/templates/cpp-project/build.gradle
+++ b/subprojects/performance/src/templates/cpp-project/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'cpp-library'
+}

--- a/subprojects/performance/src/templates/cpp-source/src.cpp
+++ b/subprojects/performance/src/templates/cpp-source/src.cpp
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+<% functionCount.times { %>
+int CPP_${functionName}_${it + 1} () {
+  printf("Hello world!");
+  return 0;
+}
+<% } %>

--- a/subprojects/performance/src/templates/cpp-source/src.h
+++ b/subprojects/performance/src/templates/cpp-source/src.h
@@ -1,0 +1,5 @@
+#pragma once
+
+<% functionCount.times { %>
+int CPP_${functionName}_${it + 1} ();
+<% } %>

--- a/subprojects/performance/src/templates/cpp-source/src.h
+++ b/subprojects/performance/src/templates/cpp-source/src.h
@@ -1,5 +1,6 @@
-#pragma once
-
+#ifndef PROJECT_HEADER_${functionName}_H
+#define PROJECT_HEADER_${functionName}_H
 <% functionCount.times { %>
 int CPP_${functionName}_${it + 1} ();
 <% } %>
+#endif // PROJECT_HEADER_${functionName}_H

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.testing.performance.generator.tasks.CppProjectGeneratorTask
 import org.gradle.testing.performance.generator.tasks.JavaExecProjectGeneratorTask
 import org.gradle.testing.performance.generator.tasks.JvmProjectGeneratorTask
 import org.gradle.testing.performance.generator.tasks.KtsProjectGeneratorTask
@@ -80,7 +81,7 @@ task ktsManyProjects(type: KtsProjectGeneratorTask) {
 task ktsSmall(type: KtsProjectGeneratorTask) {
 }
 
-// === Native ===
+// === Native Software Model ===
 task smallNative(type: NativeProjectGeneratorTask) {
     projects = 1
     sourceFiles = 20
@@ -216,6 +217,35 @@ task nativeDependentsDeep(type: NativeProjectWithDepsGeneratorTask) {
     generateDeepHierarchy = true
 }
 
+// === Native Current Model Plugins ===
+task smallCppLibrary(type: CppProjectGeneratorTask) {
+    projects = 1
+    sourceFiles = 20
+    templateArgs = [
+        functionCount: 1
+    ]
+    subProjectTemplates = ['cpp-source', 'cpp-project']
+}
+
+task mediumCppLibrary(type: CppProjectGeneratorTask) {
+    projects = 1
+    sourceFiles = 100
+    templateArgs = [
+        functionCount: 20
+    ]
+    subProjectTemplates = ['cpp-source', 'cpp-project']
+}
+
+task bigCppLibrary(type: CppProjectGeneratorTask) {
+    projects = 1
+    sourceFiles = 500
+    templateArgs = [
+        functionCount: 50
+    ]
+    subProjectTemplates = ['cpp-source', 'cpp-project']
+}
+
+// === Android ===
 task k9AndroidBuild(type: RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-k-9.git'
     branch = 'gradle'


### PR DESCRIPTION
This takes care of single-project C++ builds of three varying sizes.

Part of gradle/gradle-native#158
