### PR TITLE
Update Maven Central URL to repo.maven.apache.org

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactRepositoryContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactRepositoryContainer.java
@@ -49,7 +49,7 @@ import org.gradle.util.Configurable;
 public interface ArtifactRepositoryContainer extends NamedDomainObjectList<ArtifactRepository>, Configurable<ArtifactRepositoryContainer> {
     String DEFAULT_MAVEN_CENTRAL_REPO_NAME = "MavenRepo";
     String DEFAULT_MAVEN_LOCAL_REPO_NAME = "MavenLocal";
-    String MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2/";
+    String MAVEN_CENTRAL_URL = "https://repo.maven.apache.org/maven2/";
     String GOOGLE_URL = "https://dl.google.com/dl/android/maven2/";
 
     /**


### PR DESCRIPTION
### Context

https://issues.sonatype.org/browse/MVNCENTRAL-2870 caused build issues all over the world. The TL;DR is that the SSL certificates for repo1.maven.org were broken (no subject alternative DNS name).

I believe this was fixed (still propagating at this time afaik), but this made me realize that `mavenCentral()` still points to  the old `repo1.maven.org` and should probably be updated to `repo.maven.apache.org`.

I don't have much context here so feel free to decline if you think Gradle should stick to `repo1`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
=> N/A
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
=> N/A
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
=> N/A
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`
=> N/A

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
