### PR TITLE
Add ability to define an executable for rendering sample output in docs

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/build/docs/UserGuideTransformTask.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/UserGuideTransformTask.groovy
@@ -246,18 +246,19 @@ class UserGuideTransformTask extends DefaultTask {
                     String args = child.'@args'
                     String outputFile = child.'@outputFile' ?: "${sampleId}.out"
                     boolean hidden = child.'@hidden' ?: false
+                    String executable = child.'@executable' ?: 'gradle'
 
                     if (!hidden) {
                         Element outputTitle = doc.createElement("para")
                         outputTitle.appendChild(doc.createTextNode("Output of "))
                         Element commandElement = doc.createElement('userinput')
-                        commandElement.appendChild(doc.createTextNode("gradle $args"))
+                        commandElement.appendChild(doc.createTextNode("$executable $args"))
                         outputTitle.appendChild(commandElement)
                         exampleElement.appendChild(outputTitle)
 
                         Element screenElement = doc.createElement('screen')
                         File srcFile = new File(sourceFile.parentFile, "../../../src/samples/userguideOutput/${outputFile}").canonicalFile
-                        screenElement.appendChild(doc.createTextNode("> gradle $args\n" + normalise(srcFile.text)))
+                        screenElement.appendChild(doc.createTextNode("> $executable $args\n" + normalise(srcFile.text)))
                         exampleElement.appendChild(screenElement)
                     }
                 } else if (child.name() == 'layout') {

--- a/subprojects/docs/src/docs/userguide/potentialTraps.adoc
+++ b/subprojects/docs/src/docs/userguide/potentialTraps.adoc
@@ -25,7 +25,7 @@ For Gradle users it is important to understand how Groovy deals with script vari
 ++++
 <sample xmlns:xi="http://www.w3.org/2001/XInclude" id="scope" dir="userguide/tutorial" title="Variables scope: local and script wide">
             <sourcefile file="scope.groovy"/>
-            <output args="scope.groovy" executable="groovy" />
+            <output executable="groovy" args="scope.groovy" />
         </sample>
 ++++
 

--- a/subprojects/docs/src/docs/userguide/potentialTraps.adoc
+++ b/subprojects/docs/src/docs/userguide/potentialTraps.adoc
@@ -29,7 +29,7 @@ For Gradle users it is important to understand how Groovy deals with script vari
         </sample>
 ++++
 
-Variables which are declared with a type modifier are visible within closures but not visible within methods. This is a heavily discussed behavior in the Groovy community.footnote:[One of those discussions can be found here: http://groovy.329449.n5.nabble.com/script-scoping-question-td355887.html[] ]
+Variables which are declared with a type modifier are visible within closures but not visible within methods.
 
 [[sec:configuration_and_execution_phase]]
 === Configuration and execution phase

--- a/subprojects/docs/src/docs/userguide/potentialTraps.adoc
+++ b/subprojects/docs/src/docs/userguide/potentialTraps.adoc
@@ -25,11 +25,11 @@ For Gradle users it is important to understand how Groovy deals with script vari
 ++++
 <sample xmlns:xi="http://www.w3.org/2001/XInclude" id="scope" dir="userguide/tutorial" title="Variables scope: local and script wide">
             <sourcefile file="scope.groovy"/>
-            <output args=""/>
+            <output args="scope.groovy" executable="groovy" />
         </sample>
 ++++
 
-Variables which are declared with a type modifier are visible within closures but not visible within methods. This is a heavily discussed behavior in the Groovy community.footnote:[One of those discussions can be found here: http://groovy.329449.n5.nabble.com/script-scoping-question-td355887.html[] ] 
+Variables which are declared with a type modifier are visible within closures but not visible within methods. This is a heavily discussed behavior in the Groovy community.footnote:[One of those discussions can be found here: http://groovy.329449.n5.nabble.com/script-scoping-question-td355887.html[] ]
 
 [[sec:configuration_and_execution_phase]]
 === Configuration and execution phase


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle/issues/3489

This change will also come in handy in other contexts e.g. to render output for builds that have been invoked via `./gradlew` on the Wrapper documentation page (see https://github.com/gradle/gradle/pull/3544).