### PR TITLE
Fix Java version number in JDT properties file

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
@@ -45,4 +45,70 @@ class EclipseJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
         '1.9'   | 'JavaSE-9'
         '1.10'  | 'JavaSE-10'
     }
+
+    def "generated JDT preferences have correct compiler version"(String version, String expectedVersion) {
+        settingsFile << "rootProject.name = 'java'"
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+            sourceCompatibility = $version
+        """
+
+        when:
+        run "eclipse"
+
+        then:
+        def properties = parseProperties('.settings/org.eclipse.jdt.core.prefs')
+        properties['org.eclipse.jdt.core.compiler.compliance'] == expectedVersion
+        properties['org.eclipse.jdt.core.compiler.source'] == expectedVersion
+
+        where:
+        version | expectedVersion
+        '1.1'   | '1.1'
+        '1.2'   | '1.2'
+        '1.3'   | '1.3'
+        '1.4'   | '1.4'
+        '1.5'   | '1.5'
+        '1.6'   | '1.6'
+        '1.7'   | '1.7'
+        '1.8'   | '1.8'
+        '1.9'   | '9'
+        '1.10'  | '10'
+    }
+
+    def "generated JDT preferences have correct target platform version"(String version, String expectedVersion) {
+        settingsFile << "rootProject.name = 'java'"
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+            targetCompatibility = $version
+        """
+
+        when:
+        run "eclipse"
+
+        then:
+        def properties = parseProperties('.settings/org.eclipse.jdt.core.prefs')
+        properties['org.eclipse.jdt.core.compiler.codegen.targetPlatform'] == expectedVersion
+
+        where:
+        version | expectedVersion
+        '1.1'   | '1.1'
+        '1.2'   | '1.2'
+        '1.3'   | '1.3'
+        '1.4'   | '1.4'
+        '1.5'   | '1.5'
+        '1.6'   | '1.6'
+        '1.7'   | '1.7'
+        '1.8'   | '1.8'
+        '1.9'   | '9'
+        '1.10'  | '10'
+    }
+
+    protected parseProperties(String filename) {
+        Properties properties = new Properties()
+        File propertiesFile = file(filename)
+        propertiesFile.withInputStream { properties.load(it) }
+        properties
+    }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -58,6 +58,7 @@ import org.gradle.plugins.ide.eclipse.model.EclipseJdt;
 import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.gradle.plugins.ide.eclipse.model.EclipseProject;
 import org.gradle.plugins.ide.eclipse.model.Link;
+import org.gradle.plugins.ide.eclipse.model.internal.EclipseJavaVersionMapper;
 import org.gradle.plugins.ide.internal.configurer.UniqueProjectNameProvider;
 import org.gradle.plugins.ide.internal.IdePlugin;
 import org.gradle.util.SingleMessageLogger;
@@ -356,6 +357,7 @@ public class EclipsePlugin extends IdePlugin {
     private static String eclipseJavaRuntimeNameFor(JavaVersion version) {
         // Default Eclipse JRE paths:
         // https://github.com/eclipse/eclipse.jdt.debug/blob/master/org.eclipse.jdt.launching/plugin.xml#L241-L303
+        String eclipseJavaVersion = EclipseJavaVersionMapper.toEclipseJavaVersion(version);
         switch (version) {
             case VERSION_1_1:
                 return "JRE-1.1";
@@ -363,13 +365,9 @@ public class EclipsePlugin extends IdePlugin {
             case VERSION_1_3:
             case VERSION_1_4:
             case VERSION_1_5:
-                return "J2SE-" + version;
-            case VERSION_1_6:
-            case VERSION_1_7:
-            case VERSION_1_8:
-                return "JavaSE-" + version;
+                return "J2SE-" + eclipseJavaVersion;
             default:
-                return "JavaSE-" + version.getMajorVersion();
+                return "JavaSE-" + eclipseJavaVersion;
         }
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Jdt.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/Jdt.java
@@ -19,6 +19,7 @@ import java.util.Properties;
 
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.PropertiesTransformer;
+import org.gradle.plugins.ide.eclipse.model.internal.EclipseJavaVersionMapper;
 import org.gradle.plugins.ide.internal.generator.PropertiesPersistableConfigurationObject;
 
 /**
@@ -31,7 +32,7 @@ public class Jdt extends PropertiesPersistableConfigurationObject {
     public Jdt(PropertiesTransformer transformer) {
         super(transformer);
     }
-    
+
     /**
      * Sets the source compatibility for the compiler.
      */
@@ -57,8 +58,11 @@ public class Jdt extends PropertiesPersistableConfigurationObject {
 
     @Override
     protected void store(Properties properties) {
-        properties.put("org.eclipse.jdt.core.compiler.compliance", sourceCompatibility.toString());
-        properties.put("org.eclipse.jdt.core.compiler.source", sourceCompatibility.toString());
+        String sourceVersion = EclipseJavaVersionMapper.toEclipseJavaVersion(sourceCompatibility);
+        String targetVersion = EclipseJavaVersionMapper.toEclipseJavaVersion(targetCompatibility);
+
+        properties.put("org.eclipse.jdt.core.compiler.compliance", sourceVersion);
+        properties.put("org.eclipse.jdt.core.compiler.source", sourceVersion);
 
         if (sourceCompatibility.compareTo(JavaVersion.VERSION_1_3) <= 0) {
             properties.put("org.eclipse.jdt.core.compiler.problem.assertIdentifier", "ignore");
@@ -71,6 +75,6 @@ public class Jdt extends PropertiesPersistableConfigurationObject {
             properties.put("org.eclipse.jdt.core.compiler.problem.enumIdentifier", "error");
         }
 
-        properties.put("org.eclipse.jdt.core.compiler.codegen.targetPlatform", targetCompatibility.toString());
+        properties.put("org.eclipse.jdt.core.compiler.codegen.targetPlatform", targetVersion);
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseJavaVersionMapper.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseJavaVersionMapper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.eclipse.model.internal;
+
+import org.gradle.api.JavaVersion;
+
+/**
+ * Utility class for saving Java versions in Eclipse descriptors.
+ */
+public class EclipseJavaVersionMapper {
+
+    private EclipseJavaVersionMapper() {
+    }
+
+    /**
+     * Converts the target Java version to to its Eclipse-specific representation.
+     *
+     * @param version the target Java version
+     * @return the Eclipse-specific representation of the version
+     */
+    public static String toEclipseJavaVersion(JavaVersion version) {
+        switch (version) {
+            case VERSION_1_1:
+            case VERSION_1_2:
+            case VERSION_1_3:
+            case VERSION_1_4:
+            case VERSION_1_5:
+            case VERSION_1_6:
+            case VERSION_1_7:
+            case VERSION_1_8:
+                return version.toString();
+            case VERSION_1_9:
+            case VERSION_1_10:
+            default:
+                return version.getMajorVersion();
+        }
+    }
+}


### PR DESCRIPTION
If the source and/or target compatibility is set to Java 9, then the `eclipse` plugin generates wrong JDT preferences. This PR adjusts the preference values for this scenario.