### PR TITLE
Let the Gradle build *Wrapper tasks use -all wrapper distributions

### DIFF
--- a/gradle/wrapper.gradle
+++ b/gradle/wrapper.gradle
@@ -25,8 +25,9 @@ def wrapperUpdateTask = { name, label ->
                 if (version.empty) {
                     throw new GradleException("Cannot update wrapper to '${label}' version as there is currently no version of that label")
                 }
-                distributionUrl version.downloadUrl.replace("-bin", "-all")
-                println "updating wrapper to $label version: $version.version (distributionUrl: $distributionUrl)"
+                gradleVersion = version.version
+                distributionType = Wrapper.DistributionType.ALL
+                println "updating wrapper to $label version: $gradleVersion (distributionUrl: $distributionUrl)"
             }
         }
     }

--- a/gradle/wrapper.gradle
+++ b/gradle/wrapper.gradle
@@ -25,8 +25,8 @@ def wrapperUpdateTask = { name, label ->
                 if (version.empty) {
                     throw new GradleException("Cannot update wrapper to '${label}' version as there is currently no version of that label")
                 }
-                println "updating wrapper to $label version: $version.version (downloadUrl: $version.downloadUrl)"
-                distributionUrl version.downloadUrl
+                distributionUrl version.downloadUrl.replace("-bin", "-all")
+                println "updating wrapper to $label version: $version.version (distributionUrl: $distributionUrl)"
             }
         }
     }


### PR DESCRIPTION
### Context
In order to get Gradle sources in the IDE when editing build logic.
