### PR TITLE
Improve error messages for ToolingParameterProxy

### DIFF
--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/BuildControllerAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/BuildControllerAdapter.java
@@ -86,8 +86,8 @@ class BuildControllerAdapter extends AbstractBuildController implements BuildCon
             throw new NullPointerException("parameterType and parameterInitializer both need to be set for a parametrized model request.");
         }
 
-        if (parameterType != null && !ToolingParameterProxy.isValid(parameterType)) {
-            throw new IllegalArgumentException(parameterType.getName() + " is not a valid parameter type. Parameter types need to be interfaces with only getters and setters.");
+        if (parameterType != null) {
+            ToolingParameterProxy.validateParameter(parameterType);
         }
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildControllerAdapterTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildControllerAdapterTest.groovy
@@ -198,7 +198,7 @@ class BuildControllerAdapterTest extends Specification {
 
         then:
         IllegalArgumentException e1 = thrown()
-        e1.message == "org.gradle.tooling.internal.consumer.connection.BuildControllerAdapterTest\$InvalidParameter is not a valid parameter type. Parameter types need to be interfaces with only getters and setters."
+        e1.message == "org.gradle.tooling.internal.consumer.connection.BuildControllerAdapterTest\$InvalidParameter is not a valid parameter type. It must be an interface."
     }
 
     interface ValidParameter {

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ToolingParameterProxyTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ToolingParameterProxyTest.groovy
@@ -24,50 +24,73 @@ class ToolingParameterProxyTest extends Specification {
 
     def "returns parameter valid when well defined"() {
         when:
-        boolean isValid = ToolingParameterProxy.isValid(ValidParameter)
+        ToolingParameterProxy.validateParameter(ValidParameter)
 
         then:
-        assert isValid
+        noExceptionThrown()
     }
 
     def "returns parameter invalid when not a getter or setter"() {
         when:
-        boolean isValid = ToolingParameterProxy.isValid(InvalidParameter1)
+        ToolingParameterProxy.validateParameter(InvalidParameter1)
 
         then:
-        assert !isValid
+        IllegalArgumentException e = thrown()
+        e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter1 is not a valid parameter type. Method notASetterOrGetter is neither a setter nor a getter."
     }
 
     def "returns parameter invalid when setter not correct"() {
         when:
-        boolean isValid = ToolingParameterProxy.isValid(InvalidParameter2)
+        ToolingParameterProxy.validateParameter(InvalidParameter2)
 
         then:
-        assert !isValid
+        IllegalArgumentException e = thrown()
+        e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter2 is not a valid parameter type. Method setValue is neither a setter nor a getter."
     }
 
     def "returns parameter invalid when setter and getter have different types"() {
         when:
-        boolean isValid = ToolingParameterProxy.isValid(InvalidParameter3)
+        ToolingParameterProxy.validateParameter(InvalidParameter3)
 
         then:
-        assert !isValid
+        IllegalArgumentException e = thrown()
+        e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter3 is not a valid parameter type. Setter and getter for property value have non corresponding types."
     }
 
     def "returns parameter invalid when no getter for setter"() {
         when:
-        boolean isValid = ToolingParameterProxy.isValid(InvalidParameter4)
+        ToolingParameterProxy.validateParameter(InvalidParameter4)
 
         then:
-        assert !isValid
+        IllegalArgumentException e = thrown()
+        e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter4 is not a valid parameter type. It contains a different number of getters and setters."
     }
 
     def "returns parameter invalid when no setter for getter"() {
         when:
-        boolean isValid = ToolingParameterProxy.isValid(InvalidParameter5)
+        ToolingParameterProxy.validateParameter(InvalidParameter5)
 
         then:
-        assert !isValid
+        IllegalArgumentException e = thrown()
+        e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter5 is not a valid parameter type. It contains a different number of getters and setters."
+    }
+
+    def "returns parameter invalid when it is not an interface"() {
+        when:
+        ToolingParameterProxy.validateParameter(InvalidParameter6)
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter6 is not a valid parameter type. It must be an interface."
+    }
+
+    def "returns parameter invalid when more than one getter for property"() {
+        when:
+        ToolingParameterProxy.validateParameter(InvalidParameter7)
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter7 is not a valid parameter type. More than one getter for property value was found."
     }
 
     def "getter gets what setter sets"() {
@@ -114,5 +137,21 @@ class ToolingParameterProxyTest extends Specification {
 
     interface InvalidParameter5 {
         String getValue()
+    }
+
+    class InvalidParameter6 {
+        String value
+        String getValue() {
+            return value
+        }
+        void setValue(String value) {
+            this.value = value
+        }
+    }
+
+    interface InvalidParameter7 {
+        boolean getValue()
+        boolean isValue()
+        void setValue(boolean value)
     }
 }


### PR DESCRIPTION
ToolingParameterProxy#isValid is replaced by #validateParameter which instead
of returning a boolean indicating if the given Class<?> is a valid parameter
type, it throws an error with a precise description message if not valid.

### Context
This pull request follows [PR](https://github.com/gradle/gradle/pull/2729)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
