### PR TITLE
Set the minimum version of Gradle to 4.0

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
@@ -22,6 +22,7 @@ import spock.lang.Unroll
 class NativeBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def setup() {
+        runner.minimumVersion = '4.0'
         runner.targetVersions = ["4.3-20171011120745+0000"]
     }
 


### PR DESCRIPTION
This will keep these performance tests from running on older versions
of Gradle where the `cpp-library` and `cpp-executable` rules weren't
yet introduced.