### PR TITLE
Allow modification of dependencies in component metadata rules

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.artifacts;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
 
@@ -52,4 +53,14 @@ public interface ComponentMetadataDetails extends ComponentMetadata {
      * @param statusScheme the status scheme of the component
      */
     void setStatusScheme(List<String> statusScheme);
+
+    /**
+     * Add a rule for adjusting an existing variant of the component.
+     *
+     * @param name name of the variant to adjust (e.g. 'compile')
+     * @param action the action to modify the variant
+     *
+     * @since 4.4
+     */
+    void withVariant(String name, Action<VariantMetadata> action);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependenciesMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependenciesMetadata.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Describes the dependencies of a variant declared in a resolved component's metadata, which typically originate from
+ * a component descriptor (Gradle metadata file, Ivy file, Maven POM). This interface can be used to adjust the dependencies
+ * of a published component via metadata rules (see {@link org.gradle.api.artifacts.dsl.ComponentMetadataHandler}.
+ *
+ * @since 4.4
+ */
+@Incubating
+public interface DependenciesMetadata extends Collection<DependencyMetadata> {
+
+    /**
+     * Add a dependency using the string notation: <code><i>group</i>:<i>name</i>:<i>version</i></code>.
+     *
+     * @param dependencyNotation the dependency
+     */
+    void add(String dependencyNotation);
+
+    /**
+     * Add a dependency using the map notation: <code>group: <i>group</i>, name: <i>name</i>, version: <i>version</i></code>.
+     *
+     * @param dependencyNotation the dependency
+     */
+    void add(Map<String, String> dependencyNotation);
+
+    /**
+     * Add a dependency using the string notation: <code><i>group</i>:<i>name</i>:<i>version</i></code>.
+     *
+     * @param dependencyNotation the dependency
+     * @param configureAction action to configure details of the dependency - see {@link DependencyMetadata}
+     */
+    void add(String dependencyNotation, Action<DependencyMetadata> configureAction);
+
+    /**
+     * Add a dependency using the map notation: <code>group: <i>group</i>, name: <i>name</i>, version: <i>version</i></code>.
+     *
+     * @param dependencyNotation the dependency
+     * @param configureAction action to configure details of the dependency - see {@link DependencyMetadata}
+     */
+    void add(Map<String, String> dependencyNotation, Action<DependencyMetadata> configureAction);
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Describes a dependency declared in a resolved component's metadata, which typically originates from
+ * a component descriptor (Gradle metadata file, Ivy file, Maven POM). This interface can be used to adjust
+ * a dependency's properties via metadata rules (see {@link org.gradle.api.artifacts.dsl.ComponentMetadataHandler}.
+ *
+ * @since 4.4
+ */
+@Incubating
+public interface DependencyMetadata {
+
+    /**
+     * Returns the group of this dependency. The group is often required to find the artifacts of a dependency in a
+     * repository. For example, the group name corresponds to a directory name in a Maven like repository.
+     */
+    String getGroup();
+
+    /**
+     * Returns the name of this dependency. The name is almost always required to find the artifacts of a dependency in
+     * a repository.
+     */
+    String getName();
+
+    /**
+     * Returns the version of this dependency. The version is often required to find the artifacts of a dependency in a
+     * repository. For example the version name corresponds to a directory name in a Maven like repository.
+     */
+    String getVersion();
+
+    /**
+     * Returns the optional property of the dependency
+     */
+    boolean isOptional();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
@@ -29,20 +29,19 @@ import org.gradle.api.Incubating;
 public interface DependencyMetadata {
 
     /**
-     * Returns the group of this dependency. The group is often required to find the artifacts of a dependency in a
-     * repository. For example, the group name corresponds to a directory name in a Maven like repository.
+     * Returns the group of the module that is targeted by this dependency.
+     * The group allows the definition of modules of the same name in different organizations or contexts.
      */
     String getGroup();
 
     /**
-     * Returns the name of this dependency. The name is almost always required to find the artifacts of a dependency in
-     * a repository.
+     * Returns the name of the module that is targeted by this dependency.
      */
     String getName();
 
     /**
-     * Returns the version of this dependency. The version is often required to find the artifacts of a dependency in a
-     * repository. For example the version name corresponds to a directory name in a Maven like repository.
+     * Returns the version of the module that is targeted by this dependency,
+     * which usually expresses what API level of the module you are compatible with.
      */
     String getVersion();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
@@ -45,9 +45,4 @@ public interface DependencyMetadata {
      * repository. For example the version name corresponds to a directory name in a Maven like repository.
      */
     String getVersion();
-
-    /**
-     * Returns the optional property of the dependency
-     */
-    boolean isOptional();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantMetadata.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+
+/**
+ * Represents the metadata of one variant of a component, see {@link ComponentMetadataDetails#withVariant(String, Action)}.
+ *
+ * @since 4.4
+ */
+@Incubating
+public interface VariantMetadata {
+    //This interface should extend HasAttributes to allow modification of the variant's attributes
+
+    /**
+     * Register a rule that modifies the dependencies of this variant.
+     *
+     * @param action the action that performs the dependencies adjustment
+     */
+    void withDependencies(Action<DependenciesMetadata> action);
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.test.fixtures.HttpRepository
+import org.gradle.test.fixtures.Module
+import org.gradle.test.fixtures.maven.MavenFileRepository
+import spock.lang.Unroll
+
+abstract class DependencyMetadataRulesIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    def resolve = new ResolveTestFixture(buildFile, variantToTest)
+    def moduleA, moduleB
+
+    abstract HttpRepository getRepo()
+
+    abstract String getRepoDeclaration()
+
+    abstract Module setupCustomVariantsForModule(Module module)
+
+    abstract String getVariantToTest()
+
+    /**
+     * Does the published metadata provide variants with attributes? Eventually all metadata should do that.
+     * For Ivy and Maven POM metadata, the variants and attributes should be derived from configurations and scopes.
+     */
+    abstract boolean getPublishedModulesHaveAttributes()
+
+    def setup() {
+        resolve.prepare()
+        moduleA = setupCustomVariantsForModule(repo.module("org.test", "moduleA").allowAll()).publish()
+        moduleB = repo.module("org.test", "moduleB").allowAll().publish()
+
+        settingsFile << """
+            rootProject.name = 'testproject'
+        """
+        buildFile << """
+            $repoDeclaration
+            
+            configurations { $variantToTest { attributes { attribute(Attribute.of('format', String), 'custom') } } }
+            
+            dependencies {
+                $variantToTest group: 'org.test', name: 'moduleA', version: '1.0' ${publishedModulesHaveAttributes ? "" : ", configuration: '$variantToTest'"}
+            }
+        """
+    }
+
+    @Unroll
+    def "a dependency can be added using #notation notation"() {
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org.test:moduleA') {
+                        withVariant("$variantToTest") { 
+                            withDependencies {
+                                add $dependency
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        then:
+        succeeds 'checkDep'
+        def variantToTest = variantToTest
+        resolve.expectGraph {
+            root(':', ':testproject:') {
+                module("org.test:moduleA:1.0:$variantToTest") {
+                    module('org.test:moduleB:1.0')
+                }
+            }
+        }
+
+        where:
+        notation | dependency
+        "string" | "'org.test:moduleB:1.0'"
+        "map"    | "group: 'org.test', name: 'moduleB', version: '1.0'"
+    }
+
+    def "a dependency can be removed"() {
+        given:
+        moduleA.dependsOn(moduleB).publish()
+
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    all {
+                        withVariant("$variantToTest") {
+                            withDependencies {
+                                removeAll { it.version == '1.0' }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        then:
+        succeeds 'checkDep'
+        def variantToTest = variantToTest
+        resolve.expectGraph {
+            root(':', ':testproject:') {
+                module("org.test:moduleA:1.0:$variantToTest")
+            }
+        }
+    }
+
+    def "dependency modifications are visible in the next rule"() {
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org.test:moduleA') {
+                        withVariant("$variantToTest") { 
+                            withDependencies { dependencies ->
+                                assert dependencies.size() == 0
+                                dependencies.add 'org.test:moduleB:1.0'
+                            }
+                        }
+                    }
+                    withModule('org.test:moduleA') {
+                        withVariant("$variantToTest") {
+                            withDependencies { dependencies ->
+                                assert dependencies.size() == 1
+                                dependencies.removeAll { true }
+                            }
+                        }
+                    }
+                    all {
+                        withVariant("$variantToTest") { 
+                            withDependencies { dependencies ->
+                                assert dependencies.size() == 0
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        then:
+        succeeds 'checkDep'
+        def variantToTest = variantToTest
+        resolve.expectGraph {
+            root(':', ':testproject:') {
+                module("org.test:moduleA:1.0:$variantToTest")
+            }
+        }
+    }
+
+    def "changing dependencies in one variant leaves other variants untouched"() {
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org.test:moduleA') {
+                        withVariant("default") {
+                            withDependencies {
+                                add('org.test:moduleB:1.0')
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        then:
+        succeeds 'checkDep'
+        def variantToTest = variantToTest
+        resolve.expectGraph {
+            root(':', ':testproject:') {
+                module("org.test:moduleA:1.0:$variantToTest")
+            }
+        }
+    }
+
+    def "dependencies of transitive dependencies can be changed"() {
+        given:
+        setupCustomVariantsForModule(moduleB).publish()
+        moduleA.dependsOn(moduleB).publish()
+        repo.module("org.test", "moduleC").allowAll().publish() //.withModuleMetadata().variant("anotherVariant", [format: "custom"]).publish()
+
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org.test:moduleB') {
+                        withVariant('$variantToTest') {
+                            withDependencies {
+                                add('org.test:moduleC:1.0')
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        then:
+        succeeds 'checkDep'
+        def variantToTest = variantToTest
+        resolve.expectGraph {
+            root(':', ':testproject:') {
+                module("org.test:moduleA:1.0:$variantToTest") {
+                    module("org.test:moduleB:1.0") {
+                        module('org.test:moduleC:1.0')
+                    }
+                }
+            }
+        }
+    }
+
+    def "attribute matching is used for all dependencies added by rules"() {
+        given:
+        setupCustomVariantsForModule(moduleB).publish()
+        moduleA.dependsOn(moduleB).publish()
+        repo.module("org.test", "moduleC").allowAll()
+        repo.module("org.test", "moduleD").allowAll().publish()
+
+        def mavenGradleRepo = new MavenFileRepository(file("maven-gradle-repo"))
+        buildFile << """
+            repositories {
+                maven {
+                    url "$mavenGradleRepo.uri"
+                    useGradleMetadata()
+                }
+            }
+        """
+
+        //All dependencies added by rules are of type GradleDependencyMetadata and thus use attribute matching
+        //Here we add a module with Gradle metadata which defines a variant that uses the same attributes declared in the build script (format: "custom").
+        //The dependency to this module is then added using the rule and thus is matched correctly.
+        mavenGradleRepo.module("org.test", "moduleC").withModuleMetadata().variant("anotherVariantWithFormatCustom", [format: "custom"]).publish()
+
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org.test:moduleB') {
+                        withVariant('$variantToTest') {
+                            withDependencies {
+                                add('org.test:moduleC:1.0')
+                            }
+                        }
+                    }
+                    withModule('org.test:moduleC') { //this second rule is here to test that the correct variant was chosen, which is the one adding the dependency to moduleD
+                        withVariant('anotherVariantWithFormatCustom') {
+                            withDependencies {
+                                add('org.test:moduleD:1.0')
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        then:
+        succeeds 'checkDep'
+        def variantToTest = variantToTest
+        resolve.expectGraph {
+            root(':', ':testproject:') {
+                module("org.test:moduleA:1.0:$variantToTest") {
+                    module("org.test:moduleB:1.0") {
+                        module('org.test:moduleC:1.0') {
+                            module('org.test:moduleD:1.0')
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    def "fails when attempting to select a variant that does not exist"() {
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org.test:moduleA') {
+                        withVariant("testBlue") { }
+                    }
+                }
+            }
+        """
+
+        then:
+        fails 'checkDep'
+        failure.assertHasCause("Variant testBlue is not declared for org.test:moduleA:1.0")
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDependencyMetadataRulesIntegrationTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.ivy
+
+import org.gradle.integtests.resolve.DependencyMetadataRulesIntegrationTest
+import org.gradle.test.fixtures.Module
+import org.gradle.test.fixtures.ivy.IvyModule
+import org.gradle.test.fixtures.server.http.IvyHttpRepository
+
+class IvyDependencyMetadataRulesIntegrationTest extends DependencyMetadataRulesIntegrationTest {
+    @Override
+    IvyHttpRepository getRepo() {
+        ivyHttpRepo
+    }
+
+    @Override
+    String getRepoDeclaration() {
+        """
+            repositories {
+                ivy {
+                    url "$repo.uri"
+                }
+            }
+        """
+    }
+
+    @Override
+    Module setupCustomVariantsForModule(Module module) {
+        return ((IvyModule) module).configuration('customConfiguration').configuration('anotherConfiguration')
+    }
+
+    @Override
+    String getVariantToTest() {
+        return 'customConfiguration'
+    }
+
+    @Override
+    boolean getPublishedModulesHaveAttributes() {
+        return false
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/GradleDependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/GradleDependencyMetadataRulesIntegrationTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.maven
+
+import org.gradle.integtests.resolve.DependencyMetadataRulesIntegrationTest
+import org.gradle.test.fixtures.Module
+import org.gradle.test.fixtures.maven.MavenModule
+import org.gradle.test.fixtures.server.http.MavenHttpRepository
+
+class GradleDependencyMetadataRulesIntegrationTest extends DependencyMetadataRulesIntegrationTest {
+    @Override
+    MavenHttpRepository getRepo() {
+        mavenHttpRepo
+    }
+
+    @Override
+    String getRepoDeclaration() {
+        """
+            repositories {
+                maven {
+                    url "$repo.uri"
+                    useGradleMetadata()
+                }
+            }
+        """
+    }
+
+    @Override
+    Module setupCustomVariantsForModule(Module module) {
+        return ((MavenModule) module).withModuleMetadata().variant("customVariant", [format: "custom"])
+    }
+
+    @Override
+    String getVariantToTest() {
+        return 'customVariant'
+    }
+
+    @Override
+    boolean getPublishedModulesHaveAttributes() {
+        return true
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyMetadataRulesIntegrationTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.maven
+
+import org.gradle.integtests.resolve.DependencyMetadataRulesIntegrationTest
+import org.gradle.test.fixtures.Module
+import org.gradle.test.fixtures.server.http.MavenHttpRepository
+
+class MavenDependencyMetadataRulesIntegrationTest extends DependencyMetadataRulesIntegrationTest {
+    @Override
+    MavenHttpRepository getRepo() {
+        mavenHttpRepo
+    }
+
+    @Override
+    String getRepoDeclaration() {
+        """
+            repositories {
+                maven {
+                    url "$repo.uri"
+                }
+            }
+        """
+    }
+
+    @Override
+    Module setupCustomVariantsForModule(Module module) {
+        return module
+    }
+
+    @Override
+    String getVariantToTest() {
+        return 'compile'
+    }
+
+    @Override
+    boolean getPublishedModulesHaveAttributes() {
+        return false
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.artifacts.DependencyMetadata;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
@@ -28,6 +29,7 @@ import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
+import org.gradle.api.internal.notations.DependencyMetadataNotationParser;
 import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -60,6 +62,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
     private final Set<SpecRuleAction<? super ComponentMetadataDetails>> rules = Sets.newLinkedHashSet();
     private final RuleActionAdapter<ComponentMetadataDetails> ruleActionAdapter;
     private final NotationParser<Object, ModuleIdentifier> moduleIdentifierNotationParser;
+    private final NotationParser<Object, DependencyMetadata> dependencyMetadataNotationParser;
 
     public DefaultComponentMetadataHandler(Instantiator instantiator, RuleActionAdapter<ComponentMetadataDetails> ruleActionAdapter, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
         this.instantiator = instantiator;
@@ -68,6 +71,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
             .toType(ModuleIdentifier.class)
             .converter(new ModuleIdentifierNotationConverter(moduleIdentifierFactory))
             .toComposite();
+        this.dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator);
     }
 
     public DefaultComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
@@ -131,7 +135,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
             updatedMetadata = metadata;
         } else {
             MutableModuleComponentResolveMetadata mutableMetadata = metadata.asMutable();
-            ComponentMetadataDetails details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata);
+            ComponentMetadataDetails details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser);
             processAllRules(metadata, details);
             updatedMetadata = mutableMetadata.asImmutable();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -16,8 +16,9 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.DependencyMetadata;
+import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.DependencyMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VariantMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
@@ -73,6 +74,13 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
 
     @Override
     public void withVariant(String name, Action<VariantMetadata> action) {
+        assertVariantExists(name);
         action.execute(instantiator.newInstance(VariantMetadataAdapter.class, name, metadata, instantiator, dependencyMetadataNotationParser));
+    }
+
+    private void assertVariantExists(String name) {
+        if (!metadata.definesVariant(name)) {
+            throw new GradleException("Variant " + name + " is not declared for " + metadata.getId());
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -15,23 +15,34 @@
  */
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.DependencyMetadata;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.VariantMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
 
 import java.util.List;
 
 public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails {
     private final MutableModuleComponentResolveMetadata metadata;
+    private final Instantiator instantiator;
+    private final NotationParser<Object, DependencyMetadata> dependencyMetadataNotationParser;
 
-    public ComponentMetadataDetailsAdapter(MutableModuleComponentResolveMetadata metadata) {
+    public ComponentMetadataDetailsAdapter(MutableModuleComponentResolveMetadata metadata, Instantiator instantiator, NotationParser<Object, DependencyMetadata> dependencyMetadataNotationParser) {
         this.metadata = metadata;
+        this.instantiator = instantiator;
+        this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
     }
 
+    @Override
     public ModuleVersionIdentifier getId() {
         return metadata.getId();
     }
 
+    @Override
     public boolean isChanging() {
         return metadata.isChanging();
     }
@@ -40,19 +51,28 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
         return metadata.getStatus();
     }
 
+    @Override
     public List<String> getStatusScheme() {
         return metadata.getStatusScheme();
     }
 
+    @Override
     public void setChanging(boolean changing) {
         metadata.setChanging(changing);
     }
 
+    @Override
     public void setStatus(String status) {
         metadata.setStatus(status);
     }
 
+    @Override
     public void setStatusScheme(List<String> statusScheme) {
         metadata.setStatusScheme(statusScheme);
+    }
+
+    @Override
+    public void withVariant(String name, Action<VariantMetadata> action) {
+        action.execute(instantiator.newInstance(VariantMetadataAdapter.class, name, metadata, instantiator, dependencyMetadataNotationParser));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import com.google.common.collect.Maps;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.DependenciesMetadata;
+import org.gradle.api.artifacts.DependencyMetadata;
+import org.gradle.api.artifacts.ModuleVersionSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector;
+import org.gradle.internal.component.model.GradleDependencyMetadata;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
+
+import javax.annotation.Nullable;
+import java.util.AbstractList;
+import java.util.List;
+import java.util.Map;
+
+public class DependenciesMetadataAdapter extends AbstractList<DependencyMetadata> implements DependenciesMetadata {
+    private final List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata;
+    private final Map<Integer, DependencyMetadata> dependencyMetadataAdapters;
+    private final Instantiator instantiator;
+    private final NotationParser<Object, DependencyMetadata> dependencyNotationParser;
+
+    public DependenciesMetadataAdapter(List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata, Instantiator instantiator, NotationParser<Object, DependencyMetadata> dependencyNotationParser) {
+        this.dependenciesMetadata = dependenciesMetadata;
+        this.dependencyMetadataAdapters = Maps.newHashMap();
+        this.instantiator = instantiator;
+        this.dependencyNotationParser = dependencyNotationParser;
+    }
+
+    @Override
+    public DependencyMetadata get(int index) {
+        if (!dependencyMetadataAdapters.containsKey(index)) {
+            dependencyMetadataAdapters.put(index, instantiator.newInstance(DependencyMetadataAdapter.class, dependenciesMetadata, index));
+        }
+        return dependencyMetadataAdapters.get(index);
+    }
+
+    @Override
+    public int size() {
+        return dependenciesMetadata.size();
+    }
+
+    @Override
+    public DependencyMetadata remove(int index) {
+        DependencyMetadata componentDependencyMetadata = get(index);
+        dependenciesMetadata.remove(index);
+        dependencyMetadataAdapters.remove(index);
+        return componentDependencyMetadata;
+    }
+
+    @Override
+    public void add(String dependencyNotation) {
+        doAdd(dependencyNotation, null);
+    }
+
+    @Override
+    public void add(Map<String, String> dependencyNotation) {
+        doAdd(dependencyNotation, null);
+    }
+
+    @Override
+    public void add(String dependencyNotation, Action<DependencyMetadata> configureAction) {
+        doAdd(dependencyNotation, configureAction);
+    }
+
+    @Override
+    public void add(Map<String, String> dependencyNotation, Action<DependencyMetadata> configureAction) {
+        doAdd(dependencyNotation, configureAction);
+    }
+
+    private void doAdd(Object dependencyNotation, @Nullable Action<DependencyMetadata> configureAction) {
+        DependencyMetadata dependencyMetadata = dependencyNotationParser.parseNotation(dependencyNotation);
+        if (configureAction != null) {
+            configureAction.execute(dependencyMetadata);
+        }
+        dependenciesMetadata.add(toDependencyMetadata(dependencyMetadata));
+    }
+
+    private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(DependencyMetadata details) {
+        ModuleVersionSelector requested = new DefaultModuleVersionSelector(details.getGroup(), details.getName(), details.getVersion());
+        return new GradleDependencyMetadata(requested);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import org.gradle.api.artifacts.DependencyMetadata;
+
+import java.util.List;
+
+public class DependencyMetadataAdapter implements DependencyMetadata {
+    private final List<org.gradle.internal.component.model.DependencyMetadata> container;
+    private final int originalIndex;
+
+    public DependencyMetadataAdapter(List<org.gradle.internal.component.model.DependencyMetadata> container, int originalIndex) {
+        this.container = container;
+        this.originalIndex = originalIndex;
+    }
+
+    private org.gradle.internal.component.model.DependencyMetadata getOriginalMetadata() {
+        return container.get(originalIndex);
+    }
+
+    @Override
+    public String getGroup() {
+        return getOriginalMetadata().getRequested().getGroup();
+    }
+
+    @Override
+    public String getName() {
+        return getOriginalMetadata().getRequested().getName();
+    }
+
+    @Override
+    public String getVersion() {
+        return getOriginalMetadata().getRequested().getVersion();
+    }
+
+    @Override
+    public boolean isOptional() {
+        return getOriginalMetadata().isOptional();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataAdapter.java
@@ -47,9 +47,4 @@ public class DependencyMetadataAdapter implements DependencyMetadata {
     public String getVersion() {
         return getOriginalMetadata().getRequested().getVersion();
     }
-
-    @Override
-    public boolean isOptional() {
-        return getOriginalMetadata().isOptional();
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataImpl.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataImpl.java
@@ -24,7 +24,6 @@ public class DependencyMetadataImpl implements DependencyMetadata {
     private final String group;
     private final String name;
     private String version;
-    private boolean optional;
 
     public DependencyMetadataImpl(String group, String name, String version) {
         this.group = group;
@@ -45,10 +44,5 @@ public class DependencyMetadataImpl implements DependencyMetadata {
     @Override
     public String getVersion() {
         return this.version;
-    }
-
-    @Override
-    public boolean isOptional() {
-        return this.optional;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataImpl.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.api.artifacts.DependencyMetadata;
+
+@NonNullApi
+public class DependencyMetadataImpl implements DependencyMetadata {
+    private final String group;
+    private final String name;
+    private String version;
+    private boolean optional;
+
+    public DependencyMetadataImpl(String group, String name, String version) {
+        this.group = group;
+        this.name = name;
+        this.version = version;
+    }
+
+    @Override
+    public String getGroup() {
+        return this.group;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getVersion() {
+        return this.version;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return this.optional;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.DependenciesMetadata;
+import org.gradle.api.artifacts.DependencyMetadata;
+import org.gradle.api.artifacts.VariantMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
+
+public class VariantMetadataAdapter implements VariantMetadata {
+    private String name;
+    private MutableModuleComponentResolveMetadata metadata;
+    private Instantiator instantiator;
+    private NotationParser<Object, DependencyMetadata> dependencyMetadataNotationParser;
+
+    public VariantMetadataAdapter(String name, MutableModuleComponentResolveMetadata metadata, Instantiator instantiator, NotationParser<Object, DependencyMetadata> dependencyMetadataNotationParser) {
+        this.name = name;
+        this.metadata = metadata;
+        this.instantiator = instantiator;
+        this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
+        assertVariantExists();
+    }
+
+    private void assertVariantExists() {
+        if (!metadata.definesVariant(name)) {
+            throw new GradleException("Variant " + name + " is not declared for " + metadata.getId());
+        }
+    }
+
+    @Override
+    public void withDependencies(Action<DependenciesMetadata> action) {
+        metadata.addDependencyMetadataRule(name, action, instantiator, dependencyMetadataNotationParser);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.Action;
-import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.DependenciesMetadata;
 import org.gradle.api.artifacts.DependencyMetadata;
 import org.gradle.api.artifacts.VariantMetadata;
@@ -36,13 +35,6 @@ public class VariantMetadataAdapter implements VariantMetadata {
         this.metadata = metadata;
         this.instantiator = instantiator;
         this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
-        assertVariantExists();
-    }
-
-    private void assertVariantExists() {
-        if (!metadata.definesVariant(name)) {
-            throw new GradleException("Variant " + name + " is not declared for " + metadata.getId());
-        }
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/package-info.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/package-info.java
@@ -14,33 +14,8 @@
  * limitations under the License.
  */
 
+/**
+ * Implementation classes of API declaring and using artifacts and artifact dependencies.
+ */
+@org.gradle.api.NonNullApi
 package org.gradle.api.internal.artifacts.repositories.resolver;
-
-import org.gradle.api.artifacts.DependencyMetadata;
-
-public class DependencyMetadataImpl implements DependencyMetadata {
-    private final String group;
-    private final String name;
-    private String version;
-
-    public DependencyMetadataImpl(String group, String name, String version) {
-        this.group = group;
-        this.name = name;
-        this.version = version;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getVersion() {
-        return this.version;
-    }
-}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
@@ -23,7 +23,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.MapKey;
 import org.gradle.internal.typeconversion.MapNotationConverter;
 
-public class DependencyMapNotationConverter<T extends ExternalDependency> extends MapNotationConverter<T> {
+public class DependencyMapNotationConverter<T> extends MapNotationConverter<T> {
 
     private final Instantiator instantiator;
     private final Class<T> resultingType;
@@ -44,8 +44,15 @@ public class DependencyMapNotationConverter<T extends ExternalDependency> extend
                          @MapKey("configuration") @Optional String configuration,
                          @MapKey("ext") @Optional String ext,
                          @MapKey("classifier") @Optional String classifier) {
-        T dependency = instantiator.newInstance(resultingType, group, name, version, configuration);
-        ModuleFactoryHelper.addExplicitArtifactsIfDefined(dependency, ext, classifier);
+        T dependency;
+        if (configuration == null) {
+            dependency = instantiator.newInstance(resultingType, group, name, version);
+        } else {
+            dependency = instantiator.newInstance(resultingType, group, name, version, configuration);
+        }
+        if (dependency instanceof ExternalDependency) {
+            ModuleFactoryHelper.addExplicitArtifactsIfDefined((ExternalDependency) dependency, ext, classifier);
+        }
         return dependency;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMetadataNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMetadataNotationParser.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.notations;
+
+import org.gradle.api.artifacts.DependencyMetadata;
+import org.gradle.api.internal.artifacts.repositories.resolver.DependencyMetadataImpl;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.internal.typeconversion.NotationParserBuilder;
+
+public class DependencyMetadataNotationParser {
+    public static NotationParser<Object, DependencyMetadata> parser(Instantiator instantiator) {
+        return NotationParserBuilder
+            .toType(DependencyMetadata.class)
+            .fromCharSequence(new DependencyStringNotationConverter<DependencyMetadataImpl>(instantiator, DependencyMetadataImpl.class))
+            .converter(new DependencyMapNotationConverter<DependencyMetadataImpl>(instantiator, DependencyMetadataImpl.class))
+            .invalidNotationMessage("Comprehensive documentation on dependency notations is available in DSL reference for DependencyHandler type.")
+            .toComposite();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyStringNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyStringNotationConverter.java
@@ -26,7 +26,7 @@ import org.gradle.internal.typeconversion.NotationConvertResult;
 import org.gradle.internal.typeconversion.NotationConverter;
 import org.gradle.internal.typeconversion.TypeConversionException;
 
-public class DependencyStringNotationConverter<T extends ExternalDependency> implements NotationConverter<String, T> {
+public class DependencyStringNotationConverter<T> implements NotationConverter<String, T> {
     private final Instantiator instantiator;
     private final Class<T> wantedType;
 
@@ -49,7 +49,9 @@ public class DependencyStringNotationConverter<T extends ExternalDependency> imp
         ParsedModuleStringNotation parsedNotation = splitModuleFromExtension(notation);
         T moduleDependency = instantiator.newInstance(wantedType,
             parsedNotation.getGroup(), parsedNotation.getName(), parsedNotation.getVersion());
-        ModuleFactoryHelper.addExplicitArtifactsIfDefined(moduleDependency, parsedNotation.getArtifactType(), parsedNotation.getClassifier());
+        if (moduleDependency instanceof ExternalDependency) {
+            ModuleFactoryHelper.addExplicitArtifactsIfDefined((ExternalDependency) moduleDependency, parsedNotation.getArtifactType(), parsedNotation.getClassifier());
+        }
 
         return moduleDependency;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -231,7 +231,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
         if (rulesForVariant == null) {
             dependencyMetadataRules.put(variantName, new DependencyMetadataRules(instantiator, dependencyNotationParser));
         }
-        dependencyMetadataRules.get(variantName).getActions().add(action);
+        dependencyMetadataRules.get(variantName).addAction(action);
         resetConfigurations();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -18,10 +18,7 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.Action;
-import org.gradle.api.artifacts.DependenciesMetadata;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.artifacts.repositories.resolver.DependenciesMetadataAdapter;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
@@ -137,11 +134,7 @@ abstract class DefaultConfigurationMetadata implements ConfigurationMetadata {
             if (dependencyMetadataRules == null) {
                 calculatedDependencies = configDependencies;
             } else {
-                calculatedDependencies = new ArrayList<DependencyMetadata>(configDependencies);
-                for (Action<DependenciesMetadata> dependenciesMetadataAction : dependencyMetadataRules.getActions()) {
-                    dependenciesMetadataAction.execute(dependencyMetadataRules.getInstantiator().newInstance(
-                        DependenciesMetadataAdapter.class, calculatedDependencies, dependencyMetadataRules.getInstantiator(), dependencyMetadataRules.getDependencyNotationParser()));
-                }
+                calculatedDependencies = dependencyMetadataRules.execute(configDependencies);
             }
         }
         return calculatedDependencies;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadata.java
@@ -123,6 +123,11 @@ public class DefaultMutableIvyModuleResolveMetadata extends AbstractMutableModul
     }
 
     @Override
+    public boolean definesVariant(String name) {
+        return configurations.containsKey(name);
+    }
+
+    @Override
     public ImmutableList<Artifact> getArtifactDefinitions() {
         return artifactDefinitions;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -17,12 +17,16 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.DependenciesMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -75,6 +79,13 @@ public interface MutableModuleComponentResolveMetadata {
     ImmutableMap<String, ? extends ConfigurationMetadata> getConfigurations();
 
     /**
+     * Checks if the metadata defines the given variant. Depending on the origin of the metadata, a "variant" can be backed
+     * by another concept (for example an ivy configuration). The check should be implemented in a cheap way without creating
+     * full variant/configuration metadata objects since the method only needs to check the name.
+     */
+    boolean definesVariant(String name);
+
+    /**
      * Returns the dependency declarations of this component.
      */
     List<? extends DependencyMetadata> getDependencies();
@@ -99,4 +110,6 @@ public interface MutableModuleComponentResolveMetadata {
      * Creates an artifact for this module. Does not mutate this metadata.
      */
     ModuleComponentArtifactMetadata artifact(String type, @Nullable String extension, @Nullable String classifier);
+
+    void addDependencyMetadataRule(String name, Action<DependenciesMetadata> action, Instantiator instantiator, NotationParser<Object, org.gradle.api.artifacts.DependencyMetadata> dependencyNotationParser);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -18,13 +18,10 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.Action;
-import org.gradle.api.artifacts.DependenciesMetadata;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
-import org.gradle.api.internal.artifacts.repositories.resolver.DependenciesMetadataAdapter;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
@@ -134,11 +131,7 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
             if (dependencyMetadataRules == null) {
                 calculatedDependencies = dependencies;
             } else {
-                calculatedDependencies = new ArrayList<GradleDependencyMetadata>(dependencies);
-                for (Action<DependenciesMetadata> dependenciesMetadataAction : dependencyMetadataRules.getActions()) {
-                    dependenciesMetadataAction.execute(dependencyMetadataRules.getInstantiator().newInstance(
-                        DependenciesMetadataAdapter.class, calculatedDependencies, dependencyMetadataRules.getInstantiator(), dependencyMetadataRules.getDependencyNotationParser()));
-                }
+                calculatedDependencies = dependencyMetadataRules.execute(dependencies);
             }
         }
         return calculatedDependencies;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -41,6 +41,9 @@ public interface ConfigurationMetadata extends HasAttributes {
 
     /**
      * Returns the dependencies that apply to this configuration.
+     *
+     * If the implementation supports {@link DependencyMetadataRules}, this method
+     * is responsible for lazily applying the rules the first time it is called.
      */
     List<? extends DependencyMetadata> getDependencies();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.model;
+
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.DependencyMetadata;
+import org.gradle.api.artifacts.DependenciesMetadata;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A set of rules provided by the build script author (as {@link Action<DependenciesMetadata>}) that
+ * are applied on the dependencies defined in variant/configuration metadata.
+ * The rules are applied in implementations of {@link ConfigurationMetadata#getDependencies()}.
+ */
+public class DependencyMetadataRules {
+    private final Instantiator instantiator;
+    private final NotationParser<Object, DependencyMetadata> dependencyNotationParser;
+
+    private final List<Action<DependenciesMetadata>> actions = new ArrayList<Action<DependenciesMetadata>>();
+
+    public DependencyMetadataRules(Instantiator instantiator, NotationParser<Object, DependencyMetadata> dependencyNotationParser) {
+        this.instantiator = instantiator;
+        this.dependencyNotationParser = dependencyNotationParser;
+    }
+
+    public List<Action<DependenciesMetadata>> getActions() {
+        return actions;
+    }
+
+    public Instantiator getInstantiator() {
+        return instantiator;
+    }
+
+    public NotationParser<Object, DependencyMetadata> getDependencyNotationParser() {
+        return dependencyNotationParser;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/GradleDependencyMetadata.java
@@ -59,7 +59,7 @@ public class GradleDependencyMetadata extends AbstractDependencyMetadata {
         if (requestedVersion.equals(requested.getVersion())) {
             return this;
         }
-        return new GradleDependencyMetadata(DefaultModuleVersionSelector.newSelector(requested.getGroup(), requestedVersion, requested.getVersion()));
+        return new GradleDependencyMetadata(DefaultModuleVersionSelector.newSelector(requested.getGroup(), requested.getName(), requestedVersion));
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver
+
+import org.gradle.api.Action
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorBuilder
+import org.gradle.api.internal.notations.DependencyMetadataNotationParser
+import org.gradle.api.reflect.ObjectInstantiationException
+import org.gradle.internal.component.external.descriptor.Configuration
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.DefaultMutableIvyModuleResolveMetadata
+import org.gradle.internal.component.external.model.DefaultMutableMavenModuleResolveMetadata
+import org.gradle.internal.reflect.DirectInstantiator
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+class ComponentMetadataDetailsAdapterTest extends Specification {
+    private instantiator = DirectInstantiator.INSTANCE
+    private notationParser = DependencyMetadataNotationParser.parser(instantiator)
+
+    def versionIdentifier = new DefaultModuleVersionIdentifier("org.test", "producer", "1.0")
+    def componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
+    def attributes = TestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
+    def variantDefinedInGradleMetadata
+
+    def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(new DefaultMutableMavenModuleResolveMetadata(versionIdentifier, componentIdentifier), instantiator, notationParser)
+    def adapterOnIvyMetadata = new ComponentMetadataDetailsAdapter(ivyComponentMetadata(), instantiator, notationParser)
+    def adapterOnGradleMetadata = new ComponentMetadataDetailsAdapter(gradleComponentMetadata(), instantiator, notationParser)
+
+    private ivyComponentMetadata() {
+        new DefaultMutableIvyModuleResolveMetadata(versionIdentifier, componentIdentifier, [new Configuration("configurationDefinedInIvyMetadata", true, true, [])], [], [])
+    }
+    private gradleComponentMetadata() {
+        def metadata = new DefaultMutableMavenModuleResolveMetadata(versionIdentifier, componentIdentifier)
+        variantDefinedInGradleMetadata = metadata.addVariant("variantDefinedInGradleMetadata", attributes) //gradle metadata is distinguished from maven POM metadata by explicitly defining variants
+        metadata
+    }
+
+    def "sees variants defined in Gradle metadata"() {
+        given:
+        def rule = Mock(Action)
+
+        when:
+        adapterOnGradleMetadata.withVariant("variantDefinedInGradleMetadata", rule)
+
+        then:
+        noExceptionThrown()
+        1 * rule.execute(_)
+    }
+
+    def "treats ivy configurations as variants"() {
+        given:
+        def rule = Mock(Action)
+
+        when:
+        adapterOnIvyMetadata.withVariant("configurationDefinedInIvyMetadata", rule)
+
+        then:
+        noExceptionThrown()
+        1 * rule.execute(_)
+    }
+
+    def "treats maven scopes as variants"() {
+        given:
+        //historically, we defined default MAVEN2_CONFIGURATIONS which eventually should become MAVEN2_VARIANTS
+        def mavenVariants = GradlePomModuleDescriptorBuilder.MAVEN2_CONFIGURATIONS.keySet()
+        def variantCount = mavenVariants.size()
+        def rule = Mock(Action)
+
+        when:
+        mavenVariants.each {
+            adapterOnMavenMetadata.withVariant(it, rule)
+        }
+
+        then:
+        noExceptionThrown()
+        variantCount * rule.execute(_)
+    }
+
+    def "fails when selecting a variant that does not exist"() {
+        when:
+        adapterOnGradleMetadata.withVariant("doesNotExist", {})
+
+        then:
+        def e = thrown(ObjectInstantiationException)
+        e.cause.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
+    }
+
+    def "fails when selecting a maven scope that does not exist"() {
+        when:
+        adapterOnMavenMetadata.withVariant("doesNotExist", {})
+
+        then:
+        def e = thrown(ObjectInstantiationException)
+        e.cause.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
+    }
+
+    def "fails when selecting an ivy configuration that does not exist"() {
+        when:
+        adapterOnIvyMetadata.withVariant("doesNotExist", {})
+
+        then:
+        def e = thrown(ObjectInstantiationException)
+        e.cause.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.api.internal.artifacts.repositories.resolver
 
 import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorBuilder
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
-import org.gradle.api.reflect.ObjectInstantiationException
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultMutableIvyModuleResolveMetadata
@@ -98,8 +98,8 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         adapterOnGradleMetadata.withVariant("doesNotExist", {})
 
         then:
-        def e = thrown(ObjectInstantiationException)
-        e.cause.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
+        def e = thrown(GradleException)
+        e.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
     }
 
     def "fails when selecting a maven scope that does not exist"() {
@@ -107,8 +107,8 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         adapterOnMavenMetadata.withVariant("doesNotExist", {})
 
         then:
-        def e = thrown(ObjectInstantiationException)
-        e.cause.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
+        def e = thrown(GradleException)
+        e.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
     }
 
     def "fails when selecting an ivy configuration that does not exist"() {
@@ -116,7 +116,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         adapterOnIvyMetadata.withVariant("doesNotExist", {})
 
         then:
-        def e = thrown(ObjectInstantiationException)
-        e.cause.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
+        def e = thrown(GradleException)
+        e.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver
+
+import org.gradle.api.artifacts.ModuleVersionSelector
+import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
+import org.gradle.api.internal.notations.DependencyMetadataNotationParser
+import org.gradle.internal.component.external.descriptor.MavenScope
+import org.gradle.internal.component.external.model.MavenDependencyMetadata
+import org.gradle.internal.component.model.DependencyMetadata
+import org.gradle.internal.reflect.DirectInstantiator
+import spock.lang.Specification
+
+class DependenciesMetadataAdapterTest extends Specification {
+    List<DependencyMetadata> dependenciesMetadata = []
+    DependenciesMetadataAdapter adapter
+
+    def setup() {
+        fillDependencyList(0)
+    }
+
+    def "add via string id is propagate to the underlying dependency list"() {
+        when:
+        adapter.add "org.gradle.test:module1:1.0"
+
+        then:
+        dependenciesMetadata.size() == 1
+        dependenciesMetadata[0].requested.group == "org.gradle.test"
+        dependenciesMetadata[0].requested.name == "module1"
+        dependenciesMetadata[0].requested.version == "1.0"
+    }
+
+    def "add via map id propagate to the underlying dependency list"() {
+        when:
+        adapter.add group: "org.gradle.test", name: "module1", version: "1.0"
+
+        then:
+        dependenciesMetadata.size() == 1
+        dependenciesMetadata[0].requested.group == "org.gradle.test"
+        dependenciesMetadata[0].requested.name == "module1"
+        dependenciesMetadata[0].requested.version == "1.0"
+    }
+
+    def "remove is propagated to the underlying dependency list"() {
+        given:
+        fillDependencyList(1)
+
+        when:
+        adapter.removeAll { true }
+
+        then:
+        dependenciesMetadata == []
+    }
+
+    def "can add a dependency with the same coordinates more than once"() {
+        //this test documents given behavior, which is not necessarily needed
+        given:
+        fillDependencyList(1)
+
+        when:
+        adapter.add("org.gradle.test:module1:2.0")
+
+        then:
+        dependenciesMetadata.size() == 2
+        dependenciesMetadata[0].requested.group == "org.gradle.test"
+        dependenciesMetadata[0].requested.name == "module1"
+        dependenciesMetadata[0].requested.version == "1.0"
+        dependenciesMetadata[1].requested.group == "org.gradle.test"
+        dependenciesMetadata[1].requested.name == "module1"
+        dependenciesMetadata[1].requested.version == "2.0"
+    }
+
+    def "adapters for list items are created lazily"() {
+        when:
+        fillDependencyList(2)
+
+        then:
+        dependenciesMetadata.size() == 2
+        adapter.dependencyMetadataAdapters.size() == 0
+
+        when:
+        ++adapter.iterator()
+
+        then:
+        dependenciesMetadata.size() == 2
+        adapter.dependencyMetadataAdapters.size() == 1
+
+        when:
+        adapter.each {}
+
+        then:
+        dependenciesMetadata.size() == 2
+        adapter.dependencyMetadataAdapters.size() == 2
+    }
+
+    def "size check is propagated to the underlying dependency list"() {
+        when:
+        fillDependencyList(3)
+
+        then:
+        dependenciesMetadata.size() == 3
+        adapter.size() == 3
+        adapter.dependencyMetadataAdapters.size() == 0
+    }
+
+    def "iterator returns views on underlying list items"() {
+        given:
+        fillDependencyList(1)
+
+        when:
+        def dependencyMetadata = ++adapter.iterator()
+
+        then:
+        dependencyMetadata instanceof DependencyMetadataAdapter
+        !(dependencyMetadata instanceof DependencyMetadataImpl)
+    }
+
+    private fillDependencyList(int size) {
+        dependenciesMetadata = []
+        for (int i = 0; i < size; i++) {
+            ModuleVersionSelector requested = new DefaultModuleVersionSelector("org.gradle.test", "module$size", "1.0")
+            dependenciesMetadata += [ new MavenDependencyMetadata(MavenScope.Compile, false, requested, [], []) ]
+        }
+        adapter = new DependenciesMetadataAdapter(dependenciesMetadata, DirectInstantiator.INSTANCE, DependencyMetadataNotationParser.parser(DirectInstantiator.INSTANCE))
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
@@ -260,6 +260,16 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
         immutable2.getConfiguration("runtime").excludes == [exclude1]
     }
 
+    def "treats ivy configurations as variants when checking if a variant exists"() {
+        when:
+        configuration("compile")
+        def metadata = getMetadata()
+
+        then:
+        metadata.definesVariant("compile")
+        !metadata.definesVariant("runtime")
+    }
+
     def exclude(String group, String module, String... confs) {
         def exclude = new DefaultExclude(DefaultModuleIdentifier.newId(group, module), confs, "whatever")
         return exclude

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyMetadataRulesTest.groovy
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model
+
+import com.google.common.collect.ImmutableListMultimap
+import org.gradle.api.Action
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.attributes.DefaultAttributesSchema
+import org.gradle.api.internal.notations.DependencyMetadataNotationParser
+import org.gradle.internal.component.external.descriptor.MavenScope
+import org.gradle.internal.component.model.ComponentAttributeMatcher
+import org.gradle.internal.component.model.LocalComponentDependencyMetadata
+import org.gradle.internal.reflect.DirectInstantiator
+import org.gradle.testing.internal.util.Specification
+import org.gradle.util.TestUtil
+import spock.lang.Shared
+import spock.lang.Unroll
+
+import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.newSelector
+
+class DependencyMetadataRulesTest extends Specification {
+    private instantiator = DirectInstantiator.INSTANCE
+    private notationParser = DependencyMetadataNotationParser.parser(instantiator)
+
+    @Shared versionIdentifier = new DefaultModuleVersionIdentifier("org.test", "producer", "1.0")
+    @Shared componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
+    @Shared attributes = TestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
+    @Shared schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory())
+    @Shared defaultVariant
+
+    private ivyComponentMetadata() { new DefaultMutableIvyModuleResolveMetadata(versionIdentifier, componentIdentifier) }
+    private mavenComponentMetadata() { new DefaultMutableMavenModuleResolveMetadata(versionIdentifier, componentIdentifier) }
+    private gradleComponentMetadata() {
+        def metadata = new DefaultMutableMavenModuleResolveMetadata(versionIdentifier, componentIdentifier)
+        //gradle metadata is distinguished from maven POM metadata by explicitly defining variants
+        defaultVariant = metadata.addVariant("default", attributes)
+        metadata
+    }
+
+
+    @Unroll
+    def "dependency metadata rules are evaluated once and lazily for #metadataType metadata"() {
+        given:
+        def rule = Mock(Action)
+
+        when:
+        metadataImplementation.addDependencyMetadataRule("default", rule, instantiator, notationParser)
+
+        then:
+        0 * rule.execute(_)
+
+        when:
+        selectTargetConfigurationMetadata(metadataImplementation).dependencies
+
+        then:
+        1 * rule.execute(_)
+
+        when:
+        selectTargetConfigurationMetadata(metadataImplementation).dependencies
+        selectTargetConfigurationMetadata(metadataImplementation).dependencies
+        selectTargetConfigurationMetadata(metadataImplementation).dependencies
+
+        then:
+        0 * rule.execute(_)
+
+        where:
+        metadataType | metadataImplementation
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
+    }
+
+    @Unroll
+    def "dependency metadata rules are not evaluated if their variant is not selected for #metadataType metadata"() {
+        given:
+        def rule = Mock(Action)
+
+        when:
+        metadataImplementation.addDependencyMetadataRule("anotherVariant", rule, instantiator, notationParser)
+        selectTargetConfigurationMetadata(metadataImplementation).dependencies
+
+        then:
+        0 * rule.execute(_)
+
+        where:
+        metadataType | metadataImplementation
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
+    }
+
+    @Unroll
+    def "dependencies of selected variant are accessible in dependency metadata rule for #metadataType metadata"() {
+        given:
+        addDependency(metadataImplementation, "org.test", "dep1", "1.0")
+        addDependency(metadataImplementation, "org.test", "dep2", "1.0")
+        def rule = { dependencies ->
+            assert dependencies.size() == 2
+            assert dependencies[0].name == "dep1"
+            assert dependencies[1].name == "dep2"
+        }
+
+        when:
+        metadataImplementation.addDependencyMetadataRule("default", rule, instantiator, notationParser)
+
+        then:
+        selectTargetConfigurationMetadata(metadataImplementation).dependencies.size() == 2
+
+        where:
+        metadataType | metadataImplementation
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
+    }
+
+    @Unroll
+    def "dependencies added in dependency metadata rules are added to dependency list for #metadataType metadata"() {
+        given:
+        def rule = { dependencies ->
+            dependencies.add("org.test:added:1.0")
+        }
+
+        when:
+        metadataImplementation.addDependencyMetadataRule("default", rule, instantiator, notationParser)
+
+        then:
+        selectTargetConfigurationMetadata(metadataImplementation).dependencies.collect { it.requested } == [ newSelector("org.test", "added", "1.0") ]
+
+        where:
+        metadataType | metadataImplementation
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
+    }
+
+    @Unroll
+    def "dependencies removed in dependency metadata rules are removed from dependency list for #metadataType metadata"() {
+        given:
+        addDependency(metadataImplementation, "org.test", "toRemove", "1.0")
+        def rule = { dependencies ->
+            assert dependencies.size() == 1
+            dependencies.removeAll { it.name == "toRemove" }
+        }
+
+        when:
+        metadataImplementation.addDependencyMetadataRule("default", rule, instantiator, notationParser)
+
+        then:
+        selectTargetConfigurationMetadata(metadataImplementation).dependencies.empty
+
+        where:
+        metadataType | metadataImplementation
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
+    }
+
+    private addDependency(AbstractMutableModuleComponentResolveMetadata<? extends DefaultConfigurationMetadata> resolveMetadata, String group, String name, String version) {
+        if (resolveMetadata instanceof MutableMavenModuleResolveMetadata && !resolveMetadata.variants.empty) {
+            defaultVariant.addDependency(group, name, version)
+        } else if (resolveMetadata instanceof MutableMavenModuleResolveMetadata) {
+            //legacy dependency handling
+            resolveMetadata.dependencies += new MavenDependencyMetadata(MavenScope.Compile, false, newSelector(group, name, version), [], [])
+        } else if (resolveMetadata instanceof MutableIvyModuleResolveMetadata) {
+            //legacy dependency handling
+            resolveMetadata.dependencies += new IvyDependencyMetadata(newSelector(group, name, version), ImmutableListMultimap.of("default", "default"))
+        }
+    }
+
+    private selectTargetConfigurationMetadata(MutableModuleComponentResolveMetadata targetComponent) {
+        def consumerIdentifier = new DefaultModuleVersionIdentifier("org.test", "consumer", "1.0")
+        def componentSelector = DefaultModuleComponentSelector.newSelector(consumerIdentifier.group, consumerIdentifier.name, consumerIdentifier.version)
+        def selector = newSelector(consumerIdentifier.group, consumerIdentifier.name, consumerIdentifier.version)
+        def consumerResolveMetadata = new DefaultMutableMavenModuleResolveMetadata(consumerIdentifier, DefaultModuleComponentIdentifier.newId(consumerIdentifier)).asImmutable()
+        def consumer = new LocalComponentDependencyMetadata(componentSelector, selector, "default", attributes, null, [] as Set, [], false, false, true)
+
+        consumer.selectConfigurations(attributes, consumerResolveMetadata, consumerResolveMetadata.getConfiguration("default"), targetComponent.asImmutable(), schema)[0]
+    }
+}

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -279,7 +279,7 @@ allprojects {
             def attrs
             if (moduleVersionId.matches(':\\w+:')) {
                 def parts = moduleVersionId.split(':')
-                attrs = [group: null, module: parts[1], version:null]
+                attrs = [group: null, module: parts[1], version: null]
                 moduleVersionId = ":${attrs.module}:unspecified"
             } else if (moduleVersionId.matches('\\w+:\\w+:')) {
                 def parts = moduleVersionId.split(':')
@@ -287,8 +287,14 @@ allprojects {
                 moduleVersionId = "${attrs.group}:${attrs.module}:unspecified"
             } else {
                 def parts = moduleVersionId.split(':')
-                assert parts.length == 3
-                attrs = [group: parts[0], module: parts[1], version: parts[2]]
+                if (parts.length == 3) {
+                    attrs = [group: parts[0], module: parts[1], version: parts[2]]
+                } else {
+                    assert parts.length == 4
+                    attrs = [group: parts[0], module: parts[1], version: parts[2], configuration: parts[3]]
+                    id = "${attrs.group}:${attrs.module}:${attrs.version}"
+                    moduleVersionId = id
+                }
             }
             return node(id, moduleVersionId, attrs)
         }
@@ -357,7 +363,7 @@ allprojects {
         final String group
         final String module
         final String version
-        String configuration = "default"
+        String configuration
         private boolean implicitArtifact = true
         final List<String> files = []
         private final Set<ExpectedArtifact> artifacts = new LinkedHashSet<>()
@@ -368,6 +374,7 @@ allprojects {
             this.group = attrs.group
             this.module = attrs.module
             this.version = attrs.version
+            this.configuration = attrs.configuration ? attrs.configuration : "default"
             this.moduleVersionId = moduleVersionId
             this.id = id
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -176,6 +176,12 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     }
 
     @Override
+    public MavenModule variant(String variant, Map<String, String> attributes) {
+        backingModule.variant(variant, attributes);
+        return t();
+    }
+
+    @Override
     public T parent(String group, String artifactId, String version) {
         backingModule.parent(group, artifactId, version);
         return t();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -69,6 +69,11 @@ interface MavenModule extends Module {
     MavenModule hasType(String type)
 
     /**
+     * Define a variant with attributes. Variants are only published when using {@link #withModuleMetadata()}.
+     */
+    MavenModule variant(String variant, Map<String, String> attributes)
+
+    /**
      * Asserts exactly pom and jar published, along with checksums.
      */
     void assertPublishedAsJavaModule()


### PR DESCRIPTION
This PR adds functionality to add/remove dependencies in component metadata rules (#3157). Since we want to move forward defining dependencies _per_ variant, this PR includes some additional functionality to work with variants in component metadata rules. It...

- adds variant selection in a rule by introducing the `withVariant('variantName') {}` API
- adds implementation for that API for all three supported metadata types (maven, ivy, gradle)
- adds the dependency addition/removal by introducing the `withDependencies {}` API

To get a feel for the API of this and the follow up #3186, I started to experiment with using the rules in the Gradle build:
https://github.com/gradle/gradle/commit/6340bf54176fd0291077ee9d83cb21bfd54040c7