### PR TITLE
Use canonical URL for Maven Central repository shortcut method

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactRepositoryContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactRepositoryContainer.java
@@ -49,7 +49,7 @@ import org.gradle.util.Configurable;
 public interface ArtifactRepositoryContainer extends NamedDomainObjectList<ArtifactRepository>, Configurable<ArtifactRepositoryContainer> {
     String DEFAULT_MAVEN_CENTRAL_REPO_NAME = "MavenRepo";
     String DEFAULT_MAVEN_LOCAL_REPO_NAME = "MavenLocal";
-    String MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2/";
+    String MAVEN_CENTRAL_URL = "https://repo.maven.apache.org/maven2/";
     String GOOGLE_URL = "https://dl.google.com/dl/android/maven2/";
 
     /**

--- a/subprojects/docs/src/docs/userguide/depMngmt.adoc
+++ b/subprojects/docs/src/docs/userguide/depMngmt.adoc
@@ -516,7 +516,7 @@ There are several different types of repositories you can declare:
 [[sub:maven_central]]
 ==== Maven central repository
 
-To add the central Maven 2 repository (https://repo1.maven.org/maven2[]) simply add this to your build script:
+To add the central Maven 2 repository (https://repo.maven.apache.org/maven2[]) simply add this to your build script:
 
 ++++
 <sample id="mavenCentral" dir="userguide/artifacts/defineRepository" title="Adding central Maven repository">
@@ -1394,7 +1394,7 @@ For more details, take a look at the API documentation for api:org.gradle.api.ar
 [[sec:strategies_of_transitive_dependency_management]]
 === Strategies for transitive dependency management
 
-Many projects rely on the https://repo1.maven.org/maven2[Maven Central repository]. This is not without problems.
+Many projects rely on the https://repo.maven.apache.org/maven2[Maven Central repository]. This is not without problems.
 
 * The Maven Central repository can be down or can be slow to respond.
 * The POM files of many popular projects specify dependencies or other configuration that are just plain wrong (for instance, the POM file of the “`commons-httpclient-3.0`” module declares JUnit as a runtime dependency).

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenInstallationDownloader.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/MavenInstallationDownloader.groovy
@@ -53,7 +53,7 @@ class MavenInstallationDownloader {
 
     private static File downloadMavenBinArchiveWithRetry(String mavenVersion) {
         def binArchiveUrls = [
-            new URL("http://repo1.maven.org/maven2/org/apache/maven/apache-maven/$mavenVersion/apache-maven-$mavenVersion-bin.zip"),
+            new URL("https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/$mavenVersion/apache-maven-$mavenVersion-bin.zip"),
             new URL(fetchPreferredUrl(mavenVersion))
         ]
 

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheDirectoryListingParserTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheDirectoryListingParserTest.groovy
@@ -165,7 +165,7 @@ class ApacheDirectoryListingParserTest extends Specification {
         where:
         artifactRootURI                                                         | repoType
         "http://localhost:8081/artifactory/repo1/junit/junit/"                  | "artifactory"
-        "https://repo1.maven.org/maven2/junit/junit/"                           | "mavencentral"
+        "https://repo.maven.apache.org/maven2/junit/junit/"                     | "mavencentral"
         "http://localhost:8081/nexus/content/repositories/central/junit/junit/" | "nexus"
     }
 


### PR DESCRIPTION
### Context
The default Maven URL is https://repo.maven.apache.org/maven2/. (https://repo1.maven.org/maven2/ is no longer the default)

From reading online, As Robert Scholte informed, as of 3.0.4 the default URL has been changed from http://repo1.maven.org/maven2 to http://repo.maven.apache.org/maven2. 

Additional Sources:
- http://svn.apache.org/viewvc/maven/site/trunk/src/site/xdoc/repository/index.xml?r1=1243210&r2=1243209&pathrev=1243210
- https://stackoverflow.com/questions/18471432/maven-why-does-my-computer-always-download-from-http-repo1-maven-org
- https://github.com/gradle/gradle/issues/3463

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
