### PR TITLE
Minus 1 when submit `max-workers` to thread pool

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
@@ -108,8 +108,10 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
             lock.unlock();
         }
 
-        // Use this thread to process any work - this should only actually process work if none of the
-        // submitted workers make it onto the executor thread pool.
+        // Use this thread to process any work - this allows work to be executed using the
+        // worker lease acquired by this thread even if the executor thread pool is full of
+        // workers from other threads.  In other words, it ensures that all worker leases
+        // are being utilized, regardless of the bounds of the thread pool.
         try {
             new WorkerRunnable().run();
         } catch (Throwable t) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
@@ -70,7 +70,8 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
             workQueue.add(operation);
             pendingOperations++;
             workAvailable.signalAll();
-            if (workerCount == 0 || workerCount < workerLeases.getMaxWorkerCount()) {
+            if (workerCount == 0 || workerCount < workerLeases.getMaxWorkerCount() - 1) {
+                // `getMaxWorkerCount() - 1` because main thread executes work as well. See https://github.com/gradle/gradle/issues/3273
                 // TODO This could be more efficient, so that we only start a worker when there are none idle _and_ there is a worker lease available
                 executor.execute(new WorkerRunnable());
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.test.fixtures.server.http.HttpResource
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import spock.lang.Unroll
-import spock.lang.Ignore
 
 import static org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpTimeoutSettings.SOCKET_TIMEOUT_SYSTEM_PROPERTY
 
@@ -127,7 +126,6 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         protocol << ['http', 'https']
     }
 
-    @Ignore
     def "skips subsequent dependency resolution if HTTP connection exceeds timeout"() {
         given:
         MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')
@@ -150,7 +148,6 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         !downloadedLibsDir.isDirectory()
     }
 
-    @Ignore
     def "skipped repositories are only recorded for the time of a single build execution"() {
         given:
         MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')


### PR DESCRIPTION
### Context

As stated in #3273, currently, we allow main thread (i.e. the thread which is waiting for build operation queue's completion) to execute some work. The consequence is, the actual worker number is max-workers number +1. Since we can't set --max-workers=0 via command line, that means the work would always be executed parallelly.

This PR only submit `max-workers`-1 threads to thread pool to avoid this issue.

### Gradle Core Team Checklist
- [x] Verify test coverage and CI build status