### PR TITLE
PluginRequest can indicate a generic location that requests a plugin

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultExceptionAnalyser.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultExceptionAnalyser.java
@@ -29,6 +29,8 @@ import org.gradle.internal.exceptions.LocationAwareException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName;
+
 public class DefaultExceptionAnalyser implements ExceptionAnalyser, ScriptExecutionListener {
     private final Map<String, ScriptSource> scripts = new HashMap<String, ScriptSource>();
 
@@ -71,7 +73,7 @@ public class DefaultExceptionAnalyser implements ExceptionAnalyser, ScriptExecut
             }
         }
 
-        return new LocationAwareException(actualException, source, lineNumber);
+        return new LocationAwareException(actualException, scriptSourceDisplayName(source, lineNumber));
     }
 
     private Throwable findDeepestRootException(Throwable exception) {

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/LocationAwareException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/LocationAwareException.java
@@ -15,9 +15,7 @@
  */
 package org.gradle.internal.exceptions;
 
-import org.apache.commons.lang.StringUtils;
 import org.gradle.api.GradleException;
-import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -31,25 +29,11 @@ import java.util.List;
  */
 @UsedByScanPlugin
 public class LocationAwareException extends GradleException implements FailureResolutionAware {
-    private final String sourceDisplayName;
-    private final Integer lineNumber;
+    private final String location;
 
-    public LocationAwareException(Throwable cause, ScriptSource source, Integer lineNumber) {
-        this(cause, source != null ? source.getDisplayName() : null, lineNumber);
-    }
-
-    public LocationAwareException(Throwable cause, String sourceDisplayName, Integer lineNumber) {
-        this.sourceDisplayName = sourceDisplayName;
-        this.lineNumber = lineNumber;
+    public LocationAwareException(Throwable cause, String location) {
+        this.location = location;
         initCause(cause);
-    }
-
-    /**
-     * <p>Returns the display name of the script where this exception occurred.</p>
-     * @return The source display name. May return null.
-     */
-    public String getSourceDisplayName() {
-        return sourceDisplayName;
     }
 
     /**
@@ -58,23 +42,7 @@ public class LocationAwareException extends GradleException implements FailureRe
      * @return The location description. May return null.
      */
     public String getLocation() {
-        if (sourceDisplayName == null) {
-            return null;
-        }
-        String sourceMsg = StringUtils.capitalize(sourceDisplayName);
-        if (lineNumber == null) {
-            return sourceMsg;
-        }
-        return String.format("%s line: %d", sourceMsg, lineNumber);
-    }
-
-    /**
-     * Returns the line in the script where this exception occurred, if known.
-     *
-     * @return The line number, or null if not known.
-     */
-    public Integer getLineNumber() {
-        return lineNumber;
+        return location;
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
@@ -17,7 +17,6 @@
 package org.gradle.plugin.management.internal;
 
 import org.gradle.api.artifacts.ModuleVersionSelector;
-import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.plugin.use.PluginId;
 import org.gradle.plugin.use.internal.DefaultPluginId;
 
@@ -28,38 +27,28 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     private final PluginId id;
     private final String version;
     private final boolean apply;
-    private final int lineNumber;
-    private final String scriptDisplayName;
+    private final String origin;
     private final ModuleVersionSelector artifact;
     private final PluginRequestInternal originalRequest;
 
-    public DefaultPluginRequest(String id, String version, boolean apply, int lineNumber, ScriptSource scriptSource) {
-        this(DefaultPluginId.of(id), version, apply, lineNumber, scriptSource);
+    public DefaultPluginRequest(String id, String version, boolean apply, String origin) {
+        this(DefaultPluginId.of(id), version, apply, origin);
     }
 
-    public DefaultPluginRequest(PluginId id, String version, boolean apply, int lineNumber, ScriptSource scriptSource) {
-        this(id, version, apply, lineNumber, scriptSource.getDisplayName(), null);
+    public DefaultPluginRequest(PluginId id, String version, boolean apply, String origin) {
+        this(id, version, apply, origin, null);
     }
 
-    public DefaultPluginRequest(String id, String version, boolean apply, int lineNumber, String scriptDisplayName) {
-        this(DefaultPluginId.of(id), version, apply, lineNumber, scriptDisplayName, null);
+    public DefaultPluginRequest(PluginId id, String version, boolean apply, String origin, ModuleVersionSelector artifact) {
+        this(id, version, apply, origin, artifact, null);
     }
 
-    public DefaultPluginRequest(PluginRequestInternal from) {
-        this(from.getId(), from.getVersion(), from.isApply(), from.getLineNumber(), from.getScriptDisplayName(), from.getModule());
-    }
-
-    public DefaultPluginRequest(PluginId id, String version, boolean apply, int lineNumber, String scriptDisplayName, ModuleVersionSelector artifact) {
-        this(id, version, apply, lineNumber, scriptDisplayName, artifact, null);
-    }
-
-    public DefaultPluginRequest(PluginId id, String version, boolean apply, int lineNumber, String scriptDisplayName, ModuleVersionSelector artifact,
+    public DefaultPluginRequest(PluginId id, String version, boolean apply, String origin, ModuleVersionSelector artifact,
                                 PluginRequestInternal originalRequest) {
         this.id = id;
         this.version = version;
         this.apply = apply;
-        this.lineNumber = lineNumber;
-        this.scriptDisplayName = scriptDisplayName;
+        this.origin = origin;
         this.artifact = artifact;
         this.originalRequest = originalRequest != null ? originalRequest : this;
     }
@@ -84,14 +73,8 @@ public class DefaultPluginRequest implements PluginRequestInternal {
         return apply;
     }
 
-    @Override
-    public int getLineNumber() {
-        return lineNumber;
-    }
-
-    @Override
-    public String getScriptDisplayName() {
-        return scriptDisplayName;
+    public String getOrigin() {
+        return origin;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
@@ -18,7 +18,6 @@ package org.gradle.plugin.management.internal;
 
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.plugin.use.PluginId;
-import org.gradle.plugin.use.internal.DefaultPluginId;
 
 import javax.annotation.Nullable;
 
@@ -30,10 +29,6 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     private final String origin;
     private final ModuleVersionSelector artifact;
     private final PluginRequestInternal originalRequest;
-
-    public DefaultPluginRequest(String id, String version, boolean apply, String origin) {
-        this(DefaultPluginId.of(id), version, apply, origin);
-    }
 
     public DefaultPluginRequest(PluginId id, String version, boolean apply, String origin) {
         this(id, version, apply, origin, null);

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestInternal.java
@@ -22,9 +22,7 @@ public interface PluginRequestInternal extends PluginRequest {
 
     boolean isApply();
 
-    int getLineNumber();
-
-    String getScriptDisplayName();
+    String getOrigin();
 
     String getDisplayName();
 

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestsSerializer.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestsSerializer.java
@@ -34,10 +34,8 @@ public class PluginRequestsSerializer extends AbstractSerializer<PluginRequests>
             PluginId pluginId = DefaultPluginId.unvalidated(decoder.readString());
             String version = decoder.readNullableString();
             boolean apply = decoder.readBoolean();
-            int lineNumber = decoder.readSmallInt();
-            String scriptDisplayName = decoder.readString();
-
-            requests.add(i, new DefaultPluginRequest(pluginId, version, apply, lineNumber, scriptDisplayName, null));
+            String origin = decoder.readString();
+            requests.add(i, new DefaultPluginRequest(pluginId, version, apply, origin, null));
         }
         return new DefaultPluginRequests(requests);
     }
@@ -49,8 +47,7 @@ public class PluginRequestsSerializer extends AbstractSerializer<PluginRequests>
             encoder.writeString(request.getId().getId());
             encoder.writeNullableString(request.getVersion());
             encoder.writeBoolean(request.isApply());
-            encoder.writeSmallInt(request.getLineNumber());
-            encoder.writeString(request.getScriptDisplayName());
+            encoder.writeString(request.getOrigin());
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestsSerializer.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestsSerializer.java
@@ -35,7 +35,7 @@ public class PluginRequestsSerializer extends AbstractSerializer<PluginRequests>
             String version = decoder.readNullableString();
             boolean apply = decoder.readBoolean();
             String origin = decoder.readString();
-            requests.add(i, new DefaultPluginRequest(pluginId, version, apply, origin, null));
+            requests.add(i, new DefaultPluginRequest(pluginId, version, apply, origin));
         }
         return new DefaultPluginRequests(requests);
     }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginOriginUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginOriginUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.use.internal;
+
+import org.apache.commons.lang.StringUtils;
+import org.gradle.groovy.scripts.ScriptSource;
+
+public final class PluginOriginUtil {
+
+    private PluginOriginUtil() {}
+
+    public static String scriptSourceDisplayName(ScriptSource scriptSource, Integer lineNumber) {
+        if (scriptSource == null || scriptSource.getDisplayName() == null) {
+            return null;
+        }
+        String sourceMsg = StringUtils.capitalize(scriptSource.getDisplayName());
+        if (lineNumber == null) {
+            return sourceMsg;
+        }
+        return String.format("%s line: %d", sourceMsg, lineNumber);
+    }
+
+    public static String autoAppliedPluginDisplayName() {
+        return "auto-applied";
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginOriginUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginOriginUtil.java
@@ -16,6 +16,7 @@
 
 package org.gradle.plugin.use.internal;
 
+import org.apache.commons.lang.StringUtils;
 import org.gradle.groovy.scripts.ScriptSource;
 
 public final class PluginOriginUtil {
@@ -26,11 +27,10 @@ public final class PluginOriginUtil {
         if (scriptSource == null || scriptSource.getDisplayName() == null) {
             return null;
         }
-
+        String sourceMsg = StringUtils.capitalize(scriptSource.getDisplayName());
         if (lineNumber == null) {
-            return scriptSource.getDisplayName();
+            return sourceMsg;
         }
-
-        return String.format("%s at line %d", scriptSource.getDisplayName(), lineNumber);
+        return String.format("%s line: %d", sourceMsg, lineNumber);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginOriginUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginOriginUtil.java
@@ -16,7 +16,6 @@
 
 package org.gradle.plugin.use.internal;
 
-import org.apache.commons.lang.StringUtils;
 import org.gradle.groovy.scripts.ScriptSource;
 
 public final class PluginOriginUtil {
@@ -27,14 +26,11 @@ public final class PluginOriginUtil {
         if (scriptSource == null || scriptSource.getDisplayName() == null) {
             return null;
         }
-        String sourceMsg = StringUtils.capitalize(scriptSource.getDisplayName());
-        if (lineNumber == null) {
-            return sourceMsg;
-        }
-        return String.format("%s line: %d", sourceMsg, lineNumber);
-    }
 
-    public static String autoAppliedPluginDisplayName() {
-        return "auto-applied";
+        if (lineNumber == null) {
+            return scriptSource.getDisplayName();
+        }
+
+        return String.format("%s at line %d", scriptSource.getDisplayName(), lineNumber);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -34,6 +34,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName;
 import static org.gradle.util.CollectionUtils.collect;
 
 /**
@@ -92,7 +93,7 @@ public class PluginRequestCollector {
     public List<PluginRequestInternal> listPluginRequests() {
         List<PluginRequestInternal> pluginRequests = collect(specs, new Transformer<PluginRequestInternal, DependencySpecImpl>() {
             public PluginRequestInternal transform(DependencySpecImpl original) {
-                return new DefaultPluginRequest(original.id, original.version, original.apply, original.lineNumber, scriptSource);
+                return new DefaultPluginRequest(original.id, original.version, original.apply, scriptSourceDisplayName(scriptSource, original.lineNumber));
             }
         });
 
@@ -109,11 +110,10 @@ public class PluginRequestCollector {
                 PluginRequestInternal first = pluginRequests.get(0);
                 PluginRequestInternal second = pluginRequests.get(1);
 
-                InvalidPluginRequestException exception = new InvalidPluginRequestException(second, "Plugin with id '" + key + "' was already requested at line " + first.getLineNumber());
-                throw new LocationAwareException(exception, second.getScriptDisplayName(), second.getLineNumber());
+                InvalidPluginRequestException exception = new InvalidPluginRequestException(second, "Plugin with id '" + key + "' was already requested: " + first.getDisplayName());
+                throw new LocationAwareException(exception, second.getDisplayName());
             }
         }
         return pluginRequests;
     }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -110,7 +110,7 @@ public class PluginRequestCollector {
                 PluginRequestInternal first = pluginRequests.get(0);
                 PluginRequestInternal second = pluginRequests.get(1);
 
-                InvalidPluginRequestException exception = new InvalidPluginRequestException(second, "Plugin with id '" + key + "' was already requested: " + first.getOrigin());
+                InvalidPluginRequestException exception = new InvalidPluginRequestException(second, "Plugin with id '" + key + "' was already requested (" + first.getOrigin() + ")");
                 throw new LocationAwareException(exception, second.getOrigin());
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -110,7 +110,7 @@ public class PluginRequestCollector {
                 PluginRequestInternal first = pluginRequests.get(0);
                 PluginRequestInternal second = pluginRequests.get(1);
 
-                InvalidPluginRequestException exception = new InvalidPluginRequestException(second, "Plugin with id '" + key + "' was already requested: " + first.getDisplayName());
+                InvalidPluginRequestException exception = new InvalidPluginRequestException(second, "Plugin with id '" + key + "' was already requested: " + first.getOrigin());
                 throw new LocationAwareException(exception, second.getDisplayName());
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -111,7 +111,7 @@ public class PluginRequestCollector {
                 PluginRequestInternal second = pluginRequests.get(1);
 
                 InvalidPluginRequestException exception = new InvalidPluginRequestException(second, "Plugin with id '" + key + "' was already requested: " + first.getOrigin());
-                throw new LocationAwareException(exception, second.getDisplayName());
+                throw new LocationAwareException(exception, second.getOrigin());
             }
         }
         return pluginRequests;

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultExceptionAnalyserTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultExceptionAnalyserTest.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.initialization;
 
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.GradleScriptException;
 import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.groovy.scripts.Script;
@@ -115,8 +116,7 @@ public class DefaultExceptionAnalyserTest {
         assertThat(transformedFailure, instanceOf(LocationAwareException.class));
 
         LocationAwareException gse = (LocationAwareException) transformedFailure;
-        assertThat(gse.getSourceDisplayName(), equalTo(source.getDisplayName()));
-        assertThat(gse.getLineNumber(), equalTo(7));
+        assertThat(gse.getLocation(), equalTo(getExpectedLocation(source)));
     }
 
     @Test
@@ -133,8 +133,7 @@ public class DefaultExceptionAnalyserTest {
         assertThat(transformedFailure, instanceOf(LocationAwareException.class));
 
         LocationAwareException gse = (LocationAwareException) transformedFailure;
-        assertThat(gse.getSourceDisplayName(), equalTo(source.getDisplayName()));
-        assertThat(gse.getLineNumber(), equalTo(7));
+        assertThat(gse.getLocation(), equalTo(getExpectedLocation(source)));
     }
 
     @Test
@@ -144,8 +143,7 @@ public class DefaultExceptionAnalyserTest {
         assertThat(transformedFailure, instanceOf(LocationAwareException.class));
 
         LocationAwareException gse = (LocationAwareException) transformedFailure;
-        assertThat(gse.getSourceDisplayName(), nullValue());
-        assertThat(gse.getLineNumber(), nullValue());
+        assertThat(gse.getLocation(), nullValue());
     }
 
     @Test
@@ -228,8 +226,7 @@ public class DefaultExceptionAnalyserTest {
         assertThat(transformedFailure, instanceOf(LocationAwareException.class));
 
         LocationAwareException gse = (LocationAwareException) transformedFailure;
-        assertThat(gse.getSourceDisplayName(), equalTo(source.getDisplayName()));
-        assertThat(gse.getLineNumber(), equalTo(7));
+        assertThat(gse.getLocation(), equalTo(getExpectedLocation(source)));
         assertThat(gse.getCause(), sameInstance(failure));
     }
 
@@ -281,8 +278,12 @@ public class DefaultExceptionAnalyserTest {
 
     @Contextual
     public abstract static class TestException extends LocationAwareException {
-        protected TestException(Throwable cause, ScriptSource source, Integer lineNumber) {
-            super(cause, source, lineNumber);
+        protected TestException(Throwable cause, String origin) {
+            super(cause, origin);
         }
+    }
+
+    private static String getExpectedLocation(ScriptSource source) {
+        return StringUtils.capitalize(source.getDisplayName()) + " line: 7";
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/LocationAwareExceptionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/LocationAwareExceptionTest.groovy
@@ -22,7 +22,7 @@ class LocationAwareExceptionTest extends Specification {
     def "visit reportable causes does not visit direct cause"() {
         TreeVisitor visitor = Mock()
         def cause = new RuntimeException()
-        def e = new LocationAwareException(cause, null, 100)
+        def e = newLocationAwareException(cause)
 
         when:
         e.visitReportableCauses(visitor)
@@ -39,7 +39,7 @@ class LocationAwareExceptionTest extends Specification {
         TreeVisitor visitor = Mock()
         def childCause = new RuntimeException()
         def cause = new RuntimeException(childCause)
-        def e = new LocationAwareException(cause, null, 100)
+        def e = newLocationAwareException(cause)
 
         when:
         e.visitReportableCauses(visitor)
@@ -65,7 +65,7 @@ class LocationAwareExceptionTest extends Specification {
         TreeVisitor visitor = Mock()
         def childCause = new RuntimeException()
         def cause = new TestContextualException(childCause)
-        def e = new LocationAwareException(cause, null, 100)
+        def e = newLocationAwareException(cause)
 
         when:
         e.visitReportableCauses(visitor)
@@ -96,7 +96,7 @@ class LocationAwareExceptionTest extends Specification {
         def contextual = new TestContextualException(interveningUnreported)
         def interveningUnreported2 = new RuntimeException(contextual)
         def cause = new TestContextualException(interveningUnreported2)
-        def e = new LocationAwareException(cause, null, 100)
+        def e = newLocationAwareException(cause)
 
         when:
         e.visitReportableCauses(visitor)
@@ -121,7 +121,7 @@ class LocationAwareExceptionTest extends Specification {
         def childCause1 = new RuntimeException()
         def childCause2 = new RuntimeException()
         def cause = new DefaultMultiCauseException("broken", childCause1, childCause2)
-        def e = new LocationAwareException(cause, null, 100)
+        def e = newLocationAwareException(cause)
 
         when:
         e.visitReportableCauses(visitor)
@@ -154,7 +154,7 @@ class LocationAwareExceptionTest extends Specification {
         def childCause3 = new TestContextualException(childCause2)
         def childCause4 = new TestContextualException(childCause3)
         def cause = new DefaultMultiCauseException("broken", childCause1, childCause4)
-        def e = new LocationAwareException(cause, null, 100)
+        def e = newLocationAwareException(cause)
 
         when:
         e.visitReportableCauses(visitor)
@@ -180,5 +180,9 @@ class LocationAwareExceptionTest extends Specification {
         TestContextualException(Throwable throwable) {
             super(throwable)
         }
+    }
+
+    static LocationAwareException newLocationAwareException(Throwable cause) {
+        new LocationAwareException(cause, 'buildscript')
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/plugin/use/internal/PluginRequestsSerializerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/plugin/use/internal/PluginRequestsSerializerTest.groovy
@@ -36,9 +36,9 @@ class PluginRequestsSerializerTest extends SerializerSpec {
     def "non empty"() {
         when:
         def serialized = serialize(new DefaultPluginRequests([
-            new DefaultPluginRequest("java", null, true, "buildscript"),
-            new DefaultPluginRequest("groovy", null, false, "initscript"),
-            new DefaultPluginRequest("custom", "1.0", false, "other.gradle")
+            new DefaultPluginRequest(DefaultPluginId.of("java"), null, true, "buildscript"),
+            new DefaultPluginRequest(DefaultPluginId.of("groovy"), null, false, "initscript"),
+            new DefaultPluginRequest(DefaultPluginId.of("custom"), "1.0", false, "other.gradle")
         ]), serializer)
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/plugin/use/internal/PluginRequestsSerializerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/plugin/use/internal/PluginRequestsSerializerTest.groovy
@@ -36,16 +36,15 @@ class PluginRequestsSerializerTest extends SerializerSpec {
     def "non empty"() {
         when:
         def serialized = serialize(new DefaultPluginRequests([
-            new DefaultPluginRequest("java", null, true, 1, "buildscript"),
-            new DefaultPluginRequest("groovy", null, false, 2, "buildscript"),
-            new DefaultPluginRequest("custom", "1.0", false, 3, "initscript")
+            new DefaultPluginRequest("java", null, true, "buildscript"),
+            new DefaultPluginRequest("groovy", null, false, "initscript"),
+            new DefaultPluginRequest("custom", "1.0", false, "other.gradle")
         ]), serializer)
 
         then:
         serialized*.id == ["java", "groovy", "custom"].collect { DefaultPluginId.of(it) }
         serialized*.version == [null, null, "1.0"]
-        serialized*.lineNumber == [1, 2, 3]
-        serialized*.scriptDisplayName == ["buildscript", "buildscript", "initscript"]
+        serialized*.origin == ["buildscript", "initscript", "other.gradle"]
         serialized*.apply == [true, false, false]
     }
 }

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/CorePluginUseIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/CorePluginUseIntegrationSpec.groovy
@@ -116,7 +116,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         fails "tasks"
 
         then:
-        failure.assertThatDescription(startsWith("Plugin with id 'java' was already requested: Build file '$buildFile.absolutePath' line: 3"))
+        failure.assertThatDescription(startsWith("Plugin with id 'java' was already requested (Build file '$buildFile.absolutePath' line: 3)"))
         failure.assertHasFileName("Build file '$buildFile.absolutePath'")
         failure.assertHasLineNumber(4)
     }

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/CorePluginUseIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/CorePluginUseIntegrationSpec.groovy
@@ -116,7 +116,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         fails "tasks"
 
         then:
-        failure.assertThatDescription(startsWith("Plugin with id 'java' was already requested at line 3"))
+        failure.assertThatDescription(startsWith("Plugin with id 'java' was already requested: Build file '$buildFile.absolutePath' line: 3"))
         failure.assertHasFileName("Build file '$buildFile.absolutePath'")
         failure.assertHasLineNumber(4)
     }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginResolveDetails.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginResolveDetails.java
@@ -44,8 +44,7 @@ public class DefaultPluginResolveDetails implements PluginResolveDetails {
             targetPluginRequest.getId(),
             targetPluginRequest.getVersion(),
             targetPluginRequest.isApply(),
-            targetPluginRequest.getLineNumber(),
-            targetPluginRequest.getScriptDisplayName(),
+            targetPluginRequest.getOrigin(),
             NOTATION_PARSER.parseNotation(notation),
             targetPluginRequest.getOriginalRequest()
         );
@@ -57,8 +56,7 @@ public class DefaultPluginResolveDetails implements PluginResolveDetails {
             targetPluginRequest.getId(),
             version,
             targetPluginRequest.isApply(),
-            targetPluginRequest.getLineNumber(),
-            targetPluginRequest.getScriptDisplayName(),
+            targetPluginRequest.getOrigin(),
             targetPluginRequest.getModule(),
             targetPluginRequest.getOriginalRequest()
         );

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import org.gradle.StartParameter;
 import org.gradle.api.Project;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector;
+import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.plugin.management.internal.DefaultPluginRequest;
 import org.gradle.plugin.management.internal.DefaultPluginRequests;
 import org.gradle.plugin.management.internal.PluginRequestInternal;
@@ -28,8 +29,6 @@ import org.gradle.plugin.use.PluginId;
 import org.gradle.plugin.use.internal.DefaultPluginId;
 
 import java.util.List;
-
-import static org.gradle.plugin.use.internal.PluginOriginUtil.autoAppliedPluginDisplayName;
 
 /**
  * A hardcoded {@link AutoAppliedPluginRegistry} that only knows about the build-scan plugin for now.
@@ -61,6 +60,10 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
 
     private DefaultPluginRequest createScanPluginRequest() {
         DefaultModuleVersionSelector artifact = new DefaultModuleVersionSelector(BUILD_SCAN_PLUGIN_GROUP, BUILD_SCAN_PLUGIN_NAME, BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION);
-        return new DefaultPluginRequest(BUILD_SCAN_PLUGIN_ID, BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION, true, autoAppliedPluginDisplayName(), artifact);
+        return new DefaultPluginRequest(BUILD_SCAN_PLUGIN_ID, BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION, true, getOrigin(), artifact);
+    }
+
+    private static String getOrigin() {
+        return String.format("auto-applied plugin by declaring %s", StartParameterBuildOptions.BuildScanOption.LONG_OPTION);
     }
 }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -29,6 +29,8 @@ import org.gradle.plugin.use.internal.DefaultPluginId;
 
 import java.util.List;
 
+import static org.gradle.plugin.use.internal.PluginOriginUtil.autoAppliedPluginDisplayName;
+
 /**
  * A hardcoded {@link AutoAppliedPluginRegistry} that only knows about the build-scan plugin for now.
  */
@@ -59,6 +61,6 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
 
     private DefaultPluginRequest createScanPluginRequest() {
         DefaultModuleVersionSelector artifact = new DefaultModuleVersionSelector(BUILD_SCAN_PLUGIN_GROUP, BUILD_SCAN_PLUGIN_NAME, BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION);
-        return new DefaultPluginRequest(BUILD_SCAN_PLUGIN_ID, BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION, true, 0, "", artifact);
+        return new DefaultPluginRequest(BUILD_SCAN_PLUGIN_ID, BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION, true, autoAppliedPluginDisplayName(), artifact);
     }
 }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -239,7 +239,7 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
                 throw exceptionOccurred(request, e);
             }
         } catch (Exception e) {
-            throw new LocationAwareException(e, request.getScriptDisplayName(), request.getLineNumber());
+            throw new LocationAwareException(e, request.getOrigin());
         }
     }
 
@@ -264,13 +264,13 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
         } catch (Exception e) {
             throw new LocationAwareException(
                 new GradleException(String.format("Error resolving plugin %s", request.getDisplayName()), e),
-                request.getScriptDisplayName(), request.getLineNumber());
+                request.getOrigin());
         }
 
         if (!result.isFound()) {
             String message = buildNotFoundMessage(request, result);
             Exception exception = new UnknownPluginException(message);
-            throw new LocationAwareException(exception, request.getScriptDisplayName(), request.getLineNumber());
+            throw new LocationAwareException(exception, request.getOrigin());
         }
 
         return result;

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoryPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoryPluginResolverTest.groovy
@@ -23,6 +23,8 @@ import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
 import spock.lang.Specification
 
+import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName
+
 class ArtifactRepositoryPluginResolverTest extends Specification {
     def versionSelectorScheme = new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme())
     def result = Mock(PluginResolutionResult)
@@ -30,7 +32,7 @@ class ArtifactRepositoryPluginResolverTest extends Specification {
     def resolver = new ArtifactRepositoryPluginResolver("maven", null, versionSelectorScheme);
 
     PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 
     def "fail pluginRequests without versions"() {

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoryPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoryPluginResolverTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVer
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
 import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName
@@ -32,7 +33,7 @@ class ArtifactRepositoryPluginResolverTest extends Specification {
     def resolver = new ArtifactRepositoryPluginResolver("maven", null, versionSelectorScheme);
 
     PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 
     def "fail pluginRequests without versions"() {

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
@@ -45,7 +45,7 @@ class CorePluginResolverTest extends Specification {
     def resolver = new CorePluginResolver(docRegistry, pluginRegistry)
 
     PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 
     def "non core plugins are ignored"() {

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
@@ -19,14 +19,16 @@ package org.gradle.plugin.use.resolve.internal
 import org.gradle.api.Plugin
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.internal.DocumentationRegistry
-import org.gradle.api.internal.plugins.PluginRegistry
 import org.gradle.api.internal.plugins.PluginImplementation
+import org.gradle.api.internal.plugins.PluginRegistry
 import org.gradle.groovy.scripts.StringScriptSource
-import org.gradle.plugin.use.internal.DefaultPluginId
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.InvalidPluginRequestException
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
+
+import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName
 
 class CorePluginResolverTest extends Specification {
 
@@ -43,7 +45,7 @@ class CorePluginResolverTest extends Specification {
     def resolver = new CorePluginResolver(docRegistry, pluginRegistry)
 
     PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 
     def "non core plugins are ignored"() {
@@ -85,7 +87,7 @@ class CorePluginResolverTest extends Specification {
 
     def "cannot have custom artifact"() {
         when:
-        resolver.resolve(new DefaultPluginRequest(DefaultPluginId.of("foo"), null, true, 1, "test", Mock(ModuleVersionSelector)), result)
+        resolver.resolve(new DefaultPluginRequest(DefaultPluginId.of("foo"), null, true, "test", Mock(ModuleVersionSelector)), result)
 
         then:
         1 * pluginRegistry.lookup(DefaultPluginId.of("foo")) >> Mock(PluginImplementation) { asClass() >> MyPlugin }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/DeprecationListeningPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/DeprecationListeningPluginResolutionServiceClientTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.plugin.use.resolve.service.internal
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
 import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName
@@ -93,6 +94,6 @@ class DeprecationListeningPluginResolutionServiceClientTest extends Specificatio
     }
 
     static PluginRequestInternal request(String id, String version = "1") {
-        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/DeprecationListeningPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/DeprecationListeningPluginResolutionServiceClientTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
 import spock.lang.Specification
 
+import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName
 import static org.gradle.plugin.use.resolve.service.internal.DeprecationListeningPluginResolutionServiceClient.toMessage
 
 class DeprecationListeningPluginResolutionServiceClientTest extends Specification {
@@ -92,6 +93,6 @@ class DeprecationListeningPluginResolutionServiceClientTest extends Specificatio
     }
 
     static PluginRequestInternal request(String id, String version = "1") {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/InMemoryCachingPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/InMemoryCachingPluginResolutionServiceClientTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
 import spock.lang.Specification
 
+import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName
+
 class InMemoryCachingPluginResolutionServiceClientTest extends Specification {
 
     public static final String PORTAL_URL_1 = "http://foo"
@@ -129,7 +131,7 @@ class InMemoryCachingPluginResolutionServiceClientTest extends Specification {
     }
 
     static PluginRequestInternal request(String id, String version = "1") {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 
 }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/InMemoryCachingPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/InMemoryCachingPluginResolutionServiceClientTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.plugin.use.resolve.service.internal
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
 import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName
@@ -131,7 +132,7 @@ class InMemoryCachingPluginResolutionServiceClientTest extends Specification {
     }
 
     static PluginRequestInternal request(String id, String version = "1") {
-        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 
 }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/PersistentCachingPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/PersistentCachingPluginResolutionServiceClientTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.cache.PersistentIndexedCache
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.internal.InMemoryCacheFactory
 import org.junit.Rule
@@ -151,7 +152,7 @@ class PersistentCachingPluginResolutionServiceClientTest extends Specification {
     }
 
     static PluginRequestInternal request(String id, String version = "1") {
-        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 
 }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/PersistentCachingPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/PersistentCachingPluginResolutionServiceClientTest.groovy
@@ -25,6 +25,8 @@ import org.gradle.testfixtures.internal.InMemoryCacheFactory
 import org.junit.Rule
 import spock.lang.Specification
 
+import static org.gradle.plugin.use.internal.PluginOriginUtil.scriptSourceDisplayName
+
 class PersistentCachingPluginResolutionServiceClientTest extends Specification {
 
     public static final String PORTAL_URL_1 = "http://foo"
@@ -149,7 +151,7 @@ class PersistentCachingPluginResolutionServiceClientTest extends Specification {
     }
 
     static PluginRequestInternal request(String id, String version = "1") {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(id, version, true, scriptSourceDisplayName(new StringScriptSource("test", "test"), 1))
     }
 
 }


### PR DESCRIPTION
### Context

`PluginRequest` used to use the line number and script file name to indicate the location that requested the plugin. Plugins can now also be auto-applied and are therefore not requested by the user from a build script or another plugin. The line number and script file name are meaningless in that context.

This change refactors the implementation to provide a generic location as `String`.

__Side notes:__

- `LocationAwareException` is marked `@UsedByScanPlugin`. With this change the constructor signature had to change. I confirmed with the CS team that the class is likely only being used in tests.
- Instead of using a `String` we could have used a `Describable`. I didn't not go for that option as we are also serializing `PluginRequest`. Any `Describable` would have to be serialized and deserialized as well and I didn't want to deal with the different types in the process.