### PR TITLE
Fix use of IntelliJ IDEA dependencies scopes.

### DIFF
--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r34/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r34/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -122,18 +122,17 @@ class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
         def module = ideaProject.modules.find {it. name == 'root'}
 
         then:
-        module.dependencies.size() == 11
+        module.dependencies.size() == 9
+
         hasDependency(module, "a", "PROVIDED")
         hasDependency(module, "a", "RUNTIME")
-        hasDependency(module, "a", "TEST")
-        hasDependency(module, "f", "TEST")
         hasDependency(module, "b", "PROVIDED")
         hasDependency(module, "b", "RUNTIME")
-        hasDependency(module, "b", "TEST")
         hasDependency(module, "c", "RUNTIME")
         hasDependency(module, "c", "TEST")
         hasDependency(module, "e", "RUNTIME")
         hasDependency(module, "e", "TEST")
+        hasDependency(module, "f", "TEST")
     }
 
     def hasDependency(IdeaModule module, String name, String scope) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -391,42 +391,38 @@ public class IdeaPlugin extends IdePlugin {
     }
 
     private void setupScopes(GenerateIdeaModule ideaModule) {
-        Map<String, Map<String, Collection<Configuration>>> scopes = Maps.newLinkedHashMap();
-        for (GeneratedIdeaScope scope : GeneratedIdeaScope.values()) {
-            Map<String, Collection<Configuration>> plusMinus = Maps.newLinkedHashMap();
-            plusMinus.put(IdeaDependenciesProvider.SCOPE_PLUS, Lists.<Configuration>newArrayList());
-            plusMinus.put(IdeaDependenciesProvider.SCOPE_MINUS, Lists.<Configuration>newArrayList());
-            scopes.put(scope.name(), plusMinus);
-        }
 
         Project project = ideaModule.getProject();
-        ConfigurationContainer configurations = project.getConfigurations();
+        IdeaScopesConfig scopes = new IdeaScopesConfig(project.getConfigurations());
 
-        Collection<Configuration> provided = scopes.get(GeneratedIdeaScope.PROVIDED.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);
-        provided.add(configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+        scopes.named(GeneratedIdeaScope.COMPILE)
+            .plus(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+            .minus(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
 
-        Collection<Configuration> runtime = scopes.get(GeneratedIdeaScope.RUNTIME.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);
-        runtime.add(configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+        scopes.named(GeneratedIdeaScope.PROVIDED)
+            .plus(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
 
-        Collection<Configuration> test = scopes.get(GeneratedIdeaScope.TEST.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);
-        test.add(configurations.getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME));
-        test.add(configurations.getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+        scopes.named(GeneratedIdeaScope.RUNTIME)
+            .plus(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+            .minus(JavaPlugin.COMPILE_CONFIGURATION_NAME);
 
-        ideaModule.getModule().setScopes(scopes);
+        scopes.named(GeneratedIdeaScope.TEST)
+            .plus(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME)
+            .plus(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+            .minus(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
+
+        ideaModule.getModule().setScopes(scopes.build());
     }
 
     private void configureIdeaModuleForWar(final Project project) {
         project.getTasks().withType(GenerateIdeaModule.class, new Action<GenerateIdeaModule>() {
             @Override
             public void execute(GenerateIdeaModule ideaModule) {
-                ConfigurationContainer configurations = project.getConfigurations();
-                Configuration providedRuntime = configurations.getByName(WarPlugin.PROVIDED_RUNTIME_CONFIGURATION_NAME);
-                Collection<Configuration> providedPlus = ideaModule.getModule().getScopes().get(GeneratedIdeaScope.PROVIDED.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);
-                providedPlus.add(providedRuntime);
-                Collection<Configuration> runtimeMinus = ideaModule.getModule().getScopes().get(GeneratedIdeaScope.RUNTIME.name()).get(IdeaDependenciesProvider.SCOPE_MINUS);
-                runtimeMinus.add(providedRuntime);
-                Collection<Configuration> testMinus = ideaModule.getModule().getScopes().get(GeneratedIdeaScope.TEST.name()).get(IdeaDependenciesProvider.SCOPE_MINUS);
-                testMinus.add(providedRuntime);
+                IdeaScopesConfig scopes = new IdeaScopesConfig(ideaModule.getModule().getScopes(), project.getConfigurations());
+
+                scopes.named(GeneratedIdeaScope.PROVIDED).plus(WarPlugin.PROVIDED_RUNTIME_CONFIGURATION_NAME);
+                scopes.named(GeneratedIdeaScope.RUNTIME).minus(WarPlugin.PROVIDED_RUNTIME_CONFIGURATION_NAME);
+                scopes.named(GeneratedIdeaScope.TEST).minus(WarPlugin.PROVIDED_RUNTIME_CONFIGURATION_NAME);
             }
         });
     }
@@ -529,4 +525,53 @@ public class IdeaPlugin extends IdePlugin {
         }
     }
 
+    private static class IdeaScopesConfig {
+        private final Map<String, Map<String, Collection<Configuration>>> scopes;
+        private final ConfigurationContainer configurations;
+
+        public IdeaScopesConfig(Map<String, Map<String, Collection<Configuration>>> scopes, ConfigurationContainer configurations) {
+            this.scopes = scopes;
+            this.configurations = configurations;
+        }
+
+        public IdeaScopesConfig(ConfigurationContainer configurations) {
+            scopes = Maps.newLinkedHashMap();
+            for (GeneratedIdeaScope scope : GeneratedIdeaScope.values()) {
+                Map<String, Collection<Configuration>> plusMinus = Maps.newLinkedHashMap();
+                plusMinus.put(IdeaDependenciesProvider.SCOPE_PLUS, Lists.<Configuration>newArrayList());
+                plusMinus.put(IdeaDependenciesProvider.SCOPE_MINUS, Lists.<Configuration>newArrayList());
+                scopes.put(scope.name(), plusMinus);
+            }
+            this.configurations = configurations;
+        }
+
+        public ScopeConfig named(GeneratedIdeaScope ideaScope) {
+            return new ScopeConfig(scopes.get(ideaScope.name()), configurations);
+        }
+
+        public Map<String, Map<String, Collection<Configuration>>> build() {
+            return scopes;
+        }
+    }
+
+    private static class ScopeConfig {
+
+        private final Map<String, Collection<Configuration>> includeConfigurationMap;
+        private final ConfigurationContainer configurations;
+
+        public ScopeConfig(Map<String, Collection<Configuration>> includeConfigurationMap, ConfigurationContainer configurations) {
+            this.includeConfigurationMap = includeConfigurationMap;
+            this.configurations = configurations;
+        }
+
+        public ScopeConfig plus(String configurationName) {
+            includeConfigurationMap.get(IdeaDependenciesProvider.SCOPE_PLUS).add(configurations.getByName(configurationName));
+            return this;
+        }
+
+        public ScopeConfig minus(String configurationName) {
+            includeConfigurationMap.get(IdeaDependenciesProvider.SCOPE_MINUS).add(configurations.getByName(configurationName));
+            return this;
+        }
+    }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -395,21 +395,17 @@ public class IdeaPlugin extends IdePlugin {
         Project project = ideaModule.getProject();
         IdeaScopesConfig scopes = new IdeaScopesConfig(project.getConfigurations());
 
-        scopes.named(GeneratedIdeaScope.COMPILE)
-            .plus(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
-            .minus(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
-
         scopes.named(GeneratedIdeaScope.PROVIDED)
-            .plus(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
+            .plus(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
 
         scopes.named(GeneratedIdeaScope.RUNTIME)
-            .plus(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
-            .minus(JavaPlugin.COMPILE_CONFIGURATION_NAME);
+            .plus(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
 
         scopes.named(GeneratedIdeaScope.TEST)
             .plus(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME)
             .plus(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
             .minus(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
+
 
         ideaModule.getModule().setScopes(scopes.build());
     }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
@@ -93,10 +93,10 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         project.idea.project.languageLevel.level == new IdeaLanguageLevel(project.sourceCompatibility).level
 
         project.idea.module.scopes == [
-                PROVIDED: [plus: [project.configurations.compileClasspath], minus: []],
-                COMPILE: [plus: [], minus: []],
-                RUNTIME: [plus: [project.configurations.runtimeClasspath], minus: []],
-                TEST: [plus: [project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath], minus: []],
+                PROVIDED: [plus: [project.configurations.compileOnly], minus: []],
+                COMPILE: [plus: [project.configurations.compileClasspath], minus: [project.configurations.compileOnly]],
+                RUNTIME: [plus: [project.configurations.runtimeClasspath], minus: [project.configurations.compile]],
+                TEST: [plus: [project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath], minus: [project.configurations.compileClasspath]],
         ]
     }
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
@@ -93,10 +93,10 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         project.idea.project.languageLevel.level == new IdeaLanguageLevel(project.sourceCompatibility).level
 
         project.idea.module.scopes == [
-                PROVIDED: [plus: [project.configurations.compileOnly], minus: []],
-                COMPILE: [plus: [project.configurations.compileClasspath], minus: [project.configurations.compileOnly]],
-                RUNTIME: [plus: [project.configurations.runtimeClasspath], minus: [project.configurations.compile]],
-                TEST: [plus: [project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath], minus: [project.configurations.compileClasspath]],
+                PROVIDED: [plus: [project.configurations.compileClasspath], minus: []],
+                COMPILE: [plus: [], minus: []],
+                RUNTIME: [plus: [project.configurations.runtimeClasspath], minus: []],
+                TEST: [plus: [project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath], minus: [project.configurations.compileClasspath]]
         ]
     }
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
@@ -66,8 +66,9 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 2
-        assertSingleLibrary(result, 'COMPILE', 'guava.jar')
+        result.size() == 3
+        assertSingleLibrary(result, 'PROVIDED', 'guava.jar')
+        assertSingleLibrary(result, 'RUNTIME', 'guava.jar')
         assertSingleLibrary(result, 'TEST', 'mockito.jar')
     }
 
@@ -142,8 +143,9 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 1
-        result.findAll { it.scope == 'COMPILE' }.size() == 1
+        result.size() == 2
+        result.findAll { it.scope == 'PROVIDED' }.size() == 1
+        result.findAll { it.scope == 'RUNTIME' }.size() == 1
     }
 
     def "test and runtime scope for the same dependency"() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
@@ -66,10 +66,8 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 4
-        assertSingleLibrary(result, 'PROVIDED', 'guava.jar')
-        assertSingleLibrary(result, 'RUNTIME', 'guava.jar')
-        assertSingleLibrary(result, 'TEST', 'guava.jar')
+        result.size() == 2
+        assertSingleLibrary(result, 'COMPILE', 'guava.jar')
         assertSingleLibrary(result, 'TEST', 'mockito.jar')
     }
 
@@ -144,10 +142,8 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 3
-        result.findAll { it.scope == 'PROVIDED' }.size() == 1
-        result.findAll { it.scope == 'RUNTIME' }.size() == 1
-        result.findAll { it.scope == 'TEST' }.size() == 1
+        result.size() == 1
+        result.findAll { it.scope == 'COMPILE' }.size() == 1
     }
 
     def "test and runtime scope for the same dependency"() {
@@ -201,12 +197,10 @@ public class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def result = dependenciesProvider.provide(module)
 
         then:
-        result.size() == 5
+        result.size() == 3
         assertSingleLibrary(result, 'PROVIDED', 'foo-runtime.jar')
         assertSingleLibrary(result, 'PROVIDED', 'foo-testRuntime.jar')
         assertSingleLibrary(result, 'RUNTIME', 'foo-runtime.jar')
-        assertSingleLibrary(result, 'TEST', 'foo-runtime.jar')
-        assertSingleLibrary(result, 'TEST', 'foo-testRuntime.jar')
     }
 
     def "ignore unknown configurations"() {


### PR DESCRIPTION
Reduce number of dependencies in generated or imported Idea projects by using the "scope inheritance" similar to what Gradle have. E.g., compile and provided scope dependencies are always included in test compile and runtime, etc.

This reduces number of dependencies twice on average, speeding up project import, sync and improving overall IntelliJ performance on middle to large projects.