### PR TITLE
Upgrade gradle-kotlin-dsl {0.12.1 => 0.12.2}

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
     libraries = [:]
 }
 
-versions.gradle_kotlin_dsl = '0.12.1'
+versions.gradle_kotlin_dsl = '0.12.2'
 
 versions.commons_io = 'commons-io:commons-io:2.2'
 


### PR DESCRIPTION
v0.12.2 includes the fix for #3250 when the applied script is written
in Kotlin.

See #3250