### PR TITLE
Allow updating of existing dependencies in component metadata rules

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
@@ -44,4 +44,11 @@ public interface DependencyMetadata {
      * which usually expresses what API level of the module you are compatible with.
      */
     String getVersion();
+
+    /**
+     * Adjust the version constraints of the dependency.
+     *
+     * @param version version in string notation
+     */
+    DependencyMetadata setVersion(String version);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataAdapter.java
@@ -33,6 +33,10 @@ public class DependencyMetadataAdapter implements DependencyMetadata {
         return container.get(originalIndex);
     }
 
+    private void updateMetadata(org.gradle.internal.component.model.DependencyMetadata modifiedMetadata) {
+        container.set(originalIndex, modifiedMetadata);
+    }
+
     @Override
     public String getGroup() {
         return getOriginalMetadata().getRequested().getGroup();
@@ -46,5 +50,11 @@ public class DependencyMetadataAdapter implements DependencyMetadata {
     @Override
     public String getVersion() {
         return getOriginalMetadata().getRequested().getVersion();
+    }
+
+    @Override
+    public DependencyMetadata setVersion(String version) {
+        updateMetadata(getOriginalMetadata().withRequestedVersion(version));
+        return this;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataImpl.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyMetadataImpl.java
@@ -43,4 +43,10 @@ public class DependencyMetadataImpl implements DependencyMetadata {
     public String getVersion() {
         return this.version;
     }
+
+    @Override
+    public DependencyMetadata setVersion(String version) {
+        this.version = version;
+        return this;
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -55,6 +55,32 @@ class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata[0].requested.version == "1.0"
     }
 
+    def "add via string id with action is propagate to the underlying dependency list"() {
+        when:
+        adapter.add("org.gradle.test:module1") {
+            it.version = '1.0'
+        }
+
+        then:
+        dependenciesMetadata.size() == 1
+        dependenciesMetadata[0].requested.group == "org.gradle.test"
+        dependenciesMetadata[0].requested.name == "module1"
+        dependenciesMetadata[0].requested.version == "1.0"
+    }
+
+    def "add via map id with action propagate to the underlying dependency list"() {
+        when:
+        adapter.add(group: "org.gradle.test", name: "module1") {
+            it.version = '1.0'
+        }
+
+        then:
+        dependenciesMetadata.size() == 1
+        dependenciesMetadata[0].requested.group == "org.gradle.test"
+        dependenciesMetadata[0].requested.name == "module1"
+        dependenciesMetadata[0].requested.version == "1.0"
+    }
+
     def "remove is propagated to the underlying dependency list"() {
         given:
         fillDependencyList(1)
@@ -127,6 +153,20 @@ class DependenciesMetadataAdapterTest extends Specification {
         then:
         dependencyMetadata instanceof DependencyMetadataAdapter
         !(dependencyMetadata instanceof DependencyMetadataImpl)
+    }
+
+    def "can modify underlying list items"() {
+        given:
+        fillDependencyList(1)
+
+        when:
+        adapter.get(0).version = "2.0"
+
+        then:
+        dependenciesMetadata.size() == 1
+        dependenciesMetadata[0].requested.group == "org.gradle.test"
+        dependenciesMetadata[0].requested.name == "module1"
+        dependenciesMetadata[0].requested.version == "2.0"
     }
 
     private fillDependencyList(int size) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyMetadataRulesTest.groovy
@@ -129,6 +129,28 @@ class DependencyMetadataRulesTest extends Specification {
     }
 
     @Unroll
+    def "dependencies of selected variant are modifiable in dependency metadata rule for #metadataType metadata"() {
+        given:
+        addDependency(metadataImplementation, "org.test", "toModify", "1.0")
+        def rule = { dependencies ->
+            assert dependencies.size() == 1
+            dependencies[0].version = "2.0"
+        }
+
+        when:
+        metadataImplementation.addDependencyMetadataRule("default", rule, instantiator, notationParser)
+
+        then:
+        selectTargetConfigurationMetadata(metadataImplementation).dependencies[0].requested.version == "2.0"
+
+        where:
+        metadataType | metadataImplementation
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
+    }
+
+    @Unroll
     def "dependencies added in dependency metadata rules are added to dependency list for #metadataType metadata"() {
         given:
         def rule = { dependencies ->


### PR DESCRIPTION
This is a follow up to #3158.

It adds the functionality of modifying exiting dependencies in component metadata rules. It allows to modify the `version` (version constraint in string notation) and `optional` properties of an existing dependency.