### PR TITLE
Re-enable Windows test and remove path length restriction

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/process/ArgWriter.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/process/ArgWriter.java
@@ -90,7 +90,7 @@ public class ArgWriter implements ArgCollector {
                 } catch (IOException e) {
                     throw new UncheckedIOException(String.format("Could not write options file '%s'.", argsFile.getAbsolutePath()), e);
                 }
-                return Collections.singletonList("@" + GFileUtils.relativize(workingDir, argsFile));
+                return Collections.singletonList("@" + GFileUtils.relativizeToBase(workingDir, argsFile));
             }
         };
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/process/ArgWriter.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/process/ArgWriter.java
@@ -18,6 +18,7 @@ package org.gradle.internal.process;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.util.GFileUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,6 +63,34 @@ public class ArgWriter implements ArgCollector {
         return new Transformer<ArgWriter, PrintWriter>() {
             public ArgWriter transform(PrintWriter original) {
                 return windowsStyle(original);
+            }
+        };
+    }
+
+
+    /**
+     * Returns an args transformer that replaces the provided args with a generated args file containing the args. Uses platform text encoding.
+     */
+    public static Transformer<List<String>, List<String>> argsFileGenerator(final File workingDir, final File argsFile, final Transformer<ArgWriter, PrintWriter> argWriterFactory) {
+        return new Transformer<List<String>, List<String>>() {
+            @Override
+            public List<String> transform(List<String> args) {
+                if (args.isEmpty()) {
+                    return args;
+                }
+                argsFile.getParentFile().mkdirs();
+                try {
+                    PrintWriter writer = new PrintWriter(argsFile);
+                    try {
+                        ArgWriter argWriter = argWriterFactory.transform(writer);
+                        argWriter.args(args);
+                    } finally {
+                        writer.close();
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(String.format("Could not write options file '%s'.", argsFile.getAbsolutePath()), e);
+                }
+                return Collections.singletonList("@" + GFileUtils.relativize(workingDir, argsFile));
             }
         };
     }

--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -27,7 +27,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -27,6 +27,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -36,8 +37,14 @@ import java.util.zip.Checksum;
 
 public class GFileUtils {
 
-    public static String relativize(File baseDir, File file) {
-        return baseDir.toPath().relativize(file.toPath()).toString();
+    public static String relativizeToBase(File baseDir, File file) {
+        Path basePath = baseDir.toPath();
+        Path filePath = file.toPath();
+        if (filePath.startsWith(basePath)) {
+            return basePath.relativize(filePath).toString();
+        } else {
+            return filePath.toString();
+        }
     }
 
     public static FileInputStream openInputStream(File file) {

--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -27,6 +27,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,6 +36,10 @@ import java.util.List;
 import java.util.zip.Checksum;
 
 public class GFileUtils {
+
+    public static String relativize(File baseDir, File file) {
+        return baseDir.toPath().relativize(file.toPath()).toString();
+    }
 
     public static FileInputStream openInputStream(File file) {
         try {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
@@ -18,11 +18,8 @@ package org.gradle.language.cpp
 
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.gradle.vcs.fixtures.GitRepository
 
-@Requires(TestPrecondition.NOT_WINDOWS)
 class CppDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     def app = new CppAppWithLibraries()
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
@@ -71,13 +71,13 @@ class CppDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrati
         writeLogLibrary()
 
         when:
-        succeeds ":app:installDebug"
+        succeeds ":app:installDebug", "--info"
         then:
         assertTasksExecutedFor("Debug")
         assertAppHasOutputFor("debug")
 
         when:
-        succeeds ":app:installRelease"
+        succeeds ":app:installRelease", "--info"
         then:
         assertTasksExecutedFor("Release")
         assertAppHasOutputFor("release")

--- a/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
@@ -80,6 +80,7 @@ public class Assemble extends DefaultTask {
 
         DefaultAssembleSpec spec = new DefaultAssembleSpec();
         spec.setTempDir(getTemporaryDir());
+        spec.setWorkingDir(getProject().getRootDir());
 
         spec.setObjectFileDir(getObjectFileDir());
         spec.source(getSource());

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -98,6 +98,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
         NativeCompileSpec spec = createCompileSpec();
         spec.setTargetPlatform(targetPlatform);
         spec.setTempDir(getTemporaryDir());
+        spec.setWorkingDir(getProject().getRootDir());
         spec.setObjectFileDir(objectFileDir.get().getAsFile());
         spec.include(includes);
         spec.source(getSource());

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -92,6 +92,7 @@ public class WindowsResourceCompile extends DefaultTask {
 
         NativeCompileSpec spec = new DefaultWindowsResourceCompileSpec();
         spec.setTempDir(getTemporaryDir());
+        spec.setWorkingDir(getProject().getRootDir());
         spec.setObjectFileDir(getOutputDir());
         spec.include(getIncludes());
         spec.source(getSource());

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/AbstractBinaryToolSpec.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/AbstractBinaryToolSpec.java
@@ -28,6 +28,7 @@ public class AbstractBinaryToolSpec implements BinaryToolSpec {
     private File tempDir;
     private NativePlatform platform;
     private BuildOperationLogger oplogger;
+    private File workingDir;
 
     @Override
     public NativePlatform getTargetPlatform() {
@@ -87,5 +88,15 @@ public class AbstractBinaryToolSpec implements BinaryToolSpec {
     @Override
     public void setOperationLogger(BuildOperationLogger oplogger) {
         this.oplogger = oplogger;
+    }
+
+    @Override
+    public File getWorkingDir() {
+        return workingDir;
+    }
+
+    @Override
+    public void setWorkingDir(File workingDir) {
+        this.workingDir = workingDir;
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/BinaryToolSpec.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/BinaryToolSpec.java
@@ -24,6 +24,9 @@ import java.io.File;
 import java.util.List;
 
 public interface BinaryToolSpec extends CompileSpec {
+    File getWorkingDir();
+    void setWorkingDir(File workingDir);
+
     NativePlatform getTargetPlatform();
 
     void setTargetPlatform(NativePlatform platform);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/CompilerOutputFileNamingSchemeFactory.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/CompilerOutputFileNamingSchemeFactory.java
@@ -19,6 +19,8 @@ package org.gradle.nativeplatform.internal;
 import org.gradle.internal.Factory;
 import org.gradle.internal.file.RelativeFilePathResolver;
 
+import javax.annotation.Nonnull;
+
 public class CompilerOutputFileNamingSchemeFactory implements Factory<CompilerOutputFileNamingScheme> {
     private final RelativeFilePathResolver fileResolver;
 
@@ -27,6 +29,7 @@ public class CompilerOutputFileNamingSchemeFactory implements Factory<CompilerOu
     }
 
     @Override
+    @Nonnull
     public CompilerOutputFileNamingScheme create() {
         return new CompilerOutputFileNamingScheme(fileResolver);
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -221,6 +221,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
         LinkerSpec spec = createLinkerSpec();
         spec.setTargetPlatform(getTargetPlatform());
         spec.setTempDir(getTemporaryDir());
+        spec.setWorkingDir(getProject().getRootDir());
         spec.setOutputFile(getOutputFile());
 
         spec.objectFiles(getSource());

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
@@ -92,6 +92,7 @@ public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBin
 
         StaticLibraryArchiverSpec spec = new DefaultStaticLibraryArchiverSpec();
         spec.setTempDir(getTemporaryDir());
+        spec.setWorkingDir(getProject().getRootDir());
         spec.setOutputFile(getOutputFile());
         spec.objectFiles(getSource());
         spec.args(getStaticLibArgs());

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractCompiler.java
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
-import org.gradle.internal.operations.logging.BuildOperationLogger;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.nativeplatform.internal.BinaryToolSpec;
@@ -75,18 +74,14 @@ public abstract class AbstractCompiler<T extends BinaryToolSpec> implements Comp
         if (useCommandFile) {
             // Shorten args and write out an options.txt file
             // This must be called only once per execute()
-            addOptionsFileArgs(args, spec.getTempDir());
+            addOptionsFileArgs(spec, args, spec.getTempDir());
         }
         return args;
     }
 
-    protected abstract void addOptionsFileArgs(List<String> args, File tempDir);
+    protected abstract void addOptionsFileArgs(T spec, List<String> args, File tempDir);
 
-    protected CommandLineToolInvocation newInvocation(String name, File workingDirectory, Iterable<String> args, BuildOperationLogger operationLogger) {
-        return invocationContext.createInvocation(name, workingDirectory, args, operationLogger);
-    }
-
-    protected CommandLineToolInvocation newInvocation(String name, Iterable<String> args, BuildOperationLogger operationLogger) {
-        return invocationContext.createInvocation(name, args, operationLogger);
+    protected CommandLineToolInvocation newInvocation(String name, T spec, Iterable<String> args) {
+        return invocationContext.createInvocation(name, spec.getWorkingDir(), args, spec.getOperationLogger());
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
@@ -77,13 +77,13 @@ public abstract class NativeCompiler<T extends NativeCompileSpec> extends Abstra
         };
     }
 
-    protected List<String> getSourceArgs(File sourceFile) {
-        return Collections.singletonList(sourceFile.getAbsolutePath());
+    protected List<String> getSourceArgs(T spec, File sourceFile) {
+        return Collections.singletonList(GFileUtils.relativize(spec.getWorkingDir(), sourceFile));
     }
 
     protected abstract List<String> getOutputArgs(T spec, File outputFile);
 
-    protected abstract void addOptionsFileArgs(List<String> args, File tempDir);
+    protected abstract void addOptionsFileArgs(T spec, List<String> args, File tempDir);
 
     protected abstract List<String> getPCHArgs(T spec);
 
@@ -132,11 +132,11 @@ public abstract class NativeCompiler<T extends NativeCompileSpec> extends Abstra
     }
 
     protected CommandLineToolInvocation createPerFileInvocation(List<String> genericArgs, File sourceFile, File objectDir, T spec) {
-        List<String> sourceArgs = getSourceArgs(sourceFile);
+        List<String> sourceArgs = getSourceArgs(spec, sourceFile);
         List<String> outputArgs = getOutputArgs(spec, getOutputFileDir(sourceFile, objectDir, objectFileExtension));
         List<String> pchArgs = maybeGetPCHArgs(spec, sourceFile);
 
-        return newInvocation("compiling ".concat(sourceFile.getName()), objectDir, buildPerFileArgs(genericArgs, sourceArgs, outputArgs, pchArgs), spec.getOperationLogger());
+        return newInvocation("compiling ".concat(sourceFile.getName()), spec, buildPerFileArgs(genericArgs, sourceArgs, outputArgs, pchArgs));
     }
 
     protected Iterable<String> buildPerFileArgs(List<String> genericArgs, List<String> sourceArgs, List<String> outputArgs, List<String> pchArgs) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
@@ -26,15 +26,14 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
-import org.gradle.internal.FileUtils;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
-import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.language.nativeplatform.internal.Include;
 import org.gradle.language.nativeplatform.internal.IncludeDirectives;
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory;
 import org.gradle.util.CollectionUtils;
+import org.gradle.util.GFileUtils;
 
 import java.io.File;
 import java.util.Collections;
@@ -89,17 +88,12 @@ public abstract class NativeCompiler<T extends NativeCompileSpec> extends Abstra
     protected abstract List<String> getPCHArgs(T spec);
 
     protected File getOutputFileDir(File sourceFile, File objectFileDir, String fileSuffix) {
-        boolean windowsPathLimitation = OperatingSystem.current().isWindows();
-
         File outputFile = compilerOutputFileNamingSchemeFactory.create()
                 .withObjectFileNameSuffix(fileSuffix)
                 .withOutputBaseFolder(objectFileDir)
                 .map(sourceFile);
-        File outputDirectory = outputFile.getParentFile();
-        if (!outputDirectory.exists()) {
-            outputDirectory.mkdirs();
-        }
-        return windowsPathLimitation ? FileUtils.assertInWindowsPathLengthLimitation(outputFile) : outputFile;
+        GFileUtils.mkdirs(outputFile.getParentFile());
+        return outputFile;
     }
 
     protected List<String> maybeGetPCHArgs(final T spec, File sourceFile) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompiler.java
@@ -78,7 +78,7 @@ public abstract class NativeCompiler<T extends NativeCompileSpec> extends Abstra
     }
 
     protected List<String> getSourceArgs(T spec, File sourceFile) {
-        return Collections.singletonList(GFileUtils.relativize(spec.getWorkingDir(), sourceFile));
+        return Collections.singletonList(GFileUtils.relativizeToBase(spec.getWorkingDir(), sourceFile));
     }
 
     protected abstract List<String> getOutputArgs(T spec, File outputFile);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ArStaticLibraryArchiver.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ArStaticLibraryArchiver.java
@@ -60,8 +60,7 @@ class ArStaticLibraryArchiver extends AbstractCompiler<StaticLibraryArchiverSpec
 
     @Override
     protected Action<BuildOperationQueue<CommandLineToolInvocation>> newInvocationAction(final StaticLibraryArchiverSpec spec, List<String> args) {
-        final CommandLineToolInvocation invocation = newInvocation(
-            "archiving " + spec.getOutputFile().getName(), spec.getOutputFile().getParentFile(), args, spec.getOperationLogger());
+        final CommandLineToolInvocation invocation = newInvocation("archiving " + spec.getOutputFile().getName(), spec, args);
 
         return new Action<BuildOperationQueue<CommandLineToolInvocation>>() {
             @Override
@@ -73,7 +72,7 @@ class ArStaticLibraryArchiver extends AbstractCompiler<StaticLibraryArchiverSpec
     }
 
     @Override
-    protected void addOptionsFileArgs(List<String> args, File tempDir) {
+    protected void addOptionsFileArgs(StaticLibraryArchiverSpec spec, List<String> args, File tempDir) {
         // No support for command file
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompatibleNativeCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompatibleNativeCompiler.java
@@ -44,7 +44,7 @@ class GccCompatibleNativeCompiler<T extends NativeCompileSpec> extends NativeCom
     }
 
     @Override
-    protected void addOptionsFileArgs(List<String> args, File tempDir) {
+    protected void addOptionsFileArgs(T spec, List<String> args, File tempDir) {
         OptionsFileArgsWriter writer = new GccOptionsFileArgsWriter(tempDir);
         // modifies args in place
         writer.execute(args);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccLinker.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccLinker.java
@@ -40,8 +40,7 @@ class GccLinker extends AbstractCompiler<LinkerSpec> {
 
     @Override
     protected Action<BuildOperationQueue<CommandLineToolInvocation>> newInvocationAction(final LinkerSpec spec, List<String> args) {
-        final CommandLineToolInvocation invocation = newInvocation(
-            "linking " + spec.getOutputFile().getName(), args, spec.getOperationLogger());
+        final CommandLineToolInvocation invocation = newInvocation("linking " + spec.getOutputFile().getName(), spec, args);
 
         return new Action<BuildOperationQueue<CommandLineToolInvocation>>() {
             @Override
@@ -53,7 +52,7 @@ class GccLinker extends AbstractCompiler<LinkerSpec> {
     }
 
     @Override
-    protected void addOptionsFileArgs(List<String> args, File tempDir) {
+    protected void addOptionsFileArgs(LinkerSpec spec, List<String> args, File tempDir) {
         new GccOptionsFileArgsWriter(tempDir).execute(args);
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/LibExeStaticLibraryArchiver.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/LibExeStaticLibraryArchiver.java
@@ -53,7 +53,7 @@ class LibExeStaticLibraryArchiver extends AbstractCompiler<StaticLibraryArchiver
     @Override
     protected Action<BuildOperationQueue<CommandLineToolInvocation>> newInvocationAction(final StaticLibraryArchiverSpec spec, List<String> args) {
         final CommandLineToolInvocation invocation = newInvocation(
-            "archiving " + spec.getOutputFile().getName(), spec.getOutputFile().getParentFile(), args, spec.getOperationLogger());
+            "archiving " + spec.getOutputFile().getName(), spec, args);
 
         return new Action<BuildOperationQueue<CommandLineToolInvocation>>() {
             @Override
@@ -65,7 +65,7 @@ class LibExeStaticLibraryArchiver extends AbstractCompiler<StaticLibraryArchiver
     }
 
     @Override
-    protected void addOptionsFileArgs(List<String> args, File tempDir) {
+    protected void addOptionsFileArgs(StaticLibraryArchiverSpec spec, List<String> args, File tempDir) {
         new VisualCppOptionsFileArgsWriter(tempDir).execute(args);
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/LinkExeLinker.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/LinkExeLinker.java
@@ -68,7 +68,8 @@ class LinkExeLinker extends AbstractCompiler<LinkerSpec> {
         };
     }
 
-    protected void addOptionsFileArgs(List<String> args, File tempDir) {
+    @Override
+    protected void addOptionsFileArgs(LinkerSpec spec, List<String> args, File tempDir) {
         new VisualCppOptionsFileArgsWriter(tempDir).execute(args);
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
@@ -56,8 +56,9 @@ abstract class VisualCppCompilerArgsTransformer<T extends NativeCompileSpec> imp
     }
 
     protected void addIncludeArgs(T spec, List<String> args) {
+        File workingDir = spec.getWorkingDir();
         for (File file : spec.getIncludeRoots()) {
-            args.add("/I" + GFileUtils.relativize(spec.getWorkingDir(), file));
+            args.add("/I" + GFileUtils.relativizeToBase(workingDir, file));
         }
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import org.gradle.nativeplatform.toolchain.internal.ArgsTransformer;
 import org.gradle.nativeplatform.toolchain.internal.MacroArgsConverter;
 import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
+import org.gradle.util.GFileUtils;
 
 import java.io.File;
 import java.util.List;
@@ -56,7 +57,7 @@ abstract class VisualCppCompilerArgsTransformer<T extends NativeCompileSpec> imp
 
     protected void addIncludeArgs(T spec, List<String> args) {
         for (File file : spec.getIncludeRoots()) {
-            args.add("/I" + file.getAbsolutePath());
+            args.add("/I" + GFileUtils.relativize(spec.getWorkingDir(), file));
         }
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppNativeCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppNativeCompiler.java
@@ -42,10 +42,10 @@ class VisualCppNativeCompiler<T extends NativeCompileSpec> extends NativeCompile
     protected List<String> getOutputArgs(T spec, File outputFile) {
         List<String> args = new ArrayList<String>();
         if (spec.isDebuggable()) {
-            args.add("/Fd" + GFileUtils.relativize(spec.getWorkingDir(), new File(outputFile.getParentFile(), outputFile.getName() + ".pdb")));
+            args.add("/Fd" + GFileUtils.relativizeToBase(spec.getWorkingDir(), new File(outputFile.getParentFile(), outputFile.getName() + ".pdb")));
         }
         // MSVC doesn't allow a space between Fo and the file name
-        args.add("/Fo" + GFileUtils.relativize(spec.getWorkingDir(), outputFile));
+        args.add("/Fo" + GFileUtils.relativizeToBase(spec.getWorkingDir(), outputFile));
         return args;
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppOptionsFileArgsWriter.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppOptionsFileArgsWriter.java
@@ -39,10 +39,6 @@ class VisualCppOptionsFileArgsWriter extends OptionsFileArgsWriter {
 
     @Override
     protected List<String> transformArgs(List<String> originalArgs, File tempDir) {
-        if (workingDir == null) {
-            return ArgWriter.argsFileGenerator(new File(tempDir, "options.txt"), ArgWriter.windowsStyleFactory()).transform(originalArgs);
-        } else {
-            return ArgWriter.argsFileGenerator(workingDir, new File(tempDir, "options.txt"), ArgWriter.windowsStyleFactory()).transform(originalArgs);
-        }
+        return ArgWriter.argsFileGenerator(new File(tempDir, "options.txt"), ArgWriter.windowsStyleFactory()).transform(originalArgs);
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppOptionsFileArgsWriter.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppOptionsFileArgsWriter.java
@@ -26,12 +26,23 @@ import java.util.List;
  * Uses an option file for arguments passed to Visual C++.
  */
 class VisualCppOptionsFileArgsWriter extends OptionsFileArgsWriter {
+    private File workingDir;
+
     public VisualCppOptionsFileArgsWriter(File tempDir) {
         super(tempDir);
     }
 
+    public VisualCppOptionsFileArgsWriter(File workingDir, File tempDir) {
+        super(tempDir);
+        this.workingDir = workingDir;
+    }
+
     @Override
     protected List<String> transformArgs(List<String> originalArgs, File tempDir) {
-        return ArgWriter.argsFileGenerator(new File(tempDir, "options.txt"), ArgWriter.windowsStyleFactory()).transform(originalArgs);
+        if (workingDir == null) {
+            return ArgWriter.argsFileGenerator(new File(tempDir, "options.txt"), ArgWriter.windowsStyleFactory()).transform(originalArgs);
+        } else {
+            return ArgWriter.argsFileGenerator(workingDir, new File(tempDir, "options.txt"), ArgWriter.windowsStyleFactory()).transform(originalArgs);
+        }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
@@ -57,7 +57,7 @@ class SwiftCompiler extends AbstractCompiler<SwiftCompileSpec> {
     }
 
     @Override
-    protected void addOptionsFileArgs(List<String> args, File tempDir) {
+    protected void addOptionsFileArgs(SwiftCompileSpec spec, List<String> args, File tempDir) {
     }
 
     protected File getOutputFileDir(File sourceFile, File objectFileDir, String fileSuffix) {
@@ -122,7 +122,7 @@ class SwiftCompiler extends AbstractCompiler<SwiftCompileSpec> {
                 }
 
                 CommandLineToolInvocation perFileInvocation =
-                    newInvocation("compiling swift file(s)", objectDir, Iterables.concat(genericArgs, outputArgs, importRootArgs), spec.getOperationLogger());
+                    newInvocation("compiling swift file(s)", spec, Iterables.concat(genericArgs, outputArgs, importRootArgs));
                 buildQueue.add(perFileInvocation);
             }
         };

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
@@ -40,13 +40,13 @@ class SwiftLinker extends AbstractCompiler<LinkerSpec> {
     }
 
     @Override
-    protected void addOptionsFileArgs(List<String> args, File tempDir) {
+    protected void addOptionsFileArgs(LinkerSpec spec, List<String> args, File tempDir) {
     }
 
     @Override
     protected Action<BuildOperationQueue<CommandLineToolInvocation>> newInvocationAction(final LinkerSpec spec, List<String> args) {
         final CommandLineToolInvocation invocation = newInvocation(
-            "linking " + spec.getOutputFile().getName(), spec.getOutputFile().getParentFile(), args, spec.getOperationLogger());
+            "linking " + spec.getOutputFile().getName(), spec, args);
 
         return new Action<BuildOperationQueue<CommandLineToolInvocation>>() {
             @Override

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -87,7 +87,7 @@ abstract class NativeCompilerTest extends Specification {
         def sourceFile = testDir.file("source.ext")
 
         when:
-        def args = compiler.getSourceArgs(sourceFile)
+        def args = compiler.getSourceArgs(spec, sourceFile)
 
         then:
         args == [ sourceFile.absoluteFile.toString() ]


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-native/issues/182

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
