### PR TITLE
Increase default HTTP timeout to 30s

### DIFF
--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesHttpTimeoutSettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesHttpTimeoutSettings.java
@@ -25,8 +25,8 @@ public class JavaSystemPropertiesHttpTimeoutSettings implements HttpTimeoutSetti
     private static final Logger LOGGER = LoggerFactory.getLogger(JavaSystemPropertiesHttpTimeoutSettings.class);
     public static final String CONNECTION_TIMEOUT_SYSTEM_PROPERTY = "http.connectionTimeout";
     public static final String SOCKET_TIMEOUT_SYSTEM_PROPERTY = "http.socketTimeout";
-    public static final int DEFAULT_CONNECTION_TIMEOUT = 10000;
-    public static final int DEFAULT_SOCKET_TIMEOUT = 10000;
+    public static final int DEFAULT_CONNECTION_TIMEOUT = 30000;
+    public static final int DEFAULT_SOCKET_TIMEOUT = 30000;
     private final int connectionTimeoutMs;
     private final int socketTimeoutMs;
 


### PR DESCRIPTION
### Context

Now the default value of HTTP time out is 10s, which could cause some pontential issues. 
This PR increases it to 30s.

### Gradle Core Team Checklist
- [x] Verify test coverage and CI build status
