### PR TITLE
Fix ValidateTaskProperties producing output in wrong directory

### DIFF
--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -247,9 +247,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
         validator.setGroup(PLUGIN_DEVELOPMENT_GROUP);
         validator.setDescription(VALIDATE_TASK_PROPERTIES_TASK_DESCRIPTION);
 
-        File reportsDir = new File(project.getBuildDir(), "reports");
-        File validatorReportsDir = new File(reportsDir, "task-properties");
-        validator.setOutputFile(new File(validatorReportsDir, "report.txt"));
+        validator.getOutputFile().set(project.getLayout().getBuildDirectory().file("reports/task-properties/report.txt"));
 
         final SourceSet mainSourceSet = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
         validator.setClasses(mainSourceSet.getOutput().getClassesDirs());

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -33,11 +33,9 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.EmptyFileVisitor;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileVisitDetails;
-import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.DocumentationRegistry;
-import org.gradle.api.internal.provider.AbstractProvider;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -55,12 +53,10 @@ import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
-import org.gradle.util.DeprecationLogger;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
@@ -323,45 +319,6 @@ public class ValidateTaskProperties extends ConventionTask implements Verificati
     @OutputFile
     public RegularFileProperty getOutputFile() {
         return outputFile;
-    }
-
-    /**
-     * Sets the output file to store the report in.
-     *
-     * @since 4.0
-     *
-     * @deprecated Use {@link #getOutputFile()} instead.
-     */
-    @Deprecated
-    public void setOutputFile(File outputFile) {
-        DeprecationLogger.nagUserOfReplacedMethod("ValidateTaskProperties.setOutputFile(File)", "getOutputFile()");
-        this.outputFile.set(outputFile);
-    }
-
-    /**
-     * Sets the output file to store the report in.
-     *
-     * @deprecated Use {@link #getOutputFile()} instead.
-     */
-    @Deprecated
-    public void setOutputFile(@Nullable final Object outputFile) {
-        DeprecationLogger.nagUserOfReplacedMethod("ValidateTaskProperties.setOutputFile(Object)", "getOutputFile()");
-        this.outputFile.set(new AbstractProvider<RegularFile>() {
-            @Override
-            public Class<RegularFile> getType() {
-                return RegularFile.class;
-            }
-
-            @Override
-            public RegularFile getOrNull() {
-                return outputFile == null ? null : new RegularFile() {
-                    @Override
-                    public File getAsFile() {
-                        return getProject().file(outputFile);
-                    }
-                };
-            }
-        });
     }
 
     /**


### PR DESCRIPTION
Previously the task did not respect if the `buildDir` location was changed.

Fixes #3546.