### PR TITLE
Unify implicit imports for Groovy and Kotlin

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/build/docs/dsl/source/GenerateDefaultImportsTask.java
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/dsl/source/GenerateDefaultImportsTask.java
@@ -16,7 +16,7 @@
 
 package org.gradle.build.docs.dsl.source;
 
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
@@ -34,7 +34,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 @CacheableTask
 public class GenerateDefaultImportsTask extends DefaultTask {
@@ -42,7 +46,6 @@ public class GenerateDefaultImportsTask extends DefaultTask {
     private File importsDestFile;
     private File mappingDestFile;
     private Set<String> excludePatterns = new LinkedHashSet<String>();
-    private Set<String> extraPackages = new LinkedHashSet<String>();
 
     @PathSensitive(PathSensitivity.NONE)
     @InputFile
@@ -88,19 +91,6 @@ public class GenerateDefaultImportsTask extends DefaultTask {
         excludePatterns.add(name);
     }
 
-    @Input
-    public Set<String> getExtraPackages() {
-        return extraPackages;
-    }
-
-    public void setExtraPackages(Set<String> extraPackages) {
-        this.extraPackages = extraPackages;
-    }
-
-    public void extraPackage(String name) {
-        extraPackages.add(name);
-    }
-
     @TaskAction
     public void generate() throws IOException {
         SimpleClassMetaDataRepository<ClassMetaData> repository = new SimpleClassMetaDataRepository<ClassMetaData>();
@@ -117,9 +107,8 @@ public class GenerateDefaultImportsTask extends DefaultTask {
                 excludedPackages.add(excludePattern);
             }
         }
-        final Set<String> packages = new TreeSet<String>();
-        packages.addAll(extraPackages);
-        final Multimap<String, String> simpleNames = HashMultimap.create();
+        final Set<String> packages = new LinkedHashSet<>();
+        final Multimap<String, String> simpleNames = LinkedHashMultimap.create();
 
         repository.each(new Action<ClassMetaData>() {
             public void execute(ClassMetaData classMetaData) {

--- a/buildSrc/src/main/groovy/org/gradle/build/docs/model/SimpleClassMetaDataRepository.java
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/model/SimpleClassMetaDataRepository.java
@@ -19,13 +19,24 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.UnknownDomainObjectException;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
 import static org.apache.commons.lang.StringUtils.getLevenshteinDistance;
 
-import java.io.*;
-import java.util.*;
-
 public class SimpleClassMetaDataRepository<T extends Attachable<T>> implements ClassMetaDataRepository<T> {
-    private final Map<String, T> classes = new HashMap<String, T>();
+    private final Map<String, T> classes = new TreeMap<>();
 
     @SuppressWarnings("unchecked")
     public void load(File repoFile) {

--- a/subprojects/core/src/main/java/org/gradle/configuration/ImportsReader.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/ImportsReader.java
@@ -20,7 +20,19 @@ import java.util.List;
 import java.util.Map;
 
 public interface ImportsReader {
+    /**
+     * Returns the list of packages that are imported by default into each Gradle build script.
+     * This list is only meant for concise presentation to the user (e.g. in documentation). For
+     * machine consumption, use the {@link #getSimpleNameToFullClassNamesMapping()} method, as it
+     * provides a direct mapping from each simple name to the qualified name of the class to use.
+     */
     String[] getImportPackages();
 
+    /**
+     * Returns a mapping from simple to qualified class name, derived from
+     * the packages returned by {@link #getImportPackages()}. For historical reasons,
+     * some simple name match multiple qualified names. In those cases the first match
+     * should be used when resolving a name in the DSL.
+     */
     Map<String, List<String>> getSimpleNameToFullClassNamesMapping();
 }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -78,13 +78,11 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
     private static final int HAS_METHODS_FLAG = 2;
 
     private final ClassLoaderCache classLoaderCache;
-    private final String[] importPackages;
     private final Map<String, List<String>> simpleNameToFQN;
 
     public DefaultScriptCompilationHandler(ClassLoaderCache classLoaderCache, ImportsReader importsReader) {
         this.classLoaderCache = classLoaderCache;
         simpleNameToFQN = importsReader.getSimpleNameToFullClassNamesMapping();
-        importPackages = importsReader.getImportPackages();
     }
 
     @Override
@@ -289,7 +287,7 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
                     super.visitClass(node);
                 }
             };
-            final GradleResolveVisitor resolveVisitor = new GradleResolveVisitor(this, importPackages, simpleNameToFQN);
+            final GradleResolveVisitor resolveVisitor = new GradleResolveVisitor(this, simpleNameToFQN);
             this.resolveVisitor = resolveVisitor;
             this.progressCallback = new ProgressCallback() {
                 @Override

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
@@ -85,7 +85,6 @@ public class GradleResolveVisitor extends ResolveVisitor {
 
     private ClassNode currentClass;
     private final Map<String, List<String>> simpleNameToFQN;
-    private final String[] gradlePublicPackages;
     private CompilationUnit compilationUnit;
     private SourceUnit source;
     private VariableScope currentScope;
@@ -211,12 +210,11 @@ public class GradleResolveVisitor extends ResolveVisitor {
         }
     }
 
-    public GradleResolveVisitor(CompilationUnit cu, String[] exportedPackages, Map<String, List<String>> simpleNameToFQN) {
+    public GradleResolveVisitor(CompilationUnit cu, Map<String, List<String>> simpleNameToFQN) {
         super(cu);
         compilationUnit = cu;
         this.classNodeResolver = new ClassNodeResolver();
         this.simpleNameToFQN = simpleNameToFQN;
-        this.gradlePublicPackages = exportedPackages;
     }
 
     public void startResolving(ClassNode node, SourceUnit source) {
@@ -555,7 +553,7 @@ public class GradleResolveVisitor extends ResolveVisitor {
             String name = type.getName();
             List<String> fqn = simpleNameToFQN.get(type.getName());
             if (fqn != null) {
-                if (fqn.size() == 1 && resolveFromResolver(type, fqn.get(0))) {
+                if (resolveFromResolver(type, fqn.get(0))) {
                     return true;
                 }
             }
@@ -572,13 +570,9 @@ public class GradleResolveVisitor extends ResolveVisitor {
                     return true;
                 }
             }
-            for (String gradlePublicPackage : gradlePublicPackages) {
-                if (resolveFromResolver(type, gradlePublicPackage + "." + name)) {
-                    if ("org.gradle.util".equals(gradlePublicPackage)) {
-                        deprecatedImports.add(name);
-                    }
-                    return true;
-                }
+            if (resolveFromResolver(type, "org.gradle.util." + name)) {
+                deprecatedImports.add(name);
+                return true;
             }
             if (name.equals("BigInteger")) {
                 type.setRedirect(ClassHelper.BigInteger_TYPE);

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -300,7 +300,6 @@ task defaultImports(type: GenerateDefaultImportsTask, dependsOn: dslMetaData) {
     excludePackage 'org.gradle.plugins.ide.eclipse.model'
     excludePackage 'org.gradle.plugins.ide.idea.model'
     excludePackage 'org.gradle.api.tasks.testing.logging'
-    extraPackage 'org.gradle.util'
 
     // TODO - rename some incubating types to remove collisions and then remove these exclusions
     excludePackage 'org.gradle.plugins.binaries.model'

--- a/subprojects/tooling-api/tooling-api.gradle
+++ b/subprojects/tooling-api/tooling-api.gradle
@@ -1,3 +1,5 @@
+import org.gradle.ShadedJar
+
 // GradleConnector entry point requires Java 5
 sourceCompatibility = javaVersion.java9Compatible ? 1.6 : 1.5
 


### PR DESCRIPTION
The Kotlin DSL uses the simple name to qualified name mapping
provided by the `ImportReader`, while the Groovy DSL so far fell
back to the imported packages list in some cases. The qualified
name mapping had a different order than the imported packages list,
leading to potential differences between Groovy and Kotlin.

The imported packages list predates the simple name to class mapping
and was still being used when there was more than one qualified class
name for a given simple name.

This commit fixes the discrepancy by ensuring that both collections
have the same order. I.e. selecting the first qualified name for a
simple name will yield the same result as iterating through the package
list and trying each one in turn.

The imported packages list is now only used in documentation, where it is
easier to digest than the full simple name to qualified name mapping.