### PR TITLE
Integrate dependencies check as Branch Build Accept job

### DIFF
--- a/.teamcity/Gradle_Check/configurations/DependenciesCheck.kt
+++ b/.teamcity/Gradle_Check/configurations/DependenciesCheck.kt
@@ -1,0 +1,16 @@
+package configurations
+
+import model.CIBuildModel
+
+class DependenciesCheck(model: CIBuildModel) : BaseGradleBuildType(model, {
+    uuid = "${model.projectPrefix}DependenciesCheck"
+    extId = uuid
+    name = "Dependencies Check - Java8 Linux"
+    description = "Checks external dependencies in Gradle distribution for known, published vulnerabilities"
+
+    params {
+        param("env.JAVA_HOME", "%linux.java8.oracle.64bit%")
+    }
+
+    applyDefaults(model, this, "dependencyCheckAnalyze", notQuick = true)
+})

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -4,6 +4,7 @@ import configurations.BuildDistributions
 import configurations.Gradleception
 import configurations.SanityCheck
 import configurations.SmokeTests
+import configurations.DependenciesCheck
 import jetbrains.buildServer.configs.kotlin.v10.BuildType
 
 data class CIBuildModel (
@@ -28,7 +29,8 @@ data class CIBuildModel (
                     specificBuilds = listOf(
                             SpecificBuild.BuildDistributions,
                             SpecificBuild.Gradleception,
-                            SpecificBuild.SmokeTests),
+                            SpecificBuild.SmokeTests,
+                            SpecificBuild.DependenciesCheck),
                     functionalTests = listOf(
                             TestCoverage(TestType.platform, OS.linux, JvmVersion.java7),
                             TestCoverage(TestType.platform, OS.windows, JvmVersion.java8)),
@@ -238,6 +240,11 @@ enum class SpecificBuild {
     SmokeTests {
         override fun create(model: CIBuildModel): BuildType {
             return SmokeTests(model)
+        }
+    },
+    DependenciesCheck {
+        override fun create(model: CIBuildModel): BuildType {
+            return DependenciesCheck(model)
         }
     };
 


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle/issues/3217 and https://github.com/gradle/gradle/pull/3436

Right now the task `dependencyCheckAnalyze` only exists on `master`.  The builds will likely fail on any branch that doesn't have the task yet. Is there a way to only activate the job on `master` but not on branches or `release` for now?