### PR TITLE
Improve layout and vertical rhythm for docs

### DIFF
--- a/subprojects/docs/src/docs/css/base.css
+++ b/subprojects/docs/src/docs/css/base.css
@@ -1,223 +1,391 @@
-/* reset.css */
-html {margin:0;padding:0;border:0;}
-body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, code, del, dfn, em, img, q, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, dialog, figure, footer, header, hgroup, nav, section {margin:0;padding:0;border:0;font-size:100%;font:inherit;vertical-align:baseline;}
-article, aside, details, figcaption, figure, dialog, footer, header, hgroup, menu, nav, section {display:block;}
-body {line-height:1.5;background:white;}
-table {border-collapse:separate;border-spacing:0;}
-caption, th, td {text-align:left;font-weight:normal;float:none !important;}
-table, th, td {vertical-align:middle;}
-blockquote:before, blockquote:after, q:before, q:after {content:'';}
-blockquote, q {quotes:"" "";}
-a img {border:none;}
-:focus {outline:0;}
+/*! normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */html{line-height:1.15;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}article,aside,footer,header,nav,section{display:block}h1{font-size:2em;margin:.67em 0}figcaption,figure,main{display:block}figure{margin:1em 40px}hr{box-sizing:content-box;height:0;overflow:visible}pre{font-family:monospace,monospace;font-size:1em}a{background-color:transparent;-webkit-text-decoration-skip:objects}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:inherit}b,strong{font-weight:bolder}code,kbd,samp{font-family:monospace,monospace;font-size:1em}dfn{font-style:italic}mark{background-color:#ff0;color:#000}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}audio,video{display:inline-block}audio:not([controls]){display:none;height:0}img{border-style:none}svg:not(:root){overflow:hidden}button,input,optgroup,select,textarea{font-family:sans-serif;font-size:100%;line-height:1.15;margin:0}button,input{overflow:visible}button,select{text-transform:none}[type=reset],[type=submit],button,html [type=button]{-webkit-appearance:button}[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{border-style:none;padding:0}[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring,button:-moz-focusring{outline:1px dotted ButtonText}fieldset{padding:.35em .75em .625em}legend{box-sizing:border-box;color:inherit;display:table;max-width:100%;padding:0;white-space:normal}progress{display:inline-block;vertical-align:baseline}textarea{overflow:auto}[type=checkbox],[type=radio]{box-sizing:border-box;padding:0}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-cancel-button,[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}details,menu{display:block}summary{display:list-item}canvas{display:inline-block}template{display:none}[hidden]{display:none}
 
-/* typography.css */
-html {font-size:100.01%;}
-h1, h2, h3, h4, h5, h6 {font-weight:normal; line-height: 1;color: #007042;}
-h1 {font-size:4em;}
-h2 {font-size:2.2em;}
-h3 {font-size:1.5em;}
-h4 {font-size:1.3em;}
-h5 {font-size:1.1em;}
-h6 {font-size:1em;font-weight:bold;}
-h1 img, h2 img, h3 img, h4 img, h5 img, h6 img {margin:0;}
-.left {float:left !important;}
-p .left {margin:1.5em 1.5em 1.5em 0;padding:0;}
-.right {float:right !important;}
-p .right {margin:1.5em 0 1.5em 1.5em;padding:0;}
-a:focus, a:hover {color:#09f;}
-a {color:#06c;text-decoration:underline;}
-blockquote {margin:1.5em;color:#666;font-style:italic;}
-strong, dfn {font-weight:bold;}
-em, dfn {font-style:italic;}
-sup, sub {line-height:0;}
-abbr, acronym {border-bottom:1px dotted #666;}
-address {margin:0 0 1.5em;font-style:italic;}
-del {color:#666;}
-pre {margin:1.5em 0;white-space:pre;}
-/*pre, code, tt {font:1em 'andale mono', 'lucida console', monospace;line-height:1.5;}*/
-li ul, li ol {margin:0;}
-ul, ol {padding-left:1.5em;}
-ul {list-style-type:disc;}
-ol {list-style-type:decimal;}
-dl {margin:0 0 1.5em 0;}
-dl dt {font-weight:normal;}
-dd {margin-left:1.5em;}
-table {margin-bottom:1.4em;}
-th {font-weight:bold;}
-thead th {background:#c3d9ff;}
-th, td, caption {padding:4px 10px 4px 5px;}
-tfoot {font-style:italic;}
-caption {background:#eee;}
-.small {font-size:.8em;margin-bottom:1.875em;line-height:1.875em;}
-.large {font-size:1.2em;line-height:2.5em;margin-bottom:1.25em;}
-.hide {display:none;}
-.quiet {color:#666;}
-.loud {color:#000;}
-.highlight {background:#ff0;}
-.added {background:#060;color:#fff;}
-.removed {background:#900;color:#fff;}
-.first {margin-left:0;padding-left:0;}
-.last {margin-right:0;padding-right:0;}
-.top {margin-top:0;padding-top:0;}
-.bottom {margin-bottom:0;padding-bottom:0;}
 
-::selection {
-    background-color: #DDF0DD;
+* {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
 }
 
-@font-face {
-  font-family: 'Lato';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Lato Regular'), local('Lato-Regular'), url('data:font/opentype;base64,@lato-regular@') format('truetype');
+html,
+body {
+    margin: 0;
+    padding: 0;
 }
 
-@font-face {
-  font-family: 'Lato';
-  font-style: italic;
-  font-weight: 400;
-  src: local('Lato Italic'), local('Lato-Italic'), url('data:font/opentype;base64,@lato-regular-italic@') format('truetype');
-}
-
-@font-face {
-  font-family: 'Lato';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Lato Bold'), local('Lato-Bold'), url('data:font/opentype;base64,@lato-bold@') format('truetype');
-}
-
-@font-face {
-  font-family: 'Lato';
-  font-style: italic;
-  font-weight: 700;
-  src: local('Lato Bold Italic'), local('Lato-BoldItalic'), url('data:font/opentype;base64,@lato-bold-italic@') format('truetype');
-}
-
-@font-face {
-  font-family: 'Ubuntu Mono';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Ubuntu Mono Bold'), local('UbuntuMono-Bold'), url('data:font/opentype;base64,@ubuntumono-bold@') format('truetype');
-}
-@font-face {
-  font-family: 'Ubuntu Mono';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Ubuntu Mono'), local('UbuntuMono-Regular'), url('data:font/opentype;base64,@ubuntumono-regular@') format('truetype');
-}
-@font-face {
-  font-family: 'Ubuntu Mono';
-  font-style: italic;
-  font-weight: 700;
-  src: local('Ubuntu Mono Bold Italic'), local('UbuntuMono-BoldItalic'), url('data:font/opentype;base64,@ubuntumono-bold-italic@') format('truetype');
-}
-@font-face {
-  font-family: 'Ubuntu Mono';
-  font-style: italic;
-  font-weight: 400;
-  src: local('Ubuntu Mono Italic'), local('UbuntuMono-Italic'), url('data:font/opentype;base64,@ubuntumono-regular-italic@') format('truetype');
+html {
+    font-family: "Lato", "Helvetica Neue", Arial, sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 body {
-  font-size: 16px;
-  font-family: 'Lato', Arial, serif;
-  margin: 28px 28px 14px;
-  color: #333;
-  background: url('data:image/gif;base64,@gradle-logo_25o.gif@') no-repeat right top;
-}
-
-p, ol, ul, .para {
-  margin: 0 0 16px;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  margin-bottom: 14px
-}
-
-h2 {
-  margin-top: 32px;
-}
-
-h3, h4, h5, h6 {
-  margin-top: 22px;
-}
-
-.text-container,
-div.book,
-div.chapter,
-div.part,
-div.appendix,
-div.glossary {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.text-container h1, .text-container h2, .text-container h3, .text-container h4, .text-container h5,
-div.book h1, div.book h2, div.book h3, div.book h4, div.book h5,
-div.chapter h1, div.chapter h2, div.chapter h3, div.chapter h4, div.chapter h5 {
-  margin-left: -10px;
-}
-
-code, tt, pre {
-  font-family: "Ubuntu Mono", courier, monospace;
-}
-
-h1, h2, h3, h4 {
-  text-shadow: 0px 0px 3px rgba(0, 0, 0, 0.4);
-}
-
-h5, h6 {
- color: #666;
-}
-
-h1 {
-    font-weight: bold;
-}
-
-h3.releaseinfo {
-   color: #666666;
-   padding-top: 0;
+    color: #02303A;
+    background-color: #fff;
+    -webkit-text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased;
 }
 
 a {
-    color: #007042;
+    color: #00c489;
     text-decoration: none;
 }
-a:visited {
-    color: #007042;
+
+a:hover, a:focus {
+    text-decoration: underline;
 }
-a:hover {
-    color: #007042;
-    border-bottom: 1px dotted #007042;
+
+a strong {
+    color: inherit;
 }
-a:focus {
-    outline: thin dotted;
-}
-a:hover, a:active {
-    outline: 0;
+
+img {
+    max-width: 100%;
 }
 
 table {
+    margin-bottom: 1rem;
+    width: 100%;
+    font-size: 85%;
+    border: 1px solid #e5e5e5;
     border-collapse: collapse;
-    font-size: 100%;
-    min-width: 50%;
-    border: solid #d0d0d0 1px;
 }
 
-table td {
+td,
+th {
+    padding: .25rem .5rem;
+    border: 1px solid #e5e5e5;
+}
+
+th {
     text-align: left;
-    vertical-align: text-top;
-    padding-left: 0.8em;
-    padding-right: 0.8em;
-    padding-top: 0.3em;
-    padding-bottom: 0.3em;
 }
 
-table thead td, table th {
+tbody tr:nth-child(odd) td,
+tbody tr:nth-child(odd) th {
+    background-color: #f9f9f9;
+}
+
+/* typography */
+h1, h2, h3, h4, h5, h6 {
+    margin-bottom: .5rem;
+    font-weight: 700;
+    line-height: 1.2;
+    color: #02303A;
+    text-rendering: optimizeLegibility;
+}
+
+h1 {
+    font-size: 2rem;
+}
+
+h2 {
+    margin-top: 1.5rem;
+    font-size: 1.5rem;
+}
+
+h3 {
+    margin-top: 1rem;
+    font-size: 1.125rem;
+}
+
+h4, h5, h6 {
+    margin-top: 1rem;
+    font-size: 1rem;
+}
+
+p {
+    margin-top: 0.9375rem;
+    margin-bottom: 1.5rem;
+}
+
+strong {
+    color: #303030;
+}
+
+ul, ol, dl {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+dt {
     font-weight: bold;
-    border-bottom: solid #d0d0d0 1px;
-    background-color: #f2f2f2;
+}
+
+dd {
+    margin-bottom: .5rem;
+    margin-left: 1.5em;
+}
+
+hr {
+    position: relative;
+    border: 0;
+    border-top: 1px solid #eee;
+    border-bottom: 1px solid #fff;
+    margin: 0;
+}
+
+li ul, li ol {
+    margin: 0;
+}
+
+ul, ol {
+    padding-left: 1.5em;
+}
+
+ul {
+    list-style-type: disc;
+}
+
+ol {
+    list-style-type: decimal;
+}
+
+dl {
+    margin: 0 0 1.5em 0;
+}
+
+dl dt {
+    font-weight: normal;
+}
+
+tfoot {
+    font-style: italic;
+}
+
+caption {
+    background: #eee;
+}
+
+abbr, acronym {
+    font-size: 85%;
+    font-weight: bold;
+    color: #555;
+    text-transform: uppercase;
+}
+
+abbr[title], acronym[title] {
+    cursor: help;
+    border-bottom: 1px dotted #e5e5e5;
+}
+
+strong, dfn {
+    font-weight: bold;
+}
+
+em, dfn {
+    font-style: italic;
+}
+
+sup, sub {
+    line-height: 0;
+}
+
+address {
+    margin: 0 0 1.5em;
+    font-style: italic;
+}
+
+del {
+    color: #666;
+}
+
+blockquote {
+    padding: .5rem 1rem;
+    margin: .8rem 0;
+    color: #7a7a7a;
+    border-left: .25rem solid #e5e5e5;
+}
+
+blockquote p:first-child {
+    margin-top: 0;
+}
+
+blockquote p:last-child {
+    margin-bottom: 0;
+}
+
+@media (min-width: 30em) {
+    blockquote {
+        padding-right: 5rem;
+        padding-left: 1.25rem;
+    }
+}
+
+/* layout */
+.container, .book, .chapter, .footer {
+    max-width: 44.3125rem;
+    margin: 0 auto;
+    padding: 0 0.75rem;
+}
+
+.content, .text-container {
+    width: 44.3125rem;
+}
+
+.content-container {
+    min-height: calc(100vh - 60px);
+}
+
+.content, .sidebar {
+    display: inline-block;
+}
+
+.sidebar {
+    float: right;
+    width: 12.5rem;
+}
+
+@media screen and (max-width: 38em) {
+    .container, .footer {
+        max-width: 44.3125rem;
+    }
+    .content {
+        display: block;
+        width: auto;
+    }
+    .sidebar {
+        display: none;
+    }
+}
+
+/* code */
+code, pre {
+    font-family: monospace;
+}
+
+code {
+    padding: .25em .5em;
+    font-size: 85%;
+    color: #02303A;
+    border-radius: 3px;
+}
+
+pre {
+    line-height: 1.3;
+    margin-top: 0;
+    margin-bottom: 1rem;
+    padding: 0.8em;
+}
+
+pre code {
+    padding: 0;
+    font-size: 100%;
+    color: inherit;
+    background-color: transparent;
+}
+
+pre.code, pre.programlisting, pre.screen, pre.tt {
+    font-size: .8rem;
+    padding: 1rem;
+    line-height: 1.4;
+    border-radius: 5px;
+    overflow-x: auto;
+}
+
+pre.code, pre.programlisting {
+    margin-bottom: 1rem;
+    background-color: #f9f9f9;
+}
+
+pre.screen, pre.tt {
+    background-color: black;
+    box-shadow: 0 10px 50px 2px rgba(0, 0, 0, 0.56);
+    color: white;
+    font-weight: bold;
+    margin: 1em 1em 2em;
+}
+
+tbody tr:nth-child(even) td, tbody tr.even td {
+    background: #F7F7F7;
+}
+
+li em, p em {
+    padding: 0 1px 0 1px;
+    text-decoration: underline;
+}
+
+code em, tt em {
+    text-decoration: none;
+}
+
+/* util classes */
+.left {
+    float: left !important;
+}
+
+p .left {
+    margin: 1.5em 1.5em 1.5em 0;
+    padding: 0;
+}
+
+.right {
+    float: right !important;
+}
+
+p .right {
+    margin: 1.5em 0 1.5em 1.5em;
+    padding: 0;
+}
+
+.small {
+    font-size: .8em;
+    margin-bottom: 1.875em;
+    line-height: 1.875em;
+}
+
+.large {
+    font-size: 1.2em;
+    line-height: 2.5em;
+    margin-bottom: 1.25em;
+}
+
+.hide {
+    display: none;
+}
+
+.quiet {
+    color: #666;
+}
+
+.loud {
+    color: #000;
+}
+
+.highlight {
+    background: #ff0;
+}
+
+.added {
+    background: #060;
+    color: #fff;
+}
+
+.removed {
+    background: #900;
+    color: #fff;
+}
+
+.first {
+    margin-left: 0;
+    padding-left: 0;
+}
+
+.last {
+    margin-right: 0;
+    padding-right: 0;
+}
+
+.top {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+.bottom {
+    margin-bottom: 0;
+    padding-bottom: 0;
 }
 
 table th.border-right {
@@ -228,32 +396,31 @@ table th.no-border-bottom {
     border-bottom: none;
 }
 
-pre {
-  border-radius: 5px;
-  padding: 0.8em;
-  line-height: 1.3;
+h3.releaseinfo {
+    color: #999;
+    font-weight: normal;
+    margin-top: -0.5em;
 }
 
-pre.code, pre.programlisting {
-  background-color: #3F3F3F;
-  color: white;
+/* font declarations */
+@font-face {
+    font-family: 'Lato';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Lato Regular'), local('Lato-Regular'), url('data:font/opentype;base64,@lato-regular@') format('truetype');
 }
 
-pre.screen, pre.tt {
-  color: darkGreen;
-  background-color: white;
-  box-shadow: inset 0 0 7px 0px darkGray;
+@font-face {
+    font-family: 'Lato';
+    font-style: italic;
+    font-weight: 400;
+    src: local('Lato Italic'), local('Lato-Italic'), url('data:font/opentype;base64,@lato-regular-italic@') format('truetype');
 }
 
-tbody tr:nth-child(even) td, tbody tr.even td {
-    background: #F7F7F7;
+@font-face {
+    font-family: 'Lato';
+    font-style: normal;
+    font-weight: 700;
+    src: local('Lato Bold'), local('Lato-Bold'), url('data:font/opentype;base64,@lato-bold@') format('truetype');
 }
 
-li em, p em {
-  padding: 0 1px 0 1px;
-  text-decoration: underline;
-}
-
-code em, tt em {
-  text-decoration: none;
-}

--- a/subprojects/docs/src/docs/css/base.css
+++ b/subprojects/docs/src/docs/css/base.css
@@ -97,8 +97,9 @@ h4, h5, h6 {
 }
 
 p {
-    margin-top: 0.9375rem;
-    margin-bottom: 1.5rem;
+    font-size: 1.0625rem;
+    margin-bottom: 1.25rem;
+    text-rendering: optimizeLegibility;
 }
 
 strong {
@@ -106,8 +107,8 @@ strong {
 }
 
 ul, ol, dl {
+    line-height: 1.6;
     margin-top: 0;
-    margin-bottom: 1rem;
 }
 
 dt {
@@ -127,12 +128,10 @@ hr {
     margin: 0;
 }
 
-li ul, li ol {
-    margin: 0;
-}
-
-ul, ol {
-    padding-left: 1.5em;
+ul, ol, dl {
+    list-style-position: outside;
+    margin: 0 0 1.25rem 1.5em;
+    padding: 0;
 }
 
 ul {
@@ -141,10 +140,6 @@ ul {
 
 ol {
     list-style-type: decimal;
-}
-
-dl {
-    margin: 0 0 1.5em 0;
 }
 
 dl dt {
@@ -253,49 +248,45 @@ blockquote p:last-child {
 
 /* code */
 code, pre {
-    font-family: monospace;
+    background-color: #f7f7f8;
+    border-radius: 4px;
+    font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
+    font-size: 1em;
+    font-style: normal;
 }
 
-code {
-    padding: .25em .5em;
-    font-size: 85%;
-    color: #02303A;
-    border-radius: 3px;
+*:not(pre) > code {
+    font-size: 0.9375em;
+    letter-spacing: 0;
+    padding: 0.1em 0.5ex;
+    text-rendering: optimizeSpeed;
+    word-spacing: -0.15em;
+    word-wrap: break-word;
 }
 
 pre {
-    line-height: 1.3;
+    line-height: 1.45;
     margin-top: 0;
-    margin-bottom: 1rem;
-    padding: 0.8em;
+    margin-bottom: 1.5em;
+    padding: 1rem;
 }
 
 pre code {
-    padding: 0;
-    font-size: 100%;
-    color: inherit;
     background-color: transparent;
+    color: inherit;
+    line-height: 1.45;
+    font-size: 100%;
+    padding: 0;
 }
 
 pre.code, pre.programlisting, pre.screen, pre.tt {
-    font-size: .8rem;
-    padding: 1rem;
-    line-height: 1.4;
-    border-radius: 5px;
+    background-color: #f7f7f8;
+    border-radius: 4px;
+    font-size: 1em;
+    line-height: 1.45;
+    margin-bottom: 1.25em;
     overflow-x: auto;
-}
-
-pre.code, pre.programlisting {
-    margin-bottom: 1rem;
-    background-color: #f9f9f9;
-}
-
-pre.screen, pre.tt {
-    background-color: black;
-    box-shadow: 0 10px 50px 2px rgba(0, 0, 0, 0.56);
-    color: white;
-    font-weight: bold;
-    margin: 1em 1em 2em;
+    padding: 1rem;
 }
 
 tbody tr:nth-child(even) td, tbody tr.even td {
@@ -303,8 +294,7 @@ tbody tr:nth-child(even) td, tbody tr.even td {
 }
 
 li em, p em {
-    padding: 0 1px 0 1px;
-    text-decoration: underline;
+    padding: 0 1px;
 }
 
 code em, tt em {

--- a/subprojects/docs/src/docs/css/base.css
+++ b/subprojects/docs/src/docs/css/base.css
@@ -98,17 +98,13 @@ h4, h5, h6 {
 
 p {
     font-size: 1.0625rem;
+    line-height: 1.6;
     margin-bottom: 1.25rem;
     text-rendering: optimizeLegibility;
 }
 
 strong {
     color: #303030;
-}
-
-ul, ol, dl {
-    line-height: 1.6;
-    margin-top: 0;
 }
 
 dt {
@@ -130,6 +126,7 @@ hr {
 
 ul, ol, dl {
     list-style-position: outside;
+    line-height: 1.6;
     margin: 0 0 1.25rem 1.5em;
     padding: 0;
 }
@@ -256,7 +253,7 @@ code, pre {
 }
 
 *:not(pre) > code {
-    font-size: 0.9375em;
+    font-size: 0.9375rem;
     letter-spacing: 0;
     padding: 0.1em 0.5ex;
     text-rendering: optimizeSpeed;
@@ -277,6 +274,10 @@ pre code {
     line-height: 1.45;
     font-size: 100%;
     padding: 0;
+}
+
+a code {
+    color: #02303A;
 }
 
 pre.code, pre.programlisting, pre.screen, pre.tt {

--- a/subprojects/docs/src/docs/css/docs.css
+++ b/subprojects/docs/src/docs/css/docs.css
@@ -66,7 +66,7 @@
     font-size: 100%;
 }
 
-.note p:first-child {
+.note p:first-child, .tip p:first-child {
     margin-top: 0;
 }
 
@@ -75,34 +75,24 @@
 }
 
 .note, .tip {
-    padding: 1em 1.2em;
-    margin-bottom: 1em;
+    border-left: 1px solid #ddddd8;
+    color: rgba(0,0,0,0.6);
+    margin: 0 0 1.5em 1.25em;
+    padding-left: 1.125em;
+    padding-right: 1.25em;
 }
 
-.note {
-    background: #ebf4f7;
-    border: solid #c3d9e6 1px;
+.note p:first-child:before {
+    content: "Note: ";
+    font-weight: bold;
 }
 
-.note .title {
-    color: #5283a1;
-    margin-left: 0px;
+.tip p:first-child:before {
+    content: "Tip: ";
+    font-weight: bold;
 }
 
-.tip {
-    background: #FAF7F5;
-    border: solid #e2d2c9 1px;
-    float: right;
-    clear: right;
-    margin-left: 2em;
-    margin-top: 1em;
-    margin-bottom: 1em;
-    max-width: 30%;
-    width: 30%;
-}
-
-.tip .title {
-    color: #80614D;
+.note .title, .tip .title {
     margin-left: 0px;
 }
 
@@ -111,8 +101,7 @@
 .tip h3, .note h3,
 .tip h4, .note h4,
 .tip h5, .note h5,
-.tip h6, .note h6
-{
+.tip h6, .note h6 {
    margin-top: 0;
 }
 

--- a/subprojects/docs/src/docs/css/docs.css
+++ b/subprojects/docs/src/docs/css/docs.css
@@ -66,8 +66,12 @@
     font-size: 100%;
 }
 
+.note p:first-child {
+    margin-top: 0;
+}
+
 .note > :last-child, .tip > :last-child, .examplelocation > :last-child {
-    margin-bottom: 0px
+    margin-bottom: 0;
 }
 
 .note, .tip {

--- a/subprojects/docs/src/docs/css/docs.css
+++ b/subprojects/docs/src/docs/css/docs.css
@@ -7,7 +7,7 @@
 }
 
 .itemizedlist li p {
-    margin: 0;
+    margin-bottom: 0.625em;
 }
 
 .example, .figure, .table {
@@ -112,15 +112,15 @@
 /*
  * Code highlighting
  */
-.hl-string, .hl-number, .hl-value { color: #83C283; }
+.hl-string, .hl-number, .hl-value { color: #d14; }
 
-.hl-keyword { color: #DDC498 }
+.hl-keyword { color: #963; }
 
-.hl-comment, .hl-doccomment { color: #AFAFAF; }
+.hl-comment, .hl-doccomment { color: #998; }
 
-.hl-annotation { color: #DDDD97; }
+.hl-annotation { color: #007; }
 
-.hl-directive { color: white !important; }
+.hl-directive { color: #555; }
 
 a.link {
     white-space: nowrap;

--- a/subprojects/docs/src/docs/css/dsl.css
+++ b/subprojects/docs/src/docs/css/dsl.css
@@ -1,3 +1,6 @@
+.titlepage h1 {
+    margin-top: 0;
+}
 
 .caution {
   font-size: 15px;
@@ -43,6 +46,10 @@ table .caution {
     left: 14.6em;
 }
 
+.sidebar a {
+    color: #02303A;
+}
+
 .sidebar ul {
     padding-left: 0;
     padding-right: 0;
@@ -74,10 +81,6 @@ table .caution {
     -webkit-border-radius: 2px;
     -moz-border-radius: 2px;
     border-radius: 2px;
-}
-
-.sidebar ul.sections {
-    padding-left: 1em;
 }
 
 .segmentedlist {

--- a/subprojects/docs/src/docs/css/dsl.css
+++ b/subprojects/docs/src/docs/css/dsl.css
@@ -50,6 +50,10 @@ table .caution {
     color: #02303A;
 }
 
+.sidebar a .code {
+    background-color: transparent;
+}
+
 .sidebar ul {
     padding-left: 0;
     padding-right: 0;

--- a/subprojects/docs/src/docs/css/release-notes.css
+++ b/subprojects/docs/src/docs/css/release-notes.css
@@ -1,10 +1,14 @@
+.table-of-contents a {
+  color: #02303A;
+}
+
 ul li {
-    list-style-type: none;
+  list-style-type: none;
 }
 ul li:before {
-    content: '\00276F';
-    padding-right: 5px;
-    margin-left: -20px;
+  content: '\00276F';
+  padding-right: 5px;
+  margin-left: -20px;
 }
 
 img.logo {

--- a/subprojects/docs/src/docs/css/release-notes.css
+++ b/subprojects/docs/src/docs/css/release-notes.css
@@ -1,3 +1,12 @@
+ul li {
+    list-style-type: none;
+}
+ul li:before {
+    content: '\00276F';
+    padding-right: 5px;
+    margin-left: -20px;
+}
+
 img.logo {
   margin-bottom: 1em;
 }

--- a/subprojects/docs/src/docs/css/userguide.css
+++ b/subprojects/docs/src/docs/css/userguide.css
@@ -13,8 +13,7 @@
 
 .book .toc > dl > dt > .part {
     display: inline-block;
-    font-size: 1.4em;
-    font-variant: small-caps;
+    font-size: 1.25em;
     margin-top: 0.6em;
     margin-bottom: 0.3em;
 }
@@ -28,21 +27,16 @@
 }
 
 div.toc p { /* Is "Table Of Contents" header */
-    font-size: 28px;
-    color: #007042;
+    font-size: 1.5em;
     margin-bottom: 0.5em;
-}
-
-div.toc p b {
-    font-weight: normal;
 }
 
 .chapter > .toc {
     margin-bottom: 1em;
 }
 
-.chapter > .toc > dl {
-    margin-left: 1.5em;
+.toc a {
+    color: #02303A;
 }
 
 /*
@@ -55,9 +49,9 @@ div.toc p b {
 
 .navfooter {
     margin-top: 3em;
-    padding-top: 1em;
+    padding: 1em 0;
     width: 100%;
-    border-top: solid #d0d0d0 0.4em;
+    border-top: 1px solid #d0d0d0;
 }
 
 .navbar {
@@ -82,14 +76,6 @@ div.toc p b {
 
 .titlepage .author {
     color: #666666;
-}
-
-.titlepage .copyright {
-    color: #a2a2a2;
-}
-
-.titlepage .legalnotice {
-    color: #a2a2a2;
 }
 
 .titlepage p {

--- a/subprojects/docs/src/docs/css/userguide.css
+++ b/subprojects/docs/src/docs/css/userguide.css
@@ -3,8 +3,7 @@
  */
 
 .toc dl, .list-of-examples dl {
-    margin-top: 0;
-    margin-bottom: 0;
+    margin-left: 0;
 }
 
 .book .toc > dl > dt {

--- a/subprojects/docs/src/transforms/release-notes.gradle
+++ b/subprojects/docs/src/transforms/release-notes.gradle
@@ -170,12 +170,6 @@ transformDocument {
     body().prepend("<h1>Gradle Release Notes</h1>")
 }
 
-// Add the footer
-transformDocument {
-    def footer = body().append("<section class='footer'/>").children().last()
-    footer.html("Gradle @version@ Release Notes<br />")
-}
-
 // Syntax highlighting
 transformDocument {
     body().select("code").each { code ->

--- a/subprojects/docs/src/transforms/release-notes.gradle
+++ b/subprojects/docs/src/transforms/release-notes.gradle
@@ -211,7 +211,7 @@ transformDocument {
 // Wrap the page in a text container to get the margins
 transformDocument {
     def bodyContent = body().children().remove()
-    body().prepend("<div class='text-container'/>")
+    body().prepend("<div class='container'/>")
     body().children()[0].html(bodyContent.outerHtml())
 }
 


### PR DESCRIPTION
This change improves readability of documentation pages in the
following ways:
 - Reduce width of content area, making tracking a single line
   easier
 - Unifies vertical rhythm and header styles with other Gradle
   properties
 - Lots of stylistic tweaks that make the pages pleasant
 - Uses system monospace font instead of Ubuntu Mono,
   improving page speed and consistency with other Gradle sites

Issue: gradle/dotorg-docs#61

### Context
The goal here is to make cheap improvements that allow us to avoid so many overrides in the dotcom-docs project, improve speed, improve readability, and improve consistency of the styles with the Gradle Blog and gradle.org

Before and Afters:
![screenshot 2017-11-15 12 41 10](https://user-images.githubusercontent.com/51534/32856568-6a4e5d02-ca02-11e7-9383-ddcfb5b6d2dc.png)

![screenshot 2017-11-15 12 38 11](https://user-images.githubusercontent.com/51534/32856575-6eaa9e10-ca02-11e7-99ac-25e0fa5b317f.png)

![screenshot 2017-11-15 12 37 34](https://user-images.githubusercontent.com/51534/32856584-737d884e-ca02-11e7-96a5-a7236ca4a618.png)


### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
