### PR TITLE
Make DefaultCppComponent recognize files ending in cc

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -49,7 +49,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
         super(fileOperations);
         this.name = name;
         this.fileOperations = fileOperations;
-        cppSource = createSourceView("src/" + name + "/cpp", Arrays.asList("cpp", "c++"));
+        cppSource = createSourceView("src/" + name + "/cpp", Arrays.asList("cpp", "c++", "cc"));
         privateHeaders = fileOperations.files();
         privateHeadersWithConvention = createDirView(privateHeaders, "src/" + name + "/headers");
         baseName = objectFactory.property(String.class);

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
@@ -55,22 +55,24 @@ class DefaultCppComponentTest extends Specification {
     def "can include individual source files"() {
         def f1 = tmpDir.createFile("a.cpp")
         def f2 = tmpDir.createFile("b.c++")
+        def f3 = tmpDir.createFile("c.cc")
 
         expect:
-        component.source.from(f1, f2)
-        component.cppSource.files == [f1, f2] as Set
+        component.source.from(f1, f2, f3)
+        component.cppSource.files == [f1, f2, f3] as Set
     }
 
     def "can include source files from a directory"() {
         def d = tmpDir.createDir("dir")
         def f1 = d.createFile("a.cpp")
         def f2 = d.createFile("nested/b.cpp")
+        def f3 = d.createFile("c.cc")
         d.createFile("ignore.txt")
         d.createFile("other/ignore.txt")
 
         expect:
         component.source.from(d)
-        component.cppSource.files == [f1, f2] as Set
+        component.cppSource.files == [f1, f2, f3] as Set
     }
 
     def "uses source layout convention when no other source files specified"() {


### PR DESCRIPTION
This is a common extension for C++ files, so it should be acceptable
for source files for a `DefaultCppComponent`.
