### PR TITLE
Fix failure with missing output file for UnexportMainSymbol

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/tasks/UnexportMainSymbolIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/tasks/UnexportMainSymbolIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift.tasks
 
-import groovy.transform.NotYetImplemented
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.NativeBinaryFixture
 import org.gradle.nativeplatform.fixtures.binaryinfo.BinaryInfo
@@ -46,7 +45,6 @@ class UnexportMainSymbolIntegrationTest extends AbstractInstalledToolChainIntegr
         succeeds("clean", "unexport", "assemble")
     }
 
-    @NotYetImplemented
     @Issue("https://github.com/gradle/gradle-native/issues/297")
     def "unexport is incremental"() {
         writeMainSwift()

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -52,6 +52,8 @@ public class UnexportMainSymbol extends SourceTask {
 
     /**
      * Collection of modified object files.
+     *
+     * @since 4.5
      */
     @Internal
     public FileCollection getObjects() {
@@ -60,6 +62,8 @@ public class UnexportMainSymbol extends SourceTask {
 
     /**
      * Location of modified object files.
+     *
+     * @since 4.5
      */
     @OutputDirectory
     public Provider<Directory> getOutputDirectory() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -18,12 +18,15 @@ package org.gradle.language.swift.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputFiles;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.os.OperatingSystem;
@@ -48,11 +51,19 @@ public class UnexportMainSymbol extends SourceTask {
     }
 
     /**
-     * Modified object files.
+     * Collection of modified object files.
      */
-    @OutputFiles
-    public FileCollection getOutputFiles() {
+    @Internal
+    public FileCollection getObjects() {
         return outputDirectory.getAsFileTree();
+    }
+
+    /**
+     * Location of modified object files.
+     */
+    @OutputDirectory
+    public Provider<Directory> getOutputDirectory() {
+        return outputDirectory;
     }
 
     /**
@@ -72,7 +83,6 @@ public class UnexportMainSymbol extends SourceTask {
         final File mainObjectFile = getMainObject();
         if (mainObjectFile != null) {
             final File relocatedMainObject = outputDirectory.file(mainObjectFile.getName()).get().getAsFile();
-            relocatedMainObject.getParentFile().mkdirs();
             getProject().exec(new Action<ExecSpec>() {
                 @Override
                 public void execute(ExecSpec execSpec) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -41,10 +41,10 @@ import java.util.Set;
 @Incubating
 public class UnexportMainSymbol extends SourceTask {
     private File mainObjectFile;
-    private final DirectoryProperty outputFile = newOutputDirectory();
+    private final DirectoryProperty outputDirectory = newOutputDirectory();
 
     public UnexportMainSymbol() {
-        outputFile.set(getTemporaryDir());
+        outputDirectory.set(getTemporaryDir());
     }
 
     /**
@@ -52,7 +52,7 @@ public class UnexportMainSymbol extends SourceTask {
      */
     @OutputFiles
     public FileCollection getOutputFiles() {
-        return outputFile.getAsFileTree();
+        return outputDirectory.getAsFileTree();
     }
 
     /**
@@ -71,7 +71,8 @@ public class UnexportMainSymbol extends SourceTask {
     public void unexport() {
         final File mainObjectFile = getMainObject();
         if (mainObjectFile != null) {
-            final File relocatedMainObject = outputFile.file(mainObjectFile.getName()).get().getAsFile();
+            final File relocatedMainObject = outputDirectory.file(mainObjectFile.getName()).get().getAsFile();
+            relocatedMainObject.getParentFile().mkdirs();
             getProject().exec(new Action<ExecSpec>() {
                 @Override
                 public void execute(ExecSpec execSpec) {
@@ -93,7 +94,7 @@ public class UnexportMainSymbol extends SourceTask {
             });
             setDidWork(true);
         } else {
-            setDidWork(getProject().delete(outputFile.get().getAsFile()));
+            setDidWork(getProject().delete(outputDirectory));
         }
     }
 

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -246,14 +246,14 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
                 AbstractLinkTask linkTest = tasks.withType(AbstractLinkTask.class).getByName("linkTest");
 
                 if (testedComponent instanceof SwiftApplication) {
-                    final UnexportMainSymbol relocate = tasks.create("relocateMainForTest", UnexportMainSymbol.class);
-                    relocate.source(testedComponent.getDevelopmentBinary().getObjects());
+                    final UnexportMainSymbol unexportMainSymbol = tasks.create("relocateMainForTest", UnexportMainSymbol.class);
+                    unexportMainSymbol.source(testedComponent.getDevelopmentBinary().getObjects());
 
-                    linkTest.source(relocate);
+                    linkTest.source(unexportMainSymbol);
                     linkTest.source(testedComponent.getDevelopmentBinary().getObjects().filter(new Spec<File>() {
                         @Override
                         public boolean isSatisfiedBy(File objectFile) {
-                            return !objectFile.equals(relocate.getMainObject());
+                            return !objectFile.equals(unexportMainSymbol.getMainObject());
                         }
                     }));
                 } else {

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -249,7 +249,7 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
                     final UnexportMainSymbol unexportMainSymbol = tasks.create("relocateMainForTest", UnexportMainSymbol.class);
                     unexportMainSymbol.source(testedComponent.getDevelopmentBinary().getObjects());
 
-                    linkTest.source(unexportMainSymbol);
+                    linkTest.source(unexportMainSymbol.getObjects());
                     linkTest.source(testedComponent.getDevelopmentBinary().getObjects().filter(new Spec<File>() {
                         @Override
                         public boolean isSatisfiedBy(File objectFile) {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-native/issues/304

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
