### PR TITLE
Revert android plugin upgrade in smoke test

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -28,9 +28,9 @@ import spock.lang.Unroll
  *
  */
 class AndroidPluginsSmokeTest extends AbstractSmokeTest {
-    public static final ANDROID_BUILD_TOOLS_VERSION = '26.0.2'
+    public static final ANDROID_BUILD_TOOLS_VERSION = '25.0.0'
     public static final String STABLE_ANDROID_VERSION = '2.3.3'
-    public static final String EXPERIMENTAL_ANDROID_VERSION = '3.0.0-beta7'
+    public static final String EXPERIMENTAL_ANDROID_VERSION = '3.0.0-beta6'
     public static final TESTED_ANDROID_PLUGIN_VERSIONS = [STABLE_ANDROID_VERSION, EXPERIMENTAL_ANDROID_VERSION]
 
     def setup() {


### PR DESCRIPTION
Looks like something is wrong on CI with the change.
Let's revert it for now.

Success here: https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger&branch_Gradle_Check=blindpirate%2Fsmoke-4.3&tab=buildTypeStatusDiv

But failure here: https://builds.gradle.org/viewLog.html?buildId=8663193&buildTypeId=Gradle_Check_SmokeTests