### PR TITLE
Expose information about configurations related to scripts

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -27,4 +27,10 @@ public interface DomainObjectContext {
      * Returns a path for the item with the given name that is unique within the current build.
      */
     Path projectPath(String name);
+
+    /**
+     * Returns wheather the context is a script
+     * */
+    boolean isScriptContext();
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationDependenciesBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationDependenciesBuildOperationType.java
@@ -32,7 +32,12 @@ public final class ResolveConfigurationDependenciesBuildOperationType implements
     @UsedByScanPlugin
     public interface Details {
 
-        String getConfigurationPath();
+        String getConfigurationName();
+
+        @Nullable
+        String getProjectPath();
+
+        boolean isScriptConfiguration();
 
         @Nullable
         String getConfigurationDescription();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/BasicDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/BasicDomainObjectContext.java
@@ -29,4 +29,9 @@ public class BasicDomainObjectContext implements DomainObjectContext {
     public Path projectPath(String name) {
         return Path.path(name);
     }
+
+    @Override
+    public boolean isScriptContext() {
+        return true;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -581,6 +581,11 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     }
 
     @Override
+    public boolean isScriptContext() {
+        return false;
+    }
+
+    @Override
     public String relativeProjectPath(String path) {
         return this.path.relativePath(path);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -86,6 +86,7 @@ import org.gradle.normalization.internal.RuntimeClasspathNormalizationInternal;
 import org.gradle.process.internal.DefaultExecActionFactory;
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry;
+import org.gradle.util.Path;
 
 import java.io.File;
 
@@ -210,9 +211,31 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
             get(FileResolver.class),
             get(DependencyMetaDataProvider.class),
             get(ScriptClassPathResolver.class));
-        return factory.create(project.getBuildScriptSource(), project.getClassLoaderScope(), project);
+        return factory.create(project.getBuildScriptSource(), project.getClassLoaderScope(), new ScriptScopedContext(project));
     }
 
+    private class ScriptScopedContext implements DomainObjectContext {
+        private final DomainObjectContext delegate;
+
+        public ScriptScopedContext(DomainObjectContext delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Path identityPath(String name) {
+            return delegate.identityPath(name);
+        }
+
+        @Override
+        public Path projectPath(String name) {
+            return delegate.projectPath(name);
+        }
+
+        @Override
+        public boolean isScriptContext() {
+            return true;
+        }
+    }
     protected DependencyMetaDataProvider createDependencyMetaDataProvider() {
         return new ProjectBackedModuleMetaDataProvider();
     }

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
@@ -42,7 +42,7 @@ class NameValidatorTest extends Specification {
     @Shared
     def domainObjectContainersWithValidation = [
         ["artifact types", new DefaultArtifactTypeContainer(DirectInstantiator.INSTANCE, TestUtil.attributesFactory())],
-        ["configurations", new DefaultConfigurationContainer(null, DirectInstantiator.INSTANCE, Mock(DomainObjectContext), Mock(ListenerManager), null, null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, TestUtil.attributesFactory(), null, null)],
+        ["configurations", new DefaultConfigurationContainer(null, DirectInstantiator.INSTANCE, domainObjectContext(), Mock(ListenerManager), null, null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, TestUtil.attributesFactory(), null, null)],
         ["flavors",  new DefaultFlavorContainer(DirectInstantiator.INSTANCE)]
     ]
 
@@ -90,6 +90,12 @@ class NameValidatorTest extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    private DomainObjectContext domainObjectContext() {
+        def mock = Mock(DomainObjectContext)
+        mock.projectPath(_) >> Mock(Path)
+        mock
     }
 
     void assertForbidden(name, message) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedConfigurationBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedConfigurationBuildOperationIntegrationTest.groovy
@@ -61,8 +61,10 @@ class ResolvedConfigurationBuildOperationIntegrationTest extends AbstractHttpDep
 
         then:
         def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
-        op.details.configurationPath == ":compile"
+        op.details.configurationName == "compile"
+        op.details.projectPath == ":"
         op.details.buildPath == ":"
+        op.details.scriptConfiguration == false
         op.details.configurationDescription ==~ /Dependencies for source set 'main'.*/
         op.details.configurationVisible == false
         op.details.configurationTransitive == true
@@ -75,22 +77,7 @@ class ResolvedConfigurationBuildOperationIntegrationTest extends AbstractHttpDep
         def m1 = mavenHttpRepo.module('org.foo', 'app-dep').publish()
         def m2 = mavenHttpRepo.module('org.foo', 'root-dep').publish()
 
-        file("my-composite-app/src/main/java/App.java") << "public class App {}"
-        file("my-composite-app/build.gradle") << """
-            group = "org.foo"
-            version = '1.0'
-
-            apply plugin: "java"
-            repositories {
-                maven { url '${mavenHttpRepo.uri}' }
-            }
-            
-            dependencies {
-                compile 'org.foo:app-dep:1.0'
-            }
-        """
-
-        file("my-composite-app/settings.gradle") << "rootProject.name = 'my-composite-app'"
+        setupComposite()
         buildFile << """                
             allprojects {
                 apply plugin: "java"
@@ -108,10 +95,7 @@ class ResolvedConfigurationBuildOperationIntegrationTest extends AbstractHttpDep
                 into "build/resolved"
             }
         """
-        settingsFile << """
-        rootProject.name='root'
-        includeBuild 'my-composite-app'
-        """
+
 
         m1.allowAll()
         m2.allowAll()
@@ -119,18 +103,23 @@ class ResolvedConfigurationBuildOperationIntegrationTest extends AbstractHttpDep
         when:
         run "resolve"
 
-        then:
+        then: "configuration of composite are exposed"
         def resolveOperations = operations.all(ResolveConfigurationDependenciesBuildOperationType)
         resolveOperations.size() == 2
-        resolveOperations[0].details.configurationPath == ":compile"
+        resolveOperations[0].details.configurationName == "compile"
+        resolveOperations[0].details.projectPath == ":"
         resolveOperations[0].details.buildPath == ":"
+        resolveOperations[0].details.scriptConfiguration == false
         resolveOperations[0].details.configurationDescription ==~ /Dependencies for source set 'main'.*/
         resolveOperations[0].details.configurationVisible == false
         resolveOperations[0].details.configurationTransitive == true
         resolveOperations[0].result.resolvedDependenciesCount == 2
 
-        resolveOperations[1].details.configurationPath == ":compileClasspath"
+        and: "classpath configuration is exposed"
+        resolveOperations[1].details.configurationName == "compileClasspath"
+        resolveOperations[1].details.projectPath == ":"
         resolveOperations[1].details.buildPath == ":my-composite-app"
+        resolveOperations[1].details.scriptConfiguration == false
         resolveOperations[1].details.configurationDescription == "Compile classpath for source set 'main'."
         resolveOperations[1].details.configurationVisible == false
         resolveOperations[1].details.configurationTransitive == true
@@ -160,13 +149,85 @@ class ResolvedConfigurationBuildOperationIntegrationTest extends AbstractHttpDep
 
         then:
         def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
-        op.details.configurationPath == ":detachedConfiguration1"
+        op.details.configurationName == "detachedConfiguration1"
+        op.details.projectPath == ":"
+        op.details.scriptConfiguration == false
         op.details.buildPath == ":"
         op.details.configurationDescription == null
         op.details.configurationVisible == true
         op.details.configurationTransitive == true
 
         op.result.resolvedDependenciesCount == 1
+    }
+
+    def "script classpath dependencies are exposed"() {
+        setup:
+        def m1 = mavenHttpRepo.module('org.foo', 'root-dep').publish()
+        setupComposite()
+        buildFile << """                
+            buildscript {
+                repositories {
+                    maven { url '${mavenHttpRepo.uri}' }
+                }
+                dependencies {
+                    classpath 'org.foo:root-dep:1.0'
+                    classpath 'org.foo:my-composite-app:1.0'
+                }
+            }
+            
+            apply plugin: "java"
+        """
+
+
+        m1.allowAll()
+
+        when:
+        run "buildEnvironment"
+
+        then:
+        def resolveOperations = operations.all(ResolveConfigurationDependenciesBuildOperationType)
+        resolveOperations.size() == 2
+        resolveOperations[0].details.configurationName == "compileClasspath"
+        resolveOperations[0].details.projectPath == ":"
+        resolveOperations[0].details.buildPath == ":my-composite-app"
+        resolveOperations[0].details.scriptConfiguration == false
+        resolveOperations[0].details.configurationDescription == "Compile classpath for source set 'main'."
+        resolveOperations[0].details.configurationVisible == false
+        resolveOperations[0].details.configurationTransitive == true
+        resolveOperations[0].result.resolvedDependenciesCount == 1
+
+        resolveOperations[1].details.configurationName == "classpath"
+        resolveOperations[1].details.projectPath == null
+        resolveOperations[1].details.buildPath == ":"
+        resolveOperations[1].details.scriptConfiguration == true
+        resolveOperations[1].details.configurationDescription == null
+        resolveOperations[1].details.configurationVisible == true
+        resolveOperations[1].details.configurationTransitive == true
+        resolveOperations[1].result.resolvedDependenciesCount == 2
+    }
+
+    private void setupComposite() {
+        file("my-composite-app/src/main/java/App.java") << "public class App {}"
+        file("my-composite-app/build.gradle") << """
+            group = "org.foo"
+            version = '1.0'
+
+            apply plugin: "java"
+            repositories {
+                maven { url '${mavenHttpRepo.uri}' }
+            }
+            
+            dependencies {
+                compile 'org.foo:app-dep:1.0'
+            }
+        """
+        file("my-composite-app/settings.gradle") << "rootProject.name = 'my-composite-app'"
+
+        settingsFile << """
+        rootProject.name='root'
+        includeBuild 'my-composite-app'
+        """
+        mavenHttpRepo.module('org.foo', 'app-dep').publish().allowAll()
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationUseSite.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationUseSite.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.configurations;
+
+interface ConfigurationUseSite {
+    String getProjectPath(); // project path if owned by project
+    boolean isScript();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -105,7 +105,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     protected Configuration doCreate(String name) {
         DefaultConfiguration configuration = instantiator.newInstance(DefaultConfiguration.class, context.identityPath(name), context.projectPath(name), name, this, resolver,
             listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
-            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, rootComponentMetadataBuilder);
+            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, rootComponentMetadataBuilder, context.isScriptContext());
         configuration.addMutationValidator(rootComponentMetadataBuilder.getValidator());
         return configuration;
     }
@@ -135,7 +135,8 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         DefaultConfiguration detachedConfiguration = instantiator.newInstance(DefaultConfiguration.class,
             context.identityPath(name), context.projectPath(name), name, detachedConfigurationsProvider, resolver,
             listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
-            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, rootComponentMetadataBuilder.withConfigurationsProvider(detachedConfigurationsProvider));
+            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory,
+            rootComponentMetadataBuilder.withConfigurationsProvider(detachedConfigurationsProvider), context.isScriptContext());
         DomainObjectSet<Dependency> detachedDependencies = detachedConfiguration.getDependencies();
         for (Dependency dependency : dependencies) {
             detachedDependencies.add(dependency.copy());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultRe
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.TaskResolver;
+import org.gradle.util.Path;
 import org.gradle.vcs.internal.VcsMappingsInternal;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.Factory;
@@ -50,6 +51,7 @@ import java.util.Set;
 public class DefaultConfigurationContainer extends AbstractValidatingNamedDomainObjectContainer<Configuration>
     implements ConfigurationContainerInternal, ConfigurationsProvider {
     public static final String DETACHED_CONFIGURATION_DEFAULT_NAME = "detachedConfiguration";
+    private static final Object SCRIPT_CONFIGURATION_USE_SITE = new DefaultConfigurationUseSite(null, true);
 
     private final ConfigurationResolver resolver;
     private final Instantiator instantiator;
@@ -103,11 +105,20 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
 
     @Override
     protected Configuration doCreate(String name) {
-        DefaultConfiguration configuration = instantiator.newInstance(DefaultConfiguration.class, context.identityPath(name), context.projectPath(name), name, this, resolver,
+        Path projectPath = context.projectPath(name);
+        DefaultConfiguration configuration = instantiator.newInstance(DefaultConfiguration.class, context.identityPath(name), projectPath, name, this, resolver,
             listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
-            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, rootComponentMetadataBuilder, context.isScriptContext());
+            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory, rootComponentMetadataBuilder, configurationSite(projectPath.getParent(), context.isScriptContext()));
         configuration.addMutationValidator(rootComponentMetadataBuilder.getValidator());
         return configuration;
+    }
+
+    private Object configurationSite(Path projectPath, boolean scriptContext) {
+        if (scriptContext) {
+            return SCRIPT_CONFIGURATION_USE_SITE;
+        } else {
+            return new DefaultConfigurationUseSite(projectPath, scriptContext);
+        }
     }
 
     public Set<? extends ConfigurationInternal> getAll() {
@@ -132,11 +143,12 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     public ConfigurationInternal detachedConfiguration(Dependency... dependencies) {
         String name = DETACHED_CONFIGURATION_DEFAULT_NAME + detachedConfigurationDefaultNameCounter++;
         DetachedConfigurationsProvider detachedConfigurationsProvider = new DetachedConfigurationsProvider();
+        Path projectPath = context.projectPath(name);
         DefaultConfiguration detachedConfiguration = instantiator.newInstance(DefaultConfiguration.class,
-            context.identityPath(name), context.projectPath(name), name, detachedConfigurationsProvider, resolver,
+            context.identityPath(name), projectPath, name, detachedConfigurationsProvider, resolver,
             listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
             fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, attributesFactory,
-            rootComponentMetadataBuilder.withConfigurationsProvider(detachedConfigurationsProvider), context.isScriptContext());
+            rootComponentMetadataBuilder.withConfigurationsProvider(detachedConfigurationsProvider), configurationSite(projectPath.getParent(), context.isScriptContext()));
         DomainObjectSet<Dependency> detachedDependencies = detachedConfiguration.getDependencies();
         for (Dependency dependency : dependencies) {
             detachedDependencies.add(dependency.copy());
@@ -146,8 +158,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     }
 
     /**
-     * Build a formatted representation of all Configurations in this ConfigurationContainer.
-     * Configuration(s) being toStringed are likely derivations of DefaultConfiguration.
+     * Build a formatted representation of all Configurations in this ConfigurationContainer. Configuration(s) being toStringed are likely derivations of DefaultConfiguration.
      */
     public String dump() {
         StringBuilder reply = new StringBuilder();
@@ -159,5 +170,25 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         }
 
         return reply.toString();
+    }
+
+    private static class DefaultConfigurationUseSite implements ConfigurationUseSite {
+        private final Path projectPath;
+        private final boolean isScript;
+
+        public DefaultConfigurationUseSite(Path projectPath, boolean isScript) {
+            this.projectPath = projectPath;
+            this.isScript = isScript;
+        }
+
+        @Override
+        public String getProjectPath() {
+            return projectPath == null ? null : projectPath.getPath();
+        }
+
+        @Override
+        public boolean isScript() {
+            return isScript;
+        }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -112,6 +112,7 @@ class DefaultConfigurationContainerSpec extends Specification {
 
     def "creates detached"() {
         given:
+        1 * domainObjectContext.projectPath("detachedConfiguration1") >> Path.path(":detachedConfiguration1")
         def dependency1 = new DefaultExternalModuleDependency("group", "name", "version")
         def dependency2 = new DefaultExternalModuleDependency("group", "name2", "version")
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1614,7 +1614,7 @@ All Artifacts:
     private DefaultConfiguration conf(String confName = "conf", String path = ":conf") {
         new DefaultConfiguration(Path.path(path), Path.path(path), confName, configurationsProvider, resolver, listenerManager, metaDataProvider,
             Factories.constant(resolutionStrategy), projectAccessListener, projectFinder, TestFiles.fileCollectionFactory(),
-            new TestBuildOperationExecutor(), instantiator, Stub(NotationParser), immutableAttributesFactory, rootComponentMetadataBuilder)
+            new TestBuildOperationExecutor(), instantiator, Stub(NotationParser), immutableAttributesFactory, rootComponentMetadataBuilder, false)
     }
 
     private DefaultPublishArtifact artifact(String name) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1614,7 +1614,7 @@ All Artifacts:
     private DefaultConfiguration conf(String confName = "conf", String path = ":conf") {
         new DefaultConfiguration(Path.path(path), Path.path(path), confName, configurationsProvider, resolver, listenerManager, metaDataProvider,
             Factories.constant(resolutionStrategy), projectAccessListener, projectFinder, TestFiles.fileCollectionFactory(),
-            new TestBuildOperationExecutor(), instantiator, Stub(NotationParser), immutableAttributesFactory, rootComponentMetadataBuilder, false)
+            new TestBuildOperationExecutor(), instantiator, Stub(NotationParser), immutableAttributesFactory, rootComponentMetadataBuilder, Mock(ConfigurationUseSite))
     }
 
     private DefaultPublishArtifact artifact(String name) {


### PR DESCRIPTION
- tweaked the ResolveConfigurationDependenciesBuildOperationType.Details interface
to expose information about configuration related to projects and related to
script classpath.

As discussed a tweak in how we expose resolved configuration to allow better distinction between build script related configurations (settings, init, build.gradle, script plugin classpath) and project related configuration.

As discussed with @ldaley and @oehme in #bt-cs channel this should get into the 4.4 rc 1. 

CI: https://builds.gradle.org/project.html?projectId=Gradle_Check_Stage_BranchBuildAccept&branch_Gradle_Check_Stage_BranchBuildAccept=breskeby%2Fresolved-script-configuration-ops