### PR TITLE
Add support for prefer/rejects in Gradle metadata file

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -84,7 +84,7 @@ dependencies {
                 "buildType": "debug"
             },
             "files": [ { "name": "a-1.2-debug.jar", "url": "a-1.2-debug.jar" } ],
-            "dependencies": [ { "group": "test", "module": "b", "version": "2.0" } ]
+            "dependencies": [ { "group": "test", "module": "b", "version": { "prefers": "2.0", "rejects": [] } } ]
         },
         {
             "name": "release",
@@ -92,7 +92,7 @@ dependencies {
                 "buildType": "release"
             },
             "files": [ { "name": "a-1.2-release.jar", "url": "a-1.2-release.jar" } ],
-            "dependencies": [ { "group": "test", "module": "c", "version": "2.2" } ]
+            "dependencies": [ { "group": "test", "module": "c", "version": { "prefers": "2.2" } } ]
         }
     ]
 }
@@ -151,14 +151,14 @@ task checkRelease {
                 { "name": "a-1.2-api.jar", "url": "a-1.2-api.jar" },
                 { "name": "a-1.2-runtime.jar", "url": "a-1.2-runtime.jar" } 
             ],
-            "dependencies": [ { "group": "test", "module": "b", "version": "2.0" } ]
+            "dependencies": [ { "group": "test", "module": "b", "version": { "prefers": "2.0" } } ]
         },
         {
             "name": "release",
             "attributes": {
                 "buildType": "release"
             },
-            "dependencies": [ { "group": "test", "module": "b", "version": "2.0" } ]
+            "dependencies": [ { "group": "test", "module": "b", "version": { "prefers": "2.0" } } ]
         }
     ]
 }
@@ -343,14 +343,14 @@ task checkDebug {
                 "buildType": "debug"
             },
             "files": [ { "name": "a-1.2-debug.jar", "url": "a-1.2-debug.jar" } ],
-            "dependencies": [ { "group": "test", "module": "b", "version": "2.0" } ]
+            "dependencies": [ { "group": "test", "module": "b", "version": { "prefers": "2.0" } } ]
         },
         {
             "name": "release",
             "attributes": {
                 "buildType": "release"
             },
-            "dependencies": [ { "group": "test", "module": "c", "version": "preview" } ]
+            "dependencies": [ { "group": "test", "module": "c", "version": { "prefers": "preview" } } ]
         }
     ]
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -227,7 +227,7 @@ dependencies {
                 "buildType": "debug"
             },
             "files": [ { "name": "a-1.2-debug.jar", "url": "a-1.2-debug.jar" } ],
-            "dependencies": [ { "group": "test", "module": "b", "version": "2.0" } ]
+            "dependencies": [ { "group": "test", "module": "b", "version": { "prefers": "2.0", "rejects": [] } } ]
         },
         {
             "name": "release",
@@ -235,7 +235,7 @@ dependencies {
                 "buildType": "release"
             },
             "files": [ { "name": "a-1.2-release.jar", "url": "a-1.2-release.jar" } ],
-            "dependencies": [ { "group": "test", "module": "c", "version": "2.2" } ]
+            "dependencies": [ { "group": "test", "module": "c", "version": { "prefers": "2.2" } } ]
         }
     ]
 }
@@ -312,14 +312,14 @@ task checkRelease {
                 { "name": "a-1.2-api.jar", "url": "a-1.2-api.jar" },
                 { "name": "a-1.2-runtime.jar", "url": "a-1.2-runtime.jar" } 
             ],
-            "dependencies": [ { "group": "test", "module": "b", "version": "2.0" } ]
+            "dependencies": [ { "group": "test", "module": "b", "version": { "prefers": "2.0" } } ]
         },
         {
             "name": "release",
             "attributes": {
                 "buildType": "release"
             },
-            "dependencies": [ { "group": "test", "module": "b", "version": "2.0" } ]
+            "dependencies": [ { "group": "test", "module": "b", "version": { "prefers": "2.0" } } ]
         }
     ]
 }
@@ -581,14 +581,14 @@ task checkDebug {
                 "buildType": "debug"
             },
             "files": [ { "name": "a-1.2-debug.jar", "url": "a-1.2-debug.jar" } ],
-            "dependencies": [ { "group": "test", "module": "b", "version": "2.0" } ]
+            "dependencies": [ { "group": "test", "module": "b", "version": { "prefers": "2.0" } } ]
         },
         {
             "name": "release",
             "attributes": {
                 "buildType": "release"
             },
-            "dependencies": [ { "group": "test", "module": "c", "version": "preview" } ]
+            "dependencies": [ { "group": "test", "module": "c", "version": { "prefers": "preview" }} ]
         }
     ]
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
@@ -65,4 +65,8 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
     public static ImmutableVersionConstraint of(String preferredVersion) {
         return new DefaultImmutableVersionConstraint(preferredVersion);
     }
+
+    public static ImmutableVersionConstraint of(String preferredVersion, List<String> rejects) {
+        return new DefaultImmutableVersionConstraint(preferredVersion, rejects);
+    }
 }

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
@@ -85,7 +85,9 @@ This value must contain an array with zero or more elements. Each element must b
 
 - `group`: The group of the dependency.
 - `module`: The module of the dependency.
-- `version`: The version selector of the dependency. Has the same meaning as in the Gradle DSL.
+- `version`: The version constraint of the dependency. Has the same meaning as in the Gradle DSL. A version constraint consists of:
+   - `prefers`: The preferred version for this dependency
+   - `rejects`: An array of rejected versions for this dependency. Can be omitted.
 
 ### `files` value
 
@@ -129,7 +131,7 @@ This value must contain an array with zero or more elements. Each element must b
                 }
             ],
             "dependencies": [
-                { "group": "some.group", "module": "other-lib", "version": "3.4" }
+                { "group": "some.group", "module": "other-lib", "version": { "prefers": "3.4" } }
             ]
         },
         {
@@ -147,7 +149,7 @@ This value must contain an array with zero or more elements. Each element must b
                 }
             ],
             "dependencies": [
-                { "group": "some.group", "module": "other-lib", "version": "3.4" }
+                { "group": "some.group", "module": "other-lib", "version": { "prefers": "3.4", "rejects": ["3.4.1"] } }
             ]
         }
     ]

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -131,7 +131,7 @@ class GradleModuleMetadata {
         }
 
         List<Dependency> getDependencies() {
-            return (values.dependencies ?: []).collect { new Dependency(it.group, it.module, it.version) }
+            return (values.dependencies ?: []).collect { new Dependency(it.group, it.module, it.version.prefers, it.version.rejects?:[]) }
         }
 
         List<File> getFiles() {
@@ -143,11 +143,13 @@ class GradleModuleMetadata {
         final String group
         final String module
         final String version
+        final List<String> rejectsVersion
 
-        Coords(String group, String module, String version) {
+        Coords(String group, String module, String version, List<String> rejectsVersion = []) {
             this.group = group
             this.module = module
             this.version = version
+            this.rejectsVersion = rejectsVersion
         }
 
         String getCoords() {
@@ -165,8 +167,8 @@ class GradleModuleMetadata {
     }
 
     static class Dependency extends Coords {
-        Dependency(String group, String module, String version) {
-            super(group, module, version)
+        Dependency(String group, String module, String version, List<String> rejectedVersions) {
+            super(group, module, version, rejectedVersions)
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -403,7 +403,9 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                         "dependencies": [
 """
             value << dependencies.collect { d ->
-                "                            { \"group\": \"$d.groupId\", \"module\": \"$d.artifactId\", \"version\": \"$d.version\" }\n"
+                def rejects = d.rejects?", \"rejects\": [${d.rejects.collect { "\"$it\""}.join(',')}]":""
+                def versionConstraint = "{ \"prefers\": \"${d.version}\"$rejects }"
+                "                            { \"group\": \"$d.groupId\", \"module\": \"$d.artifactId\", \"version\": $versionConstraint }\n"
             }.join(",\n")
             value << """                        ]
                     }${i.hasNext() ? ',' : ''}"""

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -96,8 +96,8 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private boolean isPublishWithOriginalFileName;
 
     public DefaultMavenPublication(
-            String name, MavenProjectIdentity projectIdentity, NotationParser<Object, MavenArtifact> mavenArtifactParser, Instantiator instantiator,
-            ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory
+        String name, MavenProjectIdentity projectIdentity, NotationParser<Object, MavenArtifact> mavenArtifactParser, Instantiator instantiator,
+        ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory
     ) {
         this.name = name;
         this.projectDependencyResolver = projectDependencyResolver;
@@ -356,9 +356,10 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
 
     private String getArtifactFileName(String classifier, String extension) {
         StringBuilder artifactPath = new StringBuilder();
-        artifactPath.append(getCoordinates().getName());
+        ModuleVersionIdentifier coordinates = getCoordinates();
+        artifactPath.append(coordinates.getName());
         artifactPath.append('-');
-        artifactPath.append(getCoordinates().getVersion());
+        artifactPath.append(coordinates.getVersion());
         if (GUtil.isTrue(classifier)) {
             artifactPath.append('-');
             artifactPath.append(classifier);

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.component.ComponentWithVariants;
@@ -37,6 +38,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -92,6 +94,21 @@ public class ModuleMetadataFileGenerator {
         writeIdentity(publication.getCoordinates(), component, componentCoordinates, owners, jsonWriter);
         writeCreator(jsonWriter);
         writeVariants(publication, component, componentCoordinates, jsonWriter);
+        jsonWriter.endObject();
+    }
+
+    private void writeVersionConstraint(VersionConstraint versionConstraint, JsonWriter jsonWriter) throws IOException {
+        jsonWriter.name("version");
+        jsonWriter.beginObject();
+        jsonWriter.name("prefers");
+        jsonWriter.value(versionConstraint.getPreferredVersion());
+        jsonWriter.name("rejects");
+        jsonWriter.beginArray();
+        List<String> rejectedVersions = versionConstraint.getRejectedVersions();
+        for (String reject : rejectedVersions) {
+            jsonWriter.value(reject);
+        }
+        jsonWriter.endArray();
         jsonWriter.endObject();
     }
 
@@ -304,15 +321,13 @@ public class ModuleMetadataFileGenerator {
             jsonWriter.value(identifier.getGroup());
             jsonWriter.name("module");
             jsonWriter.value(identifier.getName());
-            jsonWriter.name("version");
-            jsonWriter.value(identifier.getVersion());
+            writeVersionConstraint(moduleDependency.getVersionConstraint(), jsonWriter);
         } else {
             jsonWriter.name("group");
             jsonWriter.value(moduleDependency.getGroup());
             jsonWriter.name("module");
             jsonWriter.value(moduleDependency.getName());
-            jsonWriter.name("version");
-            jsonWriter.value(moduleDependency.getVersion());
+            writeVersionConstraint(moduleDependency.getVersionConstraint(), jsonWriter);
         }
         jsonWriter.endObject();
     }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -27,6 +27,7 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
@@ -321,7 +322,7 @@ public class ModuleMetadataFileGenerator {
             jsonWriter.value(identifier.getGroup());
             jsonWriter.name("module");
             jsonWriter.value(identifier.getName());
-            writeVersionConstraint(moduleDependency.getVersionConstraint(), jsonWriter);
+            writeVersionConstraint(DefaultImmutableVersionConstraint.of(identifier.getVersion()), jsonWriter);
         } else {
             jsonWriter.name("group");
             jsonWriter.value(moduleDependency.getGroup());

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Named
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
@@ -35,6 +36,21 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class ModuleMetadataFileGeneratorTest extends Specification {
+
+    VersionConstraint prefers(String version) {
+        Mock(VersionConstraint) {
+            getPreferredVersion() >> version
+            getRejectedVersions() >> []
+        }
+    }
+
+    VersionConstraint prefersAndRejects(String version, List<String> rejects) {
+        Mock(VersionConstraint) {
+            getPreferredVersion() >> version
+            getRejectedVersions() >> rejects
+        }
+    }
+
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def buildId = UniqueId.generate()
@@ -161,12 +177,12 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def d1 = Stub(ModuleDependency)
         d1.group >> "g1"
         d1.name >> "m1"
-        d1.version >> "v1"
+        d1.versionConstraint >> prefers("v1")
 
         def d2 = Stub(ModuleDependency)
         d2.group >> "g2"
         d2.name >> "m2"
-        d2.version >> "v2"
+        d2.versionConstraint >> prefersAndRejects("v2", ["v3", "v4"])
 
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
@@ -206,7 +222,10 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         {
           "group": "g1",
           "module": "m1",
-          "version": "v1"
+          "version": {
+            "prefers": "v1",
+            "rejects": []
+          }
         }
       ]
     },
@@ -219,7 +238,13 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         {
           "group": "g2",
           "module": "m2",
-          "version": "v2"
+          "version": {
+            "prefers": "v2",
+            "rejects": [
+              "v3",
+              "v4"
+            ]
+          }
         }
       ]
     }


### PR DESCRIPTION
This pull request adds support for reading and writing `accepts`/`rejects` version constraints in the Gradle metadata file.

This is part of the [strict dependencies epic](https://github.com/gradle/gradle/issues/3311) and is required to support both publishing and resolving of modules that declare strict dependencies (as strict dependencies are neither possible with Ivy or Maven POM).