### PR TITLE
Use an `AtomicBoolean` instead of `ThreadLocal`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/metaobject/ConfigureDelegate.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/metaobject/ConfigureDelegate.java
@@ -21,15 +21,12 @@ import groovy.lang.GroovyObjectSupport;
 import groovy.lang.MissingMethodException;
 import org.gradle.api.internal.DynamicObjectUtil;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class ConfigureDelegate extends GroovyObjectSupport {
     protected final DynamicObject _owner;
     protected final DynamicObject _delegate;
-    private final ThreadLocal<Boolean> _configuring = new ThreadLocal<Boolean>() {
-        @Override
-        protected Boolean initialValue() {
-            return false;
-        }
-    };
+    private final AtomicBoolean _configuring = new AtomicBoolean(false);
 
     public ConfigureDelegate(Closure configureClosure, Object delegate) {
         _owner = DynamicObjectUtil.asDynamicObject(configureClosure.getOwner());


### PR DESCRIPTION
### Context

This changes the code in `ConfigureDelegate` to use an `AtomicBoolean` instead
of a `ThreadLocal<Boolean>`. The rationale for this change is that the current
code leaks memory. On some scenarios, after a single build run, the thread
local map contains more than 60MB of memory just to retain booleans that will
never ever be used.

Instead, we're now using an `AtomicBoolean`. The semantics are going to be
different, but in any case if code is called concurrently, all bets are off.

