### PR TITLE
Pass Xcode parameters via project properties instead of environment v…

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GUtil.java
@@ -27,6 +27,7 @@ import org.gradle.internal.io.SkipFirstTextStream;
 import org.gradle.internal.io.StreamByteBuffer;
 import org.gradle.internal.io.WriterTextStream;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -141,7 +142,7 @@ public class GUtil {
         return prefixed;
     }
 
-    public static boolean isTrue(Object object) {
+    public static boolean isTrue(@Nullable Object object) {
         if (object == null) {
             return false;
         }
@@ -153,7 +154,7 @@ public class GUtil {
         return true;
     }
 
-    public static <T> T elvis(T object, T defaultValue) {
+    public static <T> T elvis(@Nullable T object, T defaultValue) {
         return isTrue(object) ? object : defaultValue;
     }
 

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
@@ -165,7 +165,6 @@ Actual: ${actual[key]}
         assert target.buildConfigurationList.buildConfigurations.name == [DefaultXcodeProject.BUILD_DEBUG, DefaultXcodeProject.BUILD_RELEASE]
         assert target.buildConfigurationList.buildConfigurations.every { it.buildSettings.PRODUCT_NAME == expectedProductName }
         assert target.buildArgumentsString == '-P_XCODE_ACTION="${ACTION}" -P_XCODE_PRODUCT_NAME="${PRODUCT_NAME}" -P_XCODE_CONFIGURATION="${CONFIGURATION}" -P_XCODE_BUILT_PRODUCTS_DIR="${BUILT_PRODUCTS_DIR}" :_xcode__${ACTION}_${PRODUCT_NAME}_${CONFIGURATION}'
-        assert target.buildToolPath == "gradle"
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[0].buildSettings)
         assert target.buildConfigurationList.buildConfigurations[0].buildSettings.CONFIGURATION_BUILD_DIR == file("build/exe/main/debug").absolutePath
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[1].buildSettings)

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
@@ -164,7 +164,7 @@ Actual: ${actual[key]}
         assert target.productReference.path == exe("build/exe/main/debug/$expectedBinaryName").absolutePath
         assert target.buildConfigurationList.buildConfigurations.name == [DefaultXcodeProject.BUILD_DEBUG, DefaultXcodeProject.BUILD_RELEASE]
         assert target.buildConfigurationList.buildConfigurations.every { it.buildSettings.PRODUCT_NAME == expectedProductName }
-        assert target.buildArgumentsString == '-P_XCODE_ACTION="${ACTION}" -P_XCODE_PRODUCT_NAME="${PRODUCT_NAME}" -P_XCODE_CONFIGURATION="${CONFIGURATION}" -P_XCODE_BUILT_PRODUCTS_DIR="${BUILT_PRODUCTS_DIR}" :_xcode__${ACTION}_${PRODUCT_NAME}_${CONFIGURATION}'
+        assert target.buildArgumentsString == '-Porg.gradle.internal.xcode.bridge.ACTION="${ACTION}" -Porg.gradle.internal.xcode.bridge.PRODUCT_NAME="${PRODUCT_NAME}" -Porg.gradle.internal.xcode.bridge.CONFIGURATION="${CONFIGURATION}" -Porg.gradle.internal.xcode.bridge.BUILT_PRODUCTS_DIR="${BUILT_PRODUCTS_DIR}" :_xcode__${ACTION}_${PRODUCT_NAME}_${CONFIGURATION}'
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[0].buildSettings)
         assert target.buildConfigurationList.buildConfigurations[0].buildSettings.CONFIGURATION_BUILD_DIR == file("build/exe/main/debug").absolutePath
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[1].buildSettings)

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
@@ -164,6 +164,8 @@ Actual: ${actual[key]}
         assert target.productReference.path == exe("build/exe/main/debug/$expectedBinaryName").absolutePath
         assert target.buildConfigurationList.buildConfigurations.name == [DefaultXcodeProject.BUILD_DEBUG, DefaultXcodeProject.BUILD_RELEASE]
         assert target.buildConfigurationList.buildConfigurations.every { it.buildSettings.PRODUCT_NAME == expectedProductName }
+        assert target.buildArgumentsString == '-P_XCODE_ACTION="${ACTION}" -P_XCODE_PRODUCT_NAME="${PRODUCT_NAME}" -P_XCODE_CONFIGURATION="${CONFIGURATION}" -P_XCODE_BUILT_PRODUCTS_DIR="${BUILT_PRODUCTS_DIR}" :_xcode__${ACTION}_${PRODUCT_NAME}_${CONFIGURATION}'
+        assert target.buildToolPath == "gradle"
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[0].buildSettings)
         assert target.buildConfigurationList.buildConfigurations[0].buildSettings.CONFIGURATION_BUILD_DIR == file("build/exe/main/debug").absolutePath
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[1].buildSettings)

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodePropertyAdapter.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodePropertyAdapter.java
@@ -63,6 +63,6 @@ public class XcodePropertyAdapter {
     }
 
     private static String prefixName(String source) {
-        return "_XCODE_" + source;
+        return "org.gradle.internal.xcode.bridge." + source;
     }
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodePropertyAdapter.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodePropertyAdapter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.ide.xcode.internal;
+
+import org.gradle.api.Project;
+import org.gradle.util.GUtil;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class XcodePropertyAdapter {
+    private final Project project;
+
+    public XcodePropertyAdapter(Project project) {
+        this.project = project;
+    }
+
+    public String getAction() {
+        return getXcodeProperty("ACTION");
+    }
+
+    public String getProductName() {
+        return getXcodeProperty("PRODUCT_NAME");
+    }
+
+    public String getConfiguration() {
+        return getXcodeProperty("CONFIGURATION");
+    }
+
+    public String getBuiltProductsDir() {
+        return getXcodeProperty("BUILT_PRODUCTS_DIR");
+    }
+
+    private String getXcodeProperty(String name) {
+        return String.valueOf(GUtil.elvis(project.findProperty(prefixName(name)), ""));
+    }
+
+    public static List<String> getAdapterCommandLine() {
+        return Arrays.asList(
+            toGradleProperty("ACTION"),
+            toGradleProperty("PRODUCT_NAME"),
+            toGradleProperty("CONFIGURATION"),
+            toGradleProperty("BUILT_PRODUCTS_DIR")
+        );
+    }
+
+    private static String toGradleProperty(String source) {
+        return "-P" + prefixName(source) + "=\"${" + source + "}\"";
+    }
+
+    private static String prefixName(String source) {
+        return "_XCODE_" + source;
+    }
+}

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/internal/XcodePropertyAdapterTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/internal/XcodePropertyAdapterTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.ide.xcode.internal
+
+import org.gradle.api.Project
+import spock.lang.Specification
+import spock.lang.Subject
+
+class XcodePropertyAdapterTest extends Specification {
+    def project = Mock(Project)
+
+    @Subject
+    def xcodePropertyAdapter = new XcodePropertyAdapter(project)
+
+    def "getAction"() {
+        expectProperty("_XCODE_ACTION", "myaction")
+
+        expect:
+        xcodePropertyAdapter.action == "" // default value
+        xcodePropertyAdapter.action == "myaction"
+    }
+
+    def "getProductName"() {
+        expectProperty("_XCODE_PRODUCT_NAME", "myproduct")
+
+        expect:
+        xcodePropertyAdapter.productName == "" // default value
+        xcodePropertyAdapter.productName == "myproduct"
+    }
+
+    def "getConfiguration"() {
+        expectProperty("_XCODE_CONFIGURATION", "configuration")
+
+        expect:
+        xcodePropertyAdapter.configuration == "" // default value
+        xcodePropertyAdapter.configuration == "configuration"
+    }
+
+    def "getBuiltProductsDir"() {
+        expectProperty("_XCODE_BUILT_PRODUCTS_DIR", "dir")
+
+        expect:
+        xcodePropertyAdapter.builtProductsDir == "" // default value
+        xcodePropertyAdapter.builtProductsDir == "dir"
+    }
+
+    def "getAdapterCommandLine"() {
+        expect:
+        XcodePropertyAdapter.adapterCommandLine == [
+                '-P_XCODE_ACTION="${ACTION}"',
+                '-P_XCODE_PRODUCT_NAME="${PRODUCT_NAME}"',
+                '-P_XCODE_CONFIGURATION="${CONFIGURATION}"',
+                '-P_XCODE_BUILT_PRODUCTS_DIR="${BUILT_PRODUCTS_DIR}"',
+        ]
+    }
+
+    private void expectProperty(String propertyName, String expected) {
+        1 * project.findProperty(propertyName)
+        1 * project.findProperty(propertyName) >> expected
+    }
+}

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/internal/XcodePropertyAdapterTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/internal/XcodePropertyAdapterTest.groovy
@@ -27,7 +27,7 @@ class XcodePropertyAdapterTest extends Specification {
     def xcodePropertyAdapter = new XcodePropertyAdapter(project)
 
     def "getAction"() {
-        expectProperty("_XCODE_ACTION", "myaction")
+        expectProperty("org.gradle.internal.xcode.bridge.ACTION", "myaction")
 
         expect:
         xcodePropertyAdapter.action == "" // default value
@@ -35,7 +35,7 @@ class XcodePropertyAdapterTest extends Specification {
     }
 
     def "getProductName"() {
-        expectProperty("_XCODE_PRODUCT_NAME", "myproduct")
+        expectProperty("org.gradle.internal.xcode.bridge.PRODUCT_NAME", "myproduct")
 
         expect:
         xcodePropertyAdapter.productName == "" // default value
@@ -43,7 +43,7 @@ class XcodePropertyAdapterTest extends Specification {
     }
 
     def "getConfiguration"() {
-        expectProperty("_XCODE_CONFIGURATION", "configuration")
+        expectProperty("org.gradle.internal.xcode.bridge.CONFIGURATION", "configuration")
 
         expect:
         xcodePropertyAdapter.configuration == "" // default value
@@ -51,7 +51,7 @@ class XcodePropertyAdapterTest extends Specification {
     }
 
     def "getBuiltProductsDir"() {
-        expectProperty("_XCODE_BUILT_PRODUCTS_DIR", "dir")
+        expectProperty("org.gradle.internal.xcode.bridge.BUILT_PRODUCTS_DIR", "dir")
 
         expect:
         xcodePropertyAdapter.builtProductsDir == "" // default value
@@ -61,10 +61,10 @@ class XcodePropertyAdapterTest extends Specification {
     def "getAdapterCommandLine"() {
         expect:
         XcodePropertyAdapter.adapterCommandLine == [
-                '-P_XCODE_ACTION="${ACTION}"',
-                '-P_XCODE_PRODUCT_NAME="${PRODUCT_NAME}"',
-                '-P_XCODE_CONFIGURATION="${CONFIGURATION}"',
-                '-P_XCODE_BUILT_PRODUCTS_DIR="${BUILT_PRODUCTS_DIR}"',
+                '-Porg.gradle.internal.xcode.bridge.ACTION="${ACTION}"',
+                '-Porg.gradle.internal.xcode.bridge.PRODUCT_NAME="${PRODUCT_NAME}"',
+                '-Porg.gradle.internal.xcode.bridge.CONFIGURATION="${CONFIGURATION}"',
+                '-Porg.gradle.internal.xcode.bridge.BUILT_PRODUCTS_DIR="${BUILT_PRODUCTS_DIR}"',
         ]
     }
 


### PR DESCRIPTION
…ariables

This works around issues with JDK9 environment variable passing

https://github.com/gradle/gradle-native/issues/280

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
