### PR TITLE
Avoid Maven repository lookups for unsupported notations

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -122,6 +122,10 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
     }
 
     protected void doResolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+        if (isIncomplete(moduleComponentIdentifier)) {
+            result.missing();
+            return;
+        }
         if (isNonUniqueSnapshot(moduleComponentIdentifier)) {
             MavenUniqueSnapshotModuleSource uniqueSnapshotVersion = findUniqueSnapshotVersion(moduleComponentIdentifier, result);
             if (uniqueSnapshotVersion != null) {
@@ -139,6 +143,10 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
         }
 
         resolveStaticDependency(moduleComponentIdentifier, prescribedMetaData, result, super.createArtifactResolver());
+    }
+
+    private boolean isIncomplete(ModuleComponentIdentifier moduleComponentIdentifier) {
+        return moduleComponentIdentifier.getGroup().isEmpty() || moduleComponentIdentifier.getModule().isEmpty() || moduleComponentIdentifier.getVersion().isEmpty();
     }
 
     protected boolean isMetaDataArtifact(ArtifactType artifactType) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionLister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionLister.java
@@ -40,6 +40,9 @@ public class MavenVersionLister implements VersionLister {
             final Set<ExternalResourceName> searched = new HashSet<ExternalResourceName>();
 
             public void visit(ResourcePattern pattern, IvyArtifactName artifact) throws ResourceException {
+                if (isIncomplete(module)) {
+                    return;
+                }
                 ExternalResourceName metadataLocation = pattern.toModulePath(module).resolve("maven-metadata.xml");
                 if (!searched.add(metadataLocation)) {
                     return;
@@ -51,5 +54,9 @@ public class MavenVersionLister implements VersionLister {
                 }
             }
         };
+    }
+
+    private boolean isIncomplete(ModuleIdentifier module) {
+        return module.getGroup().isEmpty() || module.getName().isEmpty();
     }
 }


### PR DESCRIPTION
A Maven repository always requires a group, name and version to
be specified. Asking without them will result in either a 400 or 404,
depending on the artifact server. This creates unnecessary network traffic,
so instead we now don't even ask and report the module as missing.

This can happen when a user mixes a flatDir repository and a Maven
repository. Modules in the flatDir repository don't have a group.
Depending on the order of repositories, Gradle will end up asking the
Maven repository for things that can never be found there.