### PR TITLE
Upgrade httpclient and httpcore

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -78,8 +78,8 @@ libraries.jetty = dependencies.module("org.mortbay.jetty:jetty:6.1.26") {
 
 libraries.commons_codec = "commons-codec:commons-codec:1.6@jar"
 libraries.jcifs = "org.samba.jcifs:jcifs:1.3.17@jar"
-libraries.commons_httpclient = dependencies.module('org.apache.httpcomponents:httpclient:4.4.1') {
-    dependency "org.apache.httpcomponents:httpcore:4.4.4@jar"
+libraries.commons_httpclient = dependencies.module('org.apache.httpcomponents:httpclient:4.5.3') {
+    dependency "org.apache.httpcomponents:httpcore:4.4.8@jar"
     dependency libraries.jcl_to_slf4j
     dependency libraries.commons_codec
     dependency libraries.jcifs


### PR DESCRIPTION
Both libraries are two years old and a lot of fixes were
delivered during that time in particular for SSL connections.

Both release notes are quite explicit:

https://archive.apache.org/dist/httpcomponents/httpcore/RELEASE_NOTES.txt
https://archive.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.5.x.txt

