### PR TITLE
Locate settings scripts according to available scripting languages

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/CachingServiceLocator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/CachingServiceLocator.java
@@ -27,6 +27,7 @@ public class CachingServiceLocator implements ServiceLocator {
     private final Map<Class<?>, DefaultServiceLocator.ServiceFactory<?>> serviceFactories = new HashMap<Class<?>, DefaultServiceLocator.ServiceFactory<?>>();
     private final Map<Class<?>, Object> services = new HashMap<Class<?>, Object>();
     private final Map<Class<?>, List<?>> allServices = new HashMap<Class<?>, List<?>>();
+    private final Map<Class<?>, List<?>> allServicesLenient = new HashMap<Class<?>, List<?>>();
 
     public static CachingServiceLocator of(ServiceLocator other) {
         return new CachingServiceLocator(other);
@@ -64,6 +65,16 @@ public class CachingServiceLocator implements ServiceLocator {
         List<T> all = delegate.getAll(serviceType);
         allServices.put(serviceType, all);
         return all;
+    }
+
+    @Override
+    public synchronized <T> List<T> getAllLenient(Class<T> serviceType) {
+        if (allServicesLenient.containsKey(serviceType)) {
+            return Cast.uncheckedCast(allServicesLenient.get(serviceType));
+        }
+        List<T> allLenient = delegate.getAllLenient(serviceType);
+        allServicesLenient.put(serviceType, allLenient);
+        return allLenient;
     }
 
     @Override

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/CachingServiceLocator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/CachingServiceLocator.java
@@ -27,7 +27,6 @@ public class CachingServiceLocator implements ServiceLocator {
     private final Map<Class<?>, DefaultServiceLocator.ServiceFactory<?>> serviceFactories = new HashMap<Class<?>, DefaultServiceLocator.ServiceFactory<?>>();
     private final Map<Class<?>, Object> services = new HashMap<Class<?>, Object>();
     private final Map<Class<?>, List<?>> allServices = new HashMap<Class<?>, List<?>>();
-    private final Map<Class<?>, List<?>> allServicesLenient = new HashMap<Class<?>, List<?>>();
 
     public static CachingServiceLocator of(ServiceLocator other) {
         return new CachingServiceLocator(other);
@@ -65,16 +64,6 @@ public class CachingServiceLocator implements ServiceLocator {
         List<T> all = delegate.getAll(serviceType);
         allServices.put(serviceType, all);
         return all;
-    }
-
-    @Override
-    public synchronized <T> List<T> getAllLenient(Class<T> serviceType) {
-        if (allServicesLenient.containsKey(serviceType)) {
-            return Cast.uncheckedCast(allServicesLenient.get(serviceType));
-        }
-        List<T> allLenient = delegate.getAllLenient(serviceType);
-        allServicesLenient.put(serviceType, allLenient);
-        return allLenient;
     }
 
     @Override

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceLocator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceLocator.java
@@ -15,9 +15,11 @@
  */
 package org.gradle.internal.service;
 
+import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.DirectInstantiator;
 
+import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,13 +49,10 @@ public class DefaultServiceLocator implements ServiceLocator {
 
     @Override
     public <T> List<T> getAll(Class<T> serviceType) throws UnknownServiceException {
-        List<T> services = new ArrayList<T>();
         List<ServiceFactory<T>> factories = findFactoriesForServiceType(serviceType);
+        ArrayList<T> services = new ArrayList<T>();
         for (ServiceFactory<T> factory : factories) {
-            T service = factory.create();
-            if (service != null) {
-                services.add(service);
-            }
+            services.add(factory.create());
         }
         return services;
     }
@@ -171,6 +170,7 @@ public class DefaultServiceLocator implements ServiceLocator {
             return implementationClass;
         }
 
+        @Nonnull
         public T create() {
             return newInstance();
         }
@@ -178,7 +178,7 @@ public class DefaultServiceLocator implements ServiceLocator {
         public T newInstance(Object... params) {
             try {
                 return DirectInstantiator.instantiate(implementationClass, params);
-            } catch (Throwable t) {
+            } catch (ObjectInstantiationException t) {
                 throw new RuntimeException(String.format("Could not create an implementation of service '%s'.", serviceType.getName()), t);
             }
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceLocator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceLocator.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.service;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public interface ServiceLocator {
@@ -22,7 +23,10 @@ public interface ServiceLocator {
 
     <T> List<T> getAll(Class<T> serviceType) throws UnknownServiceException;
 
+    <T> List<T> getAllLenient(Class<T> serviceType);
+
     <T> DefaultServiceLocator.ServiceFactory<T> getFactory(Class<T> serviceType) throws UnknownServiceException;
 
+    @Nullable
     <T> DefaultServiceLocator.ServiceFactory<T> findFactory(Class<T> serviceType);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceLocator.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceLocator.java
@@ -23,8 +23,6 @@ public interface ServiceLocator {
 
     <T> List<T> getAll(Class<T> serviceType) throws UnknownServiceException;
 
-    <T> List<T> getAllLenient(Class<T> serviceType);
-
     <T> DefaultServiceLocator.ServiceFactory<T> getFactory(Class<T> serviceType) throws UnknownServiceException;
 
     @Nullable

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
@@ -68,7 +68,7 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
 
         and:
         failure.assertHasDescription("A problem occurred evaluating settings 'buildA'.")
-        failure.assertHasCause("Included build 'b1' must have a 'settings.gradle' file.")
+        failure.assertHasCause("Included build 'b1' must have a 'settings.*' file.")
     }
 
     def "reports failure when included build is itself a composite"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
@@ -68,7 +68,7 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
 
         and:
         failure.assertHasDescription("A problem occurred evaluating settings 'buildA'.")
-        failure.assertHasCause("Included build 'b1' must have a 'settings.*' file.")
+        failure.assertHasCause("Included build 'b1' must have a settings file.")
     }
 
     def "reports failure when included build is itself a composite"() {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.TaskReferenceResolver;
 import org.gradle.initialization.BuildIdentity;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
@@ -41,8 +42,8 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
     }
 
     private static class CompositeBuildTreeScopeServices {
-        public IncludedBuildRegistry createIncludedBuildRegistry(CompositeBuildContext context, DefaultProjectPathRegistry projectRegistry, Instantiator instantiator, StartParameter startParameter, WorkerLeaseService workerLeaseService, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-            IncludedBuildFactory includedBuildFactory = new DefaultIncludedBuildFactory(instantiator, startParameter, workerLeaseService);
+        public IncludedBuildRegistry createIncludedBuildRegistry(CompositeBuildContext context, DefaultProjectPathRegistry projectRegistry, Instantiator instantiator, StartParameter startParameter, WorkerLeaseService workerLeaseService, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ScriptFileResolver scriptFileResolver) {
+            IncludedBuildFactory includedBuildFactory = new DefaultIncludedBuildFactory(instantiator, startParameter, workerLeaseService, scriptFileResolver);
             IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder = new IncludedBuildDependencySubstitutionsBuilder(context, moduleIdentifierFactory);
             return new DefaultIncludedBuildRegistry(includedBuildFactory, projectRegistry, dependencySubstitutionsBuilder, context);
         }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -25,7 +25,6 @@ import org.gradle.initialization.BuildIdentity;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
@@ -43,8 +42,8 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
     }
 
     private static class CompositeBuildTreeScopeServices {
-        public IncludedBuildRegistry createIncludedBuildRegistry(CompositeBuildContext context, DefaultProjectPathRegistry projectRegistry, Instantiator instantiator, StartParameter startParameter, WorkerLeaseService workerLeaseService, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ScriptFileResolver scriptFileResolver) {
-            IncludedBuildFactory includedBuildFactory = new DefaultIncludedBuildFactory(instantiator, startParameter, workerLeaseService, new BuildLayoutFactory(scriptFileResolver));
+        public IncludedBuildRegistry createIncludedBuildRegistry(CompositeBuildContext context, DefaultProjectPathRegistry projectRegistry, Instantiator instantiator, StartParameter startParameter, WorkerLeaseService workerLeaseService, ImmutableModuleIdentifierFactory moduleIdentifierFactory, BuildLayoutFactory buildLayoutFactory) {
+            IncludedBuildFactory includedBuildFactory = new DefaultIncludedBuildFactory(instantiator, startParameter, workerLeaseService, buildLayoutFactory);
             IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder = new IncludedBuildDependencySubstitutionsBuilder(context, moduleIdentifierFactory);
             return new DefaultIncludedBuildRegistry(includedBuildFactory, projectRegistry, dependencySubstitutionsBuilder, context);
         }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.api.internal.initialization.ScriptClassPathInitializer;
 import org.gradle.api.internal.tasks.TaskReferenceResolver;
 import org.gradle.initialization.BuildIdentity;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scripts.ScriptFileResolver;
@@ -43,7 +44,7 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
 
     private static class CompositeBuildTreeScopeServices {
         public IncludedBuildRegistry createIncludedBuildRegistry(CompositeBuildContext context, DefaultProjectPathRegistry projectRegistry, Instantiator instantiator, StartParameter startParameter, WorkerLeaseService workerLeaseService, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ScriptFileResolver scriptFileResolver) {
-            IncludedBuildFactory includedBuildFactory = new DefaultIncludedBuildFactory(instantiator, startParameter, workerLeaseService, scriptFileResolver);
+            IncludedBuildFactory includedBuildFactory = new DefaultIncludedBuildFactory(instantiator, startParameter, workerLeaseService, new BuildLayoutFactory(scriptFileResolver));
             IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder = new IncludedBuildDependencySubstitutionsBuilder(context, moduleIdentifierFactory);
             return new DefaultIncludedBuildRegistry(includedBuildFactory, projectRegistry, dependencySubstitutionsBuilder, context);
         }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
@@ -19,7 +19,6 @@ package org.gradle.composite.internal;
 import org.gradle.StartParameter;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.initialization.IncludedBuild;
-import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
@@ -55,7 +54,7 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory {
     private void validateIncludedBuild(IncludedBuild includedBuild, SettingsInternal settings) {
         File settingsFile = buildLayoutFactory.findExistingSettingsFileIn(settings.getSettingsDir());
         if (settingsFile == null) {
-            throw new InvalidUserDataException(String.format("Included build '%s' must have a '%s.*' file.", includedBuild.getName(), Settings.DEFAULT_SETTINGS_FILE_BASENAME));
+            throw new InvalidUserDataException(String.format("Included build '%s' must have a settings file.", includedBuild.getName()));
         }
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
@@ -25,6 +25,7 @@ import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.work.WorkerLeaseService;
 
 import java.io.File;
@@ -33,11 +34,13 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory {
     private final Instantiator instantiator;
     private final StartParameter startParameter;
     private final WorkerLeaseService workerLeaseService;
+    private final ScriptFileResolver scriptFileResolver;
 
-    public DefaultIncludedBuildFactory(Instantiator instantiator, StartParameter startParameter, WorkerLeaseService workerLeaseService) {
+    public DefaultIncludedBuildFactory(Instantiator instantiator, StartParameter startParameter, WorkerLeaseService workerLeaseService, ScriptFileResolver scriptFileResolver) {
         this.instantiator = instantiator;
         this.startParameter = startParameter;
         this.workerLeaseService = workerLeaseService;
+        this.scriptFileResolver = scriptFileResolver;
     }
 
     private void validateBuildDirectory(File dir) {
@@ -50,8 +53,9 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory {
     }
 
     private void validateIncludedBuild(IncludedBuild includedBuild, SettingsInternal settings) {
-        if (!new File(settings.getSettingsDir(), Settings.DEFAULT_SETTINGS_FILE).exists()) {
-            throw new InvalidUserDataException(String.format("Included build '%s' must have a '%s' file.", includedBuild.getName(), Settings.DEFAULT_SETTINGS_FILE));
+        File defaultSettingsFile = new File(settings.getSettingsDir(), Settings.DEFAULT_SETTINGS_FILE);
+        if (!defaultSettingsFile.exists() && scriptFileResolver.resolveScriptFile(settings.getSettingsDir(), Settings.DEFAULT_SETTINGS_FILE_BASENAME) == null) {
+            throw new InvalidUserDataException(String.format("Included build '%s' must have a '%s.*' file.", includedBuild.getName(), Settings.DEFAULT_SETTINGS_FILE_BASENAME));
         }
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
@@ -23,9 +23,9 @@ import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.work.WorkerLeaseService;
 
 import java.io.File;
@@ -34,13 +34,13 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory {
     private final Instantiator instantiator;
     private final StartParameter startParameter;
     private final WorkerLeaseService workerLeaseService;
-    private final ScriptFileResolver scriptFileResolver;
+    private final BuildLayoutFactory buildLayoutFactory;
 
-    public DefaultIncludedBuildFactory(Instantiator instantiator, StartParameter startParameter, WorkerLeaseService workerLeaseService, ScriptFileResolver scriptFileResolver) {
+    public DefaultIncludedBuildFactory(Instantiator instantiator, StartParameter startParameter, WorkerLeaseService workerLeaseService, BuildLayoutFactory buildLayoutFactory) {
         this.instantiator = instantiator;
         this.startParameter = startParameter;
         this.workerLeaseService = workerLeaseService;
-        this.scriptFileResolver = scriptFileResolver;
+        this.buildLayoutFactory = buildLayoutFactory;
     }
 
     private void validateBuildDirectory(File dir) {
@@ -53,8 +53,8 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory {
     }
 
     private void validateIncludedBuild(IncludedBuild includedBuild, SettingsInternal settings) {
-        File defaultSettingsFile = new File(settings.getSettingsDir(), Settings.DEFAULT_SETTINGS_FILE);
-        if (!defaultSettingsFile.exists() && scriptFileResolver.resolveScriptFile(settings.getSettingsDir(), Settings.DEFAULT_SETTINGS_FILE_BASENAME) == null) {
+        File settingsFile = buildLayoutFactory.findExistingSettingsFileIn(settings.getSettingsDir());
+        if (settingsFile == null) {
             throw new InvalidUserDataException(String.format("Included build '%s' must have a '%s.*' file.", includedBuild.getName(), Settings.DEFAULT_SETTINGS_FILE_BASENAME));
         }
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -71,13 +71,6 @@ import java.io.File;
 @HasInternalProtocol
 public interface Settings extends PluginAware {
     /**
-     * <p>The default file base name for the settings file.</p>
-     *
-     * @since 4.0
-     */
-    String DEFAULT_SETTINGS_FILE_BASENAME = "settings";
-
-    /**
      * <p>The default name for the settings file.</p>
      */
     String DEFAULT_SETTINGS_FILE = "settings.gradle";

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -71,6 +71,13 @@ import java.io.File;
 @HasInternalProtocol
 public interface Settings extends PluginAware {
     /**
+     * <p>The default file base name for the settings file.</p>
+     *
+     * @since 4.0
+     */
+    String DEFAULT_SETTINGS_FILE_BASENAME = "settings";
+
+    /**
      * <p>The default name for the settings file.</p>
      */
     String DEFAULT_SETTINGS_FILE = "settings.gradle";

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildLayoutParametersBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildLayoutParametersBuildOptions.java
@@ -17,7 +17,6 @@
 package org.gradle.initialization;
 
 import org.gradle.api.Transformer;
-import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.file.BasicFileResolver;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
@@ -75,7 +74,7 @@ public class BuildLayoutParametersBuildOptions {
 
     public static class NoSearchUpwardsOption extends EnabledOnlyBooleanBuildOption<BuildLayoutParameters> {
         public NoSearchUpwardsOption() {
-            super(null, CommandLineOptionConfiguration.create("no-search-upward", "u", "Don't search in parent folders for a " + Settings.DEFAULT_SETTINGS_FILE + " file."));
+            super(null, CommandLineOptionConfiguration.create("no-search-upward", "u", "Don't search in parent folders for a settings file."));
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.initialization.layout;
 
+import org.gradle.api.Nullable;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.resources.MissingResourceException;
 import org.gradle.internal.FileUtils;
@@ -59,6 +60,14 @@ public class BuildLayoutFactory {
         return getLayoutFor(currentDir, searchUpwards ? null : currentDir.getParentFile());
     }
 
+    @Nullable
+    public File findExistingSettingsFileIn(File directory) {
+        File defaultSettingsFile = new File(directory, Settings.DEFAULT_SETTINGS_FILE);
+        return defaultSettingsFile.isFile()
+            ? defaultSettingsFile
+            : scriptFileResolver.resolveScriptFile(directory, Settings.DEFAULT_SETTINGS_FILE_BASENAME);
+    }
+
     BuildLayout getLayoutFor(File currentDir, File stopAt) {
         File settingsFile = findExistingSettingsFileIn(currentDir);
         if (settingsFile != null) {
@@ -78,13 +87,5 @@ public class BuildLayoutFactory {
 
     private BuildLayout layout(File rootDir, File settingsDir, File settingsFile) {
         return new BuildLayout(rootDir, settingsDir, FileUtils.canonicalize(settingsFile));
-    }
-
-    private File findExistingSettingsFileIn(File directory) {
-        File defaultSettingsFile = new File(directory, Settings.DEFAULT_SETTINGS_FILE);
-        if (defaultSettingsFile.isFile()) {
-            return defaultSettingsFile;
-        }
-        return scriptFileResolver.resolveScriptFile(directory, Settings.DEFAULT_SETTINGS_FILE_BASENAME);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -27,6 +27,8 @@ import java.io.File;
 @UsedByScanPlugin
 public class BuildLayoutFactory {
 
+    private static final String DEFAULT_SETTINGS_FILE_BASENAME = "settings";
+
     private final ScriptFileResolver scriptFileResolver;
 
     public BuildLayoutFactory(ScriptFileResolver scriptFileResolver) {
@@ -65,7 +67,7 @@ public class BuildLayoutFactory {
         File defaultSettingsFile = new File(directory, Settings.DEFAULT_SETTINGS_FILE);
         return defaultSettingsFile.isFile()
             ? defaultSettingsFile
-            : scriptFileResolver.resolveScriptFile(directory, Settings.DEFAULT_SETTINGS_FILE_BASENAME);
+            : scriptFileResolver.resolveScriptFile(directory, DEFAULT_SETTINGS_FILE_BASENAME);
     }
 
     BuildLayout getLayoutFor(File currentDir, File stopAt) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -28,6 +28,12 @@ import java.io.File;
 @UsedByScanPlugin
 public class BuildLayoutFactory {
 
+    /**
+     * Constructs a {@code BuildLayoutFactory} that searches for script files
+     * matching all available scripting languages.
+     *
+     * @see ScriptFileResolver
+     */
     public static BuildLayoutFactory forDefaultScriptingLanguages() {
         return new BuildLayoutFactory();
     }
@@ -42,8 +48,10 @@ public class BuildLayoutFactory {
 
     /**
      * This constructor should not be used in Gradle.
-     * It's sole purpose is backwards compatibility with the build scan plugin.
-     * {@link #BuildLayoutFactory(ScriptFileResolver)} should be used instead.
+     * Its sole purpose is backwards compatibility with the build scan plugin.
+     *
+     * {@code BuildLayoutFactory} should be either consumed as a service or instantiated via
+     * {@link #forDefaultScriptingLanguages()}.
      */
     @Deprecated
     public BuildLayoutFactory() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -19,11 +19,19 @@ import org.gradle.api.initialization.Settings;
 import org.gradle.api.resources.MissingResourceException;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.scan.UsedByScanPlugin;
+import org.gradle.internal.scripts.ScriptFileResolver;
 
 import java.io.File;
 
 @UsedByScanPlugin
 public class BuildLayoutFactory {
+
+    private final ScriptFileResolver scriptFileResolver;
+
+    public BuildLayoutFactory(ScriptFileResolver scriptFileResolver) {
+        this.scriptFileResolver = scriptFileResolver;
+    }
+
     /**
      * Determines the layout of the build, given a current directory and some other configuration.
      */
@@ -52,24 +60,31 @@ public class BuildLayoutFactory {
     }
 
     BuildLayout getLayoutFor(File currentDir, File stopAt) {
-        File settingsFile = new File(currentDir, Settings.DEFAULT_SETTINGS_FILE);
-        if (settingsFile.isFile()) {
+        File settingsFile = findExistingSettingsFileIn(currentDir);
+        if (settingsFile != null) {
             return layout(currentDir, currentDir, settingsFile);
         }
         for (File candidate = currentDir.getParentFile(); candidate != null && !candidate.equals(stopAt); candidate = candidate.getParentFile()) {
-            settingsFile = new File(candidate, Settings.DEFAULT_SETTINGS_FILE);
-            if (settingsFile.isFile()) {
-                return layout(candidate, candidate, settingsFile);
+            settingsFile = findExistingSettingsFileIn(candidate);
+            if (settingsFile == null) {
+                settingsFile = findExistingSettingsFileIn(new File(candidate, "master"));
             }
-            settingsFile = new File(candidate, "master/" + Settings.DEFAULT_SETTINGS_FILE);
-            if (settingsFile.isFile()) {
+            if (settingsFile != null) {
                 return layout(candidate, settingsFile.getParentFile(), settingsFile);
             }
         }
-        return layout(currentDir, currentDir, settingsFile);
+        return layout(currentDir, currentDir, new File(currentDir, Settings.DEFAULT_SETTINGS_FILE));
     }
 
     private BuildLayout layout(File rootDir, File settingsDir, File settingsFile) {
         return new BuildLayout(rootDir, settingsDir, FileUtils.canonicalize(settingsFile));
+    }
+
+    private File findExistingSettingsFileIn(File directory) {
+        File defaultSettingsFile = new File(directory, Settings.DEFAULT_SETTINGS_FILE);
+        if (defaultSettingsFile.isFile()) {
+            return defaultSettingsFile;
+        }
+        return scriptFileResolver.resolveScriptFile(directory, Settings.DEFAULT_SETTINGS_FILE_BASENAME);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.initialization.layout;
 
-import org.gradle.api.Nullable;
+import javax.annotation.Nullable;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.resources.MissingResourceException;
 import org.gradle.internal.FileUtils;
@@ -58,19 +58,23 @@ public class BuildLayoutFactory {
      */
     public BuildLayout getLayoutFor(BuildLayoutConfiguration configuration) {
         if (configuration.isUseEmptySettings()) {
-            return new BuildLayout(configuration.getCurrentDir(), configuration.getCurrentDir(), null);
+            return buildLayoutFrom(configuration, null);
         }
         File explicitSettingsFile = configuration.getSettingsFile();
         if (explicitSettingsFile != null) {
             if (!explicitSettingsFile.isFile()) {
                 throw new MissingResourceException(explicitSettingsFile.toURI(), String.format("Could not read settings file '%s' as it does not exist.", explicitSettingsFile.getAbsolutePath()));
             }
-            return new BuildLayout(configuration.getCurrentDir(), configuration.getCurrentDir(), explicitSettingsFile);
+            return buildLayoutFrom(configuration, explicitSettingsFile);
         }
 
         File currentDir = configuration.getCurrentDir();
         boolean searchUpwards = configuration.isSearchUpwards();
         return getLayoutFor(currentDir, searchUpwards ? null : currentDir.getParentFile());
+    }
+
+    private BuildLayout buildLayoutFrom(BuildLayoutConfiguration configuration, File settingsFile) {
+        return new BuildLayout(configuration.getCurrentDir(), configuration.getCurrentDir(), settingsFile);
     }
 
     @Nullable
@@ -84,7 +88,7 @@ public class BuildLayoutFactory {
     BuildLayout getLayoutFor(File currentDir, File stopAt) {
         File settingsFile = findExistingSettingsFileIn(currentDir);
         if (settingsFile != null) {
-            return layout(currentDir, currentDir, settingsFile);
+            return layout(currentDir, settingsFile);
         }
         for (File candidate = currentDir.getParentFile(); candidate != null && !candidate.equals(stopAt); candidate = candidate.getParentFile()) {
             settingsFile = findExistingSettingsFileIn(candidate);
@@ -92,13 +96,13 @@ public class BuildLayoutFactory {
                 settingsFile = findExistingSettingsFileIn(new File(candidate, "master"));
             }
             if (settingsFile != null) {
-                return layout(candidate, settingsFile.getParentFile(), settingsFile);
+                return layout(candidate, settingsFile);
             }
         }
-        return layout(currentDir, currentDir, new File(currentDir, Settings.DEFAULT_SETTINGS_FILE));
+        return layout(currentDir, new File(currentDir, Settings.DEFAULT_SETTINGS_FILE));
     }
 
-    private BuildLayout layout(File rootDir, File settingsDir, File settingsFile) {
-        return new BuildLayout(rootDir, settingsDir, FileUtils.canonicalize(settingsFile));
+    private BuildLayout layout(File rootDir, File settingsFile) {
+        return new BuildLayout(rootDir, settingsFile.getParentFile(), FileUtils.canonicalize(settingsFile));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -28,6 +28,10 @@ import java.io.File;
 @UsedByScanPlugin
 public class BuildLayoutFactory {
 
+    public static BuildLayoutFactory forDefaultScriptingLanguages() {
+        return new BuildLayoutFactory();
+    }
+
     private static final String DEFAULT_SETTINGS_FILE_BASENAME = "settings";
 
     private final ScriptFileResolver scriptFileResolver;

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -20,6 +20,7 @@ import org.gradle.api.initialization.Settings;
 import org.gradle.api.resources.MissingResourceException;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.scan.UsedByScanPlugin;
+import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.internal.scripts.ScriptFileResolver;
 
 import java.io.File;
@@ -33,6 +34,16 @@ public class BuildLayoutFactory {
 
     public BuildLayoutFactory(ScriptFileResolver scriptFileResolver) {
         this.scriptFileResolver = scriptFileResolver;
+    }
+
+    /**
+     * This constructor should not be used in Gradle.
+     * It's sole purpose is backwards compatibility with the build scan plugin.
+     * {@link #BuildLayoutFactory(ScriptFileResolver)} should be used instead.
+     */
+    @Deprecated
+    public BuildLayoutFactory() {
+        this(DefaultScriptFileResolver.forDefaultScriptingLanguages());
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
@@ -28,6 +28,10 @@ public class DefaultScriptFileResolver implements ScriptFileResolver {
         return new DefaultScriptFileResolver(Collections.<String>emptyList());
     }
 
+    public static ScriptFileResolver forDefaultScriptingLanguages() {
+        return forScriptingLanguages(new DefaultScriptingLanguages());
+    }
+
     public static ScriptFileResolver forScriptingLanguages(Iterable<ScriptingLanguage> scriptingLanguages) {
         List<String> extensions = new ArrayList<String>();
         for (ScriptingLanguage scriptingLanguage : scriptingLanguages) {

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
@@ -29,7 +29,11 @@ public class DefaultScriptFileResolver implements ScriptFileResolver {
     }
 
     public static ScriptFileResolver forDefaultScriptingLanguages() {
-        return forScriptingLanguages(new DefaultScriptingLanguages());
+        return forScriptingLanguages(DefaultScriptingLanguages.create());
+    }
+
+    public static ScriptFileResolver forLenientScriptingLanguages() {
+        return forScriptingLanguages(DefaultScriptingLanguages.createLenient());
     }
 
     public static ScriptFileResolver forScriptingLanguages(Iterable<ScriptingLanguage> scriptingLanguages) {

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
@@ -32,10 +32,6 @@ public class DefaultScriptFileResolver implements ScriptFileResolver {
         return forScriptingLanguages(DefaultScriptingLanguages.create());
     }
 
-    public static ScriptFileResolver forLenientScriptingLanguages() {
-        return forScriptingLanguages(DefaultScriptingLanguages.createLenient());
-    }
-
     public static ScriptFileResolver forScriptingLanguages(Iterable<ScriptingLanguage> scriptingLanguages) {
         List<String> extensions = new ArrayList<String>();
         for (ScriptingLanguage scriptingLanguage : scriptingLanguages) {

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
@@ -19,9 +19,14 @@ import org.gradle.scripts.ScriptingLanguage;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class DefaultScriptFileResolver implements ScriptFileResolver {
+
+    public static ScriptFileResolver empty() {
+        return new DefaultScriptFileResolver(Collections.<String>emptyList());
+    }
 
     public static ScriptFileResolver forScriptingLanguages(Iterable<ScriptingLanguage> scriptingLanguages) {
         List<String> extensions = new ArrayList<String>();

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptingLanguages.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptingLanguages.java
@@ -26,10 +26,6 @@ public class DefaultScriptingLanguages implements ScriptingLanguages {
         return new DefaultScriptingLanguages(new DefaultServiceLocator(DefaultScriptingLanguages.class.getClassLoader()).getAll(ScriptingLanguage.class));
     }
 
-    static ScriptingLanguages createLenient() {
-        return new DefaultScriptingLanguages(new DefaultServiceLocator(DefaultScriptingLanguages.class.getClassLoader()).getAllLenient(ScriptingLanguage.class));
-    }
-
     private final Iterable<ScriptingLanguage> scriptingLanguages;
 
     private DefaultScriptingLanguages(Iterable<ScriptingLanguage> scriptingLanguages) {

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptingLanguages.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/DefaultScriptingLanguages.java
@@ -22,10 +22,18 @@ import java.util.Iterator;
 
 public class DefaultScriptingLanguages implements ScriptingLanguages {
 
+    public static ScriptingLanguages create() {
+        return new DefaultScriptingLanguages(new DefaultServiceLocator(DefaultScriptingLanguages.class.getClassLoader()).getAll(ScriptingLanguage.class));
+    }
+
+    static ScriptingLanguages createLenient() {
+        return new DefaultScriptingLanguages(new DefaultServiceLocator(DefaultScriptingLanguages.class.getClassLoader()).getAllLenient(ScriptingLanguage.class));
+    }
+
     private final Iterable<ScriptingLanguage> scriptingLanguages;
 
-    public DefaultScriptingLanguages() {
-        scriptingLanguages = new DefaultServiceLocator(getClass().getClassLoader()).getAll(ScriptingLanguage.class);
+    private DefaultScriptingLanguages(Iterable<ScriptingLanguage> scriptingLanguages) {
+        this.scriptingLanguages = scriptingLanguages;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -148,6 +148,7 @@ import org.gradle.internal.operations.logging.DefaultBuildOperationLoggerFactory
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.TextResourceLoader;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.scripts.ScriptingLanguages;
 import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceRegistry;
@@ -313,14 +314,14 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             get(AutoAppliedPluginHandler.class));
     }
 
-    protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, NestedBuildFactory nestedBuildFactory,
+    protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, ScriptFileResolver scriptFileResolver, NestedBuildFactory nestedBuildFactory,
                                                                 ClassLoaderScopeRegistry classLoaderScopeRegistry, CacheRepository cacheRepository,
                                                                 BuildOperationExecutor buildOperationExecutor,
                                                                 CachedClasspathTransformer cachedClasspathTransformer,
                                                                 CachingServiceLocator cachingServiceLocator,
                                                                 IncludedBuildRegistry includedBuildRegistry) {
         return new DefaultSettingsLoaderFactory(
-            new DefaultSettingsFinder(new BuildLayoutFactory()),
+            new DefaultSettingsFinder(new BuildLayoutFactory(scriptFileResolver)),
             settingsProcessor,
             new BuildSourceBuilder(
                 nestedBuildFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -148,7 +148,6 @@ import org.gradle.internal.operations.logging.DefaultBuildOperationLoggerFactory
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.TextResourceLoader;
-import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.scripts.ScriptingLanguages;
 import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceRegistry;
@@ -314,14 +313,14 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             get(AutoAppliedPluginHandler.class));
     }
 
-    protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, ScriptFileResolver scriptFileResolver, NestedBuildFactory nestedBuildFactory,
+    protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, BuildLayoutFactory buildLayoutFactory, NestedBuildFactory nestedBuildFactory,
                                                                 ClassLoaderScopeRegistry classLoaderScopeRegistry, CacheRepository cacheRepository,
                                                                 BuildOperationExecutor buildOperationExecutor,
                                                                 CachedClasspathTransformer cachedClasspathTransformer,
                                                                 CachingServiceLocator cachingServiceLocator,
                                                                 IncludedBuildRegistry includedBuildRegistry) {
         return new DefaultSettingsLoaderFactory(
-            new DefaultSettingsFinder(new BuildLayoutFactory(scriptFileResolver)),
+            new DefaultSettingsFinder(buildLayoutFactory),
             settingsProcessor,
             new BuildSourceBuilder(
                 nestedBuildFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -84,6 +84,7 @@ import org.gradle.internal.scopeids.PersistentScopeIdLoader;
 import org.gradle.internal.scopeids.ScopeIdsServices;
 import org.gradle.internal.scopeids.id.UserScopeId;
 import org.gradle.internal.scopeids.id.WorkspaceScopeId;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.serialize.HashCodeSerializer;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
@@ -174,8 +175,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new BuildOperationCrossProjectConfigurator(buildOperationExecutor);
     }
 
-    ProjectCacheDir createCacheLayout(StartParameter startParameter) {
-        BuildLayout buildLayout = new BuildLayoutFactory().getLayoutFor(new BuildLayoutConfiguration(startParameter));
+    ProjectCacheDir createCacheLayout(StartParameter startParameter, ScriptFileResolver scriptFileResolver) {
+        BuildLayout buildLayout = new BuildLayoutFactory(scriptFileResolver).getLayoutFor(new BuildLayoutConfiguration(startParameter));
         File cacheDir = startParameter.getProjectCacheDir() != null ? startParameter.getProjectCacheDir() : new File(buildLayout.getRootDirectory(), ".gradle");
         return new ProjectCacheDir(cacheDir);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -84,7 +84,6 @@ import org.gradle.internal.scopeids.PersistentScopeIdLoader;
 import org.gradle.internal.scopeids.ScopeIdsServices;
 import org.gradle.internal.scopeids.id.UserScopeId;
 import org.gradle.internal.scopeids.id.WorkspaceScopeId;
-import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.serialize.HashCodeSerializer;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
@@ -175,8 +174,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new BuildOperationCrossProjectConfigurator(buildOperationExecutor);
     }
 
-    ProjectCacheDir createCacheLayout(StartParameter startParameter, ScriptFileResolver scriptFileResolver) {
-        BuildLayout buildLayout = new BuildLayoutFactory(scriptFileResolver).getLayoutFor(new BuildLayoutConfiguration(startParameter));
+    ProjectCacheDir createCacheLayout(StartParameter startParameter, BuildLayoutFactory buildLayoutFactory) {
+        BuildLayout buildLayout = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
         File cacheDir = startParameter.getProjectCacheDir() != null ? startParameter.getProjectCacheDir() : new File(buildLayout.getRootDirectory(), ".gradle");
         return new ProjectCacheDir(cacheDir);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -66,6 +66,7 @@ import org.gradle.initialization.FlatClassLoaderRegistry;
 import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.initialization.JdkToolsInitializer;
 import org.gradle.initialization.LegacyTypesSupport;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.DefaultClassLoaderFactory;
 import org.gradle.internal.classpath.ClassPath;
@@ -325,6 +326,10 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
 
     ScriptFileResolver createScriptFileResolver(ScriptingLanguages scriptingLanguages) {
         return DefaultScriptFileResolver.forScriptingLanguages(scriptingLanguages);
+    }
+
+    BuildLayoutFactory createBuildLayoutFactory(ScriptFileResolver scriptFileResolver) {
+        return new BuildLayoutFactory(scriptFileResolver);
     }
 
     TaskInputsListener createTaskInputsListener() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -320,7 +320,7 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
     }
 
     ScriptingLanguages createScriptingLanguages() {
-        return new DefaultScriptingLanguages();
+        return DefaultScriptingLanguages.create();
     }
 
     ScriptFileResolver createScriptFileResolver(ScriptingLanguages scriptingLanguages) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -18,39 +18,96 @@ package org.gradle.initialization.layout
 import org.gradle.StartParameter
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.groovy.scripts.TextResourceScriptSource
+import org.gradle.internal.scripts.DefaultScriptFileResolver
+import org.gradle.internal.scripts.ScriptFileResolver
+import org.gradle.scripts.ScriptingLanguage
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class BuildLayoutFactoryTest extends Specification {
+
+    // This pair of constants is used to unroll most of the tests in this class
+    static final def SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS =
+        [[], ['.gradle.kts'], ['.gradle.kts'], ['.gradle.kts', '.tic'], ['.gradle.kts', '.tac'], ['.tic', '.gradle.kts'], ['.tac', '.gradle.kts']]
+    static final def SETTINGS_FILENAME_PERMUTATIONS =
+        ['settings.gradle', 'settings.gradle', 'settings.gradle.kts', 'settings.gradle', 'settings.gradle.kts', 'settings.gradle', 'settings.gradle.kts']
+
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
-    final BuildLayoutFactory locator = new BuildLayoutFactory()
 
-    def "returns current directory when it contains a settings file"() {
+    @Unroll
+    def "returns current directory when it contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.testDirectory
-        def settingsFile = currentDir.createFile("settings.gradle")
+        def settingsFile = currentDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "looks for sibling directory called 'master' that it contains a settings file"() {
+    @Unroll
+    def "returns current directory when no ancestor directory contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and: "temporary tree created out of the Gradle build tree"
+        def tmpDir = File.createTempFile("stop-", "-at").canonicalFile
+        def stopAt = new File(tmpDir, 'stopAt')
+        def currentDir = new File(new File(stopAt, "intermediate"), 'current')
+        currentDir.mkdirs()
+
+        expect:
+        def layout = locator.getLayoutFor(currentDir, true)
+        layout.rootDirectory == currentDir
+        layout.settingsDir == currentDir
+        isEmpty(layout.settingsScriptSource)
+
+        cleanup: "temporary tree"
+        tmpDir.deleteDir()
+
+        where:
+        extensions << [[], ['.gradle.kts']]
+    }
+
+    @Unroll
+    def "looks for sibling directory called 'master' that it contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("current")
         def masterDir = tmpDir.createDir("master")
-        def settingsFile = masterDir.createFile("settings.gradle")
+        def settingsFile = masterDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == masterDir.parentFile
         layout.settingsDir == masterDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "searches ancestors for a directory called 'master' that contains a settings file"() {
+    @Unroll
+    def "searches ancestors for a directory called 'master' that contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
         def masterDir = tmpDir.createDir("master")
         def settingsFile = masterDir.createFile("settings.gradle")
@@ -60,73 +117,127 @@ class BuildLayoutFactoryTest extends Specification {
         layout.rootDirectory == masterDir.parentFile
         layout.settingsDir == masterDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "ignores 'master' directory when it does not contain a settings file"() {
+    @Unroll
+    def "ignores 'master' directory when it does not contain a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
         def masterDir = tmpDir.createDir("sub/master")
         masterDir.createFile("gradle.properties")
-        def settingsFile = tmpDir.createFile("settings.gradle")
+        def settingsFile = tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == tmpDir.testDirectory
         layout.settingsDir == tmpDir.testDirectory
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "returns closest ancestor directory that contains a settings file"() {
+    @Unroll
+    def "returns closest ancestor directory that contains a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
         def subDir = tmpDir.createDir("sub")
-        def settingsFile = subDir.createFile("settings.gradle")
-        tmpDir.createFile("settings.gradle")
+        def settingsFile = subDir.createFile(settingsFilename)
+        tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == subDir
         layout.settingsDir == subDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "prefers the current directory as root directory"() {
+    @Unroll
+    def "prefers the current directory as root directory with a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
-        def settingsFile = currentDir.createFile("settings.gradle")
-        tmpDir.createFile("sub/settings.gradle")
-        tmpDir.createFile("settings.gradle")
+        def settingsFile = currentDir.createFile(settingsFilename)
+        tmpDir.createFile("sub/$settingsFilename")
+        tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "prefers the 'master' directory over ancestor directory"() {
+    @Unroll
+    def "prefers the 'master' directory over ancestor directory with a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
         def masterDir = tmpDir.createDir("sub/master")
-        def settingsFile = masterDir.createFile("settings.gradle")
-        tmpDir.createFile("settings.gradle")
+        def settingsFile = masterDir.createFile(settingsFilename)
+        tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, true)
         layout.rootDirectory == masterDir.parentFile
         layout.settingsDir == masterDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "returns start directory when search upwards is disabled"() {
+    @Unroll
+    def "returns start directory when search upwards is disabled with a #settingsFilename file when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
-        tmpDir.createFile("sub/settings.gradle")
-        tmpDir.createFile("settings.gradle")
+        tmpDir.createFile("sub/$settingsFilename")
+        tmpDir.createFile(settingsFilename)
 
         expect:
         def layout = locator.getLayoutFor(currentDir, false)
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         isEmpty(layout.settingsScriptSource)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
     }
 
-    def "returns current directory when no settings or wrapper properties files found"() {
+    @Unroll
+    def "returns current directory when no settings or wrapper properties files found when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("sub/current")
 
         expect:
@@ -134,13 +245,21 @@ class BuildLayoutFactoryTest extends Specification {
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         isEmpty(layout.settingsScriptSource)
+
+        where:
+        extensions << [[], ['.gradle.kts']]
     }
 
-    def "can override build layout by specifying the settings file"() {
+    @Unroll
+    def "can override build layout by specifying the settings file to #overrideSettingsFilename with existing #settingsFilename when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("current")
-        currentDir.createFile("settings.gradle")
+        currentDir.createFile(settingsFilename)
         def rootDir = tmpDir.createDir("root")
-        def settingsFile = rootDir.createFile("some-settings.gradle")
+        def settingsFile = rootDir.createFile(overrideSettingsFilename)
         def startParameter = new StartParameter()
         startParameter.currentDir = currentDir
         startParameter.settingsFile = settingsFile
@@ -151,11 +270,21 @@ class BuildLayoutFactoryTest extends Specification {
         layout.rootDirectory == rootDir
         layout.settingsDir == rootDir
         refersTo(layout.settingsScriptSource, settingsFile)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        overrideSettingsFilename << SETTINGS_FILENAME_PERMUTATIONS.collect { "some-$it" }
     }
 
-    def "can override build layout by specifying an empty settings script"() {
+    @Unroll
+    def "can override build layout by specifying an empty settings script with existing #settingsFilename when script languages #extensions"() {
+        given:
+        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+
+        and:
         def currentDir = tmpDir.createDir("current")
-        currentDir.createFile("settings.gradle")
+        currentDir.createFile(settingsFilename)
         def startParameter = new StartParameter()
         startParameter.currentDir = currentDir
         startParameter.useEmptySettings()
@@ -166,6 +295,16 @@ class BuildLayoutFactoryTest extends Specification {
         layout.rootDirectory == currentDir
         layout.settingsDir == currentDir
         isEmpty(layout.settingsScriptSource)
+
+        where:
+        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
+        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+    }
+
+    ScriptFileResolver scriptFileResolver(List<String> extensions) {
+        DefaultScriptFileResolver.forScriptingLanguages(extensions.collect { extension ->
+            Stub(ScriptingLanguage) { getExtension() >> extension }
+        })
     }
 
     void refersTo(ScriptSource scriptSource, File file) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -29,10 +29,17 @@ import spock.lang.Unroll
 class BuildLayoutFactoryTest extends Specification {
 
     // This pair of constants is used to unroll most of the tests in this class
-    static final def SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS =
-        [[], ['.gradle.kts'], ['.gradle.kts'], ['.gradle.kts', '.tic'], ['.gradle.kts', '.tac'], ['.tic', '.gradle.kts'], ['.tac', '.gradle.kts']]
-    static final def SETTINGS_FILENAME_PERMUTATIONS =
-        ['settings.gradle', 'settings.gradle', 'settings.gradle.kts', 'settings.gradle', 'settings.gradle.kts', 'settings.gradle', 'settings.gradle.kts']
+    //
+    // | settings file name   | scripting language extensions |
+    static final def TEST_CASES = [
+        ['settings.gradle',     []],
+        ['settings.gradle',     ['.gradle.kts']],
+        ['settings.gradle.kts', ['.gradle.kts']],
+        ['settings.gradle',     ['.gradle.kts', '.tic']],
+        ['settings.gradle.kts', ['.gradle.kts', '.tac']],
+        ['settings.gradle',     ['.tic', '.gradle.kts']],
+        ['settings.gradle.kts', ['.tac', '.gradle.kts']],
+    ]
 
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
@@ -53,8 +60,7 @@ class BuildLayoutFactoryTest extends Specification {
         refersTo(layout.settingsScriptSource, settingsFile)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        [settingsFilename, extensions] << TEST_CASES
     }
 
     @Unroll
@@ -98,8 +104,7 @@ class BuildLayoutFactoryTest extends Specification {
         refersTo(layout.settingsScriptSource, settingsFile)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        [settingsFilename, extensions] << TEST_CASES
     }
 
     @Unroll
@@ -119,8 +124,7 @@ class BuildLayoutFactoryTest extends Specification {
         refersTo(layout.settingsScriptSource, settingsFile)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        [settingsFilename, extensions] << TEST_CASES
     }
 
     @Unroll
@@ -141,8 +145,7 @@ class BuildLayoutFactoryTest extends Specification {
         refersTo(layout.settingsScriptSource, settingsFile)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        [settingsFilename, extensions] << TEST_CASES
     }
 
     @Unroll
@@ -163,8 +166,7 @@ class BuildLayoutFactoryTest extends Specification {
         refersTo(layout.settingsScriptSource, settingsFile)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        [settingsFilename, extensions] << TEST_CASES
     }
 
     @Unroll
@@ -185,8 +187,7 @@ class BuildLayoutFactoryTest extends Specification {
         refersTo(layout.settingsScriptSource, settingsFile)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        [settingsFilename, extensions] << TEST_CASES
     }
 
     @Unroll
@@ -207,8 +208,7 @@ class BuildLayoutFactoryTest extends Specification {
         refersTo(layout.settingsScriptSource, settingsFile)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        [settingsFilename, extensions] << TEST_CASES
     }
 
     @Unroll
@@ -228,8 +228,7 @@ class BuildLayoutFactoryTest extends Specification {
         isEmpty(layout.settingsScriptSource)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        [settingsFilename, extensions] << TEST_CASES
     }
 
     @Unroll
@@ -272,9 +271,8 @@ class BuildLayoutFactoryTest extends Specification {
         refersTo(layout.settingsScriptSource, settingsFile)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
-        overrideSettingsFilename << SETTINGS_FILENAME_PERMUTATIONS.collect { "some-$it" }
+        [settingsFilename, extensions] << TEST_CASES
+        overrideSettingsFilename = "some-$settingsFilename"
     }
 
     @Unroll
@@ -297,8 +295,7 @@ class BuildLayoutFactoryTest extends Specification {
         isEmpty(layout.settingsScriptSource)
 
         where:
-        extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
-        settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+        [settingsFilename, extensions] << TEST_CASES
     }
 
     BuildLayoutFactory buildLayoutFactoryFor(List<String> extensions) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -40,7 +40,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "returns current directory when it contains a #settingsFilename file when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.testDirectory
@@ -60,7 +60,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "returns current directory when no ancestor directory contains a #settingsFilename file when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and: "temporary tree created out of the Gradle build tree"
         def tmpDir = File.createTempFile("stop-", "-at").canonicalFile
@@ -84,7 +84,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "looks for sibling directory called 'master' that it contains a #settingsFilename file when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("current")
@@ -105,7 +105,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "searches ancestors for a directory called 'master' that contains a #settingsFilename file when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("sub/current")
@@ -126,7 +126,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "ignores 'master' directory when it does not contain a #settingsFilename file when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("sub/current")
@@ -148,7 +148,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "returns closest ancestor directory that contains a #settingsFilename file when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("sub/current")
@@ -170,7 +170,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "prefers the current directory as root directory with a #settingsFilename file when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("sub/current")
@@ -192,7 +192,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "prefers the 'master' directory over ancestor directory with a #settingsFilename file when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("sub/current")
@@ -214,7 +214,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "returns start directory when search upwards is disabled with a #settingsFilename file when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("sub/current")
@@ -235,7 +235,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "returns current directory when no settings or wrapper properties files found when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("sub/current")
@@ -253,7 +253,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "can override build layout by specifying the settings file to #overrideSettingsFilename with existing #settingsFilename when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("current")
@@ -280,7 +280,7 @@ class BuildLayoutFactoryTest extends Specification {
     @Unroll
     def "can override build layout by specifying an empty settings script with existing #settingsFilename when script languages #extensions"() {
         given:
-        def locator = new BuildLayoutFactory(scriptFileResolver(extensions))
+        def locator = buildLayoutFactoryFor(extensions)
 
         and:
         def currentDir = tmpDir.createDir("current")
@@ -299,6 +299,10 @@ class BuildLayoutFactoryTest extends Specification {
         where:
         extensions << SCRIPT_LANGUAGE_EXTENSION_PERMUTATIONS
         settingsFilename << SETTINGS_FILENAME_PERMUTATIONS
+    }
+
+    BuildLayoutFactory buildLayoutFactoryFor(List<String> extensions) {
+        new BuildLayoutFactory(scriptFileResolver(extensions))
     }
 
     ScriptFileResolver scriptFileResolver(List<String> extensions) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -37,6 +37,7 @@ import org.gradle.initialization.DefaultBuildRequestContext;
 import org.gradle.initialization.DefaultBuildRequestMetaData;
 import org.gradle.initialization.NoOpBuildEventConsumer;
 import org.gradle.initialization.ReportedException;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.integtests.fixtures.logging.GroupedOutputFixture;
 import org.gradle.internal.Factory;
 import org.gradle.internal.SystemProperties;
@@ -50,7 +51,6 @@ import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
-import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.Main;
 import org.gradle.launcher.cli.ExecuteBuildAction;
 import org.gradle.launcher.cli.Parameters;
@@ -288,8 +288,8 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
         // TODO: Reuse more of CommandlineActionFactory
         CommandLineParser parser = new CommandLineParser();
-        ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forDefaultScriptingLanguages();
-        ParametersConverter parametersConverter = new ParametersConverter(scriptFileResolver);
+        BuildLayoutFactory buildLayoutFactory = new BuildLayoutFactory(DefaultScriptFileResolver.forDefaultScriptingLanguages());
+        ParametersConverter parametersConverter = new ParametersConverter(buildLayoutFactory);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);
         parametersConverter.convert(parser.parse(getAllArgs()), parameters);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -50,7 +50,6 @@ import org.gradle.internal.io.TextStream;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
-import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.launcher.Main;
 import org.gradle.launcher.cli.ExecuteBuildAction;
 import org.gradle.launcher.cli.Parameters;
@@ -288,7 +287,7 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
         // TODO: Reuse more of CommandlineActionFactory
         CommandLineParser parser = new CommandLineParser();
-        BuildLayoutFactory buildLayoutFactory = new BuildLayoutFactory(DefaultScriptFileResolver.forDefaultScriptingLanguages());
+        BuildLayoutFactory buildLayoutFactory = BuildLayoutFactory.forDefaultScriptingLanguages();
         ParametersConverter parametersConverter = new ParametersConverter(buildLayoutFactory);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -50,7 +50,6 @@ import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
-import org.gradle.internal.scripts.DefaultScriptingLanguages;
 import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.Main;
 import org.gradle.launcher.cli.ExecuteBuildAction;
@@ -289,7 +288,7 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
         // TODO: Reuse more of CommandlineActionFactory
         CommandLineParser parser = new CommandLineParser();
-        ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages());
+        ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forDefaultScriptingLanguages();
         ParametersConverter parametersConverter = new ParametersConverter(scriptFileResolver);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -49,6 +49,9 @@ import org.gradle.internal.io.TextStream;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
+import org.gradle.internal.scripts.DefaultScriptFileResolver;
+import org.gradle.internal.scripts.DefaultScriptingLanguages;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.Main;
 import org.gradle.launcher.cli.ExecuteBuildAction;
 import org.gradle.launcher.cli.Parameters;
@@ -286,7 +289,8 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
         // TODO: Reuse more of CommandlineActionFactory
         CommandLineParser parser = new CommandLineParser();
-        ParametersConverter parametersConverter = new ParametersConverter();
+        ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages());
+        ParametersConverter parametersConverter = new ParametersConverter(scriptFileResolver);
         parametersConverter.configure(parser);
         final Parameters parameters = new Parameters(startParameter);
         parametersConverter.convert(parser.parse(getAllArgs()), parameters);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -67,7 +67,7 @@ public class CommandLineActionFactory {
     private static final String HELP = "h";
     private static final String VERSION = "v";
 
-    private final ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forDefaultScriptingLanguages();
+    private final ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forLenientScriptingLanguages();
 
     /**
      * <p>Converts the given command-line arguments to an {@link Action} which performs the action requested by the

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -44,7 +44,6 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
-import org.gradle.internal.scripts.DefaultScriptingLanguages;
 import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.bootstrap.ExecutionListener;
@@ -68,7 +67,7 @@ public class CommandLineActionFactory {
     private static final String HELP = "h";
     private static final String VERSION = "v";
 
-    private final ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages());
+    private final ScriptFileResolver scriptFileResolver = DefaultScriptFileResolver.forDefaultScriptingLanguages();
 
     /**
      * <p>Converts the given command-line arguments to an {@link Action} which performs the action requested by the

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -45,6 +45,8 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
+import org.gradle.internal.scripts.ScriptFileResolver;
+import org.gradle.internal.service.ServiceLookupException;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.bootstrap.ExecutionListener;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
@@ -67,7 +69,7 @@ public class CommandLineActionFactory {
     private static final String HELP = "h";
     private static final String VERSION = "v";
 
-    private final BuildLayoutFactory buildLayoutFactory = new BuildLayoutFactory(DefaultScriptFileResolver.forLenientScriptingLanguages());
+    private final BuildLayoutFactory buildLayoutFactory = new BuildLayoutFactory(lenientScriptFileResolver());
 
     /**
      * <p>Converts the given command-line arguments to an {@link Action} which performs the action requested by the
@@ -111,6 +113,15 @@ public class CommandLineActionFactory {
         out.println();
         parser.printUsage(out);
         out.println();
+    }
+
+    private ScriptFileResolver lenientScriptFileResolver() {
+        try {
+            return DefaultScriptFileResolver.forDefaultScriptingLanguages();
+        } catch (ServiceLookupException e) {
+            // Kotlin ScriptingLanguage provider will fail to load on JVMs < 6
+            return DefaultScriptFileResolver.empty();
+        }
     }
 
     private static class BuiltInActions implements CommandLineAction {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
@@ -19,6 +19,7 @@ package org.gradle.launcher.cli;
 import org.gradle.cli.*;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.LayoutCommandLineConverter;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.cli.converter.DaemonCommandLineConverter;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
@@ -57,10 +58,10 @@ public class ParametersConverter extends AbstractCommandLineConverter<Parameters
         this.propertiesToDaemonParametersConverter = propertiesToDaemonParametersConverter;
     }
 
-    public ParametersConverter() {
+    public ParametersConverter(ScriptFileResolver scriptFileResolver) {
         this(new LayoutCommandLineConverter(),
             new SystemPropertiesCommandLineConverter(),
-            new LayoutToPropertiesConverter(),
+            new LayoutToPropertiesConverter(scriptFileResolver),
             new PropertiesToStartParameterConverter(),
             new DefaultCommandLineConverter(),
             new DaemonCommandLineConverter(),

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/ParametersConverter.java
@@ -16,10 +16,14 @@
 
 package org.gradle.launcher.cli;
 
-import org.gradle.cli.*;
+import org.gradle.cli.AbstractCommandLineConverter;
+import org.gradle.cli.CommandLineArgumentException;
+import org.gradle.cli.CommandLineParser;
+import org.gradle.cli.ParsedCommandLine;
+import org.gradle.cli.SystemPropertiesCommandLineConverter;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.LayoutCommandLineConverter;
-import org.gradle.internal.scripts.ScriptFileResolver;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.launcher.cli.converter.DaemonCommandLineConverter;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
@@ -58,10 +62,10 @@ public class ParametersConverter extends AbstractCommandLineConverter<Parameters
         this.propertiesToDaemonParametersConverter = propertiesToDaemonParametersConverter;
     }
 
-    public ParametersConverter(ScriptFileResolver scriptFileResolver) {
+    public ParametersConverter(BuildLayoutFactory buildLayoutFactory) {
         this(new LayoutCommandLineConverter(),
             new SystemPropertiesCommandLineConverter(),
-            new LayoutToPropertiesConverter(scriptFileResolver),
+            new LayoutToPropertiesConverter(buildLayoutFactory),
             new PropertiesToStartParameterConverter(),
             new DefaultCommandLineConverter(),
             new DaemonCommandLineConverter(),

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -27,6 +27,7 @@ import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
 import org.gradle.util.CollectionUtils;
 
@@ -42,8 +43,10 @@ import java.util.Properties;
 public class LayoutToPropertiesConverter {
 
     private final List<BuildOption<?>> allBuildOptions = new ArrayList<BuildOption<?>>();
+    private final ScriptFileResolver scriptFileResolver;
 
-    public LayoutToPropertiesConverter() {
+    public LayoutToPropertiesConverter(ScriptFileResolver scriptFileResolver) {
+        this.scriptFileResolver = scriptFileResolver;
         allBuildOptions.addAll(BuildLayoutParametersBuildOptions.get());
         allBuildOptions.addAll(StartParameterBuildOptions.get());
         allBuildOptions.addAll(LoggingConfigurationBuildOptions.get());
@@ -73,7 +76,7 @@ public class LayoutToPropertiesConverter {
     }
 
     private void configureFromBuildDir(File currentDir, boolean searchUpwards, Map<String, String> result) {
-        BuildLayoutFactory factory = new BuildLayoutFactory();
+        BuildLayoutFactory factory = new BuildLayoutFactory(scriptFileResolver);
         BuildLayout layout = factory.getLayoutFor(currentDir, searchUpwards);
         maybeConfigureFrom(new File(layout.getRootDirectory(), Project.GRADLE_PROPERTIES), result);
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -27,7 +27,6 @@ import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
-import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
 import org.gradle.util.CollectionUtils;
 
@@ -43,10 +42,10 @@ import java.util.Properties;
 public class LayoutToPropertiesConverter {
 
     private final List<BuildOption<?>> allBuildOptions = new ArrayList<BuildOption<?>>();
-    private final ScriptFileResolver scriptFileResolver;
+    private final BuildLayoutFactory buildLayoutFactory;
 
-    public LayoutToPropertiesConverter(ScriptFileResolver scriptFileResolver) {
-        this.scriptFileResolver = scriptFileResolver;
+    public LayoutToPropertiesConverter(BuildLayoutFactory buildLayoutFactory) {
+        this.buildLayoutFactory = buildLayoutFactory;
         allBuildOptions.addAll(BuildLayoutParametersBuildOptions.get());
         allBuildOptions.addAll(StartParameterBuildOptions.get());
         allBuildOptions.addAll(LoggingConfigurationBuildOptions.get());
@@ -76,8 +75,7 @@ public class LayoutToPropertiesConverter {
     }
 
     private void configureFromBuildDir(File currentDir, boolean searchUpwards, Map<String, String> result) {
-        BuildLayoutFactory factory = new BuildLayoutFactory(scriptFileResolver);
-        BuildLayout layout = factory.getLayoutFor(currentDir, searchUpwards);
+        BuildLayout layout = buildLayoutFactory.getLayoutFor(currentDir, searchUpwards);
         maybeConfigureFrom(new File(layout.getRootDirectory(), Project.GRADLE_PROPERTIES), result);
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
@@ -20,6 +20,7 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
@@ -60,6 +61,7 @@ public class ConnectionScopeServices {
 
     ProviderConnection createProviderConnection(BuildExecuter buildActionExecuter,
                                                 DaemonClientFactory daemonClientFactory,
+                                                ScriptFileResolver scriptFileResolver,
                                                 ServiceRegistry serviceRegistry,
                                                 JvmVersionDetector jvmVersionDetector,
                                                 // This is here to trigger creation of the ShutdownCoordinator. Could do this in a nicer way
@@ -68,6 +70,7 @@ public class ConnectionScopeServices {
         return new ProviderConnection(
                 serviceRegistry,
                 loggingServices,
+                scriptFileResolver,
                 daemonClientFactory,
                 buildActionExecuter,
                 new PayloadSerializer(

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.internal.provider;
 
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.events.OutputEventListener;
@@ -70,7 +71,7 @@ public class ConnectionScopeServices {
         return new ProviderConnection(
                 serviceRegistry,
                 loggingServices,
-                scriptFileResolver,
+                new BuildLayoutFactory(scriptFileResolver),
                 daemonClientFactory,
                 buildActionExecuter,
                 new PayloadSerializer(

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
@@ -21,7 +21,6 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
-import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
@@ -62,7 +61,7 @@ public class ConnectionScopeServices {
 
     ProviderConnection createProviderConnection(BuildExecuter buildActionExecuter,
                                                 DaemonClientFactory daemonClientFactory,
-                                                ScriptFileResolver scriptFileResolver,
+                                                BuildLayoutFactory buildLayoutFactory,
                                                 ServiceRegistry serviceRegistry,
                                                 JvmVersionDetector jvmVersionDetector,
                                                 // This is here to trigger creation of the ShutdownCoordinator. Could do this in a nicer way
@@ -71,7 +70,7 @@ public class ConnectionScopeServices {
         return new ProviderConnection(
                 serviceRegistry,
                 loggingServices,
-                new BuildLayoutFactory(scriptFileResolver),
+                buildLayoutFactory,
                 daemonClientFactory,
                 buildActionExecuter,
                 new PayloadSerializer(

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -31,6 +31,7 @@ import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
@@ -69,14 +70,16 @@ public class ProviderConnection {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProviderConnection.class);
     private final PayloadSerializer payloadSerializer;
     private final LoggingServiceRegistry loggingServices;
+    private final ScriptFileResolver scriptFileResolver;
     private final DaemonClientFactory daemonClientFactory;
     private final BuildActionExecuter<BuildActionParameters> embeddedExecutor;
     private final ServiceRegistry sharedServices;
     private final JvmVersionDetector jvmVersionDetector;
 
-    public ProviderConnection(ServiceRegistry sharedServices, LoggingServiceRegistry loggingServices, DaemonClientFactory daemonClientFactory,
+    public ProviderConnection(ServiceRegistry sharedServices, LoggingServiceRegistry loggingServices, ScriptFileResolver scriptFileResolver, DaemonClientFactory daemonClientFactory,
                               BuildActionExecuter<BuildActionParameters> embeddedExecutor, PayloadSerializer payloadSerializer, JvmVersionDetector jvmVersionDetector) {
         this.loggingServices = loggingServices;
+        this.scriptFileResolver = scriptFileResolver;
         this.daemonClientFactory = daemonClientFactory;
         this.embeddedExecutor = embeddedExecutor;
         this.payloadSerializer = payloadSerializer;
@@ -176,7 +179,7 @@ public class ProviderConnection {
         layout.setProjectDir(operationParameters.getProjectDir());
 
         Map<String, String> properties = new HashMap<String, String>();
-        new LayoutToPropertiesConverter().convert(layout, properties);
+        new LayoutToPropertiesConverter(scriptFileResolver).convert(layout, properties);
 
         DaemonParameters daemonParams = new DaemonParameters(layout);
         new PropertiesToDaemonParametersConverter().convert(properties, daemonParams);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -25,13 +25,13 @@ import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.DefaultBuildRequestContext;
 import org.gradle.initialization.DefaultBuildRequestMetaData;
 import org.gradle.initialization.NoOpBuildEventConsumer;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
-import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
 import org.gradle.launcher.cli.converter.PropertiesToDaemonParametersConverter;
@@ -70,16 +70,16 @@ public class ProviderConnection {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProviderConnection.class);
     private final PayloadSerializer payloadSerializer;
     private final LoggingServiceRegistry loggingServices;
-    private final ScriptFileResolver scriptFileResolver;
+    private final BuildLayoutFactory buildLayoutFactory;
     private final DaemonClientFactory daemonClientFactory;
     private final BuildActionExecuter<BuildActionParameters> embeddedExecutor;
     private final ServiceRegistry sharedServices;
     private final JvmVersionDetector jvmVersionDetector;
 
-    public ProviderConnection(ServiceRegistry sharedServices, LoggingServiceRegistry loggingServices, ScriptFileResolver scriptFileResolver, DaemonClientFactory daemonClientFactory,
+    public ProviderConnection(ServiceRegistry sharedServices, LoggingServiceRegistry loggingServices, BuildLayoutFactory buildLayoutFactory, DaemonClientFactory daemonClientFactory,
                               BuildActionExecuter<BuildActionParameters> embeddedExecutor, PayloadSerializer payloadSerializer, JvmVersionDetector jvmVersionDetector) {
         this.loggingServices = loggingServices;
-        this.scriptFileResolver = scriptFileResolver;
+        this.buildLayoutFactory = buildLayoutFactory;
         this.daemonClientFactory = daemonClientFactory;
         this.embeddedExecutor = embeddedExecutor;
         this.payloadSerializer = payloadSerializer;
@@ -179,7 +179,7 @@ public class ProviderConnection {
         layout.setProjectDir(operationParameters.getProjectDir());
 
         Map<String, String> properties = new HashMap<String, String>();
-        new LayoutToPropertiesConverter(scriptFileResolver).convert(layout, properties);
+        new LayoutToPropertiesConverter(buildLayoutFactory).convert(layout, properties);
 
         DaemonParameters daemonParams = new DaemonParameters(layout);
         new PropertiesToDaemonParametersConverter().convert(properties, daemonParams);

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.launcher.cli.converter
 
 import org.gradle.initialization.BuildLayoutParameters
+import org.gradle.internal.scripts.DefaultScriptFileResolver
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.SetSystemProperties
@@ -27,7 +28,7 @@ class LayoutToPropertiesConverterTest extends Specification {
 
     @Rule SetSystemProperties sysProperties = new SetSystemProperties()
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
-    def converter = new LayoutToPropertiesConverter()
+    def converter = new LayoutToPropertiesConverter(DefaultScriptFileResolver.empty())
     BuildLayoutParameters layout
     Map<String, String> props = new HashMap<String, String>()
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.launcher.cli.converter
 
 import org.gradle.initialization.BuildLayoutParameters
+import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.scripts.DefaultScriptFileResolver
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -28,7 +29,7 @@ class LayoutToPropertiesConverterTest extends Specification {
 
     @Rule SetSystemProperties sysProperties = new SetSystemProperties()
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
-    def converter = new LayoutToPropertiesConverter(DefaultScriptFileResolver.empty())
+    def converter = new LayoutToPropertiesConverter(new BuildLayoutFactory(DefaultScriptFileResolver.empty()))
     BuildLayoutParameters layout
     Map<String, String> props = new HashMap<String, String>()
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
@@ -17,6 +17,7 @@
 package org.gradle.tooling.internal.consumer;
 
 import org.gradle.api.JavaVersion;
+import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
@@ -84,7 +85,7 @@ public class ConnectorServices {
         }
 
         protected DistributionFactory createDistributionFactory(Clock clock) {
-            return new DistributionFactory(clock, DefaultScriptFileResolver.forDefaultScriptingLanguages());
+            return new DistributionFactory(clock, new BuildLayoutFactory(DefaultScriptFileResolver.forDefaultScriptingLanguages()));
         }
 
         protected ToolingImplementationLoader createToolingImplementationLoader() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
@@ -22,7 +22,6 @@ import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
-import org.gradle.internal.scripts.DefaultScriptingLanguages;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
@@ -85,7 +84,7 @@ public class ConnectorServices {
         }
 
         protected DistributionFactory createDistributionFactory(Clock clock) {
-            return new DistributionFactory(clock, DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages()));
+            return new DistributionFactory(clock, DefaultScriptFileResolver.forDefaultScriptingLanguages());
         }
 
         protected ToolingImplementationLoader createToolingImplementationLoader() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
@@ -21,6 +21,8 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
+import org.gradle.internal.scripts.DefaultScriptFileResolver;
+import org.gradle.internal.scripts.DefaultScriptingLanguages;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
@@ -37,6 +39,7 @@ public class ConnectorServices {
         checkJavaVersion();
         return singletonRegistry.getFactory(DefaultGradleConnector.class).create();
     }
+
     public static CancellationTokenSource createCancellationTokenSource() {
         checkJavaVersion();
         return new DefaultCancellationTokenSource();
@@ -82,7 +85,7 @@ public class ConnectorServices {
         }
 
         protected DistributionFactory createDistributionFactory(Clock clock) {
-            return new DistributionFactory(clock);
+            return new DistributionFactory(clock, DefaultScriptFileResolver.forScriptingLanguages(new DefaultScriptingLanguages()));
         }
 
         protected ToolingImplementationLoader createToolingImplementationLoader() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
@@ -22,7 +22,6 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
-import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
@@ -85,7 +84,7 @@ public class ConnectorServices {
         }
 
         protected DistributionFactory createDistributionFactory(Clock clock) {
-            return new DistributionFactory(clock, new BuildLayoutFactory(DefaultScriptFileResolver.forDefaultScriptingLanguages()));
+            return new DistributionFactory(clock, BuildLayoutFactory.forDefaultScriptingLanguages());
         }
 
         protected ToolingImplementationLoader createToolingImplementationLoader() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
@@ -23,6 +23,7 @@ import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.time.Clock;
 import org.gradle.tooling.BuildCancelledException;
 import org.gradle.tooling.GradleConnectionException;
@@ -44,10 +45,12 @@ import static org.gradle.internal.FileUtils.hasExtension;
 
 public class DistributionFactory {
     private final Clock clock;
+    private final ScriptFileResolver scriptFileResolver;
     private File distributionBaseDir;
 
-    public DistributionFactory(Clock clock) {
+    public DistributionFactory(Clock clock, ScriptFileResolver scriptFileResolver) {
         this.clock = clock;
+        this.scriptFileResolver = scriptFileResolver;
     }
 
     public void setDistributionBaseDir(File distributionBaseDir) {
@@ -58,7 +61,7 @@ public class DistributionFactory {
      * Returns the default distribution to use for the specified project.
      */
     public Distribution getDefaultDistribution(File projectDir, boolean searchUpwards) {
-        BuildLayout layout = new BuildLayoutFactory().getLayoutFor(projectDir, searchUpwards);
+        BuildLayout layout = new BuildLayoutFactory(scriptFileResolver).getLayoutFor(projectDir, searchUpwards);
         WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory(layout.getRootDirectory());
         if (wrapper.getDistribution() != null) {
             return new ZippedDistribution(wrapper.getConfiguration(), distributionBaseDir, clock);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
@@ -23,7 +23,6 @@ import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
-import org.gradle.internal.scripts.ScriptFileResolver;
 import org.gradle.internal.time.Clock;
 import org.gradle.tooling.BuildCancelledException;
 import org.gradle.tooling.GradleConnectionException;
@@ -45,12 +44,12 @@ import static org.gradle.internal.FileUtils.hasExtension;
 
 public class DistributionFactory {
     private final Clock clock;
-    private final ScriptFileResolver scriptFileResolver;
+    private final BuildLayoutFactory buildLayoutFactory;
     private File distributionBaseDir;
 
-    public DistributionFactory(Clock clock, ScriptFileResolver scriptFileResolver) {
+    public DistributionFactory(Clock clock, BuildLayoutFactory buildLayoutFactory) {
         this.clock = clock;
-        this.scriptFileResolver = scriptFileResolver;
+        this.buildLayoutFactory = buildLayoutFactory;
     }
 
     public void setDistributionBaseDir(File distributionBaseDir) {
@@ -61,7 +60,7 @@ public class DistributionFactory {
      * Returns the default distribution to use for the specified project.
      */
     public Distribution getDefaultDistribution(File projectDir, boolean searchUpwards) {
-        BuildLayout layout = new BuildLayoutFactory(scriptFileResolver).getLayoutFor(projectDir, searchUpwards);
+        BuildLayout layout = buildLayoutFactory.getLayoutFor(projectDir, searchUpwards);
         WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory(layout.getRootDirectory());
         if (wrapper.getDistribution() != null) {
             return new ZippedDistribution(wrapper.getConfiguration(), distributionBaseDir, clock);
@@ -74,7 +73,7 @@ public class DistributionFactory {
      */
     public Distribution getDistribution(File gradleHomeDir) {
         return new InstalledDistribution(gradleHomeDir, "Gradle installation '" + gradleHomeDir + "'",
-                "Gradle installation directory '" + gradleHomeDir + "'");
+            "Gradle installation directory '" + gradleHomeDir + "'");
     }
 
     /**
@@ -145,7 +144,7 @@ public class DistributionFactory {
         }
 
         private File determineRealUserHomeDir(final File userHomeDir) {
-            if(distributionBaseDir != null) {
+            if (distributionBaseDir != null) {
                 return distributionBaseDir;
             }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.tooling.internal.consumer
 
 import org.gradle.initialization.BuildCancellationToken
+import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.logging.progress.ProgressLogger
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.scripts.DefaultScriptFileResolver
@@ -35,7 +36,7 @@ class DistributionFactoryTest extends Specification {
     final ProgressLoggerFactory progressLoggerFactory = Mock()
     final ProgressLogger progressLogger = Mock()
     final BuildCancellationToken cancellationToken = Mock()
-    final DistributionFactory factory = new DistributionFactory(Time.clock(), DefaultScriptFileResolver.empty())
+    final DistributionFactory factory = new DistributionFactory(Time.clock(), new BuildLayoutFactory(DefaultScriptFileResolver.empty()))
     final InternalBuildProgressListener buildProgressListener = Mock()
 
     def setup() {

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.tooling.internal.consumer
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.internal.logging.progress.ProgressLogger
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.scripts.DefaultScriptFileResolver
 import org.gradle.internal.time.Time
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -34,7 +35,7 @@ class DistributionFactoryTest extends Specification {
     final ProgressLoggerFactory progressLoggerFactory = Mock()
     final ProgressLogger progressLogger = Mock()
     final BuildCancellationToken cancellationToken = Mock()
-    final DistributionFactory factory = new DistributionFactory(Time.clock())
+    final DistributionFactory factory = new DistributionFactory(Time.clock(), DefaultScriptFileResolver.empty())
     final InternalBuildProgressListener buildProgressListener = Mock()
 
     def setup() {


### PR DESCRIPTION
First step for supporting settings scripts written using the Gradle Kotlin DSL, aka. `settings.gradle.kts`.

See https://github.com/gradle/kotlin-dsl/issues/527
