### PR TITLE
Only abort repository lookups on critical resolution failure

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyHttpRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyHttpRepoResolveIntegrationTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.test.fixtures.server.RepositoryServer
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
 import org.junit.Rule
 
+import static org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpTimeoutSettings.SOCKET_TIMEOUT_SYSTEM_PROPERTY
+
 class IvyHttpRepoResolveIntegrationTest extends AbstractIvyRemoteRepoResolveIntegrationTest {
 
     @Rule
@@ -105,5 +107,59 @@ class IvyHttpRepoResolveIntegrationTest extends AbstractIvyRemoteRepoResolveInte
 
         then:
         succeeds 'listJars'
+    }
+
+    void "skip subsequent Ivy repositories on timeout and recovers for later resolution"() {
+        given:
+        executer.withArgument("-D${SOCKET_TIMEOUT_SYSTEM_PROPERTY}=1000")
+        def repo1 = server.getRemoteIvyRepo("/repo1")
+        def repo2 = server.getRemoteIvyRepo("/repo2")
+        def module1 = repo1.module('group', 'projectA').publish()
+        def module2 = repo2.module('group', 'projectA').publish()
+
+        and:
+        buildFile << """
+            repositories {
+                ivy {
+                    url "${repo1.uri}"
+                    $server.validCredentials
+                }
+                ivy {
+                    url "${repo2.uri}"
+                    $server.validCredentials
+                }
+            }
+            configurations {
+                compile
+            }
+            dependencies {
+                compile 'group:projectA:1.0'
+            }
+            task listJars {
+                doLast {
+                    assert configurations.compile.collect { it.name } == ['projectA-1.0.jar']
+                }
+            }
+        """
+
+        when:
+        // Timeout connecting to repo1: do not continue search to repo2
+        module1.ivy.expectGetBlocking()
+
+        then:
+        fails'listJars'
+        failureHasCause("Could not resolve group:projectA:1.0")
+        failureHasCause("Could not GET '$repo1.uri/group/projectA/1.0/ivy-1.0.xml'")
+        failureHasCause('Read timed out')
+
+        when:
+        server.resetExpectations()
+        module1.ivy.expectGetMissing()
+        module1.jar.expectHeadMissing()
+        module2.ivy.expectGet()
+        module2.jar.expectDownload()
+
+        then:
+        succeeds('listJars')
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 
+import static org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpTimeoutSettings.SOCKET_TIMEOUT_SYSTEM_PROPERTY
+
 class MavenDynamicResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
 
     def "can resolve snapshot versions with version range"() {
@@ -298,42 +300,6 @@ Searched in the following locations:
         file('libs').assertHasDescendants('projectA-1.1.jar')
     }
 
-    def "dynamic version fails on broken module in one repository"() {
-        given:
-        def repo1 = mavenHttpRepo("repo1")
-        def repo2 = mavenHttpRepo("repo2")
-        def projectA1 = repo1.module('group', 'projectA', '1.1').publish()
-        def projectA2 = repo2.module('group', 'projectA', '1.5').publish()
-
-        buildFile << createBuildFile(repo1.uri, repo2.uri)
-
-        when:
-        repo1.getModuleMetaData("group", "projectA").expectGet()
-        projectA1.pom.expectGet()
-
-        repo2.getModuleMetaData("group", "projectA").expectGet()
-        projectA2.pom.expectGetBroken()
-
-        and:
-        fails 'retrieve'
-
-        then:
-        failure.assertHasCause('Could not resolve group:projectA:1.+')
-        failure.assertHasCause('Could not resolve group:projectA:1.5')
-        failure.assertHasCause("Could not GET '${repo2.uri}/group/projectA/1.5/projectA-1.5.pom'")
-
-        when:
-        server.resetExpectations()
-        projectA2.pom.expectGet()
-        projectA2.artifact.expectGet()
-
-        and:
-        succeeds 'retrieve'
-
-        then:
-        file('libs').assertHasDescendants('projectA-1.5.jar')
-    }
-
     def "dynamic version ignores missing module in one repository when available in another repository"() {
         given:
         def repo1 = mavenHttpRepo("repo1")
@@ -358,20 +324,98 @@ Searched in the following locations:
         file('libs').assertHasDescendants('projectA-1.5.jar')
     }
 
+    def "dynamic version ignores broken module in one repository when available in another repository"() {
+        given:
+        def repo1 = mavenHttpRepo("repo1")
+        def repo2 = mavenHttpRepo("repo2")
+        def repo3 = mavenHttpRepo("repo3")
+        def projectA1 = repo1.module('group', 'projectA', '1.1').publish()
+        def projectA2 = repo2.module('group', 'projectA', '1.5').publish()
+        def projectA3 = repo3.module('group', 'projectA', '1.3').publish()
+
+        buildFile << createBuildFile(repo1.uri, repo2.uri, repo3.uri)
+
+        when:
+        repo1.getModuleMetaData("group", "projectA").expectGet()
+        projectA1.pom.expectGet()
+
+        repo2.getModuleMetaData("group", "projectA").expectGet()
+        projectA2.pom.expectGetBroken()
+
+        repo3.getModuleMetaData("group", "projectA").expectGet()
+        projectA3.pom.expectGet()
+        projectA3.artifact.expectGet()
+
+        and:
+        run 'retrieve'
+
+        then:
+        file('libs').assertHasDescendants('projectA-1.3.jar')
+
+        when:
+        server.resetExpectations()
+        projectA2.pom.expectGet()
+        projectA2.artifact.expectGet()
+
+        and:
+        run 'retrieve'
+
+        then:
+        file('libs').assertHasDescendants('projectA-1.5.jar')
+    }
+
+    def "dynamic version fails on timeout in one repository even when available in another repository"() {
+        given:
+        def repo1 = mavenHttpRepo("repo1")
+        def repo2 = mavenHttpRepo("repo2")
+        def projectA1 = repo1.module('group', 'projectA', '1.1').publish()
+        def projectA2 = repo2.module('group', 'projectA', '1.5').publish()
+
+        executer.withArgument("-D${SOCKET_TIMEOUT_SYSTEM_PROPERTY}=1000")
+
+        buildFile << createBuildFile(repo1.uri, repo2.uri)
+
+        when:
+        repo1.getModuleMetaData("group", "projectA").expectGet()
+        projectA1.pom.expectGetBlocking()
+
+        and:
+        fails 'retrieve'
+
+        then:
+        failure.assertHasCause('Could not resolve group:projectA:1.+')
+        failure.assertHasCause('Could not resolve group:projectA:1.1')
+        failure.assertHasCause("Could not GET '${repo1.uri}/group/projectA/1.1/projectA-1.1.pom'")
+        failure.assertHasCause('Read timed out')
+
+        when:
+        server.resetExpectations()
+        repo2.getModuleMetaData("group", "projectA").expectGet()
+        projectA1.pom.expectGet()
+        projectA2.pom.expectGet()
+        projectA2.artifact.expectGet()
+
+        and:
+        succeeds 'retrieve'
+
+        then:
+        file('libs').assertHasDescendants('projectA-1.5.jar')
+    }
+
     static String createBuildFile(URI... repoUris) {
         """
-        repositories {
-            ${repoUris.collect { "maven { url '${it.toString()}' }" }.join("\n")}
-        }
-        configurations { compile }
-        dependencies {
-            compile 'group:projectA:1.+'
-        }
-
+         repositories {
+             ${repoUris.collect { "maven { url '${it.toString()}' }" }.join("\n")}
+         }
+         configurations { compile }
+         dependencies {
+             compile 'group:projectA:1.+'
+         }
+ 
         task retrieve(type: Sync) {
             into 'libs'
-            from configurations.compile
-        }
-        """
+             from configurations.compile
+         }
+         """
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -133,32 +133,6 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         failure.assertHasCause("Unable to parse local Maven settings: " + m2.userSettingsFile.absolutePath)
     }
 
-    def "fail if metadata in local repo corrupts and remote repo is #remoteStatus"() {
-        given:
-        def corruptLocalPom = m2.mavenRepo().rootDir.file('group/projectA/1.2/projectA-1.2.pom')
-        corruptLocalPom << "invalid content"
-
-        if (remoteStatus == 'valid') {
-            def remoteRepo = maven("remote")
-            remoteRepo.module('group', 'projectA', '1.2').publish()
-
-            buildFile << """
-            repositories{
-                maven { url "${remoteRepo.uri}" }
-            }
-            """
-        }
-
-        when:
-        runAndFail 'retrieve'
-
-        then:
-        failure.assertHasCause("Could not parse POM $corruptLocalPom.absolutePath")
-
-        where:
-        remoteStatus << ['valid', 'invalid']
-    }
-
     def "mavenLocal is ignored if no local maven repository exists"() {
         given:
         def anotherRepo = maven("another-local-repo")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryBlacklister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryBlacklister.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang.exception.ExceptionUtils;
 
 import java.io.InterruptedIOException;
+import java.util.Collection;
 import java.util.Set;
 
 public class ConnectionFailureRepositoryBlacklister implements RepositoryBlacklister {
@@ -52,7 +53,15 @@ public class ConnectionFailureRepositoryBlacklister implements RepositoryBlackli
         return blacklistedRepositories;
     }
 
-    private static boolean isCriticalFailure(Throwable throwable) {
+    public static boolean hasCriticalFailure(Collection<? extends Throwable> failures) {
+        for (Throwable failure : failures) {
+            if (isCriticalFailure(failure)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    public static boolean isCriticalFailure(Throwable throwable) {
         return isTimeoutException(throwable);
     }
     private static boolean isTimeoutException(Throwable throwable) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -50,6 +50,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConnectionFailureRepositoryBlacklister.hasCriticalFailure;
+import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConnectionFailureRepositoryBlacklister.isCriticalFailure;
 import static org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult.State.*;
 
 public class DynamicVersionResolver {
@@ -114,7 +116,7 @@ public class DynamicVersionResolver {
 
         // A first pass to do local resolves only
         RepositoryChainModuleResolution best = findLatestModule(queue, failures, missing);
-        if (!failures.isEmpty()) {
+        if (hasCriticalFailure(failures)) {
             return null;
         }
         if (best != null) {
@@ -135,12 +137,18 @@ public class DynamicVersionResolver {
                 request.resolve();
             } catch (Throwable t) {
                 failures.add(t);
+                if (isCriticalFailure(t)) {
+                    queue.clear();
+                }
                 continue;
             }
             switch (request.resolvedVersionMetadata.getState()) {
                 case Failed:
                     failures.add(request.resolvedVersionMetadata.getFailure());
-                    queue.clear();
+                    if (isCriticalFailure(request.resolvedVersionMetadata.getFailure())) {
+                        // TODO:DAZ Consider re-throwing here
+                        queue.clear();
+                    }
                     break;
                 case Missing:
                 case Unknown:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/RepositoryHttpServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/RepositoryHttpServer.groovy
@@ -18,7 +18,6 @@ package org.gradle.test.fixtures.server.http
 
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.ivy.IvyFileRepository
-import org.gradle.test.fixtures.ivy.RemoteIvyRepository
 import org.gradle.test.fixtures.server.RepositoryServer
 import org.gradle.util.GradleVersion
 
@@ -48,11 +47,11 @@ class RepositoryHttpServer extends HttpServer implements RepositoryServer {
         new IvyFileRepository(testDirectoryProvider.testDirectory.file('ivy-repo'), m2Compatible, dirPattern, ivyFilePattern, artifactFilePattern)
     }
 
-    RemoteIvyRepository getRemoteIvyRepo(boolean m2Compatible = false, String dirPattern = null, String ivyFilePattern = null, String artifactFilePattern = null) {
+    IvyHttpRepository getRemoteIvyRepo(boolean m2Compatible = false, String dirPattern = null, String ivyFilePattern = null, String artifactFilePattern = null) {
         return new IvyHttpRepository(this, '/repo', getBackingRepository(m2Compatible, dirPattern, ivyFilePattern, artifactFilePattern), m2Compatible)
     }
 
-    RemoteIvyRepository getRemoteIvyRepo(String contextPath) {
+    IvyHttpRepository getRemoteIvyRepo(String contextPath) {
         new IvyHttpRepository(this, contextPath, backingRepository)
     }
 


### PR DESCRIPTION
Gradle 4.3 introduced an improvement where an error in resolving a module from
one repository would prevent Gradle from searching for that same module in
subsequent repositories (see #2853).

However, the change to abort searching repositories on _all_ unrecognised errors
proved to be too aggressive. With this change, only repository timeout errors
will prevent Gradle from searching for a module in a subsequent repository.
These timeout errors are considered 'critical' and will blacklist the repository
and abort resolution for that module.

In a future release of Gradle, it is likely that we will expand the set of resolution
failures that we consider 'critical' to include server errors (HTTP 500) and the
like. This commit keeps the set small to miminize impact on the 4.3.1 release.