### PR TITLE
Attempt to fix https://github.com/gradle/gradle-private/issues/975

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/AbstractUserInputHandlerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/AbstractUserInputHandlerIntegrationTest.groovy
@@ -25,12 +25,16 @@ class AbstractUserInputHandlerIntegrationTest extends AbstractIntegrationSpec {
         executer.withStdinPipe().withForceInteractive(true)
     }
 
-    protected void withDaemon() {
-        executer.requireDaemon().requireIsolatedDaemons()
+    protected void withDaemon(boolean enabled) {
+        if (enabled) {
+            executer.requireDaemon().requireIsolatedDaemons()
+        }
     }
 
-    protected void withConsoleOutput(ConsoleOutput consoleOutput) {
-        executer.withConsole(consoleOutput)
+    protected void withRichConsole(boolean enabled) {
+        if (enabled) {
+            executer.withConsole(ConsoleOutput.Rich)
+        }
     }
 
     protected void withParallel() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildScanUserInputFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildScanUserInputFixture.groovy
@@ -63,16 +63,14 @@ final class BuildScanUserInputFixture {
         "$ANSWER_PREFIX $answer"
     }
 
-    static void writeToStdIn(GradleHandle gradleHandle, input) {
+    static void writeToStdInAndClose(GradleHandle gradleHandle, input) {
         gradleHandle.stdinPipe.write(input)
-        writeLineSeparatorToStdIn(gradleHandle)
+        writeLineSeparatorToStdInAndClose(gradleHandle)
     }
 
-    private static void writeLineSeparatorToStdIn(GradleHandle gradleHandle) {
+    private static void writeLineSeparatorToStdInAndClose(GradleHandle gradleHandle) {
         gradleHandle.stdinPipe.write(getPlatformLineSeparator().bytes)
-    }
-
-    static void closeStdIn(GradleHandle gradleHandle) {
+        gradleHandle.stdinPipe.flush()
         gradleHandle.stdinPipe.close()
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ForwardClientInput.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ForwardClientInput.java
@@ -40,7 +40,7 @@ public class ForwardClientInput implements DaemonCommandAction {
         final PipedOutputStream inputSource = new PipedOutputStream();
         final PipedInputStream replacementStdin;
         try {
-            replacementStdin = new CloseAwareInputStream(inputSource);
+            replacementStdin = new EndOnClosedInputStream(inputSource);
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
@@ -85,10 +85,10 @@ public class ForwardClientInput implements DaemonCommandAction {
         }
     }
 
-    private static class CloseAwareInputStream extends PipedInputStream {
+    private static class EndOnClosedInputStream extends PipedInputStream {
         private volatile boolean closed;
 
-        public CloseAwareInputStream(PipedOutputStream src) throws IOException {
+        private EndOnClosedInputStream(PipedOutputStream src) throws IOException {
             super(src);
         }
 

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
@@ -66,9 +66,8 @@ class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
         def gradleHandle = startBuildWithBuildScanCommandLineOption()
 
         then:
-        writeToStdIn(gradleHandle, YES.bytes)
+        writeToStdInAndClose(gradleHandle, YES.bytes)
         def result = gradleHandle.waitForFinish()
-        closeStdIn(gradleHandle)
         result.output.contains(BUILD_SCAN_LICENSE_QUESTION)
         result.output.contains(BUILD_SCAN_LICENSE_ACCEPTANCE)
         result.output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING)
@@ -85,9 +84,8 @@ class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
         def gradleHandle = startBuildWithBuildScanCommandLineOption()
 
         then:
-        writeToStdIn(gradleHandle, NO.bytes)
+        writeToStdInAndClose(gradleHandle, NO.bytes)
         def result = gradleHandle.waitForFinish()
-        closeStdIn(gradleHandle)
         result.output.contains(BUILD_SCAN_LICENSE_QUESTION)
         result.output.contains(BUILD_SCAN_LICENSE_DECLINATION)
         result.output.contains(BUILD_SCAN_PLUGIN_CONFIG_PROBLEM)
@@ -107,9 +105,8 @@ class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
         def gradleHandle = startBuildWithBuildScanCommandLineOption()
 
         then:
-        writeToStdIn(gradleHandle, EOF)
+        writeToStdInAndClose(gradleHandle, EOF)
         def result = gradleHandle.waitForFinish()
-        closeStdIn(gradleHandle)
         result.output.contains(BUILD_SCAN_LICENSE_QUESTION)
         !result.output.contains(BUILD_SCAN_LICENSE_ACCEPTANCE)
         !result.output.contains(BUILD_SCAN_LICENSE_DECLINATION)
@@ -133,9 +130,8 @@ class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
         def gradleHandle = startBuildWithBuildScanCommandLineOption()
 
         then:
-        writeToStdIn(gradleHandle, EOF)
+        writeToStdInAndClose(gradleHandle, EOF)
         def result = gradleHandle.waitForFinish()
-        closeStdIn(gradleHandle)
         !result.output.contains(BUILD_SCAN_WARNING)
         result.output.contains(BUILD_SCAN_LICENSE_QUESTION)
         !result.output.contains(BUILD_SCAN_LICENSE_ACCEPTANCE)


### PR DESCRIPTION
This PR adds a guard for PipedInputStream to make sure it's safe to
read after being closed.

### Context

See https://github.com/gradle/gradle-private/issues/975

The detail of this issue is still unclear. However, looks like this fixes the issue according to 50~60  AdHoc Functional Tests.