### PR TITLE
Add flag to disable transitive unresolved header detection

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
@@ -420,38 +420,38 @@ class CppIncrementalBuildIntegrationTest extends AbstractCppInstalledToolChainIn
             #define _HELLO(X) #X
             #define HELLO _HELLO(hello.h)
             #include HELLO
-        ''' | false
-        'HELLO' | '''            
+        '''                      | false
+        'HELLO'           | '''            
             #define _HELLO(X) #X
             #define HELLO _HELLO(hello.h)
             #include HELLO
-        ''' | true
+        '''                      | true
         '_HELLO(hello.h)' | '''
             #define _HELLO(X) #X
             #include _HELLO(hello.h)
-        ''' | false
-        'MISSING' | '''
+        '''                      | false
+        'MISSING'         | '''
             #ifdef MISSING
             #include MISSING
             #else
             #include "hello.h"
             #endif
-        ''' | false
-        'GARBAGE' | '''
+        '''                      | false
+        'GARBAGE'         | '''
             #if 0
             #define GARBAGE a b c
             #include GARBAGE
             #else
             #include "hello.h"
             #endif
-        ''' | false
-        'a b c' | '''
+        '''                      | false
+        'a b c'           | '''
             #if 0
             #include a b c
             #else
             #include "hello.h"
             #endif
-        ''' | false
+        '''                      | false
 
         specialFlagText = specialFlagActive ? ' (special flag active)' : ''
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultHeaderDependenciesCollector.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultHeaderDependenciesCollector.java
@@ -39,10 +39,10 @@ public class DefaultHeaderDependenciesCollector implements HeaderDependenciesCol
     }
 
     @Override
-    public ImmutableSortedSet<File> collectHeaderDependencies(String taskName, List<File> includeRoots, IncrementalCompilation incrementalCompilation) {
+    public ImmutableSortedSet<File> collectHeaderDependencies(String taskPath, List<File> includeRoots, IncrementalCompilation incrementalCompilation) {
         final Set<File> headerDependencies = new HashSet<File>();
         if (incrementalCompilation.isUnresolvedHeaders()) {
-            addIncludeRoots(taskName, includeRoots, headerDependencies);
+            addIncludeRoots(taskPath, includeRoots, headerDependencies);
         } else {
             headerDependencies.addAll(incrementalCompilation.getDiscoveredInputs());
         }
@@ -50,10 +50,10 @@ public class DefaultHeaderDependenciesCollector implements HeaderDependenciesCol
     }
 
     @Override
-    public ImmutableSortedSet<File> collectExistingHeaderDependencies(String taskName, List<File> includeRoots, IncrementalCompilation incrementalCompilation) {
+    public ImmutableSortedSet<File> collectExistingHeaderDependencies(String taskPath, List<File> includeRoots, IncrementalCompilation incrementalCompilation) {
         final Set<File> headerDependencies = new HashSet<File>();
         if (incrementalCompilation.isUnresolvedHeaders()) {
-            addIncludeRoots(taskName, includeRoots, headerDependencies);
+            addIncludeRoots(taskPath, includeRoots, headerDependencies);
         } else {
             headerDependencies.addAll(incrementalCompilation.getExistingHeaders());
         }
@@ -61,7 +61,7 @@ public class DefaultHeaderDependenciesCollector implements HeaderDependenciesCol
     }
 
     private void addIncludeRoots(String taskName, List<File> includeRoots, final Set<File> headerDependencies) {
-        logger.info("After parsing the source files, Gradle cannot calculate the exact set of include files for {}. Every file in the include search path will be considered a header dependency.", taskName);
+        logger.info("After parsing the source files, Gradle cannot calculate the exact set of include files for '{}'. Every file in the include search path will be considered a header dependency.", taskName);
         for (final File includeRoot : includeRoots) {
             logger.info("adding files in {} to header dependencies for {}", includeRoot, taskName);
             directoryFileTreeFactory.create(includeRoot).visit(new EmptyFileVisitor() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultHeaderDependenciesCollector.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultHeaderDependenciesCollector.java
@@ -60,10 +60,10 @@ public class DefaultHeaderDependenciesCollector implements HeaderDependenciesCol
         return ImmutableSortedSet.copyOf(headerDependencies);
     }
 
-    private void addIncludeRoots(String taskName, List<File> includeRoots, final Set<File> headerDependencies) {
-        logger.info("After parsing the source files, Gradle cannot calculate the exact set of include files for '{}'. Every file in the include search path will be considered a header dependency.", taskName);
+    private void addIncludeRoots(String taskPath, List<File> includeRoots, final Set<File> headerDependencies) {
+        logger.info("After parsing the source files, Gradle cannot calculate the exact set of include files for '{}'. Every file in the include search path will be considered a header dependency.", taskPath);
         for (final File includeRoot : includeRoots) {
-            logger.info("adding files in {} to header dependencies for {}", includeRoot, taskName);
+            logger.info("adding files in {} to header dependencies for {}", includeRoot, taskPath);
             directoryFileTreeFactory.create(includeRoot).visit(new EmptyFileVisitor() {
                 @Override
                 public void visitFile(FileVisitDetails fileDetails) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/HeaderDependenciesCollector.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/HeaderDependenciesCollector.java
@@ -26,17 +26,17 @@ import java.util.List;
 public interface HeaderDependenciesCollector {
     HeaderDependenciesCollector NOOP = new HeaderDependenciesCollector() {
         @Override
-        public ImmutableSortedSet<File> collectHeaderDependencies(String taskName, List<File> includeRoots, IncrementalCompilation incrementalCompilation) {
+        public ImmutableSortedSet<File> collectHeaderDependencies(String taskPath, List<File> includeRoots, IncrementalCompilation incrementalCompilation) {
             return ImmutableSortedSet.of();
         }
 
         @Override
-        public ImmutableSortedSet<File> collectExistingHeaderDependencies(String taskName, List<File> includeRoots, IncrementalCompilation incrementalCompilation) {
+        public ImmutableSortedSet<File> collectExistingHeaderDependencies(String taskPath, List<File> includeRoots, IncrementalCompilation incrementalCompilation) {
             return ImmutableSortedSet.of();
         }
     };
 
-    ImmutableSortedSet<File> collectHeaderDependencies(String taskName, List<File> includeRoots, IncrementalCompilation incrementalCompilation);
+    ImmutableSortedSet<File> collectHeaderDependencies(String taskPath, List<File> includeRoots, IncrementalCompilation incrementalCompilation);
 
-    ImmutableSortedSet<File> collectExistingHeaderDependencies(String taskName, List<File> includeRoots, IncrementalCompilation incrementalCompilation);
+    ImmutableSortedSet<File> collectExistingHeaderDependencies(String taskPath, List<File> includeRoots, IncrementalCompilation incrementalCompilation);
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
@@ -84,7 +84,7 @@ public class IncrementalNativeCompiler<T extends NativeCompileSpec> implements C
     }
 
     protected void handleDiscoveredInputs(T spec, IncrementalCompilation compilation, final DiscoveredInputRecorder discoveredInputRecorder) {
-        ImmutableSortedSet<File> headerDependencies = headerDependenciesCollector.collectHeaderDependencies(getTask().getName(), spec.getIncludeRoots(), compilation);
+        ImmutableSortedSet<File> headerDependencies = headerDependenciesCollector.collectHeaderDependencies(getTask().getPath(), spec.getIncludeRoots(), compilation);
         discoveredInputRecorder.newInputs(headerDependencies);
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/Depend.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/Depend.java
@@ -101,8 +101,8 @@ public class Depend extends DefaultTask {
         IncrementalCompileProcessor incrementalCompileProcessor = createIncrementalCompileProcessor(includeRoots, compileStateCache);
 
         IncrementalCompilation incrementalCompilation = incrementalCompileProcessor.processSourceFiles(source.getFiles());
-        ImmutableSortedSet<File> headerDependencies = headerDependenciesCollector.collectHeaderDependencies(getName(), includeRoots, incrementalCompilation);
-        ImmutableSortedSet<File> existingHeaderDependencies = headerDependenciesCollector.collectExistingHeaderDependencies(getName(), includeRoots, incrementalCompilation);
+        ImmutableSortedSet<File> headerDependencies = headerDependenciesCollector.collectHeaderDependencies(getPath(), includeRoots, incrementalCompilation);
+        ImmutableSortedSet<File> existingHeaderDependencies = headerDependenciesCollector.collectExistingHeaderDependencies(getPath(), includeRoots, incrementalCompilation);
         compileStateCache.set(incrementalCompilation.getFinalState());
 
         inputs.newInputs(headerDependencies);


### PR DESCRIPTION
We should be able to fix this for good for 4.5 and make it possible to
resolve boost's headers. Currently, we can't, so we add a special flag
to revert to the behavior of 4.2 - i.e. not detecting unresolved headers
in transitive includes but only in the actual source files.
