### PR TITLE
Fix #3065: replace variables even if missing POM properties

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyVariableContainerWithFallback.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyVariableContainerWithFallback.java
@@ -1,0 +1,45 @@
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser;
+
+import org.apache.ivy.core.settings.IvyVariableContainer;
+import org.apache.ivy.core.settings.IvyVariableContainerImpl;
+
+import java.util.Map;
+
+public class IvyVariableContainerWithFallback implements IvyVariableContainer {
+    private final IvyVariableContainerImpl delegate;
+    private final String fallback;
+
+    public IvyVariableContainerWithFallback(Map<String, String> properties, String fallback) {
+        this(new IvyVariableContainerImpl(properties), fallback);
+    }
+
+    private IvyVariableContainerWithFallback(IvyVariableContainerImpl delegate, String fallback) {
+        this.delegate = delegate;
+        this.fallback = fallback;
+    }
+
+    @Override
+    public void setVariable(String varName, String value, boolean overwrite) {
+        delegate.setVariable(varName, value, overwrite);
+    }
+
+    @Override
+    public String getVariable(String name) {
+        String result = delegate.getVariable(name);
+        if(result == null) {
+            result = fallback;
+        }
+        return result;
+    }
+
+    @Override
+    public void setEnvironmentPrefix(String prefix) {
+        delegate.setEnvironmentPrefix(prefix);
+    }
+
+    @Override
+    public IvyVariableContainerWithFallback clone() {
+        IvyVariableContainerImpl delegateClone = (IvyVariableContainerImpl) delegate.clone();
+        return new IvyVariableContainerWithFallback(delegateClone,fallback);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyVariableContainerWithFallback.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyVariableContainerWithFallback.java
@@ -3,27 +3,19 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser;
 import org.apache.ivy.core.settings.IvyVariableContainer;
 import org.apache.ivy.core.settings.IvyVariableContainerImpl;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 public class IvyVariableContainerWithFallback implements IvyVariableContainer {
     private final IvyVariableContainerImpl delegate;
     private final String fallback;
-    private final Set<String> enableFallbackFor; // null to enable fallback for all variables
 
     public IvyVariableContainerWithFallback(Map<String, String> properties, String fallback) {
-        this(properties, fallback, null);
+        this(new IvyVariableContainerImpl(properties), fallback);
     }
 
-    public IvyVariableContainerWithFallback(Map<String, String> properties, String fallback, Set<String> enableFallbackFor) {
-        this(new IvyVariableContainerImpl(properties), fallback, enableFallbackFor);
-    }
-
-    private IvyVariableContainerWithFallback(IvyVariableContainerImpl delegate, String fallback, Set<String> enableFallbackFor) {
-         this.delegate =  delegate;
-         this.fallback = fallback;
-         this.enableFallbackFor = enableFallbackFor;
+    private IvyVariableContainerWithFallback(IvyVariableContainerImpl delegate, String fallback) {
+        this.delegate = delegate;
+        this.fallback = fallback;
     }
 
     @Override
@@ -34,7 +26,7 @@ public class IvyVariableContainerWithFallback implements IvyVariableContainer {
     @Override
     public String getVariable(String name) {
         String result = delegate.getVariable(name);
-        if(result == null && (enableFallbackFor == null || enableFallbackFor.contains(name))) {
+        if(result == null) {
             result = fallback;
         }
         return result;
@@ -48,10 +40,6 @@ public class IvyVariableContainerWithFallback implements IvyVariableContainer {
     @Override
     public IvyVariableContainerWithFallback clone() {
         IvyVariableContainerImpl delegateClone = (IvyVariableContainerImpl) delegate.clone();
-        Set<String> enableFallbackForClone = enableFallbackFor;
-        if(enableFallbackForClone != null) {
-            enableFallbackForClone = new HashSet<String>(enableFallbackForClone);
-        }
-        return new IvyVariableContainerWithFallback(delegateClone, fallback, enableFallbackForClone);
+        return new IvyVariableContainerWithFallback(delegateClone,fallback);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -45,12 +45,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.PomDomParser.*;
 
@@ -700,7 +695,8 @@ public class PomReader implements PomParent {
         if (val == null) {
             return null;
         } else {
-            IvyVariableContainer variableContainer = new IvyVariableContainerWithFallback(effectiveProperties, "");
+            Set<String> fallbackForMissingProperties = Collections.singleton("packaging.type"); // because of #3065
+            IvyVariableContainer variableContainer = new IvyVariableContainerWithFallback(effectiveProperties, "", fallbackForMissingProperties);
             return IvyPatternHelper.substituteVariables(val, variableContainer).trim();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -45,7 +45,12 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.PomDomParser.*;
 
@@ -695,8 +700,7 @@ public class PomReader implements PomParent {
         if (val == null) {
             return null;
         } else {
-            Set<String> fallbackForMissingProperties = Collections.singleton("packaging.type"); // because of #3065
-            IvyVariableContainer variableContainer = new IvyVariableContainerWithFallback(effectiveProperties, "", fallbackForMissingProperties);
+            IvyVariableContainer variableContainer = new IvyVariableContainerWithFallback(effectiveProperties, "");
             return IvyPatternHelper.substituteVariables(val, variableContainer).trim();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser;
 import com.google.common.collect.Lists;
 import org.apache.commons.io.IOUtils;
 import org.apache.ivy.core.IvyPatternHelper;
+import org.apache.ivy.core.settings.IvyVariableContainer;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -699,7 +700,8 @@ public class PomReader implements PomParent {
         if (val == null) {
             return null;
         } else {
-            return IvyPatternHelper.substituteVariables(val, effectiveProperties).trim();
+            IvyVariableContainer variableContainer = new IvyVariableContainerWithFallback(effectiveProperties, "");
+            return IvyPatternHelper.substituteVariables(val, variableContainer).trim();
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
@@ -860,7 +860,7 @@ class PomReaderTest extends AbstractPomReaderTest {
     <groupId>group-one</groupId>
     <artifactId>artifact-one</artifactId>
     <version>version-one</version>
-    <packaging>\${packaege.type}</packaging>
+    <packaging>\${package.type}</packaging>
 
     <properties>
         <!-- missing property for package.type --> 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
@@ -860,7 +860,7 @@ class PomReaderTest extends AbstractPomReaderTest {
     <groupId>group-one</groupId>
     <artifactId>artifact-one</artifactId>
     <version>version-one</version>
-    <packaging>\${packaging.type}</packaging>
+    <packaging>\${package.type}</packaging>
 
     <properties>
         <!-- missing property for package.type --> 
@@ -873,7 +873,7 @@ class PomReaderTest extends AbstractPomReaderTest {
         pomReader.groupId == 'group-one'
         pomReader.artifactId == 'artifact-one'
         pomReader.version == 'version-one'
-        !pomReader.properties.containsKey('packaging.type')
+        !pomReader.properties.containsKey('package.type')
         pomReader.packaging == ''
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
@@ -850,4 +850,30 @@ class PomReaderTest extends AbstractPomReaderTest {
         pomReader.artifactId == pomReader.parentArtifactId
         pomReader.version == pomReader.parentVersion
     }
+
+    @Issue("GRADLE-3065")
+    def "uses fallback for variables with missing properties"() {
+        when:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group-one</groupId>
+    <artifactId>artifact-one</artifactId>
+    <version>version-one</version>
+    <packaging>\${packaege.type}</packaging>
+
+    <properties>
+        <!-- missing property for package.type --> 
+    </properties>
+</project>
+"""
+        pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
+
+        then:
+        pomReader.groupId == 'group-one'
+        pomReader.artifactId == 'artifact-one'
+        pomReader.version == 'version-one'
+        !pomReader.properties.containsKey('package.type')
+        pomReader.packaging == ''
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
@@ -860,7 +860,7 @@ class PomReaderTest extends AbstractPomReaderTest {
     <groupId>group-one</groupId>
     <artifactId>artifact-one</artifactId>
     <version>version-one</version>
-    <packaging>\${package.type}</packaging>
+    <packaging>\${packaging.type}</packaging>
 
     <properties>
         <!-- missing property for package.type --> 
@@ -873,7 +873,7 @@ class PomReaderTest extends AbstractPomReaderTest {
         pomReader.groupId == 'group-one'
         pomReader.artifactId == 'artifact-one'
         pomReader.version == 'version-one'
-        !pomReader.properties.containsKey('package.type')
+        !pomReader.properties.containsKey('packaging.type')
         pomReader.packaging == ''
     }
 }


### PR DESCRIPTION
For the replacement of variables with missing properties, a fallback-string
can be defined. At the moment this replacement is an empty string, but
the implementation allows the usage of any other string.

Please excuse me if this commit should be rough around the edges. I lack any experience with IntelliJ and Groovy.

@oehme 
I mention you just for you to take notice of this pull request.

