### PR TITLE
Improve error messages and test coverage for task dependency containers

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -97,7 +97,7 @@ import java.util.Set;
  *
  * <li>A {@link Buildable} object.</li>
  *
- * <li>A {@link org.gradle.api.provider.Provider} object.</li>
+ * <li>A {@link org.gradle.api.provider.Provider} of {@link org.gradle.api.file.RegularFile} or {@link org.gradle.api.file.Directory}.</li>
  *
  * <li>A {@code Iterable}, {@code Collection}, {@code Map} or array. May contain any of the types listed here. The elements of the
  * iterable/collection/map/array are recursively converted to tasks.</li>
@@ -244,7 +244,7 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      *
      * <li>A {@link Buildable} object.</li>
      *
-     * <li>A {@link org.gradle.api.provider.Provider} object.</li>
+     * <li>A {@link org.gradle.api.provider.Provider} of {@link org.gradle.api.file.RegularFile} or {@link org.gradle.api.file.Directory}.</li>
      *
      * <li>A {@code Iterable}, {@code Collection}, {@code Map} or array. May contain any of the types listed here. The elements of the
      * iterable/collection/map/array are recursively converted to tasks.</li>

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -97,7 +97,7 @@ import java.util.Set;
  *
  * <li>A {@link Buildable} object.</li>
  *
- * <li>A {@link org.gradle.api.provider.Provider} of {@link org.gradle.api.file.RegularFile} or {@link org.gradle.api.file.Directory}.</li>
+ * <li>A {@link org.gradle.api.file.RegularFileProperty} or {@link org.gradle.api.file.DirectoryProperty}.</li>
  *
  * <li>A {@code Iterable}, {@code Collection}, {@code Map} or array. May contain any of the types listed here. The elements of the
  * iterable/collection/map/array are recursively converted to tasks.</li>
@@ -244,7 +244,7 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      *
      * <li>A {@link Buildable} object.</li>
      *
-     * <li>A {@link org.gradle.api.provider.Provider} of {@link org.gradle.api.file.RegularFile} or {@link org.gradle.api.file.Directory}.</li>
+     * <li>A {@link org.gradle.api.file.RegularFileProperty} or {@link org.gradle.api.file.DirectoryProperty}.</li>
      *
      * <li>A {@code Iterable}, {@code Collection}, {@code Map} or array. May contain any of the types listed here. The elements of the
      * iterable/collection/map/array are recursively converted to tasks.</li>

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -21,6 +21,7 @@ import groovy.lang.Closure;
 import org.gradle.api.Buildable;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskReference;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
@@ -107,7 +108,12 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
             } else if (resolver != null && dependency instanceof CharSequence) {
                 context.add(resolver.resolveTask(dependency.toString()));
             } else if (dependency instanceof TaskDependencyContainer) {
-                ((TaskDependencyContainer)dependency).visitDependencies(context);
+                ((TaskDependencyContainer) dependency).visitDependencies(context);
+            } else if (dependency instanceof Provider) {
+                List<String> formats = new ArrayList<String>();
+                formats.add("A RegularFileProperty");
+                formats.add("A Directory");
+                throw new UnsupportedNotationException(dependency, String.format("Cannot convert Provider %s to a task.", dependency), null, formats);
             } else {
                 List<String> formats = new ArrayList<String>();
                 if (resolver != null) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -112,7 +112,7 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
             } else if (dependency instanceof Provider) {
                 List<String> formats = new ArrayList<String>();
                 formats.add("A RegularFileProperty");
-                formats.add("A Directory");
+                formats.add("A DirectoryProperty");
                 throw new UnsupportedNotationException(dependency, String.format("Cannot convert Provider %s to a task.", dependency), null, formats);
             } else {
                 List<String> formats = new ArrayList<String>();
@@ -123,7 +123,7 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 formats.add("A Task instance");
                 formats.add("A Buildable instance");
                 formats.add("A TaskDependency instance");
-                formats.add("A Provider instance");
+                formats.add("A RegularFileProperty or DirectoryProperty instance");
                 formats.add("A Closure instance that returns any of the above types");
                 formats.add("A Callable instance that returns any of the above types");
                 formats.add("An Iterable, Collection, Map or array instance that contains any of the above types");


### PR DESCRIPTION
https://github.com/gradle/gradle/pull/3239 added support for creating task dependencies on certain types of Provider objects.  This PR clarifies the documentation a little and improves the error message when an unacceptable Provider type is passed as a task dependency.