### PR TITLE
Improve JDK 9 compatibility

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
@@ -70,9 +70,14 @@ public class ClasspathUtil {
         return DefaultClassPath.of(implementationClassPath);
     }
 
-    public static File getClasspathForClass(String targetClassName){
+    public static File getClasspathForClass(String targetClassName) {
         try {
-            return getClasspathForClass(Class.forName(targetClassName));
+            Class clazz = Class.forName(targetClassName);
+            if (clazz.getClassLoader() == null) {
+                return null;
+            } else {
+                return getClasspathForClass(Class.forName(targetClassName));
+            }
         } catch (ClassNotFoundException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultClassLoaderFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultClassLoaderFactory.java
@@ -23,10 +23,12 @@ import org.gradle.internal.service.ServiceLocator;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParserFactory;
+import java.io.File;
+import java.util.Collections;
 
 import static java.lang.ClassLoader.getSystemClassLoader;
-import static java.util.Arrays.*;
-import static org.gradle.internal.classloader.ClasspathUtil.*;
+import static org.gradle.internal.classloader.ClasspathUtil.getClasspathForClass;
+import static org.gradle.internal.classloader.ClasspathUtil.getClasspathForResource;
 
 public class DefaultClassLoaderFactory implements ClassLoaderFactory {
     // This uses the system classloader and will not release any loaded classes for the life of the daemon process.
@@ -55,15 +57,18 @@ public class DefaultClassLoaderFactory implements ClassLoaderFactory {
         // Note that in practise, this is only triggered when running in our tests
 
         if (needJaxpImpl()) {
-            classPath = classPath.plus(
-                asList(
-                    getClasspathForResource(getSystemClassLoader(), "META-INF/services/javax.xml.parsers.SAXParserFactory"),
-                    getClasspathForClass("org.w3c.dom.ElementTraversal")
-                )
-            );
+            classPath = addToClassPath(classPath, getClasspathForResource(getSystemClassLoader(), "META-INF/services/javax.xml.parsers.SAXParserFactory"));
+            classPath = addToClassPath(classPath, getClasspathForClass("org.w3c.dom.ElementTraversal"));
         }
 
         return doCreateClassLoader(getIsolatedSystemClassLoader(), classPath);
+    }
+
+    private ClassPath addToClassPath(ClassPath classPath, File file) {
+        if (file != null) {
+            return classPath.plus(Collections.singletonList(file));
+        }
+        return classPath;
     }
 
     @Override

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
@@ -93,7 +93,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
      * This is used by consumers 1.2-rc-1 and later.
      */
     public void configure(ConnectionParameters parameters) {
-        UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", JavaVersion.VERSION_1_7);
+        assertUsingJava7();
         ProviderConnectionParameters providerConnectionParameters = new ProtocolToModelAdapter().adapt(ProviderConnectionParameters.class, parameters);
         File gradleUserHomeDir = providerConnectionParameters.getGradleUserHomeDir(null);
         if (gradleUserHomeDir == null) {
@@ -102,6 +102,15 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
         initializeServices(gradleUserHomeDir);
         connection.configure(providerConnectionParameters);
         consumerVersion = GradleVersion.version(providerConnectionParameters.getConsumerVersion());
+    }
+
+    private void assertUsingJava7() {
+        try {
+            UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", JavaVersion.VERSION_1_7);
+        } catch (IllegalArgumentException e) {
+            // https://github.com/gradle/gradle/issues/3317
+            DeprecationLogger.nagUserWith(e.getMessage());
+        }
     }
 
     private void initializeServices(File gradleUserHomeDir) {
@@ -241,7 +250,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
 
     private ProviderOperationParameters validateAndConvert(BuildParameters buildParameters) {
         LOGGER.info("Tooling API is using target Gradle version: {}.", GradleVersion.current().getVersion());
-        UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", JavaVersion.VERSION_1_7);
+        assertUsingJava7();
 
         checkUnsupportedTapiVersion();
         ProviderOperationParameters parameters = adapter.builder(ProviderOperationParameters.class).mixInTo(ProviderOperationParameters.class, BuildLogLevelMixIn.class).build(buildParameters);

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r44/JavaVersionCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r44/JavaVersionCrossVersionTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.gradle.integtests.tooling.r44
+
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.ProjectConnection
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.IgnoreIf
+import spock.lang.Issue
+
+@Issue('https://github.com/gradle/gradle/issues/3317')
+@TargetGradleVersion(">=3.0 <4.2.1")
+@ToolingApiVersion("current")
+class JavaVersionCrossVersionTest extends ToolingApiSpecification {
+    def configureJava8() {
+        projectDir.file("gradle.properties").writeProperties("org.gradle.java.home": AvailableJavaHomes.jdk8.javaHome.absolutePath)
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    @IgnoreIf({ AvailableJavaHomes.jdk8 == null })
+    def "smoke test for JavaVersion scheme patch"() {
+        configureJava8()
+        def output = new ByteArrayOutputStream()
+
+        when:
+        toolingApi.withConnection { ProjectConnection connection ->
+            def build = connection.newBuild()
+            build.forTasks('help')
+            build.standardOutput = output
+            build.run()
+        }
+
+        then:
+        output.toString().count("Welcome to Gradle")
+    }
+}


### PR DESCRIPTION
In JDK 9, `org.w3c.dom.ElementTraversal` class is provided in JDK by default,
so previous `ClassPathUtil.getClasspathForResource` would throw NPE.
This PR fixes this issue.

In addition, as an attempt to fix #3317 and #3355 , this PR also 
catches the exception to avoid unexpected failures.

@donat I'd appreciate your opinion on this. After looking into #3355 carefully, 
I don't think it's a good way to return `UnknownVersion` because its behaviour is undefined. What's the result of `UnknownVersion.isJava8Compatible()`? What's the result of `UnknownVersion.getMajorVersion()`? So I catch the exception and leave a warning there.
