### PR TITLE
Allow Task.dependsOn to accept Provider objects

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -97,6 +97,8 @@ import java.util.Set;
  *
  * <li>A {@link Buildable} object.</li>
  *
+ * <li>A {@link org.gradle.api.provider.Provider} object.</li>
+ *
  * <li>A {@code Iterable}, {@code Collection}, {@code Map} or array. May contain any of the types listed here. The elements of the
  * iterable/collection/map/array are recursively converted to tasks.</li>
  *
@@ -241,6 +243,8 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * <li>A {@link org.gradle.api.tasks.TaskReference} object.</li>
      *
      * <li>A {@link Buildable} object.</li>
+     *
+     * <li>A {@link org.gradle.api.provider.Provider} object.</li>
      *
      * <li>A {@code Iterable}, {@code Collection}, {@code Map} or array. May contain any of the types listed here. The elements of the
      * iterable/collection/map/array are recursively converted to tasks.</li>

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -106,6 +106,8 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 context.add(resolver.resolveTask((TaskReference) dependency));
             } else if (resolver != null && dependency instanceof CharSequence) {
                 context.add(resolver.resolveTask(dependency.toString()));
+            } else if (dependency instanceof TaskDependencyContainer) {
+                ((TaskDependencyContainer)dependency).visitDependencies(context);
             } else {
                 List<String> formats = new ArrayList<String>();
                 if (resolver != null) {
@@ -115,6 +117,7 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 formats.add("A Task instance");
                 formats.add("A Buildable instance");
                 formats.add("A TaskDependency instance");
+                formats.add("A Provider instance");
                 formats.add("A Closure instance that returns any of the above types");
                 formats.add("A Callable instance that returns any of the above types");
                 formats.add("An Iterable, Collection, Map or array instance that contains any of the above types");


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle/issues/3236

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=gh%2Fstable-native%2Fprovider-dependencies)
- [ ] Verify documentation
- [x] Recognize contributor in release notes
