### PR TITLE
Fix #3029: Use correct server class when distributing Play applications

### DIFF
--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
@@ -182,7 +182,7 @@ public class PlayDistributionPlugin extends RuleSource {
             case PLAY_2_6_X:
                 return "play.core.server.ProdServerStart";
             default:
-                throw new RuntimeException("Could not create Twirl compile spec for Play version: " + playVersion);
+                throw new RuntimeException("Could not determine main class for Play version:" + playVersion);
         }
     }
 

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
@@ -176,9 +176,9 @@ public class PlayDistributionPlugin extends RuleSource {
         switch (PlayMajorVersion.forPlatform(playPlatform)) {
             case PLAY_2_2_X:
             case PLAY_2_3_X:
+                return "play.core.server.NettyServer";
             case PLAY_2_4_X:
             case PLAY_2_5_X:
-                return "play.core.server.NettyServer";
             case PLAY_2_6_X:
                 return "play.core.server.ProdServerStart";
             default:

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayDistributionPluginTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayDistributionPluginTest.groovy
@@ -163,8 +163,8 @@ class PlayDistributionPluginTest extends Specification {
         where:
         playVersion | mainClass
         "2.3.10"    | "play.core.server.NettyServer"
-        "2.4.11"    | "play.core.server.NettyServer"
-        "2.5.18"    | "play.core.server.NettyServer"
+        "2.4.11"    | "play.core.server.ProdServerStart"
+        "2.5.18"    | "play.core.server.ProdServerStart"
         "2.6.6"     | "play.core.server.ProdServerStart"
     }
 

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayDistributionPluginTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayDistributionPluginTest.groovy
@@ -41,8 +41,10 @@ import org.gradle.platform.base.BinaryTasksCollection
 import org.gradle.play.PlayApplicationBinarySpec
 import org.gradle.play.distribution.PlayDistribution
 import org.gradle.play.distribution.PlayDistributionContainer
+import org.gradle.play.internal.DefaultPlayPlatform
 import org.gradle.play.internal.PlayApplicationBinarySpecInternal
 import org.gradle.play.internal.distribution.DefaultPlayDistribution
+import org.gradle.play.platform.PlayPlatform
 import org.gradle.util.WrapUtil
 import spock.lang.Specification
 
@@ -90,7 +92,7 @@ class PlayDistributionPluginTest extends Specification {
         def distributions = Mock(PlayDistributionContainer)
         File buildDir = new File("")
         DomainObjectSet jarTasks = Stub(DomainObjectSet)
-        PlayApplicationBinarySpec binary = binary("playBinary", jarTasks)
+        PlayApplicationBinarySpec binary = binary("playBinary", jarTasks, playVersion)
         binary.getJarFile() >> Stub(File) {
             getName() >> "playBinary.zip"
         }
@@ -136,7 +138,7 @@ class PlayDistributionPluginTest extends Specification {
             action.execute(Mock(CreateStartScripts) {
                 1 * setDescription(_)
                 1 * setClasspath(_)
-                1 * setMainClassName("play.core.server.NettyServer")
+                1 * setMainClassName(mainClass)
                 1 * setApplicationName("playBinary")
                 1 * setOutputDir(_)
             })
@@ -157,6 +159,13 @@ class PlayDistributionPluginTest extends Specification {
                 }
             })
         }
+
+        where:
+        playVersion | mainClass
+        "2.3.10"    | "play.core.server.NettyServer"
+        "2.4.11"    | "play.core.server.NettyServer"
+        "2.5.18"    | "play.core.server.NettyServer"
+        "2.6.6"     | "play.core.server.ProdServerStart"
     }
 
     def "adds dist and stage tasks for binary" () {
@@ -222,13 +231,20 @@ class PlayDistributionPluginTest extends Specification {
         }
     }
 
-    def binary(String name, DomainObjectSet jarTasks) {
+    def binary(String name, DomainObjectSet jarTasks, String playVersion = DefaultPlayPlatform.DEFAULT_PLAY_VERSION) {
         return Stub(PlayApplicationBinarySpecInternal) {
             getTasks() >> Stub(BinaryTasksCollection) {
                 withType(Jar.class) >> jarTasks
             }
             getName() >> name
             getProjectScopedName() >> name
+            getTargetPlatform() >> platform(playVersion)
+        }
+    }
+
+    def platform(String playVersion) {
+        return Stub(PlayPlatform) {
+            getPlayVersion() >> playVersion
         }
     }
 


### PR DESCRIPTION
### Context

This fixes #3029 where the wrong main class is used when running dist tasks. The full qualified class name for Play 2.6 is `"play.core.server.ProdServerStart"`

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist

- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
