### PR TITLE
Provide more specific information for auto-applied plugin requests

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
@@ -28,7 +28,7 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     private final PluginId id;
     private final String version;
     private final boolean apply;
-    private final int lineNumber;
+    private final Integer lineNumber;
     private final String scriptDisplayName;
     private final ModuleVersionSelector artifact;
     private final PluginRequestInternal originalRequest;
@@ -81,7 +81,7 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     }
 
     @Override
-    public int getLineNumber() {
+    public Integer getLineNumber() {
         return lineNumber;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
@@ -33,27 +33,23 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     private final ModuleVersionSelector artifact;
     private final PluginRequestInternal originalRequest;
 
-    public DefaultPluginRequest(String id, String version, boolean apply, int lineNumber, ScriptSource scriptSource) {
+    public DefaultPluginRequest(String id, String version, boolean apply, Integer lineNumber, ScriptSource scriptSource) {
         this(DefaultPluginId.of(id), version, apply, lineNumber, scriptSource);
     }
 
-    public DefaultPluginRequest(PluginId id, String version, boolean apply, int lineNumber, ScriptSource scriptSource) {
+    public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, ScriptSource scriptSource) {
         this(id, version, apply, lineNumber, scriptSource.getDisplayName(), null);
     }
 
-    public DefaultPluginRequest(String id, String version, boolean apply, int lineNumber, String scriptDisplayName) {
+    public DefaultPluginRequest(String id, String version, boolean apply, Integer lineNumber, String scriptDisplayName) {
         this(DefaultPluginId.of(id), version, apply, lineNumber, scriptDisplayName, null);
     }
 
-    public DefaultPluginRequest(PluginRequestInternal from) {
-        this(from.getId(), from.getVersion(), from.isApply(), from.getLineNumber(), from.getScriptDisplayName(), from.getModule());
-    }
-
-    public DefaultPluginRequest(PluginId id, String version, boolean apply, int lineNumber, String scriptDisplayName, ModuleVersionSelector artifact) {
+    public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, String scriptDisplayName, ModuleVersionSelector artifact) {
         this(id, version, apply, lineNumber, scriptDisplayName, artifact, null);
     }
 
-    public DefaultPluginRequest(PluginId id, String version, boolean apply, int lineNumber, String scriptDisplayName, ModuleVersionSelector artifact,
+    public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, String scriptDisplayName, ModuleVersionSelector artifact,
                                 PluginRequestInternal originalRequest) {
         this.id = id;
         this.version = version;

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
@@ -33,10 +33,6 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     private final ModuleVersionSelector artifact;
     private final PluginRequestInternal originalRequest;
 
-    public DefaultPluginRequest(String id, String version, boolean apply, Integer lineNumber, ScriptSource scriptSource) {
-        this(DefaultPluginId.of(id), version, apply, lineNumber, scriptSource);
-    }
-
     public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, ScriptSource scriptSource) {
         this(id, version, apply, lineNumber, scriptSource.getDisplayName(), null);
     }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestInternal.java
@@ -22,7 +22,7 @@ public interface PluginRequestInternal extends PluginRequest {
 
     boolean isApply();
 
-    int getLineNumber();
+    Integer getLineNumber();
 
     String getScriptDisplayName();
 

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestsSerializer.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestsSerializer.java
@@ -34,7 +34,8 @@ public class PluginRequestsSerializer extends AbstractSerializer<PluginRequests>
             PluginId pluginId = DefaultPluginId.unvalidated(decoder.readString());
             String version = decoder.readNullableString();
             boolean apply = decoder.readBoolean();
-            int lineNumber = decoder.readSmallInt();
+            String decodedLineNumber = decoder.readNullableString();
+            Integer lineNumber = decodedLineNumber == null ? null : Integer.valueOf(decodedLineNumber);
             String scriptDisplayName = decoder.readString();
 
             requests.add(i, new DefaultPluginRequest(pluginId, version, apply, lineNumber, scriptDisplayName, null));
@@ -49,7 +50,7 @@ public class PluginRequestsSerializer extends AbstractSerializer<PluginRequests>
             encoder.writeString(request.getId().getId());
             encoder.writeNullableString(request.getVersion());
             encoder.writeBoolean(request.isApply());
-            encoder.writeSmallInt(request.getLineNumber());
+            encoder.writeNullableString(request.getLineNumber() == null ? null : request.getLineNumber().toString());
             encoder.writeString(request.getScriptDisplayName());
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/plugin/use/internal/PluginRequestsSerializerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/plugin/use/internal/PluginRequestsSerializerTest.groovy
@@ -38,14 +38,15 @@ class PluginRequestsSerializerTest extends SerializerSpec {
         def serialized = serialize(new DefaultPluginRequests([
             new DefaultPluginRequest("java", null, true, 1, "buildscript"),
             new DefaultPluginRequest("groovy", null, false, 2, "buildscript"),
-            new DefaultPluginRequest("custom", "1.0", false, 3, "initscript")
+            new DefaultPluginRequest("custom", "1.0", false, 3, "initscript"),
+            new DefaultPluginRequest("auto-apply", "2.0", true, null, "auto-applied plugin")
         ]), serializer)
 
         then:
-        serialized*.id == ["java", "groovy", "custom"].collect { DefaultPluginId.of(it) }
-        serialized*.version == [null, null, "1.0"]
-        serialized*.lineNumber == [1, 2, 3]
-        serialized*.scriptDisplayName == ["buildscript", "buildscript", "initscript"]
-        serialized*.apply == [true, false, false]
+        serialized*.id == ["java", "groovy", "custom", "auto-apply"].collect { DefaultPluginId.of(it) }
+        serialized*.version == [null, null, "1.0", "2.0"]
+        serialized*.lineNumber == [1, 2, 3, null]
+        serialized*.scriptDisplayName == ["buildscript", "buildscript", "initscript", "auto-applied plugin"]
+        serialized*.apply == [true, false, false, true]
     }
 }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -29,6 +29,8 @@ import org.gradle.plugin.use.internal.DefaultPluginId;
 
 import java.util.List;
 
+import static org.gradle.initialization.StartParameterBuildOptions.BuildScanOption;
+
 /**
  * A hardcoded {@link AutoAppliedPluginRegistry} that only knows about the build-scan plugin for now.
  */
@@ -59,6 +61,10 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
 
     private DefaultPluginRequest createScanPluginRequest() {
         DefaultModuleVersionSelector artifact = new DefaultModuleVersionSelector(BUILD_SCAN_PLUGIN_GROUP, BUILD_SCAN_PLUGIN_NAME, BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION);
-        return new DefaultPluginRequest(BUILD_SCAN_PLUGIN_ID, BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION, true, 0, "", artifact);
+        return new DefaultPluginRequest(BUILD_SCAN_PLUGIN_ID, BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION, true, null, getScriptDisplayName(), artifact);
+    }
+
+    private static String getScriptDisplayName() {
+        return String.format("auto-applied by using --%s", BuildScanOption.LONG_OPTION);
     }
 }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoryPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoryPluginResolverTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVer
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
 class ArtifactRepositoryPluginResolverTest extends Specification {
@@ -30,7 +31,7 @@ class ArtifactRepositoryPluginResolverTest extends Specification {
     def resolver = new ArtifactRepositoryPluginResolver("maven", null, versionSelectorScheme);
 
     PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new StringScriptSource("test", "test"))
     }
 
     def "fail pluginRequests without versions"() {

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
@@ -19,13 +19,13 @@ package org.gradle.plugin.use.resolve.internal
 import org.gradle.api.Plugin
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.internal.DocumentationRegistry
-import org.gradle.api.internal.plugins.PluginRegistry
 import org.gradle.api.internal.plugins.PluginImplementation
+import org.gradle.api.internal.plugins.PluginRegistry
 import org.gradle.groovy.scripts.StringScriptSource
-import org.gradle.plugin.use.internal.DefaultPluginId
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.InvalidPluginRequestException
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
 class CorePluginResolverTest extends Specification {
@@ -43,7 +43,7 @@ class CorePluginResolverTest extends Specification {
     def resolver = new CorePluginResolver(docRegistry, pluginRegistry)
 
     PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new StringScriptSource("test", "test"))
     }
 
     def "non core plugins are ignored"() {

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/DeprecationListeningPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/DeprecationListeningPluginResolutionServiceClientTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.plugin.use.resolve.service.internal
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
 import static org.gradle.plugin.use.resolve.service.internal.DeprecationListeningPluginResolutionServiceClient.toMessage
@@ -92,6 +93,6 @@ class DeprecationListeningPluginResolutionServiceClientTest extends Specificatio
     }
 
     static PluginRequestInternal request(String id, String version = "1") {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new StringScriptSource("test", "test"))
     }
 }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/InMemoryCachingPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/InMemoryCachingPluginResolutionServiceClientTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.plugin.use.resolve.service.internal
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
 class InMemoryCachingPluginResolutionServiceClientTest extends Specification {
@@ -129,7 +130,7 @@ class InMemoryCachingPluginResolutionServiceClientTest extends Specification {
     }
 
     static PluginRequestInternal request(String id, String version = "1") {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new StringScriptSource("test", "test"))
     }
 
 }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/PersistentCachingPluginResolutionServiceClientTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/service/internal/PersistentCachingPluginResolutionServiceClientTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.cache.PersistentIndexedCache
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.plugin.management.internal.DefaultPluginRequest
 import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.internal.InMemoryCacheFactory
 import org.junit.Rule
@@ -149,7 +150,7 @@ class PersistentCachingPluginResolutionServiceClientTest extends Specification {
     }
 
     static PluginRequestInternal request(String id, String version = "1") {
-        new DefaultPluginRequest(id, version, true, 1, new StringScriptSource("test", "test"))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new StringScriptSource("test", "test"))
     }
 
 }


### PR DESCRIPTION
### Context

As described in https://github.com/gradle/gradle/pull/3135#issuecomment-335898213 to minimize risk for the release:

- Keep `LocationAwareException` unchanged
- Keep `DefaultPluginIdentifier` unchanged
- For auto-applied plugins set `lineNumber` to null (`LocationAwareException` accepts this)
- Set the displayName to `plugin auto-applied by using --scan`
- Create an issue to further clean this up on master
