### PR TITLE
Only search for swiftc and Clang on macOS

### DIFF
--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -93,6 +93,9 @@ public class AvailableToolChains {
                 compilers.addAll(findVisualCpps());
                 compilers.add(findMinGW());
                 compilers.add(findCygwin());
+            } else if (OperatingSystem.current().isMacOsX()) {
+                compilers.add(findClang());
+                compilers.add(findSwiftc());
             } else {
                 compilers.add(findGcc());
                 compilers.add(findClang());


### PR DESCRIPTION
platformTest tries to test all "supported" tool chains on a given OS
We assumed that if the OS was not Windows, we must be on Linux and
we must support GCC/Clang/swiftc.

On macOS, GCC is usually just a wrapper around Clang, so we detect
GCC as missing.  This causes tests to fail in platformTest because
we cannot find a GCC tool chain.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
