### PR TITLE
Update external plugin versions in smoke test suite to latest

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -29,9 +29,9 @@ import spock.lang.Unroll
  */
 class AndroidPluginsSmokeTest extends AbstractSmokeTest {
     public static final ANDROID_BUILD_TOOLS_VERSION = '26.0.2'
-    public static final String STABLE_ANDROID_VERSION = '2.3.3'
-    public static final String EXPERIMENTAL_ANDROID_VERSION = '3.0.0-beta7'
-    public static final TESTED_ANDROID_PLUGIN_VERSIONS = [STABLE_ANDROID_VERSION, EXPERIMENTAL_ANDROID_VERSION]
+    public static final String STABLE_ANDROID_2x_VERSION = '2.3.3'
+    public static final String STABLE_ANDROID_3x_VERSION = '3.0.0'
+    public static final TESTED_ANDROID_PLUGIN_VERSIONS = [STABLE_ANDROID_2x_VERSION, STABLE_ANDROID_3x_VERSION]
 
     def setup() {
         assertAndroidHomeSet()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -29,9 +29,9 @@ import spock.lang.Unroll
  */
 class AndroidPluginsSmokeTest extends AbstractSmokeTest {
     public static final ANDROID_BUILD_TOOLS_VERSION = '26.0.2'
-    public static final String STABLE_ANDROID_2x_VERSION = '2.3.3'
-    public static final String STABLE_ANDROID_3x_VERSION = '3.0.0'
-    public static final TESTED_ANDROID_PLUGIN_VERSIONS = [STABLE_ANDROID_2x_VERSION, STABLE_ANDROID_3x_VERSION]
+    public static final String STABLE_ANDROID_2X_VERSION = '2.3.3'
+    public static final String STABLE_ANDROID_3X_VERSION = '3.0.0'
+    public static final TESTED_ANDROID_PLUGIN_VERSIONS = [STABLE_ANDROID_2X_VERSION, STABLE_ANDROID_3X_VERSION]
 
     def setup() {
         assertAndroidHomeSet()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -16,13 +16,14 @@
 
 package org.gradle.smoketests
 
+import static AndroidPluginsSmokeTest.STABLE_ANDROID_2X_VERSION
+import static AndroidPluginsSmokeTest.STABLE_ANDROID_3X_VERSION
 import static org.gradle.smoketests.AndroidPluginsSmokeTest.assertAndroidHomeSet
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class KotlinPluginSmokeTest extends AbstractSmokeTest {
     // https://blog.jetbrains.com/kotlin/
     private kotlinVersion = '1.1.60'
-    private androidPluginVersion = AndroidPluginsSmokeTest.STABLE_ANDROID_2X_VERSION
     private androidBuildToolsVersion = AndroidPluginsSmokeTest.ANDROID_BUILD_TOOLS_VERSION
 
     def 'kotlin plugin'() {
@@ -51,5 +52,8 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
 
         then:
         build.task(':testDebugUnitTestCoverage').outcome == SUCCESS
+
+        where:
+        androidPluginVersion << [STABLE_ANDROID_2X_VERSION, STABLE_ANDROID_3X_VERSION]
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -22,7 +22,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class KotlinPluginSmokeTest extends AbstractSmokeTest {
     // https://blog.jetbrains.com/kotlin/
     private kotlinVersion = '1.1.60'
-    private androidPluginVersion = AndroidPluginsSmokeTest.STABLE_ANDROID_2x_VERSION
+    private androidPluginVersion = AndroidPluginsSmokeTest.STABLE_ANDROID_2X_VERSION
     private androidBuildToolsVersion = AndroidPluginsSmokeTest.ANDROID_BUILD_TOOLS_VERSION
 
     def 'kotlin plugin'() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -21,8 +21,8 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class KotlinPluginSmokeTest extends AbstractSmokeTest {
     // https://blog.jetbrains.com/kotlin/
-    private kotlinVersion = '1.1.50'
-    private androidPluginVersion = AndroidPluginsSmokeTest.STABLE_ANDROID_VERSION
+    private kotlinVersion = '1.1.60'
+    private androidPluginVersion = AndroidPluginsSmokeTest.STABLE_ANDROID_2x_VERSION
     private androidBuildToolsVersion = AndroidPluginsSmokeTest.ANDROID_BUILD_TOOLS_VERSION
 
     def 'kotlin plugin'() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -50,7 +50,7 @@ class NebulaPluginsSmokeTest extends AbstractSmokeTest {
         when:
         buildFile << """
             plugins {
-                id 'nebula.plugin-plugin' version '5.17.2'
+                id 'nebula.plugin-plugin' version '5.18.0'
             }
         """
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -154,7 +154,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
             buildscript {
                 ${mavenCentralRepository()}
                 dependencies {
-                    classpath('org.springframework.boot:spring-boot-gradle-plugin:1.5.7.RELEASE')
+                    classpath('org.springframework.boot:spring-boot-gradle-plugin:1.5.8.RELEASE')
                 }
             }
 
@@ -224,7 +224,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
         def stopPort = portAllocator.assignPort()
         buildFile << """
             plugins {
-                id "com.bmuschko.tomcat" version "2.3"
+                id "com.bmuschko.tomcat" version "2.4.1"
             }
 
             ${mavenCentralRepository()}
@@ -278,8 +278,6 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
             plugins {
                 id 'org.gosu-lang.gosu' version '0.3.5'
             }
-
-            apply plugin: 'org.gosu-lang.gosu'
 
             ${mavenCentralRepository()}
 
@@ -342,7 +340,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
         GitRepository.init(testProjectDir.root)
         buildFile << """
             plugins {
-                id "org.ajoberstar.grgit" version "2.0.1"
+                id "org.ajoberstar.grgit" version "2.1.0"
             }
 
             def sourceFile = file("sourceFile")

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example/build.gradle
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:$androidPluginVersion'


### PR DESCRIPTION
### Context

Update to the latest plugin version in smoke test suite to ensure compatibility. The change also uses Android 3.0.0 instead of a beta version.