### PR TITLE
Display time saved by cache at end of build

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -20,6 +20,8 @@ import org.gradle.api.GradleException;
 import org.gradle.api.internal.TaskOutputCachingState;
 import org.gradle.api.tasks.TaskState;
 
+import static org.gradle.api.internal.tasks.TaskExecutionOutcome.*;
+
 public class TaskStateInternal implements TaskState {
     private boolean executing;
     private boolean actionable = true;
@@ -27,6 +29,7 @@ public class TaskStateInternal implements TaskState {
     private Throwable failure;
     private TaskOutputCachingState taskOutputCaching = DefaultTaskOutputCachingState.disabled(TaskOutputCachingDisabledReasonCategory.UNKNOWN, "Cacheability was not determined");
     private TaskExecutionOutcome outcome;
+    private Long timeSaved;
 
     public boolean getDidWork() {
         return didWork;
@@ -48,17 +51,33 @@ public class TaskStateInternal implements TaskState {
         return outcome;
     }
 
-    public void setOutcome(TaskExecutionOutcome outcome) {
-        assert this.outcome == null;
-        this.outcome = outcome;
+    public void recordExecuted() {
+        this.outcome = EXECUTED;
+    }
+
+    public void recordUpToDate() {
+        this.outcome = UP_TO_DATE;
+    }
+
+    public void recordNoSource() {
+        this.outcome = NO_SOURCE;
+    }
+
+    public void recordSkipped() {
+        this.outcome = SKIPPED;
+    }
+
+    public void recordFromCache(long timeSaved) {
+        this.outcome = FROM_CACHE;
+        this.timeSaved = timeSaved;
     }
 
     /**
      * Marks this task as executed with the given failure. This method can be called at most once.
      */
-    public void setOutcome(Throwable failure) {
+    public void recordFailure(Throwable failure) {
         assert this.failure == null;
-        this.outcome = TaskExecutionOutcome.EXECUTED;
+        this.outcome = EXECUTED;
         this.failure = failure;
     }
 
@@ -114,6 +133,13 @@ public class TaskStateInternal implements TaskState {
 
     public boolean isFromCache() {
         return outcome == TaskExecutionOutcome.FROM_CACHE;
+    }
+
+    public long getTimeSaved() {
+        if (!isFromCache()) {
+            throw new IllegalStateException("Not loaded from cache");
+        }
+        return timeSaved;
     }
 
     public boolean isActionable() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -29,7 +29,7 @@ public class TaskStateInternal implements TaskState {
     private Throwable failure;
     private TaskOutputCachingState taskOutputCaching = DefaultTaskOutputCachingState.disabled(TaskOutputCachingDisabledReasonCategory.UNKNOWN, "Cacheability was not determined");
     private TaskExecutionOutcome outcome;
-    private Long timeSaved;
+    private long cacheTimeImpact;
 
     public boolean getDidWork() {
         return didWork;
@@ -67,9 +67,17 @@ public class TaskStateInternal implements TaskState {
         this.outcome = SKIPPED;
     }
 
-    public void recordFromCache(long timeSaved) {
+    public void recordLoadedFromCache(long timeSaved) {
         this.outcome = FROM_CACHE;
-        this.timeSaved = timeSaved;
+        this.cacheTimeImpact += timeSaved;
+    }
+
+    public void recordStoredInCache(long storeTime) {
+        this.cacheTimeImpact -= storeTime;
+    }
+
+    public void recordCacheMiss(long lookupTime) {
+        this.cacheTimeImpact -= lookupTime;
     }
 
     /**
@@ -135,11 +143,8 @@ public class TaskStateInternal implements TaskState {
         return outcome == TaskExecutionOutcome.FROM_CACHE;
     }
 
-    public long getTimeSaved() {
-        if (!isFromCache()) {
-            throw new IllegalStateException("Not loaded from cache");
-        }
-        return timeSaved;
+    public long getCacheTimeImpact() {
+        return cacheTimeImpact;
     }
 
     public boolean isActionable() {
@@ -149,5 +154,4 @@ public class TaskStateInternal implements TaskState {
     public void setActionable(boolean actionable) {
         this.actionable = actionable;
     }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
@@ -51,7 +51,7 @@ public interface TaskValidationContext {
                     causes.add(new InvalidUserDataException(message));
                 }
                 String errorMessage = getMainMessage(task, messages);
-                state.setOutcome(new TaskValidationException(errorMessage, causes));
+                state.recordFailure(new TaskValidationException(errorMessage, causes));
                 return false;
             }
         };

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CatchExceptionTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CatchExceptionTaskExecuter.java
@@ -33,7 +33,7 @@ public class CatchExceptionTaskExecuter implements TaskExecuter {
         try {
             delegate.execute(task, state, context);
         } catch (RuntimeException e) {
-            state.setOutcome(e);
+            state.recordFailure(e);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -22,7 +22,6 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.ContextAwareTaskAction;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
-import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -69,11 +68,13 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         try {
             GradleException failure = executeActions(task, state, context);
             if (failure != null) {
-                state.setOutcome(failure);
+                state.recordFailure(failure);
             } else {
-                state.setOutcome(
-                    state.getDidWork() ? TaskExecutionOutcome.EXECUTED : TaskExecutionOutcome.UP_TO_DATE
-                );
+                if (state.getDidWork()) {
+                    state.recordExecuted();
+                } else {
+                    state.recordUpToDate();
+                }
             }
             context.getTaskArtifactState().snapshotAfterTaskExecution(failure);
         } finally {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
 import org.gradle.api.internal.tasks.ResolvedTaskOutputFilePropertySpec;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
-import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskPropertyUtils;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.caching.internal.controller.BuildCacheController;
@@ -85,7 +84,7 @@ public class SkipCachedTaskExecuter implements TaskExecuter {
                             buildCacheCommandFactory.createLoad(cacheKey, outputProperties, task, taskOutputsGenerationListener, taskState, clock)
                         );
                         if (originMetadata != null) {
-                            state.setOutcome(TaskExecutionOutcome.FROM_CACHE);
+                            state.recordFromCache(originMetadata.getExecutionTime() - clock.getElapsedMillis());
                             context.setOriginBuildInvocationId(originMetadata.getBuildInvocationId());
                             return;
                         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuter.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.changedetection.TaskArtifactState;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
-import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -58,7 +57,7 @@ public class SkipEmptySourceFilesTaskExecuter implements TaskExecuter {
             TaskExecutionHistory executionHistory = taskArtifactState.getExecutionHistory();
             Set<File> outputFiles = executionHistory.getOutputFiles();
             if (outputFiles.isEmpty()) {
-                state.setOutcome(TaskExecutionOutcome.NO_SOURCE);
+                state.recordNoSource();
                 LOGGER.info("Skipping {} as it has no source files and no previous output files.", task);
             } else {
                 boolean cleanupDirectories = executionHistory.getOverlappingOutputs() == null;
@@ -83,9 +82,9 @@ public class SkipEmptySourceFilesTaskExecuter implements TaskExecuter {
                 }
                 if (deletedFiles) {
                     LOGGER.info("Cleaned previous output of {} as it has no source files.", task);
-                    state.setOutcome(TaskExecutionOutcome.EXECUTED);
+                    state.recordExecuted();
                 } else {
-                    state.setOutcome(TaskExecutionOutcome.NO_SOURCE);
+                    state.recordNoSource();
                 }
                 taskArtifactState.snapshotAfterTaskExecution(null);
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipOnlyIfTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipOnlyIfTaskExecuter.java
@@ -20,7 +20,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
-import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -41,13 +40,13 @@ public class SkipOnlyIfTaskExecuter implements TaskExecuter {
         try {
             skip = !task.getOnlyIf().isSatisfiedBy(task);
         } catch (Throwable t) {
-            state.setOutcome(new GradleException(String.format("Could not evaluate onlyIf predicate for %s.", task), t));
+            state.recordFailure(new GradleException(String.format("Could not evaluate onlyIf predicate for %s.", task), t));
             return;
         }
 
         if (skip) {
             LOGGER.info("Skipping {} as task onlyIf is false.", task);
-            state.setOutcome(TaskExecutionOutcome.SKIPPED);
+            state.recordSkipped();
             return;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuter.java
@@ -19,7 +19,6 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
-import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -46,7 +45,11 @@ public class SkipTaskWithNoActionsExecuter implements TaskExecuter {
                 }
             }
             state.setActionable(false);
-            state.setOutcome(upToDate ? TaskExecutionOutcome.UP_TO_DATE : TaskExecutionOutcome.EXECUTED);
+            if (upToDate) {
+                state.recordUpToDate();
+            } else {
+                state.recordExecuted();
+            }
             return;
         }
         executer.execute(task, state, context);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuter.java
@@ -22,7 +22,6 @@ import org.gradle.api.internal.changedetection.TaskArtifactState;
 import org.gradle.api.internal.changedetection.rules.TaskUpToDateState;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
-import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
@@ -52,7 +51,7 @@ public class SkipUpToDateTaskExecuter implements TaskExecuter {
         List<String> messages = new ArrayList<String>(TaskUpToDateState.MAX_OUT_OF_DATE_MESSAGES);
         if (taskArtifactState.isUpToDate(messages)) {
             LOGGER.info("Skipping {} as it is up-to-date (took {}).", task, clock.getElapsed());
-            state.setOutcome(TaskExecutionOutcome.UP_TO_DATE);
+            state.recordUpToDate();
             context.setOriginBuildInvocationId(taskArtifactState.getOriginBuildInvocationId());
             return;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatistics.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatistics.java
@@ -21,14 +21,16 @@ public class TaskExecutionStatistics {
     private final int executedTasksCount;
     private final int fromCacheTaskCount;
     private final int upToDateTaskCount;
+    private final long timeSaved;
 
-    public TaskExecutionStatistics(int executedTasksCount, int fromCacheTaskCount, int upToDateTaskCount) {
+    public TaskExecutionStatistics(int executedTasksCount, int fromCacheTaskCount, int upToDateTaskCount, long timeSaved) {
         checkArgument(executedTasksCount >= 0, "executedTasksCount must be non-negative");
         checkArgument(fromCacheTaskCount >= 0, "fromCacheTaskCount must be non-negative");
         checkArgument(upToDateTaskCount >= 0, "upToDateTaskCount must be non-negative");
         this.executedTasksCount = executedTasksCount;
         this.fromCacheTaskCount = fromCacheTaskCount;
         this.upToDateTaskCount = upToDateTaskCount;
+        this.timeSaved = timeSaved;
     }
 
     public int getExecutedTasksCount() {
@@ -45,5 +47,9 @@ public class TaskExecutionStatistics {
 
     public int getTotalTaskCount() {
         return executedTasksCount + fromCacheTaskCount + upToDateTaskCount;
+    }
+
+    public long getTimeSaved() {
+        return timeSaved;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatistics.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatistics.java
@@ -21,16 +21,16 @@ public class TaskExecutionStatistics {
     private final int executedTasksCount;
     private final int fromCacheTaskCount;
     private final int upToDateTaskCount;
-    private final long timeSaved;
+    private final long cacheTimeImpact;
 
-    public TaskExecutionStatistics(int executedTasksCount, int fromCacheTaskCount, int upToDateTaskCount, long timeSaved) {
+    public TaskExecutionStatistics(int executedTasksCount, int fromCacheTaskCount, int upToDateTaskCount, long cacheTimeImpact) {
         checkArgument(executedTasksCount >= 0, "executedTasksCount must be non-negative");
         checkArgument(fromCacheTaskCount >= 0, "fromCacheTaskCount must be non-negative");
         checkArgument(upToDateTaskCount >= 0, "upToDateTaskCount must be non-negative");
         this.executedTasksCount = executedTasksCount;
         this.fromCacheTaskCount = fromCacheTaskCount;
         this.upToDateTaskCount = upToDateTaskCount;
-        this.timeSaved = timeSaved;
+        this.cacheTimeImpact = cacheTimeImpact;
     }
 
     public int getExecutedTasksCount() {
@@ -49,7 +49,7 @@ public class TaskExecutionStatistics {
         return executedTasksCount + fromCacheTaskCount + upToDateTaskCount;
     }
 
-    public long getTimeSaved() {
-        return timeSaved;
+    public long getCacheTimeImpact() {
+        return cacheTimeImpact;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatisticsEventAdapter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatisticsEventAdapter.java
@@ -28,7 +28,7 @@ public class TaskExecutionStatisticsEventAdapter extends BuildAdapter implements
     private int executedTasksCount;
     private int fromCacheTaskCount;
     private int upToDateTaskCount;
-    private long timeSaved;
+    private long cacheTimeImpact;
 
     public TaskExecutionStatisticsEventAdapter(TaskExecutionStatisticsListener listener) {
         this.listener = listener;
@@ -38,7 +38,7 @@ public class TaskExecutionStatisticsEventAdapter extends BuildAdapter implements
     public void buildFinished(BuildResult result) {
         // Do not report stats for nested builds
         if (result.getGradle().getParent() == null) {
-            listener.buildFinished(new TaskExecutionStatistics(executedTasksCount, fromCacheTaskCount, upToDateTaskCount, timeSaved));
+            listener.buildFinished(new TaskExecutionStatistics(executedTasksCount, fromCacheTaskCount, upToDateTaskCount, cacheTimeImpact));
         }
     }
 
@@ -51,6 +51,7 @@ public class TaskExecutionStatisticsEventAdapter extends BuildAdapter implements
     public void afterExecute(Task task, TaskState state) {
         if (!taskIsForNestedBuild(task)) {
             TaskStateInternal stateInternal = (TaskStateInternal) state;
+            cacheTimeImpact += stateInternal.getCacheTimeImpact();
             if (stateInternal.isActionable()) {
                 switch (stateInternal.getOutcome()) {
                     case EXECUTED:
@@ -58,7 +59,6 @@ public class TaskExecutionStatisticsEventAdapter extends BuildAdapter implements
                         break;
                     case FROM_CACHE:
                         fromCacheTaskCount++;
-                        timeSaved += stateInternal.getTimeSaved();
                         break;
                     case UP_TO_DATE:
                         upToDateTaskCount++;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatisticsEventAdapter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/statistics/TaskExecutionStatisticsEventAdapter.java
@@ -28,6 +28,7 @@ public class TaskExecutionStatisticsEventAdapter extends BuildAdapter implements
     private int executedTasksCount;
     private int fromCacheTaskCount;
     private int upToDateTaskCount;
+    private long timeSaved;
 
     public TaskExecutionStatisticsEventAdapter(TaskExecutionStatisticsListener listener) {
         this.listener = listener;
@@ -37,7 +38,7 @@ public class TaskExecutionStatisticsEventAdapter extends BuildAdapter implements
     public void buildFinished(BuildResult result) {
         // Do not report stats for nested builds
         if (result.getGradle().getParent() == null) {
-            listener.buildFinished(new TaskExecutionStatistics(executedTasksCount, fromCacheTaskCount, upToDateTaskCount));
+            listener.buildFinished(new TaskExecutionStatistics(executedTasksCount, fromCacheTaskCount, upToDateTaskCount, timeSaved));
         }
     }
 
@@ -57,6 +58,7 @@ public class TaskExecutionStatisticsEventAdapter extends BuildAdapter implements
                         break;
                     case FROM_CACHE:
                         fromCacheTaskCount++;
+                        timeSaved += stateInternal.getTimeSaved();
                         break;
                     case UP_TO_DATE:
                         upToDateTaskCount++;

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/origin/TaskOutputOriginMetadata.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/origin/TaskOutputOriginMetadata.java
@@ -21,13 +21,18 @@ import org.gradle.internal.id.UniqueId;
 public class TaskOutputOriginMetadata {
 
     private final UniqueId buildInvocationId;
+    private final long executionTime;
 
-    public TaskOutputOriginMetadata(UniqueId buildInvocationId) {
+    public TaskOutputOriginMetadata(UniqueId buildInvocationId, long executionTime) {
         this.buildInvocationId = buildInvocationId;
+        this.executionTime = executionTime;
     }
 
     public UniqueId getBuildInvocationId() {
         return buildInvocationId;
     }
 
+    public long getExecutionTime() {
+        return executionTime;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionStatisticsReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionStatisticsReporter.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.execution.statistics.TaskExecutionStatistic
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.internal.time.TimeFormatting;
 
 public class TaskExecutionStatisticsReporter implements TaskExecutionStatisticsListener {
     private final StyledTextOutputFactory textOutputFactory;
@@ -38,7 +39,25 @@ public class TaskExecutionStatisticsReporter implements TaskExecutionStatisticsL
             printedDetail = formatDetail(textOutput, statistics.getFromCacheTaskCount(), "from cache", printedDetail);
             formatDetail(textOutput, statistics.getUpToDateTaskCount(), "up-to-date", printedDetail);
             textOutput.println();
+
+            if (statistics.getFromCacheTaskCount() > 0) {
+                long timeSaved = statistics.getTimeSaved();
+                if (timeSaved > 500) {
+                    textOutput.format("Using the build cache saved %s in this build", formatTime(timeSaved));
+                    textOutput.println();
+                } else if (timeSaved < -500) {
+                    textOutput.format("Without the build cache this build would have been %s faster", formatTime(-timeSaved));
+                    textOutput.println();
+                }
+            }
         }
+    }
+
+    private static String formatTime(long time) {
+        if (time < 1000) {
+            return ((double) time / 1000) + "s";
+        }
+        return TimeFormatting.formatDurationTerse(time);
     }
 
     private static boolean formatDetail(StyledTextOutput textOutput, int count, String title, boolean alreadyPrintedDetail) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskStateInternalTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskStateInternalTest.groovy
@@ -16,124 +16,128 @@
 package org.gradle.api.internal.tasks
 
 import org.gradle.api.GradleException
-import org.junit.Test
+import spock.lang.Specification
 
-import static org.hamcrest.Matchers.*
-import static org.junit.Assert.*
+class TaskStateInternalTest extends Specification {
+    def state = new TaskStateInternal()
 
-class TaskStateInternalTest {
-    private final TaskStateInternal state = new TaskStateInternal()
-
-    @Test
-    public void defaultValues() {
-        assertFalse(state.getExecuted())
-        assertFalse(state.getExecuting())
-        assertTrue(state.configurable)
-        assertThat(state.getFailure(), nullValue())
-        assertFalse(state.getDidWork())
-        assertFalse(state.getSkipped())
-        assertThat(state.getSkipMessage(), nullValue())
-        assertFalse(state.upToDate)
-        assertFalse(state.taskOutputCaching.enabled)
-        assertTrue(state.actionable)
+    void defaultValues() {
+        expect:
+        !state.executed
+        !state.executing
+        state.configurable
+        state.failure == null
+        !state.didWork
+        !state.skipped
+        state.skipMessage == null
+        !state.upToDate
+        !state.taskOutputCaching.enabled
+        state.actionable
     }
 
-    @Test
-    public void canMarkTaskAsExecuted() {
-        state.setOutcome(TaskExecutionOutcome.EXECUTED)
-        assertTrue(state.executed)
-        assertFalse(state.skipped)
-        assertFalse(state.upToDate)
-        assertFalse(state.configurable)
-        assertThat(state.getFailure(), nullValue())
+    void canMarkTaskAsExecuted() {
+        state.recordExecuted()
+
+        expect:
+        state.executed
+        !state.skipped
+        !state.upToDate
+        !state.configurable
+        state.failure == null
     }
 
-    @Test
-    public void canMarkTaskAsExecutedWithFailure() {
+    void canMarkTaskAsExecutedWithFailure() {
         RuntimeException failure = new RuntimeException()
-        state.setOutcome(failure)
-        assertTrue(state.executed)
-        assertFalse(state.skipped)
-        assertFalse(state.upToDate)
-        assertFalse(state.configurable)
-        assertThat(state.failure, sameInstance(failure))
+        state.recordFailure(failure)
+
+        expect:
+        state.executed
+        !state.skipped
+        !state.upToDate
+        !state.configurable
+        state.failure == failure
     }
 
-    @Test
-    public void canMarkTaskAsSkipped() {
-        state.setOutcome(TaskExecutionOutcome.SKIPPED)
-        assertTrue(state.executed)
-        assertTrue(state.skipped)
-        assertFalse(state.upToDate)
-        assertFalse(state.configurable)
-        assertThat(state.skipMessage, equalTo("SKIPPED"))
+    void canMarkTaskAsSkipped() {
+        state.recordSkipped()
+
+        expect:
+        state.executed
+        state.skipped
+        !state.upToDate
+        !state.configurable
+        state.skipMessage == "SKIPPED"
     }
 
-    @Test
-    public void canMarkTaskAsUpToDate() {
-        state.setOutcome(TaskExecutionOutcome.UP_TO_DATE)
-        assertTrue(state.executed)
-        assertTrue(state.skipped)
-        assertTrue(state.upToDate)
-        assertFalse(state.configurable)
-        assertThat(state.skipMessage, equalTo('UP-TO-DATE'))
+    void canMarkTaskAsUpToDate() {
+        state.recordUpToDate()
+
+        expect:
+        state.executed
+        state.skipped
+        state.upToDate
+        !state.configurable
+        state.skipMessage == 'UP-TO-DATE'
     }
 
-    @Test
-    public void canMarkTaskAsFromCache() {
-        state.setOutcome(TaskExecutionOutcome.FROM_CACHE)
-        assertTrue(state.executed)
-        assertTrue(state.skipped)
-        assertTrue(state.upToDate)
-        assertFalse(state.configurable)
-        assertThat(state.skipMessage, equalTo('FROM-CACHE'))
+    void canMarkTaskAsFromCache() {
+        state.recordFromCache(0L)
+
+        expect:
+        state.executed
+        state.skipped
+        state.upToDate
+        !state.configurable
+        state.skipMessage == 'FROM-CACHE'
     }
 
-    @Test
-    public void rethrowFailureDoesNothingWhenTaskHasNotExecuted() {
+    void rethrowFailureDoesNothingWhenTaskHasNotExecuted() {
+        when:
         state.rethrowFailure()
+        then:
+        noExceptionThrown()
     }
 
-    @Test
-    public void rethrowFailureDoesNothingWhenTaskDidNotFail() {
-        state.setOutcome(TaskExecutionOutcome.EXECUTED)
+    void rethrowFailureDoesNothingWhenTaskDidNotFail() {
+        state.recordExecuted()
+
+        when:
         state.rethrowFailure()
+        then:
+        noExceptionThrown()
     }
 
-    @Test
-    public void rethrowsFailureWhenFailureIsRuntimeException() {
+    void rethrowsFailureWhenFailureIsRuntimeException() {
         RuntimeException failure = new RuntimeException()
-        state.setOutcome(failure)
-        try {
-            state.rethrowFailure()
-            fail()
-        } catch (RuntimeException e) {
-            assertThat(e, sameInstance(failure))
-        }
+        state.recordFailure(failure)
+
+        when:
+        state.rethrowFailure()
+        then:
+        def e = thrown RuntimeException
+        e == failure
     }
 
-    @Test
-    public void rethrowsFailureWhenFailureIsError() {
+    void rethrowsFailureWhenFailureIsError() {
         Error failure = new Error()
-        state.setOutcome(failure)
-        try {
-            state.rethrowFailure()
-            fail()
-        } catch (Error e) {
-            assertThat(e, sameInstance(failure))
-        }
+        state.recordFailure(failure)
+
+        when:
+        state.rethrowFailure()
+        then:
+        def e = thrown Error
+        e == failure
     }
 
-    @Test
-    public void rethrowsFailureWhenFailureIsException() {
+    void rethrowsFailureWhenFailureIsException() {
         Exception failure = new Exception()
-        state.setOutcome(failure)
-        try {
-            state.rethrowFailure()
-            fail()
-        } catch (GradleException e) {
-            assertThat(e.message, equalTo('Task failed with an exception.'))
-            assertThat(e.cause, sameInstance(failure))
-        }
+        state.recordFailure(failure)
+
+        when:
+        state.rethrowFailure()
+        then:
+        def e = thrown GradleException
+        e.message == 'Task failed with an exception.'
+        e.cause == failure
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskStateInternalTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskStateInternalTest.groovy
@@ -81,7 +81,7 @@ class TaskStateInternalTest extends Specification {
     }
 
     void canMarkTaskAsFromCache() {
-        state.recordFromCache(0L)
+        state.recordLoadedFromCache(0L)
 
         expect:
         state.executed

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/CatchExceptionTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/CatchExceptionTaskExecuterTest.groovy
@@ -36,7 +36,7 @@ class CatchExceptionTaskExecuterTest extends Specification {
 
         then:
         1 * delegate.execute(task, state, context) >> {
-            state.setOutcome(TaskExecutionOutcome.EXECUTED)
+            state.recordExecuted()
         }
         0 * _
         state.outcome == TaskExecutionOutcome.EXECUTED

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
@@ -104,6 +104,7 @@ class SkipCachedTaskExecuterTest extends Specification {
 
         then:
         1 * buildCacheController.load(loadCommand) >> null
+        1 * taskState.recordCacheMiss(_)
 
         then:
         1 * delegate.execute(task, taskState, taskContext)
@@ -170,6 +171,7 @@ class SkipCachedTaskExecuterTest extends Specification {
         then:
         1 * buildCacheCommandFactory.createLoad(*_)
         1 * buildCacheController.load(_)
+        1 * taskState.recordCacheMiss(_)
 
         then:
         1 * delegate.execute(task, taskState, taskContext)
@@ -288,6 +290,7 @@ class SkipCachedTaskExecuterTest extends Specification {
         then:
         1 * buildCacheCommandFactory.createLoad(*_)
         1 * buildCacheController.load(_)
+        1 * taskState.recordCacheMiss(_)
 
         then:
         1 * delegate.execute(task, taskState, taskContext)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.changedetection.TaskArtifactState
 import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskExecutionContext
-import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.caching.internal.controller.BuildCacheController
 import org.gradle.caching.internal.controller.BuildCacheLoadCommand
@@ -78,10 +77,10 @@ class SkipCachedTaskExecuterTest extends Specification {
         1 * buildCacheCommandFactory.createLoad(cacheKey, _, task, taskOutputGenerationListener, _, _) >> loadCommand
 
         then:
-        1 * buildCacheController.load(loadCommand) >> new TaskOutputOriginMetadata(originId)
+        1 * buildCacheController.load(loadCommand) >> new TaskOutputOriginMetadata(originId, 123L)
 
         then:
-        1 * taskState.setOutcome(TaskExecutionOutcome.FROM_CACHE)
+        1 * taskState.recordFromCache(_)
         1 * taskContext.setOriginBuildInvocationId(originId)
         0 * _
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
@@ -80,7 +80,7 @@ class SkipCachedTaskExecuterTest extends Specification {
         1 * buildCacheController.load(loadCommand) >> new TaskOutputOriginMetadata(originId, 123L)
 
         then:
-        1 * taskState.recordFromCache(_)
+        1 * taskState.recordLoadedFromCache(_)
         1 * taskContext.setOriginBuildInvocationId(originId)
         0 * _
     }
@@ -117,6 +117,7 @@ class SkipCachedTaskExecuterTest extends Specification {
 
         then:
         1 * buildCacheController.store(storeCommand)
+        1 * taskState.recordStoredInCache(_)
         0 * _
     }
 
@@ -148,6 +149,7 @@ class SkipCachedTaskExecuterTest extends Specification {
 
         then:
         1 * buildCacheController.store(storeCommand)
+        1 * taskState.recordStoredInCache(_)
         0 * _
     }
 
@@ -240,6 +242,7 @@ class SkipCachedTaskExecuterTest extends Specification {
 
         then:
         1 * buildCacheController.store(storeCommand)
+        1 * taskState.recordStoredInCache(_)
         0 * _
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuterTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.internal.changedetection.TaskArtifactState
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskExecutionContext
-import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.internal.cleanup.BuildOutputCleanupRegistry
 import spock.lang.Specification
@@ -65,7 +64,7 @@ class SkipEmptySourceFilesTaskExecuterTest extends Specification {
         1 * taskExecutionHistory.outputFiles >> new HashSet<File>()
 
         then:
-        1 * state.setOutcome(TaskExecutionOutcome.NO_SOURCE)
+        1 * state.recordNoSource()
 
         then:
         1 * taskInputsListener.onExecute(task, sourceFiles)
@@ -102,7 +101,7 @@ class SkipEmptySourceFilesTaskExecuterTest extends Specification {
         1 * previousFile.delete() >> true
 
         then:
-        1 * state.setOutcome(TaskExecutionOutcome.EXECUTED)
+        1 * state.recordExecuted()
         1 * taskArtifactState.snapshotAfterTaskExecution(null)
 
         then:
@@ -138,7 +137,7 @@ class SkipEmptySourceFilesTaskExecuterTest extends Specification {
         1 * cleanupRegistry.isOutputOwnedByBuild(previousFile) >> false
 
         then:
-        1 * state.setOutcome(TaskExecutionOutcome.NO_SOURCE)
+        1 * state.recordNoSource()
         1 * taskArtifactState.snapshotAfterTaskExecution(null)
 
         then:
@@ -182,7 +181,7 @@ class SkipEmptySourceFilesTaskExecuterTest extends Specification {
         1 * previousFile.delete() >> true
 
         then:
-        1 * state.setOutcome(TaskExecutionOutcome.EXECUTED)
+        1 * state.recordExecuted()
         1 * taskArtifactState.snapshotAfterTaskExecution(null)
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipOnlyIfTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipOnlyIfTaskExecuterTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskExecutionContext
-import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.specs.Spec
 import org.gradle.groovy.scripts.ScriptSource
@@ -73,7 +72,7 @@ public class SkipOnlyIfTaskExecuterTest extends Specification {
 
         then:
         1 * spec.isSatisfiedBy(task) >> false
-        1 * state.setOutcome(TaskExecutionOutcome.SKIPPED)
+        1 * state.recordSkipped()
         noMoreInteractions()
     }
 
@@ -87,7 +86,7 @@ public class SkipOnlyIfTaskExecuterTest extends Specification {
 
         then:
         1 * spec.isSatisfiedBy(task) >> { throw failure }
-        1 * state.setOutcome(_ as Throwable) >> { args -> thrownException = args[0] }
+        1 * state.recordFailure(_ as Throwable) >> { args -> thrownException = args[0] }
         noMoreInteractions()
 
         thrownException.message.startsWith('Could not evaluate onlyIf predicate for')

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuterTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.execution
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskExecutionContext
-import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskDependency
@@ -50,7 +49,7 @@ class SkipTaskWithNoActionsExecuterTest extends Specification {
 
         then:
         1 * state.setActionable(false)
-        1 * state.setOutcome(TaskExecutionOutcome.UP_TO_DATE)
+        1 * state.recordUpToDate()
         0 * target._
         0 * state._
     }
@@ -65,7 +64,7 @@ class SkipTaskWithNoActionsExecuterTest extends Specification {
 
         then:
         1 * state.setActionable(false)
-        1 * state.setOutcome(TaskExecutionOutcome.EXECUTED)
+        1 * state.recordExecuted()
         0 * target._
         0 * state._
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuterTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.changedetection.TaskArtifactState
 import org.gradle.api.internal.tasks.TaskExecuter
 import org.gradle.api.internal.tasks.TaskExecutionContext
-import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.internal.id.UniqueId
 import spock.lang.Specification
@@ -50,7 +49,7 @@ class SkipUpToDateTaskExecuterTest extends Specification {
         1 * taskArtifactState.isUpToDate(_) >> true
         1 * taskArtifactState.getOriginBuildInvocationId() >> originBuildInvocationId
         1 * taskContext.taskArtifactState >> taskArtifactState
-        1 * taskState.setOutcome(TaskExecutionOutcome.UP_TO_DATE)
+        1 * taskState.recordUpToDate()
         1 * taskContext.setOriginBuildInvocationId(originBuildInvocationId)
         0 * _
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ValidatingTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ValidatingTaskExecuterTest.groovy
@@ -64,7 +64,7 @@ class ValidatingTaskExecuterTest extends Specification {
         1 * inputs.validate(_) >> { TaskValidationContext context -> context.recordValidationMessage(ERROR,'failure') }
         1 * task.getOutputs() >> outputs
         1 * outputs.validate(_)
-        1 * state.setOutcome(!null as Throwable) >> {
+        1 * state.recordFailure(!null as Throwable) >> {
             def failure = it[0]
             assert failure instanceof TaskValidationException
             assert failure.message == "A problem was found with the configuration of $task."
@@ -84,7 +84,7 @@ class ValidatingTaskExecuterTest extends Specification {
         1 * inputs.validate(_) >> { TaskValidationContext context -> context.recordValidationMessage(ERROR, 'failure1') }
         1 * task.getOutputs() >> outputs
         1 * outputs.validate(_) >> { TaskValidationContext context -> context.recordValidationMessage(ERROR, 'failure2') }
-        1 * state.setOutcome(!null as Throwable) >> {
+        1 * state.recordFailure(!null as Throwable) >> {
             def failure = it[0]
             assert failure instanceof TaskValidationException
             assert failure.message == "Some problems were found with the configuration of $task."

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
@@ -30,7 +30,7 @@ class TaskExecutionStatisticsReporterTest extends Specification {
 
     def "does not report statistics given 0 tasks"() {
         when:
-        reporter.buildFinished(new TaskExecutionStatistics(0, 0, 0))
+        reporter.buildFinished(new TaskExecutionStatistics(0, 0, 0, 0))
 
         then:
         (textOutputFactory as String) == ""
@@ -39,7 +39,7 @@ class TaskExecutionStatisticsReporterTest extends Specification {
 
     def "disallows negative task counts as input"() {
         when:
-        reporter.buildFinished(new TaskExecutionStatistics(-1, 12, 7))
+        reporter.buildFinished(new TaskExecutionStatistics(-1, 12, 7, 0))
 
         then:
         thrown IllegalArgumentException
@@ -47,7 +47,7 @@ class TaskExecutionStatisticsReporterTest extends Specification {
 
     def "properly pluralizes output"() {
         when:
-        reporter.buildFinished(new TaskExecutionStatistics(1, 0, 0))
+        reporter.buildFinished(new TaskExecutionStatistics(1, 0, 0, 0))
 
         then:
         TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}1 actionable task: 1 executed\n"
@@ -56,7 +56,7 @@ class TaskExecutionStatisticsReporterTest extends Specification {
     @Unroll
     def "reports only task counts > 0 (exec: #executed, from cache: #fromCache, up-to-date #upToDate)"() {
         when:
-        reporter.buildFinished(new TaskExecutionStatistics(executed, fromCache, upToDate))
+        reporter.buildFinished(new TaskExecutionStatistics(executed, fromCache, upToDate, 0))
 
         then:
         TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}$expected\n"
@@ -68,5 +68,37 @@ class TaskExecutionStatisticsReporterTest extends Specification {
         2        | 0         | 1        | "3 actionable tasks: 2 executed, 1 up-to-date"
         0        | 7         | 0        | "7 actionable tasks: 7 from cache"
         0        | 0         | 5        | "5 actionable tasks: 5 up-to-date"
+    }
+
+    @Unroll
+    def "does not report time saved or wasted by caching if under #timeSaved"() {
+        when:
+        reporter.buildFinished(new TaskExecutionStatistics(0, 2, 0, timeSaved))
+
+        then:
+        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}2 actionable tasks: 2 from cache\n"
+
+        where:
+        timeSaved << [0, 100, 499, -100, -499]
+    }
+
+    @Unroll
+    def "reports time saved or wasted by caching as: #expected"() {
+        when:
+        reporter.buildFinished(new TaskExecutionStatistics(0, 2, 0, timeSaved))
+
+        then:
+        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}2 actionable tasks: 2 from cache\n$expected\n"
+
+        where:
+        timeSaved | expected
+        750       | "Using the build cache saved 0.75s in this build"
+        1250      | "Using the build cache saved 1s in this build"
+        1750      | "Using the build cache saved 1s in this build"
+        62000     | "Using the build cache saved 1m 2s in this build"
+        -750      | "Without the build cache this build would have been 0.75s faster"
+        -1250     | "Without the build cache this build would have been 1s faster"
+        -1750     | "Without the build cache this build would have been 1s faster"
+        -62000    | "Without the build cache this build would have been 1m 2s faster"
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
@@ -71,34 +71,22 @@ class TaskExecutionStatisticsReporterTest extends Specification {
     }
 
     @Unroll
-    def "does not report time saved or wasted by caching if under #timeSaved"() {
+    def "reports cache impact of #cacheTimeImpact as:#expected"() {
         when:
-        reporter.buildFinished(new TaskExecutionStatistics(0, 2, 0, timeSaved))
+        reporter.buildFinished(new TaskExecutionStatistics(0, 2, 0, cacheTimeImpact))
 
         then:
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}2 actionable tasks: 2 from cache\n"
+        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}2 actionable tasks: 2 from cache$expected\n"
 
         where:
-        timeSaved << [0, 100, 499, -100, -499]
-    }
-
-    @Unroll
-    def "reports time saved or wasted by caching as: #expected"() {
-        when:
-        reporter.buildFinished(new TaskExecutionStatistics(0, 2, 0, timeSaved))
-
-        then:
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}2 actionable tasks: 2 from cache\n$expected\n"
-
-        where:
-        timeSaved | expected
-        750       | "Using the build cache saved 0.75s in this build"
-        1250      | "Using the build cache saved 1s in this build"
-        1750      | "Using the build cache saved 1s in this build"
-        62000     | "Using the build cache saved 1m 2s in this build"
-        -750      | "Without the build cache this build would have been 0.75s faster"
-        -1250     | "Without the build cache this build would have been 1s faster"
-        -1750     | "Without the build cache this build would have been 1s faster"
-        -62000    | "Without the build cache this build would have been 1m 2s faster"
+        cacheTimeImpact | expected
+        750             | ""
+        1250            | " (caching saved 1s)"
+        1750            | " (caching saved 1s)"
+        62000           | " (caching saved 1m 2s)"
+        -750            | ""
+        -1250           | " (caching took 1s)"
+        -1750           | " (caching took 1s)"
+        -62000          | " (caching took 1m 2s)"
     }
 }


### PR DESCRIPTION
Display a short summary at the end of the build about the awesomeness of the cache like this:

```text
BUILD SUCCESSFUL in 0s
17 actionable tasks: 10 executed, 7 from cache (caching saved 2m 0s)
```

Very simple demo:

[![asciicast](https://asciinema.org/a/IZqUqkWEVgFvsrpXYzbyN33KL.png)](https://asciinema.org/a/IZqUqkWEVgFvsrpXYzbyN33KL)