### PR TITLE
Allow plugin projects to depend on each other

### DIFF
--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -79,6 +79,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
     private FileCollection descriptorFile;
     private SoftwareComponentInternal component;
+    private boolean alias;
 
     public DefaultIvyPublication(
             String name, Instantiator instantiator, IvyPublicationIdentity publicationIdentity, NotationParser<Object, IvyArtifact> ivyArtifactNotationParser,
@@ -113,6 +114,16 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
 
     public void descriptor(Action<? super IvyModuleDescriptorSpec> configure) {
         configure.execute(descriptor);
+    }
+
+    @Override
+    public boolean isAlias() {
+        return alias;
+    }
+
+    @Override
+    public void setAlias(boolean alias) {
+        this.alias = alias;
     }
 
     public void from(SoftwareComponent component) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -94,6 +94,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private FileCollection pomFile;
     private SoftwareComponentInternal component;
     private boolean isPublishWithOriginalFileName;
+    private boolean alias;
 
     public DefaultMavenPublication(
             String name, MavenProjectIdentity projectIdentity, NotationParser<Object, MavenArtifact> mavenArtifactParser, Instantiator instantiator,
@@ -127,6 +128,16 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
 
     public void pom(Action<? super MavenPom> configure) {
         configure.execute(pom);
+    }
+
+    @Override
+    public boolean isAlias() {
+        return alias;
+    }
+
+    @Override
+    public void setAlias(boolean alias) {
+        this.alias = alias;
     }
 
     public void from(SoftwareComponent component) {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.plugin.devel.plugins
 
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.test.fixtures.archive.JarTestFixture
+import spock.lang.Issue
 
 class JavaGradlePluginPluginIntegrationTest extends WellBehavedPluginTest {
     final static String NO_DESCRIPTOR_WARNING = JavaGradlePluginPlugin.NO_DESCRIPTOR_WARNING_MESSAGE.substring(4)
@@ -247,6 +248,35 @@ class JavaGradlePluginPluginIntegrationTest extends WellBehavedPluginTest {
         succeeds "jar"
         file("build", "pluginDescriptors").listFiles().size() == 1
         file("build", "resources", "main", "META-INF", "gradle-plugins").listFiles().size() == 1
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/1061")
+    def "one plugin project can depend on another when using publishing plugins"() {
+        given:
+        settingsFile << "include 'a', 'b'"
+        file("a/build.gradle") << """
+            apply plugin: 'java-gradle-plugin'
+            apply plugin: 'maven-publish'
+            apply plugin: 'ivy-publish'
+            gradlePlugin {
+                plugins {
+                    foo {
+                        id = 'foo-plugin'
+                        implementationClass = "com.foo.Foo"
+                    }
+                }
+            }
+        """
+        file("b/build.gradle") << """
+            apply plugin: 'java-gradle-plugin'
+            apply plugin: 'maven-publish'
+            apply plugin: 'ivy-publish'
+            dependencies {
+                implementation project(':a')
+            }
+        """
+        expect:
+        succeeds("assemble")
     }
 
     def buildFile() {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingRules.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingRules.java
@@ -25,6 +25,7 @@ import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.ivy.IvyModuleDescriptorSpec;
 import org.gradle.api.publish.ivy.IvyPublication;
+import org.gradle.api.publish.ivy.internal.publication.IvyPublicationInternal;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.model.Finalize;
 import org.gradle.model.Mutate;
@@ -71,7 +72,8 @@ class IvyPluginPublishingRules extends RuleSource {
 
     private void createIvyMarkerPublication(PluginDeclaration declaration, final IvyPublication mainPublication, PublicationContainer publications) {
         String pluginId = declaration.getId();
-        IvyPublication publication = publications.create(declaration.getName() + "PluginMarkerIvy", IvyPublication.class);
+        IvyPublicationInternal publication = (IvyPublicationInternal) publications.create(declaration.getName() + "PluginMarkerIvy", IvyPublication.class);
+        publication.setAlias(true);
         publication.setOrganisation(pluginId);
         publication.setModule(pluginId + PLUGIN_MARKER_SUFFIX);
         publication.descriptor(new Action<IvyModuleDescriptorSpec>() {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishingRules.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishingRules.java
@@ -24,6 +24,7 @@ import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.model.Finalize;
 import org.gradle.model.Mutate;
@@ -69,7 +70,8 @@ class MavenPluginPublishingRules extends RuleSource {
 
     private void createMavenMarkerPublication(PluginDeclaration declaration, final MavenPublication coordinates, PublicationContainer publications) {
         String pluginId = declaration.getId();
-        MavenPublication publication = publications.create(declaration.getName() + "PluginMarkerMaven", MavenPublication.class);
+        MavenPublicationInternal publication = (MavenPublicationInternal) publications.create(declaration.getName() + "PluginMarkerMaven", MavenPublication.class);
+        publication.setAlias(true);
         publication.setArtifactId(pluginId + PLUGIN_MARKER_SUFFIX);
         publication.setGroupId(pluginId);
         publication.getPom().withXml(new Action<XmlProvider>() {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ProjectDependencyPublicationResolver.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ProjectDependencyPublicationResolver.java
@@ -57,7 +57,7 @@ public class ProjectDependencyPublicationResolver {
         }
         Set<PublicationInternal> topLevel = new LinkedHashSet<PublicationInternal>();
         for (PublicationInternal publication : publications) {
-            if (publication.getComponent() == null || !ignored.contains(publication.getComponent())) {
+            if (!publication.isAlias() && (publication.getComponent() == null || !ignored.contains(publication.getComponent()))) {
                 topLevel.add(publication);
             }
         }
@@ -72,7 +72,7 @@ public class ProjectDependencyPublicationResolver {
                 formatter.node("Publishing is not yet able to resolve a dependency on a project with multiple publications that have different coordinates.");
                 formatter.node("Found the following publications in " + dependencyProject.getDisplayName());
                 formatter.startChildren();
-                for (PublicationInternal publication : publications) {
+                for (PublicationInternal publication : topLevel) {
                     formatter.node("Publication '" + publication.getName() + "' with coordinates " + publication.getCoordinates());
                 }
                 formatter.endChildren();

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
@@ -29,6 +29,14 @@ public interface PublicationInternal extends Publication {
     ModuleVersionIdentifier getCoordinates();
 
     /**
+     * Specifies that this publication is just an alias for another one and should not
+     * be considered when converting project dependencies to published metadata.
+     */
+    boolean isAlias();
+
+    void setAlias(boolean alias);
+
+    /**
      * Provide the file coordinates for the published artifact, if any.
      *
      * @param source The original PublishArtifact


### PR DESCRIPTION
The plugin marker artifacts are just aliases for the actual
plugin and thus shouldn't lead to an exception when one plugin
depends on another.

Long term we'll probably want to model plugins as components and use
a dependency on a component instead of depending on the whole project.

Fixes #3419