### PR TITLE
Test should only close standard input pipe after daemon becomes idle

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/DefaultBuildScanUserInputHandlerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/DefaultBuildScanUserInputHandlerIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.userinput
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.integtests.fixtures.daemon.DaemonsFixture
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.*
@@ -55,7 +54,6 @@ class DefaultBuildScanUserInputHandlerIntegrationTest extends AbstractUserInputH
         ConsoleOutput.Rich  | RICH_CONSOLE
     }
 
-    @Ignore("flaky test - sometimes fails with java.io.IOException: Write end dead or Pipe closed")
     @Unroll
     def "can ask for license acceptance in interactive build with daemon and #description console"() {
         given:
@@ -69,11 +67,12 @@ class DefaultBuildScanUserInputHandlerIntegrationTest extends AbstractUserInputH
         then:
         writeToStdIn(gradleHandle, YES.bytes)
         gradleHandle.waitForFinish()
+        daemons.daemon.becomesIdle()
         closeStdIn(gradleHandle)
         expectRenderedPromptAndAnswer(gradleHandle, true)
 
         cleanup:
-        daemons.killAll()
+        daemons.daemon.kill()
 
         where:
         consoleOutput       | description
@@ -100,7 +99,6 @@ class DefaultBuildScanUserInputHandlerIntegrationTest extends AbstractUserInputH
         ConsoleOutput.Rich  | RICH_CONSOLE
     }
 
-    @Ignore("flaky test - sometimes fails with java.io.IOException: Write end dead or Pipe closed")
     @Unroll
     def "use of ctrl-d when asking for license acceptance returns null with daemon and #description console"() {
         given:
@@ -113,10 +111,12 @@ class DefaultBuildScanUserInputHandlerIntegrationTest extends AbstractUserInputH
 
         then:
         gradleHandle.cancelWithEOT().waitForFinish()
+        daemons.daemon.becomesIdle()
+        closeStdIn(gradleHandle)
         expectRenderedPromptAndAnswer(gradleHandle, null)
 
         cleanup:
-        daemons.killAll()
+        daemons.daemon.kill()
 
         where:
         consoleOutput       | description


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle-private/issues/975