### PR TITLE
Settings include(..) & includeFlat(..) array parameter as varargs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/ProjectDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/ProjectDescriptor.java
@@ -24,7 +24,7 @@ import java.util.Set;
  * org.gradle.api.Project}.</p>
  *
  * <p> A {@code ProjectDescriptor} is created when you add a project to the build from the settings script, using {@link
- * Settings#include(String[])} or {@link Settings#includeFlat(String[])}. You can access the descriptors using one of
+ * Settings#include(String...)} or {@link Settings#includeFlat(String...)}. You can access the descriptors using one of
  * the lookup methods on the {@link Settings} object.</p>
  */
 public interface ProjectDescriptor {

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -41,7 +41,7 @@ import java.io.File;
  * <h3>Assembling a Multi-Project Build</h3>
  *
  * <p>One of the purposes of the <code>Settings</code> object is to allow you to declare the projects which are to be
- * included in the build. You add projects to the build using the {@link #include(String[])} method.  There is always a
+ * included in the build. You add projects to the build using the {@link #include(String...)} method.  There is always a
  * root project included in a build.  It is added automatically when the <code>Settings</code> object is created.  The
  * root project's name defaults to the name of the directory containing the settings file. The root project's project
  * directory defaults to the directory containing the settings file.</p>
@@ -108,7 +108,7 @@ public interface Settings extends PluginAware {
      *
      * @param projectPaths the projects to add.
      */
-    void include(String[] projectPaths);
+    void include(String... projectPaths);
 
     /**
      * <p>Adds the given projects to the build. Each name in the supplied list is treated as the name of a project to
@@ -122,7 +122,7 @@ public interface Settings extends PluginAware {
      *
      * @param projectNames the projects to add.
      */
-    void includeFlat(String[] projectNames);
+    void includeFlat(String... projectNames);
 
     /**
      * <p>Returns this settings object.</p>

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -120,7 +120,7 @@ public class DefaultSettings extends AbstractPluginAware implements SettingsInte
         return projectDescriptor;
     }
 
-    public void include(String[] projectPaths) {
+    public void include(String... projectPaths) {
         for (String projectPath : projectPaths) {
             String subPath = "";
             String[] pathElements = removeTrailingColon(projectPath).split(":");
@@ -137,7 +137,7 @@ public class DefaultSettings extends AbstractPluginAware implements SettingsInte
         }
     }
 
-    public void includeFlat(String[] projectNames) {
+    public void includeFlat(String... projectNames) {
         for (String projectName : projectNames) {
             createProjectDescriptor(rootProjectDescriptor, projectName,
                 new File(rootProjectDescriptor.getProjectDir().getParentFile(), projectName));


### PR DESCRIPTION
Change method signatures:
- `include(String[])` to `include(String...)`
- `includeFlat(String[])` to `includeFlat(String...)`

This isn't a binary breaking change as call sites for array and varags taking methods are identical, they both instantiate the array.

Motivation is to be able to write the following in `settings.gradle.kts` files:

```kotlin
include("a", "b", "c")
```

instead of:

```kotlin
include(arrayOf("a", "b", "c"))
```

See https://github.com/gradle/kotlin-dsl/issues/543
