### PR TITLE
Revert dependency resolution handling that fails build for unexpected error in repository

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -182,10 +182,10 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
-    def "fails build if HTTP connection #reason when resolving metadata"() {
+    def "resolves metadata if HTTP connection #reason for first repository but succeeds for second repository"() {
         given:
         MavenHttpRepository backupMavenHttpRepo = new MavenHttpRepository(server, '/repo-2', new MavenFileRepository(file('maven-repo-2')))
-        publishMavenModule(backupMavenHttpRepo, 'a')
+        def moduleInFallbackRepo = publishMavenModule(backupMavenHttpRepo, 'a')
 
         buildFile << """
             ${mavenRepository(mavenHttpRepo)}
@@ -196,16 +196,17 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
 
         when:
         moduleA.pom."$action"()
-        fails('resolve')
+        moduleInFallbackRepo.pom.expectGet()
+        moduleInFallbackRepo.artifact.expectGet()
+        succeeds('resolve')
 
         then:
-        "$outcome"(moduleA)
-        !downloadedLibsDir.isDirectory()
+        downloadedLibsDir.assertContainsDescendants('a-1.0.jar')
 
         where:
-        reason                          | action              | outcome
-        'exceeds timeout'               | 'expectGetBlocking' | 'assertDependencyMetaDataReadTimeout'
-        'returns internal server error' | 'expectGetBroken'   | 'assertDependencyMetaDataInternalServerError'
+        reason                          | action
+        'exceeds timeout'               | 'expectGetBlocking'
+        'returns internal server error' | 'expectGetBroken'
     }
 
     @Unroll
@@ -237,10 +238,10 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
-    def "fails build if HTTP connection #reason when resolving dynamic version"() {
+    def "resolves dynamic version if HTTP connection #reason for first repository but succeeds for second repository"() {
         given:
         MavenHttpRepository backupMavenHttpRepo = new MavenHttpRepository(server, '/repo-2', new MavenFileRepository(file('maven-repo-2')))
-        publishMavenModule(backupMavenHttpRepo, 'a')
+        def module = publishMavenModule(backupMavenHttpRepo, 'a')
 
         buildFile << """
             ${mavenRepository(mavenHttpRepo)}
@@ -251,16 +252,18 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
 
         when:
         mavenHttpRepo.getModuleMetaData('group', 'a')"$action"()
-        fails('resolve')
+        backupMavenHttpRepo.getModuleMetaData('group', 'a').expectGet()
+        module.pom.expectGet()
+        module.artifact.expectGet()
+        succeeds('resolve')
 
         then:
-        "$outcome"('group', 'a', '1.+')
-        !downloadedLibsDir.isDirectory()
+        downloadedLibsDir.assertContainsDescendants('a-1.0.jar')
 
         where:
-        reason                          | action              | outcome
-        'exceeds timeout'               | 'expectGetBlocking' | 'assertDependencyListingReadTimeout'
-        'returns internal server error' | 'expectGetBroken'   | 'assertDependencyListingInternalServerError'
+        reason                          | action
+        'exceeds timeout'               | 'expectGetBlocking'
+        'returns internal server error' | 'expectGetBroken'
     }
 
     private String mavenRepository(MavenRepository repo) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
@@ -361,7 +361,7 @@ dependencies {
         checkResolve "group:projectA:1.+": "group:projectA:1.2"
     }
 
-    def "fails on broken directory listing in subsequent resolution"() {
+    def "recovers from broken directory listing in subsequent resolution"() {
         def repo1 = ivyHttpRepo("repo1")
         def repo2 = ivyHttpRepo("repo2")
 
@@ -380,17 +380,14 @@ dependencies {
 
         and: "projectA is broken in repo1"
         repo1.directoryList("group", "projectA").expectGetBroken()
+        expectGetDynamicRevision(projectA11)
 
         then:
-        fails "checkDeps"
-        failure.assertHasCause "Could not resolve group:projectA:1.+."
-        failure.assertHasCause "Could not list versions"
-        failure.assertHasCause "Could not GET '$repo1.uri/group/projectA/'"
+        checkResolve "group:projectA:1.+": "group:projectA:1.1"
 
         when:
         server.resetExpectations()
         expectGetDynamicRevision(projectA12)
-        expectGetDynamicRevisionMetadata(projectA11)
 
         then:
         checkResolve "group:projectA:1.+": "group:projectA:1.2"
@@ -1217,13 +1214,9 @@ dependencies {
     }
 
     def expectGetDynamicRevision(IvyHttpModule module) {
-        expectGetDynamicRevisionMetadata(module)
-        module.jar.expectGet()
-    }
-
-    def expectGetDynamicRevisionMetadata(IvyHttpModule module) {
         expectListVersions(module)
         module.ivy.expectGet()
+        module.jar.expectGet()
     }
 
     private expectListVersions(IvyHttpModule module) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -156,7 +156,7 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         failure.assertHasCause("Could not parse POM $corruptLocalPom.absolutePath")
 
         where:
-        remoteStatus << ['valid', 'invalid']
+        remoteStatus << ['invalid']
     }
 
     def "mavenLocal is ignored if no local maven repository exists"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -114,9 +114,6 @@ public class DynamicVersionResolver {
 
         // A first pass to do local resolves only
         RepositoryChainModuleResolution best = findLatestModule(queue, failures, missing);
-        if (!failures.isEmpty()) {
-            return null;
-        }
         if (best != null) {
             return best;
         }
@@ -140,7 +137,6 @@ public class DynamicVersionResolver {
             switch (request.resolvedVersionMetadata.getState()) {
                 case Failed:
                     failures.add(request.resolvedVersionMetadata.getFailure());
-                    queue.clear();
                     break;
                 case Missing:
                 case Unknown:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -79,54 +79,66 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
     private void resolveModule(ModuleComponentIdentifier identifier, ComponentOverrideMetadata componentOverrideMetadata, BuildableComponentResolveResult result) {
         LOGGER.debug("Attempting to resolve component for {} using repositories {}", identifier, repositoryNames);
 
+        List<Throwable> errors = new ArrayList<Throwable>();
+
         List<ComponentMetaDataResolveState> resolveStates = new ArrayList<ComponentMetaDataResolveState>();
         for (ModuleComponentRepository repository : repositories) {
             resolveStates.add(new ComponentMetaDataResolveState(identifier, componentOverrideMetadata, repository, versionedComponentChooser));
         }
 
-        try {
-            final RepositoryChainModuleResolution latestResolved = findBestMatch(resolveStates);
-            if (latestResolved == null) {
-                for (ComponentMetaDataResolveState resolveState : resolveStates) {
-                    resolveState.applyTo(result);
-                }
-                result.notFound(identifier);
-            } else {
-                LOGGER.debug("Using {} from {}", latestResolved.module.getId(), latestResolved.repository);
-                result.resolved(metaDataFactory.transform(latestResolved));
+        final RepositoryChainModuleResolution latestResolved = findBestMatch(resolveStates, errors);
+        if (latestResolved != null) {
+            LOGGER.debug("Using {} from {}", latestResolved.module.getId(), latestResolved.repository);
+            for (Throwable error : errors) {
+                LOGGER.debug("Discarding resolve failure.", error);
             }
-        } catch (Throwable error) {
-            result.failed(new ModuleVersionResolveException(identifier, error));
+
+            result.resolved(metaDataFactory.transform(latestResolved));
+            return;
+        }
+        if (!errors.isEmpty()) {
+            result.failed(new ModuleVersionResolveException(identifier, errors));
+        } else {
+            for (ComponentMetaDataResolveState resolveState : resolveStates) {
+                resolveState.applyTo(result);
+            }
+            result.notFound(identifier);
         }
     }
 
-    private RepositoryChainModuleResolution findBestMatch(List<ComponentMetaDataResolveState> resolveStates) throws Throwable {
+    private RepositoryChainModuleResolution findBestMatch(List<ComponentMetaDataResolveState> resolveStates, Collection<Throwable> failures) {
         LinkedList<ComponentMetaDataResolveState> queue = new LinkedList<ComponentMetaDataResolveState>();
         queue.addAll(resolveStates);
 
         LinkedList<ComponentMetaDataResolveState> missing = new LinkedList<ComponentMetaDataResolveState>();
 
         // A first pass to do local resolves only
-        RepositoryChainModuleResolution best = findBestMatch(queue, missing);
+        RepositoryChainModuleResolution best = findBestMatch(queue, failures, missing);
         if (best != null) {
             return best;
         }
 
-        // Nothing found locally - try a remote search for all resolve states that were not yet searched remotely
+        // Nothing found - do a second pass
         queue.addAll(missing);
         missing.clear();
-        return findBestMatch(queue, missing);
+        return findBestMatch(queue, failures, missing);
     }
 
-    private RepositoryChainModuleResolution findBestMatch(LinkedList<ComponentMetaDataResolveState> queue, Collection<ComponentMetaDataResolveState> missing) throws Throwable {
+    private RepositoryChainModuleResolution findBestMatch(LinkedList<ComponentMetaDataResolveState> queue, Collection<Throwable> failures, Collection<ComponentMetaDataResolveState> missing) {
         RepositoryChainModuleResolution best = null;
         while (!queue.isEmpty()) {
             ComponentMetaDataResolveState request = queue.removeFirst();
             BuildableModuleComponentMetaDataResolveResult metaDataResolveResult;
-            metaDataResolveResult = request.resolve();
+            try {
+                metaDataResolveResult = request.resolve();
+            } catch (Throwable t) {
+                failures.add(t);
+                continue;
+            }
             switch (metaDataResolveResult.getState()) {
                 case Failed:
-                    throw metaDataResolveResult.getFailure();
+                    failures.add(metaDataResolveResult.getFailure());
+                    break;
                 case Missing:
                     // Queue this up for checking again later
                     if (request.canMakeFurtherAttempts()) {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/ivy/AbstractIvyRemoteRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/ivy/AbstractIvyRemoteRepoResolveIntegrationTest.groovy
@@ -179,9 +179,6 @@ abstract class AbstractIvyRemoteRepoResolveIntegrationTest extends AbstractInteg
         def missingModuleB = repo1.module('group', 'projectB')
         def moduleB = repo2.module('group', 'projectB')
         moduleB.publish()
-        def brokenModuleC = repo1.module('group', 'projectC')
-        def moduleC = repo2.module('group', 'projectC')
-        moduleC.publish()
 
         and:
         buildFile << """
@@ -201,11 +198,11 @@ abstract class AbstractIvyRemoteRepoResolveIntegrationTest extends AbstractInteg
                 }
             }
             dependencies {
-                compile 'group:projectA:1.0', 'group:projectB:1.0', 'group:projectC:1.0'
+                compile 'group:projectA:1.0', 'group:projectB:1.0'
             }
             task listJars {
                 doLast {
-                    assert configurations.compile.collect { it.name } == ['projectA-1.0.jar', 'projectB-1.0.jar', 'projectC-1.0.jar']
+                    assert configurations.compile.collect { it.name } == ['projectA-1.0.jar', 'projectB-1.0.jar']
                 }
             }
         """
@@ -221,20 +218,12 @@ abstract class AbstractIvyRemoteRepoResolveIntegrationTest extends AbstractInteg
         moduleB.ivy.expectDownload()
         moduleB.jar.expectDownload()
 
-        // Handles from broken url in repo1 (but does not cache)
-        brokenModuleC.ivy.expectDownloadBroken()
-
-        moduleC.ivy.expectDownload()
-        moduleC.jar.expectDownload()
 
         then:
         succeeds('listJars')
 
         when:
         server.resetExpectations()
-        // Will always re-attempt a broken repository
-        brokenModuleC.ivy.expectMetadataRetrieveBroken()
-        // No extra calls for cached dependencies
 
         then:
         succeeds('listJars')


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle/issues/3335

Some HTTP repositories do not respond with expected HTTP error codes and therefore fail the build.

I believe the test `DependencyUnresolvedModuleIntegrationTest."fails build if HTTP connection #reason when resolving artifact"` still behaves as expected. If we can resolve the metadata but not the artifact then we fail the build.