### PR TITLE
Show deprecation warning when incorrect input is used for runtime API

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -54,7 +54,7 @@ public interface TaskInputs extends CompatibilityAdapterForTaskInputs {
     /**
      * Registers some input file for this task.
      *
-     * @param path The input file. The given path is evaluated as per {@link org.gradle.api.Project#files(Object...)}.
+     * @param path The input file. The given path is evaluated as per {@link org.gradle.api.Project#file(Object)}.
      * @return a property builder to further configure the property.
      */
     TaskInputFilePropertyBuilder file(Object path);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -31,6 +31,8 @@ import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.tasks.TaskInputPropertyBuilder;
 import org.gradle.api.tasks.TaskInputs;
+import org.gradle.internal.typeconversion.UnsupportedNotationException;
+import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -110,7 +112,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
         return taskMutator.mutate("TaskInputs.file(Object)", new Callable<TaskInputFilePropertyBuilderInternal>() {
             @Override
             public TaskInputFilePropertyBuilderInternal call() {
-                return file(new StaticValue(path));
+                return addSpec(new StaticValue(path), RUNTIME_INPUT_FILE_VALIDATOR);
             }
         });
     }
@@ -125,7 +127,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
         return taskMutator.mutate("TaskInputs.dir(Object)", new Callable<TaskInputFilePropertyBuilderInternal>() {
             @Override
             public TaskInputFilePropertyBuilderInternal call() {
-                return dir(new StaticValue(dirPath));
+                return addSpec(new StaticValue(dirPath), RUNTIME_INPUT_DIRECTORY_VALIDATOR);
             }
         });
     }
@@ -206,7 +208,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
     public TaskInputPropertyBuilder property(final String name, @Nullable final Object value) {
         return taskMutator.mutate("TaskInputs.property(String, Object)", new Callable<TaskInputPropertyBuilder>() {
             @Override
-            public TaskInputPropertyBuilder call() throws Exception {
+            public TaskInputPropertyBuilder call() {
                 return property(name, new StaticValue(value));
             }
         });
@@ -362,6 +364,24 @@ public class DefaultTaskInputs implements TaskInputsInternal {
             }
         }
     };
+
+    private static final ValidationAction RUNTIME_INPUT_FILE_VALIDATOR = wrapRuntimeApiValidator("file", INPUT_FILE_VALIDATOR);
+
+    private static final ValidationAction RUNTIME_INPUT_DIRECTORY_VALIDATOR = wrapRuntimeApiValidator("dir", INPUT_DIRECTORY_VALIDATOR);
+
+    private static ValidationAction wrapRuntimeApiValidator(final String method, final ValidationAction validator) {
+        return new ValidationAction() {
+            @Override
+            public void validate(String propertyName, Object value, TaskValidationContext context, TaskValidationContext.Severity severity) {
+                try {
+                    validator.validate(propertyName, value, context, severity);
+                } catch (UnsupportedNotationException ex) {
+                    DeprecationLogger.nagUserOfDeprecated("Using TaskInputs." + method + "() with something that doesn't resolve to a File object", "Use TaskInputs.files() instead");
+                }
+            }
+        };
+    }
+
 
     private static File toFile(TaskValidationContext context, Object value) {
         return context.getResolver().resolve(value);

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -305,6 +305,26 @@ task myTask {
 }
 ```
 
+### Calling `TaskInputs` methods with incorrect parameters
+
+`TaskInputs.file()` used to accept anything that `files()` would, and the same was true for `dir()`. Starting with Gradle 4.3 this behavior is deprecated, and only values that resolve to a single file or directory are accepted.
+
+Do not do this:
+
+```
+task myTask {
+    inputs.dir fileTree(...)
+}
+```
+
+Do this instead:
+
+```
+task myTask {
+    inputs.files fileTree(...)
+}
+```
+
 ### Deprecation of `TaskInternal.execute()`
 
 In this release we deprecate calling `TaskInternal.execute()`. Calling `task.execute()` should never be necessary.


### PR DESCRIPTION
Instead of failing the build when incorrect inputs are given to `TaskInputs.file()` and `dir()`, we show a deprecation warning.

Fixes #3193.