### PR TITLE
Deprecate support for nested build without a settings.gradle

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedRelocationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedRelocationIntegrationTest.groovy
@@ -42,6 +42,7 @@ class CachedRelocationIntegrationTest extends AbstractIntegrationSpec implements
             apply plugin: "java"
             apply from: "external.gradle"
         """
+        originalLocation.file('settings.gradle') << localCacheConfiguration()
 
         when:
         executer.usingProjectDirectory(originalLocation)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
@@ -75,6 +75,7 @@ class PluginBuilder {
         """
 
         writePluginDescriptors(pluginIds)
+        projectDir.file('settings.gradle').write('')
         executer.inDirectory(projectDir).withTasks("jar").run()
     }
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -182,6 +182,7 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppInstalledToolChainI
 
         when:
         def consumer = file("consumer").createDir()
+        consumer.file('settings.gradle') << ''
         consumer.file("build.gradle") << """
             apply plugin: 'cpp-executable'
             repositories { maven { url '${repoDir.toURI()}' } }
@@ -264,6 +265,7 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppInstalledToolChainI
 
         when:
         def consumer = file("consumer").createDir()
+        consumer.file('settings.gradle') << ''
         consumer.file("build.gradle") << """
             apply plugin: 'cpp-executable'
             repositories { maven { url '${repoDir.toURI()}' } }

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/PrebuiltLibrariesIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/PrebuiltLibrariesIntegrationTest.groovy
@@ -51,6 +51,7 @@ model {
     }
 
     private void preBuildLibrary() {
+        file('libs/settings.gradle').write('')
         executer.inDirectory(file("libs"))
         run "assemble"
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
@@ -26,6 +26,7 @@ class CachedGroovyCompileIntegrationTest extends AbstractCachedCompileIntegratio
     @Override
     def setupProjectInDirectory(TestFile project = temporaryFolder.testDirectory) {
         project.with {
+            file('settings.gradle') << localCacheConfiguration()
             file('build.gradle').text = """
             plugins {
                 id 'groovy'

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CachedJavaCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CachedJavaCompileIntegrationTest.groovy
@@ -25,6 +25,7 @@ class CachedJavaCompileIntegrationTest extends AbstractCachedCompileIntegrationT
 
     def setupProjectInDirectory(TestFile project = temporaryFolder.testDirectory) {
         project.with {
+            file('settings.gradle') << localCacheConfiguration()
             file('build.gradle').text = """
             plugins {
                 id 'java'

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
@@ -27,6 +27,7 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
     @Override
     def setupProjectInDirectory(TestFile project = temporaryFolder.testDirectory) {
         project.with {
+            file('settings.gradle') << localCacheConfiguration()
             file('build.gradle').text = """
             plugins {
                 id 'scala'


### PR DESCRIPTION
### Context

As stated in #3137 and https://github.com/gradle/gradle-private/issues/708 , we're to deprecate support for nested builds without a settings.gradle.

### Gradle Core Team Checklist
- [x] Verify test coverage and CI build status
