### PR TITLE
Use a specific version of an external git source dependency

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -138,7 +138,7 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
         gitCheckout.file('.git').assertExists()
     }
 
-    def 'missing version error makes sense'() {
+    def 'handle missing version by adding tag to git repository'() {
         given:
         settingsFile << """
             sourceControl {
@@ -165,6 +165,14 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
 
         then:
         failureCauseContains("does not contain a version matching 1.4.0")
+
+        when:
+        javaFile.setText(javaFile.text.replace('interface', 'class'))
+        repo.commit('Switch it back to a class.', GFileUtils.listFiles(file('dep'), null, true))
+        repo.createLightWeightTag('1.4.0')
+
+        then:
+        succeeds('assemble')
     }
 
     // TODO: Use HTTP hosting for git repo

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
@@ -40,24 +40,6 @@ class VcsMappingsIntegrationTest extends AbstractVcsIntegrationTest {
         assertRepoCheckedOut()
     }
 
-    def "only use source repositories when version matches latest.integration"() {
-        settingsFile << """
-            sourceControl {
-                vcsMappings {
-                    withModule("org.test:dep") {
-                        from vcs(DirectoryRepositorySpec) {
-                            sourceDir = file("dep")
-                        }
-                    }
-                }
-            }
-        """
-        buildFile.text = buildFile.text.replace("latest.integration", "1.0")
-        expect:
-        fails("assemble")
-        assertRepoNotCheckedOut("dep")
-    }
-
     def 'emits sensible error when bad code is in vcsMappings block'() {
         settingsFile << """
             sourceControl {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -81,7 +81,8 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
                 VersionControlSystem versionControlSystem = versionControlSystemFactory.create(spec);
                 VersionRef selectedVersion = selectVersionFromRepository(spec, versionControlSystem, depSelector.getVersion());
                 if (selectedVersion == null) {
-                    result.failed(new ModuleVersionResolveException(depSelector, spec.getDisplayName() + " does not contain a version matching " + depSelector.getVersion()));
+                    result.failed(new ModuleVersionResolveException(depSelector,
+                        "Could not resolve " + depSelector.toString() + ". " + spec.getDisplayName() + " does not contain a version matching " + depSelector.getVersion()));
                     return;
                 }
                 File dependencyWorkingDir = populateWorkingDirectory(baseWorkingDir, spec, versionControlSystem, selectedVersion);

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
@@ -71,7 +71,13 @@ public class GitVersionControlSystem implements VersionControlSystem {
         }
         Set<VersionRef> versions = Sets.newHashSet();
         for (Ref ref : refs) {
-            versions.add(GitVersionRef.from(ref));
+            GitVersionRef gitRef = GitVersionRef.from(ref);
+            versions.add(gitRef);
+            // The HEAD reference in a Git Repository is a logical choice if the user is looking
+            // for the 'latest.integration' version of a dependency.
+            if (gitRef.getVersion().equals("HEAD")) {
+                versions.add(GitVersionRef.from("latest.integration", gitRef.getCanonicalId()));
+            }
         }
         return versions;
     }

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionRef.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionRef.java
@@ -38,6 +38,10 @@ public class GitVersionRef implements VersionRef {
         return new GitVersionRef(extractName(ref), commitId.getName());
     }
 
+    public static GitVersionRef from(String version, String canonicalId) {
+        return new GitVersionRef(version, canonicalId);
+    }
+
     @Override
     public String getVersion() {
         return version;

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionRef.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionRef.java
@@ -21,7 +21,7 @@ import org.gradle.vcs.VersionRef;
 public class DefaultVersionRef implements VersionRef {
     @Override
     public String getVersion() {
-        return "master";
+        return "latest.integration";
     }
 
     @Override

--- a/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
+++ b/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
@@ -176,11 +176,12 @@ class GitVersionControlSystemSpec extends Specification {
         }
 
         expect:
-        versions.size() == 5
+        versions.size() == 6
         versionMap['release'] == c1.id.name
         versionMap['1.0.1'] == c1.id.name
         versionMap['v1.0.1'] == c1.id.name
         versionMap['HEAD'] == c2.id.name
+        versionMap['latest.integration'] == c2.id.name
         versionMap['master'] == c2.id.name
     }
 }


### PR DESCRIPTION
This change allows repositories to be cloned at a specific tag, or
branch if the name matches the exact name of the version of the
dependency being resolved.

Fixes gradle/gradle-native#185
