### PR TITLE
Make XCTest depend on binary under test for swift

### DIFF
--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -116,7 +116,7 @@ apply plugin: 'xctest'
         assertTargetIsTool(project.targets[0], 'App')
         assertTargetIsUnitTest(project.targets[1], 'AppTest')
         assertTargetIsIndexer(project.targets[2], 'App')
-        assertTargetIsIndexer(project.targets[3], 'AppTest')
+        assertTargetIsIndexerWithTestComponent(project.targets[3], 'AppTest')
 
         project.products.children.size() == 1
         project.products.children[0].path == exe("build/exe/main/debug/App").absolutePath
@@ -149,7 +149,7 @@ apply plugin: 'xctest'
         assertTargetIsDynamicLibrary(project.targets[0], 'App')
         assertTargetIsUnitTest(project.targets[1], 'AppTest')
         assertTargetIsIndexer(project.targets[2], 'App')
-        assertTargetIsIndexer(project.targets[3], 'AppTest')
+        assertTargetIsIndexerWithTestComponent(project.targets[3], 'AppTest')
 
         project.products.children.size() == 1
         project.products.children[0].path == sharedLib("build/lib/main/debug/App").absolutePath

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -116,7 +116,7 @@ apply plugin: 'xctest'
         assertTargetIsTool(project.targets[0], 'App')
         assertTargetIsUnitTest(project.targets[1], 'AppTest')
         assertTargetIsIndexer(project.targets[2], 'App')
-        assertTargetIsIndexerWithTestComponent(project.targets[3], 'AppTest')
+        assertTargetIsIndexer(project.targets[3], 'AppTest', '"' + file('build/modules/main').absolutePath + '"')
 
         project.products.children.size() == 1
         project.products.children[0].path == exe("build/exe/main/debug/App").absolutePath
@@ -149,7 +149,7 @@ apply plugin: 'xctest'
         assertTargetIsDynamicLibrary(project.targets[0], 'App')
         assertTargetIsUnitTest(project.targets[1], 'AppTest')
         assertTargetIsIndexer(project.targets[2], 'App')
-        assertTargetIsIndexerWithTestComponent(project.targets[3], 'AppTest')
+        assertTargetIsIndexer(project.targets[3], 'AppTest', '"' + file('build/modules/main').absolutePath + '"')
 
         project.products.children.size() == 1
         project.products.children[0].path == sharedLib("build/lib/main/debug/App").absolutePath

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
@@ -136,7 +136,10 @@ Actual: ${actual[key]}
         assert target.name == "$expectedProductName XCTestBundle"
         assert target.productReference.path == xctest("build/bundle/test/$expectedBinaryName").absolutePath
         assert target.buildConfigurationList.buildConfigurations.name == [DefaultXcodeProject.BUILD_DEBUG, DefaultXcodeProject.BUILD_RELEASE, DefaultXcodeProject.TEST_DEBUG]
-            assert target.buildConfigurationList.buildConfigurations.every { it.buildSettings.PRODUCT_NAME == expectedProductName }
+        assert target.buildConfigurationList.buildConfigurations.every { it.buildSettings.PRODUCT_NAME == expectedProductName }
+        assert target.buildConfigurationList.buildConfigurations.every {
+            it.buildSettings.SWIFT_INCLUDE_PATHS == '"' + file('build/modules/main/debug').absolutePath + '"'
+        }
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[0].buildSettings)
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[1].buildSettings)
         assertUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[2].buildSettings)
@@ -184,19 +187,11 @@ Actual: ${actual[key]}
         assert buildSettings.SWIFT_OBJC_INTERFACE_HEADER_NAME == null
     }
 
-    void assertTargetIsIndexer(ProjectFile.PBXTarget target, String expectedProductName) {
+    void assertTargetIsIndexer(ProjectFile.PBXTarget target, String expectedProductName, String swiftIncludes = null) {
         assert target.productName == expectedProductName
         assert target.name.startsWith("[INDEXING ONLY] $expectedProductName")
         assert target.buildConfigurationList.buildConfigurations.name == [DefaultXcodeProject.BUILD_DEBUG]
         assert target.buildConfigurationList.buildConfigurations[0].buildSettings.PRODUCT_NAME == expectedProductName
-        assert target.buildConfigurationList.buildConfigurations[0].buildSettings.SWIFT_INCLUDE_PATHS == null
-    }
-
-    void assertTargetIsIndexerWithTestComponent(ProjectFile.PBXTarget target, String expectedProductName) {
-        assert target.productName == expectedProductName
-        assert target.name.startsWith("[INDEXING ONLY] $expectedProductName")
-        assert target.buildConfigurationList.buildConfigurations.name == [DefaultXcodeProject.BUILD_DEBUG]
-        assert target.buildConfigurationList.buildConfigurations[0].buildSettings.PRODUCT_NAME == expectedProductName
-        assert target.buildConfigurationList.buildConfigurations[0].buildSettings.SWIFT_INCLUDE_PATHS == '"' + file('build/modules/main').absolutePath + '"'
+        assert target.buildConfigurationList.buildConfigurations[0].buildSettings.SWIFT_INCLUDE_PATHS == swiftIncludes
     }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
@@ -191,4 +191,12 @@ Actual: ${actual[key]}
         assert target.buildConfigurationList.buildConfigurations[0].buildSettings.PRODUCT_NAME == expectedProductName
         assert target.buildConfigurationList.buildConfigurations[0].buildSettings.SWIFT_INCLUDE_PATHS == null
     }
+
+    void assertTargetIsIndexerWithTestComponent(ProjectFile.PBXTarget target, String expectedProductName) {
+        assert target.productName == expectedProductName
+        assert target.name.startsWith("[INDEXING ONLY] $expectedProductName")
+        assert target.buildConfigurationList.buildConfigurations.name == [DefaultXcodeProject.BUILD_DEBUG]
+        assert target.buildConfigurationList.buildConfigurations[0].buildSettings.PRODUCT_NAME == expectedProductName
+        assert target.buildConfigurationList.buildConfigurations[0].buildSettings.SWIFT_INCLUDE_PATHS == '"' + file('build/modules/main').absolutePath + '"'
+    }
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
@@ -212,13 +212,15 @@ public class XcodePlugin extends IdePlugin {
         final CreateSwiftBundle bundleDebug = (CreateSwiftBundle) project.getTasks().getByName("bundleSwiftTest");
         xcode.getProject().getGroups().getTests().from(bundleDebug.getInformationFile());
 
-        XcodeTarget target = newTarget(component.getModule().get() + " " + toString(productType), component.getModule().get(), productType, toGradleCommand(project.getRootProject()), getBridgeTaskPath(project), bundleDebug.getOutputDir(), bundleDebug.getOutputDir(), sources);
+        String targetName = component.getModule().get() + " " + toString(productType);
+        XcodeTarget target = newTarget(targetName, component.getModule().get(), productType, toGradleCommand(project.getRootProject()), getBridgeTaskPath(project), bundleDebug.getOutputDir(), bundleDebug.getOutputDir(), sources);
         target.getCompileModules().from(component.getDevelopmentBinary().getCompileModules());
         xcode.getProject().addTarget(target);
     }
 
     private void configureXcodeForSwift(final Project project, PBXTarget.ProductType productType) {
-        SwiftComponent component = project.getExtensions().getByType(SwiftComponent.class);
+        // TODO: Assumes there's a single 'main' Swift component
+        SwiftComponent component = project.getComponents().withType(SwiftComponent.class).getByName("main");
         FileCollection sources = component.getSwiftSource();
         xcode.getProject().getGroups().getSources().from(sources);
 
@@ -227,11 +229,12 @@ public class XcodePlugin extends IdePlugin {
         AbstractLinkTask linkDebug = (AbstractLinkTask) project.getTasks().getByName("linkDebug");
         AbstractLinkTask linkRelease = (AbstractLinkTask) project.getTasks().getByName("linkRelease");
 
-        XcodeTarget target = newTarget(component.getModule().get() + " " + toString(productType), component.getModule().get(), productType, toGradleCommand(project.getRootProject()), getBridgeTaskPath(project), linkDebug.getBinaryFile(), linkRelease.getBinaryFile(), sources);
+        String targetName = component.getModule().get() + " " + toString(productType);
+        XcodeTarget target = newTarget(targetName, component.getModule().get(), productType, toGradleCommand(project.getRootProject()), getBridgeTaskPath(project), linkDebug.getBinaryFile(), linkRelease.getBinaryFile(), sources);
         target.getCompileModules().from(component.getDevelopmentBinary().getCompileModules());
         xcode.getProject().addTarget(target);
 
-        createSchemeTask(project.getTasks(), component.getModule().get() + " " + toString(productType), xcode.getProject());
+        createSchemeTask(project.getTasks(), targetName, xcode.getProject());
     }
 
     private void configureForCppPlugin(final Project project) {
@@ -251,7 +254,8 @@ public class XcodePlugin extends IdePlugin {
     }
 
     private void configureXcodeForCpp(Project project, PBXTarget.ProductType productType) {
-        CppComponent component = project.getExtensions().getByType(CppComponent.class);
+        // TODO: Assumes there's a single 'main' C++ component
+        CppComponent component = project.getComponents().withType(CppComponent.class).getByName("main");
         FileCollection sources = component.getCppSource();
         xcode.getProject().getGroups().getSources().from(sources);
 

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/tasks/GenerateXcodeProjectFileTask.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/tasks/GenerateXcodeProjectFileTask.java
@@ -199,6 +199,12 @@ public class GenerateXcodeProjectFileTask extends PropertyListGeneratorTask<Xcod
         NSDictionary releaseSettings = target.getBuildConfigurationList().getBuildConfigurationsByName().getUnchecked(BUILD_RELEASE).getBuildSettings();
         NSDictionary testRunnerSettings = target.getBuildConfigurationList().getBuildConfigurationsByName().getUnchecked(TEST_DEBUG).getBuildSettings();
 
+        if (!xcodeTarget.getCompileModules().isEmpty()) {
+            debugSettings.put("SWIFT_INCLUDE_PATHS", toSpaceSeparatedList(xcodeTarget.getCompileModules()));
+            releaseSettings.put("SWIFT_INCLUDE_PATHS", toSpaceSeparatedList(xcodeTarget.getCompileModules()));
+            testRunnerSettings.put("SWIFT_INCLUDE_PATHS", toSpaceSeparatedList(xcodeTarget.getCompileModules()));
+        }
+
         testRunnerSettings.put("SWIFT_VERSION", "3.0");  // TODO - Choose the right version for swift
         testRunnerSettings.put("PRODUCT_NAME", target.getProductName());
         testRunnerSettings.put("OTHER_LDFLAGS", "-help");

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
@@ -22,6 +22,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.util.PatternSet;
@@ -40,6 +41,7 @@ public class DefaultSwiftBinary implements SwiftBinary {
     private final FileCollection linkLibs;
     private final Configuration runtimeLibs;
     private final DirectoryProperty objectsDir;
+    private final RegularFileProperty moduleFile;
 
     public DefaultSwiftBinary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation) {
         this.name = name;
@@ -48,6 +50,7 @@ public class DefaultSwiftBinary implements SwiftBinary {
         this.testable = testable;
         this.source = source;
         this.objectsDir = projectLayout.directoryProperty();
+        this.moduleFile = projectLayout.fileProperty();
 
         Names names = Names.of(name);
 
@@ -117,6 +120,10 @@ public class DefaultSwiftBinary implements SwiftBinary {
 
     public DirectoryProperty getObjectsDir() {
         return objectsDir;
+    }
+
+    public RegularFileProperty getModuleFile() {
+        return moduleFile;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -96,6 +96,7 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                         return "modules/" + names.getDirName() + binary.getModule().get() + ".swiftmodule";
                     }
                 })));
+                ((DefaultSwiftBinary)binary).getModuleFile().set(compile.getModuleFile());
 
                 DefaultNativePlatform currentPlatform = new DefaultNativePlatform("current");
                 compile.setTargetPlatform(currentPlatform);

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -232,7 +232,6 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
                 // Test configuration extends main configuration
                 testSuite.getImplementationDependencies().extendsFrom(testedComponent.getImplementationDependencies());
                 ((Configuration)(testSuite.getDevelopmentBinary().getCompileModules())).getDependencies()
-                // testSuite.getImplementationDependencies().getDependencies()
                     .add(new DefaultSelfResolvingDependency((FileCollectionInternal)project.files(((DefaultSwiftBinary)testedComponent.getDevelopmentBinary()).getModuleFile().map(new Transformer<File, RegularFile>() {
                         @Override
                         public File transform(RegularFile regularFile) {

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -22,7 +22,12 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.internal.artifacts.dependencies.DefaultSelfResolvingDependency;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskContainer;
@@ -30,6 +35,7 @@ import org.gradle.internal.os.OperatingSystem;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.swift.SwiftComponent;
 import org.gradle.language.swift.SwiftExecutable;
+import org.gradle.language.swift.internal.DefaultSwiftBinary;
 import org.gradle.language.swift.plugins.SwiftBasePlugin;
 import org.gradle.language.swift.plugins.SwiftExecutablePlugin;
 import org.gradle.language.swift.plugins.SwiftLibraryPlugin;
@@ -225,6 +231,14 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
 
                 // Test configuration extends main configuration
                 testSuite.getImplementationDependencies().extendsFrom(testedComponent.getImplementationDependencies());
+                ((Configuration)(testSuite.getDevelopmentBinary().getCompileModules())).getDependencies()
+                // testSuite.getImplementationDependencies().getDependencies()
+                    .add(new DefaultSelfResolvingDependency((FileCollectionInternal)project.files(((DefaultSwiftBinary)testedComponent.getDevelopmentBinary()).getModuleFile().map(new Transformer<File, RegularFile>() {
+                        @Override
+                        public File transform(RegularFile regularFile) {
+                            return regularFile.getAsFile().getParentFile();
+                        }
+                    }))));
 
                 // Configure test suite link task from tested component compiled objects
                 AbstractLinkTask linkTest = tasks.withType(AbstractLinkTask.class).getByName("linkTest");


### PR DESCRIPTION
Without this, there is a failure highlighted in the XCode UI when you open an XCode project or workspace generated by a Gradle build.

Fixes gradle/gradle-native#203
