### PR TITLE
Compress verbose console output

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/BasicGroupedTaskLoggingFunctionalSpec.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/BasicGroupedTaskLoggingFunctionalSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.logging.console.taskgrouping
 
 import org.fusesource.jansi.Ansi
 import org.gradle.integtests.fixtures.executer.GradleHandle
-import org.gradle.internal.SystemProperties
 import org.gradle.internal.logging.sink.GroupingProgressLogEventGenerator
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -194,7 +193,7 @@ class BasicGroupedTaskLoggingFunctionalSpec extends AbstractConsoleGroupedTaskFu
 
         when:
         handle.waitForAllPendingCalls()
-        assertOutputContains(gradle, "Before${SystemProperties.instance.lineSeparator}")
+        assertOutputContains(gradle, "Before")
         handle.releaseAll()
         result = gradle.waitForFinish()
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatter.java
@@ -29,7 +29,7 @@ public class PrettyPrefixedLogHeaderFormatter implements LogHeaderFormatter {
         final String message = header != null ? header : description;
         if (message != null) {
             // Visually indicate group by adding surrounding lines
-            return Lists.newArrayList(eol(), header(message, failed), status(status, failed), eol());
+            return Lists.newArrayList(header(message, failed), status(status, failed), eol());
         } else {
             return Collections.emptyList();
         }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatterTest.groovy
@@ -29,7 +29,7 @@ class PrettyPrefixedLogHeaderFormatterTest extends Specification {
         def formattedText = formatter.format(":test", "", null, "XYZ", true)
 
         then:
-        formattedText[1].style == StyledTextOutput.Style.FailureHeader
+        formattedText[0].style == StyledTextOutput.Style.FailureHeader
     }
 
     def "prints header of not-failing tasks white"() {
@@ -40,6 +40,6 @@ class PrettyPrefixedLogHeaderFormatterTest extends Specification {
         def formattedText = formatter.format(":test", "", null, "XYZ", false)
 
         then:
-        formattedText[1].style == StyledTextOutput.Style.Header
+        formattedText[0].style == StyledTextOutput.Style.Header
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
@@ -266,7 +266,7 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.restore(snapshot) // close console to flush
 
         then:
-        console.buildOutputArea.toString().readLines() == ['', '{header}> description{info} status{normal}', 'info', '{error}error', '{normal}']
+        console.buildOutputArea.toString().readLines() == ['{header}> description{info} status{normal}', 'info', '{error}error', '{normal}']
     }
 
     def rendersLogEventsWhenOnlyStdOutIsConsole() {
@@ -281,7 +281,7 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.restore(snapshot) // close console to flush
 
         then:
-        console.buildOutputArea.toString().readLines() == ['', '{header}> description{info} status{normal}', 'info']
+        console.buildOutputArea.toString().readLines() == ['{header}> description{info} status{normal}', 'info']
     }
 
     def rendersLogEventsWhenOnlyStdErrIsConsole() {


### PR DESCRIPTION

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
This makes verbose output look more like plain output, for consistency.

Resolves: #3325

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

I'm not sure what to do about the one failing test. It fails because AnsiConsole outputs the "erase-forward" command after all newlines, but for some reason it didn't happen before this change. Should I update the test, or is there some bug that I'm hitting in AnsiConsole?

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
