### PR TITLE
Check validity of .gradle/buildOutputCleanup/cache.properties

### DIFF
--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
@@ -83,6 +83,11 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
                 return true;
             }
 
+            if (!propertiesFile.exists()) {
+                LOGGER.warn("Invalidating {} as the cache properties file was missing.", DefaultPersistentDirectoryCache.this);
+                return true;
+            }
+
             Properties cachedProperties = GUtil.loadProperties(propertiesFile);
             for (Map.Entry<?, ?> entry : properties.entrySet()) {
                 String previousValue = cachedProperties.getProperty(entry.getKey().toString());


### PR DESCRIPTION
### Context

This is an attempt to fix https://github.com/gradle/gradle/issues/3176 .

When `.gradle/buildOutputCleanup/cache.properties` is missing unexpectedly,
Gradle will fail to start. Although the cause is still not clear, this PR adds a safe-check before accessing the file.

### Gradle Core Team Checklist
- [x] Verify test coverage and CI build status
