### PR TITLE
Change "Mac OS X" and "OS X" To macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ atlassian-ide-plugin.xml
 # ----
 .java-version
 
-# OS X
+# macOS
 # ----
 .DS_Store
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
@@ -142,7 +142,7 @@ class OperatingSystemTest extends Specification {
         os.findInPath("unknown") == null
     }
 
-    def "uses os.name property to determine if Mac OS X"() {
+    def "uses os.name property to determine if macOS"() {
         when:
         System.properties['os.name'] = 'Mac OS X'
 
@@ -162,7 +162,7 @@ class OperatingSystemTest extends Specification {
         OperatingSystem.current() instanceof OperatingSystem.MacOs
     }
 
-    def "Mac OS X identifies itself correctly"() {
+    def "macOS identifies itself correctly"() {
         def os = new OperatingSystem.MacOs()
 
         expect:
@@ -299,14 +299,14 @@ class OperatingSystemTest extends Specification {
         [arch, prefix] << [['i386', 'unknown-i386'], ['x86', 'unknown-i386']]
     }
 
-    def "os x uses same prefix for all architectures"() {
+    def "macOS uses same prefix for all architectures"() {
         def osx = new OperatingSystem.MacOs()
 
         expect:
         osx.nativePrefix == 'darwin'
     }
 
-    def "os x transforms shared library names"() {
+    def "macOS transforms shared library names"() {
         def os = new OperatingSystem.MacOs()
 
         expect:

--- a/subprojects/docs/src/docs/userguide/announcePlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/announcePlugin.adoc
@@ -20,7 +20,7 @@ The Gradle announce plugin allows you to send custom announcements during a buil
 * http://twitter.com[Twitter]
 * http://manpages.ubuntu.com/manpages/gutsy/man1/notify-send.1.html[notify-send] (Ubuntu)
 * https://sites.google.com/site/snarlapp/home[Snarl] (Windows)
-* http://growl.info/[Growl] (Mac OS X)
+* http://growl.info/[Growl] (macOS)
  
 
 
@@ -72,7 +72,7 @@ The `announce` method takes two String arguments: The message to be sent, and th
 | 
 
 | growl
-| Mac OS X
+| macOS
 | 
 | 
 
@@ -82,7 +82,7 @@ The `announce` method takes two String arguments: The message to be sent, and th
 | Requires the notify-send package to be installed. Use `sudo apt-get install libnotify-bin` to install it.
 
 | local
-| Windows, Mac OS X, Ubuntu
+| Windows, macOS, Ubuntu
 | 
 | Automatically chooses between snarl, growl, and notify-send depending on the current operating system.
 |===

--- a/subprojects/docs/src/docs/userguide/applicationPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/applicationPlugin.adoc
@@ -94,7 +94,7 @@ You can run `gradle installDist` to create an image of the application in `build
 [[sec:customizing_start_script_generation]]
 ==== Customizing start script generation
 
-The application plugin can generate Unix (suitable for Linux, Mac OS X etc.) and Windows start scripts out of the box. The start scripts launch a JVM with the specified settings defined as part of the original build and runtime environment (e.g. `JAVA_OPTS` env var). The default script templates are based on the same scripts used to launch Gradle itself, that ship as part of a Gradle distribution.
+The application plugin can generate Unix (suitable for Linux, macOS etc.) and Windows start scripts out of the box. The start scripts launch a JVM with the specified settings defined as part of the original build and runtime environment (e.g. `JAVA_OPTS` env var). The default script templates are based on the same scripts used to launch Gradle itself, that ship as part of a Gradle distribution.
 
 The start scripts are completely customizable. Please refer to the documentation of api:org.gradle.jvm.application.tasks.CreateStartScripts[] for more details and customization examples.
 

--- a/subprojects/docs/src/docs/userguide/continuousBuild.adoc
+++ b/subprojects/docs/src/docs/userguide/continuousBuild.adoc
@@ -94,16 +94,16 @@ If your build enters a build cycle like this, you can track down the task by loo
 
 Due to class access restrictions related to Java 9, Gradle cannot set some operating system specific options, which means that: 
 
-* On Mac OS X, Gradle will poll for file changes every 10 seconds instead of every 2 seconds.
+* On macOS, Gradle will poll for file changes every 10 seconds instead of every 2 seconds.
 * On Windows, Gradle must use individual file watches (like on Linux/Mac OS), which may cause continuous build to no longer work on very large projects.
  
 
 [[sec:performance_and_stability]]
 ==== Performance and stability
 
-The JDK file watching facility relies on inefficient file system polling on Mac OS X (see: https://bugs.openjdk.java.net/browse/JDK-7133447[JDK-7133447]). This can significantly delay notification of changes on large projects with many source files.
+The JDK file watching facility relies on inefficient file system polling on macOS (see: https://bugs.openjdk.java.net/browse/JDK-7133447[JDK-7133447]). This can significantly delay notification of changes on large projects with many source files.
 
-Additionally, the watching mechanism may deadlock under _heavy_ load on Mac OS X (see: https://bugs.openjdk.java.net/browse/JDK-8079620[JDK-8079620]). This will manifest as Gradle appearing not to notice file changes. If you suspect this is occurring, exit continuous build and start again.
+Additionally, the watching mechanism may deadlock under _heavy_ load on macOS (see: https://bugs.openjdk.java.net/browse/JDK-8079620[JDK-8079620]). This will manifest as Gradle appearing not to notice file changes. If you suspect this is occurring, exit continuous build and start again.
 
 On Linux, OpenJDK's implementation of the file watch service can sometimes miss file system events (see: https://bugs.openjdk.java.net/browse/JDK-8145981[JDK-8145981]).
 

--- a/subprojects/docs/src/docs/userguide/gradleDaemon.adoc
+++ b/subprojects/docs/src/docs/userguide/gradleDaemon.adoc
@@ -63,7 +63,7 @@ The Gradle Daemon is enabled by default, and we recommend always enabling it. Th
 to the file `«USER_HOME»/.gradle/gradle.properties`, where `«USER_HOME»` is your home directory. That’s typically one of the following, depending on your platform:
 
 * `C:\Users\<username>` (Windows Vista & 7+)
-* `/Users/<username>` (Mac OS X)
+* `/Users/<username>` (macOS)
 * `/home/<username>` (Linux)
 
 If that file doesn’t exist, just create it using a text editor. You can find details of other ways to disable (and enable) the Daemon in <<daemon_faq>> further down. That section also contains more detailed information on how the Daemon works.

--- a/subprojects/docs/src/docs/userguide/gradleWrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/gradleWrapper.adoc
@@ -25,7 +25,7 @@ The Gradle Wrapper (henceforth referred to as the “Wrapper”) solves both the
 
 If a Gradle project has set up the Wrapper (and we recommend all projects do so), you can execute the build using one of the following commands from the root of the project:
 
-* `./gradlew <task>` (on Unix-like platforms such as Linux and Mac OS X)
+* `./gradlew <task>` (on Unix-like platforms such as Linux and macOS)
 * `gradlew <task>` (on Windows using the gradlew.bat batch file)
 
 Each Wrapper is tied to a specific version of Gradle, so when you first run one of the commands above for a given Gradle version, it will download the corresponding Gradle distribution and use it to execute the build.

--- a/subprojects/docs/src/docs/userguide/nativeBinaries.adoc
+++ b/subprojects/docs/src/docs/userguide/nativeBinaries.adoc
@@ -33,7 +33,7 @@ The native software plugins make use of the Gradle <<software_model,software mod
 
 The native software plugins provide:
 
-* Support for building native libraries and applications on Windows, Linux, OS X and other platforms.
+* Support for building native libraries and applications on Windows, Linux, macOS and other platforms.
 * Support for several source languages.
 * Support for building different variants of the same software, for different architectures, operating systems, or for any purpose.
 * Incremental parallel compilation, precompiled headers.
@@ -77,7 +77,7 @@ The following tool chains are supported:
 | http://clang.llvm.org[Clang]
 |
 
-| Mac OS X
+| macOS
 | XCode
 | Uses the Clang tool chain bundled with XCode.
 
@@ -102,11 +102,11 @@ The following tool chains are unofficially supported. They generally work fine, 
 | Tool Chain
 | Notes
 
-| Mac OS X
+| macOS
 | http://gcc.gnu.org/[GCC] from Macports
 |
 
-| Mac OS X
+| macOS
 | http://clang.llvm.org[Clang] from Macports
 |
 
@@ -145,10 +145,10 @@ To build on Windows, install a compatible version of Visual Studio. The native p
 
 Alternatively, you can install Cygwin with GCC or MinGW. Clang is currently not supported.
 
-[[sec:os_x]]
-==== OS X
+[[sec:macOS]]
+==== macOS
 
-To build on OS X, you should install XCode. The native plugins will discover the XCode installation using the system PATH.
+To build on macOS, you should install XCode. The native plugins will discover the XCode installation using the system PATH.
 
 The native plugins also work with GCC and Clang bundled with Macports. To use one of the Macports tool chains, you will need to make the tool chain the default using the `port select` command and add Macports to the system PATH.
 

--- a/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/gtest.h
+++ b/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/gtest.h
@@ -2226,7 +2226,7 @@ bool StaticAssertTypeEq() {
 // Note that we call GetTestTypeId() instead of GetTypeId<
 // ::testing::Test>() here to get the type ID of testing::Test.  This
 // is to work around a suspected linker bug when using Google Test as
-// a framework on Mac OS X.  The bug causes GetTypeId<
+// a framework on macOS.  The bug causes GetTypeId<
 // ::testing::Test>() to return different values depending on whether
 // the call is from the Google Test framework itself or from user test
 // code.  GetTestTypeId() is guaranteed to always return the same

--- a/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-internal.h
+++ b/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-internal.h
@@ -425,7 +425,7 @@ TypeId GetTypeId() {
 // Returns the type ID of ::testing::Test.  Always call this instead
 // of GetTypeId< ::testing::Test>() to get the type ID of
 // ::testing::Test, as the latter may give the wrong result due to a
-// suspected linker bug when compiling Google Test as a Mac OS X
+// suspected linker bug when compiling Google Test as a macOS
 // framework.
 GTEST_API_ TypeId GetTestTypeId();
 

--- a/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-port.h
+++ b/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-port.h
@@ -95,7 +95,7 @@
 //   GTEST_OS_HPUX     - HP-UX
 //   GTEST_OS_LINUX    - Linux
 //     GTEST_OS_LINUX_ANDROID - Google Android
-//   GTEST_OS_MAC      - Mac OS X
+//   GTEST_OS_MAC      - macOS
 //     GTEST_OS_IOS    - iOS
 //       GTEST_OS_IOS_SIMULATOR - iOS simulator
 //   GTEST_OS_NACL     - Google Native Client (NaCl)
@@ -109,7 +109,7 @@
 //     GTEST_OS_WINDOWS_MOBILE   - Windows Mobile
 //   GTEST_OS_ZOS      - z/OS
 //
-// Among the platforms, Cygwin, Linux, Max OS X, and Windows have the
+// Among the platforms, Cygwin, Linux, macOS, and Windows have the
 // most stable support.  Since core members of the Google Test project
 // don't have access to other platforms, support for them may be less
 // stable.  If you notice any problems on your platform, please notify
@@ -523,7 +523,7 @@
 # endif
 
 // C++11 specifies that <tuple> provides std::tuple. Use that if gtest is used
-// in C++11 mode and libstdc++ isn't very old (binaries targeting OS X 10.6
+// in C++11 mode and libstdc++ isn't very old (binaries targeting Mac OS X 10.6
 // can build with clang but need to use gcc4.2's libstdc++).
 # if GTEST_LANG_CXX11 && (!defined(__GLIBCXX__) || __GLIBCXX__ > 20110325)
 #  define GTEST_ENV_HAS_STD_TUPLE_ 1

--- a/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-string.h
+++ b/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-string.h
@@ -134,7 +134,7 @@ class GTEST_API_ String {
   // On windows, this method uses _wcsicmp which compares according to LC_CTYPE
   // environment variable. On GNU platform this method uses wcscasecmp
   // which compares according to LC_CTYPE category of the current locale.
-  // On MacOS X, it uses towlower, which also uses LC_CTYPE category of the
+  // On macOS, it uses towlower, which also uses LC_CTYPE category of the
   // current locale.
   static bool CaseInsensitiveWideCStringEquals(const wchar_t* lhs,
                                                const wchar_t* rhs);

--- a/subprojects/docs/src/samples/native-binaries/objective-c/build.gradle
+++ b/subprojects/docs/src/samples/native-binaries/objective-c/build.gradle
@@ -14,7 +14,7 @@ model {
 model {
     binaries {
         all {
-            //on OS X we need different settings than on Linux or Windows
+            //on macOS we need different settings than on Linux or Windows
             if (targetPlatform.operatingSystem.macOsX) {
                 linker.args "-framework", "Foundation"
             } else {

--- a/subprojects/docs/src/samples/native-binaries/objective-cpp/build.gradle
+++ b/subprojects/docs/src/samples/native-binaries/objective-cpp/build.gradle
@@ -14,7 +14,7 @@ model {
 model {
     binaries {
         all {
-            //on OS X we need different linker settings than on Linux or Windows
+            //on macOS we need different linker settings than on Linux or Windows
             if (targetPlatform.operatingSystem.macOsX) {
                 linker.args "-framework", "Foundation"
             } else {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/YourKitProfiler.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/YourKitProfiler.groovy
@@ -23,20 +23,20 @@ import org.gradle.internal.os.OperatingSystem
  * Helper class for adding Yourkit Java Profiler (YJP) agent start up arguments for builds launched in performance tests.
  * <p>
  * Currently, YJP_HOME environment variable or YJP_AGENT_PATH environment variable is used to locate the agent library file. This is not needed if you install YJP in /opt/yjp on Linux
- * or rename the application as "yjp" on Mac OS X (directory: /Applications/yjp.app). These locations are searched by default.
+ * or rename the application as "yjp" on macOS (directory: /Applications/yjp.app). These locations are searched by default.
  *
  * <p>
  * Examples of specifying YJP_HOME
  * <pre>
  * export YJP_HOME="/opt/yjp" # on linux
- * export YJP_HOME="/Applications/yjp.app/Contents/Resources" # on Mac OS X
+ * export YJP_HOME="/Applications/yjp.app/Contents/Resources" # on macOS
  * </pre>
  *
  * <p>
  * Examples of specifying YJP_AGENT_PATH directly
  * <pre>
  * export YJP_AGENT_PATH="/opt/yjp/bin/linux-x86-64/libyjpagent.so" # on linux
- * export YJP_AGENT_PATH="/Applications/yjp.app/Contents/Resources/bin/mac/libyjpagent.jnilib" # on Mac OS X
+ * export YJP_AGENT_PATH="/Applications/yjp.app/Contents/Resources/bin/mac/libyjpagent.jnilib" # on macOS
  * </pre>
  *
  * <p>

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/encoding/Identifier.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/encoding/Identifier.java
@@ -87,7 +87,7 @@ public class Identifier {
 
     public static Identifier getNonAscii() {
         if (OperatingSystem.current().isMacOsX()) {
-            // The hfs+ file system stores file names in decomposed form. Don't use precomposed characters on OS X, as way too few things normalise text correctly
+            // The hfs+ file system stores file names in decomposed form. Don't use precomposed characters on macOS, as way too few things normalise text correctly
             return new Identifier(NON_PRECOMPOSED_NON_ASCII, "non-ascii");
         }
         return new Identifier(NON_ASCII_CHARS, "non-ascii");

--- a/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/gtest.h
+++ b/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/gtest.h
@@ -2226,7 +2226,7 @@ bool StaticAssertTypeEq() {
 // Note that we call GetTestTypeId() instead of GetTypeId<
 // ::testing::Test>() here to get the type ID of testing::Test.  This
 // is to work around a suspected linker bug when using Google Test as
-// a framework on Mac OS X.  The bug causes GetTypeId<
+// a framework on macOS.  The bug causes GetTypeId<
 // ::testing::Test>() to return different values depending on whether
 // the call is from the Google Test framework itself or from user test
 // code.  GetTestTypeId() is guaranteed to always return the same

--- a/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-internal.h
+++ b/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-internal.h
@@ -425,7 +425,7 @@ TypeId GetTypeId() {
 // Returns the type ID of ::testing::Test.  Always call this instead
 // of GetTypeId< ::testing::Test>() to get the type ID of
 // ::testing::Test, as the latter may give the wrong result due to a
-// suspected linker bug when compiling Google Test as a Mac OS X
+// suspected linker bug when compiling Google Test as a macOS
 // framework.
 GTEST_API_ TypeId GetTestTypeId();
 

--- a/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-port.h
+++ b/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-port.h
@@ -95,7 +95,7 @@
 //   GTEST_OS_HPUX     - HP-UX
 //   GTEST_OS_LINUX    - Linux
 //     GTEST_OS_LINUX_ANDROID - Google Android
-//   GTEST_OS_MAC      - Mac OS X
+//   GTEST_OS_MAC      - macOS
 //     GTEST_OS_IOS    - iOS
 //       GTEST_OS_IOS_SIMULATOR - iOS simulator
 //   GTEST_OS_NACL     - Google Native Client (NaCl)
@@ -109,7 +109,7 @@
 //     GTEST_OS_WINDOWS_MOBILE   - Windows Mobile
 //   GTEST_OS_ZOS      - z/OS
 //
-// Among the platforms, Cygwin, Linux, Max OS X, and Windows have the
+// Among the platforms, Cygwin, Linux, macOS, and Windows have the
 // most stable support.  Since core members of the Google Test project
 // don't have access to other platforms, support for them may be less
 // stable.  If you notice any problems on your platform, please notify
@@ -523,7 +523,7 @@
 # endif
 
 // C++11 specifies that <tuple> provides std::tuple. Use that if gtest is used
-// in C++11 mode and libstdc++ isn't very old (binaries targeting OS X 10.6
+// in C++11 mode and libstdc++ isn't very old (binaries targeting Mac OS X 10.6
 // can build with clang but need to use gcc4.2's libstdc++).
 # if GTEST_LANG_CXX11 && (!defined(__GLIBCXX__) || __GLIBCXX__ > 20110325)
 #  define GTEST_ENV_HAS_STD_TUPLE_ 1

--- a/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-string.h
+++ b/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-string.h
@@ -134,7 +134,7 @@ class GTEST_API_ String {
   // On windows, this method uses _wcsicmp which compares according to LC_CTYPE
   // environment variable. On GNU platform this method uses wcscasecmp
   // which compares according to LC_CTYPE category of the current locale.
-  // On MacOS X, it uses towlower, which also uses LC_CTYPE category of the
+  // On macOS, it uses towlower, which also uses LC_CTYPE category of the
   // current locale.
   static bool CaseInsensitiveWideCStringEquals(const wchar_t* lhs,
                                                const wchar_t* rhs);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/OperatingSystem.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/OperatingSystem.java
@@ -37,7 +37,7 @@ import org.gradle.api.tasks.Internal;
  *         <td>"linux"</td>
  *     </tr>
  *     <tr>
- *         <td>Mac OS X</td>
+ *         <td>macOS</td>
  *         <td>"osx", "mac os x", "darwin"</td>
  *     </tr>
  *     <tr>
@@ -71,7 +71,7 @@ public interface OperatingSystem extends Named {
     boolean isWindows();
 
     /**
-     * Is it Mac OS X?
+     * Is it macOS?
      */
     @Internal
     boolean isMacOsX();

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
@@ -219,7 +219,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         }
     }
 
-    def "supplies args for supported architecture for non-os x platforms"() {
+    def "supplies args for supported architecture for non-macOS platforms"() {
         def action = Mock(Action)
 
         given:
@@ -248,7 +248,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         "x86_64" | "-m64"    | "-m64"
     }
 
-    def "supplies args for supported architecture for os x platforms"() {
+    def "supplies args for supported architecture for macOS platforms"() {
         def action = Mock(Action)
 
         given:

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/application/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/application/CreateStartScripts.java
@@ -30,7 +30,7 @@ package org.gradle.api.tasks.application;
  * <p>
  * Note: the Gradle {@code "application"} plugin adds a pre-configured task of this type named {@code "startScripts"}.
  * <p>
- * The task generates separate scripts targeted at Microsoft Windows environments and UNIX-like environments (e.g. Linux, Mac OS X).
+ * The task generates separate scripts targeted at Microsoft Windows environments and UNIX-like environments (e.g. Linux, macOS).
  * The actual generation is implemented by the {@link #getWindowsStartScriptGenerator()} and {@link #getUnixStartScriptGenerator()} properties, of type
  * {@link org.gradle.jvm.application.scripts.ScriptGenerator}.
  * <p>

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -51,7 +51,7 @@ import java.io.File;
  * <p>
  * Note: the Gradle {@code "application"} plugin adds a pre-configured task of this type named {@code "startScripts"}.
  * <p>
- * The task generates separate scripts targeted at Microsoft Windows environments and UNIX-like environments (e.g. Linux, Mac OS X).
+ * The task generates separate scripts targeted at Microsoft Windows environments and UNIX-like environments (e.g. Linux, macOS).
  * The actual generation is implemented by the {@link #getWindowsStartScriptGenerator()} and {@link #getUnixStartScriptGenerator()} properties, of type {@link ScriptGenerator}.
  * <p>
  * Example:


### PR DESCRIPTION
"Mac OS X" was renamed to "OS X" in 2012 and to "macOS" in 2016.
Many places in code and comments still referred to the old names.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] (n/a) Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] (n/a) Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes