### PR TITLE
Unify deprecation message

### DIFF
--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/AbstractBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/AbstractBuildOption.java
@@ -52,11 +52,13 @@ public abstract class AbstractBuildOption<T> implements BuildOption<T> {
         return value != null && value.trim().equalsIgnoreCase("true");
     }
 
-    protected CommandLineOption configureCommandLineOption(CommandLineParser parser, String[] options, String description, String deprecationWarning, boolean incubating) {
+    protected CommandLineOption configureCommandLineOption(CommandLineParser parser, String[] options, String description, boolean deprecated, boolean incubating) {
         CommandLineOption option = parser.option(options)
-            .hasDescription(description)
-            .deprecated(deprecationWarning);
+            .hasDescription(description);
 
+        if(deprecated) {
+            option.deprecated();
+        }
         if (incubating) {
             option.incubating();
         }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BooleanBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/BooleanBuildOption.java
@@ -50,9 +50,9 @@ public abstract class BooleanBuildOption<T> extends AbstractBuildOption<T> {
     @Override
     public void configure(CommandLineParser parser) {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
-            configureCommandLineOption(parser, new String[] {config.getLongOption()}, config.getDescription(), config.getDeprecationWarning(), config.isIncubating());
+            configureCommandLineOption(parser, new String[] {config.getLongOption()}, config.getDescription(), config.isDeprecated(), config.isIncubating());
             String disabledOption = getDisabledCommandLineOption(config);
-            configureCommandLineOption(parser, new String[] {disabledOption}, config.getDescription(), config.getDeprecationWarning(), config.isIncubating());
+            configureCommandLineOption(parser, new String[] {disabledOption}, config.getDescription(), config.isDeprecated(), config.isIncubating());
             parser.allowOneOf(config.getLongOption(), disabledOption);
         }
     }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/CommandLineOptionConfiguration.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/CommandLineOptionConfiguration.java
@@ -30,7 +30,7 @@ public final class CommandLineOptionConfiguration {
     private final String shortOption;
     private final String description;
     private boolean incubating;
-    private String deprecationWarning;
+    private boolean deprecated;
 
     private CommandLineOptionConfiguration(String longOption, String description) {
         this(longOption, null, description);
@@ -57,8 +57,8 @@ public final class CommandLineOptionConfiguration {
         return this;
     }
 
-    public CommandLineOptionConfiguration deprecated(String deprecationWarning) {
-        this.deprecationWarning = deprecationWarning;
+    public CommandLineOptionConfiguration deprecated() {
+        this.deprecated = true;
         return this;
     }
 
@@ -90,7 +90,7 @@ public final class CommandLineOptionConfiguration {
         return incubating;
     }
 
-    public String getDeprecationWarning() {
-        return deprecationWarning;
+    public boolean isDeprecated() {
+        return deprecated;
     }
 }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOption.java
@@ -46,7 +46,7 @@ public abstract class EnabledOnlyBooleanBuildOption<T> extends AbstractBuildOpti
     @Override
     public void configure(CommandLineParser parser) {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
-            configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.getDeprecationWarning(), config.isIncubating());
+            configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.isDeprecated(), config.isIncubating());
         }
     }
 

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/ListBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/ListBuildOption.java
@@ -51,7 +51,7 @@ public abstract class ListBuildOption<T> extends AbstractBuildOption<T> {
     @Override
     public void configure(CommandLineParser parser) {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
-            configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.getDeprecationWarning(), config.isIncubating()).hasArguments();
+            configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.isDeprecated(), config.isIncubating()).hasArguments();
         }
     }
 

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/StringBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/StringBuildOption.java
@@ -48,7 +48,7 @@ public abstract class StringBuildOption<T> extends AbstractBuildOption<T> {
     @Override
     public void configure(CommandLineParser parser) {
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
-            configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.getDeprecationWarning(), config.isIncubating()).hasArgument();
+            configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.isDeprecated(), config.isIncubating()).hasArgument();
         }
     }
 

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BooleanBuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BooleanBuildOptionTest.groovy
@@ -67,8 +67,8 @@ class BooleanBuildOptionTest extends Specification {
         CommandLineOption disabledOption = commandLineParser.optionsByString[DISABLED_LONG_OPTION]
         assertNoArguments(enabledOption)
         assertNoArguments(disabledOption)
-        assertNoDeprecationWarning(enabledOption)
-        assertNoDeprecationWarning(disabledOption)
+        assertDeprecated(enabledOption, false)
+        assertDeprecated(disabledOption, false)
     }
 
     def "can configure incubating command line option"() {
@@ -91,19 +91,16 @@ class BooleanBuildOptionTest extends Specification {
     }
 
     def "can configure deprecated command line option"() {
-        given:
-        String deprecationWarning = 'replaced by other'
-
         when:
         def commandLineOptionConfiguration = CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION, DESCRIPTION)
-            .deprecated(deprecationWarning)
+            .deprecated()
 
         def testOption = new TestOption(GRADLE_PROPERTY, commandLineOptionConfiguration)
         testOption.configure(commandLineParser)
 
         then:
-        assertDeprecationWarning(commandLineParser.optionsByString[LONG_OPTION], deprecationWarning)
-        assertDeprecationWarning(commandLineParser.optionsByString[DISABLED_LONG_OPTION], deprecationWarning)
+        assertDeprecated(commandLineParser.optionsByString[LONG_OPTION], true)
+        assertDeprecated(commandLineParser.optionsByString[DISABLED_LONG_OPTION], true)
     }
 
     def "can apply from command line"() {

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BuildOptionFixture.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/BuildOptionFixture.groovy
@@ -46,11 +46,7 @@ final class BuildOptionFixture {
         assert option.incubating == incubating
     }
 
-    static void assertNoDeprecationWarning(CommandLineOption option) {
-        assert !option.deprecationWarning
-    }
-
-    static void assertDeprecationWarning(CommandLineOption option, String deprecationWarning) {
-        assert option.deprecationWarning == deprecationWarning
+    static void assertDeprecated(CommandLineOption option, boolean deprecated) {
+        assert option.deprecated == deprecated
     }
 }

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/CommandLineOptionConfigurationTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/CommandLineOptionConfigurationTest.groovy
@@ -34,7 +34,7 @@ class CommandLineOptionConfigurationTest extends Specification {
         configuration.shortOption == null
         configuration.description == DESCRIPTION
         !configuration.incubating
-        !configuration.deprecationWarning
+        !configuration.deprecated
         configuration.allOptions == [LONG_OPTION] as String[]
     }
 
@@ -47,7 +47,7 @@ class CommandLineOptionConfigurationTest extends Specification {
         configuration.shortOption == SHORT_OPTION
         configuration.description == DESCRIPTION
         !configuration.incubating
-        !configuration.deprecationWarning
+        !configuration.deprecated
         configuration.allOptions == [LONG_OPTION, SHORT_OPTION] as String[]
     }
 
@@ -61,15 +61,12 @@ class CommandLineOptionConfigurationTest extends Specification {
     }
 
     def "can mark option as deprecated"() {
-        given:
-        String deprecationWarning = 'replaced by other'
-
         when:
         CommandLineOptionConfiguration configuration = CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION, DESCRIPTION)
-        configuration.deprecated(deprecationWarning)
+        configuration.deprecated()
 
         then:
-        configuration.deprecationWarning == deprecationWarning
+        configuration.deprecated
     }
 
     @Unroll

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/EnabledOnlyBooleanBuildOptionTest.groovy
@@ -66,8 +66,8 @@ class EnabledOnlyBooleanBuildOptionTest extends Specification {
         CommandLineOption shortOption = commandLineParser.optionsByString[SHORT_OPTION]
         assertNoArguments(longOption)
         assertNoArguments(shortOption)
-        assertNoDeprecationWarning(longOption)
-        assertNoDeprecationWarning(shortOption)
+        assertDeprecated(longOption, false)
+        assertDeprecated(shortOption, false)
     }
 
     def "can configure incubating command line option"() {
@@ -90,19 +90,16 @@ class EnabledOnlyBooleanBuildOptionTest extends Specification {
     }
 
     def "can configure deprecated command line option"() {
-        given:
-        String deprecationWarning = 'replaced by other'
-
         when:
         def commandLineOptionConfiguration = CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION, DESCRIPTION)
-            .deprecated(deprecationWarning)
+            .deprecated()
 
         def testOption = new TestOption(GRADLE_PROPERTY, commandLineOptionConfiguration)
         testOption.configure(commandLineParser)
 
         then:
-        assertDeprecationWarning(commandLineParser.optionsByString[LONG_OPTION], deprecationWarning)
-        assertDeprecationWarning(commandLineParser.optionsByString[SHORT_OPTION], deprecationWarning)
+        assertDeprecated(commandLineParser.optionsByString[LONG_OPTION], true)
+        assertDeprecated(commandLineParser.optionsByString[SHORT_OPTION], true)
     }
 
     def "can apply from command line"() {

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/ListBuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/ListBuildOptionTest.groovy
@@ -68,8 +68,8 @@ class ListBuildOptionTest extends Specification {
         CommandLineOption shortOption = commandLineParser.optionsByString[SHORT_OPTION]
         assertMultipleArgument(longOption)
         assertMultipleArgument(shortOption)
-        assertNoDeprecationWarning(longOption)
-        assertNoDeprecationWarning(shortOption)
+        assertDeprecated(longOption, false)
+        assertDeprecated(shortOption, false)
     }
 
     def "can configure incubating command line option"() {
@@ -92,19 +92,16 @@ class ListBuildOptionTest extends Specification {
     }
 
     def "can configure deprecated command line option"() {
-        given:
-        String deprecationWarning = 'replaced by other'
-
         when:
         def commandLineOptionConfiguration = CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION, DESCRIPTION)
-            .deprecated(deprecationWarning)
+            .deprecated()
 
         def testOption = new TestOption(GRADLE_PROPERTY, commandLineOptionConfiguration)
         testOption.configure(commandLineParser)
 
         then:
-        assertDeprecationWarning(commandLineParser.optionsByString[LONG_OPTION], deprecationWarning)
-        assertDeprecationWarning(commandLineParser.optionsByString[SHORT_OPTION], deprecationWarning)
+        assertDeprecated(commandLineParser.optionsByString[LONG_OPTION], true)
+        assertDeprecated(commandLineParser.optionsByString[SHORT_OPTION], true)
     }
 
     def "can apply from command line"() {

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/StringBuildOptionTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/StringBuildOptionTest.groovy
@@ -67,8 +67,8 @@ class StringBuildOptionTest extends Specification {
         CommandLineOption shortOption = commandLineParser.optionsByString[SHORT_OPTION]
         assertSingleArgument(longOption)
         assertSingleArgument(shortOption)
-        assertNoDeprecationWarning(longOption)
-        assertNoDeprecationWarning(shortOption)
+        assertDeprecated(longOption, false)
+        assertDeprecated(shortOption, false)
     }
 
     def "can configure incubating command line option"() {
@@ -91,19 +91,16 @@ class StringBuildOptionTest extends Specification {
     }
 
     def "can configure deprecated command line option"() {
-        given:
-        String deprecationWarning = 'replaced by other'
-
         when:
         def commandLineOptionConfiguration = CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION, DESCRIPTION)
-            .deprecated(deprecationWarning)
+            .deprecated()
 
         def testOption = new TestOption(GRADLE_PROPERTY, commandLineOptionConfiguration)
         testOption.configure(commandLineParser)
 
         then:
-        assertDeprecationWarning(commandLineParser.optionsByString[LONG_OPTION], deprecationWarning)
-        assertDeprecationWarning(commandLineParser.optionsByString[SHORT_OPTION], deprecationWarning)
+        assertDeprecated(commandLineParser.optionsByString[LONG_OPTION], true)
+        assertDeprecated(commandLineParser.optionsByString[SHORT_OPTION], true)
     }
 
     def "can apply from command line"() {

--- a/subprojects/cli/src/main/java/org/gradle/cli/CommandLineOption.java
+++ b/subprojects/cli/src/main/java/org/gradle/cli/CommandLineOption.java
@@ -23,7 +23,7 @@ public class CommandLineOption {
     private final Set<String> options = new HashSet<String>();
     private Class<?> argumentType = Void.TYPE;
     private String description;
-    private String deprecationWarning;
+    private boolean deprecated;
     private boolean incubating;
     private final Set<CommandLineOption> groupWith = new HashSet<CommandLineOption>();
 
@@ -57,12 +57,11 @@ public class CommandLineOption {
         if (description != null) {
             result.append(description);
         }
-        if (deprecationWarning != null) {
+        if (deprecated) {
             if (result.length() > 0) {
                 result.append(' ');
             }
-            result.append("[deprecated - ");
-            result.append(deprecationWarning);
+            result.append("[deprecated - is scheduled to be removed in Gradle 5.0");
             result.append("]");
         }
         if (incubating) {
@@ -87,8 +86,8 @@ public class CommandLineOption {
         return argumentType == List.class;
     }
 
-    public CommandLineOption deprecated(String deprecationWarning) {
-        this.deprecationWarning = deprecationWarning;
+    public CommandLineOption deprecated() {
+        this.deprecated = true;
         return this;
     }
 
@@ -97,8 +96,8 @@ public class CommandLineOption {
         return this;
     }
 
-    public String getDeprecationWarning() {
-        return deprecationWarning;
+    public boolean isDeprecated() {
+        return deprecated;
     }
 
     public boolean isIncubating() {

--- a/subprojects/cli/src/main/java/org/gradle/cli/CommandLineParser.java
+++ b/subprojects/cli/src/main/java/org/gradle/cli/CommandLineParser.java
@@ -454,7 +454,7 @@ public class CommandLineParser {
             if (getHasArgument() && values.isEmpty()) {
                 throw new CommandLineArgumentException(String.format("No argument was provided for command-line option '%s'.", optionString));
             }
-            
+
             ParsedCommandLineOption parsedOption = commandLine.addOption(optionString.option, option);
             if (values.size() + parsedOption.getValues().size() > 1 && !option.getAllowsMultipleArguments()) {
                 throw new CommandLineArgumentException(String.format("Multiple arguments were provided for command-line option '%s'.", optionString));
@@ -462,8 +462,8 @@ public class CommandLineParser {
             for (String value : values) {
                 parsedOption.addArgument(value);
             }
-            if (option.getDeprecationWarning() != null) {
-                deprecationPrinter.println("The " + optionString + " option is deprecated - " + option.getDeprecationWarning());
+            if (option.isDeprecated()) {
+                deprecationPrinter.println("The " + optionString + " option is deprecated and is scheduled to be removed in Gradle 5.0.");
             }
 
             for (CommandLineOption otherOption : option.getGroupWith()) {

--- a/subprojects/cli/src/test/groovy/org/gradle/cli/CommandLineParserTest.groovy
+++ b/subprojects/cli/src/test/groovy/org/gradle/cli/CommandLineParserTest.groovy
@@ -386,8 +386,8 @@ class CommandLineParserTest extends Specification {
     }
 
     def formatsUsageMessageForDeprecatedAndIncubatingOptions() {
-        parser.option('a', 'long-option').hasDescription('this is option a').deprecated("don't use this")
-        parser.option('b').deprecated('will be removed')
+        parser.option('a', 'long-option').hasDescription('this is option a').deprecated()
+        parser.option('b').deprecated()
         parser.option('c').hasDescription('option c').incubating()
         parser.option('d').incubating()
         def outstr = new StringWriter()
@@ -405,7 +405,7 @@ class CommandLineParserTest extends Specification {
     def showsDeprecationWarning() {
         def outstr = new StringWriter()
         def parser = new CommandLineParser(outstr)
-        parser.option("foo").hasDescription("usless option, just for testing").deprecated("Please use --bar instead.")
+        parser.option("foo").hasDescription("usless option, just for testing").deprecated()
         parser.option("x").hasDescription("I'm not deprecated")
 
         when:

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -90,9 +90,8 @@ public class StartParameterBuildOptions {
     }
 
     public static class RecompileScriptsOption extends EnabledOnlyBooleanBuildOption<StartParameter> {
-        public static final String DEPRECATION_MESSAGE = "Support for --recompile-scripts was deprecated and is scheduled to be removed in Gradle 5.0.";
         public RecompileScriptsOption() {
-            super(null, CommandLineOptionConfiguration.create("recompile-scripts", "Force build script recompiling.").deprecated(DEPRECATION_MESSAGE));
+            super(null, CommandLineOptionConfiguration.create("recompile-scripts", "Force build script recompiling.").deprecated());
         }
 
         @Override
@@ -168,9 +167,8 @@ public class StartParameterBuildOptions {
     }
 
     public static class NoProjectDependenciesRebuildOption extends EnabledOnlyBooleanBuildOption<StartParameter> {
-        public static final String DEPRECATION_MESSAGE = "Support for --no-rebuild and -a was deprecated and is scheduled to be removed in Gradle 5.0.";
         public NoProjectDependenciesRebuildOption() {
-            super(null, CommandLineOptionConfiguration.create("no-rebuild", "a", "Do not rebuild project dependencies.").deprecated(DEPRECATION_MESSAGE));
+            super(null, CommandLineOptionConfiguration.create("no-rebuild", "a", "Do not rebuild project dependencies.").deprecated());
         }
 
         @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -83,7 +83,7 @@ public class LoggingConfigurationBuildOptions {
         @Override
         public void configure(CommandLineParser parser) {
             for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
-                configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.getDeprecationWarning(), config.isIncubating());
+                configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.isDeprecated(), config.isIncubating());
             }
 
             parser.allowOneOf(ALL_SHORT_OPTIONS);
@@ -135,7 +135,7 @@ public class LoggingConfigurationBuildOptions {
         @Override
         public void configure(CommandLineParser parser) {
             for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
-                configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.getDeprecationWarning(), config.isIncubating());
+                configureCommandLineOption(parser, config.getAllOptions(), config.getDescription(), config.isDeprecated(), config.isIncubating());
             }
 
             parser.allowOneOf(ALL_SHORT_OPTIONS);


### PR DESCRIPTION
See #3228 

This PR handles `deprecated()` method in the same way as `incubating()`. A small problem bothering me is that we can't utilize the logic in [`SingleMessageLogger`](https://github.com/gradle/gradle/blob/6c2b04fe585446bad67724714bf8ae974922ddf9/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java#L56) because it's in `logging` module but `logging` module depends on `cli`/`buildOption` module. 

We could:

- Extract the logic in `SingleMessageLogger` and move it to `cli`/`buildOption`. Since it will reference `GradleVersion`, we also need to let `cli`/`buildOption` depend on `baseServices`.
- Hard code like [this](https://github.com/gradle/gradle/blob/7b5dccda9f0210a3749aadeea67e19fa3e26d716/subprojects/cli/src/main/java/org/gradle/cli/CommandLineOption.java#L64) (the current implementation): `result.append("[deprecated - is scheduled to be removed in Gradle 5.0");` 

@bmuschko Any good ideas?
