### PR TITLE
Fix link to ParameterizedToolingModelBuilder in 4.4 release notes

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -28,7 +28,7 @@ The Tooling API now allows model builders to accept parameters from the tooling 
 
 Android Studio, for instance, will use this API to request just the dependencies for the variant that the user currently selected in the UI. This will greatly reduce synchronization times.
 
-For more information see the [documentation](javadoc/org/gradle/tooling/provider/model/ParametrizedToolingModelBuilder.html) of the new API.
+For more information see the [documentation](javadoc/org/gradle/tooling/provider/model/ParameterizedToolingModelBuilder.html) of the new API.
 
 ### Eclipse plugin separates output folders
 


### PR DESCRIPTION
### Context

Release notes links to https://docs.gradle.org/4.4-rc-1/javadoc/org/gradle/tooling/provider/model/ParametrizedToolingModelBuilder.html instead of https://docs.gradle.org/4.4-rc-1/javadoc/org/gradle/tooling/provider/model/ParametrizedToolingModelBuilder.html

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
