### PR TITLE
Make repo mirror URLs configurable via environmental variable

### DIFF
--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -47,11 +47,10 @@ distributionTestTasks.all { DistributionTest task ->
     systemProperties['org.gradle.integtest.multiversion'] = project.hasProperty("testAllVersions") && project.testAllVersions ? 'all' : 'default'
 
     def mirrorUrls = collectMirrorUrls()
-    systemProperties['org.gradle.integtest.mirrors.mavencentral'] = mirrorUrls['mavencentral'] ?: ''
-    systemProperties['org.gradle.integtest.mirrors.jcenter'] = mirrorUrls['jcenter'] ?: ''
-    systemProperties['org.gradle.integtest.mirrors.typesafemaven'] = mirrorUrls['typesafemaven'] ?: ''
-    systemProperties['org.gradle.integtest.mirrors.typesafeivy'] = mirrorUrls['typesafeivy'] ?: ''
-    systemProperties['org.gradle.integtest.mirrors.google'] = mirrorUrls['google'] ?: ''
+    def mirrors = ['mavencentral', 'jcenter', 'typesafemaven', 'typesafeivy', 'google']
+    mirrors.each { mirror ->
+        systemProperties["org.gradle.integtest.mirrors.$mirror"] = mirrorUrls[mirror] ?: ''
+    }
 
     dependsOn project.task("configure${task.name.capitalize()}") {
         doLast {
@@ -109,13 +108,11 @@ distributionTestTasks.all { DistributionTest task ->
 
 def collectMirrorUrls() {
     // expected env var format: repo1_id:repo1_url,repo2_id:repo2_url,...
-    def mirrors = System.getenv().get('REPO_MIRROR_URLS')
-    !mirrors ? [:] : mirrors.split(',').collectEntries { nameToUrl ->
+    System.getenv('REPO_MIRROR_URLS')?.split(',')?.collectEntries { nameToUrl ->
         def index = nameToUrl.indexOf(':')
         [(nameToUrl.substring(0, index)) : nameToUrl.substring(index + 1)]
-    }
+    } ?: [:]
 }
-
 
 /**
  * Clean up cache files for older versions that aren't multi-process safe.

--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -46,11 +46,12 @@ distributionTestTasks.all { DistributionTest task ->
 
     systemProperties['org.gradle.integtest.multiversion'] = project.hasProperty("testAllVersions") && project.testAllVersions ? 'all' : 'default'
 
-    systemProperties['org.gradle.integtest.mirrors.mavencentral'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/repo1' : ''
-    systemProperties['org.gradle.integtest.mirrors.jcenter'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/jcenter' : ''
-    systemProperties['org.gradle.integtest.mirrors.typesafemaven'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/typesafe-maven-releases' : ''
-    systemProperties['org.gradle.integtest.mirrors.typesafeivy'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/typesafe-ivy-releases' : ''
-    systemProperties['org.gradle.integtest.mirrors.google'] = isCiServer ? 'http://dev12.gradle.org:8081/artifactory/google' : ''
+    def mirrorUrls = collectMirrorUrls()
+    systemProperties['org.gradle.integtest.mirrors.mavencentral'] = mirrorUrls['mavencentral'] ?: ''
+    systemProperties['org.gradle.integtest.mirrors.jcenter'] = mirrorUrls['jcenter'] ?: ''
+    systemProperties['org.gradle.integtest.mirrors.typesafemaven'] = mirrorUrls['typesafemaven'] ?: ''
+    systemProperties['org.gradle.integtest.mirrors.typesafeivy'] = mirrorUrls['typesafeivy'] ?: ''
+    systemProperties['org.gradle.integtest.mirrors.google'] = mirrorUrls['google'] ?: ''
 
     dependsOn project.task("configure${task.name.capitalize()}") {
         doLast {
@@ -103,6 +104,15 @@ distributionTestTasks.all { DistributionTest task ->
 
     doLast {
         gradle.removeListener(daemonListener)
+    }
+}
+
+def collectMirrorUrls() {
+    // expected env var format: repo1_id:repo1_url,repo2_id:repo2_url,...
+    def mirrors = System.getenv().get('REPO_MIRROR_URLS')
+    !mirrors ? [:] : mirrors.split(',').collectEntries { nameToUrl ->
+        def index = nameToUrl.indexOf(':')
+        [(nameToUrl.substring(0, index)) : nameToUrl.substring(index + 1)]
     }
 }
 


### PR DESCRIPTION
Currently, the internal repository mirrors are hardcoded in the build script. This means every time we want to change repository mirrors we need to adjust the build script. 

This change makes the mirror URLs read from an environmental variable and passes the values to the integration tests. The env variable is already set up in TeamCity.

Also, I think we should merge this PR both to the master/release branch. 