### PR TITLE
Support dependency excludes in module metadata

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
@@ -16,19 +16,11 @@
 
 package org.gradle.integtests.resolve
 
-import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
-import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import spock.lang.Issue
 
 /**
  * Demonstrates the resolution of dependency excludes in published module metadata.
  */
-@RequiredFeatures([
-    // TODO:DAZ add support for Gradle metadata
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="false")
-]
-)
 class ModuleDependencyExcludeResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
     def setup() {
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/AbstractIvyDescriptorExcludeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/AbstractIvyDescriptorExcludeResolveIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.integtests.resolve.ivy
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 
-class AbstractIvyDescriptorExcludeResolveIntegrationTest extends AbstractDependencyResolutionTest {
+abstract class AbstractIvyDescriptorExcludeResolveIntegrationTest extends AbstractDependencyResolutionTest {
     protected static final EXCLUDE_ATTRIBUTE = 'exclude'
 
     def setup() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
+import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser.FORMAT_VERSION
+
 class MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest extends AbstractDependencyResolutionTest {
     def resolve = new ResolveTestFixture(buildFile)
 
@@ -77,7 +79,7 @@ dependencies {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "debug",
@@ -139,7 +141,7 @@ task checkRelease {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "debug",
@@ -202,7 +204,7 @@ task checkRelease {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "lot-o-files",
@@ -251,7 +253,7 @@ task checkDebug {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "lot-o-files",
@@ -298,7 +300,7 @@ task checkDebug {
         c.publish()
         c.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "debug",
@@ -328,7 +330,7 @@ task checkDebug {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "debug",

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Unroll
 
+import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser.FORMAT_VERSION
+
 class MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def resolve = new ResolveTestFixture(buildFile)
 
@@ -218,7 +220,7 @@ dependencies {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "debug",
@@ -299,7 +301,7 @@ task checkRelease {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "debug",
@@ -391,7 +393,7 @@ task checkRelease {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "lot-o-files",
@@ -462,7 +464,7 @@ task checkDebug {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "lot-o-files",
@@ -535,7 +537,7 @@ task checkDebug {
         c.publish()
         c.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "debug",
@@ -565,7 +567,7 @@ task checkDebug {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "debug",
@@ -638,7 +640,7 @@ task checkRelease {
         a.publish()
         a.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "debug",
@@ -852,7 +854,7 @@ dependencies {
 
     def "reports failure to accept module metadata with unexpected format version"() {
         def m = mavenHttpRepo.module("test", "a", "1.2").withModuleMetadata().publish()
-        m.moduleMetadata.file.text = m.moduleMetadata.file.text.replace("0.2", "123.67")
+        m.moduleMetadata.file.text = m.moduleMetadata.file.text.replace(FORMAT_VERSION, "123.67")
 
         given:
         buildFile << """
@@ -877,7 +879,7 @@ dependencies {
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
         failure.assertHasCause("Could not resolve test:a:1.2.")
         failure.assertHasCause("Could not parse module metadata ${m.moduleMetadata.uri}")
-        failure.assertHasCause("Unsupported format version '123.67' specified in module metadata. This version of Gradle supports format version 0.2 only.")
+        failure.assertHasCause("Unsupported format version '123.67' specified in module metadata. This version of Gradle supports format version ${FORMAT_VERSION} only.")
 
         when:
         server.resetExpectations()
@@ -890,7 +892,7 @@ dependencies {
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
         failure.assertHasCause("Could not resolve test:a:1.2.")
         failure.assertHasCause("Could not parse module metadata ${m.moduleMetadata.uri}")
-        failure.assertHasCause("Unsupported format version '123.67' specified in module metadata. This version of Gradle supports format version 0.2 only.")
+        failure.assertHasCause("Unsupported format version '123.67' specified in module metadata. This version of Gradle supports format version ${FORMAT_VERSION} only.")
     }
 
     def "reports failure to locate files"() {
@@ -901,7 +903,7 @@ dependencies {
         m.publish()
         m.moduleMetadata.file.text = """
 {
-    "formatVersion": "0.2",
+    "formatVersion": "${FORMAT_VERSION}",
     "variants": [
         {
             "name": "lot-o-files",

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -148,7 +148,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 artifactIdentifierFileStore,
                 externalResourceFileStore,
                 new GradlePomModuleDescriptorParser(versionSelectorScheme, moduleIdentifierFactory, fileResourceRepository),
-                new ModuleMetadataParser(attributesFactory, NamedObjectInstantiator.INSTANCE),
+                new ModuleMetadataParser(attributesFactory, moduleIdentifierFactory, NamedObjectInstantiator.INSTANCE),
                 authenticationSchemeRegistry,
                 ivyContextManager,
                 moduleIdentifierFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -22,7 +22,7 @@ import java.io.File;
 public enum CacheLayout {
     ROOT(null, "modules", 2),
     FILE_STORE(ROOT, "files", 1),
-    META_DATA(ROOT, "metadata", 37),
+    META_DATA(ROOT, "metadata", 38),
     RESOURCES(ROOT, "resources", 1),
     TRANSFORMS(null, "transforms", 1),
     TRANSFORMS_META_DATA(TRANSFORMS, "metadata", 1),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -177,7 +177,7 @@ public class ModuleMetadataParser {
             }
         }
         reader.endObject();
-        return ImmutableList.of(new ModuleDependency(group, module, new DefaultImmutableVersionConstraint(version), Collections.<Exclude>emptyList()));
+        return ImmutableList.of(new ModuleDependency(group, module, new DefaultImmutableVersionConstraint(version), ImmutableList.<Exclude>of()));
     }
 
     private List<ModuleDependency> consumeDependencies(JsonReader reader) throws IOException {
@@ -188,7 +188,7 @@ public class ModuleMetadataParser {
             String group = null;
             String module = null;
             VersionConstraint version = null;
-            List<Exclude> excludes = Collections.emptyList();
+            ImmutableList<Exclude> excludes = ImmutableList.of();
             while (reader.peek() != END_OBJECT) {
                 String name = reader.nextName();
                 if (name.equals("group")) {
@@ -230,8 +230,8 @@ public class ModuleMetadataParser {
         return DefaultImmutableVersionConstraint.of(preferred, rejects);
     }
 
-    private List<Exclude> consumeExcludes(JsonReader reader) throws IOException {
-        List<Exclude> excludes = Lists.newArrayList();
+    private ImmutableList<Exclude> consumeExcludes(JsonReader reader) throws IOException {
+        ImmutableList.Builder<Exclude> builder = new ImmutableList.Builder<Exclude>();
         reader.beginArray();
         while (reader.peek() != END_ARRAY) {
             reader.beginObject();
@@ -249,10 +249,10 @@ public class ModuleMetadataParser {
             }
             reader.endObject();
             Exclude exclude = excludeRuleConverter.createExcludeRule(group, module);
-            excludes.add(exclude);
+            builder.add(exclude);
         }
         reader.endArray();
-        return excludes;
+        return builder.build();
     }
 
     private List<ModuleFile> consumeFiles(JsonReader reader) throws IOException {
@@ -320,9 +320,9 @@ public class ModuleMetadataParser {
         final String group;
         final String module;
         final VersionConstraint versionConstraint;
-        final List<Exclude> excludes;
+        final ImmutableList<Exclude> excludes;
 
-        ModuleDependency(String group, String module, VersionConstraint versionConstraint, List<Exclude> excludes) {
+        ModuleDependency(String group, String module, VersionConstraint versionConstraint, ImmutableList<Exclude> excludes) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -24,7 +24,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -50,10 +50,12 @@ import static com.google.gson.stream.JsonToken.*;
 public class ModuleMetadataParser {
     public static final String FORMAT_VERSION = "0.2";
     private final ImmutableAttributesFactory attributesFactory;
+    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final NamedObjectInstantiator instantiator;
 
-    public ModuleMetadataParser(ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator instantiator) {
+    public ModuleMetadataParser(ImmutableAttributesFactory attributesFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, NamedObjectInstantiator instantiator) {
         this.attributesFactory = attributesFactory;
+        this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.instantiator = instantiator;
     }
 
@@ -245,8 +247,7 @@ public class ModuleMetadataParser {
                 }
             }
             reader.endObject();
-            // TODO:DAZ Use `ImmutableModuleIdentifierFactory`
-            Exclude exclude = new DefaultExclude(DefaultModuleIdentifier.newId(group, module));
+            Exclude exclude = new DefaultExclude(moduleIdentifierFactory.module(group, module));
             excludes.add(exclude);
         }
         reader.endArray();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -48,7 +48,7 @@ import java.util.List;
 import static com.google.gson.stream.JsonToken.*;
 
 public class ModuleMetadataParser {
-    public static final String FORMAT_VERSION = "0.2";
+    public static final String FORMAT_VERSION = "0.3";
     private final ImmutableAttributesFactory attributesFactory;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final NamedObjectInstantiator instantiator;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.SetMultimap;
@@ -403,20 +404,21 @@ public class ModuleMetadataSerializer {
             int count = decoder.readSmallInt();
             for (int i = 0; i < count; i++) {
                 ModuleComponentSelector selector = COMPONENT_SELECTOR_SERIALIZER.read(decoder);
-                List<Exclude> excludes = readVariantDependencyExcludes();
+                ImmutableList<Exclude> excludes = readVariantDependencyExcludes();
                 variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes);
             }
         }
 
-        private List<Exclude> readVariantDependencyExcludes() throws IOException {
+        private ImmutableList<Exclude> readVariantDependencyExcludes() throws IOException {
+            ImmutableList.Builder<Exclude> builder = new ImmutableList.Builder<Exclude>();
             int len = readCount();
             List<Exclude> result = Lists.newArrayListWithCapacity(len);
             for (int i = 0; i < len; i++) {
                 String group = readString();
                 String module = readString();
-                result.add(excludeRuleConverter.createExcludeRule(group, module));
+                builder.add(excludeRuleConverter.createExcludeRule(group, module));
             }
-            return result;
+            return builder.build();
         }
 
         private void readVariantFiles(MutableComponentVariant variant) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -26,6 +26,8 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleComponentSelectorSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultExcludeRuleConverter;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.changedetection.state.CoercingStringValueSnapshot;
@@ -328,6 +330,7 @@ public class ModuleMetadataSerializer {
         private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
         private final ImmutableAttributesFactory attributesFactory;
         private final NamedObjectInstantiator instantiator;
+        private final ExcludeRuleConverter excludeRuleConverter;
         private ModuleComponentIdentifier id;
         private ModuleVersionIdentifier mvi;
 
@@ -336,6 +339,7 @@ public class ModuleMetadataSerializer {
             this.moduleIdentifierFactory = moduleIdentifierFactory;
             this.attributesFactory = attributesFactory;
             this.instantiator = instantiator;
+            this.excludeRuleConverter = new DefaultExcludeRuleConverter(moduleIdentifierFactory);
         }
 
         public MutableModuleComponentResolveMetadata read() throws IOException {
@@ -410,7 +414,7 @@ public class ModuleMetadataSerializer {
             for (int i = 0; i < len; i++) {
                 String group = readString();
                 String module = readString();
-                result.add(new DefaultExclude(moduleIdentifierFactory.module(group, module)));
+                result.add(excludeRuleConverter.createExcludeRule(group, module));
             }
             return result;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleComponentSelectorSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
@@ -411,7 +410,7 @@ public class ModuleMetadataSerializer {
             for (int i = 0; i < len; i++) {
                 String group = readString();
                 String module = readString();
-                result.add(new DefaultExclude(DefaultModuleIdentifier.newId(group, module)));
+                result.add(new DefaultExclude(moduleIdentifierFactory.module(group, module)));
             }
             return result;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -58,6 +58,7 @@ import org.gradle.internal.serialize.Encoder;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -129,6 +130,7 @@ public class ModuleMetadataSerializer {
             for (ComponentVariant.Dependency dependency : dependencies) {
                 COMPONENT_SELECTOR_SERIALIZER.write(encoder, dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint());
             }
+            // TODO:DAZ Need to serialize exclude rules
         }
 
         private void writeAttributes(AttributeContainer attributes) throws IOException {
@@ -390,7 +392,7 @@ public class ModuleMetadataSerializer {
             int count = decoder.readSmallInt();
             for (int i = 0; i < count; i++) {
                 ModuleComponentSelector selector = COMPONENT_SELECTOR_SERIALIZER.read(decoder);
-                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint());
+                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), Collections.<String>emptyList());
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultExcludeRuleConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultExcludeRuleConverter.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.PatternMatchers;
 import org.gradle.internal.component.external.descriptor.DefaultExclude;
+import org.gradle.internal.component.model.Exclude;
 import org.gradle.util.GUtil;
 
 public class DefaultExcludeRuleConverter implements ExcludeRuleConverter {
@@ -33,5 +34,12 @@ public class DefaultExcludeRuleConverter implements ExcludeRuleConverter {
         String module = GUtil.elvis(excludeRule.getModule(), PatternMatchers.ANY_EXPRESSION);
         String[] configurationNames = GUtil.isTrue(configurationName) ? new String[]{configurationName} : new String[0];
         return new DefaultExclude(moduleIdentifierFactory.module(org, module), configurationNames, PatternMatchers.EXACT);
+    }
+
+    @Override
+    public Exclude createExcludeRule(String group, String module) {
+        group = GUtil.elvis(group, PatternMatchers.ANY_EXPRESSION);
+        module = GUtil.elvis(module, PatternMatchers.ANY_EXPRESSION);
+        return new DefaultExclude(moduleIdentifierFactory.module(group, module));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExcludeRuleConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExcludeRuleConverter.java
@@ -20,4 +20,5 @@ import org.gradle.internal.component.model.Exclude;
 
 public interface ExcludeRuleConverter {
     Exclude convertExcludeRule(String configuration, ExcludeRule excludeRule);
+    Exclude createExcludeRule(String group, String module);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/DefaultExclude.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/DefaultExclude.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.descriptor;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.PatternMatchers;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.Exclude;
@@ -47,6 +48,13 @@ public class DefaultExclude implements Exclude {
 
     public DefaultExclude(ModuleIdentifier id) {
         this.moduleId = id;
+        this.artifact = new DefaultIvyArtifactName(PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION);
+        this.configurations = ImmutableSet.of();
+        this.patternMatcher = PatternMatchers.EXACT;
+    }
+
+    public DefaultExclude(String group, String module) {
+        this.moduleId = DefaultModuleIdentifier.newId(group, module);
         this.artifact = new DefaultIvyArtifactName(PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION);
         this.configurations = ImmutableSet.of();
         this.patternMatcher = PatternMatchers.EXACT;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/DefaultExclude.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/DefaultExclude.java
@@ -18,7 +18,6 @@ package org.gradle.internal.component.external.descriptor;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.PatternMatchers;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.Exclude;
@@ -48,13 +47,6 @@ public class DefaultExclude implements Exclude {
 
     public DefaultExclude(ModuleIdentifier id) {
         this.moduleId = id;
-        this.artifact = new DefaultIvyArtifactName(PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION);
-        this.configurations = ImmutableSet.of();
-        this.patternMatcher = PatternMatchers.EXACT;
-    }
-
-    public DefaultExclude(String group, String module) {
-        this.moduleId = DefaultModuleIdentifier.newId(group, module);
         this.artifact = new DefaultIvyArtifactName(PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION);
         this.configurations = ImmutableSet.of();
         this.patternMatcher = PatternMatchers.EXACT;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -371,8 +371,8 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
         }
 
         @Override
-        public void addDependency(String group, String module, VersionConstraint versionConstraint) {
-            dependencies.add(new DependencyImpl(group, module, versionConstraint));
+        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<String> excludes) {
+            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes));
         }
 
         @Override
@@ -409,11 +409,13 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
         private final String group;
         private final String module;
         private final VersionConstraint versionConstraint;
+        private final List<String> excludes;
 
-        DependencyImpl(String group, String module, VersionConstraint versionConstraint) {
+        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<String> excludes) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
+            this.excludes = excludes;
         }
 
         @Override
@@ -429,6 +431,11 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
         @Override
         public VersionConstraint getVersionConstraint() {
             return versionConstraint;
+        }
+
+        @Override
+        public List<String> getExcludes() {
+            return excludes;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -410,13 +410,13 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
         private final String group;
         private final String module;
         private final VersionConstraint versionConstraint;
-        private final List<Exclude> excludes;
+        private final ImmutableList<Exclude> excludes;
 
         DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<Exclude> excludes) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
-            this.excludes = excludes;
+            this.excludes = ImmutableList.copyOf(excludes);
         }
 
         @Override
@@ -435,7 +435,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
         }
 
         @Override
-        public List<Exclude> getExcludes() {
+        public ImmutableList<Exclude> getExcludes() {
             return excludes;
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -34,6 +34,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.DependencyMetadataRules;
+import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantMetadata;
@@ -371,7 +372,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
         }
 
         @Override
-        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<String> excludes) {
+        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<Exclude> excludes) {
             dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes));
         }
 
@@ -409,9 +410,9 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
         private final String group;
         private final String module;
         private final VersionConstraint versionConstraint;
-        private final List<String> excludes;
+        private final List<Exclude> excludes;
 
-        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<String> excludes) {
+        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<Exclude> excludes) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
@@ -434,7 +435,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata<T extends DefaultCo
         }
 
         @Override
-        public List<String> getExcludes() {
+        public List<Exclude> getExcludes() {
             return excludes;
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.internal.component.model.VariantMetadata;
 
+import java.util.List;
+
 /**
  * An _immutable_ view of the variant of a component.
  *
@@ -38,6 +40,8 @@ public interface ComponentVariant extends VariantMetadata {
         String getModule();
 
         VersionConstraint getVersionConstraint();
+
+        List<String> getExcludes();
     }
 
     interface File {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
@@ -21,8 +21,6 @@ import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.VariantMetadata;
 
-import java.util.List;
-
 /**
  * An _immutable_ view of the variant of a component.
  *
@@ -42,7 +40,7 @@ public interface ComponentVariant extends VariantMetadata {
 
         VersionConstraint getVersionConstraint();
 
-        List<Exclude> getExcludes();
+        ImmutableList<Exclude> getExcludes();
     }
 
     interface File {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.VariantMetadata;
 
 import java.util.List;
@@ -41,7 +42,7 @@ public interface ComponentVariant extends VariantMetadata {
 
         VersionConstraint getVersionConstraint();
 
-        List<String> getExcludes();
+        List<Exclude> getExcludes();
     }
 
     interface File {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
@@ -18,8 +18,10 @@ package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.VersionConstraint;
 
+import java.util.List;
+
 public interface MutableComponentVariant {
     void addFile(String name, String uri);
 
-    void addDependency(String group, String module, VersionConstraint versionConstraint);
+    void addDependency(String group, String module, VersionConstraint versionConstraint, List<String> excludes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
@@ -17,11 +17,12 @@
 package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.internal.component.model.Exclude;
 
 import java.util.List;
 
 public interface MutableComponentVariant {
     void addFile(String name, String uri);
 
-    void addDependency(String group, String module, VersionConstraint versionConstraint, List<String> excludes);
+    void addDependency(String group, String module, VersionConstraint versionConstraint, List<Exclude> excludes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -18,17 +18,13 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.Transformer;
-import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.external.descriptor.DefaultExclude;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
@@ -37,7 +33,6 @@ import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.GradleDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantMetadata;
-import org.gradle.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,14 +56,7 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
         List<GradleDependencyMetadata> dependencies = new ArrayList<GradleDependencyMetadata>(variant.getDependencies().size());
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint());
-            List<Exclude> excludes = CollectionUtils.collect(dependency.getExcludes(), new Transformer<Exclude, String>() {
-                @Override
-                public Exclude transform(String s) {
-                    String[] parts = s.split(":");
-                    ModuleIdentifier moduleIdentifier = DefaultModuleIdentifier.newId(parts[0], parts[1]);
-                    return new DefaultExclude(moduleIdentifier);
-                }
-            });
+            List<Exclude> excludes = dependency.getExcludes();
             dependencies.add(new GradleDependencyMetadata(selector, excludes));
         }
         this.dependencies = ImmutableList.copyOf(dependencies);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/Exclude.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/Exclude.java
@@ -20,13 +20,34 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 
 import java.util.Set;
 
+/**
+ * Represents the complete model of an exclude rule supported by Gradle.
+ * Several attributes of this model are not able to be configured in the DSL via {@link org.gradle.api.artifacts.ExcludeRule},
+ * and are only present to support the rich exclude syntax supported in Ivy.xml files.
+ */
 public interface Exclude {
+    /**
+     * The coordinates of the module to be excluded.
+     * A '*' value for group or name indicates a wildcard match.
+     */
     ModuleIdentifier getModuleId();
 
+    /**
+     * The attributes of the artifact to be excluded.
+     * NOTE: only supported for exclude rules sourced from an Ivy module descriptor (ivy.xml).
+     */
     IvyArtifactName getArtifact();
 
+    /**
+     * The configurations that should be excluded.
+     * NOTE: only supported for exclude rules sourced from an Ivy module descriptor (ivy.xml).
+     */
     Set<String> getConfigurations();
 
+    /**
+     * The name of the Ivy pattern matcher to use for this exclude.
+     * NOTE: only supported for exclude rules sourced from an Ivy module descriptor (ivy.xml).
+     */
     String getMatcher();
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/GradleDependencyMetadata.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.component.model;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
@@ -29,14 +28,22 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.local.model.DefaultProjectDependencyMetadata;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 public class GradleDependencyMetadata extends AbstractDependencyMetadata implements ModuleDependencyMetadata {
     private final ModuleComponentSelector selector;
+    private final List<Exclude> excludes;
 
     public GradleDependencyMetadata(ModuleComponentSelector selector) {
         this.selector = selector;
+        this.excludes = Collections.emptyList();
+    }
+
+    public GradleDependencyMetadata(ModuleComponentSelector selector, List<Exclude> excludes) {
+        this.selector = selector;
+        this.excludes = excludes;
     }
 
     @Override
@@ -72,12 +79,12 @@ public class GradleDependencyMetadata extends AbstractDependencyMetadata impleme
 
     @Override
     public List<Exclude> getExcludes() {
-        return ImmutableList.of();
+        return excludes;
     }
 
     @Override
     public List<Exclude> getExcludes(Collection<String> configurations) {
-        return ImmutableList.of();
+        return excludes;
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -46,10 +46,10 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        cacheLayout.key == 'metadata-2.37'
-        cacheLayout.version == VersionNumber.parse("2.37.0")
-        cacheLayout.formattedVersion == '2.37'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.37')
+        cacheLayout.key == 'metadata-2.38'
+        cacheLayout.version == VersionNumber.parse("2.38.0")
+        cacheLayout.formattedVersion == '2.38'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.38')
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -54,7 +54,7 @@ class ModuleMetadataParserTest extends Specification {
         def metadata = Mock(MutableComponentVariantResolveMetadata)
 
         when:
-        parser.parse(resource('{ "formatVersion": "0.2" }'), metadata)
+        parser.parse(resource('{ "formatVersion": "0.3" }'), metadata)
 
         then:
         0 * metadata._
@@ -66,7 +66,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "component": { "url": "elsewhere", "group": "g", "module": "m", "version": "v" },
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } }
     }
@@ -82,7 +82,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "component": { "url": "elsewhere", "group": "g", "module": "m", "version": "v", "attributes": {"foo": "bar", "org.gradle.status": "release" } },
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } }
     }
@@ -100,7 +100,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "variants": [
             {
                 "name": "api",
@@ -127,7 +127,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "variants": [
             {
                 "name": "api",
@@ -155,7 +155,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "variants": [
             {
                 "name": "api",
@@ -195,7 +195,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "variants": [
             {
                 "name": "api",
@@ -246,7 +246,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } },
         "variants": [
             {
@@ -270,7 +270,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "variants": [
             {
                 "name": "api"
@@ -299,7 +299,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "variants": [
             {
                 "name": "api",
@@ -349,7 +349,7 @@ class ModuleMetadataParserTest extends Specification {
 
         when:
         parser.parse(resource('''{ 
-            "formatVersion": "0.2",
+            "formatVersion": "0.3",
             "otherString": "string",
             "otherNumber": 123,
             "otherBoolean": true,
@@ -368,7 +368,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "variants": [
             {
                 "name": "api",
@@ -395,7 +395,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "variants": [
             {
                 "name": "api",
@@ -426,7 +426,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.2", 
+        "formatVersion": "0.3", 
         "variants": [
             {
                 "name": "api",
@@ -508,7 +508,7 @@ class ModuleMetadataParserTest extends Specification {
         then:
         def e = thrown(MetaDataParseException)
         e.message == "Could not parse module metadata <resource>"
-        e.cause.message == "Unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 0.2 only."
+        e.cause.message == "Unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 0.3 only."
     }
 
     def attributes(Map<String, ?> values) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser
 import org.gradle.api.Transformer
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.model.NamedObjectInstantiator
@@ -31,7 +32,8 @@ import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class ModuleMetadataParserTest extends Specification {
-    def parser = new ModuleMetadataParser(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE)
+    def identifierFactory = new DefaultImmutableModuleIdentifierFactory()
+    def parser = new ModuleMetadataParser(TestUtil.attributesFactory(), identifierFactory, NamedObjectInstantiator.INSTANCE)
 
     VersionConstraint prefers(String version) {
         DefaultImmutableVersionConstraint.of(version)
@@ -44,7 +46,7 @@ class ModuleMetadataParserTest extends Specification {
     List<Exclude> excludes(String... input) {
         return input.collect {
             String[] parts = it.split(":")
-            new DefaultExclude(parts[0], parts[1])
+            new DefaultExclude(identifierFactory.module(parts[0], parts[1]))
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -104,7 +104,7 @@ class ModuleMetadataParserTest extends Specification {
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant
         1 * variant.addFile("a.zip", "a.zop")
-        1 * variant.addDependency("g1", "m1", prefers("v1"))
+        1 * variant.addDependency("g1", "m1", prefers("v1"), [])
         0 * _
     }
 
@@ -209,12 +209,12 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g1", "m1", prefers("v1"))
-        1 * variant1.addDependency("g2", "m2", prefers("v2"))
+        1 * variant1.addDependency("g1", "m1", prefers("v1"), [])
+        1 * variant1.addDependency("g2", "m2", prefers("v2"), [])
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependency("g3", "m3", prefers("v3"))
-        1 * variant2.addDependency("g4", "m4", prefersAndRejects("v4", ["v5"]))
-        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]))
+        1 * variant2.addDependency("g3", "m3", prefers("v3"), [])
+        1 * variant2.addDependency("g4", "m4", prefersAndRejects("v4", ["v5"]), [])
+        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [])
         0 * _
     }
 
@@ -306,9 +306,9 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g1", "m1", prefers("v1"))
+        1 * variant1.addDependency("g1", "m1", prefers("v1"), [])
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependency("g2", "m2", prefers("v2"))
+        1 * variant2.addDependency("g2", "m2", prefers("v2"), [])
         0 * _
     }
 
@@ -427,7 +427,7 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes()) >> variant
-        1 * variant.addDependency("g", "m", prefers("v"))
+        1 * variant.addDependency("g", "m", prefers("v"), [])
         0 * metadata._
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
@@ -42,7 +42,7 @@ class DefaultFlatDirArtifactRepositoryTest extends Specification {
     final ArtifactIdentifierFileStore artifactIdentifierFileStore = Stub()
     final ivyContextManager = Mock(IvyContextManager)
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final ModuleMetadataParser metadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), Mock(NamedObjectInstantiator))
+    final ModuleMetadataParser metadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
 
     final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, ivyContextManager, moduleIdentifierFactory, Mock(FileResourceRepository), metadataParser)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -51,7 +51,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     final AuthenticationContainer authenticationContainer = Stub()
     final ivyContextManager = Mock(IvyContextManager)
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final ModuleMetadataParser moduleMetadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), Mock(NamedObjectInstantiator))
+    final ModuleMetadataParser moduleMetadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
 
     final DefaultIvyArtifactRepository repository = new DefaultIvyArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, new ExperimentalFeatures())
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
@@ -341,10 +341,10 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
 
         given:
         def v1 = metadata.addVariant("api", attributes(usage: "compile"))
-        v1.addDependency("g1", "m1", v("v1"))
-        v1.addDependency("g2", "m2", v("v2"))
+        v1.addDependency("g1", "m1", v("v1"), [])
+        v1.addDependency("g2", "m2", v("v2"), [])
         def v2 = metadata.addVariant("runtime", attributes(usage: "runtime"))
-        v2.addDependency("g1", "m1", v("v1"))
+        v2.addDependency("g1", "m1", v("v1"), [])
 
         expect:
         metadata.variants.size() == 2
@@ -391,11 +391,11 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
         def v1 = metadata.addVariant("api", attributes1)
         v1.addFile("f1.jar", "f1.jar")
         v1.addFile("f2.jar", "f2-1.2.jar")
-        v1.addDependency("g1", "m1", v("v1"))
+        v1.addDependency("g1", "m1", v("v1"), [])
         def v2 = metadata.addVariant("runtime", attributes2)
         v2.addFile("f2", "f2-version.zip")
-        v2.addDependency("g2", "m2", v("v2"))
-        v2.addDependency("g3", "m3", v("v3"))
+        v2.addDependency("g2", "m2", v("v2"), [])
+        v2.addDependency("g3", "m3", v("v3"), [])
 
         expect:
         metadata.variantsForGraphTraversal.size() == 2

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyMetadataRulesTest.groovy
@@ -198,7 +198,7 @@ class DependencyMetadataRulesTest extends Specification {
 
     private addDependency(AbstractMutableModuleComponentResolveMetadata<? extends DefaultConfigurationMetadata> resolveMetadata, String group, String name, String version) {
         if (resolveMetadata instanceof MutableMavenModuleResolveMetadata && !resolveMetadata.variants.empty) {
-            defaultVariant.addDependency(group, name, new DefaultMutableVersionConstraint(version))
+            defaultVariant.addDependency(group, name, new DefaultMutableVersionConstraint(version), [])
         } else if (resolveMetadata instanceof MutableMavenModuleResolveMetadata) {
             //legacy dependency handling
             resolveMetadata.dependencies += new MavenDependencyMetadata(MavenScope.Compile, false, newSelector(group, name, version), [], [])

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
@@ -101,8 +101,6 @@ Each element must be an object with the of the following values:
 
 An exclude that has a wildcard value for both `group` and `module` will exclude _all_ transitive dependencies.
 
-#### `exclude `
-
 ### `files` value
 
 This value must contain an array with zero or more elements. Each element must be an object with the following values:

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
@@ -2,7 +2,7 @@
 
 _Note: this format is not yet stable and may change at any time. Gradle does not guarantee to offer any long term support for this version of the format._
 
-This document describes version 0.2 of the Gradle module metadata file. A module metadata file describes the contents of a _module_, which is the unit of publication for a particular repository format, such as a module in a Maven repository. This is often called a "package" in many repository formats.
+This document describes version 0.3 of the Gradle module metadata file. A module metadata file describes the contents of a _module_, which is the unit of publication for a particular repository format, such as a module in a Maven repository. This is often called a "package" in many repository formats.
 
 The module metadata file is a JSON file published alongside the existing repository specific metadata files, such as a Maven POM or Ivy descriptor. It adds additional metadata that can be used by Gradle versions and other tooling that understand the format. This allows the rich Gradle model to be mapped to and "tunnelled" through existing repository formats, while continuing to support existing Gradle versions and tooling that does not understand the format. 
 
@@ -10,7 +10,7 @@ The module metadata file is intended to be machine generated rather than written
 
 The module metadata file is also intended to fully describe the binaries in the module where it is present so that it can replace the existing metadata files. This would allow a Gradle repository format to be added, for example.
 
-In version 0.2, the module metadata file can describe only those modules that contain a single _component_, which is some piece of software such as a library or application. Support for more sophisticated mappings will be added by later versions.
+In version 0.3, the module metadata file can describe only those modules that contain a single _component_, which is some piece of software such as a library or application. Support for more sophisticated mappings will be added by later versions.
 
 ## Usage in a Maven repository
 
@@ -24,7 +24,7 @@ The file must be encoded using UTF-8.
 
 The file must contain a JSON object with the following values:
 
-- `formatVersion`: must be present and the first value of the JSON object. Its value must be `"0.2"`
+- `formatVersion`: must be present and the first value of the JSON object. Its value must be `"0.3"`
 - `component`: optional. Describes the identity of the component contained in the module.
 - `builtBy`: optional. Describes the producer of this metadata file and the contents of the module.
 - `variants`: optional. Describes the variants of the component packaged in the module, if any.
@@ -74,7 +74,7 @@ This value must contain an object with a value for each attribute. The attribute
 
 This value must contain an object with the following values:
 
-- `url`: The location of the metadata file that describes the variant. A string. In version 0.2, this must be a path relative to the module.
+- `url`: The location of the metadata file that describes the variant. A string. In version 0.3, this must be a path relative to the module.
 - `group`: The group of the module. A string
 - `module`: The name of the module. A string
 - `version`: The version of the module. A string
@@ -108,7 +108,7 @@ An exclude that has a wildcard value for both `group` and `module` will exclude 
 This value must contain an array with zero or more elements. Each element must be an object with the following values:
 
 - `name`: The name of the file. A string. This will be used to calculate the name of the file in the cache.
-- `url`: The location of the file. A string. In version 0.2, this must be a path relative to the module.
+- `url`: The location of the file. A string. In version 0.3, this must be a path relative to the module.
 - `size`: The size of the file in bytes. A number.
 - `sha1`: The SHA1 hash of the file content. A hex string.
 - `md5`: The MD5 hash of the file content. A hex string.
@@ -117,7 +117,7 @@ This value must contain an array with zero or more elements. Each element must b
 
 ```
 {
-    "formatVersion": "0.2",
+    "formatVersion": "0.3",
     "component": {
         "group": "my.group",
         "module": "mylib",

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
@@ -88,6 +88,20 @@ This value must contain an array with zero or more elements. Each element must b
 - `version`: The version constraint of the dependency. Has the same meaning as in the Gradle DSL. A version constraint consists of:
    - `prefers`: The preferred version for this dependency
    - `rejects`: An array of rejected versions for this dependency. Can be omitted.
+- `excludes`: optional. Defines the exclusions that apply to this dependency. 
+
+#### `excludes` value
+
+This value must contain an array with zero or more elements. Each element has the same meaning as `exclude` in the Gradle DSL.
+
+Each element must be an object with the of the following values:
+
+- `group`: The group to exclude from transitive dependencies, or wildcard '*' if any group may be excluded.
+- `module`: The module to exclude from transitive dependencies, or wildcard '*' if any module may be excluded.
+
+An exclude that has a wildcard value for both `group` and `module` will exclude _all_ transitive dependencies.
+
+#### `exclude `
 
 ### `files` value
 
@@ -131,7 +145,14 @@ This value must contain an array with zero or more elements. Each element must b
                 }
             ],
             "dependencies": [
-                { "group": "some.group", "module": "other-lib", "version": { "prefers": "3.4" } }
+                { 
+                    "group": "some.group", 
+                    "module": "other-lib", 
+                    "version": { "prefers": "3.4" } 
+                    "excludes": [
+                        { "group": "*", "module": "excluded-lib" }
+                    ]
+                }
             ]
         },
         {
@@ -149,7 +170,11 @@ This value must contain an array with zero or more elements. Each element must b
                 }
             ],
             "dependencies": [
-                { "group": "some.group", "module": "other-lib", "version": { "prefers": "3.4", "rejects": ["3.4.1"] } }
+                { 
+                    "group": "some.group", 
+                    "module": "other-lib", 
+                    "version": { "prefers": "3.4", "rejects": ["3.4.1"] } 
+                }
             ]
         }
     ]

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -146,7 +146,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
 
     public VersionNumber getArtifactCacheLayoutVersion() {
         if (isSameOrNewer("4.5-rc-1")) {
-            return VersionNumber.parse("2.37");
+            return VersionNumber.parse("2.38");
         } else if (isSameOrNewer("4.4-rc-1")) {
             return VersionNumber.parse("2.36");
         } else if (isSameOrNewer("4.3-rc-1")) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -131,7 +131,7 @@ class GradleModuleMetadata {
         }
 
         List<Dependency> getDependencies() {
-            return (values.dependencies ?: []).collect { new Dependency(it.group, it.module, it.version.prefers, it.version.rejects?:[]) }
+            return (values.dependencies ?: []).collect { new Dependency(it.group, it.module, it.version.prefers, it.version.rejects?:[], it.excludes?:[]) }
         }
 
         List<File> getFiles() {
@@ -167,8 +167,10 @@ class GradleModuleMetadata {
     }
 
     static class Dependency extends Coords {
-        Dependency(String group, String module, String version, List<String> rejectedVersions) {
+        final List<String> excludes
+        Dependency(String group, String module, String version, List<String> rejectedVersions, List<String> excludes) {
             super(group, module, version, rejectedVersions)
+            this.excludes = excludes
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -131,7 +131,10 @@ class GradleModuleMetadata {
         }
 
         List<Dependency> getDependencies() {
-            return (values.dependencies ?: []).collect { new Dependency(it.group, it.module, it.version.prefers, it.version.rejects?:[], it.excludes?:[]) }
+            return (values.dependencies ?: []).collect {
+                def exclusions = it.excludes ? it.excludes.collect { "${it.group}:${it.module}" } : []
+                new Dependency(it.group, it.module, it.version.prefers, it.version.rejects?:[], exclusions)
+            }
         }
 
         List<File> getFiles() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -33,7 +33,7 @@ class GradleModuleMetadata {
             JsonReader reader = new JsonReader(r)
             values = readObject(reader)
         }
-        assert values.formatVersion == '0.2'
+        assert values.formatVersion == '0.3'
         assert values.createdBy.gradle.version == GradleVersion.current().version
         assert values.createdBy.gradle.buildId
         variants = (values.variants ?: []).collect { new Variant(it.name, it) }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -33,8 +33,8 @@ class DependencySpec {
         rejects = r?:Collections.<String>emptyList()
         if (e) {
             exclusions = e.collect { Map exclusion ->
-                def group = (String) exclusion.get('group')
-                def module = (String) exclusion.get('module')
+                String group = exclusion.get('group')?.toString()
+                String module = exclusion.get('module')?.toString()
                 new ExcludeSpec(group, module)
             }
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -24,11 +24,13 @@ class DependencySpec {
     String module
     String prefers
     List<String> rejects
+    List<String> exclusions
 
-    DependencySpec(String g, String m, String version, List<String> r) {
+    DependencySpec(String g, String m, String version, List<String> r, List<String> e = []) {
         group = g
         module = m
         prefers = version
         rejects = r?:Collections.<String>emptyList()
+        exclusions = e
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/ExcludeSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/ExcludeSpec.groovy
@@ -19,24 +19,12 @@ package org.gradle.test.fixtures.gradle
 import groovy.transform.CompileStatic
 
 @CompileStatic
-class DependencySpec {
+class ExcludeSpec {
     String group
     String module
-    String prefers
-    List<String> rejects
-    List<ExcludeSpec> exclusions = []
 
-    DependencySpec(String g, String m, String version, List<String> r, Collection<Map> e) {
-        group = g
-        module = m
-        prefers = version
-        rejects = r?:Collections.<String>emptyList()
-        if (e) {
-            exclusions = e.collect { Map exclusion ->
-                def group = (String) exclusion.get('group')
-                def module = (String) exclusion.get('module')
-                new ExcludeSpec(group, module)
-            }
-        }
+    ExcludeSpec(String g, String m) {
+        group = g ?: '*'
+        module = m ?: '*'
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -39,7 +39,7 @@ class GradleFileModuleAdapter {
         def file = moduleDir.file("$module-${version}.module")
         def jsonBuilder = new JsonBuilder()
         jsonBuilder {
-            formatVersion '0.2'
+            formatVersion '0.3'
             builtBy {
                 gradle { }
             }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -75,6 +75,9 @@ class GradleFileModuleAdapter {
                                 prefers d.prefers
                                 rejects d.rejects
                             }
+                            if (d.exclusions) {
+                                excludes d.exclusions
+                            }
                         }
                     })
                 }
@@ -83,6 +86,7 @@ class GradleFileModuleAdapter {
         file.withWriter('utf-8') {
             jsonBuilder.writeTo(it)
         }
+        println file.text
     }
 
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -76,7 +76,12 @@ class GradleFileModuleAdapter {
                                 rejects d.rejects
                             }
                             if (d.exclusions) {
-                                excludes d.exclusions
+                                excludes(d.exclusions.collect { e ->
+                                    { ->
+                                        group e.group
+                                        module e.module
+                                    }
+                                })
                             }
                         }
                     })
@@ -86,7 +91,6 @@ class GradleFileModuleAdapter {
         file.withWriter('utf-8') {
             jsonBuilder.writeTo(it)
         }
-        println file.text
     }
 
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -319,7 +319,8 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.name,
                     v.attributes,
                     dependencies.collect { d ->
-                        new DependencySpec(d.organisation, d.module, d.revision, d.rejects)
+                        List<String> exclusions = d.exclusions ? d.exclusions.collect { exc -> "${exc.group ?: '*'}:${exc.module ?: '*'}" } : []
+                        new DependencySpec(d.organisation, d.module, d.revision, d.rejects, exclusions)
                     },
                     artifacts.collect { moduleArtifact(it) }
                 )

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -319,8 +319,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.name,
                     v.attributes,
                     dependencies.collect { d ->
-                        List<String> exclusions = d.exclusions ? d.exclusions.collect { exc -> "${exc.group ?: '*'}:${exc.module ?: '*'}" } : []
-                        new DependencySpec(d.organisation, d.module, d.revision, d.rejects, exclusions)
+                        new DependencySpec(d.organisation, d.module, d.revision, d.rejects, d.exclusions)
                     },
                     artifacts.collect { moduleArtifact(it) }
                 )

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -387,7 +387,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.name,
                     v.attributes,
                     dependencies.collect { d ->
-                        new DependencySpec(d.groupId, d.artifactId, d.version, d.rejects)
+                        List<String> exclusions = d.exclusions ? d.exclusions.collect { exc -> "${exc.group ?: '*'}:${exc.module ?: '*'}" } : []
+                        new DependencySpec(d.groupId, d.artifactId, d.version, d.rejects, exclusions)
                     },
                     [getArtifact([:])]
                 )

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -387,8 +387,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.name,
                     v.attributes,
                     dependencies.collect { d ->
-                        List<String> exclusions = d.exclusions ? d.exclusions.collect { exc -> "${exc.group ?: '*'}:${exc.module ?: '*'}" } : []
-                        new DependencySpec(d.groupId, d.artifactId, d.version, d.rejects, exclusions)
+                        new DependencySpec(d.groupId, d.artifactId, d.version, d.rejects, d.exclusions)
                     },
                     [getArtifact([:])]
                 )

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -81,7 +81,6 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     def "can publish java-library with dependencies and excludes"() {
-        resolveModuleMetadata = false // Excludes not yet honoured in module metadata
         given:
         createBuildScripts("""
 
@@ -123,10 +122,18 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
 
         javaLibrary.parsedPom.scopes.keySet() == ["compile"] as Set
         javaLibrary.parsedPom.scopes.compile.assertDependsOn("commons-collections:commons-collections:3.2.2", "commons-io:commons-io:1.4", "org.springframework:spring-core:2.5.6", "commons-beanutils:commons-beanutils:1.8.3", "commons-dbcp:commons-dbcp:1.4", "org.apache.camel:camel-jackson:2.15.3")
-        assert javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("org.springframework:spring-core:2.5.6", new MavenDependencyExclusion("commons-logging", "commons-logging"))
-        assert javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("commons-beanutils:commons-beanutils:1.8.3", new MavenDependencyExclusion("commons-logging", "*"))
-        assert javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("commons-dbcp:commons-dbcp:1.4", new MavenDependencyExclusion("*", "*"))
-        assert javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("org.apache.camel:camel-jackson:2.15.3", new MavenDependencyExclusion("*", "camel-core"))
+        javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("org.springframework:spring-core:2.5.6", new MavenDependencyExclusion("commons-logging", "commons-logging"))
+        javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("commons-beanutils:commons-beanutils:1.8.3", new MavenDependencyExclusion("commons-logging", "*"))
+        javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("commons-dbcp:commons-dbcp:1.4", new MavenDependencyExclusion("*", "*"))
+        javaLibrary.parsedPom.scopes.compile.hasDependencyExclusion("org.apache.camel:camel-jackson:2.15.3", new MavenDependencyExclusion("*", "camel-core"))
+
+        and:
+        javaLibrary.assertApiDependencies("commons-collections:commons-collections:3.2.2", "commons-io:commons-io:1.4", "org.springframework:spring-core:2.5.6", "commons-beanutils:commons-beanutils:1.8.3", "commons-dbcp:commons-dbcp:1.4", "org.apache.camel:camel-jackson:2.15.3")
+        def apiVariant = javaLibrary.parsedModuleMetadata.variant('api')
+        apiVariant.dependencies.find { it.coords == 'org.springframework:spring-core:2.5.6' }.excludes == ['commons-logging:commons-logging']
+        apiVariant.dependencies.find { it.coords == 'commons-beanutils:commons-beanutils:1.8.3' }.excludes == ['commons-logging:*']
+        apiVariant.dependencies.find { it.coords == 'commons-dbcp:commons-dbcp:1.4' }.excludes == ['*:*']
+        apiVariant.dependencies.find { it.coords == 'org.apache.camel:camel-jackson:2.15.3' }.excludes == ['*:camel-core']
 
         and:
         resolveArtifacts(javaLibrary) == [

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
@@ -68,7 +69,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "0.2",
+  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -96,7 +97,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "0.2",
+  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -154,7 +155,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "0.2",
+  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -234,7 +235,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "0.2",
+  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -309,7 +310,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "0.2",
+  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -368,7 +369,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "0.2",
+  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -433,7 +434,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "0.2",
+  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "url": "../../module/1.2/module-1.2.module",
     "group": "group",


### PR DESCRIPTION
Adds support for publishing and resolving dependency excludes for variants published to Gradle module metadata. Dependency exclusions support `group` and `module` attributes, and multiple exclusions may be provided per-dependency. A `*` value for `group` or `module` represents a wildcard match.

In module metadata, a dependency exclude appears as:
```
"dependencies": [ 
    { 
        "group": "g3", 
        "module": "m3", 
        "version": { "prefers": "v3" },
        "excludes": [
            {"group": "gx", "module": "mx" },
            {"group": "excluded-group", "module": "*" }
         ]
    }
]
```