### PR TITLE
Update third party dependencies to fix potential vulnerabilities

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -102,7 +102,7 @@ libraries += [
     xbean: 'org.apache.xbean:xbean-reflect:3.4@jar', //required by maven3 classes
     nativePlatform: 'net.rubygrapefruit:native-platform:0.14',
     jansi: dependencies.module('org.fusesource.jansi:jansi:1.14'),
-    xerces: "xerces:xercesImpl:2.9.1",
+    xerces: "xerces:xercesImpl:2.11.0",
     objenesis: 'org.objenesis:objenesis:1.2@jar',
     jsoup:'org.jsoup:jsoup:1.6.3',
     jgit: [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -102,7 +102,7 @@ libraries += [
     xbean: 'org.apache.xbean:xbean-reflect:3.4@jar', //required by maven3 classes
     nativePlatform: 'net.rubygrapefruit:native-platform:0.14',
     jansi: dependencies.module('org.fusesource.jansi:jansi:1.14'),
-    xerces: "xerces:xercesImpl:2.11.0",
+    xerces: "xerces:xercesImpl:2.9.1",
     objenesis: 'org.objenesis:objenesis:1.2@jar',
     jsoup:'org.jsoup:jsoup:1.6.3',
     jgit: [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -103,7 +103,8 @@ libraries += [
     jansi: dependencies.module('org.fusesource.jansi:jansi:1.14'),
     xerces: "xerces:xercesImpl:2.11.0",
     objenesis: 'org.objenesis:objenesis:1.2@jar',
-    jsoup:'org.jsoup:jsoup:1.6.3',
+    jsoup: 'org.jsoup:jsoup:1.6.3',
+    xmlApis: 'xml-apis:xml-apis:1.4.01',
     jgit: [
         'org.eclipse.jgit:org.eclipse.jgit:4.5.3.201708160445-r@jar', // 4.6+ requires Java 8
         libraries.commons_httpclient,

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -110,8 +110,12 @@ libraries += [
         libraries.commons_httpclient,
         libraries.jsch
     ],
-    testng: 'org.testng:testng:6.3.1'
+    bsh: 'org.apache-extras.beanshell:bsh:2.0b6'
 ]
+
+libraries.testng = dependencies.module('org.testng:testng:6.3.1') {
+    exclude module: 'bsh'
+}
 
 libraries.maven3 = dependencies.module("org.apache.maven:maven-core:${versions.maven}") {
     dependency "org.apache.maven:maven-settings:${versions.maven}@jar"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -110,12 +110,9 @@ libraries += [
         libraries.commons_httpclient,
         libraries.jsch
     ],
+    testng: 'org.testng:testng:6.3.1',
     bsh: 'org.apache-extras.beanshell:bsh:2.0b6'
 ]
-
-libraries.testng = dependencies.module('org.testng:testng:6.3.1') {
-    exclude module: 'bsh'
-}
 
 libraries.nekohtml = dependencies.module("net.sourceforge.nekohtml:nekohtml:1.9.14") {
     dependency libraries.xerces
@@ -238,6 +235,8 @@ allprojects {
                 details.useTarget(libraries.ivy)
             } else if (details.requested.group == 'org.testng') {
                 details.useTarget(libraries.testng)
+            } else if (details.requested.name == 'bsh') {
+                details.useTarget(libraries.bsh)
             }
         }
     }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -79,7 +79,7 @@ libraries.jetty = dependencies.module("org.mortbay.jetty:jetty:6.1.26") {
 libraries.commons_codec = "commons-codec:commons-codec:1.6@jar"
 libraries.jcifs = "org.samba.jcifs:jcifs:1.3.17@jar"
 libraries.commons_httpclient = dependencies.module('org.apache.httpcomponents:httpclient:4.5.3') {
-    dependency "org.apache.httpcomponents:httpcore:4.4.4@jar"
+    dependency "org.apache.httpcomponents:httpcore:4.4.8@jar"
     dependency libraries.jcl_to_slf4j
     dependency libraries.commons_codec
     dependency libraries.jcifs

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -98,7 +98,6 @@ libraries += [
     junit: 'junit:junit:4.12@jar',
     xmlunit: 'xmlunit:xmlunit:1.3',
     equalsVerifier: 'nl.jqno.equalsverifier:equalsverifier:2.1.6',
-    nekohtml: 'net.sourceforge.nekohtml:nekohtml:1.9.14',
     xbean: 'org.apache.xbean:xbean-reflect:3.4@jar', //required by maven3 classes
     nativePlatform: 'net.rubygrapefruit:native-platform:0.14',
     jansi: dependencies.module('org.fusesource.jansi:jansi:1.14'),
@@ -115,6 +114,10 @@ libraries += [
 
 libraries.testng = dependencies.module('org.testng:testng:6.3.1') {
     exclude module: 'bsh'
+}
+
+libraries.nekohtml = dependencies.module("net.sourceforge.nekohtml:nekohtml:1.9.14") {
+    dependency libraries.xerces
 }
 
 libraries.maven3 = dependencies.module("org.apache.maven:maven-core:${versions.maven}") {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,7 +25,7 @@ versions.commons_io = 'commons-io:commons-io:2.2'
 
 versions.groovy = "2.4.12"
 
-versions.bouncycastle = "1.57"
+versions.bouncycastle = "1.58"
 
 versions.maven = "3.0.4"
 
@@ -78,7 +78,7 @@ libraries.jetty = dependencies.module("org.mortbay.jetty:jetty:6.1.26") {
 
 libraries.commons_codec = "commons-codec:commons-codec:1.6@jar"
 libraries.jcifs = "org.samba.jcifs:jcifs:1.3.17@jar"
-libraries.commons_httpclient = dependencies.module('org.apache.httpcomponents:httpclient:4.4.1') {
+libraries.commons_httpclient = dependencies.module('org.apache.httpcomponents:httpclient:4.5.3') {
     dependency "org.apache.httpcomponents:httpcore:4.4.4@jar"
     dependency libraries.jcl_to_slf4j
     dependency libraries.commons_codec
@@ -102,7 +102,7 @@ libraries += [
     xbean: 'org.apache.xbean:xbean-reflect:3.4@jar', //required by maven3 classes
     nativePlatform: 'net.rubygrapefruit:native-platform:0.14',
     jansi: dependencies.module('org.fusesource.jansi:jansi:1.14'),
-    xerces: "xerces:xercesImpl:2.9.1",
+    xerces: "xerces:xercesImpl:2.11.0",
     objenesis: 'org.objenesis:objenesis:1.2@jar',
     jsoup:'org.jsoup:jsoup:1.6.3',
     jgit: [
@@ -118,7 +118,7 @@ libraries.maven3 = dependencies.module("org.apache.maven:maven-core:${versions.m
     dependency "org.apache.maven:maven-settings-builder:${versions.maven}@jar"
 
     //plexus:
-    dependency "org.codehaus.plexus:plexus-utils:2.0.6@jar"
+    dependency "org.codehaus.plexus:plexus-utils:2.1@jar"
     dependency "org.codehaus.plexus:plexus-interpolation:1.14@jar"
     dependency "org.codehaus.plexus:plexus-component-annotations:1.5.5@jar"
     dependency "org.codehaus.plexus:plexus-container-default:1.5.5@jar"
@@ -192,7 +192,7 @@ libraries.bouncycastle_pgp = dependencies.module("org.bouncycastle:bcpg-jdk15on:
 libraries.joda = 'joda-time:joda-time:2.8.2@jar'
 
 versions.aws = "1.11.6"
-versions.jackson = "2.6.6"
+versions.jackson = "2.8.9"
 libraries.awsS3 = [
         "com.amazonaws:aws-java-sdk-s3:${versions.aws}@jar",
         "com.amazonaws:aws-java-sdk-kms:${versions.aws}@jar",

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
@@ -70,6 +70,14 @@ public class ClasspathUtil {
         return DefaultClassPath.of(implementationClassPath);
     }
 
+    public static File getClasspathForClass(String targetClassName){
+        try {
+            return getClasspathForClass(Class.forName(targetClassName));
+        } catch (ClassNotFoundException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
     public static File getClasspathForClass(Class<?> targetClass) {
         URI location;
         try {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultClassLoaderFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultClassLoaderFactory.java
@@ -23,9 +23,10 @@ import org.gradle.internal.service.ServiceLocator;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParserFactory;
-import java.util.Collections;
 
 import static java.lang.ClassLoader.getSystemClassLoader;
+import static java.util.Arrays.*;
+import static org.gradle.internal.classloader.ClasspathUtil.*;
 
 public class DefaultClassLoaderFactory implements ClassLoaderFactory {
     // This uses the system classloader and will not release any loaded classes for the life of the daemon process.
@@ -54,7 +55,12 @@ public class DefaultClassLoaderFactory implements ClassLoaderFactory {
         // Note that in practise, this is only triggered when running in our tests
 
         if (needJaxpImpl()) {
-            classPath = classPath.plus(Collections.singleton(ClasspathUtil.getClasspathForResource(getSystemClassLoader(), "META-INF/services/javax.xml.parsers.SAXParserFactory")));
+            classPath = classPath.plus(
+                asList(
+                    getClasspathForResource(getSystemClassLoader(), "META-INF/services/javax.xml.parsers.SAXParserFactory"),
+                    getClasspathForClass("org.w3c.dom.ElementTraversal")
+                )
+            );
         }
 
         return doCreateClassLoader(getIsolatedSystemClassLoader(), classPath);

--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation libraries.jcip
     implementation libraries.nativePlatform
     implementation libraries.commons_compress
+    implementation libraries.xmlApis
 
     runtimeOnly project(":docs")
 

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
     abstract String getDistributionLabel()
 
     int getLibJarsCount() {
-        177
+        175
     }
 
     def "no duplicate entries"() {

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
     abstract String getDistributionLabel()
 
     int getLibJarsCount() {
-        175
+        177
     }
 
     def "no duplicate entries"() {

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -91,7 +91,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents'
     }
     testCompile libraries.commons_httpclient
-    testCompile 'org.apache.httpcomponents:httpmime:4.4.1'
+    testCompile 'org.apache.httpcomponents:httpmime:4.5.3'
     testCompile project(":core")
 }
 

--- a/subprojects/testing-jvm/testing-jvm.gradle
+++ b/subprojects/testing-jvm/testing-jvm.gradle
@@ -25,13 +25,7 @@ dependencies {
     compile libraries.junit
     compile libraries.testng
     compile libraries.kryo
-<<<<<<< HEAD
-=======
-    compile ('org.testng:testng:6.3.1') {
-       exclude module:'bsh'
-    }
-    compile 'org.beanshell:bsh:2.0b5'
->>>>>>> Restore testng to 6.3.1
+    compile libraries.bsh
 
     testCompile 'com.google.inject:guice:2.0@jar' // this is for TestNG
 

--- a/subprojects/testing-jvm/testing-jvm.gradle
+++ b/subprojects/testing-jvm/testing-jvm.gradle
@@ -25,6 +25,13 @@ dependencies {
     compile libraries.junit
     compile libraries.testng
     compile libraries.kryo
+<<<<<<< HEAD
+=======
+    compile ('org.testng:testng:6.3.1') {
+       exclude module:'bsh'
+    }
+    compile 'org.beanshell:bsh:2.0b5'
+>>>>>>> Restore testng to 6.3.1
 
     testCompile 'com.google.inject:guice:2.0@jar' // this is for TestNG
 

--- a/subprojects/testing-jvm/testing-jvm.gradle
+++ b/subprojects/testing-jvm/testing-jvm.gradle
@@ -24,7 +24,6 @@ dependencies {
 
     compile libraries.junit
     compile libraries.testng
-    compile libraries.kryo
     compile libraries.bsh
 
     testCompile 'com.google.inject:guice:2.0@jar' // this is for TestNG

--- a/subprojects/testing-jvm/testing-jvm.gradle
+++ b/subprojects/testing-jvm/testing-jvm.gradle
@@ -24,6 +24,7 @@ dependencies {
 
     compile libraries.junit
     compile libraries.testng
+    compile libraries.kryo
 
     testCompile 'com.google.inject:guice:2.0@jar' // this is for TestNG
 


### PR DESCRIPTION
### Context

As stated in #2944, there're several potential security issues in Gradle. I tried the Application Health Check mentioned in #2944, here's the result of `4.2.1`:

![image](https://user-images.githubusercontent.com/12689835/31805862-e3f3919c-b529-11e7-8db5-ec9f3cf6208a.png)

So I upgraded the affected packages:

- `jackson`: `2.6.6` -> `2.8.9` 
- `httpclient`: `4.4.1` -> `4.5.3`
- `plexus-utils`: `2.0.6` -> `2.1`
- `xercesImpl`: `2.9.1` -> `2.11.0`
- `bsh`: `2.0b4` -> `2.0b6`
- `bouncycastle`: `1.57` -> `1.58`

Everything looks good except `xercesImpl`, lots of `java.lang.NoClassDefFoundError: org/w3c/dom/ElementTraversal` appeared in ant-related tests after the upgrade. The reason is that ant is in a different classloader and we add extra jars into it [here](https://github.com/gradle/gradle/blob/4869abb7e8f82fb4b67396e5415596886dbca03c/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultClassLoaderFactory.java#L57). `xercesImpl:2.11` introduces `org/w3c/dom/ElementTraversal`, so this PR adds `xml-apis` jar to it as well.

There's one more thing this PR does: resolve conflict of `xercesImpl` package. Before this PR, there're two `xercesImpl` and two `xml-apis` in our code base:

One in `dependency-management` subproject:
```
+--- net.sourceforge.nekohtml:nekohtml:1.9.14
|    \--- xerces:xercesImpl:2.9.1
|         \--- xml-apis:xml-apis:1.3.04
```

One in `docs` subproject:

```
+--- org.seleniumhq.selenium:selenium-htmlunit-driver:2.42.2
|    +--- org.seleniumhq.selenium:selenium-remote-driver:2.42.2
|    \--- net.sourceforge.htmlunit:htmlunit:2.14
|         +--- xerces:xercesImpl:2.11.0
|         |    \--- xml-apis:xml-apis:1.4.01
```

The difference is, `xercesImpl:2.11` introduces `org/w3c/dom/ElementTraversal`, which is in `xml-apis:1.4.01`. In most cases it's okay because they're in different projects. But when @lptr run `PmdRelocationIntegrationTest` in IDEA, something unexpected happened. IDEA collects all dependencies to create a classpath, which contains conflicting `xercesImpl`. Unfortunately, `xercesImpl:2.11.0` wins and it enters ant classloader [here](https://github.com/gradle/gradle/blob/4869abb7e8f82fb4b67396e5415596886dbca03c/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultClassLoaderFactory.java#L57) (but `xml-apis` doesn't), and this result in `NoClassDefFoundError`.

### Gradle Core Team Checklist
- [x] Verify test coverage and CI build status
