### PR TITLE
Ignore non-file URLs for now

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
@@ -59,10 +59,12 @@ public class ClasspathUtil {
             @Override
             public void visitClassPath(URL[] classPath) {
                 for (URL url : classPath) {
-                    try {
-                        implementationClassPath.add(new File(toURI(url)));
-                    } catch (URISyntaxException e) {
-                        throw new UncheckedException(e);
+                    if (url.getProtocol() != null && url.getProtocol().equals("file")) {
+                        try {
+                            implementationClassPath.add(new File(toURI(url)));
+                        } catch (URISyntaxException e) {
+                            throw new UncheckedException(e);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Temporary workaround for issue #2483 

Simply ignore non-file protocol URLs from the classpath. Until support for all kids of classpath entries URLs is in
