### PR TITLE
Add setTargets to AbstractGccCompatibleToolchain to allow resetting default toolchain targets.

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/GccCompatibleToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/GccCompatibleToolChain.java
@@ -49,16 +49,10 @@ public interface GccCompatibleToolChain extends NativeToolChain {
      */
     void target(String platformName, Action<? super GccPlatformToolChain> action);
 
-
     /**
-     * Override the current platform configuration with a single target platform specified by name
+     * Override the current platform configuration with target platforms specified by name
      */
-    void setTargets(String platformName);
-
-    /**
-     * Override the current platform configuration with a single target platform specified by name, with additional configuration action
-     */
-    void setTargets(String platformName, Action<? super GccPlatformToolChain> action);
+    void setTargets(String... platformNames);
 
     /**
      * Adds an action that can fine-tune the tool configuration for each platform supported by this tool chain.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/GccCompatibleToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/GccCompatibleToolChain.java
@@ -49,6 +49,17 @@ public interface GccCompatibleToolChain extends NativeToolChain {
      */
     void target(String platformName, Action<? super GccPlatformToolChain> action);
 
+
+    /**
+     * Override the current platform configuration with a single target platform specified by name
+     */
+    void setTargets(String platformName);
+
+    /**
+     * Override the current platform configuration with a single target platform specified by name, with additional configuration action
+     */
+    void setTargets(String platformName, Action<? super GccPlatformToolChain> action);
+
     /**
      * Adds an action that can fine-tune the tool configuration for each platform supported by this tool chain.
      */

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
@@ -125,6 +125,20 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
     }
 
     @Override
+    public void setTargets(String platformName) {
+        platformConfigs.clear();
+        configInsertLocation = 0;
+        target(platformName);
+    }
+
+    @Override
+    public void setTargets(String platformName, Action<? super GccPlatformToolChain> action) {
+        platformConfigs.clear();
+        configInsertLocation = 0;
+        target(platformName, action);
+    }
+
+    @Override
     public PlatformToolProvider select(NativePlatformInternal targetPlatform) {
         PlatformToolProvider toolProvider = toolProviders.get(targetPlatform);
         if (toolProvider == null) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
@@ -125,17 +125,12 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
     }
 
     @Override
-    public void setTargets(String platformName) {
+    public void setTargets(String... platformNames) {
         platformConfigs.clear();
         configInsertLocation = 0;
-        target(platformName);
-    }
-
-    @Override
-    public void setTargets(String platformName, Action<? super GccPlatformToolChain> action) {
-        platformConfigs.clear();
-        configInsertLocation = 0;
-        target(platformName, action);
+        for (String platformName : platformNames) {
+            target(platformName);
+        }
     }
 
     @Override

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
@@ -150,6 +150,16 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         toolChain.select(platform).available
     }
 
+    def "setTargets removes existing platforms"() {
+        given:
+        platform.name >> "SomePlatform"
+        toolChain.target("SomePlatform", Mock(Action))
+        toolChain.setTargets("NoPlatform", Mock(Action))
+
+        expect:
+        !toolChain.select(platform).available
+    }
+
     def "selected toolChain applies platform configuration action"() {
         def platform1 = Mock(NativePlatformInternal)
         def platform2 = Mock(NativePlatformInternal)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
@@ -154,7 +154,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         given:
         platform.name >> "SomePlatform"
         toolChain.target("SomePlatform", Mock(Action))
-        toolChain.setTargets("NoPlatform", Mock(Action))
+        toolChain.setTargets("NoPlatform")
 
         expect:
         !toolChain.select(platform).available


### PR DESCRIPTION
### Context
This pull request is designed to allow users to reset the default platforms assigned to Gcc and Clang toolchains. This is a new version of #3061 per @ghale 's suggestion.

`setTargets(String)` and `setTargets(String, Action)` have been added to GccCompatibleToolchain.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
