### PR TITLE
Show deprecation warning when incorrect input is used for runtime API (take 2)

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -54,7 +54,7 @@ public interface TaskInputs extends CompatibilityAdapterForTaskInputs {
     /**
      * Registers some input file for this task.
      *
-     * @param path The input file. The given path is evaluated as per {@link org.gradle.api.Project#files(Object...)}.
+     * @param path The input file. The given path is evaluated as per {@link org.gradle.api.Project#file(Object)}.
      * @return a property builder to further configure the property.
      */
     TaskInputFilePropertyBuilder file(Object path);

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -305,6 +305,26 @@ task myTask {
 }
 ```
 
+### Calling `TaskInputs` methods with incorrect parameters
+
+`TaskInputs.file()` used to accept anything that `files()` would, and the same was true for `dir()`. Starting with Gradle 4.3 this behavior is deprecated, and only values that resolve to a single file or directory are accepted.
+
+Do not do this:
+
+```
+task myTask {
+    inputs.dir fileTree(...)
+}
+```
+
+Do this instead:
+
+```
+task myTask {
+    inputs.files fileTree(...)
+}
+```
+
 ### Deprecation of `TaskInternal.execute()`
 
 In this release we deprecate calling `TaskInternal.execute()`. Calling `task.execute()` should never be necessary.


### PR DESCRIPTION
Instead of failing the build when incorrect inputs are given to `TaskInputs.file()` and `dir()`, we show a deprecation warning.

Fixes #3193.
