### PR TITLE
Resolve runtime variant of published java library where consuming configuration defines no attributes

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonToken;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -233,7 +234,10 @@ public class ModuleMetadataParser {
         reader.beginObject();
         while (reader.peek() != END_OBJECT) {
             String attrName = reader.nextName();
-            if (reader.peek() == BOOLEAN) {
+            if (attrName.equals(Usage.USAGE_ATTRIBUTE.getName())) {
+                String attrValue = reader.nextString();
+                attributes = attributesFactory.concat(attributes, Attribute.of(attrName, Usage.class), instantiator.named(Usage.class, attrValue));
+            } else if (reader.peek() == BOOLEAN) {
                 boolean attrValue = reader.nextBoolean();
                 attributes = attributesFactory.concat(attributes, Attribute.of(attrName, Boolean.class), attrValue);
             } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/EmptySchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/EmptySchema.java
@@ -30,7 +30,7 @@ public class EmptySchema implements AttributesSchemaInternal {
     private final DoNothingCompatibilityRule compatibilityRule = new DoNothingCompatibilityRule();
     private final DoNothingDisambiguationRule disambiguationRule = new DoNothingDisambiguationRule();
 
-    private EmptySchema() {
+    protected EmptySchema() {
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -38,6 +38,8 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
 
     public static final String POM_PACKAGING = "pom";
     public static final Collection<String> JAR_PACKAGINGS = Arrays.asList("jar", "ejb", "bundle", "maven-plugin", "eclipse-plugin");
+    private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = new PreferJavaRuntimeVariant();
+
     private final String packaging;
     private final boolean relocated;
     private final String snapshotTimestamp;
@@ -106,7 +108,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     @Nullable
     @Override
     public AttributesSchemaInternal getAttributesSchema() {
-        return new PreferJavaRuntimeVariant();
+        return SCHEMA_DEFAULT_JAVA_VARIANTS;
     }
 
     /**
@@ -122,8 +124,8 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     private static class PreferJavaRuntimeVariant extends EmptySchema {
         private static final NamedObjectInstantiator INSTANTIATOR = NamedObjectInstantiator.INSTANCE;
         private static final Usage JAVA_API = INSTANTIATOR.named(Usage.class, Usage.JAVA_API);
-        private static final Usage JAVA_RUNIME = INSTANTIATOR.named(Usage.class, Usage.JAVA_RUNTIME);
-        private static final Set<Usage> DEFAULT_JAVA_USAGES = ImmutableSet.of(JAVA_API, JAVA_RUNIME);
+        private static final Usage JAVA_RUNTIME = INSTANTIATOR.named(Usage.class, Usage.JAVA_RUNTIME);
+        private static final Set<Usage> DEFAULT_JAVA_USAGES = ImmutableSet.of(JAVA_API, JAVA_RUNTIME);
 
         @Override
         public DisambiguationRule<Object> disambiguationRules(Attribute<?> attribute) {
@@ -132,7 +134,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
                     public void execute(MultipleCandidatesResult<Usage> details) {
                         if (details.getConsumerValue() == null) {
                             if (details.getCandidateValues().equals(DEFAULT_JAVA_USAGES)) {
-                                details.closestMatch(JAVA_RUNIME);
+                                details.closestMatch(JAVA_RUNTIME);
                             }
                         }
                     }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -43,6 +43,8 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
 
         and:
         resolveArtifacts(javaLibrary) == ["publishTest-1.9.jar"]
+        resolveApiArtifacts(javaLibrary) == ["publishTest-1.9.jar"]
+        resolveRuntimeArtifacts(javaLibrary) == ["publishTest-1.9.jar"]
     }
 
     def "can publish java-library with dependencies"() {
@@ -74,6 +76,8 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
 
         and:
         resolveArtifacts(javaLibrary) == ["bar-1.0.jar", "foo-1.0.jar", "publishTest-1.9.jar"]
+        resolveApiArtifacts(javaLibrary) == ["foo-1.0.jar", "publishTest-1.9.jar"]
+        resolveRuntimeArtifacts(javaLibrary) == ["bar-1.0.jar", "foo-1.0.jar", "publishTest-1.9.jar"]
     }
 
     def "can publish java-library with dependencies and excludes"() {


### PR DESCRIPTION
This PR adds a producer-side `AttributesSchema` for maven modules, that prefers the `JAVA_RUNTIME` variant over the `JAVA_API` variant where the consumer has not provided any disambiguating attributes.

This will permit existing Gradle builds to continue to consume Maven modules published with Gradle module metadata.

See more description in #3407 