### PR TITLE
Fix cacheability of ExtractSnippetsTask

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/build/docs/ExtractSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/ExtractSnippetsTask.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.build.docs
 
-import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.FileVisitDetails
@@ -31,28 +30,41 @@ import org.gradle.api.tasks.util.PatternFilterable
 
 import java.util.regex.Matcher
 import java.util.regex.Pattern
-
 /**
  * Produces the snippets files for a set of sample source files.
  */
 @CacheableTask
 class ExtractSnippetsTask extends DefaultTask {
 
+    /**
+     * Output directory for samples
+     */
     @OutputDirectory
     File destDir
 
+    /**
+     * Output directory for extracted snippets
+     */
     @OutputDirectory
     File snippetsDir
 
-    @Input
-    List<String> excludes
-
-    // Resources that should not be filtered
+    /**
+     * Patterns for resources that should not be filtered
+     */
     @Input
     List<String> nonFiltered
 
+    /**
+     * Source directory of the samples
+     */
     @Internal
     File samples
+
+    /**
+     * Files to exclude from the samples
+     */
+    @Internal
+    List<String> excludes
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -70,73 +82,78 @@ class ExtractSnippetsTask extends DefaultTask {
             copySpec.setIncludes(nonFiltered)
         }
 
-        getSource().matching(new Action<PatternFilterable>() {
-            @Override
-            void execute(PatternFilterable patternFilterable) {
-                patternFilterable.exclude(nonFiltered)
+        getSource().matching(canBeFiltered()).visit {
+            filterSample(it)
+        }
+    }
+
+    private Closure canBeFiltered() {
+        return { PatternFilterable patternFilterable ->
+            patternFilterable.exclude(nonFiltered)
+        }
+    }
+
+    void filterSample(FileVisitDetails details) {
+        String name = details.relativePath.pathString
+        if (details.file.isDirectory()) {
+            File destDir = new File(destDir, name)
+            destDir.mkdirs()
+            destDir = new File(snippetsDir, name)
+            destDir.mkdirs()
+        } else {
+            File srcFile = details.file
+            File destFile = new File(destDir, name)
+
+            destFile.parentFile.mkdirs()
+
+            if (['.war', '.jar', '.zip', '.gpg'].find{ name.endsWith(it) }) {
+                destFile.withOutputStream { it.write(srcFile.readBytes()) }
+                return
             }
-        }).visit { FileVisitDetails details ->
-            String name = details.relativePath.pathString
-            if (details.file.isDirectory()) {
-                File destDir = new File(destDir, name)
-                destDir.mkdirs()
-                destDir = new File(snippetsDir, name)
-                destDir.mkdirs()
+
+            Map writers = [
+                0: new SnippetWriter(name, destFile).start(),
+                1: new SnippetWriter(name, new File(snippetsDir, name)).start()
+            ]
+            Pattern startSnippetPattern
+            Pattern endSnippetPattern
+            if (name.endsWith('.xml')) {
+                startSnippetPattern = Pattern.compile('\\s*<!--\\s*START\\s+SNIPPET\\s+(\\S+)\\s*-->')
+                endSnippetPattern = Pattern.compile('\\s*<!--\\s*END\\s+SNIPPET\\s+(\\S+)\\s*-->')
             } else {
-                File srcFile = details.file
-                File destFile = new File(destDir, name)
+                startSnippetPattern = Pattern.compile('\\s*//\\s*START\\s+SNIPPET\\s+(\\S+)\\s*')
+                endSnippetPattern = Pattern.compile('\\s*//\\s*END\\s+SNIPPET\\s+(\\S+)\\s*')
+            }
 
-                destFile.parentFile.mkdirs()
-
-                if (['.war', '.jar', '.zip', '.gpg'].find{ name.endsWith(it) }) {
-                    destFile.withOutputStream { it.write(srcFile.readBytes()) }
-                    return
-                }
-
-                Map writers = [
-                        0: new SnippetWriter(name, destFile).start(),
-                        1: new SnippetWriter(name, new File(snippetsDir, name)).start()
-                ]
-                Pattern startSnippetPattern
-                Pattern endSnippetPattern
-                if (name.endsWith('.xml')) {
-                    startSnippetPattern = Pattern.compile('\\s*<!--\\s*START\\s+SNIPPET\\s+(\\S+)\\s*-->')
-                    endSnippetPattern = Pattern.compile('\\s*<!--\\s*END\\s+SNIPPET\\s+(\\S+)\\s*-->')
-                } else {
-                    startSnippetPattern = Pattern.compile('\\s*//\\s*START\\s+SNIPPET\\s+(\\S+)\\s*')
-                    endSnippetPattern = Pattern.compile('\\s*//\\s*END\\s+SNIPPET\\s+(\\S+)\\s*')
-                }
-
-                try {
-                    // Can't use eachLine {} because it throws away blank lines
-                    srcFile.withReader {Reader r ->
-                        BufferedReader reader = new BufferedReader(r)
-                        reader.readLines().each {String line ->
-                            Matcher m = startSnippetPattern.matcher(line)
-                            if (m.matches()) {
-                                String snippetName = m.group(1)
-                                if (!writers[snippetName]) {
-                                    File snippetFile = new File(snippetsDir, "$name-$snippetName")
-                                    writers.put(snippetName, new SnippetWriter("Snippet $snippetName in $name", snippetFile))
-                                }
-                                writers[snippetName].start()
-                                return
+            try {
+                // Can't use eachLine {} because it throws away blank lines
+                srcFile.withReader {Reader r ->
+                    BufferedReader reader = new BufferedReader(r)
+                    reader.readLines().each {String line ->
+                        Matcher m = startSnippetPattern.matcher(line)
+                        if (m.matches()) {
+                            String snippetName = m.group(1)
+                            if (!writers[snippetName]) {
+                                File snippetFile = new File(snippetsDir, "$name-$snippetName")
+                                writers.put(snippetName, new SnippetWriter("Snippet $snippetName in $name", snippetFile))
                             }
-                            m = endSnippetPattern.matcher(line)
-                            if (m.matches()) {
-                                String snippetName = m.group(1)
-                                writers[snippetName].end()
-                                return
-                            }
-                            writers.values().each {SnippetWriter w ->
-                                w.println(line)
-                            }
+                            writers[snippetName].start()
+                            return
+                        }
+                        m = endSnippetPattern.matcher(line)
+                        if (m.matches()) {
+                            String snippetName = m.group(1)
+                            writers[snippetName].end()
+                            return
+                        }
+                        writers.values().each {SnippetWriter w ->
+                            w.println(line)
                         }
                     }
-                } finally {
-                    writers.values().each {SnippetWriter w ->
-                        w.close()
-                    }
+                }
+            } finally {
+                writers.values().each {SnippetWriter w ->
+                    w.close()
                 }
             }
         }

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -14,25 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.apache.tools.ant.filters.ReplaceTokens
+import org.gradle.build.docs.AssembleSamplesDocTask
+import org.gradle.build.docs.CacheableAsciidoctorTask
+import org.gradle.build.docs.Docbook2Xhtml
+import org.gradle.build.docs.ExtractSamplesTask
+import org.gradle.build.docs.ExtractSnippetsTask
+import org.gradle.build.docs.UserGuideSectionVerifier
+import org.gradle.build.docs.UserGuideTransformTask
+import org.gradle.build.docs.Xhtml2Pdf
+import org.gradle.build.docs.dsl.docbook.AssembleDslDocTask
+import org.gradle.build.docs.dsl.source.ExtractDslMetaDataTask
+import org.gradle.build.docs.dsl.source.GenerateDefaultImportsTask
+import org.gradle.build.docs.releasenotes.*
+import org.gradle.build.docs.releasenotes.checks.*
+import org.gradle.plugins.pegdown.PegDown
+
 import javax.xml.transform.TransformerFactory
 import javax.xml.transform.stream.StreamResult
 import javax.xml.transform.stream.StreamSource
-
-import org.gradle.build.docs.CacheableAsciidoctorTask
-import org.gradle.build.docs.UserGuideSectionVerifier
-import org.gradle.build.docs.UserGuideTransformTask
-import org.gradle.build.docs.ExtractSnippetsTask
-import org.gradle.build.docs.ExtractSamplesTask
-import org.gradle.build.docs.AssembleSamplesDocTask
-import org.gradle.build.docs.Docbook2Xhtml
-import org.gradle.build.docs.Xhtml2Pdf
-import org.gradle.build.docs.dsl.source.GenerateDefaultImportsTask
-import org.gradle.build.docs.dsl.docbook.AssembleDslDocTask
-import org.gradle.build.docs.dsl.source.ExtractDslMetaDataTask
-import org.gradle.build.docs.releasenotes.*
-import org.gradle.build.docs.releasenotes.checks.*
-import org.apache.tools.ant.filters.ReplaceTokens
-import org.gradle.plugins.pegdown.PegDown
 
 apply plugin: 'base'
 apply plugin: 'pegdown'
@@ -213,28 +213,16 @@ ext.cssFiles = fileTree(css.destinationDir) {
 }
 
 task samples(type: ExtractSnippetsTask) {
-    source samplesSrcDir
-    exclude 'userguideOutput/**'
-    exclude '**/readme.xml'
-    exclude '**/build/**'
-    exclude '**/.gradle/**'
-
-    // Resources that should not be filtered
-    exclude 'userguide/tutorial/antLoadfileResources/**'
-    exclude 'native-binaries/cunit/libs/**'
-    exclude 'native-binaries/google-test/libs/**'
-
+    samples = samplesSrcDir
     destDir = samplesDir
+    excludes = ['userguideOutput/**',
+                '**/readme.xml',
+                '**/build/**',
+                '**/.gradle/**']
+    nonFiltered = [ 'userguide/tutorial/antLoadfileResources/**',
+                    'native-binaries/cunit/libs/**',
+                    'native-binaries/google-test/libs/**' ]
     snippetsDir = new File(buildDir, 'snippets')
-    doLast {
-        copy {
-            from samplesSrcDir
-            into samplesDir
-            include 'userguide/tutorial/antLoadfileResources/**'
-            include 'native-binaries/cunit/libs/**'
-            include 'native-binaries/google-test/libs/**'
-        }
-    }
 }
 
 task userguideStyleSheets(type: Copy) {


### PR DESCRIPTION
Using `exclude` to remove non-filterable files (binary files) broke up-to-date checks since they were still an input, we were sneakily copying them into their final destination through another mechanism.