### PR TITLE
Fix IllegalStateException thrown when creating build operations with included builds

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -65,7 +65,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         executed ":buildB:jar"
         and:
         def root = CollectionUtils.single(operations.roots())
-        assertHasChild(root, "Load build (buildB)")
+        assertHasChild(root, "Load build (:buildB)")
         assertHasChild(root, "Configure build (:buildB)")
         assertHasChild(root, "Calculate task graph (:buildB)")
         assertHasChild(root, "Run tasks (:buildB)")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -66,7 +66,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         and:
         def root = CollectionUtils.single(operations.roots())
         assertHasChild(root, "Load build (buildB)")
-        assertHasChild(root, "Configure build (buildB)")
+        assertHasChild(root, "Configure build (:buildB)")
         assertHasChild(root, "Calculate task graph (:buildB)")
         assertHasChild(root, "Run tasks (:buildB)")
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -41,9 +41,10 @@ public class DefaultIncludedBuild implements IncludedBuildInternal, Stoppable {
     private boolean resolvedDependencySubstitutions;
 
     private GradleLauncher gradleLauncher;
-    private String name;
+    private String buildName;
 
-    public DefaultIncludedBuild(File projectDir, Factory<GradleLauncher> launcherFactory, WorkerLeaseRegistry.WorkerLease parentLease) {
+    public DefaultIncludedBuild(String buildName, File projectDir, Factory<GradleLauncher> launcherFactory, WorkerLeaseRegistry.WorkerLease parentLease) {
+        this.buildName = buildName;
         this.projectDir = projectDir;
         this.gradleLauncherFactory = launcherFactory;
         this.parentLease = parentLease;
@@ -61,10 +62,7 @@ public class DefaultIncludedBuild implements IncludedBuildInternal, Stoppable {
 
     @Override
     public String getName() {
-        if (name == null) {
-            name = getLoadedSettings().getRootProject().getName();
-        }
-        return name;
+        return buildName;
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
@@ -59,10 +59,10 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory {
     }
 
     @Override
-    public IncludedBuildInternal createBuild(File buildDirectory, NestedBuildFactory nestedBuildFactory) {
+    public IncludedBuildInternal createBuild(String buildName, File buildDirectory, NestedBuildFactory nestedBuildFactory) {
         validateBuildDirectory(buildDirectory);
-        Factory<GradleLauncher> factory = new ContextualGradleLauncherFactory(buildDirectory, nestedBuildFactory, startParameter);
-        DefaultIncludedBuild includedBuild = instantiator.newInstance(DefaultIncludedBuild.class, buildDirectory, factory, workerLeaseService.getCurrentWorkerLease());
+        Factory<GradleLauncher> factory = new ContextualGradleLauncherFactory(buildName, buildDirectory, nestedBuildFactory, startParameter);
+        DefaultIncludedBuild includedBuild = instantiator.newInstance(DefaultIncludedBuild.class, buildName, buildDirectory, factory, workerLeaseService.getCurrentWorkerLease());
 
         SettingsInternal settingsInternal = includedBuild.getLoadedSettings();
         validateIncludedBuild(includedBuild, settingsInternal);
@@ -70,11 +70,13 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory {
     }
 
     private class ContextualGradleLauncherFactory implements Factory<GradleLauncher> {
+        private final String buildName;
         private final File buildDirectory;
         private final NestedBuildFactory nestedBuildFactory;
         private final StartParameter buildStartParam;
 
-        public ContextualGradleLauncherFactory(File buildDirectory, NestedBuildFactory nestedBuildFactory, StartParameter buildStartParam) {
+        public ContextualGradleLauncherFactory(String buildName, File buildDirectory, NestedBuildFactory nestedBuildFactory, StartParameter buildStartParam) {
+            this.buildName = buildName;
             this.buildDirectory = buildDirectory;
             this.nestedBuildFactory = nestedBuildFactory;
             this.buildStartParam = buildStartParam;
@@ -84,6 +86,7 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory {
         public GradleLauncher create() {
             StartParameter participantStartParam = createStartParameter(buildDirectory);
             GradleLauncher gradleLauncher = nestedBuildFactory.nestedInstance(participantStartParam);
+            gradleLauncher.getGradle().setBuildName(buildName);
             return gradleLauncher;
         }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -70,7 +70,8 @@ public class DefaultIncludedBuildRegistry implements IncludedBuildRegistry, Stop
 
     @Override
     public IncludedBuildInternal addExplicitBuild(File buildDirectory, NestedBuildFactory nestedBuildFactory) {
-        return registerBuild(buildDirectory, nestedBuildFactory);
+        // Assume the build name is the same as the root directory name
+        return registerBuild(buildDirectory.getName(), buildDirectory, nestedBuildFactory);
     }
 
     @Override
@@ -121,17 +122,18 @@ public class DefaultIncludedBuildRegistry implements IncludedBuildRegistry, Stop
     public ConfigurableIncludedBuild addImplicitBuild(File buildDirectory, NestedBuildFactory nestedBuildFactory) {
         ConfigurableIncludedBuild includedBuild = includedBuilds.get(buildDirectory);
         if (includedBuild == null) {
-            includedBuild = registerBuild(buildDirectory, nestedBuildFactory);
+            // TODO: Should the name be coming from the VCS mapping instead?
+            includedBuild = registerBuild(buildDirectory.getName(), buildDirectory, nestedBuildFactory);
             registerProjects(Collections.<IncludedBuild>singletonList(includedBuild));
         }
         return includedBuild;
     }
 
-    private IncludedBuildInternal registerBuild(File buildDirectory, NestedBuildFactory nestedBuildFactory) {
+    private IncludedBuildInternal registerBuild(String buildName, File buildDirectory, NestedBuildFactory nestedBuildFactory) {
         // TODO: synchronization
         IncludedBuildInternal includedBuild = includedBuilds.get(buildDirectory);
         if (includedBuild == null) {
-            includedBuild = includedBuildFactory.createBuild(buildDirectory, nestedBuildFactory);
+            includedBuild = includedBuildFactory.createBuild(buildName, buildDirectory, nestedBuildFactory);
             includedBuilds.put(buildDirectory, includedBuild);
         }
         return includedBuild;

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildFactory.java
@@ -21,5 +21,5 @@ import org.gradle.initialization.NestedBuildFactory;
 import java.io.File;
 
 public interface IncludedBuildFactory {
-    IncludedBuildInternal createBuild(File buildDirectory, NestedBuildFactory nestedBuildFactory);
+    IncludedBuildInternal createBuild(String buildName, File buildDirectory, NestedBuildFactory nestedBuildFactory);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -17,12 +17,12 @@ package org.gradle.api.internal;
 
 import org.gradle.BuildListener;
 import org.gradle.api.ProjectEvaluationListener;
+import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.execution.TaskGraphExecuter;
-import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.internal.progress.BuildOperationState;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.service.ServiceRegistry;
@@ -109,5 +109,7 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
     Path findIdentityPath();
 
     void setIdentityPath(Path path);
+
+    void setRootProjectName(String rootProjectDescriptor);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -110,6 +110,6 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
 
     void setIdentityPath(Path path);
 
-    void setRootProjectName(String rootProjectDescriptor);
+    void setBuildName(String buildName);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
@@ -148,6 +148,7 @@ public class GradleBuild extends ConventionTask {
     void build() {
         BuildController buildController = nestedBuildFactory.nestedBuildController(getStartParameter());
         try {
+            buildController.getGradle().setBuildName(getDir().getName());
             buildController.run();
         } finally {
             buildController.stop();

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -45,7 +45,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
     public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
         StartParameter startParameter = gradle.getStartParameter();
         SettingsInternal settings = findSettingsAndLoadIfAppropriate(gradle, startParameter);
-
+        gradle.setRootProjectName(settings.getRootProject().getName());
         ProjectSpec spec = ProjectSpecs.forStartParameter(startParameter, settings);
 
         if (spec.containsProject(settings.getProjectRegistry())) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -45,7 +45,6 @@ public class DefaultSettingsLoader implements SettingsLoader {
     public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
         StartParameter startParameter = gradle.getStartParameter();
         SettingsInternal settings = findSettingsAndLoadIfAppropriate(gradle, startParameter);
-        gradle.setRootProjectName(settings.getRootProject().getName());
         ProjectSpec spec = ProjectSpecs.forStartParameter(startParameter, settings);
 
         if (spec.containsProject(settings.getProjectRegistry())) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
@@ -60,6 +60,8 @@ public class ScriptEvaluatingSettingsProcessor implements SettingsProcessor {
         Map<String, String> properties = propertiesLoader.mergeProperties(Collections.<String, String>emptyMap());
         SettingsInternal settings = settingsFactory.createSettings(gradle, settingsLocation.getSettingsDir(),
                 settingsLocation.getSettingsScriptSource(), properties, startParameter, buildRootClassLoaderScope);
+        // Set the default name for the root project so build operations have a path to rely on
+        gradle.setRootProjectName(settings.getRootProject().getName());
         applySettingsScript(settingsLocation, settings);
         LOGGER.debug("Timing: Processing settings took: {}", settingsProcessingClock.getElapsed());
         return settings;

--- a/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
@@ -60,8 +60,6 @@ public class ScriptEvaluatingSettingsProcessor implements SettingsProcessor {
         Map<String, String> properties = propertiesLoader.mergeProperties(Collections.<String, String>emptyMap());
         SettingsInternal settings = settingsFactory.createSettings(gradle, settingsLocation.getSettingsDir(),
                 settingsLocation.getSettingsScriptSource(), properties, startParameter, buildRootClassLoaderScope);
-        // Set the default name for the root project so build operations have a path to rely on
-        gradle.setRootProjectName(settings.getRootProject().getName());
         applySettingsScript(settingsLocation, settings);
         LOGGER.debug("Timing: Processing settings took: {}", settingsProcessingClock.getElapsed());
         return settings;

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
@@ -17,7 +17,6 @@
 package org.gradle.initialization.buildsrc;
 
 import org.gradle.StartParameter;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
@@ -34,7 +33,6 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.progress.BuildOperationDescriptor;
 import org.gradle.util.GradleVersion;
-import org.gradle.util.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,13 +135,7 @@ public class BuildSourceBuilder {
         startParameterArg.setSearchUpwards(false);
         startParameterArg.setProfile(startParameter.isProfile());
         GradleLauncher gradleLauncher = nestedBuildFactory.nestedInstance(startParameterArg);
-        GradleInternal build = gradleLauncher.getGradle();
-        if (build.getParent().findIdentityPath() == null) {
-            // When nested inside a nested build, we need to synthesize a path for this build, as the root project is not yet known for the parent build
-            // Use the directory structure to do this. This means that the buildSrc build and its containing build may end up with different paths
-            Path path = build.getParent().getParent().getIdentityPath().child(startParameter.getCurrentDir().getParentFile().getName()).child(startParameter.getCurrentDir().getName());
-            build.setIdentityPath(path);
-        }
+        gradleLauncher.getGradle().setBuildName("buildSrc");
         return gradleLauncher;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -52,7 +52,7 @@ import static org.gradle.internal.Cast.uncheckedCast;
  * Can be enabled for any build with `-Dorg.gradle.internal.operations.trace=«path-base»`.
  *
  * Imposes no overhead when not enabled.
- * Also used as the basis for asserting on the event stream in integration tests, via BuildOperationFixture.
+ * Also used as the basis for asserting on the event stream in integration tests, via BuildOperationsFixture.
  *
  * Three files are created:
  *

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -207,7 +207,6 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     @Override
     public void setRootProject(ProjectInternal rootProject) {
         this.rootProject = rootProject;
-        setBuildName(rootProject.getName());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -207,6 +207,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     @Override
     public void setRootProject(ProjectInternal rootProject) {
         this.rootProject = rootProject;
+        setBuildName(rootProject.getName());
     }
 
     @Override
@@ -436,7 +437,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     }
 
     public void setBuildName(String buildName) {
-        if (this.buildName!=null) {
+        if (this.buildName!=null && !this.buildName.equals(buildName)) {
             throw new IllegalStateException(String.format("Cannot change build name to '%s', build '%s' has already been set.", buildName, this.buildName));
         }
         this.buildName = buildName;

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -54,7 +54,6 @@ import org.gradle.listener.ClosureBackedMethodInvocationDispatch;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.Path;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Collection;
@@ -62,6 +61,7 @@ import java.util.Collections;
 import java.util.NoSuchElementException;
 
 public class DefaultGradle extends AbstractPluginAware implements GradleInternal {
+    private String rootProjectName;
     private ProjectInternal rootProject;
     private ProjectInternal defaultProject;
     private final GradleInternal parent;
@@ -114,14 +114,13 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
         return path;
     }
 
-    @Nullable
     @Override
     public Path findIdentityPath() {
         if (identityPath == null) {
             if (parent == null) {
                 identityPath = Path.ROOT;
             } else {
-                if (rootProject == null) {
+                if (rootProjectName == null) {
                     // Not known yet
                     return null;
                 }
@@ -130,7 +129,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
                     // Not known yet
                     return null;
                 }
-                this.identityPath = parentIdentityPath.child(rootProject.getName());
+                this.identityPath = parentIdentityPath.child(rootProjectName);
             }
         }
         return identityPath;
@@ -432,5 +431,9 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     @Inject
     public PluginManagerInternal getPluginManager() {
         throw new UnsupportedOperationException();
+    }
+
+    public void setRootProjectName(String rootProjectName) {
+        this.rootProjectName = rootProjectName;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -80,6 +80,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
         this.parent = parent;
         this.startParameter = startParameter;
         this.services = parentRegistry.createFor(this);
+        this.rootProjectName = startParameter.getCurrentDir().getName();
         classLoaderScope = services.get(ClassLoaderScopeRegistry.class).getCoreAndPluginsScope();
         buildListenerBroadcast = getListenerManager().createAnonymousBroadcaster(BuildListener.class);
         projectEvaluationListenerBroadcast = getListenerManager().createAnonymousBroadcaster(ProjectEvaluationListener.class);
@@ -120,10 +121,6 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
             if (parent == null) {
                 identityPath = Path.ROOT;
             } else {
-                if (rootProjectName == null) {
-                    // Not known yet
-                    return null;
-                }
                 Path parentIdentityPath = parent.findIdentityPath();
                 if (parentIdentityPath == null) {
                     // Not known yet

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -61,7 +61,7 @@ import java.util.Collections;
 import java.util.NoSuchElementException;
 
 public class DefaultGradle extends AbstractPluginAware implements GradleInternal {
-    private String rootProjectName;
+    private String buildName;
     private ProjectInternal rootProject;
     private ProjectInternal defaultProject;
     private final GradleInternal parent;
@@ -80,7 +80,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
         this.parent = parent;
         this.startParameter = startParameter;
         this.services = parentRegistry.createFor(this);
-        this.rootProjectName = startParameter.getCurrentDir().getName();
+
         classLoaderScope = services.get(ClassLoaderScopeRegistry.class).getCoreAndPluginsScope();
         buildListenerBroadcast = getListenerManager().createAnonymousBroadcaster(BuildListener.class);
         projectEvaluationListenerBroadcast = getListenerManager().createAnonymousBroadcaster(ProjectEvaluationListener.class);
@@ -121,12 +121,17 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
             if (parent == null) {
                 identityPath = Path.ROOT;
             } else {
+                if (buildName == null) {
+                    // Not known yet
+                    return null;
+                }
+
                 Path parentIdentityPath = parent.findIdentityPath();
                 if (parentIdentityPath == null) {
                     // Not known yet
                     return null;
                 }
-                this.identityPath = parentIdentityPath.child(rootProjectName);
+                this.identityPath = parentIdentityPath.child(buildName);
             }
         }
         return identityPath;
@@ -430,7 +435,10 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
         throw new UnsupportedOperationException();
     }
 
-    public void setRootProjectName(String rootProjectName) {
-        this.rootProjectName = rootProjectName;
+    public void setBuildName(String buildName) {
+        if (this.buildName!=null) {
+            throw new IllegalStateException(String.format("Cannot change build name to '%s', build '%s' has already been set.", buildName, this.buildName));
+        }
+        this.buildName = buildName;
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
@@ -46,6 +46,7 @@ class DefaultSettingsLoaderTest extends Specification {
         startParameter.setCurrentDir(settingsLocation.getSettingsDir())
 
         settings.getProjectRegistry() >> projectRegistry
+        settings.getRootProject() >> projectDescriptor
         projectRegistry.getAllProjects() >> WrapUtil.toSet(projectDescriptor)
         projectDescriptor.getProjectDir() >> settingsLocation.settingsDir
         projectDescriptor.getBuildFile() >> new File(settingsLocation.getSettingsDir(), "build.gradle")

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -383,11 +383,11 @@ class DefaultGradleSpec extends Specification {
     def "has identity path"() {
         given:
         def child1 = classGenerator.newInstance(DefaultGradle, gradle, Stub(StartParameter), serviceRegistryFactory)
-        child1.rootProjectName = 'child1'
+        child1.buildName = 'child1'
 
         and:
         def child2 = classGenerator.newInstance(DefaultGradle, child1, Stub(StartParameter), serviceRegistryFactory)
-        child2.rootProjectName = 'child2'
+        child2.buildName = 'child2'
 
         expect:
         gradle.identityPath == Path.ROOT

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -383,11 +383,11 @@ class DefaultGradleSpec extends Specification {
     def "has identity path"() {
         given:
         def child1 = classGenerator.newInstance(DefaultGradle, gradle, Stub(StartParameter), serviceRegistryFactory)
-        child1.rootProject = project('child1')
+        child1.rootProjectName = 'child1'
 
         and:
         def child2 = classGenerator.newInstance(DefaultGradle, child1, Stub(StartParameter), serviceRegistryFactory)
-        child2.rootProject = project('child2')
+        child2.rootProjectName = 'child2'
 
         expect:
         gradle.identityPath == Path.ROOT

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/SourceDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/SourceDependenciesIntegrationTest.groovy
@@ -143,6 +143,9 @@ class SourceDependenciesIntegrationTest extends AbstractIntegrationSpec {
     // We're only checking that we don't explode
     def "can use build scan plugin with source dependencies"() {
         executer.withStdinPipe().withForceInteractive(true).requireGradleDistribution()
+        def initScript = file("init.gradle") << """
+            // do nothing
+        """
         settingsFile << """
             sourceControl {
                 vcsMappings {
@@ -157,7 +160,7 @@ class SourceDependenciesIntegrationTest extends AbstractIntegrationSpec {
             }
         """
         when:
-        def gradleHandle = executer.withTasks("resolve", "--scan").start()
+        def gradleHandle = executer.usingInitScript(initScript).withTasks("resolve", "--scan").start()
         writeToStdInAndClose(gradleHandle, YES.bytes)
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/SourceDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/SourceDependenciesIntegrationTest.groovy
@@ -139,6 +139,8 @@ class SourceDependenciesIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
+    // NOTE: This doesn't actually verify that the build scan produced is useful
+    // We're only checking that we don't explode
     def "can use build scan plugin with source dependencies"() {
         executer.withStdinPipe().withForceInteractive(true).requireGradleDistribution()
         settingsFile << """


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
