### PR TITLE
Bump Gosu plugin version to fix API break; remove @Ignore

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.smoketests
 
 import org.gradle.util.ports.ReleasingPortAllocator
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Issue
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -266,15 +265,14 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
         runner('integrationTest').build()
     }
 
-    @Ignore("Initialization of CompileOptions fails due to API change")
     def 'gosu plugin'() { // Requires JDK 8 or later
         given:
         buildFile << """
             plugins {
-                id "org.gosu-lang.gosu" version "0.3.0"
+                id 'org.gosu-lang.gosu' version '0.3.5'
             }
 
-            apply plugin: "org.gosu-lang.gosu"
+            apply plugin: 'org.gosu-lang.gosu'
 
             ${mavenCentralRepository()}
 


### PR DESCRIPTION
### Context
@bmuschko was kind enough to let me know about a pending API break related to CompileOptions [here](https://github.com/gosu-lang/gradle-gosu-plugin/issues/34); I fixed and re-released and this PR simply bumps the version of the Gosu plugin executed by the smoke test. Thanks guys!

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
