### PR TITLE
Revert "Revert android plugin upgrade in smoke test (#3139)"

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -28,9 +28,9 @@ import spock.lang.Unroll
  *
  */
 class AndroidPluginsSmokeTest extends AbstractSmokeTest {
-    public static final ANDROID_BUILD_TOOLS_VERSION = '25.0.0'
+    public static final ANDROID_BUILD_TOOLS_VERSION = '26.0.2'
     public static final String STABLE_ANDROID_VERSION = '2.3.3'
-    public static final String EXPERIMENTAL_ANDROID_VERSION = '3.0.0-beta6'
+    public static final String EXPERIMENTAL_ANDROID_VERSION = '3.0.0-beta7'
     public static final TESTED_ANDROID_PLUGIN_VERSIONS = [STABLE_ANDROID_VERSION, EXPERIMENTAL_ANDROID_VERSION]
 
     def setup() {


### PR DESCRIPTION
This reverts commit be02d5836385dba45f42e5487d9c5019a806d40b
because we've already fixed license issues on build agents.
