### PR TITLE
Add build configurations for limited macOS agent builds

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -15,7 +15,7 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
         ""
     } + testCoverage.testType.name + "Test"
     val quickTest = testCoverage.testType == TestType.quick
-    applyDefaults(model, this, testTask, notQuick = !quickTest, runsOnWindows = testCoverage.os == OS.windows,
+    applyDefaults(model, this, testTask, notQuick = !quickTest, os = testCoverage.os,
             timeout = if (quickTest) 60 else 180)
 
     params {

--- a/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
+++ b/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
@@ -47,7 +47,7 @@ class IndividualPerformanceScenarioWorkers(model: CIBuildModel) : BaseGradleBuil
         script {
             name = "CHECK_CLEAN_M2"
             executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = m2CleanScriptLinux
+            scriptContent = m2CleanScriptUnixLike
         }
     }
 

--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -44,7 +44,7 @@ class PerformanceTest(model: CIBuildModel, type: PerformanceTestType) : BaseGrad
         script {
             name = "CHECK_CLEAN_M2"
             executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = m2CleanScriptLinux
+            scriptContent = m2CleanScriptUnixLike
         }
         if (model.tagBuilds) {
             gradle {

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -71,7 +71,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?) : BaseGr
         script {
             name = "CHECK_CLEAN_M2"
             executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = m2CleanScriptLinux
+            scriptContent = m2CleanScriptUnixLike
         }
         if (model.tagBuilds) {
             gradle {

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -48,7 +48,8 @@ data class CIBuildModel (
                             TestCoverage(TestType.allVersionsCrossVersion, OS.linux, JvmVersion.java7),
                             TestCoverage(TestType.allVersionsCrossVersion, OS.windows, JvmVersion.java7),
                             TestCoverage(TestType.noDaemon, OS.linux, JvmVersion.java8),
-                            TestCoverage(TestType.noDaemon, OS.windows, JvmVersion.java8)),
+                            TestCoverage(TestType.noDaemon, OS.windows, JvmVersion.java8),
+                            TestCoverage(TestType.platform, OS.macos, JvmVersion.java8)),
                     performanceTests = listOf(
                             PerformanceTestType.experiment)),
             Stage("Historical Performance", "Once a week: Run performance tests for multiple Gradle versions",
@@ -183,8 +184,8 @@ data class TestCoverage(val testType: TestType, val os: OS, val version: JvmVers
     }
 }
 
-enum class OS {
-    linux, windows
+enum class OS(val agentRequirement: String, val subset: List<String> = emptyList()) {
+    linux("Linux"), windows("Windows"), macos("Mac", listOf("languageNative", "platformNative", "testingNative", "ideNative"))
 }
 
 enum class JvmVersion {

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -11,6 +11,12 @@ class FunctionalTestProject(model: CIBuildModel, testConfig : TestCoverage) : Pr
     this.name = testConfig.asName()
 
     model.subProjects.forEach { subProject ->
+        // TODO: Hacky. We should really be running all the subprojects on macOS
+        // But we're restricting this to just a subset of projects for now
+        // since we only have a small pool of macOS agents
+        if (testConfig.os.subset.isNotEmpty() && !testConfig.os.subset.contains(subProject.name)) {
+            return@forEach
+        }
         if (subProject.unitTests && testConfig.testType.unitTests) {
             buildType(FunctionalTest(model, testConfig, subProject.name))
         } else if (subProject.functionalTests && testConfig.testType.functionalTests) {

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -21,11 +21,11 @@ class CIConfigIntegrationTests {
     fun macOSBuildsSubset() {
         val m = CIBuildModel()
         val p = RootProject(m)
-        val releaseAccept = p.subProjects.find { it.name.contains("Release Accept") }
-        val macOS = releaseAccept?.subProjects?.find { it.name.contains("Macos") }
+        val releaseAccept = p.subProjects.find { it.name.contains("Release Accept") }!!
+        val macOS = releaseAccept.subProjects.find { it.name.contains("Macos") }!!
 
-        assertEquals(OS.macos.subset.size, macOS?.buildTypes?.size)
-        macOS?.buildTypes?.forEach { buildType ->
+        assertEquals(OS.macos.subset.size, macOS.buildTypes.size)
+        macOS.buildTypes.forEach { buildType ->
             assertTrue(OS.macos.subset.any { subproject ->
                 buildType.name.endsWith("($subproject)")
             })

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -1,3 +1,4 @@
+
 import jetbrains.buildServer.configs.kotlin.v10.Project
 import model.*
 import org.junit.Test
@@ -14,6 +15,21 @@ class CIConfigIntegrationTests {
         val p = RootProject(m)
         printTree(p)
         assertEquals(p.subProjects.size, m.stages.size + 1)
+    }
+
+    @Test
+    fun macOSBuildsSubset() {
+        val m = CIBuildModel()
+        val p = RootProject(m)
+        val releaseAccept = p.subProjects.find { it.name.contains("Release Accept") }
+        val macOS = releaseAccept?.subProjects?.find { it.name.contains("Macos") }
+
+        assertEquals(OS.macos.subset.size, macOS?.buildTypes?.size)
+        macOS?.buildTypes?.forEach { buildType ->
+            assertTrue(OS.macos.subset.any { subproject ->
+                buildType.name.endsWith("($subproject)")
+            })
+        }
     }
 
     @Test


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
