### PR TITLE
Publish Gradle metadata for java component with dependencies

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -118,6 +118,9 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     }
 
     protected boolean isPreferGradleMetadata() {
+        if (System.getProperty("org.gradle.internal.preferGradleMetadata") != null) {
+            return true;
+        }
         return preferGradleMetadata;
     }
 
@@ -145,7 +148,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     private MavenResolver createResolver(URI rootUri) {
         RepositoryTransport transport = getTransport(rootUri.getScheme());
-        return new MavenResolver(getName(), rootUri, transport, locallyAvailableResourceFinder, artifactFileStore, pomParser, metadataParser, moduleIdentifierFactory, transport.getResourceAccessor(), resourcesFileStore, fileResourceRepository, preferGradleMetadata);
+        return new MavenResolver(getName(), rootUri, transport, locallyAvailableResourceFinder, artifactFileStore, pomParser, metadataParser, moduleIdentifierFactory, transport.getResourceAccessor(), resourcesFileStore, fileResourceRepository, isPreferGradleMetadata());
     }
 
     protected MetaDataParser<MutableMavenModuleResolveMetadata> getPomParser() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/PublishedJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/PublishedJavaModule.groovy
@@ -21,4 +21,6 @@ interface PublishedJavaModule {
     void assertNoDependencies()
 
     void assertApiDependencies(String... expected)
+
+    void assertRuntimeDependencies(String... expected)
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/PublishedJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/PublishedJavaModule.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.test.fixtures
+
+interface PublishedJavaModule {
+    void assertPublished()
+
+    void assertNoDependencies()
+
+    void assertApiDependencies(String... expected)
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/PublishedJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/PublishedJavaModule.groovy
@@ -16,6 +16,8 @@
 package org.gradle.test.fixtures
 
 interface PublishedJavaModule {
+    PublishedJavaModule withClassifiedArtifact(String classifier, String extension)
+
     void assertPublished()
 
     void assertNoDependencies()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -225,7 +225,11 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     @Override
     void assertPublishedAsJavaModule() {
         assertPublished()
-        assertArtifactsPublished("${artifactId}-${publishArtifactVersion}.jar", "${artifactId}-${publishArtifactVersion}.pom")
+        def expectedArtifacts = ["${artifactId}-${publishArtifactVersion}.jar", "${artifactId}-${publishArtifactVersion}.pom"]
+        if (moduleMetadata) {
+            expectedArtifacts << "${artifactId}-${publishArtifactVersion}.module"
+        }
+        assertArtifactsPublished(expectedArtifacts as String[])
         assert parsedPom.packaging == null
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -50,6 +50,11 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     }
 
     @Override
+    public void assertPublished() {
+        backingModule.assertPublished();
+    }
+
+    @Override
     public void assertPublishedAsJavaModule() {
         backingModule.assertPublishedAsJavaModule();
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -73,6 +73,11 @@ interface MavenModule extends Module {
      */
     MavenModule variant(String variant, Map<String, String> attributes)
 
+    /*
+     * Asserts pom and module files are published correctly. Does not verify artifacts.
+     */
+    void assertPublished()
+
     /**
      * Asserts exactly pom and jar published, along with checksums.
      */

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -73,16 +73,6 @@ interface MavenModule extends Module {
      */
     MavenModule variant(String variant, Map<String, String> attributes)
 
-    /*
-     * Asserts pom and module files are published correctly. Does not verify artifacts.
-     */
-    void assertPublished()
-
-    /**
-     * Asserts exactly pom and jar published, along with checksums.
-     */
-    void assertPublishedAsJavaModule()
-
     String getPublishArtifactVersion()
 
     String getGroupId()
@@ -138,4 +128,14 @@ interface MavenModule extends Module {
     MavenMetaData getRootMetaData()
 
     boolean getUniqueSnapshots()
+
+    /**
+     * Asserts pom and module files are published correctly. Does not verify artifacts.
+     */
+    void assertPublished()
+
+    /**
+     * Asserts exactly pom and jar published, along with checksums.
+     */
+    void assertPublishedAsJavaModule()
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
@@ -48,23 +48,23 @@ class MavenPublishedJavaModule implements PublishedJavaModule {
     @Override
     void assertApiDependencies(String... expected) {
         if (expected.length == 0) {
-             assert module.parsedPom.scopes.compile == null
-             assert module.parsedModuleMetadata.variant('api').dependencies.empty
+            assert module.parsedModuleMetadata.variant('api').dependencies.empty
+            assert module.parsedPom.scopes.compile == null
         } else {
-            module.parsedPom.scopes.compile.assertDependsOn(expected)
             assert module.parsedModuleMetadata.variant('api').dependencies*.coords as Set == expected as Set
             assert module.parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
+            module.parsedPom.scopes.compile.assertDependsOn(expected)
         }
     }
 
     @Override
     void assertRuntimeDependencies(String... expected) {
         if (expected.length == 0) {
-            assert module.parsedPom.scopes.runtime == null
             assert module.parsedModuleMetadata.variant('runtime').dependencies.empty
+            assert module.parsedPom.scopes.runtime == null
         } else {
-            module.parsedPom.scopes.runtime.assertDependsOn(expected)
             assert module.parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
+            module.parsedPom.scopes.runtime.assertDependsOn(expected)
         }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
@@ -53,6 +53,18 @@ class MavenPublishedJavaModule implements PublishedJavaModule {
         } else {
             module.parsedPom.scopes.compile.assertDependsOn(expected)
             assert module.parsedModuleMetadata.variant('api').dependencies*.coords as Set == expected as Set
+            assert module.parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
+        }
+    }
+
+    @Override
+    void assertRuntimeDependencies(String... expected) {
+        if (expected.length == 0) {
+            assert module.parsedPom.scopes.runtime == null
+            assert module.parsedModuleMetadata.variant('runtime').dependencies.empty
+        } else {
+            module.parsedPom.scopes.runtime.assertDependsOn(expected)
+            assert module.parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
         }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
@@ -27,8 +27,17 @@ class MavenPublishedJavaModule implements PublishedJavaModule {
 
     @Override
     void assertPublished() {
-        module.assertPublishedAsJavaModule()
+        String moduleVersion = "${module.artifactId}-${module.publishArtifactVersion}"
+        module.assertPublished()
+        module.assertArtifactsPublished("${moduleVersion}.module", "${moduleVersion}.pom", "${moduleVersion}.jar")
+
+        // Verify Gradle metadata particulars
         assert module.parsedModuleMetadata.variants*.name as Set == ['api', 'runtime'] as Set
+        assert module.parsedModuleMetadata.variant('api').files*.name == [moduleVersion + ".jar"]
+        assert module.parsedModuleMetadata.variant('runtime').files*.name == [moduleVersion + ".jar"]
+
+        // Verify POM particulars
+        assert module.parsedPom.packaging == null
     }
 
     void assertNoDependencies() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.maven
+
+import org.gradle.test.fixtures.PublishedJavaModule
+
+class MavenPublishedJavaModule implements PublishedJavaModule {
+    private final MavenModule module
+
+    MavenPublishedJavaModule(MavenModule module) {
+        this.module = module
+    }
+
+    @Override
+    void assertPublished() {
+        module.assertPublishedAsJavaModule()
+        assert module.parsedModuleMetadata.variants*.name as Set == ['api', 'runtime'] as Set
+    }
+
+    void assertNoDependencies() {
+        assert module.parsedPom.scopes.isEmpty()
+        assertApiDependencies()
+    }
+
+    @Override
+    void assertApiDependencies(String... expected) {
+        if (expected.length == 0) {
+             assert module.parsedPom.scopes.compile == null
+             assert module.parsedModuleMetadata.variant('api').dependencies.empty
+        } else {
+            module.parsedPom.scopes.compile.assertDependsOn(expected)
+            assert module.parsedModuleMetadata.variant('api').dependencies*.coords as Set == expected as Set
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPublishedJavaModule.groovy
@@ -18,11 +18,12 @@ package org.gradle.test.fixtures.maven
 
 import org.gradle.test.fixtures.PublishedJavaModule
 
-class MavenPublishedJavaModule implements PublishedJavaModule {
-    private final AbstractMavenModule module
+class MavenPublishedJavaModule extends DelegatingMavenModule<MavenFileModule> implements PublishedJavaModule {
+    private final MavenFileModule module
     private final List<String> additionalArtifacts = []
 
-    MavenPublishedJavaModule(AbstractMavenModule module) {
+    MavenPublishedJavaModule(MavenFileModule module) {
+        super(module)
         this.module = module
     }
 
@@ -34,7 +35,7 @@ class MavenPublishedJavaModule implements PublishedJavaModule {
 
     @Override
     void assertPublished() {
-        module.assertPublished()
+        super.assertPublished()
 
         List<String> expectedArtifacts = [artifact("module"), artifact("pom"), artifact("jar")]
         expectedArtifacts.addAll(additionalArtifacts)
@@ -54,31 +55,32 @@ class MavenPublishedJavaModule implements PublishedJavaModule {
         assertApiDependencies()
     }
 
+
     @Override
     void assertApiDependencies(String... expected) {
         if (expected.length == 0) {
-            assert module.parsedModuleMetadata.variant('api').dependencies.empty
-            assert module.parsedPom.scopes.compile == null
+            assert parsedModuleMetadata.variant('api').dependencies.empty
+            assert parsedPom.scopes.compile == null
         } else {
-            assert module.parsedModuleMetadata.variant('api').dependencies*.coords as Set == expected as Set
-            assert module.parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
-            module.parsedPom.scopes.compile.assertDependsOn(expected)
+            assert parsedModuleMetadata.variant('api').dependencies*.coords as Set == expected as Set
+            assert parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
+            parsedPom.scopes.compile.assertDependsOn(expected)
         }
     }
 
     @Override
     void assertRuntimeDependencies(String... expected) {
         if (expected.length == 0) {
-            assert module.parsedModuleMetadata.variant('runtime').dependencies.empty
-            assert module.parsedPom.scopes.runtime == null
+            assert parsedModuleMetadata.variant('runtime').dependencies.empty
+            assert parsedPom.scopes.runtime == null
         } else {
-            assert module.parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
-            module.parsedPom.scopes.runtime.assertDependsOn(expected)
+            assert parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
+            parsedPom.scopes.runtime.assertDependsOn(expected)
         }
     }
 
     private String artifact(String classifier = null, String extension) {
-        def artifactName = "${module.artifactId}-${module.publishArtifactVersion}"
+        def artifactName = "${artifactId}-${publishArtifactVersion}"
         if (classifier != null) {
             artifactName += "-${classifier}"
         }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -15,12 +15,12 @@
  */
 
 package org.gradle.api.publish.maven
+
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.maven.MavenLocalRepository
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 import spock.lang.Ignore
-import spock.lang.Issue
 
 /**
  * Tests “simple” maven publishing scenarios
@@ -87,7 +87,7 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
         resolveArtifacts(module) == []
     }
 
-    def "can publish simple jar"() {
+    def "can publish simple component"() {
         given:
         using m2
         def repoModule = mavenRepo.module('group', 'root', '1.0')
@@ -137,44 +137,6 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
 
         and:
         resolveArtifacts(repoModule) == ['root-1.0.jar']
-    }
-
-    @Issue('GRADLE-1574')
-    def "publishes wildcard exclusions for a non-transitive dependency"() {
-        given:
-        using m2
-        def repoModule = mavenRepo.module('group', 'root', '1.0')
-        def localModule = localM2Repo.module('group', 'root', '1.0')
-
-        and:
-        settingsFile << "rootProject.name = 'root'"
-        buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java'
-
-            group = 'group'
-            version = '1.0'
-
-            dependencies {
-                compile ('commons-collections:commons-collections:3.2.2') { transitive = false }
-            }
-
-            publishing {
-                publications {
-                    maven(MavenPublication) {
-                        from components.java
-                    }
-                }
-            }
-        """
-
-        when:
-        succeeds 'publishToMavenLocal'
-
-        then: "wildcard exclusions are applied to the dependency"
-        def pom = localModule.parsedPom
-        def exclusions = pom.scopes.compile.dependencies['commons-collections:commons-collections:3.2.2'].exclusions
-        exclusions.size() == 1 && exclusions[0].groupId=='*' && exclusions[0].artifactId=='*'
     }
 
     def "can publish to custom maven local repo defined in settings.xml"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCoordinatesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCoordinatesIntegTest.groovy
@@ -19,7 +19,7 @@ import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTes
 
 class MavenPublishCoordinatesIntegTest extends AbstractMavenPublishIntegTest {
 
-    def "can publish single jar with specified coordinates"() {
+    def "can publish with specified coordinates"() {
         given:
         using m2
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -18,10 +18,12 @@ package org.gradle.api.publish.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.maven.MavenDependencyExclusion
+import org.gradle.test.fixtures.maven.MavenPublishedJavaModule
 import spock.lang.Unroll
 
 class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
     def mavenModule = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
+    def javaLibrary = new MavenPublishedJavaModule(mavenModule)
 
     def "can publish java-library with no dependencies"() {
         createBuildScripts("""
@@ -63,8 +65,8 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         run "publish"
 
         then:
-        mavenModule.assertPublishedAsJavaModule()
-        mavenModule.parsedPom.scopes.isEmpty()
+        javaLibrary.assertPublished()
+        javaLibrary.assertNoDependencies()
 
         and:
         resolveArtifacts(mavenModule) == ["publishTest-1.9.jar"]

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -45,6 +45,37 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         resolveArtifacts(mavenModule) == ["publishTest-1.9.jar"]
     }
 
+    def "can publish java-library with no dependencies using Gradle metadata"() {
+        executer.withArgument("-Dorg.gradle.internal.publishJavaModuleMetadata")
+        mavenModule.withModuleMetadata()
+
+        createBuildScripts("""
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        mavenModule.assertPublishedAsJavaModule()
+        mavenModule.parsedPom.scopes.isEmpty()
+
+        and:
+        resolveArtifacts(mavenModule) == ["publishTest-1.9.jar"]
+
+        when:
+        executer.withArgument("-Dorg.gradle.internal.preferGradleMetadata")
+
+        then:
+        resolveArtifacts(mavenModule) == ["publishTest-1.9.jar"]
+    }
+
     def "can publish java-library with dependencies"() {
         given:
         createBuildScripts("""

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -18,12 +18,10 @@ package org.gradle.api.publish.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.maven.MavenDependencyExclusion
-import org.gradle.test.fixtures.maven.MavenPublishedJavaModule
 import spock.lang.Unroll
 
 class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
-    def mavenModule = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
-    def javaLibrary = new MavenPublishedJavaModule(mavenModule)
+    def javaLibrary = javaLibrary(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
 
     def "can publish java-library with no dependencies"() {
         useModuleMetadata()
@@ -46,7 +44,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         javaLibrary.assertNoDependencies()
 
         and:
-        resolveArtifacts(mavenModule) == ["publishTest-1.9.jar"]
+        resolveArtifacts(javaLibrary) == ["publishTest-1.9.jar"]
     }
 
     def "can publish java-library with dependencies"() {
@@ -79,7 +77,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         javaLibrary.assertRuntimeDependencies("org.test:bar:1.0")
 
         and:
-        resolveArtifacts(mavenModule) == ["bar-1.0.jar", "foo-1.0.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(javaLibrary) == ["bar-1.0.jar", "foo-1.0.jar", "publishTest-1.9.jar"]
     }
 
     def "can publish java-library with dependencies and excludes"() {
@@ -120,17 +118,18 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         run "publish"
 
         then:
-        mavenModule.assertPublishedAsJavaModule()
+        javaLibrary.assertPublishedAsJavaModule()
 
-        mavenModule.parsedPom.scopes.keySet() == ["compile"] as Set
-        mavenModule.parsedPom.scopes.compile.assertDependsOn("commons-collections:commons-collections:3.2.2", "commons-io:commons-io:1.4", "org.springframework:spring-core:2.5.6", "commons-beanutils:commons-beanutils:1.8.3", "commons-dbcp:commons-dbcp:1.4", "org.apache.camel:camel-jackson:2.15.3")
-        assert mavenModule.parsedPom.scopes.compile.hasDependencyExclusion("org.springframework:spring-core:2.5.6", new MavenDependencyExclusion("commons-logging", "commons-logging"))
-        assert mavenModule.parsedPom.scopes.compile.hasDependencyExclusion("commons-beanutils:commons-beanutils:1.8.3", new MavenDependencyExclusion("commons-logging", "*"))
-        assert mavenModule.parsedPom.scopes.compile.hasDependencyExclusion("commons-dbcp:commons-dbcp:1.4", new MavenDependencyExclusion("*", "*"))
-        assert mavenModule.parsedPom.scopes.compile.hasDependencyExclusion("org.apache.camel:camel-jackson:2.15.3", new MavenDependencyExclusion("*", "camel-core"))
+        // TODO:DAZ Verify excludes in .module file
+        javaLibrary.parsedPom.scopes.keySet() == ["compile"] as Set
+        javaLibrary.parsedPom.scopes.compile.assertDependsOn("commons-collections:commons-collections:3.2.2", "commons-io:commons-io:1.4", "org.springframework:spring-core:2.5.6", "commons-beanutils:commons-beanutils:1.8.3", "commons-dbcp:commons-dbcp:1.4", "org.apache.camel:camel-jackson:2.15.3")
+        assert javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("org.springframework:spring-core:2.5.6", new MavenDependencyExclusion("commons-logging", "commons-logging"))
+        assert javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("commons-beanutils:commons-beanutils:1.8.3", new MavenDependencyExclusion("commons-logging", "*"))
+        assert javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("commons-dbcp:commons-dbcp:1.4", new MavenDependencyExclusion("*", "*"))
+        assert javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("org.apache.camel:camel-jackson:2.15.3", new MavenDependencyExclusion("*", "camel-core"))
 
         and:
-        resolveArtifacts(mavenModule) == [
+        resolveArtifacts(javaLibrary) == [
             "camel-jackson-2.15.3.jar", "commons-beanutils-1.8.3.jar", "commons-collections-3.2.2.jar", "commons-dbcp-1.4.jar", "commons-io-1.4.jar",
             "jackson-annotations-2.4.0.jar", "jackson-core-2.4.3.jar", "jackson-databind-2.4.3.jar", "jackson-module-jaxb-annotations-2.4.3.jar",
             "publishTest-1.9.jar", "spring-core-2.5.6.jar"]
@@ -163,8 +162,8 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         javaLibrary.withClassifiedArtifact("source", "jar").assertPublished()
 
         and:
-        resolveArtifacts(mavenModule) == ["publishTest-1.9.jar"]
-        resolveArtifacts(mavenModule, [classifier: 'source']) == ["publishTest-1.9-source.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(javaLibrary) == ["publishTest-1.9.jar"]
+        resolveArtifacts(javaLibrary, [classifier: 'source']) == ["publishTest-1.9-source.jar", "publishTest-1.9.jar"]
     }
 
     @Unroll("'#gradleConfiguration' dependencies end up in '#mavenScope' scope with '#plugin' plugin")

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -278,12 +278,17 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         return null;
     }
 
+    // TODO:DAZ The module metadata file should never be in the artifacts collection to start with
     private Set<MavenArtifact> getUnclassifiedArtifactsWithExtension() {
         return CollectionUtils.filter(mavenArtifacts, new Spec<MavenArtifact>() {
             public boolean isSatisfiedBy(MavenArtifact mavenArtifact) {
-                return hasNoClassifier(mavenArtifact) && hasExtension(mavenArtifact);
+                return hasNoClassifier(mavenArtifact) && hasExtension(mavenArtifact) && isNotModuleMetadata(mavenArtifact);
             }
         });
+    }
+
+    private boolean isNotModuleMetadata(MavenArtifact artifact) {
+        return !artifact.getExtension().equals("module");
     }
 
     private boolean hasNoClassifier(MavenArtifact element) {

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -69,7 +69,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
             configurations {
                 resolve {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
+                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_RUNTIME))
                     }
                 }
             }

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.test.fixtures.maven.MavenFileModule
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
 
-class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
+abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
 
     protected def resolveArtifact(MavenFileModule module, def extension, def classifier) {
         doResolveArtifacts("""
@@ -49,7 +49,7 @@ class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
             def type = it.type == null ? 'jar' : it.type
             dependencies += """
             artifact {
-                name = '${sq(module.artifactId)}' // TODO:DAZ Get NPE if name isn't set
+                name = '${sq(module.artifactId)}'
                 classifier = '${it.classifier}'
                 type = '${type}'
             }
@@ -67,7 +67,11 @@ class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
         settingsFile.text = "rootProject.name = 'resolve'"
         buildFile.text = """
             configurations {
-                resolve
+                resolve {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
+                    }
+                }
             }
             repositories {
                 maven { url "${mavenRepo.uri}" }

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -79,6 +79,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
             }
             $dependencies
             task resolveArtifacts(type: Sync) {
+                outputs.upToDateWhen { false }
                 from configurations.resolve
                 into "artifacts"
             }

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -17,16 +17,22 @@ package org.gradle.integtests.fixtures.publish.maven
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.maven.MavenFileModule
+import org.gradle.test.fixtures.maven.MavenModule
+import org.gradle.test.fixtures.maven.MavenPublishedJavaModule
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
 
 abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
 
-    def useModuleMetadata = false
+    def resolveModuleMetadata = false
+
+    protected static MavenPublishedJavaModule javaLibrary(MavenFileModule mavenFileModule) {
+        return new MavenPublishedJavaModule(mavenFileModule)
+    }
 
     protected void useModuleMetadata() {
         executer.withArgument("-Dorg.gradle.internal.publishJavaModuleMetadata")
-        useModuleMetadata = true
+        resolveModuleMetadata = true
     }
 
     protected def resolveArtifact(MavenFileModule module, def extension, def classifier) {
@@ -37,7 +43,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
 """)
     }
 
-    protected def resolveArtifacts(MavenFileModule module) {
+    protected def resolveArtifacts(MavenModule module) {
         resolveArtifacts("""
     dependencies {
         resolve group: '${sq(module.groupId)}', name: '${sq(module.artifactId)}', version: '${sq(module.version)}'
@@ -45,7 +51,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
 """)
     }
 
-    protected def resolveArtifacts(MavenFileModule module, Map... additionalArtifacts) {
+    protected def resolveArtifacts(MavenModule module, Map... additionalArtifacts) {
         def dependencies = """
     dependencies {
         resolve group: '${sq(module.groupId)}', name: '${sq(module.artifactId)}', version: '${sq(module.version)}'
@@ -72,7 +78,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
     protected def resolveArtifacts(String dependencies) {
         def resolvedArtifacts = doResolveArtifacts(dependencies)
 
-        if (useModuleMetadata) {
+        if (resolveModuleMetadata) {
             executer.withArgument("-Dorg.gradle.internal.preferGradleMetadata")
             def moduleArtifacts = doResolveArtifacts(dependencies)
             assert resolvedArtifacts == moduleArtifacts

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/ComponentWithVariantsAdapter.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/ComponentWithVariantsAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.java;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.component.ComponentWithVariants;
+import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.UsageContext;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+public class ComponentWithVariantsAdapter implements SoftwareComponentInternal, ComponentWithVariants {
+    private final SoftwareComponentInternal delegate;
+
+    @Inject
+    public ComponentWithVariantsAdapter(SoftwareComponentInternal delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public Set<? extends UsageContext> getUsages() {
+        return delegate.getUsages();
+    }
+
+    @Override
+    public Set<? extends SoftwareComponent> getVariants() {
+        return ImmutableSet.of();
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -35,6 +35,8 @@ import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact;
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact;
 import org.gradle.api.internal.component.BuildableJavaComponent;
 import org.gradle.api.internal.component.ComponentRegistry;
+import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.java.ComponentWithVariantsAdapter;
 import org.gradle.api.internal.java.JavaLibrary;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -300,7 +302,11 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         addJar(runtimeConfiguration, jarArtifact);
         addRuntimeVariants(runtimeElementsConfiguration, jarArtifact, javaCompile, processResources);
 
-        project.getComponents().add(objectFactory.newInstance(JavaLibrary.class, project.getConfigurations(), jarArtifact));
+        SoftwareComponentInternal javaLibrary = objectFactory.newInstance(JavaLibrary.class, project.getConfigurations(), jarArtifact);
+        if (System.getProperty("org.gradle.internal.publishJavaModuleMetadata") != null) {
+            javaLibrary = objectFactory.newInstance(ComponentWithVariantsAdapter.class, javaLibrary);
+        }
+        project.getComponents().add(javaLibrary);
     }
 
     private void addJar(Configuration configuration, ArchivePublishArtifact jarArtifact) {


### PR DESCRIPTION
Allows the `maven-publish` plugin to produce a Gradle `.module` metadata file when publishing a Java component. This feature is not yet enabled by default, and must be explicitly enabled by the magic system property `org.gradle.internal.publishJavaModuleMetadata`.