### PR TITLE
Add support for status in Gradle metadata

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/binarycompatibility/rules/SinceAnnotationMissingRule.java
+++ b/buildSrc/src/main/groovy/org/gradle/binarycompatibility/rules/SinceAnnotationMissingRule.java
@@ -127,7 +127,7 @@ public class SinceAnnotationMissingRule extends AbstractGradleViolationRule {
             };
         } else if (member instanceof JApiConstructor) {
             final JApiConstructor constructor = (JApiConstructor) member;
-            if (isDeprecated(constructor)) {
+            if (isDeprecated(constructor) || isInject(constructor)) {
                 return null;
             }
             className = constructor.getjApiClass().getFullyQualifiedName();

--- a/buildSrc/src/test/groovy/org/gradle/binarycompatibility/PublicAPIRulesTest.groovy
+++ b/buildSrc/src/test/groovy/org/gradle/binarycompatibility/PublicAPIRulesTest.groovy
@@ -321,9 +321,10 @@ class PublicAPIRulesTest extends Specification {
         violation.humanExplanation == 'New public API in 11.38 (@Incubating)'
     }
 
+    @Unroll
     def "constructors with @Inject annotation are not considered public API"() {
         given:
-        def rule = withContext(new BinaryBreakingChangesRule([:]))
+        def rule = withContext(ruleElem)
         def annotations = []
         jApiConstructor.annotations >> annotations
 
@@ -331,13 +332,17 @@ class PublicAPIRulesTest extends Specification {
         annotations.clear()
 
         then:
-        rule.maybeViolation(jApiConstructor).humanExplanation  =~ 'Is not binary compatible.'
+        rule.maybeViolation(jApiConstructor).humanExplanation  =~ error
 
         when:
         annotations.add(injectAnnotation)
 
         then:
         rule.maybeViolation(jApiConstructor) == null
+
+        where:
+        ruleElem << [new BinaryBreakingChangesRule([:]), new SinceAnnotationMissingRule([:])]
+        error << ['Is not binary compatible.', 'Is not annotated with @since']
     }
 
     def "the @since annotation on inner classes is recognised"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.project;
 import org.gradle.api.Project;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.UnknownProjectException;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.ProcessOperations;
@@ -48,6 +49,8 @@ public interface ProjectInternal extends Project, ProjectIdentifier, FileOperati
     String HELP_TASK = "help";
     String TASKS_TASK = "tasks";
     String PROJECTS_TASK = "projects";
+
+    Attribute<String> STATUS_ATTRIBUTE = Attribute.of("org.gradle.status", String.class);
 
     ProjectInternal getParent();
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
@@ -554,6 +554,26 @@ Searched in the following locations:
   dependencies {
       conf 'org.test:projectA:latest.release'
   }
+  
+  configurations {
+      conf.resolutionStrategy.componentSelection.all { ComponentSelection s, ComponentMetadata d ->
+         if (d.status != 'release') { s.reject('nope') } 
+      }
+  }
+      
+  dependencies.components.all { ComponentMetadataDetails details, IvyModuleDescriptor ivyModule ->
+     def version = details.id.version
+     def expectedStatus = [
+        '2.0'        : 'integration',
+        '1.3'        : 'integration',
+        '1.2'        : 'milestone',
+        '1.1'        : 'release',
+        '1.1.1'      : 'milestone',
+        '1.1-beta-2' : 'integration',
+        '1.0'        : 'release',
+     ]
+     assert details.status == expectedStatus[version]
+  }
   """
         when:
         repositoryInteractions {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.descriptor.Configuration;
@@ -70,6 +71,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
     private List<MutableVariantImpl> newVariants;
     private ImmutableList<? extends ComponentVariant> variants;
     private ImmutableList<? extends ConfigurationMetadata> graphVariants;
+    private ImmutableAttributes attributes;
 
 
     protected AbstractMutableModuleComponentResolveMetadata(ModuleVersionIdentifier id, ModuleComponentIdentifier componentIdentifier, List<? extends ModuleDependencyMetadata> dependencies) {
@@ -229,6 +231,14 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
     @Override
     public void setSource(ModuleSource source) {
         this.moduleSource = source;
+    }
+
+    public void setAttributes(ImmutableAttributes attributes) {
+        this.attributes = attributes;
+        // map the "status" attribute to the "status" field
+        if (attributes.contains(ProjectInternal.STATUS_ATTRIBUTE)) {
+            setStatus(attributes.getAttribute(ProjectInternal.STATUS_ATTRIBUTE));
+        }
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariantResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariantResolveMetadata.java
@@ -23,4 +23,11 @@ public interface MutableComponentVariantResolveMetadata {
      * Adds a variant to this module.
      */
     MutableComponentVariant addVariant(String variantName, ImmutableAttributes attributes);
+
+    /**
+     * Sets the attributes of this module. Attributes <i>may</i> be mapped to legacy properties (like status)
+     *
+     * @param attributes the component attributes
+     */
+    void setAttributes(ImmutableAttributes attributes);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -65,6 +65,23 @@ class ModuleMetadataParserTest extends Specification {
         0 * _
     }
 
+    def "parses component metadata attributes"() {
+        def metadata = Mock(MutableComponentVariantResolveMetadata)
+
+        when:
+        parser.parse(resource('''
+    { 
+        "formatVersion": "0.2", 
+        "component": { "url": "elsewhere", "group": "g", "module": "m", "version": "v", "attributes": {"foo": "bar", "org.gradle.status": "release" } },
+        "builtBy": { "gradle": { "version": "123", "buildId": "abc" } }
+    }
+'''), metadata)
+
+        then:
+        1 * metadata.setAttributes(attributes(foo: 'bar', 'org.gradle.status': 'release'))
+        0 * _
+    }
+
     def "parses content with variant"() {
         def metadata = Mock(MutableComponentVariantResolveMetadata)
         def variant = Mock(MutableComponentVariant)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.fixtures.publish
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.HttpModule
 import org.gradle.test.fixtures.HttpRepository
 import org.gradle.test.fixtures.ivy.IvyModule
@@ -93,6 +92,12 @@ class ModuleVersionSpec {
         withModule << spec
     }
 
+    void allowAll() {
+        withModule {
+            delegate.allowAll()
+        }
+    }
+
     void build(HttpRepository repository) {
         def module = repository.module(groupId, artifactId, version)
         def gradleMetadataEnabled = GradleMetadataResolveRunner.isGradleMetadataEnabled()
@@ -104,15 +109,13 @@ class ModuleVersionSpec {
                 case Expectation.NONE:
                     break;
                 case Expectation.MAYBE:
-                    if (GradleContextualExecuter.parallel) {
-                        if (module instanceof MavenModule) {
-                            module.pom.allowGetOrHead()
-                        } else if (module instanceof IvyModule) {
-                            module.ivy.allowGetOrHead()
-                        }
-                        if (gradleMetadataEnabled) {
-                            module.moduleMetadata.allowGetOrHead()
-                        }
+                    if (module instanceof MavenModule) {
+                        module.pom.allowGetOrHead()
+                    } else if (module instanceof IvyModule) {
+                        module.ivy.allowGetOrHead()
+                    }
+                    if (gradleMetadataEnabled) {
+                        module.moduleMetadata.allowGetOrHead()
                     }
                     break
                 case Expectation.HEAD:

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1,9 +1,4 @@
 {
     "acceptedApiChanges": [
-        {
-            "type": "org.gradle.api.publish.ivy.plugins.IvyPublishPlugin",
-            "member": "Constructor org.gradle.api.publish.ivy.plugins.IvyPublishPlugin(org.gradle.internal.reflect.Instantiator,org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider,org.gradle.api.internal.file.FileResolver,org.gradle.api.publish.internal.ProjectDependencyPublicationResolver,org.gradle.api.internal.file.FileCollectionFactory,org.gradle.api.internal.attributes.ImmutableAttributesFactory)",
-            "acceptation": "Change constructor of incubating plugin"
-        }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1,4 +1,9 @@
 {
     "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.publish.ivy.plugins.IvyPublishPlugin",
+            "member": "Constructor org.gradle.api.publish.ivy.plugins.IvyPublishPlugin(org.gradle.internal.reflect.Instantiator,org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider,org.gradle.api.internal.file.FileResolver,org.gradle.api.publish.internal.ProjectDependencyPublicationResolver,org.gradle.api.internal.file.FileCollectionFactory,org.gradle.api.internal.attributes.ImmutableAttributesFactory)",
+            "acceptation": "Change constructor of incubating plugin"
+        }
     ]
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -24,12 +24,14 @@ class GradleFileModuleAdapter {
     private final String module
     private final String version
     private final List<VariantMetadata> variants
+    private final Map<String, String> attributes
 
-    public GradleFileModuleAdapter(String group, String module, String version, List<VariantMetadata> variants) {
+    GradleFileModuleAdapter(String group, String module, String version, List<VariantMetadata> variants, Map<String, String> attributes = [:]) {
         this.group = group
         this.module = module
         this.version = version
         this.variants = variants
+        this.attributes = attributes
     }
 
     void publishTo(TestFile moduleDir) {
@@ -40,6 +42,16 @@ class GradleFileModuleAdapter {
             formatVersion '0.2'
             builtBy {
                 gradle { }
+            }
+            component {
+                group this.group
+                module this.module
+                version this.version
+                attributes {
+                    this.attributes.each { key, value ->
+                        "$key" value
+                    }
+                }
             }
             variants(this.variants.collect { v ->
                 { ->

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
@@ -39,9 +39,14 @@ public interface IvyModule extends Module {
     TestFile getModuleMetadataFile();
 
     /**
-     * Don't publish an ivy.xml for this module.
+     * Don't publish an ivy.xml / .module for this module.
      */
     IvyModule withNoMetaData();
+
+    /**
+     * Don't publish any ivy.xml for this module, but publish .module
+     */
+    IvyModule withNoIvyMetaData();
 
     IvyModule withStatus(String status);
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
@@ -98,6 +98,12 @@ public abstract class DelegatingIvyModule<T extends IvyModule> implements IvyMod
         return t();
     }
 
+    @Override
+    public IvyModule withNoIvyMetaData() {
+        backingModule.withNoIvyMetaData();
+        return t();
+    }
+
     public T withStatus(String status) {
         backingModule.withStatus(status);
         return t();

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.publish.PublicationContainer;
@@ -66,15 +67,18 @@ public class IvyPublishPlugin implements Plugin<Project> {
     private final FileResolver fileResolver;
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
     private final FileCollectionFactory fileCollectionFactory;
+    private final ImmutableAttributesFactory immutableAttributesFactory;
 
     @Inject
     public IvyPublishPlugin(Instantiator instantiator, DependencyMetaDataProvider dependencyMetaDataProvider, FileResolver fileResolver,
-                            ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory) {
+                            ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
+                            ImmutableAttributesFactory immutableAttributesFactory) {
         this.instantiator = instantiator;
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
         this.fileResolver = fileResolver;
         this.projectDependencyResolver = projectDependencyResolver;
         this.fileCollectionFactory = fileCollectionFactory;
+        this.immutableAttributesFactory = immutableAttributesFactory;
     }
 
     public void apply(final Project project) {
@@ -146,7 +150,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
             NotationParser<Object, IvyArtifact> notationParser = new IvyArtifactNotationParserFactory(instantiator, fileResolver, publicationIdentity).create();
             return instantiator.newInstance(
                     DefaultIvyPublication.class,
-                    name, instantiator, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory
+                    name, instantiator, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory, immutableAttributesFactory
             );
         }
     }

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -38,6 +38,7 @@ import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -49,6 +50,8 @@ class DefaultIvyPublicationTest extends Specification {
     def projectIdentity = Mock(IvyPublicationIdentity)
     def notationParser = Mock(NotationParser)
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
+    def attributesFactory = TestUtil.attributesFactory()
+
     File descriptorFile
     File artifactFile
 
@@ -265,7 +268,15 @@ class DefaultIvyPublicationTest extends Specification {
     }
 
     def createPublication() {
-        def publication = instantiator.newInstance(DefaultIvyPublication, "pub-name", instantiator, projectIdentity, notationParser, projectDependencyResolver, TestFiles.fileCollectionFactory())
+        def publication = instantiator.newInstance(DefaultIvyPublication,
+            "pub-name",
+            instantiator,
+            projectIdentity,
+            notationParser,
+            projectDependencyResolver,
+            TestFiles.fileCollectionFactory(),
+            attributesFactory
+        )
         publication.setDescriptorFile(new SimpleFileCollection(descriptorFile))
         return publication;
     }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -36,6 +36,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ExperimentalFeatures;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -358,15 +359,21 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         };
     }
 
-    /*
-      When the artifacts declared in a component are modified for publishing (name/classifier/extension),
-      then the Maven publication no longer represents the underlying java component.
-      Instead of publishing incorrect metadata, we fail any attempt to publish the module metadata.
+    @Nullable
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return null;
+    }
 
-      In the long term, we will likely prevent any modification of artifacts added from a component.
-      Instead, we will make it easier to modify the component(s) produced by a project, allowing the published
-      metadata to accurately reflect the local component metadata.
-     */
+    /*
+          When the artifacts declared in a component are modified for publishing (name/classifier/extension),
+          then the Maven publication no longer represents the underlying java component.
+          Instead of publishing incorrect metadata, we fail any attempt to publish the module metadata.
+
+          In the long term, we will likely prevent any modification of artifacts added from a component.
+          Instead, we will make it easier to modify the component(s) produced by a project, allowing the published
+          metadata to accurately reflect the local component metadata.
+         */
     private void checkThatArtifactIsPublishedUnmodified(PublishArtifact source) {
         for (MavenArtifact mavenArtifact : mavenArtifacts) {
             if (source.getFile().equals(mavenArtifact.getFile())

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -366,14 +366,14 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     /*
-          When the artifacts declared in a component are modified for publishing (name/classifier/extension),
-          then the Maven publication no longer represents the underlying java component.
-          Instead of publishing incorrect metadata, we fail any attempt to publish the module metadata.
-
-          In the long term, we will likely prevent any modification of artifacts added from a component.
-          Instead, we will make it easier to modify the component(s) produced by a project, allowing the published
-          metadata to accurately reflect the local component metadata.
-         */
+     * When the artifacts declared in a component are modified for publishing (name/classifier/extension), then the
+     * Maven publication no longer represents the underlying java component. Instead of
+     * publishing incorrect metadata, we fail any attempt to publish the module metadata.
+     *
+     * In the long term, we will likely prevent any modification of artifacts added from a component. Instead, we will
+     * make it easier to modify the component(s) produced by a project, allowing the
+     * published metadata to accurately reflect the local component metadata.
+     */
     private void checkThatArtifactIsPublishedUnmodified(PublishArtifact source) {
         for (MavenArtifact mavenArtifact : mavenArtifacts) {
             if (source.getFile().equals(mavenArtifact.getFile())

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -362,7 +362,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     @Nullable
     @Override
     public ImmutableAttributes getAttributes() {
-        return null;
+        return ImmutableAttributes.EMPTY;
     }
 
     /*

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -251,7 +251,7 @@ public class ModuleMetadataFileGenerator {
     }
 
     private void writeAttributes(AttributeContainer attributes, JsonWriter jsonWriter) throws IOException {
-        if (attributes==null || attributes.isEmpty()) {
+        if (attributes.isEmpty()) {
             return;
         }
         jsonWriter.name("attributes");

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
@@ -17,6 +17,7 @@ package org.gradle.api.publish.internal;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.publish.Publication;
 
@@ -27,6 +28,9 @@ public interface PublicationInternal extends Publication {
     SoftwareComponentInternal getComponent();
 
     ModuleVersionIdentifier getCoordinates();
+
+    @Nullable
+    ImmutableAttributes getAttributes();
 
     /**
      * Specifies that this publication is just an alias for another one and should not

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
@@ -29,7 +29,6 @@ public interface PublicationInternal extends Publication {
 
     ModuleVersionIdentifier getCoordinates();
 
-    @Nullable
     ImmutableAttributes getAttributes();
 
     /**

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -72,7 +72,39 @@ class ModuleMetadataFileGeneratorTest extends Specification {
   "component": {
     "group": "group",
     "module": "module",
-    "version": "1.2"
+    "version": "1.2",
+    "attributes": {}
+  },
+  "createdBy": {
+    "gradle": {
+      "version": "${GradleVersion.current().version}",
+      "buildId": "${buildId}"
+    }
+  }
+}
+"""
+    }
+
+    def "writes file for component with attributes"() {
+        def writer = new StringWriter()
+        def component = Stub(TestComponent)
+        def publication = publication(component, id)
+
+        when:
+        publication.attributes >> attributes(status: 'release', 'test': 'value')
+        generator.generateTo(publication, [publication], writer)
+
+        then:
+        writer.toString() == """{
+  "formatVersion": "0.2",
+  "component": {
+    "group": "group",
+    "module": "module",
+    "version": "1.2",
+    "attributes": {
+      "status": "release",
+      "test": "value"
+    }
   },
   "createdBy": {
     "gradle": {
@@ -126,7 +158,8 @@ class ModuleMetadataFileGeneratorTest extends Specification {
   "component": {
     "group": "group",
     "module": "module",
-    "version": "1.2"
+    "version": "1.2",
+    "attributes": {}
   },
   "createdBy": {
     "gradle": {
@@ -205,7 +238,8 @@ class ModuleMetadataFileGeneratorTest extends Specification {
   "component": {
     "group": "group",
     "module": "module",
-    "version": "1.2"
+    "version": "1.2",
+    "attributes": {}
   },
   "createdBy": {
     "gradle": {
@@ -279,7 +313,8 @@ class ModuleMetadataFileGeneratorTest extends Specification {
   "component": {
     "group": "group",
     "module": "module",
-    "version": "1.2"
+    "version": "1.2",
+    "attributes": {}
   },
   "createdBy": {
     "gradle": {
@@ -337,7 +372,8 @@ class ModuleMetadataFileGeneratorTest extends Specification {
   "component": {
     "group": "group",
     "module": "module",
-    "version": "1.2"
+    "version": "1.2",
+    "attributes": {}
   },
   "createdBy": {
     "gradle": {
@@ -402,7 +438,8 @@ class ModuleMetadataFileGeneratorTest extends Specification {
     "url": "../../module/1.2/module-1.2.module",
     "group": "group",
     "module": "module",
-    "version": "1.2"
+    "version": "1.2",
+    "attributes": {}
   },
   "createdBy": {
     "gradle": {


### PR DESCRIPTION
This pull request adds support for the "status" property in Gradle metadata. It is exposed as an attribute, which is internally mapped to the "status" property of dependency metadata.

We're doing the minimal work here: while we serialize things as attributes, the status is the only one supported, and it's also only written for Ivy dependency metadata.

I'm also unsure where to define the `status` attribute, so for now I left it in a private interface (`ProjectInternal`), in case we plan to move it elsewhere.

See #3462 and https://github.com/gradle/gradle/issues/3394#issuecomment-344021206