### PR TITLE
Update Android performance tests

### DIFF
--- a/subprojects/internal-android-performance-testing/internal-android-performance-testing.gradle
+++ b/subprojects/internal-android-performance-testing/internal-android-performance-testing.gradle
@@ -3,9 +3,13 @@ configurations {
     compile.extendsFrom androidTools
 }
 
+repositories {
+    google()
+}
+
 dependencies {
     compile project(':toolingApi')
-    androidTools 'com.android.tools.build:gradle:2.3.0'
+    androidTools 'com.android.tools.build:gradle:3.0.0'
 }
 
 task buildClassPath(type: BuildClassPath) {

--- a/subprojects/internal-android-performance-testing/src/main/java/org/gradle/performance/android/SyncAction.java
+++ b/subprojects/internal-android-performance-testing/src/main/java/org/gradle/performance/android/SyncAction.java
@@ -34,10 +34,12 @@ public class SyncAction {
         BuildActionExecuter<Map<String, AndroidProject>> modelBuilder = connect.action(new GetModel());
         modelBuilder.setStandardOutput(System.out);
         modelBuilder.setStandardError(System.err);
+        modelBuilder.forTasks("generateDebugSources");
         modelBuilder.withArguments("-Dcom.android.build.gradle.overrideVersionCheck=true",
             "-Pandroid.injected.build.model.only=true",
-            "-Pandroid.injected.invoked.from.ide=true",
-            "-Pandroid.injected.build.model.only.versioned=2");
+            "-Pandroid.injected.build.model.only.versioned=3",
+            "-Pandroid.builder.sdkDownload=true",
+            "-s");
         modelBuilder.setJvmArguments("-Xmx2g");
         if (modelBuilderAction != null) {
             modelBuilderAction.execute(modelBuilder);

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -30,7 +30,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
         runner.warmUpRuns = warmUpRuns
         runner.runs = runs
         runner.minimumVersion = "3.4"
-        runner.targetVersions = ["4.4-20171016130954+0000"]
+        runner.targetVersions = ["4.5-20171114235929+0000"]
 
         when:
         def result = runner.run()
@@ -41,8 +41,10 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
         where:
         testProject         | memory | parallel | warmUpRuns | runs | tasks
         'k9AndroidBuild'    | '512m' | false    | null       | null | 'help'
+        'k9AndroidBuild'    | '512m' | false    | null       | null | 'assembleDebug'
         'k9AndroidBuild'    | '512m' | false    | null       | null | 'clean k9mail:assembleDebug'
         'largeAndroidBuild' | '2g'   | true     | null       | null | 'help'
+        'largeAndroidBuild' | '2g'   | true     | null       | null | 'assembleDebug'
         'largeAndroidBuild' | '2g'   | true     | 2          | 8    | 'clean phthalic:assembleDebug'
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
@@ -26,11 +26,10 @@ class RealLifeAndroidStudioMockupPerformanceTest extends AbstractAndroidStudioMo
         given:
 
         experiment(testProject) {
-            minimumVersion = "3.4"
-            targetVersions = ["4.2-20170817235727+0000"]
+            minimumVersion = "4.3.1"
+            targetVersions = ["4.3.1"]
             action('org.gradle.performance.android.SyncAction') {
                 jvmArguments = customizeJvmOptions(["-Xms2g", "-Xmx2g"])
-                withArguments("android.builder.sdkDownload=true", "-Dcom.android.build.gradle.overrideVersionCheck=true")
             }
         }
 

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -296,12 +296,12 @@ task bigCppMulti(type: CppMultiProjectGeneratorTask) {
 // === Android ===
 task k9AndroidBuild(type: RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-k-9.git'
-    branch = 'gradle'
+    branch = 'android-30'
 }
 
 task largeAndroidBuild(type: RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large.git'
-    branch = 'gradle'
+    branch = 'android-30'
 }
 
 task excludeRuleMergingBuild(type: RemoteProject) {


### PR DESCRIPTION
Use Android 3.0 now that it is stable, making it much more
important to test against than Android 2.3.

The Android studio Sync mockup was ignoring the fact that
Studio also runs some tasks. This commit corrects this to
make the test more realistic.