### PR TITLE
Build scan plugin can be auto-applied with with artifact coordinates

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/AbstractUserInputHandlerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/AbstractUserInputHandlerIntegrationTest.groovy
@@ -18,13 +18,8 @@ package org.gradle.api.internal.tasks.userinput
 
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleHandle
-
-import static org.gradle.util.TextUtil.getPlatformLineSeparator
 
 class AbstractUserInputHandlerIntegrationTest extends AbstractIntegrationSpec {
-
-    protected static final int EOF = 4
 
     protected void interactiveExecution() {
         executer.withStdinPipe().withForceInteractive(true)
@@ -44,15 +39,5 @@ class AbstractUserInputHandlerIntegrationTest extends AbstractIntegrationSpec {
 
     protected void withParallel() {
         executer.withArgument('--parallel')
-    }
-
-    static void writeToStdInAndClose(GradleHandle gradleHandle, input) {
-        gradleHandle.stdinPipe.write(input)
-        writeLineSeparatorToStdInAndClose(gradleHandle)
-    }
-
-    static void writeLineSeparatorToStdInAndClose(GradleHandle gradleHandle) {
-        gradleHandle.stdinPipe.write(getPlatformLineSeparator().bytes)
-        gradleHandle.stdinPipe.close()
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildScanUserInputFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildScanUserInputFixture.groovy
@@ -16,12 +16,17 @@
 
 package org.gradle.integtests.fixtures
 
+import org.gradle.integtests.fixtures.executer.GradleHandle
+
+import static org.gradle.util.TextUtil.getPlatformLineSeparator
+
 final class BuildScanUserInputFixture {
 
     public static final String DUMMY_TASK_NAME = 'doSomething'
     public static final String QUESTION = "Accept license?"
     public static final String YES = 'yes'
     public static final String NO = 'no'
+    public static final int EOF = 4
     public static final String PROMPT = "$QUESTION [$YES, $NO]"
     private static final String ANSWER_PREFIX = 'License accepted:'
 
@@ -56,5 +61,15 @@ final class BuildScanUserInputFixture {
 
     static String answerOutput(Boolean answer) {
         "$ANSWER_PREFIX $answer"
+    }
+
+    static void writeToStdInAndClose(GradleHandle gradleHandle, input) {
+        gradleHandle.stdinPipe.write(input)
+        writeLineSeparatorToStdInAndClose(gradleHandle)
+    }
+
+    private static void writeLineSeparatorToStdInAndClose(GradleHandle gradleHandle) {
+        gradleHandle.stdinPipe.write(getPlatformLineSeparator().bytes)
+        gradleHandle.stdinPipe.close()
     }
 }

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
@@ -18,9 +18,12 @@ package org.gradle.plugin.autoapply
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleHandle
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.*
 
+@Requires(TestPrecondition.ONLINE)
 class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
 
     private static final String BUILD_SCAN_LICENSE_QUESTION = 'Do you accept the Gradle Cloud Services license agreement (https://gradle.com/terms-of-service)? [yes, no]'

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
@@ -18,12 +18,14 @@ package org.gradle.plugin.autoapply
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleHandle
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.*
 
 @Requires(TestPrecondition.ONLINE)
+@LeaksFileHandles
 class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
 
     private static final String BUILD_SCAN_LICENSE_QUESTION = 'Do you accept the Gradle Cloud Services license agreement (https://gradle.com/terms-of-service)? [yes, no]'

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.autoapply
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleHandle
+
+import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.*
+
+class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
+
+    private static final String BUILD_SCAN_LICENSE_QUESTION = 'Do you accept the Gradle Cloud Services license agreement (https://gradle.com/terms-of-service)? [yes, no]'
+    private static final String BUILD_SCAN_SUCCESSFUL_PUBLISHING = 'Publishing build scan'
+    private static final String BUILD_SCAN_PLUGIN_CONFIG_PROBLEM = 'The build scan was not published due to a configuration problem.'
+    private static final String BUILD_SCAN_LICENSE_NOTE = 'The Gradle Cloud Services license agreement has not been agreed to.'
+    private static final String BUILD_SCAN_LICENSE_ACCEPTANCE = 'Gradle Cloud Services license agreement accepted.'
+    private static final String BUILD_SCAN_LICENSE_DECLINATION = 'Gradle Cloud Services license agreement not accepted.'
+
+    def setup() {
+        requireOwnGradleUserHomeDir()
+        requireGradleDistribution()
+    }
+
+    def "can auto-apply build scan plugin but does not ask for license acceptance in non-interactive console"() {
+        given:
+        buildFile << dummyBuildFile()
+
+        when:
+        def gradleHandle = startBuildWithBuildScanCommandLineOption()
+
+        then:
+        def result = gradleHandle.waitForFinish()
+        !result.output.contains(BUILD_SCAN_LICENSE_QUESTION)
+        result.output.contains(BUILD_SCAN_PLUGIN_CONFIG_PROBLEM)
+        result.output.contains(BUILD_SCAN_LICENSE_NOTE)
+        !result.output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING)
+    }
+
+    def "can auto-apply build scan plugin and accept license in interactive console"() {
+        given:
+        withInteractiveConsole()
+        buildFile << dummyBuildFile()
+
+        when:
+        def gradleHandle = startBuildWithBuildScanCommandLineOption()
+
+        then:
+        writeToStdInAndClose(gradleHandle, YES.bytes)
+        def result = gradleHandle.waitForFinish()
+        result.output.contains(BUILD_SCAN_LICENSE_QUESTION)
+        result.output.contains(BUILD_SCAN_LICENSE_ACCEPTANCE)
+        result.output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING)
+        !result.output.contains(BUILD_SCAN_PLUGIN_CONFIG_PROBLEM)
+        !result.output.contains(BUILD_SCAN_LICENSE_NOTE)
+    }
+
+    def "can auto-apply build scan plugin and decline license in interactive console"() {
+        given:
+        withInteractiveConsole()
+        buildFile << dummyBuildFile()
+
+        when:
+        def gradleHandle = startBuildWithBuildScanCommandLineOption()
+
+        then:
+        writeToStdInAndClose(gradleHandle, NO.bytes)
+        def result = gradleHandle.waitForFinish()
+        result.output.contains(BUILD_SCAN_LICENSE_QUESTION)
+        result.output.contains(BUILD_SCAN_LICENSE_DECLINATION)
+        result.output.contains(BUILD_SCAN_PLUGIN_CONFIG_PROBLEM)
+        !result.output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING)
+        result.output.contains(BUILD_SCAN_PLUGIN_CONFIG_PROBLEM)
+        !result.output.contains(BUILD_SCAN_LICENSE_NOTE)
+        result.output.contains("The buildScan extension 'licenseAgree' value must be exactly the string 'yes' (without quotes).")
+        result.output.contains("The value given was 'no'.")
+    }
+
+    def "can auto-apply build scan plugin and cancel license acceptance with ctrl-d in interactive console"() {
+        given:
+        withInteractiveConsole()
+        buildFile << dummyBuildFile()
+
+        when:
+        def gradleHandle = startBuildWithBuildScanCommandLineOption()
+
+        then:
+        writeToStdInAndClose(gradleHandle, EOF)
+        def result = gradleHandle.waitForFinish()
+        result.output.contains(BUILD_SCAN_LICENSE_QUESTION)
+        !result.output.contains(BUILD_SCAN_LICENSE_ACCEPTANCE)
+        !result.output.contains(BUILD_SCAN_LICENSE_DECLINATION)
+        result.output.contains(BUILD_SCAN_PLUGIN_CONFIG_PROBLEM)
+        result.output.contains(BUILD_SCAN_LICENSE_NOTE)
+        !result.output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING)
+    }
+
+    private void withInteractiveConsole() {
+        executer.withStdinPipe().withForceInteractive(true)
+    }
+
+    private GradleHandle startBuildWithBuildScanCommandLineOption() {
+        return executer.withTasks(DUMMY_TASK_NAME).withArgument('--scan').start()
+    }
+
+    static String dummyBuildFile() {
+        "task $DUMMY_TASK_NAME"
+    }
+}

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
@@ -333,8 +333,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         fails("helloWorld")
 
         then:
-        errorOutput.contains("Plugin [id: 'org.gradle.hello-world', version: '0.2', artifact: 'foo:bar:1.0']")
-        errorOutput.contains("explicit artifact coordinates are not supported")
+        errorOutput.contains("Could not find foo:bar:1.0")
     }
 
     def "Able to specify ivy resolution patterns"() {

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
@@ -106,4 +106,32 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
         failureDescriptionStartsWith("Plugin [id: 'org.gradle.non-existing', version: '1.0'] was not found in any of the following sources:")
         failureDescriptionContains("- Gradle Central Plugin Repository (no 'org.gradle.non-existing' plugin available - see https://plugins.gradle.org for available plugins)")
     }
+
+    def "can resolve and plugin from portal with buildscript notation"() {
+        given:
+        def helloWorldGroup = 'org.gradle'
+        def helloWorldName = 'gradle-hello-world-plugin'
+
+        when:
+        buildScript """
+            buildscript {
+                repositories {
+                    maven {
+                        url "https://plugins.gradle.org/m2/"
+                    }
+                }
+                dependencies {
+                    classpath "$helloWorldGroup:$helloWorldName:$HELLO_WORLD_PLUGIN_VERSION"
+                }
+            }
+
+            apply plugin: "$HELLO_WORLD_PLUGIN_ID"
+        """
+
+        then:
+        succeeds("helloWorld")
+
+        and:
+        output.contains("Hello World!")
+    }
 }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/PluginResolutionServiceResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/PluginResolutionServiceResolver.java
@@ -35,6 +35,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.exceptions.Contextual;
+import org.gradle.plugin.management.PluginRequest;
 import org.gradle.plugin.use.PluginId;
 import org.gradle.plugin.use.internal.DefaultPluginId;
 import org.gradle.plugin.management.internal.PluginRequestInternal;
@@ -78,10 +79,6 @@ public class PluginResolutionServiceResolver implements PluginResolver {
     }
 
     public void resolve(PluginRequestInternal pluginRequest, PluginResolutionResult result) throws InvalidPluginRequestException {
-        if (pluginRequest.getModule() != null) {
-            result.notFound(getDescription(), "explicit artifact coordinates are not supported by this source");
-            return;
-        }
         if (pluginRequest.getVersion() == null) {
             result.notFound(getDescription(), "plugin dependency must include a version number for this source");
             return;
@@ -102,9 +99,9 @@ public class PluginResolutionServiceResolver implements PluginResolver {
             } else {
                 PluginUseMetaData metaData = response.getResponse();
                 if (metaData.legacy) {
-                    handleLegacy(metaData, result);
+                    handleLegacy(metaData, result, pluginRequest);
                 } else {
-                    ClassPath classPath = resolvePluginDependencies(metaData);
+                    ClassPath classPath = resolvePluginDependencies(metaData, pluginRequest);
                     PluginResolution resolution = new ClassPathPluginResolution(pluginRequest.getId(), parentScope, Factories.constant(classPath), pluginInspector);
                     result.found(getDescription(), resolution);
                 }
@@ -112,7 +109,7 @@ public class PluginResolutionServiceResolver implements PluginResolver {
         }
     }
 
-    private void handleLegacy(final PluginUseMetaData metadata, PluginResolutionResult result) {
+    private void handleLegacy(final PluginUseMetaData metadata, PluginResolutionResult result, final PluginRequest pluginRequest) {
         final PluginId pluginId = DefaultPluginId.of(metadata.id);
         result.found(getDescription(), new PluginResolution() {
             @Override
@@ -121,7 +118,7 @@ public class PluginResolutionServiceResolver implements PluginResolver {
             }
 
             public void execute(PluginResolveContext context) {
-                context.addLegacy(pluginId, metadata.implementation.get("repo"), metadata.implementation.get("gav"));
+                context.addLegacy(pluginId, metadata.implementation.get("repo"), getGav(pluginRequest, metadata));
             }
         });
     }
@@ -130,7 +127,7 @@ public class PluginResolutionServiceResolver implements PluginResolver {
         return versionSelectorScheme.parseSelector(version).isDynamic();
     }
 
-    private ClassPath resolvePluginDependencies(final PluginUseMetaData metadata) {
+    private ClassPath resolvePluginDependencies(final PluginUseMetaData metadata, PluginRequest pluginRequest) {
         DependencyResolutionServices resolution = dependencyResolutionServicesFactory.create();
 
         RepositoryHandler repositories = resolution.getResolveRepositoryHandler();
@@ -141,7 +138,7 @@ public class PluginResolutionServiceResolver implements PluginResolver {
             }
         });
 
-        Dependency dependency = resolution.getDependencyHandler().create(metadata.implementation.get("gav"));
+        Dependency dependency = resolution.getDependencyHandler().create(getGav(pluginRequest, metadata));
 
         ConfigurationContainerInternal configurations = (ConfigurationContainerInternal) resolution.getConfigurationContainer();
         ConfigurationInternal configuration = configurations.detachedConfiguration(dependency);
@@ -151,6 +148,14 @@ public class PluginResolutionServiceResolver implements PluginResolver {
             return new DefaultClassPath(files);
         } catch (ResolveException e) {
             throw new DependencyResolutionException("Failed to resolve all plugin dependencies from " + repoUrl, e.getCause());
+        }
+    }
+
+    private Object getGav(PluginRequest request, PluginUseMetaData metadata) {
+        if (request.getModule() == null) {
+            return metadata.implementation.get("gav");
+        } else {
+            return request.getModule();
         }
     }
 

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/PluginResolutionServiceResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/PluginResolutionServiceResolver.java
@@ -155,7 +155,7 @@ public class PluginResolutionServiceResolver implements PluginResolver {
         if (request.getModule() == null) {
             return metadata.implementation.get("gav");
         } else {
-            return request.getModule();
+            return request.getModule().toString();
         }
     }
 


### PR DESCRIPTION
### Context

Auto-applying the build scan plugin with the `--scan` command line option for an existing version was failing. This change ensures the proper functionality and added end-to-end testing for it.

_Side note:_ I had to add `@LeaksFileHandles` as there was an issue with cleaning up the build scan JAR in the custom Gradle user home directory which is created under the test directory. Seems like this is a somewhat "known" issue. Other tests with a similar setup seem to have the same issue e.g. `ResolvingFromMultipleCustomPluginRepositorySpec`, `DeployedPortalIntegrationSpec`. I avoided diving deeper for now. Maybe a good topic for a fix-it.