### PR TITLE
Let empty version selectors match anything

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -77,7 +77,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                 module("group:bom:1.0", {
                     module("group:moduleA:2.0")
                 }).noArtifacts()
-                edge("group:moduleA:", "group:moduleA:2.0").byConflictResolution()
+                edge("group:moduleA:", "group:moduleA:2.0")
             }
         }
     }
@@ -103,7 +103,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                         module("group:moduleA:2.0")
                     }).noArtifacts()
                 }
-                edge("group:moduleA:", "group:moduleA:2.0").byConflictResolution()
+                edge("group:moduleA:", "group:moduleA:2.0")
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/ExactVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/ExactVersionSelector.java
@@ -36,7 +36,8 @@ public class ExactVersionSelector extends AbstractStringVersionSelector {
     }
 
     public boolean accept(String candidate) {
-        return getSelector().equals(candidate);
+        String selector = getSelector();
+        return selector.isEmpty() || selector.equals(candidate);
     }
 
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -140,7 +140,7 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
 
         where:
         bomSupportProvider                    | directBomDependency | reason1          | reason2          | reason3          | bomDeclaration                                        | dependencyManagementPlugin
-        "gradle"                              | true                | "conflict"       | "conflict"       | "requested"      | "dependencies { implementation $bom }"                | ""
+        "gradle"                              | true                | "requested"      | "requested"      | "requested"      | "dependencies { implementation $bom }"                | ""
         "nebula recommender plugin"           | false               | "selectedByRule" | "requested"      | "requested"      | "dependencyRecommendations { mavenBom module: $bom }" | "id 'nebula.dependency-recommender' version '5.0.0'"
         "spring dependency management plugin" | false               | "selectedByRule" | "selectedByRule" | "selectedByRule" | "dependencyManagement { imports { mavenBom $bom } }"  | "id 'io.spring.dependency-management' version '1.0.3.RELEASE'"
     }


### PR DESCRIPTION
So far the empty version selector only matched an
empty version. However, what it really means is that
the user didn't care what this selector chooses and
wants the version to be recommended by something else.
Until now this would lead to conflict resolution, where
the empty version would be upgraded to a non-empty one.

Instead, the empty version is now replaced by a non-empty
one during selection and doesn't lead to conflict resolution
anymore. This leads to a more natural resolution result for
the BOM import case.