### PR TITLE
The error message of a failed build should render a hint to use the `--scan` command line option

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanFailureMessageHintIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanFailureMessageHintIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedBuildScanPlugin
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import org.gradle.util.ToBeImplemented
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -75,7 +74,7 @@ class BuildScanFailureMessageHintIntegrationTest extends AbstractIntegrationSpec
         ["-$LogLevelOption.QUIET_SHORT_OPTION"]             | 'quiet'
     }
 
-    def "only renders hint for failing build if build scan plugin was applied in plugins DSL and not requested for generation"() {
+    def "always renders hint for failing build if build scan plugin was applied in plugins DSL and not requested for generation"() {
         given:
         buildFile << appliedBuildScanPluginInPluginsDsl()
         buildFile << buildScanLicenseConfiguration()
@@ -86,15 +85,15 @@ class BuildScanFailureMessageHintIntegrationTest extends AbstractIntegrationSpec
 
         then:
         output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING) == buildScanPublished
-        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT) == renderedHint
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
 
         where:
-        tasks                     | renderedHint | buildScanPublished
-        DUMMY_TASK_ONLY           | true         | false
-        DUMMY_TASK_AND_BUILD_SCAN | false        | true
+        tasks                     | buildScanPublished
+        DUMMY_TASK_ONLY           | false
+        DUMMY_TASK_AND_BUILD_SCAN | true
     }
 
-    def "only renders hint for failing build if build scan plugin was applied in buildscript and not requested for generation"() {
+    def "always renders hint for failing build if build scan plugin was applied in buildscript and not requested for generation"() {
         given:
         buildFile << appliedBuildScanPluginInBuildScript()
         buildFile << buildScanLicenseConfiguration()
@@ -105,15 +104,15 @@ class BuildScanFailureMessageHintIntegrationTest extends AbstractIntegrationSpec
 
         then:
         output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING) == buildScanPublished
-        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT) == renderedHint
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
 
         where:
-        tasks                     | renderedHint | buildScanPublished
-        DUMMY_TASK_ONLY           | true         | false
-        DUMMY_TASK_AND_BUILD_SCAN | false        | true
+        tasks                     | buildScanPublished
+        DUMMY_TASK_ONLY           | false
+        DUMMY_TASK_AND_BUILD_SCAN | true
     }
 
-    def "only renders hint for failing build if build scan plugin was applied in initscript and not requested for generation"() {
+    def "always renders hint for failing build if build scan plugin was applied in initscript and not requested for generation"() {
         given:
         def initScriptFileName = 'init.gradle'
         file(initScriptFileName) << appliedBuildScanPluginInInitScript()
@@ -126,15 +125,15 @@ class BuildScanFailureMessageHintIntegrationTest extends AbstractIntegrationSpec
 
         then:
         output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING) == buildScanPublished
-        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT) == renderedHint
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
 
         where:
-        tasks                     | renderedHint | buildScanPublished
-        DUMMY_TASK_ONLY           | true         | false
-        DUMMY_TASK_AND_BUILD_SCAN | false        | true
+        tasks                     | buildScanPublished
+        DUMMY_TASK_ONLY           | false
+        DUMMY_TASK_AND_BUILD_SCAN | true
     }
 
-    def "only renders hint for failing build if build scan plugin was applied in script plugin and not requested for generation"() {
+    def "always hint for failing build if build scan plugin was applied in script plugin and not requested for generation"() {
         given:
         def scriptPluginFileName = 'scan.gradle'
         file(scriptPluginFileName) << appliedBuildScanPluginInScriptPlugin()
@@ -149,16 +148,15 @@ class BuildScanFailureMessageHintIntegrationTest extends AbstractIntegrationSpec
 
         then:
         output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING) == buildScanPublished
-        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT) == renderedHint
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
 
         where:
-        tasks                     | renderedHint | buildScanPublished
-        DUMMY_TASK_ONLY           | true         | false
-        DUMMY_TASK_AND_BUILD_SCAN | false        | true
+        tasks                     | buildScanPublished
+        DUMMY_TASK_ONLY           | false
+        DUMMY_TASK_AND_BUILD_SCAN | true
     }
 
-    @ToBeImplemented("at the moment Gradle does not have the information that publishAlways() was set")
-    def "does not render hint for failing build if build scan plugin was applied in plugins DSL is configured to always publish"() {
+    def "renders hint for failing build if build scan plugin was applied in plugins DSL is configured to always publish"() {
         given:
         buildFile << appliedBuildScanPluginInPluginsDsl()
         buildFile << buildScanLicenseConfiguration()
@@ -170,7 +168,7 @@ class BuildScanFailureMessageHintIntegrationTest extends AbstractIntegrationSpec
 
         then:
         output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING)
-        //!errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
     }
 
     static String failingBuildFile() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanFailureMessageHintIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanFailureMessageHintIntegrationTest.groovy
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.scan.config
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.plugin.management.internal.autoapply.AutoAppliedBuildScanPlugin
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import org.gradle.util.ToBeImplemented
+import spock.lang.Issue
+import spock.lang.Unroll
+
+import static org.gradle.initialization.StartParameterBuildOptions.BuildScanOption
+import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.BUILD_SCAN_ERROR_MESSAGE_HINT
+import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.DUMMY_TASK_NAME
+import static org.gradle.internal.logging.LoggingConfigurationBuildOptions.LogLevelOption
+import static org.gradle.internal.logging.LoggingConfigurationBuildOptions.StacktraceOption
+
+@Issue("https://github.com/gradle/gradle/issues/3516")
+@Requires(TestPrecondition.ONLINE)
+class BuildScanFailureMessageHintIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final List<String> DUMMY_TASK_ONLY = [DUMMY_TASK_NAME]
+    private static final List<String> DUMMY_TASK_AND_BUILD_SCAN = [DUMMY_TASK_NAME, "--$BuildScanOption.LONG_OPTION"]
+    private static final String BUILD_SCAN_SUCCESSFUL_PUBLISHING = 'Publishing build scan'
+
+    def "does not render hint for successful build without applied build scan plugin"() {
+        given:
+        buildFile << """
+            task $DUMMY_TASK_NAME
+        """
+
+        when:
+        succeeds(DUMMY_TASK_NAME)
+
+        then:
+        !output.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
+        errorOutput.isEmpty()
+    }
+
+    @Unroll
+    def "renders hint for failing build without applied build scan plugin and #description"() {
+        given:
+        buildFile << failingBuildFile()
+
+        when:
+        fails(DUMMY_TASK_ONLY + options as String[])
+
+        then:
+        !output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING)
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
+
+        where:
+        options                                             | description
+        []                                                  | 'no additional command line options'
+        ["-$StacktraceOption.STACKTRACE_SHORT_OPTION"]      | 'stacktrace'
+        ["-$StacktraceOption.FULL_STACKTRACE_SHORT_OPTION"] | 'full stacktrace'
+        ["-$LogLevelOption.INFO_SHORT_OPTION"]              | 'info'
+        ["-$LogLevelOption.DEBUG_SHORT_OPTION"]             | 'debug'
+        ["-$LogLevelOption.WARN_SHORT_OPTION"]              | 'warn'
+        ["-$LogLevelOption.QUIET_SHORT_OPTION"]             | 'quiet'
+    }
+
+    def "only renders hint for failing build if build scan plugin was applied in plugins DSL and not requested for generation"() {
+        given:
+        buildFile << appliedBuildScanPluginInPluginsDsl()
+        buildFile << buildScanLicenseConfiguration()
+        buildFile << failingBuildFile()
+
+        when:
+        fails(tasks as String[])
+
+        then:
+        output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING) == buildScanPublished
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT) == renderedHint
+
+        where:
+        tasks                     | renderedHint | buildScanPublished
+        DUMMY_TASK_ONLY           | true         | false
+        DUMMY_TASK_AND_BUILD_SCAN | false        | true
+    }
+
+    def "only renders hint for failing build if build scan plugin was applied in buildscript and not requested for generation"() {
+        given:
+        buildFile << appliedBuildScanPluginInBuildScript()
+        buildFile << buildScanLicenseConfiguration()
+        buildFile << failingBuildFile()
+
+        when:
+        fails(tasks as String[])
+
+        then:
+        output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING) == buildScanPublished
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT) == renderedHint
+
+        where:
+        tasks                     | renderedHint | buildScanPublished
+        DUMMY_TASK_ONLY           | true         | false
+        DUMMY_TASK_AND_BUILD_SCAN | false        | true
+    }
+
+    def "only renders hint for failing build if build scan plugin was applied in initscript and not requested for generation"() {
+        given:
+        def initScriptFileName = 'init.gradle'
+        file(initScriptFileName) << appliedBuildScanPluginInInitScript()
+        buildFile << buildScanLicenseConfiguration()
+        buildFile << failingBuildFile()
+
+
+        when:
+        fails(['-I', initScriptFileName] + tasks as String[])
+
+        then:
+        output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING) == buildScanPublished
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT) == renderedHint
+
+        where:
+        tasks                     | renderedHint | buildScanPublished
+        DUMMY_TASK_ONLY           | true         | false
+        DUMMY_TASK_AND_BUILD_SCAN | false        | true
+    }
+
+    def "only renders hint for failing build if build scan plugin was applied in script plugin and not requested for generation"() {
+        given:
+        def scriptPluginFileName = 'scan.gradle'
+        file(scriptPluginFileName) << appliedBuildScanPluginInScriptPlugin()
+        buildFile << """
+            apply from: '$scriptPluginFileName'
+        """
+        buildFile << buildScanLicenseConfiguration()
+        buildFile << failingBuildFile()
+
+        when:
+        fails(tasks as String[])
+
+        then:
+        output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING) == buildScanPublished
+        errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT) == renderedHint
+
+        where:
+        tasks                     | renderedHint | buildScanPublished
+        DUMMY_TASK_ONLY           | true         | false
+        DUMMY_TASK_AND_BUILD_SCAN | false        | true
+    }
+
+    @ToBeImplemented("at the moment Gradle does not have the information that publishAlways() was set")
+    def "does not render hint for failing build if build scan plugin was applied in plugins DSL is configured to always publish"() {
+        given:
+        buildFile << appliedBuildScanPluginInPluginsDsl()
+        buildFile << buildScanLicenseConfiguration()
+        buildFile << buildScanPublishAlwaysConfiguration()
+        buildFile << failingBuildFile()
+
+        when:
+        fails(DUMMY_TASK_NAME)
+
+        then:
+        output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING)
+        //!errorOutput.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
+    }
+
+    static String failingBuildFile() {
+        """
+            task $DUMMY_TASK_NAME {
+                doLast {
+                    throw new GradleException('something went wrong')
+                }
+            }
+        """
+    }
+
+    static String appliedBuildScanPluginInPluginsDsl() {
+        """
+            plugins {
+                id 'com.gradle.build-scan' version '$AutoAppliedBuildScanPlugin.VERSION'
+            }
+        """
+    }
+
+    static String appliedBuildScanPluginInBuildScript() {
+        """
+            buildscript {
+                ${buildScanRepositoryAndDependency()}
+            }
+
+            apply plugin: "com.gradle.build-scan"
+        """
+    }
+
+    static String appliedBuildScanPluginInInitScript() {
+        """
+            initscript {
+                ${buildScanRepositoryAndDependency()}
+            }
+
+            rootProject {
+                apply plugin: com.gradle.scan.plugin.BuildScanPlugin
+            }
+        """
+    }
+
+    static String appliedBuildScanPluginInScriptPlugin() {
+        """
+            buildscript {
+                ${buildScanRepositoryAndDependency()}
+            }
+
+            apply plugin: com.gradle.scan.plugin.BuildScanPlugin
+        """
+    }
+
+    private static String buildScanRepositoryAndDependency() {
+        """
+            repositories {
+                maven { url "https://plugins.gradle.org/m2/" }
+            }
+
+            dependencies {
+                classpath "com.gradle:build-scan-plugin:$AutoAppliedBuildScanPlugin.VERSION"
+            }
+        """
+    }
+
+    static String buildScanLicenseConfiguration() {
+        """
+            buildScan {
+                licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+                licenseAgree = 'yes'
+            }
+        """
+    }
+
+    static String buildScanPublishAlwaysConfiguration() {
+        """
+            buildScan {
+                publishAlways()
+            }
+        """
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -18,7 +18,6 @@ package org.gradle.internal.buildevents;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.Action;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
@@ -33,7 +32,6 @@ import org.gradle.internal.logging.text.BufferingStyledTextOutput;
 import org.gradle.internal.logging.text.LinePrefixingStyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
-import org.gradle.internal.scan.config.BuildScanPluginApplied;
 import org.gradle.util.GUtil;
 import org.gradle.util.TreeVisitor;
 
@@ -215,9 +213,7 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
      * Does not take into consideration {@code buildScan.publishAlways()}. Right now Gradle does not have the information.
      */
     private boolean isBuildScanEnabled() {
-        boolean buildScanPluginApplied = ((GradleInternal) gradle).getServices().get(BuildScanPluginApplied.class).isBuildScanPluginApplied();
-        boolean buildScanStartParameterProvided = !gradle.getStartParameter().isNoBuildScan() && gradle.getStartParameter().isBuildScan();
-        return buildScanPluginApplied && buildScanStartParameterProvided;
+        return !gradle.getStartParameter().isNoBuildScan() && gradle.getStartParameter().isBuildScan();
     }
 
     private void addBuildScanMessage(BufferingStyledTextOutput resolution) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -18,6 +18,7 @@ package org.gradle.internal.buildevents;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.Action;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
@@ -32,6 +33,7 @@ import org.gradle.internal.logging.text.BufferingStyledTextOutput;
 import org.gradle.internal.logging.text.LinePrefixingStyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.internal.scan.config.BuildScanPluginApplied;
 import org.gradle.util.GUtil;
 import org.gradle.util.TreeVisitor;
 
@@ -213,7 +215,9 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
      * Does not take into consideration {@code buildScan.publishAlways()}. Right now Gradle does not have the information.
      */
     private boolean isBuildScanEnabled() {
-        return gradle != null && !gradle.getStartParameter().isNoBuildScan() && gradle.getStartParameter().isBuildScan();
+        boolean buildScanPluginApplied = ((GradleInternal) gradle).getServices().get(BuildScanPluginApplied.class).isBuildScanPluginApplied();
+        boolean buildScanStartParameterProvided = !gradle.getStartParameter().isNoBuildScan() && gradle.getStartParameter().isBuildScan();
+        return buildScanPluginApplied && buildScanStartParameterProvided;
     }
 
     private void addBuildScanMessage(BufferingStyledTextOutput resolution) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -213,7 +213,7 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
      * Does not take into consideration {@code buildScan.publishAlways()}. Right now Gradle does not have the information.
      */
     private boolean isBuildScanEnabled() {
-        return !gradle.getStartParameter().isNoBuildScan() && gradle.getStartParameter().isBuildScan();
+        return gradle != null && !gradle.getStartParameter().isNoBuildScan() && gradle.getStartParameter().isBuildScan();
     }
 
     private void addBuildScanMessage(BufferingStyledTextOutput resolution) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -18,11 +18,13 @@ package org.gradle.internal.buildevents;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.Action;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.initialization.BuildClientMetaData;
+import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.internal.exceptions.FailureResolutionAware;
 import org.gradle.internal.exceptions.LocationAwareException;
 import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
@@ -48,6 +50,7 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
     private final StyledTextOutputFactory textOutputFactory;
     private final LoggingConfiguration loggingConfiguration;
     private final BuildClientMetaData clientMetaData;
+    private Gradle gradle;
 
     public BuildExceptionReporter(StyledTextOutputFactory textOutputFactory, LoggingConfiguration loggingConfiguration, BuildClientMetaData clientMetaData) {
         this.textOutputFactory = textOutputFactory;
@@ -56,6 +59,7 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
     }
 
     public void buildFinished(BuildResult result) {
+        this.gradle = result.getGradle();
         Throwable failure = result.getFailure();
         if (failure == null) {
             return;
@@ -200,6 +204,22 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
             resolution.withStyle(UserInput).format("--%s", LoggingConfigurationBuildOptions.LogLevelOption.DEBUG_LONG_OPTION);
             resolution.text(" option to get more log output.");
         }
+        if (!isBuildScanEnabled()) {
+            addBuildScanMessage(resolution);
+        }
+    }
+
+    /**
+     * Does not take into consideration {@code buildScan.publishAlways()}. Right now Gradle does not have the information.
+     */
+    private boolean isBuildScanEnabled() {
+        return gradle != null && !gradle.getStartParameter().isNoBuildScan() && gradle.getStartParameter().isBuildScan();
+    }
+
+    private void addBuildScanMessage(BufferingStyledTextOutput resolution) {
+        resolution.text(" Run with ");
+        resolution.withStyle(UserInput).format("--%s", StartParameterBuildOptions.BuildScanOption.LONG_OPTION);
+        resolution.text(" to get full insights.");
     }
 
     private void writeGeneralTips(StyledTextOutput resolution) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -18,7 +18,6 @@ package org.gradle.internal.buildevents;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.Action;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
@@ -50,7 +49,6 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
     private final StyledTextOutputFactory textOutputFactory;
     private final LoggingConfiguration loggingConfiguration;
     private final BuildClientMetaData clientMetaData;
-    private Gradle gradle;
 
     public BuildExceptionReporter(StyledTextOutputFactory textOutputFactory, LoggingConfiguration loggingConfiguration, BuildClientMetaData clientMetaData) {
         this.textOutputFactory = textOutputFactory;
@@ -59,7 +57,6 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
     }
 
     public void buildFinished(BuildResult result) {
-        this.gradle = result.getGradle();
         Throwable failure = result.getFailure();
         if (failure == null) {
             return;
@@ -204,16 +201,8 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
             resolution.withStyle(UserInput).format("--%s", LoggingConfigurationBuildOptions.LogLevelOption.DEBUG_LONG_OPTION);
             resolution.text(" option to get more log output.");
         }
-        if (!isBuildScanEnabled()) {
-            addBuildScanMessage(resolution);
-        }
-    }
 
-    /**
-     * Does not take into consideration {@code buildScan.publishAlways()}. Right now Gradle does not have the information.
-     */
-    private boolean isBuildScanEnabled() {
-        return gradle != null && !gradle.getStartParameter().isNoBuildScan() && gradle.getStartParameter().isBuildScan();
+        addBuildScanMessage(resolution);
     }
 
     private void addBuildScanMessage(BufferingStyledTextOutput resolution) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -69,7 +69,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 '''
     }
 
-    def "doesn't suggest to use --scan if option was on command line"() {
+    def "suggests to use --scan even if option was on command line"() {
         GradleException exception = new GradleException("<message>");
 
         def result = result(exception)
@@ -89,7 +89,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <message>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Get more help at https://help.gradle.org
 '''

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -63,7 +63,7 @@ class BuildExceptionReporterTest extends Specification {
 <message>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Get more help at https://help.gradle.org
 '''
@@ -115,7 +115,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <message>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Get more help at https://help.gradle.org
 '''
@@ -133,7 +133,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 org.gradle.api.GradleException (no error message)
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Get more help at https://help.gradle.org
 '''
@@ -155,7 +155,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 {info}> {normal}<cause>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Get more help at https://help.gradle.org
 '''
@@ -177,7 +177,7 @@ java.lang.RuntimeException (no error message)
 {info}> {normal}java.io.IOException (no error message)
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Get more help at https://help.gradle.org
 '''
@@ -200,7 +200,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 {info}> {normal}<cause2>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Get more help at https://help.gradle.org
 '''
@@ -228,7 +228,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
    {info}> {normal}<cause2.1>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Get more help at https://help.gradle.org
 '''
@@ -250,7 +250,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 {info}> {normal}java.lang.RuntimeException (no error message)
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Get more help at https://help.gradle.org
 '''
@@ -274,7 +274,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 {info}> {normal}<failure>
 
 * Try:
-Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Exception is:
 org.gradle.api.GradleException: <message>
@@ -304,7 +304,7 @@ org.gradle.api.GradleException: <message>
 {info}> {normal}<cause>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 ==============================================================================
 
 {failure}2: {normal}{failure}Task failed with an exception.{normal}
@@ -313,7 +313,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <failure>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 ==============================================================================
 
 {failure}3: {normal}{failure}Task failed with an exception.{normal}
@@ -322,7 +322,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <error>
 
 * Try:
-Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 ==============================================================================
 
 * Get more help at https://help.gradle.org
@@ -343,7 +343,7 @@ Run with {userinput}--stacktrace{normal} option to get the stack trace. Run with
 <message>
 
 * Try:
-Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Exception is:
 org.gradle.api.GradleException: <message>
@@ -366,7 +366,7 @@ org.gradle.api.GradleException: <message>
 <message>
 
 * Try:
-Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output.
+Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output. Run with {userinput}--scan{normal} to get full insights.
 
 * Exception is:
 org.gradle.api.GradleException: <message>

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -315,7 +315,7 @@ BUILD SUCCESSFUL"""
         then:
         failure.assertHasDescription("Problem configuring task :help from command line.")
         failure.assertHasCause("Unknown command-line option '--tasssk'.")
-        failure.assertHasResolution("Run gradle help --task :help to get task usage details. Run with --info or --debug option to get more log output.")
+        failure.assertHasResolution("Run gradle help --task :help to get task usage details. Run with --info or --debug option to get more log output. Run with --scan to get full insights.")
     }
 
     def "listsEnumAndBooleanCmdOptionValues"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
@@ -137,18 +137,18 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasDescription("Task 'someTest' not found in root project 'test'. Some candidates are: 'someTask', 'someTaskA', 'someTaskB'.")
-        failure.assertHasResolution("Run gradle tasks to get a list of available tasks. Run with --info or --debug option to get more log output.")
+        failure.assertHasResolution("Run gradle tasks to get a list of available tasks. Run with --info or --debug option to get more log output. Run with --scan to get full insights.")
 
         when:
         fails ":someTest"
         then:
         failure.assertHasDescription("Task 'someTest' not found in root project 'test'. Some candidates are: 'someTask'.")
-        failure.assertHasResolution("Run gradle tasks to get a list of available tasks. Run with --info or --debug option to get more log output.")
+        failure.assertHasResolution("Run gradle tasks to get a list of available tasks. Run with --info or --debug option to get more log output. Run with --scan to get full insights.")
 
         when:
         fails "a:someTest"
         then:
         failure.assertHasDescription("Task 'someTest' not found in project ':a'. Some candidates are: 'someTask', 'someTaskA'.")
-        failure.assertHasResolution("Run gradle tasks to get a list of available tasks. Run with --info or --debug option to get more log output.")
+        failure.assertHasResolution("Run gradle tasks to get a list of available tasks. Run with --info or --debug option to get more log output. Run with --scan to get full insights.")
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildScanUserInputFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildScanUserInputFixture.groovy
@@ -28,6 +28,7 @@ final class BuildScanUserInputFixture {
     public static final String NO = 'no'
     public static final int EOF = 4
     public static final String PROMPT = "$QUESTION [$YES, $NO]"
+    public static final String BUILD_SCAN_ERROR_MESSAGE_HINT = 'Run with --scan to get full insights.'
     private static final String ANSWER_PREFIX = 'License accepted:'
 
     private BuildScanUserInputFixture() {}

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
@@ -146,7 +146,7 @@ class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3516")
-    def "does not render build scan hint in build failure output if command line option was requested"() {
+    def "renders build scan hint in build failure output if command line option was requested"() {
         given:
         withInteractiveConsole()
         buildFile << failingBuildFile()
@@ -163,7 +163,7 @@ class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
         result.output.contains(BUILD_SCAN_SUCCESSFUL_PUBLISHING)
         !result.output.contains(BUILD_SCAN_PLUGIN_CONFIG_PROBLEM)
         !result.output.contains(BUILD_SCAN_LICENSE_NOTE)
-        !result.error.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
+        result.error.contains(BUILD_SCAN_ERROR_MESSAGE_HINT)
     }
 
     private void withInteractiveConsole() {


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle/issues/3516

This PR renders the message even if `--scan` or `buildScan.alwaysPublish()` were configured.