### PR TITLE
Expose Settings's buildscript's ScriptHandler

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -20,6 +20,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.UnknownProjectException;
+import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.PluginAware;
 import org.gradle.vcs.SourceControl;
@@ -130,6 +131,17 @@ public interface Settings extends PluginAware {
      * @return This settings object. Never returns null.
      */
     Settings getSettings();
+
+    /**
+     * Returns the build script handler for settings. You can use this handler to query details about the build
+     * script for settings, and manage the classpath used to compile and execute the settings script.
+     *
+     * @return the classpath handler. Never returns null.
+     *
+     * @since 4.4
+     */
+    @Incubating
+    ScriptHandler getBuildscript();
 
     /**
      * <p>Returns the settings directory of the build. The settings directory is the directory containing the settings

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -22,6 +22,7 @@ import org.gradle.api.UnknownProjectException;
 import org.gradle.api.initialization.ConfigurableIncludedBuild;
 import org.gradle.api.initialization.ProjectDescriptor;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.file.FileResolver;
@@ -64,13 +65,15 @@ public class DefaultSettings extends AbstractPluginAware implements SettingsInte
 
     private final ClassLoaderScope settingsClassLoaderScope;
     private final ClassLoaderScope buildRootClassLoaderScope;
+    private final ScriptHandler scriptHandler;
     private final ServiceRegistry services;
 
     public DefaultSettings(ServiceRegistryFactory serviceRegistryFactory, GradleInternal gradle,
-                           ClassLoaderScope settingsClassLoaderScope, ClassLoaderScope buildRootClassLoaderScope, File settingsDir,
-                           ScriptSource settingsScript, StartParameter startParameter) {
+                           ClassLoaderScope settingsClassLoaderScope, ClassLoaderScope buildRootClassLoaderScope, ScriptHandler settingsScriptHandler,
+                           File settingsDir, ScriptSource settingsScript, StartParameter startParameter) {
         this.gradle = gradle;
         this.buildRootClassLoaderScope = buildRootClassLoaderScope;
+        this.scriptHandler = settingsScriptHandler;
         this.settingsDir = settingsDir;
         this.settingsScript = settingsScript;
         this.startParameter = startParameter;
@@ -90,6 +93,11 @@ public class DefaultSettings extends AbstractPluginAware implements SettingsInte
 
     public Settings getSettings() {
         return this;
+    }
+
+    @Override
+    public ScriptHandler getBuildscript() {
+        return scriptHandler;
     }
 
     public DefaultProjectDescriptor createProjectDescriptor(DefaultProjectDescriptor parent, String name, File dir) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
@@ -17,11 +17,9 @@
 package org.gradle.initialization;
 
 import org.gradle.StartParameter;
-import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
-import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.configuration.ScriptPlugin;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.groovy.scripts.ScriptSource;
@@ -37,17 +35,14 @@ import java.util.Map;
 public class ScriptEvaluatingSettingsProcessor implements SettingsProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(ScriptEvaluatingSettingsProcessor.class);
 
-    private final ScriptHandlerFactory scriptHandlerFactory;
     private final SettingsFactory settingsFactory;
     private final IGradlePropertiesLoader propertiesLoader;
     private final ScriptPluginFactory configurerFactory;
 
     public ScriptEvaluatingSettingsProcessor(ScriptPluginFactory configurerFactory,
-                                             ScriptHandlerFactory scriptHandlerFactory,
                                              SettingsFactory settingsFactory,
                                              IGradlePropertiesLoader propertiesLoader) {
         this.configurerFactory = configurerFactory;
-        this.scriptHandlerFactory = scriptHandlerFactory;
         this.settingsFactory = settingsFactory;
         this.propertiesLoader = propertiesLoader;
     }
@@ -68,8 +63,7 @@ public class ScriptEvaluatingSettingsProcessor implements SettingsProcessor {
     private void applySettingsScript(SettingsLocation settingsLocation, final SettingsInternal settings) {
         ScriptSource settingsScriptSource = settingsLocation.getSettingsScriptSource();
         ClassLoaderScope settingsClassLoaderScope = settings.getClassLoaderScope();
-        ScriptHandler scriptHandler = scriptHandlerFactory.create(settingsScriptSource, settingsClassLoaderScope);
-        ScriptPlugin configurer = configurerFactory.create(settingsScriptSource, scriptHandler, settingsClassLoaderScope, settings.getRootClassLoaderScope(), true);
+        ScriptPlugin configurer = configurerFactory.create(settingsScriptSource, settings.getBuildscript(), settingsClassLoaderScope, settings.getRootClassLoaderScope(), true);
         configurer.apply(settings);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -352,10 +352,10 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             new PropertiesLoadingSettingsProcessor(
                 new ScriptEvaluatingSettingsProcessor(
                     scriptPluginFactory,
-                    scriptHandlerFactory,
                     new SettingsFactory(
                         instantiator,
-                        serviceRegistryFactory
+                        serviceRegistryFactory,
+                        scriptHandlerFactory
                     ),
                     propertiesLoader
                 ),

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Project
 import org.gradle.api.UnknownProjectException
 import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.initialization.Settings
+import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.file.FileResolver
@@ -61,6 +62,7 @@ class DefaultSettingsTest {
     ScriptFileResolver scriptFileResolver
     ScriptPluginFactory scriptPluginFactory
     ScriptHandlerFactory scriptHandlerFactory
+    ScriptHandler settingsScriptHandler
     DefaultPluginManager pluginManager
 
     @Before
@@ -79,6 +81,7 @@ class DefaultSettingsTest {
         scriptFileResolver = context.mock(ScriptFileResolver.class)
         scriptPluginFactory = context.mock(ScriptPluginFactory.class)
         scriptHandlerFactory = context.mock(ScriptHandlerFactory.class)
+        settingsScriptHandler = context.mock(ScriptHandler.class)
         fileResolver = context.mock(FileResolver.class)
         projectDescriptorRegistry = new DefaultProjectDescriptorRegistry()
 
@@ -108,7 +111,8 @@ class DefaultSettingsTest {
 
         AsmBackedClassGenerator classGenerator = new AsmBackedClassGenerator()
         settings = classGenerator.newInstance(DefaultSettings, serviceRegistryFactory,
-                gradleMock, classLoaderScope, rootClassLoaderScope, settingsDir, scriptSourceMock, startParameter);
+                gradleMock, classLoaderScope, rootClassLoaderScope, settingsScriptHandler,
+                settingsDir, scriptSourceMock, startParameter);
     }
 
     @Test
@@ -122,6 +126,7 @@ class DefaultSettingsTest {
         assertEquals(settings.getRootProject().getProjectDir().getName(), settings.getRootProject().getName())
         assertEquals(settings.rootProject.buildFileName, Project.DEFAULT_BUILD_FILE);
         assertSame(gradleMock, settings.gradle)
+        assertSame(settingsScriptHandler, settings.buildscript)
     }
 
     @Test

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/SettingsFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/SettingsFactoryTest.groovy
@@ -20,8 +20,10 @@ import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.ThreadGlobalInstantiator
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.RootClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
+import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.api.internal.initialization.loadercache.DummyClassLoaderCache
 import org.gradle.configuration.ScriptPluginFactory
 import org.gradle.groovy.scripts.ScriptSource
@@ -51,9 +53,10 @@ class SettingsFactoryTest extends Specification {
         1 * settingsServices.get(ScriptHandlerFactory) >> scriptHandlerFactory
         1 * settingsServices.get(ProjectDescriptorRegistry) >> projectDescriptorRegistry
         1 * projectDescriptorRegistry.addProject(_ as DefaultProjectDescriptor)
+        1 * scriptHandlerFactory.create(scriptSource, _ as ClassLoaderScope) >> Mock(ScriptHandlerInternal)
 
         when:
-        SettingsFactory settingsFactory = new SettingsFactory(ThreadGlobalInstantiator.getOrCreate(), serviceRegistryFactory);
+        SettingsFactory settingsFactory = new SettingsFactory(ThreadGlobalInstantiator.getOrCreate(), serviceRegistryFactory, scriptHandlerFactory);
         GradleInternal gradle = Mock(GradleInternal)
 
         DefaultSettings settings = (DefaultSettings) settingsFactory.createSettings(gradle,


### PR DESCRIPTION
The Kotlin DSL runtime needs access to the `Settings`'s `ScriptHandler` for https://github.com/gradle/kotlin-dsl/issues/529 & https://github.com/gradle/kotlin-dsl/issues/542