### PR TITLE
Upgrade gradle-kotlin-dsl {0.12.2 => 0.12.3}

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
     libraries = [:]
 }
 
-versions.gradle_kotlin_dsl = '0.12.2'
+versions.gradle_kotlin_dsl = '0.12.3'
 
 versions.commons_io = 'commons-io:commons-io:2.2'
 


### PR DESCRIPTION
Including a fix to a regression caused by the `PropertyState => Property` rename (gradle/kotlin-dsl#574).