### PR TITLE
Only blacklist repositories on HTTP timeout

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryBlacklister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryBlacklister.java
@@ -18,9 +18,8 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.gradle.api.UncheckedIOException;
 
-import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.Set;
 
 public class ConnectionFailureRepositoryBlacklister implements RepositoryBlacklister {
@@ -40,7 +39,7 @@ public class ConnectionFailureRepositoryBlacklister implements RepositoryBlackli
             return true;
         }
 
-        if (isRootCauseIOException(throwable)) {
+        if (isCriticalFailure(throwable)) {
             blacklistedRepositories.add(repositoryId);
             return true;
         }
@@ -53,8 +52,12 @@ public class ConnectionFailureRepositoryBlacklister implements RepositoryBlackli
         return blacklistedRepositories;
     }
 
-    private boolean isRootCauseIOException(Throwable throwable) {
+    private static boolean isCriticalFailure(Throwable throwable) {
+        return isTimeoutException(throwable);
+    }
+    private static boolean isTimeoutException(Throwable throwable) {
         Throwable rootCause = ExceptionUtils.getRootCause(throwable);
-        return rootCause instanceof IOException || rootCause instanceof UncheckedIOException;
+        //http://hc.apache.org/httpclient-3.x/exception-handling.html
+        return rootCause instanceof InterruptedIOException;
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryBlacklisterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryBlacklisterTest.groovy
@@ -25,11 +25,11 @@ class ConnectionFailureRepositoryBlacklisterTest extends Specification {
 
     @Subject RepositoryBlacklister blacklister = new ConnectionFailureRepositoryBlacklister()
 
-    def "blacklists repository for normal IOException"() {
+    def "blacklists repository for timeout exception"() {
         given:
         def repositoryId1 = 'abc'
         def repositoryId2 = 'def'
-        def exception = createIOException('Read time out')
+        def exception = createDummyTimeoutException('Read time out')
 
         when:
         boolean blacklisted = blacklister.blacklistRepository(repositoryId1, exception)
@@ -76,8 +76,8 @@ class ConnectionFailureRepositoryBlacklisterTest extends Specification {
         createNestedException(new HttpErrorStatusCodeException(method, source, statusCode, reason))
     }
 
-    static RuntimeException createIOException(String message) {
-        createNestedException(new IOException(message))
+    static RuntimeException createDummyTimeoutException(String message) {
+        createNestedException(new InterruptedIOException(message))
     }
 
     static RuntimeException createNestedException(Throwable t) {


### PR DESCRIPTION
The new repository blacklisting functionality introduced in Gradle 4.3 (#3047) is overly aggressive, and will blacklist a repository on any `IOException` thrown when accessing a repository. For a blacklisted repository, all subsequent requests within the same build will be assumed to fail.

A number of users have reported this as breaking their builds (#3335 #3379 #3299). While we would like to abort builds more eagerly on failure, there are cases where an exception does not indicate a critical failure with the repository, and we should continue to use that repository when resolving other modules.

This PR makes the blacklisting much more lenient, by only blacklisting a repository that failed with a timeout.