### PR TITLE
Make the working directory of PlayRun task type configurable

### DIFF
--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayApplicationPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayApplicationPlugin.java
@@ -279,7 +279,7 @@ public class PlayApplicationPlugin implements Plugin<Project> {
         }
 
         @Mutate
-        void createPlayRunTask(ModelMap<Task> tasks, @Path("binaries") ModelMap<PlayApplicationBinarySpecInternal> playBinaries, final ServiceRegistry serviceRegistry, final PlayPluginConfigurations configurations, ProjectIdentifier projectIdentifier, final PlayToolChainInternal playToolChain) {
+        void createPlayRunTask(ModelMap<Task> tasks, @Path("binaries") ModelMap<PlayApplicationBinarySpecInternal> playBinaries, final ServiceRegistry serviceRegistry, final PlayPluginConfigurations configurations, final ProjectIdentifier projectIdentifier, final PlayToolChainInternal playToolChain) {
 
             for (final PlayApplicationBinarySpecInternal binary : playBinaries) {
                 String runTaskName = binary.getTasks().taskName("run");
@@ -289,6 +289,7 @@ public class PlayApplicationPlugin implements Plugin<Project> {
                         playRun.setDescription("Runs the Play application for local development.");
                         playRun.setGroup(RUN_GROUP);
                         playRun.setHttpPort(DEFAULT_HTTP_PORT);
+                        playRun.setWorkingDir(projectIdentifier.getProjectDir());
                         playRun.setPlayToolProvider(playToolChain.select(binary.getTargetPlatform()));
                         playRun.setApplicationJar(binary.getJarFile());
                         playRun.setAssetsJar(binary.getAssetsJarFile());

--- a/subprojects/platform-play/src/main/java/org/gradle/play/tasks/PlayRun.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/tasks/PlayRun.java
@@ -49,6 +49,8 @@ public class PlayRun extends ConventionTask {
 
     private int httpPort;
 
+    private File workingDir;
+
     @InputFile
     private File applicationJar;
 
@@ -86,7 +88,7 @@ public class PlayRun extends ConventionTask {
         PlayApplicationDeploymentHandle deploymentHandle = deploymentRegistry.get(deploymentId, PlayApplicationDeploymentHandle.class);
 
         if (deploymentHandle == null) {
-            PlayRunSpec spec = new DefaultPlayRunSpec(runtimeClasspath, changingClasspath, applicationJar, assetsJar, assetsDirs, getProject().getProjectDir(), getForkOptions(), getHttpPort());
+            PlayRunSpec spec = new DefaultPlayRunSpec(runtimeClasspath, changingClasspath, applicationJar, assetsJar, assetsDirs, workingDir, getForkOptions(), getHttpPort());
             PlayApplicationRunner playApplicationRunner = playToolProvider.get(PlayApplicationRunner.class);
             deploymentHandle = deploymentRegistry.start(deploymentId, DeploymentRegistry.ChangeBehavior.BLOCK, PlayApplicationDeploymentHandle.class, spec, playApplicationRunner);
 
@@ -110,6 +112,18 @@ public class PlayRun extends ConventionTask {
 
     public void setHttpPort(int httpPort) {
         this.httpPort = httpPort;
+    }
+
+    /**
+     * The working directory.
+     */
+    @Internal
+    public File getWorkingDir() {
+        return workingDir;
+    }
+
+    public void setWorkingDir(File workingDir) {
+        this.workingDir = workingDir;
     }
 
     /**

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/tasks/PlayRunTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/tasks/PlayRunTest.groovy
@@ -40,6 +40,7 @@ class PlayRunTest extends Specification {
 
     def setup() {
         playRun = TestUtil.create(tmpDir).task(PlayRun)
+        playRun.workingDir = tmpDir.testDirectory
         playRun.applicationJar = new File("application.jar")
         playRun.runtimeClasspath = new SimpleFileCollection()
         playRun.playToolProvider = playToolProvider


### PR DESCRIPTION
Issue: #3188

The working directory of PlayRun task defaults to project directory, but now it can be configured by users as well

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
