### PR TITLE
Publish Gradle metadata to Ivy repositories

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
@@ -18,13 +18,18 @@ package org.gradle.internal.component.external.model;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.ModuleSource;
 
+import javax.annotation.Nullable;
+
 public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentResolveMetadata implements IvyModuleResolveMetadata {
+    private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = PreferJavaRuntimeVariant.schema();
+
     private final ImmutableMap<String, Configuration> configurationDefinitions;
     private final ImmutableList<Artifact> artifacts;
     private final ImmutableList<Exclude> excludes;
@@ -96,5 +101,11 @@ public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentReso
     @Override
     public ImmutableList<? extends ConfigurationMetadata> getVariantsForGraphTraversal() {
         return graphVariants;
+    }
+
+    @Nullable
+    @Override
+    public AttributesSchemaInternal getAttributesSchema() {
+        return SCHEMA_DEFAULT_JAVA_VARIANTS;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -17,28 +17,19 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.attributes.DisambiguationRule;
-import org.gradle.api.internal.attributes.EmptySchema;
-import org.gradle.api.internal.attributes.MultipleCandidatesResult;
-import org.gradle.api.internal.model.NamedObjectInstantiator;
-import org.gradle.internal.Cast;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Set;
 
 public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentResolveMetadata implements MavenModuleResolveMetadata {
 
     public static final String POM_PACKAGING = "pom";
     public static final Collection<String> JAR_PACKAGINGS = Arrays.asList("jar", "ejb", "bundle", "maven-plugin", "eclipse-plugin");
-    private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = new PreferJavaRuntimeVariant();
+    private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = PreferJavaRuntimeVariant.schema();
 
     private final String packaging;
     private final boolean relocated;
@@ -111,36 +102,4 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
         return SCHEMA_DEFAULT_JAVA_VARIANTS;
     }
 
-    /**
-     * When no consumer attributes are provided, prefer the Java runtime variant over the API variant.
-     *
-     * Gradle has long assumed that, by default, consumers of a maven repository require the _runtime_ variant
-     * of the published library.
-     * The following disambiguation rule encodes this assumption for the case where a java library is published
-     * with variants using Gradle module metadata. This will allow us to migrate to consuming the new module
-     * metadata format by default without breaking a bunch of consumers that depend on this assumption,
-     * declaring no preference for a particular variant.
-     */
-    private static class PreferJavaRuntimeVariant extends EmptySchema {
-        private static final NamedObjectInstantiator INSTANTIATOR = NamedObjectInstantiator.INSTANCE;
-        private static final Usage JAVA_API = INSTANTIATOR.named(Usage.class, Usage.JAVA_API);
-        private static final Usage JAVA_RUNTIME = INSTANTIATOR.named(Usage.class, Usage.JAVA_RUNTIME);
-        private static final Set<Usage> DEFAULT_JAVA_USAGES = ImmutableSet.of(JAVA_API, JAVA_RUNTIME);
-
-        @Override
-        public DisambiguationRule<Object> disambiguationRules(Attribute<?> attribute) {
-            if (attribute.getType().equals(Usage.class)) {
-                return Cast.uncheckedCast(new DisambiguationRule<Usage>() {
-                    public void execute(MultipleCandidatesResult<Usage> details) {
-                        if (details.getConsumerValue() == null) {
-                            if (details.getCandidateValues().equals(DEFAULT_JAVA_USAGES)) {
-                                details.closestMatch(JAVA_RUNTIME);
-                            }
-                        }
-                    }
-                });
-            }
-            return super.disambiguationRules(attribute);
-        }
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.attributes.DisambiguationRule;
+import org.gradle.api.internal.attributes.EmptySchema;
+import org.gradle.api.internal.attributes.MultipleCandidatesResult;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.Cast;
+
+import java.util.Set;
+
+/**
+ * When no consumer attributes are provided, prefer the Java runtime variant over the API variant.
+ *
+ * Gradle has long assumed that, by default, consumers of a maven repository require the _runtime_ variant
+ * of the published library.
+ * The following disambiguation rule encodes this assumption for the case where a java library is published
+ * with variants using Gradle module metadata. This will allow us to migrate to consuming the new module
+ * metadata format by default without breaking a bunch of consumers that depend on this assumption,
+ * declaring no preference for a particular variant.
+ */
+class PreferJavaRuntimeVariant extends EmptySchema {
+    private static final NamedObjectInstantiator INSTANTIATOR = NamedObjectInstantiator.INSTANCE;
+    private static final Usage JAVA_API = INSTANTIATOR.named(Usage.class, Usage.JAVA_API);
+    private static final Usage JAVA_RUNTIME = INSTANTIATOR.named(Usage.class, Usage.JAVA_RUNTIME);
+    private static final Set<Usage> DEFAULT_JAVA_USAGES = ImmutableSet.of(JAVA_API, JAVA_RUNTIME);
+
+    private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = new PreferJavaRuntimeVariant();
+
+    static PreferJavaRuntimeVariant schema() {
+        return SCHEMA_DEFAULT_JAVA_VARIANTS;
+    }
+
+    private PreferJavaRuntimeVariant() {
+    }
+
+    @Override
+    public DisambiguationRule<Object> disambiguationRules(Attribute<?> attribute) {
+        if (attribute.getType().equals(Usage.class)) {
+            return Cast.uncheckedCast(new DisambiguationRule<Usage>() {
+                public void execute(MultipleCandidatesResult<Usage> details) {
+                    if (details.getConsumerValue() == null) {
+                        if (details.getCandidateValues().equals(DEFAULT_JAVA_USAGES)) {
+                            details.closestMatch(JAVA_RUNTIME);
+                        }
+                    }
+                }
+            });
+        }
+        return super.disambiguationRules(attribute);
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleMetadataAwarePublishingSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleMetadataAwarePublishingSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures
+
+import groovy.transform.CompileStatic
+import groovy.transform.SelfType
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+@CompileStatic
+@SelfType(AbstractIntegrationSpec)
+trait GradleMetadataAwarePublishingSpec {
+    boolean publishModuleMetadata = true
+    boolean resolveModuleMetadata = true
+
+    // cannot use "setup" because of a bug with Spock
+    void prepare() {
+        executer.beforeExecute {
+            if (publishModuleMetadata) {
+                withArgument("-Dorg.gradle.internal.experimentalFeatures")
+            }
+        }
+    }
+
+    void disableModuleMetadataPublishing() {
+        publishModuleMetadata = false
+        resolveModuleMetadata = false
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -57,6 +57,10 @@ class GradleModuleMetadata {
         return new ModuleReference(comp.group, comp.module, comp.version, comp.url)
     }
 
+    Map<String, String> getAttributes() {
+        values.component?.attributes
+    }
+
     List<Variant> getVariants() {
         return variants
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -218,6 +218,12 @@ class GradleModuleMetadata {
                 hasExclude('*', '*')
                 noMoreExcludes()
             }
+
+            DependencyView rejects(String... rejections) {
+                Set<String> actualRejects = find()?.rejectsVersion
+                Set<String> expectedRejects = rejections as Set
+                assert actualRejects == expectedRejects
+            }
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
@@ -31,5 +31,7 @@ public interface Module {
      * Returns the Gradle module metadata file of this module
      */
     ModuleArtifact getModuleMetadata()
+    GradleModuleMetadata getParsedModuleMetadata()
+
 
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
@@ -91,7 +91,7 @@ class IvyDescriptor {
 
     IvyDescriptorArtifact expectArtifact(String name) {
         return oneResult(artifacts.findAll({
-            it.name == name
+            it.name == name && it.ext != 'module'
         }), [name])
     }
 
@@ -109,6 +109,18 @@ class IvyDescriptor {
             assert dependencies.containsKey(key)
             assert dependencies[key].hasConf(conf)
         }
+        true
+    }
+
+    def assertConfigurationDependsOn(String configuration, String[] expected) {
+        def actualDependencies = dependencies.values().findAll { it.conf.contains(configuration) }
+        assert actualDependencies.size() == expected.length
+        expected.each {
+            String conf = "$configuration->default"
+            assert dependencies.containsKey(it)
+            assert dependencies[it].hasConf(conf)
+        }
+
         true
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependency.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependency.groovy
@@ -39,4 +39,9 @@ class IvyDescriptorDependency {
     boolean hasExclude(IvyDescriptorDependencyExclusion exclusion) {
         exclusions.contains(exclusion)
     }
+
+    @Override
+    String toString() {
+        "$org:$module:$revision $conf ${transitive?'(transitive)':''}"
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -19,6 +19,7 @@ import groovy.xml.MarkupBuilder
 import org.gradle.api.Action
 import org.gradle.internal.xml.XmlTransformer
 import org.gradle.test.fixtures.AbstractModule
+import org.gradle.test.fixtures.GradleModuleMetadata
 import org.gradle.test.fixtures.Module
 import org.gradle.test.fixtures.ModuleArtifact
 import org.gradle.test.fixtures.file.TestFile
@@ -219,6 +220,11 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     @Override
     ModuleArtifact getModuleMetadata() {
         moduleArtifact(name: module, type: 'module', ext: "module")
+    }
+
+    @Override
+    GradleModuleMetadata getParsedModuleMetadata() {
+        return new GradleModuleMetadata(moduleMetadataFile)
     }
 
     TestFile getIvyFile() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.ivy
+
+import org.gradle.test.fixtures.ModuleArtifact
+import org.gradle.test.fixtures.PublishedJavaModule
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.server.http.DelegatingIvyModule
+
+class IvyJavaModule extends DelegatingIvyModule<IvyFileModule> implements PublishedJavaModule {
+    private final IvyFileModule backingModule
+    final List<ModuleArtifact> additionalArtifacts = []
+
+    IvyJavaModule(IvyFileModule backingModule) {
+        super(backingModule)
+        this.backingModule = backingModule
+    }
+
+    @Override
+    ModuleArtifact getIvy() {
+        backingModule.ivy
+    }
+
+    @Override
+    ModuleArtifact getJar() {
+        backingModule.jar
+    }
+
+    @Override
+    ModuleArtifact getModuleMetadata() {
+        backingModule.moduleMetadata
+    }
+
+    @Override
+    PublishedJavaModule withClassifiedArtifact(String classifier, String extension) {
+        def module = backingModule.moduleArtifact(classifier: classifier, ext: extension)
+        additionalArtifacts << module
+        this
+    }
+
+    @Override
+    void assertNoDependencies() {
+        assert backingModule.parsedIvy.dependencies.isEmpty()
+        assertApiDependencies()
+    }
+
+    @Override
+    void assertApiDependencies(String... expected) {
+        if (expected.length == 0) {
+            assert parsedModuleMetadata.variant('api').dependencies.empty
+            assert parsedIvy.dependencies.findAll { it.value.conf == 'compile' }.isEmpty()
+        } else {
+            assert parsedModuleMetadata.variant('api').dependencies*.coords as Set == expected as Set
+            assert parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
+            parsedIvy.assertConfigurationDependsOn('compile', expected)
+        }
+    }
+
+    @Override
+    void assertRuntimeDependencies(String... expected) {
+        if (expected.length == 0) {
+            assert parsedModuleMetadata.variant('runtime').dependencies.empty
+            assert parsedIvy.dependencies.findAll { it.value.conf == 'runtime' }.isEmpty()
+        } else {
+            assert parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
+            parsedIvy.assertConfigurationDependsOn('runtime', expected)
+        }
+
+    }
+
+    @Override
+    void assertPublishedAsJavaModule() {
+        assertPublished()
+    }
+
+    @Override
+    void assertPublishedAsWebModule() {
+        super.assertPublished()
+
+        def war = backingModule.file(type:'war')
+        List<String> expectedArtifacts = [war.name, backingModule.moduleMetadataFile.name, backingModule.ivyFile.name]
+        expectedArtifacts.addAll(additionalArtifacts.file.name)
+        backingModule.assertArtifactsPublished(expectedArtifacts as String[])
+
+        // Verify Gradle metadata particulars
+        // TODO: Should probably map to 'runtime', see org.gradle.api.internal.java.WebApplication
+        assert backingModule.parsedModuleMetadata.variants*.name as Set == ['master'] as Set
+        assert backingModule.parsedModuleMetadata.variant('master').files*.name == [war.name]
+    }
+
+    @Override
+    void assertPublished() {
+        super.assertPublished()
+
+        List<String> expectedArtifacts = [backingModule.jarFile.name, backingModule.moduleMetadataFile.name, backingModule.ivyFile.name]
+        expectedArtifacts.addAll(additionalArtifacts.file.name)
+        backingModule.assertArtifactsPublished(expectedArtifacts as String[])
+
+        // Verify Gradle metadata particulars
+        assert backingModule.parsedModuleMetadata.variants*.name as Set == ['api', 'runtime'] as Set
+        assert backingModule.parsedModuleMetadata.variant('api').files*.name == [backingModule.jarFile.name]
+        assert backingModule.parsedModuleMetadata.variant('runtime').files*.name == [backingModule.jarFile.name]
+    }
+
+    void assertNotPublished() {
+        backingModule.assertNotPublished()
+    }
+
+    TestFile getModuleDir() {
+        backingModule.moduleDir
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
@@ -123,5 +123,12 @@ public interface IvyModule extends Module {
      */
     void assertIvyAndJarFilePublished();
 
+    /**
+     * Assert that exactly the module metadata file, ivy.xml and jar file for this module, plus checksum files, have been published.
+     */
+    void assertMetadataAndJarFilePublished();
+
     void assertPublishedAsJavaModule();
+
+    void assertPublishedAsWebModule();
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.test.fixtures.maven
 
-import org.gradle.test.fixtures.GradleModuleMetadata
 import org.gradle.test.fixtures.Module
 import org.gradle.test.fixtures.ModuleArtifact
 import org.gradle.test.fixtures.file.TestFile
@@ -117,8 +116,6 @@ interface MavenModule extends Module {
     TestFile getMetaDataFile()
 
     MavenPom getParsedPom()
-
-    GradleModuleMetadata getParsedModuleMetadata()
 
     ModuleArtifact getRootMetaData()
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
@@ -17,6 +17,7 @@ package org.gradle.test.fixtures.server.http;
 
 import groovy.lang.Closure;
 import org.gradle.internal.Cast;
+import org.gradle.test.fixtures.GradleModuleMetadata;
 import org.gradle.test.fixtures.Module;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.test.fixtures.ivy.IvyDescriptor;
@@ -60,6 +61,11 @@ public abstract class DelegatingIvyModule<T extends IvyModule> implements IvyMod
 
     public IvyDescriptor getParsedIvy() {
         return backingModule.getParsedIvy();
+    }
+
+    @Override
+    public GradleModuleMetadata getParsedModuleMetadata() {
+        return backingModule.getParsedModuleMetadata();
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
@@ -83,6 +83,11 @@ public abstract class DelegatingIvyModule<T extends IvyModule> implements IvyMod
         backingModule.assertPublishedAsJavaModule();
     }
 
+    @Override
+    public void assertPublishedAsWebModule() {
+        backingModule.assertPublishedAsWebModule();
+    }
+
     public T publish() {
         backingModule.publish();
         return t();
@@ -198,4 +203,8 @@ public abstract class DelegatingIvyModule<T extends IvyModule> implements IvyMod
         backingModule.assertIvyAndJarFilePublished();
     }
 
+    @Override
+    public void assertMetadataAndJarFilePublished() {
+        backingModule.assertMetadataAndJarFilePublished();
+    }
 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy
+
+class IvyGradleModuleMetadataPublishIntegrationTest extends AbstractIvyPublishIntegTest {
+    def setup() {
+        buildFile << """
+// TODO - use public APIs when available
+class TestComponent implements org.gradle.api.internal.component.SoftwareComponentInternal, ComponentWithVariants {
+    String name
+    Set usages = []
+    Set variants = []
+}
+
+class TestUsage implements org.gradle.api.internal.component.UsageContext {
+    String name
+    Usage usage
+    Set dependencies = []
+    Set artifacts = []
+    AttributeContainer attributes
+}
+
+class TestVariant implements org.gradle.api.internal.component.SoftwareComponentInternal {
+    String name
+    Set usages = []
+}
+
+    allprojects {
+        configurations { implementation }
+    }
+"""
+    }
+
+    def "generates metadata for component with no variants"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = ivyRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.variants.empty
+        module.parsedModuleMetadata.attributes.size() == 1
+        module.parsedModuleMetadata.attributes['org.gradle.status'] == 'integration'
+    }
+
+    def "publishes ivy status"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                        descriptor {
+                           status = 'milestone'
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = ivyRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.variants.empty
+        module.parsedModuleMetadata.attributes.size() == 1
+        module.parsedModuleMetadata.attributes['org.gradle.status'] == 'milestone'
+    }
+
+    def "maps project dependencies"() {
+        given:
+        settingsFile << """rootProject.name = 'root'
+            include 'a', 'b'
+"""
+        buildFile << """
+            allprojects {
+                apply plugin: 'ivy-publish'
+    
+                group = 'group'
+                version = '1.0'
+
+                publishing {
+                    repositories {
+                        ivy { url "${ivyRepo.uri}" }
+                    }
+                }
+            }
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: configurations.implementation.attributes))
+
+            dependencies {
+                implementation project(':a')
+                implementation project(':b')
+            }
+
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                    }
+                }
+            }
+            
+            project(':a') {
+                publishing {
+                    publications {
+                        ivy(IvyPublication) {
+                            organisation = 'group.a' 
+                            module = 'lib_a'
+                            revision = '4.5'
+                        }
+                    }
+                }
+            }
+            project(':b') {
+                publishing {
+                    publications {
+                        ivy(IvyPublication) {
+                            organisation = 'group.b' 
+                            module = 'utils'
+                            revision = '0.01'
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = ivyRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.variants.size() == 1
+        def api = module.parsedModuleMetadata.variant('api')
+        api.dependencies[0].coords == 'group.a:lib_a:4.5'
+        api.dependencies[1].coords == 'group.b:utils:0.01'
+    }
+
+    def "publishes component with strict dependencies"() {
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: configurations.implementation.attributes))
+
+            dependencies {
+                implementation("org:foo") {
+                    version {
+                        strictly '1.0'
+                    }
+                }
+                implementation("org:bar:2.0")
+            }
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = ivyRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.variants.size() == 1
+        def variant = module.parsedModuleMetadata.variants[0]
+        variant.dependencies.size() == 2
+
+        variant.dependencies[0].group == 'org'
+        variant.dependencies[0].module == 'foo'
+        variant.dependencies[0].version == '1.0'
+        variant.dependencies[0].rejectsVersion == [']1.0,)']
+
+        variant.dependencies[1].group == 'org'
+        variant.dependencies[1].module == 'bar'
+        variant.dependencies[1].version == '2.0'
+        variant.dependencies[1].rejectsVersion == []
+    }
+
+}

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishArtifactCustomizationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishArtifactCustomizationIntegTest.groovy
@@ -149,6 +149,7 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
     }
 
     def "can set custom artifacts to override component artifacts"() {
+        publishModuleMetadata = false
         given:
         createBuildScripts("""
             publications {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishBasicIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishBasicIntegTest.groovy
@@ -17,7 +17,7 @@
 
 package org.gradle.api.publish.ivy
 
-public class IvyPublishBasicIntegTest extends AbstractIvyPublishIntegTest {
+class IvyPublishBasicIntegTest extends AbstractIvyPublishIntegTest {
 
     def "publishes nothing without defined publication"() {
         given:
@@ -81,7 +81,7 @@ public class IvyPublishBasicIntegTest extends AbstractIvyPublishIntegTest {
 
     def "can publish simple jar"() {
         given:
-        def module = ivyRepo.module('group', 'root', '1.0')
+        def javaLibrary = javaLibrary(ivyRepo.module('group', 'root', '1.0'))
 
         and:
         settingsFile << "rootProject.name = 'root'"
@@ -108,19 +108,19 @@ public class IvyPublishBasicIntegTest extends AbstractIvyPublishIntegTest {
         succeeds 'assemble'
 
         then: "jar is built but not published"
-        module.assertNotPublished()
+        javaLibrary.assertNotPublished()
         file('build/libs/root-1.0.jar').assertExists()
 
         when:
         succeeds 'publish'
 
         then: "jar is published to defined ivy repository"
-        module.assertPublishedAsJavaModule()
-        module.parsedIvy.status == 'integration'
-        module.moduleDir.file('root-1.0.jar').assertIsCopyOf(file('build/libs/root-1.0.jar'))
+        javaLibrary.assertPublishedAsJavaModule()
+        javaLibrary.parsedIvy.status == 'integration'
+        javaLibrary.moduleDir.file('root-1.0.jar').assertIsCopyOf(file('build/libs/root-1.0.jar'))
 
         and:
-        resolveArtifacts(module) == ['root-1.0.jar']
+        resolveArtifacts(javaLibrary) == ['root-1.0.jar']
     }
 
     def "reports failure publishing when model validation fails"() {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
@@ -17,11 +17,11 @@
 
 package org.gradle.api.publish.ivy
 
-public class IvyPublishCoordinatesIntegTest extends AbstractIvyPublishIntegTest {
+class IvyPublishCoordinatesIntegTest extends AbstractIvyPublishIntegTest {
 
     def "can publish single jar with specified coordinates"() {
         given:
-        def module = ivyRepo.module('org.custom', 'custom', '2.2')
+        def javaLibrary = javaLibrary(ivyRepo.module('org.custom', 'custom', '2.2'))
 
         and:
         settingsFile << "rootProject.name = 'root'"
@@ -54,14 +54,18 @@ public class IvyPublishCoordinatesIntegTest extends AbstractIvyPublishIntegTest 
         file('build/libs/root-1.0.jar').assertExists()
 
         and:
-        module.assertPublishedAsJavaModule()
-        module.moduleDir.file('custom-2.2.jar').assertIsCopyOf(file('build/libs/root-1.0.jar'))
+        javaLibrary.assertPublishedAsJavaModule()
+        javaLibrary.moduleDir.file('custom-2.2.jar').assertIsCopyOf(file('build/libs/root-1.0.jar'))
 
         and:
-        resolveArtifacts(module) == ['custom-2.2.jar']
+        resolveArtifacts(javaLibrary) == ['custom-2.2.jar']
     }
 
     def "can produce multiple separate publications for single project"() {
+        // cannot yet publish Gradle metadata when there's no associated component
+        resolveModuleMetadata = false
+        publishModuleMetadata = false
+
         given:
         def module = ivyRepo.module('org.custom', 'custom', '2.2')
         def apiModule = ivyRepo.module('org.custom', 'custom-api', '2')

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
@@ -35,7 +35,7 @@ import static org.gradle.test.matchers.UserAgentMatcher.matchesNameAndVersion
 import static org.gradle.util.Matchers.matchesRegexp
 import static org.gradle.util.TestPrecondition.FIX_TO_WORK_ON_JAVA9
 
-public class IvyPublishHttpIntegTest extends AbstractIvyPublishIntegTest {
+class IvyPublishHttpIntegTest extends AbstractIvyPublishIntegTest {
     private static final String BAD_CREDENTIALS = '''
 credentials {
     username 'testuser'
@@ -82,15 +82,18 @@ credentials {
         module.jar.sha1.expectPut()
         module.ivy.expectPut(HttpStatus.ORDINAL_201_Created)
         module.ivy.sha1.expectPut(HttpStatus.ORDINAL_201_Created)
+        module.moduleMetadata.expectPut()
+        module.moduleMetadata.sha1.expectPut()
 
         when:
         succeeds 'publish'
 
         then:
-        module.assertIvyAndJarFilePublished()
+        module.assertMetadataAndJarFilePublished()
         module.jarFile.assertIsCopyOf(file('build/libs/publish-2.jar'))
 
         and:
+        progressLogging.uploadProgressLogged(module.moduleMetadata.uri)
         progressLogging.uploadProgressLogged(module.ivy.uri)
         progressLogging.uploadProgressLogged(module.jar.uri)
     }
@@ -132,16 +135,19 @@ credentials {
         module.jar.sha1.expectPut('testuser', 'password')
         module.ivy.expectPut('testuser', 'password')
         module.ivy.sha1.expectPut('testuser', 'password')
+        module.moduleMetadata.expectPut('testuser', 'password')
+        module.moduleMetadata.sha1.expectPut('testuser', 'password')
 
         when:
         run 'publish'
 
         then:
-        module.assertIvyAndJarFilePublished()
+        module.assertMetadataAndJarFilePublished()
         module.jarFile.assertIsCopyOf(file('build/libs/publish-2.jar'))
 
         and:
         progressLogging.uploadProgressLogged(module.ivy.uri)
+        progressLogging.uploadProgressLogged(module.moduleMetadata.uri)
         progressLogging.uploadProgressLogged(module.jar.uri)
 
         where:
@@ -278,12 +284,14 @@ credentials {
         module.jar.sha1.expectPut()
         module.ivy.expectPut()
         module.ivy.sha1.expectPut()
+        module.moduleMetadata.expectPut()
+        module.moduleMetadata.sha1.expectPut()
 
         when:
         run 'publish'
 
         then:
-        module.assertIvyAndJarFilePublished()
+        module.assertMetadataAndJarFilePublished()
         module.jarFile.assertIsCopyOf(file('build/libs/publish-2.jar'))
     }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpsIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpsIntegTest.groovy
@@ -102,6 +102,8 @@ class IvyPublishHttpsIntegTest extends AbstractIvyPublishIntegTest {
         module.jar.sha1.expectPut()
         module.ivy.expectPut()
         module.ivy.sha1.expectPut()
+        module.moduleMetadata.expectPut()
+        module.moduleMetadata.sha1.expectPut()
     }
 
     def verifyPublications() {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -18,11 +18,21 @@
 package org.gradle.api.publish.ivy
 
 import spock.lang.Issue
+import spock.lang.Unroll
 
 class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
-    def ivyModule = ivyRepo.module("org.gradle.test", "publishTest", "1.9")
+    def javaLibrary = javaLibrary(ivyRepo.module("org.gradle.test", "publishTest", "1.9"))
 
-    public void "can publish jar and descriptor to ivy repository"() {
+    String getDependencies() {
+        """dependencies {
+                api "commons-collections:commons-collections:3.2.2"
+                compileOnly "javax.servlet:servlet-api:2.5"
+                runtimeOnly "commons-io:commons-io:1.4"
+                testImplementation "junit:junit:4.12"
+            }
+"""
+    }
+    void "can publish jar and descriptor to ivy repository"() {
         given:
         createBuildScripts("""
             publishing {
@@ -32,25 +42,93 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                     }
                 }
             }
+
+            $dependencies            
 """)
 
         when:
         run "publish"
 
         then:
-        ivyModule.assertPublishedAsJavaModule()
+        javaLibrary.assertPublishedAsJavaModule()
 
-        with (ivyModule.parsedIvy) {
+        with (javaLibrary.parsedIvy) {
             configurations.keySet() == ["default", "compile", "runtime"] as Set
             configurations["default"].extend == ["runtime", "compile"] as Set
             configurations["runtime"].extend == null
 
             expectArtifact("publishTest").hasAttributes("jar", "jar", ["compile"])
         }
-        ivyModule.parsedIvy.assertDependsOn("commons-collections:commons-collections:3.2.2@compile", "commons-io:commons-io:1.4@compile")
+        javaLibrary.assertApiDependencies('commons-collections:commons-collections:3.2.2')
+        javaLibrary.assertRuntimeDependencies('commons-io:commons-io:1.4')
 
         and:
-        resolveArtifacts(ivyModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(javaLibrary) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
+
+    }
+
+    @Unroll("'#gradleConfiguration' dependencies end up in '#ivyConfiguration' configuration with '#plugin' plugin")
+    void "maps dependencies in the correct Ivy configuration"() {
+        given:
+        file("settings.gradle") << '''
+            rootProject.name = 'publishTest' 
+            include "b"
+        '''
+        buildFile << """
+            apply plugin: "$plugin"
+            apply plugin: "ivy-publish"
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                    }
+                }
+            }
+            
+            dependencies {
+                $gradleConfiguration project(':b')
+            }
+        """
+
+        file('b/build.gradle') << """
+            apply plugin: 'java'
+            
+            group = 'org.gradle.test'
+            version = '1.2'
+            
+        """
+
+        when:
+        succeeds "publish"
+
+        then:
+        javaLibrary.assertPublished()
+        if (ivyConfiguration == 'compile') {
+            javaLibrary.assertApiDependencies('org.gradle.test:b:1.2')
+        } else {
+            javaLibrary.assertRuntimeDependencies('org.gradle.test:b:1.2')
+        }
+
+        where:
+        plugin         | gradleConfiguration  | ivyConfiguration
+        'java'         | 'compile'            | 'compile'
+        'java'         | 'runtime'            | 'compile'
+        'java'         | 'implementation'     | 'runtime'
+        'java'         | 'runtimeOnly'        | 'runtime'
+
+        'java-library' | 'api'                | 'compile'
+        'java-library' | 'compile'            | 'compile'
+        'java-library' | 'runtime'            | 'compile'
+        'java-library' | 'runtimeOnly'        | 'runtime'
+        'java-library' | 'implementation'     | 'runtime'
+
     }
 
     public void "ignores extra artifacts added to configurations"() {
@@ -80,12 +158,14 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        ivyModule.assertPublishedAsJavaModule()
+        javaLibrary.assertPublishedAsJavaModule()
     }
 
-    public void "can publish additional artifacts for java project"() {
+    void "can publish additional artifacts for java project"() {
         given:
         createBuildScripts("""
+            $dependencies
+
             task sourceJar(type: Jar) {
                 from sourceSets.main.allJava
                 baseName "publishTest-source"
@@ -109,19 +189,23 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        ivyModule.assertPublished()
-        ivyModule.assertArtifactsPublished("publishTest-1.9.jar", "publishTest-1.9-source.jar", "ivy-1.9.xml")
+        javaLibrary.withClassifiedArtifact('source', 'jar')
+        javaLibrary.assertPublishedAsJavaModule()
 
-        ivyModule.parsedIvy.expectArtifact("publishTest", "jar", "source").hasAttributes("jar", "sources", ["runtime"], "source")
+        javaLibrary.parsedIvy.expectArtifact("publishTest", "jar", "source").hasAttributes("jar", "sources", ["runtime"], "source")
 
         and:
-        resolveArtifacts(ivyModule) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9-source.jar", "publishTest-1.9.jar"]
+        resolveArtifacts(javaLibrary) == ["commons-collections-3.2.2.jar", "commons-io-1.4.jar", "publishTest-1.9.jar"]
+        resolveAdditionalArtifacts(javaLibrary) == ["publishTest-1.9-source.jar"]
     }
 
     @Issue("GRADLE-3514")
-    public void "generated ivy descriptor includes dependency exclusions"() {
+    void "generated ivy descriptor includes dependency exclusions"() {
+        resolveModuleMetadata = false // Excludes not yet honoured in module metadata
         given:
         createBuildScripts("""
+            $dependencies
+
             dependencies {
                 compile 'org.springframework:spring-core:2.5.6', {
                     exclude group: 'commons-logging', module: 'commons-logging'
@@ -150,21 +234,21 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        ivyModule.assertPublishedAsJavaModule()
+        javaLibrary.assertPublishedAsJavaModule()
 
-        def dependency = ivyModule.parsedIvy.expectDependency("org.springframework:spring-core:2.5.6")
+        def dependency = javaLibrary.parsedIvy.expectDependency("org.springframework:spring-core:2.5.6")
         dependency.exclusions.size() == 1
         dependency.exclusions[0].org == 'commons-logging'
         dependency.exclusions[0].module == 'commons-logging'
 
-        ivyModule.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].hasConf("compile->default")
-        ivyModule.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].exclusions[0].org == 'commons-logging'
-        !ivyModule.parsedIvy.dependencies["commons-dbcp:commons-dbcp:1.4"].transitiveEnabled()
-        ivyModule.parsedIvy.dependencies["org.apache.camel:camel-jackson:2.15.3"].hasConf("compile->default")
-        ivyModule.parsedIvy.dependencies["org.apache.camel:camel-jackson:2.15.3"].exclusions[0].module == 'camel-core'
+        javaLibrary.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].hasConf("compile->default")
+        javaLibrary.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].exclusions[0].org == 'commons-logging'
+        !javaLibrary.parsedIvy.dependencies["commons-dbcp:commons-dbcp:1.4"].transitiveEnabled()
+        javaLibrary.parsedIvy.dependencies["org.apache.camel:camel-jackson:2.15.3"].hasConf("compile->default")
+        javaLibrary.parsedIvy.dependencies["org.apache.camel:camel-jackson:2.15.3"].exclusions[0].module == 'camel-core'
 
         and:
-        resolveArtifacts(ivyModule) == [
+        resolveArtifacts(javaLibrary) == [
             "camel-jackson-2.15.3.jar",
             "commons-beanutils-1.8.3.jar",
             "commons-collections-3.2.2.jar",
@@ -179,42 +263,13 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         ]
     }
 
-    def createBuildScripts(def append) {
-        settingsFile << "rootProject.name = 'publishTest' "
-
-        buildFile << """
-            apply plugin: 'ivy-publish'
-            apply plugin: 'java'
-
-            publishing {
-                repositories {
-                    ivy { url "${ivyRepo.uri}" }
-                }
-            }
-
-$append
-
-            group = 'org.gradle.test'
-            version = '1.9'
-
-            ${mavenCentralRepository()}
-
-            dependencies {
-                compile "commons-collections:commons-collections:3.2.2"
-                compileOnly "javax.servlet:servlet-api:2.5"
-                runtime "commons-io:commons-io:1.4"
-                testCompile "junit:junit:4.12"
-            }
-"""
-    }
-
     void "defaultDependencies are included in published ivy descriptor"() {
         given:
         settingsFile << "rootProject.name = 'publishTest' "
 
         buildFile << """
             apply plugin: 'ivy-publish'
-            apply plugin: 'java'
+            apply plugin: 'java-library'
 
             group = 'org.gradle.test'
             version = '1.9'
@@ -241,8 +296,8 @@ $append
         succeeds "publish"
 
         then:
-        ivyModule.assertPublishedAsJavaModule()
-        ivyModule.parsedIvy.assertDependsOn("org.test:default-dependency:1.1@compile")
+        javaLibrary.assertPublishedAsJavaModule()
+        javaLibrary.assertApiDependencies("org.test:default-dependency:1.1")
     }
 
     void "dependency mutations are included in published ivy descriptor"() {
@@ -251,7 +306,7 @@ $append
 
         buildFile << """
             apply plugin: 'ivy-publish'
-            apply plugin: 'java'
+            apply plugin: 'java-library'
 
             group = 'org.gradle.test'
             version = '1.9'
@@ -268,13 +323,13 @@ $append
             }
 
             dependencies {
-                compile "org.test:dep1:1.0"
+                api "org.test:dep1:1.0"
             }
 
-            configurations.compile.withDependencies { deps ->
+            configurations.api.withDependencies { deps ->
                 deps.add project.dependencies.create("org.test:dep2:1.1")
             }
-            configurations.compile.withDependencies { deps ->
+            configurations.api.withDependencies { deps ->
                 deps.each { dep ->
                     dep.version { prefer 'X' }
                 }
@@ -285,8 +340,32 @@ $append
         succeeds "publish"
 
         then:
-        ivyModule.assertPublishedAsJavaModule()
-        ivyModule.parsedIvy.assertDependsOn("org.test:dep1:X@compile", "org.test:dep2:X@compile")
+        javaLibrary.assertPublishedAsJavaModule()
+        javaLibrary.assertApiDependencies('org.test:dep1:X', 'org.test:dep2:X')
     }
+
+    private void createBuildScripts(def append) {
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        buildFile << """
+            apply plugin: 'ivy-publish'
+            apply plugin: 'java-library'
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+            }
+
+$append
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            ${mavenCentralRepository()}
+
+"""
+    }
+
 
 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.api.publish.ivy
 
 class IvyPublishMultiProjectIntegTest extends AbstractIvyPublishIntegTest {
-    def project1 = ivyRepo.module("org.gradle.test", "project1", "1.0")
-    def project2 = ivyRepo.module("org.gradle.test", "project2", "2.0")
-    def project3 = ivyRepo.module("org.gradle.test", "project3", "3.0")
+    def project1 = javaLibrary(ivyRepo.module("org.gradle.test", "project1", "1.0"))
+    def project2 = javaLibrary(ivyRepo.module("org.gradle.test", "project2", "2.0"))
+    def project3 = javaLibrary(ivyRepo.module("org.gradle.test", "project3", "3.0"))
 
     def "project dependencies are correctly bound to published project"() {
         createBuildScripts("")
@@ -29,20 +29,20 @@ class IvyPublishMultiProjectIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         project1.assertPublishedAsJavaModule()
-        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@compile", "org.gradle.test:project3:3.0@compile")
+        project1.assertApiDependencies("org.gradle.test:project2:2.0", "org.gradle.test:project3:3.0")
 
         project2.assertPublishedAsJavaModule()
-        project2.parsedIvy.assertDependsOn("org.gradle.test:project3:3.0@compile")
+        project2.assertApiDependencies("org.gradle.test:project3:3.0")
 
         project3.assertPublishedAsJavaModule()
-        project3.parsedIvy.dependencies.isEmpty()
+        project3.assertApiDependencies()
 
         and:
         resolveArtifacts(project1) == ['project1-1.0.jar', 'project2-2.0.jar', 'project3-3.0.jar']
     }
 
     def "project dependencies reference publication identity of dependent project"() {
-        def project3 = ivyRepo.module("changed.org", "changed-module", "changed")
+        def project3 = javaLibrary(ivyRepo.module("changed.org", "changed-module", "changed"))
 
         createBuildScripts("""
 project(":project3") {
@@ -61,13 +61,13 @@ project(":project3") {
 
         then:
         project1.assertPublishedAsJavaModule()
-        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@compile", "changed.org:changed-module:changed@compile")
+        project1.assertApiDependencies("org.gradle.test:project2:2.0", "changed.org:changed-module:changed")
 
         project2.assertPublishedAsJavaModule()
-        project2.parsedIvy.assertDependsOn("changed.org:changed-module:changed@compile")
+        project2.assertApiDependencies("changed.org:changed-module:changed")
 
         project3.assertPublishedAsJavaModule()
-        project3.parsedIvy.dependencies.isEmpty()
+        project3.assertApiDependencies()
 
         and:
         resolveArtifacts(project1) == ['changed-module-changed.jar', 'project1-1.0.jar', 'project2-2.0.jar']
@@ -142,7 +142,7 @@ project(":project3") {
         succeeds "publish"
 
         then:
-        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@compile", "custom:custom3:456@compile")
+        project1.assertApiDependencies("org.gradle.test:project2:2.0", "custom:custom3:456")
     }
 
     def "ivy-publish plugin does not take archivesBaseName into account"() {
@@ -157,11 +157,11 @@ project(":project2") {
 
         then:
         project1.assertPublishedAsJavaModule()
-        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:2.0@compile", "org.gradle.test:project3:3.0@compile")
+        project1.assertApiDependencies("org.gradle.test:project2:2.0", "org.gradle.test:project3:3.0")
 
         // published with the correct coordinates, even though artifact has different name
         project2.assertPublishedAsJavaModule()
-        project2.parsedIvy.assertDependsOn("org.gradle.test:project3:3.0@compile")
+        project2.assertApiDependencies("org.gradle.test:project3:3.0")
 
         project3.assertPublishedAsJavaModule()
         project3.parsedIvy.dependencies.isEmpty()
@@ -209,7 +209,7 @@ project(":project2") {
 
         then:
         project1.assertPublishedAsJavaModule()
-        project1.parsedIvy.assertDependsOn("org.gradle.test:project2:1.0@compile")
+        project1.assertApiDependencies("org.gradle.test:project2:1.0")
     }
 
     def "ivy-publish plugin publishes project dependency excludes in descriptor"() {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishVersionRangeIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishVersionRangeIntegTest.groovy
@@ -20,9 +20,9 @@ import groovy.transform.NotYetImplemented
 import spock.lang.Issue
 
 class IvyPublishVersionRangeIntegTest extends AbstractIvyPublishIntegTest {
-    def ivyModule = ivyRepo.module("org.gradle.test", "publishTest", "1.9")
+    def ivyModule = javaLibrary(ivyRepo.module("org.gradle.test", "publishTest", "1.9"))
 
-    public void "version range is mapped to ivy syntax in published ivy descriptor file"() {
+    void "version range is mapped to ivy syntax in published ivy descriptor file"() {
         given:
         settingsFile << "rootProject.name = 'publishTest' "
         buildFile << """
@@ -56,12 +56,12 @@ class IvyPublishVersionRangeIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         ivyModule.assertPublishedAsJavaModule()
-        ivyModule.parsedIvy.assertDependsOn(
-            "group:projectA:latest.release@compile",
-            "group:projectB:latest.integration@compile",
-            "group:projectC:1.+@compile",
-            "group:projectD:[1.0,2.0)@compile",
-            "group:projectE:[1.0]@compile"
+        ivyModule.assertApiDependencies(
+            "group:projectA:latest.release",
+            "group:projectB:latest.integration",
+            "group:projectC:1.+",
+            "group:projectD:[1.0,2.0)",
+            "group:projectE:[1.0]"
         )
     }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishWarIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishWarIntegTest.groovy
@@ -17,7 +17,7 @@ package org.gradle.api.publish.ivy
 
 class IvyPublishWarIntegTest extends AbstractIvyPublishIntegTest {
 
-    public void "can publish WAR only for mixed java and WAR project"() {
+    void "can publish WAR only for mixed java and WAR project"() {
         given:
         file("settings.gradle") << "rootProject.name = 'publishTest' "
 
@@ -58,7 +58,7 @@ class IvyPublishWarIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then: "module is published with artifacts"
-        def ivyModule = ivyRepo.module("org.gradle.test", "publishTest", "1.9")
+        def ivyModule = javaLibrary(ivyRepo.module("org.gradle.test", "publishTest", "1.9"))
         ivyModule.assertPublishedAsWebModule()
 
         and: "correct configurations and depdendencies declared"

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
@@ -38,4 +38,6 @@ public interface IvyPublicationInternal extends IvyPublication, PublicationInter
     Set<IvyDependencyInternal> getDependencies();
 
     IvyNormalizedPublication asNormalisedPublication();
+
+    boolean canPublishModuleMetadata();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
@@ -31,7 +31,9 @@ public interface IvyPublicationInternal extends IvyPublication, PublicationInter
 
     IvyModuleDescriptorSpecInternal getDescriptor();
 
-    void setDescriptorFile(FileCollection descriptorFile);
+    void setIvyDescriptorFile(FileCollection descriptorFile);
+
+    void setGradleModuleDescriptorFile(FileCollection descriptorFile);
 
     FileCollection getPublishableFiles();
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
@@ -26,6 +26,8 @@ import org.gradle.internal.component.external.model.DefaultModuleComponentIdenti
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.IvyArtifactName;
 
+import java.io.File;
+
 public class DependencyResolverIvyPublisher implements IvyPublisher {
 
     public void publish(IvyNormalizedPublication publication, PublicationAwareRepository repository) {
@@ -39,8 +41,15 @@ public class DependencyResolverIvyPublisher implements IvyPublisher {
             publishMetaData.addArtifact(createIvyArtifact(publishArtifact), publishArtifact.getFile());
         }
 
-        IvyArtifactName artifact = new DefaultIvyArtifactName("ivy", "ivy", "xml");
-        publishMetaData.addArtifact(artifact, publication.getDescriptorFile());
+        IvyArtifactName ivyDescriptor = new DefaultIvyArtifactName("ivy", "ivy", "xml");
+        publishMetaData.addArtifact(ivyDescriptor, publication.getIvyDescriptorFile());
+
+        File gradleModuleDescriptorFile = publication.getGradleModuleDescriptorFile();
+        if (gradleModuleDescriptorFile != null && gradleModuleDescriptorFile.exists()) {
+            // may not exist if experimental features are disabled
+            IvyArtifactName gradleDescriptor = new DefaultIvyArtifactName(projectIdentity.getModule(), "json", "module");
+            publishMetaData.addArtifact(gradleDescriptor, gradleModuleDescriptorFile);
+        }
 
         publisher.publish(publishMetaData);
     }
@@ -48,4 +57,6 @@ public class DependencyResolverIvyPublisher implements IvyPublisher {
     private IvyArtifactName createIvyArtifact(IvyArtifact ivyArtifact) {
         return new DefaultIvyArtifactName(ivyArtifact.getName(), ivyArtifact.getType(), ivyArtifact.getExtension(), ivyArtifact.getClassifier());
     }
+
+
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyNormalizedPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyNormalizedPublication.java
@@ -25,14 +25,16 @@ public class IvyNormalizedPublication {
 
     private final String name;
     private final IvyPublicationIdentity projectIdentity;
-    private final File descriptorFile;
+    private final File ivyDescriptorFile;
+    private final File gradleModuleDescriptorFile;
     private final Set<IvyArtifact> artifacts;
 
-    public IvyNormalizedPublication(String name, IvyPublicationIdentity projectIdentity, File descriptorFile, Set<IvyArtifact> artifacts) {
+    public IvyNormalizedPublication(String name, IvyPublicationIdentity projectIdentity, File ivyDescriptorFile, File gradleModuleDescriptorFile, Set<IvyArtifact> artifacts) {
         this.name = name;
         this.projectIdentity = projectIdentity;
+        this.gradleModuleDescriptorFile = gradleModuleDescriptorFile;
         this.artifacts = artifacts;
-        this.descriptorFile = descriptorFile;
+        this.ivyDescriptorFile = ivyDescriptorFile;
     }
 
     public String getName() {
@@ -43,8 +45,12 @@ public class IvyNormalizedPublication {
         return projectIdentity;
     }
 
-    public File getDescriptorFile() {
-        return descriptorFile;
+    public File getIvyDescriptorFile() {
+        return ivyDescriptorFile;
+    }
+
+    public File getGradleModuleDescriptorFile() {
+        return gradleModuleDescriptorFile;
     }
 
     public Set<IvyArtifact> getArtifacts() {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisher.java
@@ -83,7 +83,7 @@ public class ValidatingIvyPublisher implements IvyPublisher {
 
     private MutableIvyModuleResolveMetadata parseIvyFile(IvyNormalizedPublication publication) {
         try {
-            return moduleDescriptorParser.parseMetaData(parserSettings, publication.getDescriptorFile());
+            return moduleDescriptorParser.parseMetaData(parserSettings, publication.getIvyDescriptorFile());
         } catch (MetaDataParseException pe) {
             throw new InvalidIvyPublicationException(publication.getName(), pe.getLocalizedMessage(), pe);
         }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -19,16 +19,19 @@ package org.gradle.api.publish.ivy.plugins;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
+import org.gradle.api.internal.ExperimentalFeatures;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.internal.ProjectDependencyPublicationResolver;
@@ -42,6 +45,7 @@ import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
 import org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor;
 import org.gradle.api.publish.ivy.tasks.PublishToIvyRepository;
 import org.gradle.api.publish.plugins.PublishingPlugin;
+import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.model.ModelMap;
@@ -51,6 +55,8 @@ import org.gradle.model.RuleSource;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.apache.commons.lang.StringUtils.capitalize;
 
@@ -68,17 +74,19 @@ public class IvyPublishPlugin implements Plugin<Project> {
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
     private final FileCollectionFactory fileCollectionFactory;
     private final ImmutableAttributesFactory immutableAttributesFactory;
+    private final ExperimentalFeatures experimentalFeatures;
 
     @Inject
     public IvyPublishPlugin(Instantiator instantiator, DependencyMetaDataProvider dependencyMetaDataProvider, FileResolver fileResolver,
                             ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-                            ImmutableAttributesFactory immutableAttributesFactory) {
+                            ImmutableAttributesFactory immutableAttributesFactory, ExperimentalFeatures experimentalFeatures) {
         this.instantiator = instantiator;
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
         this.fileResolver = fileResolver;
         this.projectDependencyResolver = projectDependencyResolver;
         this.fileCollectionFactory = fileCollectionFactory;
         this.immutableAttributesFactory = immutableAttributesFactory;
+        this.experimentalFeatures = experimentalFeatures;
     }
 
     public void apply(final Project project) {
@@ -99,37 +107,70 @@ public class IvyPublishPlugin implements Plugin<Project> {
         public void createTasks(ModelMap<Task> tasks, PublishingExtension publishingExtension, @Path("buildDir") final File buildDir) {
             PublicationContainer publications = publishingExtension.getPublications();
             RepositoryHandler repositories = publishingExtension.getRepositories();
+            NamedDomainObjectSet<IvyPublicationInternal> mavenPublications = publications.withType(IvyPublicationInternal.class);
+            List<Publication> asPublication = new ArrayList<Publication>(publications);
 
             for (final IvyPublicationInternal publication : publications.withType(IvyPublicationInternal.class)) {
 
                 final String publicationName = publication.getName();
-                final String descriptorTaskName = "generateDescriptorFileFor" + capitalize(publicationName) + "Publication";
-
-                tasks.create(descriptorTaskName, GenerateIvyDescriptor.class, new Action<GenerateIvyDescriptor>() {
-                    public void execute(final GenerateIvyDescriptor descriptorTask) {
-                        descriptorTask.setDescription("Generates the Ivy Module Descriptor XML file for publication '" + publicationName + "'.");
-                        descriptorTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
-                        descriptorTask.setDescriptor(publication.getDescriptor());
-                        descriptorTask.setDestination(new File(buildDir, "publications/" + publicationName + "/ivy.xml"));
-                    }
-                });
-                publication.setDescriptorFile(tasks.get(descriptorTaskName).getOutputs().getFiles());
+                createGenerateIvyDescriptorTask(tasks, publicationName, publication, buildDir);
+                createGenerateMetadataTask(tasks, publication, asPublication, buildDir);
 
                 for (final IvyArtifactRepository repository : repositories.withType(IvyArtifactRepository.class)) {
                     final String repositoryName = repository.getName();
                     final String publishTaskName = "publish" + capitalize(publicationName) + "PublicationTo" + capitalize(repositoryName) + "Repository";
 
-                    tasks.create(publishTaskName, PublishToIvyRepository.class, new Action<PublishToIvyRepository>() {
-                        public void execute(PublishToIvyRepository publishTask) {
-                            publishTask.setPublication(publication);
-                            publishTask.setRepository(repository);
-                            publishTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
-                            publishTask.setDescription("Publishes Ivy publication '" + publicationName + "' to Ivy repository '" + repositoryName + "'.");
-                        }
-                    });
-                    tasks.get(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME).dependsOn(publishTaskName);
+                    createPublishToRepositoryTask(tasks, publication, publicationName, repository, repositoryName, publishTaskName);
                 }
             }
+        }
+
+        private void createPublishToRepositoryTask(ModelMap<Task> tasks, final IvyPublicationInternal publication, final String publicationName, final IvyArtifactRepository repository, final String repositoryName, String publishTaskName) {
+            tasks.create(publishTaskName, PublishToIvyRepository.class, new Action<PublishToIvyRepository>() {
+                public void execute(PublishToIvyRepository publishTask) {
+                    publishTask.setPublication(publication);
+                    publishTask.setRepository(repository);
+                    publishTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+                    publishTask.setDescription("Publishes Ivy publication '" + publicationName + "' to Ivy repository '" + repositoryName + "'.");
+                }
+            });
+            tasks.get(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME).dependsOn(publishTaskName);
+        }
+
+        private void createGenerateIvyDescriptorTask(ModelMap<Task> tasks, final String publicationName, final IvyPublicationInternal publication, @Path("buildDir") final File buildDir) {
+            final String descriptorTaskName = "generateDescriptorFileFor" + capitalize(publicationName) + "Publication";
+
+            tasks.create(descriptorTaskName, GenerateIvyDescriptor.class, new Action<GenerateIvyDescriptor>() {
+                public void execute(final GenerateIvyDescriptor descriptorTask) {
+                    descriptorTask.setDescription("Generates the Ivy Module Descriptor XML file for publication '" + publicationName + "'.");
+                    descriptorTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+                    descriptorTask.setDescriptor(publication.getDescriptor());
+                    descriptorTask.setDestination(new File(buildDir, "publications/" + publicationName + "/ivy.xml"));
+                }
+            });
+            publication.setDescriptorFile(tasks.get(descriptorTaskName).getOutputs().getFiles());
+        }
+
+        private void createGenerateMetadataTask(ModelMap<Task> tasks, final IvyPublicationInternal publication, final List<Publication> publications, final File buildDir) {
+            if (!publication.canPublishModuleMetadata()) {
+                return;
+            }
+
+            final String publicationName = publication.getName();
+            String descriptorTaskName = "generateMetadataFileFor" + capitalize(publicationName) + "Publication";
+            tasks.create(descriptorTaskName, GenerateModuleMetadata.class, new Action<GenerateModuleMetadata>() {
+                public void execute(final GenerateModuleMetadata generateTask) {
+                    generateTask.setDescription("Generates the Gradle metadata file for publication '" + publicationName + "'.");
+                    generateTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+                    generateTask.getPublication().set(publication);
+                    generateTask.getPublications().set(publications);
+                    // TODO - should deal with build dir changes
+                    generateTask.getOutputFile().set(new File(buildDir, "publications/" + publication.getName() + "/module.json"));
+                }
+            });
+            GenerateModuleMetadata generatorTask = (GenerateModuleMetadata) tasks.get(descriptorTaskName);
+            IvyArtifact metadataFile = publication.artifact(generatorTask.getOutputFile());
+            metadataFile.setExtension("module");
         }
     }
 
@@ -149,8 +190,8 @@ public class IvyPublishPlugin implements Plugin<Project> {
             IvyPublicationIdentity publicationIdentity = new DefaultIvyPublicationIdentity(module.getGroup(), module.getName(), module.getVersion());
             NotationParser<Object, IvyArtifact> notationParser = new IvyArtifactNotationParserFactory(instantiator, fileResolver, publicationIdentity).create();
             return instantiator.newInstance(
-                    DefaultIvyPublication.class,
-                    name, instantiator, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory, immutableAttributesFactory
+                DefaultIvyPublication.class,
+                name, instantiator, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory, immutableAttributesFactory, experimentalFeatures
             );
         }
     }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -148,7 +148,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
                     descriptorTask.setDestination(new File(buildDir, "publications/" + publicationName + "/ivy.xml"));
                 }
             });
-            publication.setDescriptorFile(tasks.get(descriptorTaskName).getOutputs().getFiles());
+            publication.setIvyDescriptorFile(tasks.get(descriptorTaskName).getOutputs().getFiles());
         }
 
         private void createGenerateMetadataTask(ModelMap<Task> tasks, final IvyPublicationInternal publication, final List<Publication> publications, final File buildDir) {
@@ -165,12 +165,10 @@ public class IvyPublishPlugin implements Plugin<Project> {
                     generateTask.getPublication().set(publication);
                     generateTask.getPublications().set(publications);
                     // TODO - should deal with build dir changes
-                    generateTask.getOutputFile().set(new File(buildDir, "publications/" + publication.getName() + "/module.json"));
+                    generateTask.getOutputFile().set(new File(buildDir, "publications/" + publicationName + "/module.json"));
                 }
             });
-            GenerateModuleMetadata generatorTask = (GenerateModuleMetadata) tasks.get(descriptorTaskName);
-            IvyArtifact metadataFile = publication.artifact(generatorTask.getOutputFile());
-            metadataFile.setExtension("module");
+            publication.setGradleModuleDescriptorFile(tasks.get(descriptorTaskName).getOutputs().getFiles());
         }
     }
 

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.ClassGeneratorBackedInstantiator
+import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
@@ -51,6 +52,7 @@ class DefaultIvyPublicationTest extends Specification {
     def notationParser = Mock(NotationParser)
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
     def attributesFactory = TestUtil.attributesFactory()
+    def experimentalFeatures = new ExperimentalFeatures()
 
     File descriptorFile
     File artifactFile
@@ -275,7 +277,8 @@ class DefaultIvyPublicationTest extends Specification {
             notationParser,
             projectDependencyResolver,
             TestFiles.fileCollectionFactory(),
-            attributesFactory
+            attributesFactory,
+            experimentalFeatures
         )
         publication.setDescriptorFile(new SimpleFileCollection(descriptorFile))
         return publication;

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -54,11 +54,13 @@ class DefaultIvyPublicationTest extends Specification {
     def attributesFactory = TestUtil.attributesFactory()
     def experimentalFeatures = new ExperimentalFeatures()
 
-    File descriptorFile
+    File ivyDescriptorFile
+    File moduleDescriptorFile
     File artifactFile
 
     def "setup"() {
-        descriptorFile = new File(testDirectoryProvider.testDirectory, "pom-file")
+        ivyDescriptorFile = new File(testDirectoryProvider.testDirectory, "ivy-file")
+        moduleDescriptorFile = new File(testDirectoryProvider.testDirectory, "module-file")
         artifactFile = new File(testDirectoryProvider.testDirectory, "artifact-file")
         artifactFile << "some content"
     }
@@ -85,7 +87,7 @@ class DefaultIvyPublicationTest extends Specification {
 
         then:
         publication.artifacts.empty
-        publication.publishableFiles.files == [descriptorFile] as Set
+        publication.publishableFiles.files == [ivyDescriptorFile, moduleDescriptorFile] as Set
         publication.dependencies.empty
     }
 
@@ -103,7 +105,7 @@ class DefaultIvyPublicationTest extends Specification {
         publication.from(componentWithArtifact(artifact))
 
         then:
-        publication.publishableFiles.files == [descriptorFile, artifactFile] as Set
+        publication.publishableFiles.files == [ivyDescriptorFile, moduleDescriptorFile, artifactFile] as Set
         publication.artifacts == [ivyArtifact] as Set
 
         and:
@@ -133,7 +135,7 @@ class DefaultIvyPublicationTest extends Specification {
         publication.from(componentWithDependency(moduleDependency))
 
         then:
-        publication.publishableFiles.files == [descriptorFile] as Set
+        publication.publishableFiles.files == [ivyDescriptorFile, moduleDescriptorFile] as Set
         publication.artifacts.empty
 
         and:
@@ -165,7 +167,7 @@ class DefaultIvyPublicationTest extends Specification {
         publication.from(componentWithDependency(projectDependency))
 
         then:
-        publication.publishableFiles.files == [descriptorFile] as Set
+        publication.publishableFiles.files == [ivyDescriptorFile, moduleDescriptorFile] as Set
         publication.artifacts.empty
 
         and:
@@ -222,7 +224,7 @@ class DefaultIvyPublicationTest extends Specification {
 
         then:
         publication.artifacts == [ivyArtifact] as Set
-        publication.publishableFiles.files == [descriptorFile, artifactFile] as Set
+        publication.publishableFiles.files == [ivyDescriptorFile, moduleDescriptorFile, artifactFile] as Set
     }
 
     def "attaches and configures artifacts parsed by notation parser"() {
@@ -243,7 +245,7 @@ class DefaultIvyPublicationTest extends Specification {
 
         then:
         publication.artifacts == [ivyArtifact] as Set
-        publication.publishableFiles.files == [descriptorFile, artifactFile] as Set
+        publication.publishableFiles.files == [ivyDescriptorFile, moduleDescriptorFile, artifactFile] as Set
     }
 
     def "can use setter to replace existing artifacts set on configuration"() {
@@ -280,7 +282,8 @@ class DefaultIvyPublicationTest extends Specification {
             attributesFactory,
             experimentalFeatures
         )
-        publication.setDescriptorFile(new SimpleFileCollection(descriptorFile))
+        publication.setIvyDescriptorFile(new SimpleFileCollection(ivyDescriptorFile))
+        publication.setGradleModuleDescriptorFile(new SimpleFileCollection(moduleDescriptorFile))
         return publication;
     }
 

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
@@ -36,7 +36,7 @@ import javax.xml.namespace.QName
 import static java.util.Collections.emptySet
 import static org.gradle.util.CollectionUtils.toSet
 
-public class ValidatingIvyPublisherTest extends Specification {
+class ValidatingIvyPublisherTest extends Specification {
     @Rule
     final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
 
@@ -50,7 +50,7 @@ public class ValidatingIvyPublisherTest extends Specification {
         def generator = ivyGenerator("the-group", "the-artifact", "the-version")
                             .withBranch("the-branch")
                             .withStatus("release")
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), moduleFile(), emptySet())
         def repository = Mock(PublicationAwareRepository)
 
         and:
@@ -70,7 +70,7 @@ public class ValidatingIvyPublisherTest extends Specification {
                 }))
 
         and:
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("the-group", "the-artifact", "the-version"), ivyFile, emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("the-group", "the-artifact", "the-version"), ivyFile, moduleFile(), emptySet())
         def repository = Mock(PublicationAwareRepository)
 
         and:
@@ -83,7 +83,7 @@ public class ValidatingIvyPublisherTest extends Specification {
     def "validates project coordinates"() {
         given:
         def projectIdentity = projectIdentity(group, name, version)
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(group, name, version), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(group, name, version), moduleFile(), emptySet())
         def repository = Mock(PublicationAwareRepository)
 
         when:
@@ -112,7 +112,7 @@ public class ValidatingIvyPublisherTest extends Specification {
         def generator = ivyGenerator("org", "module", "version")
                             .withBranch(branch)
                             .withStatus(status)
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), moduleFile(), emptySet())
         def repository = Stub(PublicationAwareRepository)
 
         when:
@@ -143,7 +143,7 @@ public class ValidatingIvyPublisherTest extends Specification {
         def generator = ivyGenerator("org", "module", "version")
                             .withBranch(branch)
                             .withStatus(status)
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), moduleFile(), emptySet())
         def repository = Stub(PublicationAwareRepository)
 
         when:
@@ -165,7 +165,7 @@ public class ValidatingIvyPublisherTest extends Specification {
         def projectIdentity = projectIdentity("org", "module", "version")
         def generator = ivyGenerator("org", "module", "version")
         elements.each { generator.withExtraInfo(it, "${it}Value") }
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), moduleFile(), emptySet())
         def repository = Stub(PublicationAwareRepository)
 
         when:
@@ -184,7 +184,7 @@ public class ValidatingIvyPublisherTest extends Specification {
     def "project coordinates must match ivy descriptor file"() {
         given:
         def projectIdentity = projectIdentity("org", "module", "version")
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(organisation, module, version), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(organisation, module, version), moduleFile(), emptySet())
         def repository = Mock(PublicationAwareRepository)
 
         when:
@@ -212,7 +212,7 @@ public class ValidatingIvyPublisherTest extends Specification {
         ivyFileGenerator.writeTo(ivyFile)
 
         and:
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("the-group", "the-artifact", "the-version"), ivyFile, emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("the-group", "the-artifact", "the-version"), ivyFile, moduleFile(), emptySet())
         def repository = Mock(PublicationAwareRepository)
 
         when:
@@ -232,7 +232,7 @@ public class ValidatingIvyPublisherTest extends Specification {
             getExtension() >> extension
             getClassifier() >> classifier
         }
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("org", "module", "version"), ivyFile("org", "module", "version"), toSet([ivyArtifact]))
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("org", "module", "version"), ivyFile("org", "module", "version"), moduleFile(), toSet([ivyArtifact]))
 
         when:
         publisher.publish(publication, Mock(PublicationAwareRepository))
@@ -258,7 +258,7 @@ public class ValidatingIvyPublisherTest extends Specification {
     @Unroll
     def "cannot publish with file that #message"() {
         def ivyArtifact = Mock(IvyArtifact)
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("group", "artifact", "version"), ivyFile("group", "artifact", "version"), toSet([ivyArtifact]))
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("group", "artifact", "version"), ivyFile("group", "artifact", "version"), moduleFile(), toSet([ivyArtifact]))
 
         File theFile = new TestFile(testDirectoryProvider.testDirectory, "testFile")
         if (createDir) {
@@ -301,7 +301,7 @@ public class ValidatingIvyPublisherTest extends Specification {
             getFile() >> testDirectoryProvider.createFile('artifact2')
         }
         def projectIdentity = projectIdentity("org", "module", "revision")
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile("org", "module", "revision"), toSet([artifact1, artifact2]))
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile("org", "module", "revision"), moduleFile(), toSet([artifact1, artifact2]))
 
         when:
         publisher.publish(publication, Mock(PublicationAwareRepository))
@@ -321,7 +321,7 @@ public class ValidatingIvyPublisherTest extends Specification {
             getFile() >> testDirectoryProvider.createFile('artifact1')
         }
         def projectIdentity = projectIdentity("org", "module", "revision")
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile("org", "module", "revision"), toSet([artifact1]))
+        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile("org", "module", "revision"), moduleFile(), toSet([artifact1]))
 
         when:
         publisher.publish(publication, Mock(PublicationAwareRepository))
@@ -351,6 +351,11 @@ public class ValidatingIvyPublisherTest extends Specification {
         def ivyXmlFile = testDirectoryProvider.file("ivy")
         ivyFileGenerator.writeTo(ivyXmlFile)
         return ivyXmlFile
+    }
+
+    private def moduleFile() {
+        def moduleFile = testDirectoryProvider.file("module")
+        return moduleFile
     }
 
     private QName ns(String name) {

--- a/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
+++ b/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
@@ -17,37 +17,97 @@
 package org.gradle.api.publish.ivy
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.test.fixtures.GradleMetadataAwarePublishingSpec
 import org.gradle.test.fixtures.ivy.IvyFileModule
+import org.gradle.test.fixtures.ivy.IvyJavaModule
+import org.gradle.test.fixtures.ivy.IvyModule
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
 
-class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec {
+class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec implements GradleMetadataAwarePublishingSpec {
 
-    protected def resolveArtifacts(IvyFileModule module) {
+    def setup() {
+        prepare()
+    }
+
+    ResolveParams resolveParams(Map args = [:]) {
+        new ResolveParams(args)
+    }
+
+    protected static IvyJavaModule javaLibrary(IvyFileModule module) {
+        new IvyJavaModule(module)
+    }
+
+    protected def resolveArtifacts(IvyModule module) {
         doResolveArtifacts("group: '${sq(module.organisation)}', name: '${sq(module.module)}', version: '${sq(module.revision)}'")
     }
 
-    protected def resolveArtifacts(IvyFileModule module, def configuration) {
+    protected def resolveArtifacts(IvyModule module, String configuration) {
         doResolveArtifacts("group: '${sq(module.organisation)}', name: '${sq(module.module)}', version: '${sq(module.revision)}', configuration: '${sq(configuration)}'")
     }
 
-    protected def resolveArtifactsWithStatus(IvyFileModule module, def status) {
-        doResolveArtifacts("group: '${sq(module.organisation)}', name: '${sq(module.module)}', version: '${sq(module.revision)}'", status)
+    protected def resolveAdditionalArtifacts(IvyJavaModule module) {
+        doResolveArtifacts("group: '${sq(module.organisation)}', name: '${sq(module.module)}', version: '${sq(module.revision)}'", resolveParams(additionalArtifacts: module.additionalArtifacts))
     }
 
-    private def doResolveArtifacts(def dependency, def status=null) {
+    protected def resolveArtifactsWithStatus(IvyModule module, String status) {
+        doResolveArtifacts("group: '${sq(module.organisation)}', name: '${sq(module.module)}', version: '${sq(module.revision)}'", resolveParams(status:status))
+    }
+
+    private def doResolveArtifacts(String dependency, ResolveParams params = resolveParams()) {
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
+
+        if (resolveModuleMetadata) {
+            ExperimentalFeaturesFixture.enable(settingsFile)
+        } else {
+            executer.beforeExecute {
+                // Remove the experimental flag set earlier...
+                // TODO:DAZ Remove this once we support excludes and we can have a single flag to enable publish/resolve
+                withArguments()
+            }
+        }
+
+        String attributes = params.variant == null ?
+            "" :
+            """ 
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.${params.variant}))
+    }
+"""
+
+        String extraArtifacts = ""
+        if (params.additionalArtifacts) {
+            String artifacts = params.additionalArtifacts.collect {
+                    def tokens = it.ivyTokens
+                    """
+                    artifact {
+                        name = '${sq(tokens.artifact)}'
+                        classifier = '${sq(tokens.classifier)}'
+                        type = '${sq(tokens.type)}'
+                    }"""
+            }.join('\n')
+            extraArtifacts = """
+                {
+                    transitive = false
+                    $artifacts
+                }
+            """
+        }
+
         buildFile.text = """
             configurations {
-                resolve
+                resolve {
+                    $attributes
+                }
             }
             repositories {
                 ivy { url "${ivyRepo.uri}" }
                 ${mavenCentralRepositoryDefinition()}
             }
             dependencies {
-                resolve $dependency
+                resolve($dependency) $extraArtifacts
             }
 
             task resolveArtifacts(type: Sync) {
@@ -56,11 +116,11 @@ class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec {
             }
         """
 
-        if (status != null) {
+        if (params.status != null) {
             buildFile.text = buildFile.text + """
 
                 dependencies.components.all { ComponentMetadataDetails details, IvyModuleDescriptor ivyModule ->
-                    details.statusScheme = [ '${sq(status)}' ]
+                    details.statusScheme = [ '${sq(params.status)}' ]
                 }
             """
         }
@@ -76,5 +136,11 @@ class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec {
 
     String escapeForSingleQuoting(String input) {
         return input.replace('\\', '\\\\').replace('\'', '\\\'')
+    }
+
+    static class ResolveParams {
+        List<IvyFileModule.IvyModuleArtifact> additionalArtifacts
+        String status
+        String variant
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -174,23 +174,26 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         javaLibrary.parsedPom.scopes.compile.assertDependsOn("org.springframework:spring-core:2.5.6")
         javaLibrary.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:3.2.2")
 
-        def apiVariant = javaLibrary.parsedModuleMetadata.variant('api')
-        apiVariant.dependencies.size() == 1
-        apiVariant.dependencies[0].group == 'org.springframework'
-        apiVariant.dependencies[0].module == 'spring-core'
-        apiVariant.dependencies[0].version == '2.5.6'
-        apiVariant.dependencies[0].rejectsVersion == []
+        and:
+        javaLibrary.parsedModuleMetadata.variant('api') {
+            dependency('org.springframework:spring-core:2.5.6') {
+                noMoreExcludes()
+                rejects()
+            }
+            noMoreDependencies()
+        }
 
-        def runtimeVariant = javaLibrary.parsedModuleMetadata.variant('runtime')
-        runtimeVariant.dependencies.size() == 2
-        runtimeVariant.dependencies[0].group == 'commons-collections'
-        runtimeVariant.dependencies[0].module == 'commons-collections'
-        runtimeVariant.dependencies[0].version == '3.2.2'
-        runtimeVariant.dependencies[0].rejectsVersion == [']3.2.2,)']
-        runtimeVariant.dependencies[1].group == 'org.springframework'
-        runtimeVariant.dependencies[1].module == 'spring-core'
-        runtimeVariant.dependencies[1].version == '2.5.6'
-        runtimeVariant.dependencies[1].rejectsVersion == []
+        javaLibrary.parsedModuleMetadata.variant('runtime') {
+            dependency('commons-collections:commons-collections:3.2.2') {
+                noMoreExcludes()
+                rejects ']3.2.2,)'
+            }
+            dependency('org.springframework:spring-core:2.5.6') {
+                noMoreExcludes()
+                rejects()
+            }
+            noMoreDependencies()
+        }
 
         and:
         resolveArtifacts(javaLibrary) == [

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/AbstractMavenPublishAction.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/AbstractMavenPublishAction.java
@@ -55,10 +55,11 @@ abstract class AbstractMavenPublishAction implements MavenPublishAction {
 
     private final List<Artifact> attached = new ArrayList<Artifact>();
     private final Artifact pomArtifact;
+    private final Artifact metadataArtifact;
     private Artifact mainArtifact;
     private SnapshotVersionManager snapshotVersionManager = new SnapshotVersionManager();
 
-    protected AbstractMavenPublishAction(File pomFile, List<File> wagonJars) {
+    protected AbstractMavenPublishAction(File pomFile, File metadataFile, List<File> wagonJars) {
         container = newPlexusContainer(wagonJars);
         session = new MavenRepositorySystemSession();
         session.setTransferListener(new LoggingMavenTransferListener());
@@ -66,7 +67,16 @@ abstract class AbstractMavenPublishAction implements MavenPublishAction {
 
         Model pom = parsePom(pomFile);
         pomArtifact = new DefaultArtifact(pom.getGroupId(), pom.getArtifactId(), "pom", pom.getVersion()).setFile(pomFile);
+        metadataArtifact = toGradleMetadataArtifact(pom, metadataFile);
         mainArtifact = createTypedArtifact(pom.getPackaging(), null);
+    }
+
+    private Artifact toGradleMetadataArtifact(Model pom, File metadataFile) {
+        if (metadataFile == null || !metadataFile.exists()) {
+            // possible if experimental features are disabled
+            return null;
+        }
+        return new DefaultArtifact(pom.getGroupId(), pom.getArtifactId(), "module", pom.getVersion()).setFile(metadataFile);
     }
 
     public void setLocalMavenRepositoryLocation(File localMavenRepository) {
@@ -88,6 +98,9 @@ abstract class AbstractMavenPublishAction implements MavenPublishAction {
             artifacts.add(mainArtifact);
         }
         artifacts.add(pomArtifact);
+        if (metadataArtifact != null) {
+            artifacts.add(metadataArtifact);
+        }
         for (Artifact artifact : attached) {
             File file = artifact.getFile();
             if (file != null && file.isFile()) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployAction.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployAction.java
@@ -38,8 +38,8 @@ public class MavenDeployAction extends AbstractMavenPublishAction {
     private RemoteRepository remoteRepository;
     private RemoteRepository remoteSnapshotRepository;
 
-    public MavenDeployAction(File pomFile, List<File> wagonJars) {
-        super(pomFile, wagonJars);
+    public MavenDeployAction(File pomFile, File metadataFile, List<File> wagonJars) {
+        super(pomFile, metadataFile, wagonJars);
     }
 
     public void setRepositories(RemoteRepository repository, RemoteRepository snapshotRepository) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenInstallAction.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenInstallAction.java
@@ -26,8 +26,8 @@ import java.util.Collection;
 
 public class MavenInstallAction extends AbstractMavenPublishAction {
 
-    public MavenInstallAction(File pomFile) {
-        super(pomFile, null);
+    public MavenInstallAction(File pomFile, File metadataFile) {
+        super(pomFile, metadataFile, null);
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenWagonDeployAction.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenWagonDeployAction.java
@@ -23,7 +23,7 @@ import java.util.List;
  * A deploy action that uses the baked in Maven wagon implementations, or a custom user-provided wagon implemented.
  */
 public class MavenWagonDeployAction extends MavenDeployAction {
-    public MavenWagonDeployAction(File pomFile, List<File> jars) {
-        super(pomFile, jars);
+    public MavenWagonDeployAction(File pomFile, File metadataFile, List<File> jars) {
+        super(pomFile, metadataFile, jars);
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/AbstractMavenResolver.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/AbstractMavenResolver.java
@@ -82,7 +82,7 @@ abstract class AbstractMavenResolver extends AbstractArtifactRepository implemen
         return this;
     }
 
-    protected abstract MavenPublishAction createPublishAction(File pomFile, LocalMavenRepositoryLocator mavenRepositoryLocator);
+    protected abstract MavenPublishAction createPublishAction(File pomFile, File metadataFile, LocalMavenRepositoryLocator mavenRepositoryLocator);
 
     public void publish(IvyModulePublishMetadata moduleVersion) {
         for (IvyModuleArtifactPublishMetadata artifactMetadata : moduleVersion.getArtifacts()) {
@@ -110,7 +110,7 @@ abstract class AbstractMavenResolver extends AbstractArtifactRepository implemen
         Set<MavenDeployment> mavenDeployments = getArtifactPomContainer().createDeployableFilesInfos();
         for (MavenDeployment mavenDeployment : mavenDeployments) {
             File pomFile = mavenDeployment.getPomArtifact().getFile();
-            MavenPublishAction publishAction = createPublishAction(pomFile, mavenRepositoryLocator);
+            MavenPublishAction publishAction = createPublishAction(pomFile, null, mavenRepositoryLocator);
             beforeDeploymentActions.execute(mavenDeployment);
             addArtifacts(publishAction, mavenDeployment);
             execute(publishAction);

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/BaseMavenDeployer.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/BaseMavenDeployer.java
@@ -48,8 +48,8 @@ public class BaseMavenDeployer extends AbstractMavenResolver implements MavenDep
         super(pomFilterContainer, artifactPomContainer, loggingManager, mavenSettingsProvider, mavenRepositoryLocator);
     }
 
-    protected MavenPublishAction createPublishAction(File pomFile, LocalMavenRepositoryLocator mavenRepositoryLocator) {
-        MavenWagonDeployAction deployAction = new MavenWagonDeployAction(pomFile, getJars());
+    protected MavenPublishAction createPublishAction(File pomFile, File metadataFile, LocalMavenRepositoryLocator mavenRepositoryLocator) {
+        MavenWagonDeployAction deployAction = new MavenWagonDeployAction(pomFile, metadataFile, getJars());
         deployAction.setLocalMavenRepositoryLocation(mavenRepositoryLocator.getLocalMavenRepository());
         deployAction.setUniqueVersion(isUniqueVersion());
         deployAction.setRepositories(remoteRepository, remoteSnapshotRepository);

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/BaseMavenInstaller.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/BaseMavenInstaller.java
@@ -31,8 +31,8 @@ public class BaseMavenInstaller extends AbstractMavenResolver {
         super(pomFilterContainer, artifactPomContainer, loggingManager, mavenSettingsProvider, mavenRepositoryLocator);
     }
 
-    protected MavenPublishAction createPublishAction(File pomFile, LocalMavenRepositoryLocator mavenRepositoryLocator) {
-        MavenInstallAction installAction = new MavenInstallAction(pomFile);
+    protected MavenPublishAction createPublishAction(File pomFile, File metadataFile, LocalMavenRepositoryLocator mavenRepositoryLocator) {
+        MavenInstallAction installAction = new MavenInstallAction(pomFile, metadataFile);
         installAction.setLocalMavenRepositoryLocation(mavenRepositoryLocator.getLocalMavenRepository());
         return installAction;
     }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
@@ -31,6 +31,8 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
 
     void setPomFile(FileCollection pomFile);
 
+    void setGradleModuleMetadataFile(FileCollection metadatafile);
+
     FileCollection getPublishableFiles();
 
     MavenProjectIdentity getMavenProjectIdentity();

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -42,12 +42,12 @@ public abstract class AbstractMavenPublisher implements MavenPublisher {
 
     public void publish(MavenNormalizedPublication publication, MavenArtifactRepository artifactRepository) {
         LOGGER.info("Publishing to repository {}", artifactRepository);
-        MavenPublishAction deployTask = createDeployTask(publication.getPomFile(), mavenRepositoryLocator, artifactRepository);
+        MavenPublishAction deployTask = createDeployTask(publication.getPomFile(), publication.getMetadataFile(), mavenRepositoryLocator, artifactRepository);
         addPomAndArtifacts(deployTask, publication);
         execute(deployTask);
     }
 
-    abstract protected MavenPublishAction createDeployTask(File pomFile, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository);
+    abstract protected MavenPublishAction createDeployTask(File pomFile, File metadataFile, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository);
 
     private void addPomAndArtifacts(MavenPublishAction publishAction, MavenNormalizedPublication publication) {
         MavenArtifact mainArtifact = publication.getMainArtifact();

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
@@ -30,8 +30,8 @@ public class MavenLocalPublisher extends AbstractMavenPublisher {
     }
 
     @Override
-    protected MavenInstallAction createDeployTask(File pomFile, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
-        MavenInstallAction mavenInstallTask = new MavenInstallAction(pomFile);
+    protected MavenInstallAction createDeployTask(File pomFile, File metadataFile, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
+        MavenInstallAction mavenInstallTask = new MavenInstallAction(pomFile, metadataFile);
         mavenInstallTask.setLocalMavenRepositoryLocation(mavenRepositoryLocator.getLocalMavenRepository());
         return mavenInstallTask;
     }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenNormalizedPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenNormalizedPublication.java
@@ -25,13 +25,15 @@ public class MavenNormalizedPublication {
 
     private final String name;
     private final File pomFile;
+    private final File metadataFile;
     private final MavenProjectIdentity projectIdentity;
     private final Set<MavenArtifact> artifacts;
     private final MavenArtifact mainArtifact;
 
-    public MavenNormalizedPublication(String name, File pomFile, MavenProjectIdentity projectIdentity, Set<MavenArtifact> artifacts, MavenArtifact mainArtifact) {
+    public MavenNormalizedPublication(String name, File pomFile, File gradleMetadataFile, MavenProjectIdentity projectIdentity, Set<MavenArtifact> artifacts, MavenArtifact mainArtifact) {
         this.name = name;
         this.pomFile = pomFile;
+        this.metadataFile = gradleMetadataFile;
         this.projectIdentity = projectIdentity;
         this.artifacts = artifacts;
         this.mainArtifact = mainArtifact;
@@ -43,6 +45,10 @@ public class MavenNormalizedPublication {
 
     public File getPomFile() {
         return pomFile;
+    }
+
+    public File getMetadataFile() {
+        return metadataFile;
     }
 
     public Set<MavenArtifact> getArtifacts() {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
@@ -43,8 +43,8 @@ public class MavenRemotePublisher extends AbstractMavenPublisher {
         this.repositoryTransportFactory = repositoryTransportFactory;
     }
 
-    protected MavenPublishAction createDeployTask(File pomFile, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
-        GradleWagonMavenDeployAction deployTask = new GradleWagonMavenDeployAction(pomFile, artifactRepository, repositoryTransportFactory);
+    protected MavenPublishAction createDeployTask(File pomFile, File metadataFile, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
+        GradleWagonMavenDeployAction deployTask = new GradleWagonMavenDeployAction(pomFile, metadataFile, artifactRepository, repositoryTransportFactory);
         deployTask.setLocalMavenRepositoryLocation(temporaryDirFactory.create());
         deployTask.setRepositories(createMavenRemoteRepository(artifactRepository), null);
         return deployTask;
@@ -63,8 +63,8 @@ public class MavenRemotePublisher extends AbstractMavenPublisher {
         private final MavenArtifactRepository artifactRepository;
         private final RepositoryTransportFactory repositoryTransportFactory;
 
-        public GradleWagonMavenDeployAction(File pomFile, MavenArtifactRepository artifactRepository, RepositoryTransportFactory repositoryTransportFactory) {
-            super(pomFile, null);
+        public GradleWagonMavenDeployAction(File pomFile, File metadataFile, MavenArtifactRepository artifactRepository, RepositoryTransportFactory repositoryTransportFactory) {
+            super(pomFile, metadataFile, null);
             this.artifactRepository = artifactRepository;
             this.repositoryTransportFactory = repositoryTransportFactory;
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -194,9 +194,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
                     generateTask.getOutputFile().set(new File(buildDir, "publications/" + publication.getName() + "/module.json"));
                 }
             });
-            GenerateModuleMetadata generatorTask = (GenerateModuleMetadata) tasks.get(descriptorTaskName);
-            MavenArtifact metadataFile = publication.artifact(generatorTask.getOutputFile());
-            metadataFile.setExtension("module");
+            publication.setGradleModuleMetadataFile(tasks.get(descriptorTaskName).getOutputs().getFiles());
         }
     }
 

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -41,7 +41,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
-public class DefaultMavenPublicationTest extends Specification {
+class DefaultMavenPublicationTest extends Specification {
     @Rule
     final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
 
@@ -50,11 +50,13 @@ public class DefaultMavenPublicationTest extends Specification {
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
     TestFile pomDir
     TestFile pomFile
+    TestFile gradleMetadataFile
     File artifactFile
 
     def "setup"() {
         pomDir = testDirectoryProvider.testDirectory
         pomFile = pomDir.createFile("pom-file")
+        gradleMetadataFile = pomDir.createFile("module-file")
         artifactFile = pomDir.createFile("artifact-file")
         artifactFile << "some content"
     }
@@ -160,7 +162,7 @@ public class DefaultMavenPublicationTest extends Specification {
         def publication = createPublication()
 
         then:
-        publication.publishableFiles.files == [pomFile] as Set
+        publication.publishableFiles.files == [pomFile, gradleMetadataFile] as Set
         publication.artifacts.empty
         publication.runtimeDependencies.empty
     }
@@ -184,7 +186,7 @@ public class DefaultMavenPublicationTest extends Specification {
         publication.from(componentWithArtifact(artifact))
 
         then:
-        publication.publishableFiles.files == [pomFile, artifactFile] as Set
+        publication.publishableFiles.files == [pomFile, gradleMetadataFile, artifactFile] as Set
         publication.artifacts == [mavenArtifact] as Set
         publication.runtimeDependencies.empty
 
@@ -222,7 +224,7 @@ public class DefaultMavenPublicationTest extends Specification {
         publication.from(component)
 
         then:
-        publication.publishableFiles.files == [pomFile, artifactFile] as Set
+        publication.publishableFiles.files == [pomFile, gradleMetadataFile, artifactFile] as Set
         publication.artifacts == [mavenArtifact] as Set
     }
 
@@ -337,7 +339,7 @@ public class DefaultMavenPublicationTest extends Specification {
 
         then:
         publication.artifacts == [mavenArtifact] as Set
-        publication.publishableFiles.files == [pomFile, artifactFile] as Set
+        publication.publishableFiles.files == [pomFile, gradleMetadataFile, artifactFile] as Set
     }
 
     def "attaches and configures artifacts parsed by notation parser"() {
@@ -363,7 +365,7 @@ public class DefaultMavenPublicationTest extends Specification {
 
         then:
         publication.artifacts == [mavenArtifact] as Set
-        publication.publishableFiles.files == [pomFile, artifactFile] as Set
+        publication.publishableFiles.files == [pomFile, gradleMetadataFile, artifactFile] as Set
     }
 
     def "can use setter to replace existing artifacts set"() {
@@ -393,6 +395,7 @@ public class DefaultMavenPublicationTest extends Specification {
     def createPublication() {
         def publication = new DefaultMavenPublication("pub-name", module, notationParser, DirectInstantiator.INSTANCE, projectDependencyResolver, TestFiles.fileCollectionFactory(), new ExperimentalFeatures())
         publication.setPomFile(new SimpleFileCollection(pomFile))
+        publication.setGradleModuleMetadataFile(new SimpleFileCollection(gradleMetadataFile))
         return publication;
     }
 

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Unroll
 import static java.util.Collections.emptySet
 import static org.gradle.util.CollectionUtils.toSet
 
-public class ValidatingMavenPublisherTest extends Specification {
+class ValidatingMavenPublisherTest extends Specification {
     @Rule
     final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
 
@@ -43,7 +43,7 @@ public class ValidatingMavenPublisherTest extends Specification {
     def "delegates when publication is valid"() {
         when:
         def projectIdentity = makeProjectIdentity("the-group", "the-artifact", "the-version")
-        def publication = new MavenNormalizedPublication("pub-name", createPomFile(projectIdentity), projectIdentity, emptySet(), null)
+        def publication = new MavenNormalizedPublication("pub-name", createPomFile(projectIdentity), null, projectIdentity, emptySet(), null)
 
         and:
         publisher.publish(publication, repository)
@@ -55,7 +55,7 @@ public class ValidatingMavenPublisherTest extends Specification {
     def "validates project coordinates"() {
         given:
         def projectIdentity = makeProjectIdentity(groupId, artifactId, version)
-        def publication = new MavenNormalizedPublication("pub-name", createPomFile(projectIdentity), projectIdentity, emptySet(), null)
+        def publication = new MavenNormalizedPublication("pub-name", createPomFile(projectIdentity), null, projectIdentity, emptySet(), null)
 
         when:
         publisher.publish(publication, repository)
@@ -82,7 +82,7 @@ public class ValidatingMavenPublisherTest extends Specification {
         given:
         def projectIdentity = makeProjectIdentity("group", "artifact", "version")
         def pomFile = createPomFile(makeProjectIdentity(groupId, artifactId, version))
-        def publication = new MavenNormalizedPublication("pub-name", pomFile, projectIdentity, emptySet(), null)
+        def publication = new MavenNormalizedPublication("pub-name", pomFile, null, projectIdentity, emptySet(), null)
 
         when:
         publisher.publish(publication, repository)
@@ -105,7 +105,7 @@ public class ValidatingMavenPublisherTest extends Specification {
             getExtension() >> extension
             getClassifier() >> classifier
         }
-        def publication = new MavenNormalizedPublication("pub-name", pomFile, projectIdentity, toSet([mavenArtifact]), null)
+        def publication = new MavenNormalizedPublication("pub-name", pomFile, null, projectIdentity, toSet([mavenArtifact]), null)
 
         when:
         publisher.publish(publication, repository)
@@ -129,7 +129,7 @@ public class ValidatingMavenPublisherTest extends Specification {
         def projectIdentity = makeProjectIdentity("group", "artifact", "version")
         def pomFile = createPomFile(projectIdentity)
         def mavenArtifact = Mock(MavenArtifact)
-        def publication = new MavenNormalizedPublication("pub-name", pomFile, projectIdentity, toSet([mavenArtifact]), null)
+        def publication = new MavenNormalizedPublication("pub-name", pomFile, null, projectIdentity, toSet([mavenArtifact]), null)
 
         File theFile = new TestFile(testDir.testDirectory, "testFile")
         if (createDir) {
@@ -167,7 +167,7 @@ public class ValidatingMavenPublisherTest extends Specification {
         }
         def projectIdentity = makeProjectIdentity("group", "artifact", "version")
         def pomFile = createPomFile(projectIdentity)
-        def publication = new MavenNormalizedPublication("pub-name", pomFile, projectIdentity, toSet([artifact1, artifact2]), null)
+        def publication = new MavenNormalizedPublication("pub-name", pomFile, null, projectIdentity, toSet([artifact1, artifact2]), null)
 
         when:
         publisher.publish(publication, repository)
@@ -186,7 +186,7 @@ public class ValidatingMavenPublisherTest extends Specification {
         }
         def projectIdentity = makeProjectIdentity("group", "artifact", "version")
         def pomFile = createPomFile(projectIdentity)
-        def publication = new MavenNormalizedPublication("pub-name", pomFile, projectIdentity, toSet([artifact1]), null)
+        def publication = new MavenNormalizedPublication("pub-name", pomFile, null, projectIdentity, toSet([artifact1]), null)
 
         when:
         publisher.publish(publication, repository)
@@ -204,7 +204,7 @@ public class ValidatingMavenPublisherTest extends Specification {
                 xml.asNode().appendNode("invalid", "This is not a valid pomFile element")
             }
         })
-        def publication = new MavenNormalizedPublication("pub-name", pomFile, projectIdentity, emptySet(), null)
+        def publication = new MavenNormalizedPublication("pub-name", pomFile, null, projectIdentity, emptySet(), null)
 
         when:
         publisher.publish(publication, repository)

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -17,27 +17,17 @@ package org.gradle.integtests.fixtures.publish.maven
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.test.fixtures.GradleMetadataAwarePublishingSpec
 import org.gradle.test.fixtures.maven.MavenFileModule
 import org.gradle.test.fixtures.maven.MavenModule
 import org.gradle.test.fixtures.maven.MavenJavaModule
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
 
-abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec {
-    def publishModuleMetadata = true
-    def resolveModuleMetadata = true
+abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec implements GradleMetadataAwarePublishingSpec {
 
     def setup() {
-        executer.beforeExecute {
-            if (publishModuleMetadata) {
-                withArgument("-Dorg.gradle.internal.experimentalFeatures")
-            }
-        }
-    }
-
-    protected void disableModuleMetadataPublishing() {
-        publishModuleMetadata = false
-        resolveModuleMetadata = false
+        prepare()
     }
 
     protected static MavenJavaModule javaLibrary(MavenFileModule mavenFileModule) {

--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/ivy/IvyPublishGcsIntegrationTest.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/ivy/IvyPublishGcsIntegrationTest.groovy
@@ -66,10 +66,12 @@ publishing {
         module.jar.sha1.expectUpload()
         module.ivy.expectUpload()
         module.ivy.sha1.expectUpload()
+        module.moduleMetadata.expectUpload()
+        module.moduleMetadata.sha1.expectUpload()
 
         succeeds 'publish'
 
         then:
-        module.assertPublishedAsJavaModule()
+        javaLibrary(module.backingModule).assertPublishedAsJavaModule()
     }
 }

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyPublishS3IntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyPublishS3IntegrationTest.groovy
@@ -64,10 +64,12 @@ publishing {
         module.jar.sha1.expectUpload()
         module.ivy.expectUpload()
         module.ivy.sha1.expectUpload()
+        module.moduleMetadata.expectUpload()
+        module.moduleMetadata.sha1.expectUpload()
 
         succeeds 'publish'
 
         then:
-        module.assertPublishedAsJavaModule()
+        javaLibrary(module.backingModule).assertPublishedAsJavaModule()
     }
 }

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishSftpIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishSftpIntegrationTest.groovy
@@ -108,11 +108,15 @@ class IvyPublishSftpIntegrationTest extends AbstractIvyPublishIntegTest {
         module.ivy.expectFileUpload()
         module.ivy.sha1.expectParentCheckdir()
         module.ivy.sha1.expectFileUpload()
+        module.moduleMetadata.expectParentCheckdir()
+        module.moduleMetadata.expectFileUpload()
+        module.moduleMetadata.sha1.expectParentCheckdir()
+        module.moduleMetadata.sha1.expectFileUpload()
 
         then:
         succeeds 'publish'
 
-        module.assertIvyAndJarFilePublished()
+        module.assertMetadataAndJarFilePublished()
         module.jarFile.assertIsCopyOf(file('build/libs/publish-2.jar'))
 
         where:
@@ -167,11 +171,15 @@ class IvyPublishSftpIntegrationTest extends AbstractIvyPublishIntegTest {
         module.ivy.expectFileUpload()
         module.ivy.sha1.expectParentCheckdir()
         module.ivy.sha1.expectFileUpload()
+        module.moduleMetadata.expectParentCheckdir()
+        module.moduleMetadata.expectFileUpload()
+        module.moduleMetadata.sha1.expectParentCheckdir()
+        module.moduleMetadata.sha1.expectFileUpload()
 
         then:
         succeeds 'publish'
 
-        module.assertIvyAndJarFilePublished()
+        module.assertMetadataAndJarFilePublished()
         module.jarFile.assertIsCopyOf(file('build/libs/publish-2.jar'))
 
         where:


### PR DESCRIPTION
This pull request implements the equivalent of what existed in terms of publishing Gradle metadata for Maven repositories, this time for Ivy repositories.

See #3393