### PR TITLE
Fix store-first local cache bug

### DIFF
--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheService.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheService.java
@@ -149,7 +149,12 @@ public class DirectoryBuildCacheService implements LocalBuildCacheService, Build
 
     @Override
     public void allocateTempFile(final BuildCacheKey key, final Action<? super File> action) {
-        tempFileStore.allocateTempFile(key, action);
+        persistentCache.useCache(new Runnable() {
+            @Override
+            public void run() {
+                tempFileStore.allocateTempFile(key, action);
+            }
+        });
     }
 
     @Override

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheService.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheService.java
@@ -25,7 +25,6 @@ import org.gradle.caching.BuildCacheEntryWriter;
 import org.gradle.caching.BuildCacheException;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.BuildCacheService;
-import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.resource.local.LocallyAvailableResource;
 import org.gradle.internal.resource.local.PathKeyFileStore;
@@ -88,9 +87,9 @@ public class DirectoryBuildCacheService implements LocalBuildCacheService, Build
     @Override
     public void load(final BuildCacheKey key, final Action<? super File> reader) {
         // We need to lock here because garbage collection can be under way in another process
-        persistentCache.withFileLock(new Factory<Void>() {
+        persistentCache.withFileLock(new Runnable() {
             @Override
-            public Void create() {
+            public void run() {
                 LocallyAvailableResource resource = fileStore.get(key.getHashCode());
                 if (resource != null) {
                     final File file = resource.getFile();
@@ -109,7 +108,6 @@ public class DirectoryBuildCacheService implements LocalBuildCacheService, Build
                         throw UncheckedException.throwAsUncheckedException(e);
                     }
                 }
-                return null;
             }
         });
     }
@@ -149,7 +147,7 @@ public class DirectoryBuildCacheService implements LocalBuildCacheService, Build
 
     @Override
     public void allocateTempFile(final BuildCacheKey key, final Action<? super File> action) {
-        persistentCache.useCache(new Runnable() {
+        persistentCache.withFileLock(new Runnable() {
             @Override
             public void run() {
                 tempFileStore.allocateTempFile(key, action);

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -657,6 +657,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         executed ":producer"
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/3358")
     def "re-ran task is stored in cache"() {
         file("input.txt").text = "input"
         buildFile << defineProducerTask()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -643,6 +643,33 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         skippedTasks as List == [":producer"]
     }
 
+    def "re-ran task is not loaded from cache"() {
+        file("input.txt").text = "input"
+        buildFile << defineProducerTask()
+
+        // Store in local cache
+        withBuildCache().succeeds "producer"
+
+        // Shouldn't load from cache
+        when:
+        withBuildCache().succeeds "producer", "--rerun-tasks"
+        then:
+        executed ":producer"
+    }
+
+    def "re-ran task is stored in cache"() {
+        file("input.txt").text = "input"
+        buildFile << defineProducerTask()
+
+        // Store in local cache
+        withBuildCache().succeeds "producer", "--rerun-tasks"
+
+        when:
+        withBuildCache().succeeds "producer"
+        then:
+        skipped ":producer"
+    }
+
     def "downstream task stays cached when upstream task is loaded from cache"() {
         file("input.txt").text = "input"
         buildFile << defineProducerTask()

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryCacheFactory.java
@@ -118,6 +118,11 @@ public class InMemoryCacheFactory implements CacheFactory {
         }
 
         @Override
+        public void withFileLock(Runnable action) {
+            action.run();
+        }
+
+        @Override
         public <T> T useCache(Factory<? extends T> action) {
             assertNotClosed();
             // The contract of useCache() means we have to provide some basic synchronization.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultCacheLockingManager.java
@@ -53,6 +53,11 @@ public class DefaultCacheLockingManager implements CacheLockingManager, Closeabl
     }
 
     @Override
+    public void withFileLock(Runnable action) {
+        cache.withFileLock(action);
+    }
+
+    @Override
     public <T> T useCache(Factory<? extends T> action) {
         return cache.useCache(action);
     }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheAccess.java
@@ -35,7 +35,7 @@ public interface CacheAccess {
      *
      * <p>This method is re-entrant, so that an action can call back into this method.</p>
      *
-     * <p>Note: this method differs from {@link #withFileLock(Factory)} in that this method also blocks other threads from this process and all threads from other processes from accessing the cache.</p>
+     * <p>Note: this method differs from {@link #withFileLock(Runnable)} in that this method also blocks other threads from this process and all threads from other processes from accessing the cache.</p>
      */
     void useCache(Runnable action);
 
@@ -45,5 +45,12 @@ public interface CacheAccess {
      * <p>This method is re-entrant, so that an action can call back into this method.</p>
      */
     <T> T withFileLock(Factory<? extends T> action);
+
+    /**
+     * Performs some work against the cache. Acquires exclusive locks on the appropriate file resources, so that only the actions from this process may run. Releases the locks and all resources at the end of the action. Allows other threads from this process to execute, but does not allow any threads from any other process to run.
+     *
+     * <p>This method is re-entrant, so that an action can call back into this method.</p>
+     */
+    void withFileLock(Runnable action);
 
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
@@ -194,6 +194,11 @@ public class DefaultCacheAccess implements CacheCoordinator {
     }
 
     @Override
+    public void withFileLock(Runnable action) {
+        crossProcessCacheAccess.withFileLock(Factories.toFactory(action));
+    }
+
+    @Override
     public void useCache(Runnable action) {
         useCache(Factories.toFactory(action));
     }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -181,6 +181,11 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         }
 
         @Override
+        public void withFileLock(Runnable action) {
+            reference.cache.withFileLock(action);
+        }
+
+        @Override
         public <T> T useCache(Factory<? extends T> action) {
             return reference.cache.useCache(action);
         }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
@@ -143,6 +143,11 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
     }
 
     @Override
+    public void withFileLock(Runnable action) {
+        cacheAccess.withFileLock(action);
+    }
+
+    @Override
     public <T> T useCache(Factory<? extends T> action) {
         return cacheAccess.useCache(action);
     }


### PR DESCRIPTION
Fixes #3358.

Normally, the first request to the local cache is a `DirectoryBuildCacheService.load()`, which initializes the cache, so when we hit it with the first store, the directory is already there and prepared.

However, if the task is re-run (via `--rerun-tasks`, or because it's marked as `upToDateWhen()`), then Gradle won't load any results from cache. In this case the first access to the local cache is a store:

- we first create the ".part" file inside the build-cache directory in `DirectoryBuildCacheService.allocateTempFile()`,
- the cache directory is then initialized (and all content deleted, including the ".part" file) when we hit `DirectoryBuildCacheService.store()`
- we try to move the (now deleted) ".part" file into the cache, which promptly fails

The problem was introduced in Gradle 4.1 with this: https://github.com/gradle/gradle/commit/e7344b65d8a4c4ba287b4acd7c5291beaa585c8c#diff-e43aa4ae86a4aefdc533a6c7a486d60bR170