### PR TITLE
Avoid repository lookups for unsupported notations in Maven and Ivy

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyHttpRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyHttpRepoResolveIntegrationTest.groovy
@@ -162,4 +162,49 @@ class IvyHttpRepoResolveIntegrationTest extends AbstractIvyRemoteRepoResolveInte
         then:
         succeeds('listJars')
     }
+
+    /**
+     * Ivy equivalent of "does not query Maven repository for modules without a group, name or version" in
+     * {@link org.gradle.integtests.resolve.maven.MavenHttpRepoResolveIntegrationTest}
+     */
+    def "does not query Ivy repository for modules without a group, name or version"() {
+        given:
+        def remoteIvyRepo = server.remoteIvyRepo
+        buildFile << """
+            repositories {
+                ivy {
+                    url '${remoteIvyRepo.uri}'
+                }
+            }
+            configurations { compile }
+            dependencies { 
+                compile ':name1:1.0' 
+                compile ':name1:1.0' 
+                compile ':name2:[1.0, 2.0]' 
+                compile ':name3:1.0-SNAPSHOT'
+                compile 'group1::1.0'
+                compile 'group2::[1.0, 2.0]' 
+                compile 'group3::1.0-SNAPSHOT'
+                compile 'group:name'
+            }
+            task resolve {
+                doLast {
+                    assert configurations.compile.resolve()
+                }
+            }
+        """
+
+        when:
+        fails 'resolve'
+
+        then:
+
+        errorOutput.contains('Could not find :name1:1.0.')
+        errorOutput.contains('Could not find any matches for :name2:[1.0, 2.0] as no versions of :name2 are available.')
+        errorOutput.contains('Could not find :name3:1.0-SNAPSHOT.')
+        errorOutput.contains('Could not find group1::1.0.')
+        errorOutput.contains('Could not find any matches for group2::[1.0, 2.0] as no versions of group2: are available.')
+        errorOutput.contains('Could not find group3::1.0-SNAPSHOT.')
+        errorOutput.contains('Could not find group:name:.')
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ChainedVersionLister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ChainedVersionLister.java
@@ -41,6 +41,9 @@ public class ChainedVersionLister implements VersionLister {
         }
         return new VersionPatternVisitor() {
             public void visit(ResourcePattern pattern, IvyArtifactName artifact) throws ResourceException {
+                if (!pattern.isComplete(module)) {
+                    return;
+                }
                 MissingResourceException failure = null;
                 for (VersionPatternVisitor list : visitors) {
                     try {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceArtifactResolver.java
@@ -73,6 +73,9 @@ class DefaultExternalResourceArtifactResolver implements ExternalResourceArtifac
 
     private boolean staticResourceExists(List<ResourcePattern> patternList, ModuleComponentArtifactMetadata artifact, ResourceAwareResolveResult result) {
         for (ResourcePattern resourcePattern : patternList) {
+            if (isIncomplete(resourcePattern, artifact)) {
+                continue;
+            }
             ExternalResourceName location = resourcePattern.getLocation(artifact);
             result.attempted(location);
             LOGGER.debug("Loading {}", location);
@@ -98,6 +101,9 @@ class DefaultExternalResourceArtifactResolver implements ExternalResourceArtifac
 
     private LocallyAvailableExternalResource downloadByUrl(List<ResourcePattern> patternList, final UrlBackedArtifactMetadata artifact, ResourceAwareResolveResult result) {
         for (ResourcePattern resourcePattern : patternList) {
+            if (isIncomplete(resourcePattern, artifact)) {
+                continue;
+            }
             ExternalResourceName moduleDir = resourcePattern.toModuleVersionPath(artifact.getComponentId());
             ExternalResourceName location = moduleDir.resolve(artifact.getRelativeUrl());
             result.attempted(location);
@@ -121,6 +127,9 @@ class DefaultExternalResourceArtifactResolver implements ExternalResourceArtifac
 
     private LocallyAvailableExternalResource downloadByCoords(List<ResourcePattern> patternList, final ModuleComponentArtifactMetadata artifact, ResourceAwareResolveResult result) {
         for (ResourcePattern resourcePattern : patternList) {
+            if (isIncomplete(resourcePattern, artifact)) {
+                continue;
+            }
             ExternalResourceName location = resourcePattern.getLocation(artifact);
             result.attempted(location);
             LOGGER.debug("Loading {}", location);
@@ -139,5 +148,9 @@ class DefaultExternalResourceArtifactResolver implements ExternalResourceArtifac
             }
         }
         return null;
+    }
+
+    private boolean isIncomplete(ResourcePattern resourcePattern, ModuleComponentArtifactMetadata artifact) {
+        return !resourcePattern.isComplete(artifact.getId().getComponentIdentifier());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
@@ -63,7 +63,7 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
                        boolean dynamicResolve, FileStore<ModuleComponentArtifactIdentifier> artifactFileStore, IvyContextManager ivyContextManager,
                        ImmutableModuleIdentifierFactory moduleIdentifierFactory, Factory<ComponentMetadataSupplier> componentMetadataSupplierFactory,
                        FileResourceRepository fileResourceRepository) {
-        super(name, transport.isLocal(), transport.getRepository(), transport.getResourceAccessor(), new ResourceVersionLister(transport.getRepository()), locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, fileResourceRepository);
+        super(name, transport.isLocal(), transport.getRepository(), transport.getResourceAccessor(), new ChainedVersionLister(new ResourceVersionLister(transport.getRepository())), locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, fileResourceRepository);
         this.componentMetadataSupplierFactory = componentMetadataSupplierFactory;
         this.metaDataParser = new IvyContextualMetaDataParser<MutableIvyModuleResolveMetadata>(ivyContextManager, new IvyXmlModuleDescriptorParser(new IvyModuleDescriptorConverter(moduleIdentifierFactory), moduleIdentifierFactory, fileResourceRepository));
         this.dynamicResolve = dynamicResolve;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionLister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionLister.java
@@ -40,9 +40,6 @@ public class MavenVersionLister implements VersionLister {
             final Set<ExternalResourceName> searched = new HashSet<ExternalResourceName>();
 
             public void visit(ResourcePattern pattern, IvyArtifactName artifact) throws ResourceException {
-                if (isIncomplete(module)) {
-                    return;
-                }
                 ExternalResourceName metadataLocation = pattern.toModulePath(module).resolve("maven-metadata.xml");
                 if (!searched.add(metadataLocation)) {
                     return;
@@ -54,9 +51,5 @@ public class MavenVersionLister implements VersionLister {
                 }
             }
         };
-    }
-
-    private boolean isIncomplete(ModuleIdentifier module) {
-        return module.getGroup().isEmpty() || module.getName().isEmpty();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourcePattern.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourcePattern.java
@@ -48,4 +48,14 @@ public interface ResourcePattern {
      * Returns the path for the given component.
      */
     ExternalResourceName toModuleVersionPath(ModuleComponentIdentifier componentIdentifier);
+
+    /**
+     * Checks if the given organisation and module values are sufficient to bind the [organisation] and [module] tokens in the pattern.
+     */
+    boolean isComplete(ModuleIdentifier moduleIdentifier);
+
+    /**
+     * Checks if the given organisation, module and revision values are sufficient to bind the [organisation], [module] and [revision] tokens in the pattern.
+     */
+    boolean isComplete(ModuleComponentIdentifier componentIdentifier);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
@@ -15,15 +15,24 @@
  */
 package org.gradle.api.internal.artifacts.repositories.resolver
 
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
+import org.gradle.internal.component.model.DefaultComponentOverrideMetadata
+import org.gradle.internal.resolve.result.DefaultBuildableModuleComponentMetaDataResolveResult
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.local.FileStore
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
+import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor
 import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId
+import static org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult.State.Missing
 
 class IvyResolverTest extends Specification {
+    def externalResourceAccessor = Mock(CacheAwareExternalResourceAccessor)
 
     def "has useful string representation"() {
         expect:
@@ -46,7 +55,73 @@ class IvyResolverTest extends Specification {
         resolver1.id != resolver2.id
     }
 
-    private IvyResolver resolver() {
-        new IvyResolver("repo", Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), false, Stub(FileStore), Stub(IvyContextManager), Mock(ImmutableModuleIdentifierFactory), null, Stub(FileResourceRepository))
+    @Unroll
+    def "remote access fails directly for module id #moduleId with layout #layoutPattern"() {
+        given:
+        def overrideMetadata = new DefaultComponentOverrideMetadata()
+        def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
+
+        when:
+        resolver(layoutPattern).getRemoteAccess().resolveComponentMetaData(moduleId, overrideMetadata, result)
+
+        then:
+        result.state == Missing
+        0 * externalResourceAccessor._
+        0 * _
+
+        where:
+        moduleId                    | layoutPattern
+        newId("", "", "")     | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId("", "", "")     | "[module]"
+        newId("group", "", "1")     | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId("group", "", "1")     | "[module]"
+        newId("", "name", "1")      | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId("", "name", "1")      | "[organisation]/[module]"
+        newId("group", "name", "")  | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId("group", "name", "")  | "[module]-[revision]"
+        newId("", "name", "")       | "([branch])[organisation]/[module]-[revision]"
+        newId("", "name", "")       | "([organisation])/[module]-[revision]"
+        newId("", "name", "")       | "([branch])[organization]/[module]-[revision]"
+        newId("", "name", "")       | "([organization])/[module]-[revision]"
+    }
+
+    @Unroll
+    def "remote access attempts to access metadata for id #moduleId with layout #layoutPattern"() {
+        given:
+        def overrideMetadata = new DefaultComponentOverrideMetadata()
+        def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
+
+        when:
+        resolver(layoutPattern).getRemoteAccess().resolveComponentMetaData(moduleId, overrideMetadata, result)
+
+        then:
+        1 * externalResourceAccessor.getResource(_, _, _, _) >> null
+        0 * _
+
+        where:
+        moduleId                    | layoutPattern
+        newId("group", "name", "1") | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId("group", "name", "1") | "[module]"
+        newId("", "name", "1")      | "[module]"
+        newId("", "name", "1")      | "[module]-[revision]"
+        newId("group", "name", "")  | "[module]"
+        newId("group", "name", "")  | "[organisation]/[module]"
+        newId("", "name", "1")      | "([organisation]/)[module]-[revision]"
+        newId("group", "name", "")  | "[organisation]/[module]-([revision])"
+        newId("group", "name", "")  | "[organization]/[module]"
+        newId("", "name", "1")      | "([organization]/)[module]-[revision]"
+        newId("group", "name", "")  | "[organization]/[module]-([revision])"
+    }
+
+    private IvyResolver resolver(String ivyPattern = null) {
+        def transport = Stub(RepositoryTransport)
+        transport.resourceAccessor >> externalResourceAccessor
+
+        new IvyResolver("repo", transport, Stub(LocallyAvailableResourceFinder), false, Stub(FileStore), Stub(IvyContextManager), Stub(ImmutableModuleIdentifierFactory), null, Stub(FileResourceRepository)).with {
+            if (ivyPattern) {
+                it.addDescriptorLocation(URI.create(""), ivyPattern)
+            }
+            it
+        }
     }
 }


### PR DESCRIPTION
This pulls up the check that was first added for Maven only in #3431.

`flatDir {}` repositories, which also use the `IvyResolver` implementation, require support for modules without _group_ or _version_. This case is also handled by this PR.