### PR TITLE
Fix built-in scans when buildscript block has apply statements

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.scan.config
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.scan.config.fixtures.BuildScanAutoApplyFixture
 import org.gradle.util.VersionNumber
+import spock.lang.Issue
 import spock.lang.Unroll
 
 import static org.gradle.initialization.StartParameterBuildOptions.BuildScanOption
@@ -181,6 +182,23 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         buildScanPluginNotApplied()
+    }
+
+    @Issue("gradle/gradle#3250")
+    def "automatically applies build scan plugin when --scan is provided on command-line and a script is applied in the buildscript block"() {
+        given:
+        buildFile << """
+            buildscript {
+              rootProject.apply { from(rootProject.file("gradle/dependencies.gradle")) }
+            }
+        """.stripIndent()
+        file("gradle/dependencies.gradle") << ""
+
+        when:
+        runBuildWithScanRequest()
+
+        then:
+        buildScanPluginApplied(BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION)
     }
 
     private void runBuildWithScanRequest(String... additionalArgs) {

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
@@ -185,7 +185,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
             PluginRequests initialPluginRequests = initialRunner.getData();
             PluginRequests mergedPluginRequests = autoAppliedPluginHandler.mergeWithAutoAppliedPlugins(initialPluginRequests, target);
 
-            PluginManagerInternal pluginManager = initialPassScriptTarget.getPluginManager();
+            PluginManagerInternal pluginManager = topLevelScript ? initialPassScriptTarget.getPluginManager() : null;
             pluginRequestApplicator.applyPlugins(mergedPluginRequests, scriptHandler, pluginManager, targetScope);
 
             // Pass 2, compile everything except buildscript {}, pluginRepositories{}, and plugin requests, then run

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestApplicator.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestApplicator.java
@@ -21,7 +21,18 @@ import org.gradle.api.internal.initialization.ScriptHandlerInternal;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.plugin.management.internal.PluginRequests;
 
+import javax.annotation.Nullable;
+
 // Implementation is provided by 'plugin-use' module
 public interface PluginRequestApplicator {
-    void applyPlugins(PluginRequests requests, ScriptHandlerInternal scriptHandler, PluginManagerInternal target, ClassLoaderScope classLoaderScope);
+
+    /**
+     * Resolves the given {@link PluginRequests} into the given {@link ScriptHandlerInternal#getScriptClassPath()},
+     * exports the resulting classpath into the given {@link ClassLoaderScope}, closes it and then applies
+     * the requested plugins.
+     *
+     * A null target indicates that no plugin requests should be resolved but only the setup of the given
+     * {@link ClassLoaderScope}.
+     */
+    void applyPlugins(PluginRequests requests, ScriptHandlerInternal scriptHandler, @Nullable PluginManagerInternal target, ClassLoaderScope classLoaderScope);
 }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -80,7 +80,7 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
     }
 
     public void applyPlugins(final PluginRequests requests, final ScriptHandlerInternal scriptHandler, @Nullable final PluginManagerInternal target, final ClassLoaderScope classLoaderScope) {
-        if (target == null) {
+        if (target == null || requests.isEmpty()) {
             defineScriptHandlerClassScope(scriptHandler, classLoaderScope, Collections.<PluginImplementation<?>>emptyList());
             return;
         }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -80,13 +80,9 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
     }
 
     public void applyPlugins(final PluginRequests requests, final ScriptHandlerInternal scriptHandler, @Nullable final PluginManagerInternal target, final ClassLoaderScope classLoaderScope) {
-        if (requests.isEmpty()) {
+        if (target == null) {
             defineScriptHandlerClassScope(scriptHandler, classLoaderScope, Collections.<PluginImplementation<?>>emptyList());
             return;
-        }
-
-        if (target == null) {
-            throw new IllegalStateException("Plugin target is 'null' and there are plugin requests");
         }
 
         final PluginResolver effectivePluginResolver = wrapInAlreadyInClasspathResolver(classLoaderScope);


### PR DESCRIPTION
Built-in scans were breaking with a common pattern where a
script is applied inside the buildscript block, usually in order
to provide a list of commonly used versions for usage inside the block.

This is now fixed by only trying to apply plugin requests when the
script target supports the plugins block.

See https://github.com/gradle/gradle/issues/3250. The Kotlin DSL needs to be adjusted to the new method as well.