### PR TITLE
Delegate Xcode clean to Gradle

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
@@ -81,6 +81,7 @@ public abstract class CollectionUtils {
         return Cast.uncheckedCast(input);
     }
 
+    @Nullable
     public static <T> T findFirst(Iterable<? extends T> source, Spec<? super T> filter) {
         for (T item : source) {
             if (filter.isSatisfiedBy(item)) {
@@ -91,6 +92,7 @@ public abstract class CollectionUtils {
         return null;
     }
 
+    @Nullable
     public static <T> T findFirst(T[] source, Spec<? super T> filter) {
         for (T thing : source) {
             if (filter.isSatisfiedBy(thing)) {

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -165,6 +165,11 @@
             "type": "org.gradle.api.tasks.testing.AbstractTestTask",
             "member": "Constructor org.gradle.api.tasks.testing.AbstractTestTask()",
             "acceptation": "Extracted super class out of Test which was already stable"
+        },
+        {
+            "type": "org.gradle.ide.xcode.plugins.XcodePlugin",
+            "member": "Constructor org.gradle.ide.xcode.plugins.XcodePlugin(org.gradle.ide.xcode.internal.xcodeproj.GidGenerator,org.gradle.api.model.ObjectFactory)",
+            "acceptation": "Change to constructor of incubating type/plugin"
         }
     ]
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
@@ -74,7 +74,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
 
         then:
         resultDebugApp.assertTasksExecuted(':greeter:dependDebugCpp', ':greeter:compileDebugCpp', ':greeter:linkDebug',
-            ':app:dependDebugCpp', ':app:compileDebugCpp', ':app:linkDebug')
+            ':app:dependDebugCpp', ':app:compileDebugCpp', ':app:linkDebug', ':app:_xcode___App_Debug')
 
         when:
         def resultReleaseApp = xcodebuild
@@ -85,7 +85,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
 
         then:
         resultReleaseApp.assertTasksExecuted(':greeter:dependReleaseCpp', ':greeter:compileReleaseCpp', ':greeter:linkRelease',
-            ':app:dependReleaseCpp', ':app:compileReleaseCpp', ':app:linkRelease')
+            ':app:dependReleaseCpp', ':app:compileReleaseCpp', ':app:linkRelease', ':app:_xcode___App_Release')
     }
 
     def "can create xcode project for C++ executable with transitive dependencies"() {
@@ -150,7 +150,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
         resultDebugApp.assertTasksExecuted(':shuffle:dependDebugCpp', ':shuffle:compileDebugCpp', ':shuffle:linkDebug',
             ':card:dependDebugCpp', ':card:compileDebugCpp', ':card:linkDebug',
             ':deck:dependDebugCpp', ':deck:compileDebugCpp', ':deck:linkDebug',
-            ':app:dependDebugCpp', ':app:compileDebugCpp', ':app:linkDebug')
+            ':app:dependDebugCpp', ':app:compileDebugCpp', ':app:linkDebug', ':app:_xcode___App_Debug')
 
         when:
         def resultReleaseHello = xcodebuild
@@ -162,7 +162,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
         then:
         resultReleaseHello.assertTasksExecuted(':shuffle:dependReleaseCpp', ':shuffle:compileReleaseCpp', ':shuffle:linkRelease',
             ':card:dependReleaseCpp', ':card:compileReleaseCpp', ':card:linkRelease',
-            ':deck:dependReleaseCpp', ':deck:compileReleaseCpp', ':deck:linkRelease')
+            ':deck:dependReleaseCpp', ':deck:compileReleaseCpp', ':deck:linkRelease', ':deck:_xcode___Deck_Release')
     }
 
     def "can create xcode project for C++ executable inside composite build"() {
@@ -213,7 +213,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
 
         then:
         resultDebugApp.assertTasksExecuted(':greeter:dependDebugCpp', ':greeter:compileDebugCpp', ':greeter:linkDebug',
-            ':dependDebugCpp', ':compileDebugCpp', ':linkDebug')
+            ':dependDebugCpp', ':compileDebugCpp', ':linkDebug', ':_xcode___App_Debug')
 
         when:
         def resultReleaseGreeter = xcodebuild
@@ -223,6 +223,6 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
             .succeeds()
 
         then:
-        resultReleaseGreeter.assertTasksExecuted(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease')
+        resultReleaseGreeter.assertTasksExecuted(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease', ':_xcode___Greeter_Release')
     }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
@@ -76,7 +76,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
 
         then:
         resultDebugApp.assertTasksExecuted(':greeter:compileDebugSwift', ':greeter:linkDebug',
-            ':app:compileDebugSwift', ':app:linkDebug')
+            ':app:compileDebugSwift', ':app:linkDebug', ':app:_xcode___App_Debug')
 
         when:
         def resultReleaseApp = xcodebuild
@@ -87,7 +87,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
 
         then:
         resultReleaseApp.assertTasksExecuted(':greeter:compileReleaseSwift', ':greeter:linkRelease',
-            ':app:compileReleaseSwift', ':app:linkRelease')
+            ':app:compileReleaseSwift', ':app:linkRelease', ':app:_xcode___App_Release')
     }
 
     def "can create xcode project for Swift executable with transitive dependencies"() {
@@ -144,7 +144,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
         then:
         resultDebugApp.assertTasksExecuted(':log:compileDebugSwift', ':log:linkDebug',
             ':hello:compileDebugSwift', ':hello:linkDebug',
-            ':app:compileDebugSwift', ':app:linkDebug')
+            ':app:compileDebugSwift', ':app:linkDebug', ':app:_xcode___App_Debug')
 
         when:
         def resultReleaseHello = xcodebuild
@@ -155,7 +155,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
 
         then:
         resultReleaseHello.assertTasksExecuted(':hello:compileReleaseSwift', ':hello:linkRelease',
-            ':log:compileReleaseSwift', ':log:linkRelease')
+            ':log:compileReleaseSwift', ':log:linkRelease', ':hello:_xcode___Hello_Release')
     }
 
     def "can create xcode project for Swift executable inside composite build"() {
@@ -205,7 +205,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             .succeeds()
 
         then:
-        resultDebugApp.assertTasksExecuted(':greeter:compileDebugSwift', ':greeter:linkDebug', ':compileDebugSwift', ':linkDebug')
+        resultDebugApp.assertTasksExecuted(':greeter:compileDebugSwift', ':greeter:linkDebug', ':compileDebugSwift', ':linkDebug', ':_xcode___App_Debug')
 
         when:
         def resultReleaseGreeter = xcodebuild
@@ -215,7 +215,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             .succeeds()
 
         then:
-        resultReleaseGreeter.assertTasksExecuted(':compileReleaseSwift', ':linkRelease')
+        resultReleaseGreeter.assertTasksExecuted(':compileReleaseSwift', ':linkRelease', ':_xcode___Greeter_Release')
     }
 
     def "can run tests for Swift library within multi-project from xcode"() {
@@ -245,8 +245,8 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
 
         then:
         resultTestRunner.assertTasksExecuted(':greeter:compileDebugSwift', ':greeter:compileTestSwift', ':greeter:linkTest',
-            ':greeter:bundleSwiftTest', ':greeter:syncTestBundleToXcodeBuiltProductDir', ':greeter:buildXcodeTestProduct')
-        app.library.assertTestCasesRan(resultTestRunner.output)
+            ':greeter:bundleSwiftTest', ':greeter:syncTestBundleToXcodeBuiltProductDir', ':greeter:_xcode__build_GreeterTest___GradleTestRunner_Debug')
 
+        resultTestRunner.assertOutputContains("** TEST SUCCEEDED **")
     }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
@@ -158,7 +158,6 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             ':log:compileReleaseSwift', ':log:linkRelease', ':hello:_xcode___Hello_Release')
     }
 
-
     def "can clean xcode project with transitive dependencies"() {
         def app = new SwiftAppWithLibraries()
 

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
@@ -200,8 +200,8 @@ apply plugin: 'cpp-executable'
             .succeeds()
 
         then:
-        resultDebug.assertTasksExecuted(':dependDebugCpp', ':compileDebugCpp', ':linkDebug')
-        resultDebug.assertTasksNotSkipped(':dependDebugCpp', ':compileDebugCpp', ':linkDebug')
+        resultDebug.assertTasksExecuted(':dependDebugCpp', ':compileDebugCpp', ':linkDebug', ':_xcode___App_Debug')
+        resultDebug.assertTasksNotSkipped(':dependDebugCpp', ':compileDebugCpp', ':linkDebug', ':_xcode___App_Debug')
         exe("build/exe/main/debug/App").exec().out == app.expectedOutput
 
         when:
@@ -213,8 +213,8 @@ apply plugin: 'cpp-executable'
             .succeeds()
 
         then:
-        resultRelease.assertTasksExecuted(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease')
-        resultRelease.assertTasksNotSkipped(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease')
+        resultRelease.assertTasksExecuted(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease', ':_xcode___App_Release')
+        resultRelease.assertTasksNotSkipped(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease', ':_xcode___App_Release')
         exe("build/exe/main/release/App").exec().out == app.expectedOutput
     }
 
@@ -239,8 +239,8 @@ apply plugin: 'cpp-library'
             .succeeds()
 
         then:
-        resultDebug.assertTasksExecuted(':dependDebugCpp', ':compileDebugCpp', ':linkDebug')
-        resultDebug.assertTasksNotSkipped(':dependDebugCpp', ':compileDebugCpp', ':linkDebug')
+        resultDebug.assertTasksExecuted(':dependDebugCpp', ':compileDebugCpp', ':linkDebug', ':_xcode___App_Debug')
+        resultDebug.assertTasksNotSkipped(':dependDebugCpp', ':compileDebugCpp', ':linkDebug', ':_xcode___App_Debug')
         sharedLib("build/lib/main/debug/App").assertExists()
 
         when:
@@ -252,8 +252,8 @@ apply plugin: 'cpp-library'
             .succeeds()
 
         then:
-        resultRelease.assertTasksExecuted(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease')
-        resultRelease.assertTasksNotSkipped(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease')
+        resultRelease.assertTasksExecuted(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease', ':_xcode___App_Release')
+        resultRelease.assertTasksNotSkipped(':dependReleaseCpp', ':compileReleaseCpp', ':linkRelease', ':_xcode___App_Release')
         sharedLib("build/lib/main/release/App").assertExists()
     }
 

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -370,6 +370,29 @@ apply plugin: 'swift-executable'
     }
 
     @Requires(TestPrecondition.XCODE)
+    def "produces reasonable message when xcode uses outdated xcode configuration"() {
+        useXcodebuildTool()
+        def app = new SwiftApp()
+
+        given:
+        buildFile << """
+apply plugin: 'swift-executable'
+"""
+
+        app.writeToProject(testDirectory)
+        succeeds("xcode")
+        settingsFile.text = "rootProject.name = 'NotApp'"
+
+        when:
+        def result = xcodebuild
+            .withProject(rootXcodeProject)
+            .withScheme('App Executable')
+            .fails()
+        then:
+        result.assertOutputContains("Unknown Xcode target 'App', do you need to re-generate Xcode configuration?")
+    }
+
+    @Requires(TestPrecondition.XCODE)
     def "can clean from xcode"() {
         useXcodebuildTool()
         def app = new SwiftApp()

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -297,7 +297,7 @@ apply plugin: 'xctest'
 
         then:
         resultTestRunner.assertTasksExecuted(':compileDebugSwift', ':compileTestSwift', ':linkTest', ':bundleSwiftTest',
-            ':syncTestBundleToXcodeBuiltProductDir', ':_xcode__build_GreeterTest___GradleTestRunner_Debug')
+            ':syncBundleToXcodeBuiltProductDir', ':_xcode__build_GreeterTest___GradleTestRunner_Debug')
         resultTestRunner.assertOutputContains("** TEST SUCCEEDED **")
     }
 
@@ -326,7 +326,7 @@ apply plugin: 'xctest'
 
         then:
         resultTestRunner.assertTasksExecuted(':compileDebugSwift', ':compileTestSwift', ':linkTest', ':bundleSwiftTest',
-            ':syncTestBundleToXcodeBuiltProductDir', ':_xcode__build_AppTest___GradleTestRunner_Debug')
+            ':syncBundleToXcodeBuiltProductDir', ':_xcode__build_AppTest___GradleTestRunner_Debug')
         resultTestRunner.assertOutputContains("** TEST SUCCEEDED **")
     }
 

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -19,8 +19,6 @@ package org.gradle.ide.xcode
 import org.gradle.ide.xcode.fixtures.AbstractXcodeIntegrationSpec
 import org.gradle.ide.xcode.fixtures.XcodebuildExecuter
 import org.gradle.ide.xcode.internal.DefaultXcodeProject
-import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.TestExecutionResult
 import org.gradle.nativeplatform.fixtures.app.SwiftApp
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithXCTest
 import org.gradle.nativeplatform.fixtures.app.SwiftLib
@@ -604,9 +602,5 @@ library.module = 'TestLib'
         project.targets[1].name == '[INDEXING ONLY] App SharedLibrary'
         project.products.children.size() == 1
         project.products.children[0].path == sharedLib("output/lib/main/debug/TestLib").absolutePath
-    }
-
-    TestExecutionResult getTestExecutionResult() {
-        return new DefaultTestExecutionResult(testDirectory, 'build', '', '', 'xcTest')
     }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/XcodebuildExecuter.java
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/XcodebuildExecuter.java
@@ -39,6 +39,7 @@ import static org.testng.Assert.assertTrue;
 public class XcodebuildExecuter {
     public enum XcodeAction {
         BUILD,
+        CLEAN,
         TEST;
 
         @Override

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodeTarget.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodeTarget.java
@@ -20,8 +20,7 @@ import org.gradle.api.Named;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.file.FileOperations;
-import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.ide.xcode.internal.xcodeproj.PBXTarget;
 
 import javax.inject.Inject;
@@ -38,21 +37,21 @@ public class XcodeTarget implements Named {
     private String taskName;
     private String gradleCommand;
 
-    private final Property<FileSystemLocation> debugOutputFile;
-    private final Property<FileSystemLocation> releaseOutputFile;
+    private final Provider<FileSystemLocation> debugOutputFile;
+    private final Provider<FileSystemLocation> releaseOutputFile;
     private PBXTarget.ProductType productType;
     private String productName;
     private String outputFileType;
 
     @Inject
-    public XcodeTarget(String name, String id, FileOperations fileOperations, ObjectFactory objectFactory) {
+    public XcodeTarget(String name, String id, FileOperations fileOperations, Provider<FileSystemLocation> debugOutputFile, Provider<FileSystemLocation> releaseOutputFile) {
         this.name = name;
         this.id = id;
-        this.debugOutputFile = objectFactory.property(FileSystemLocation.class);
-        this.releaseOutputFile = objectFactory.property(FileSystemLocation.class);
         this.sources = fileOperations.files();
         this.headerSearchPaths = fileOperations.files();
         this.importPaths = fileOperations.files();
+        this.debugOutputFile = debugOutputFile;
+        this.releaseOutputFile = releaseOutputFile;
     }
 
     public String getId() {
@@ -64,11 +63,11 @@ public class XcodeTarget implements Named {
         return name;
     }
 
-    public Property<FileSystemLocation> getDebugOutputFile() {
+    public Provider<FileSystemLocation> getDebugOutputFile() {
         return debugOutputFile;
     }
 
-    public Property<FileSystemLocation> getReleaseOutputFile() {
+    public Provider<FileSystemLocation> getReleaseOutputFile() {
         return releaseOutputFile;
     }
 

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
@@ -118,7 +118,7 @@ public class XcodePlugin extends IdePlugin {
         lifecycleTask.dependsOn(projectTask);
         projectTask.dependsOn(project.getTasks().withType(GenerateSchemeFileTask.class));
 
-        project.getTasks().addRule("Xcode bridge tasks being with _xcode. Do not call these directly.", new XcodeBridge(xcode.getProject(), project));
+        project.getTasks().addRule("Xcode bridge tasks begin with _xcode. Do not call these directly.", new XcodeBridge(xcode.getProject(), project));
 
         configureForSwiftPlugin(project);
         configureForCppPlugin(project);

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
@@ -449,7 +449,7 @@ public class XcodePlugin extends IdePlugin {
 
                     }
                 } else {
-                    throw new GradleException("Unrecognized bridge action from xcode '" + action + "'");
+                    throw new GradleException("Unrecognized bridge action from Xcode '" + action + "'");
                 }
             }
         }
@@ -463,7 +463,7 @@ public class XcodePlugin extends IdePlugin {
                 }
             });
             if (target == null) {
-                throw new GradleException("Unknown Xcode target " + productName);
+                throw new GradleException("Unknown Xcode target '" + productName + "', do you need to re-generate Xcode configuration?");
             }
             return target;
         }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
