### PR TITLE
Ignore Eclipse .metadata directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 /bin
 /subprojects/*/bin
 atlassian-ide-plugin.xml
+.metadata/
 
 # NetBeans
 # --------


### PR DESCRIPTION
### Context
Eclipse .metadata/ contains lot of files that polutes the changed set of files to commit.

### Contributor Checklist
- [ x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
