### PR TITLE
Fix #3065: remove invalid characters from maven coordinates

### DIFF
--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/M2ResourcePatternTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/M2ResourcePatternTest.groovy
@@ -70,10 +70,11 @@ class M2ResourcePatternTest extends Specification {
         pattern.getLocation(artifact).uri == new URI(expectPath)
 
         where:
-        group       | module     | version | expectPath
-        "group"     | "projectA" | "1.2"   | 'http://server/lookup/group/projectA/1.2/ivys/1.2/ivy.xml'
-        "org.group" | "projectA" | "1.2"   | 'http://server/lookup/org/group/projectA/1.2/ivys/1.2/ivy.xml'
-        "#?:%12"    | "projectA" | "1.2"   | 'http://server/lookup/%23%3F:%2512/projectA/1.2/ivys/1.2/ivy.xml'
+        group       | module        | version | expectPath
+        "group"     | "projectA"    | "1.2"   | 'http://server/lookup/group/projectA/1.2/ivys/1.2/ivy.xml'
+        "org.group" | "projectA"    | "1.2"   | 'http://server/lookup/org/group/projectA/1.2/ivys/1.2/ivy.xml'
+        "#?:%12"    | "projectA"    | "1.2"   | 'http://server/lookup/%23%3F:%2512/projectA/1.2/ivys/1.2/ivy.xml'
+        "org.group" | '${projectA}' | "1.2"   | 'http://server/lookup/org/group/projectA/1.2/ivys/1.2/ivy.xml'
     }
 
     def "substitutes attributes into pattern to determine version list pattern"() {


### PR DESCRIPTION
This commit fixes #3065 by removing characters from maven coordinates that are considered illegal by the official naming conventions and are known to cause problems when inserted into URIs used to retrieve artifacts.