### PR TITLE
Add a clear error when missing a settings script

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
@@ -128,6 +128,25 @@ class VcsMappingsIntegrationTest extends AbstractVcsIntegrationTest {
         assertRepoNotCheckedOut("does-not-exist")
     }
 
+    def 'missing settings has clear error'() {
+        file('dep/settings.gradle').delete()
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule("org.test:dep") {
+                        from vcs(DirectoryRepositorySpec) {
+                            sourceDir = file("dep")
+                        }
+                    }
+                }
+            }
+        """
+        expect:
+        fails('assemble')
+        assertRepoCheckedOut()
+        failureCauseContains('Missing settings script')
+    }
+
     void assertRepoCheckedOut(String repoName="dep") {
         def checkout = checkoutDir(repoName, "fixed", "directory-repo:${file(repoName).absolutePath}")
         checkout.file("checkedout").assertIsFile()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.vcs;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
@@ -77,6 +78,14 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
                 VersionControlSystem versionControlSystem = versionControlSystemFactory.create(spec);
                 VersionRef selectedVersion = selectVersionFromRepository(spec, versionControlSystem);
                 File dependencyWorkingDir = populateWorkingDirectory(baseWorkingDir, spec, versionControlSystem, selectedVersion);
+                //TODO: Allow user to provide settings script in VcsMapping
+                if (!(new File(dependencyWorkingDir, "settings.gradle").exists())
+                    && !(new File(dependencyWorkingDir, "settings.gradle.kts").exists())) {
+                    throw new GradleException(
+                        String.format(
+                            "Missing settings script: %s must contain settings.gradle or settings.kts.gradle.",
+                            spec.getUniqueId()));
+                }
 
                 // TODO: This shouldn't rely on the service registry to find NestedBuildFactory
                 IncludedBuildRegistry includedBuildRegistry = serviceRegistry.get(IncludedBuildRegistry.class);


### PR DESCRIPTION
External source dependencies build on top of the included build
infrastructure and, as such require that the builds being pulled in
through external source dependencies include settings scripts.

Fixes gradle/gradle-native#190
