### PR TITLE
Let buildSrc use the java-gradle-plugin plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ import org.gradle.cleanup.EmptyDirectoryCheck
 
 plugins {
     id 'java-base'
-    id 'org.gradle.build-types'
+    id 'build-types'
 }
 
 defaultTasks 'assemble'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,12 +15,30 @@
  */
 plugins {
     id 'groovy'
+    id 'java-gradle-plugin'
     id 'idea'
     id 'eclipse'
 }
 
 sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
+
+gradlePlugin {
+    plugins {
+        jsoup {
+            id = "jsoup"
+            implementationClass = "org.gradle.plugins.jsoup.JsoupPlugin"
+        }
+        buildTypes {
+            id = "org.gradle.build-types"
+            implementationClass = "org.gradle.plugins.buildtypes.BuildTypesPlugin"
+        }
+        pegdown {
+            id = "pegdown"
+            implementationClass = "org.gradle.plugins.pegdown.PegDownPlugin"
+        }
+    }
+}
 
 // 1.5.3 has a classloader leak (https://github.com/asciidoctor/asciidoctor-gradle-plugin/pull/215)
 // 1.5.6 requires Java 8+ (https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/218)

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -30,7 +30,7 @@ gradlePlugin {
             implementationClass = "org.gradle.plugins.jsoup.JsoupPlugin"
         }
         buildTypes {
-            id = "org.gradle.build-types"
+            id = "build-types"
             implementationClass = "org.gradle.plugins.buildtypes.BuildTypesPlugin"
         }
         pegdown {

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/jsoup.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/jsoup.properties
@@ -1,1 +1,0 @@
-implementation-class=org.gradle.plugins.jsoup.JsoupPlugin

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/org.gradle.build-types.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/org.gradle.build-types.properties
@@ -1,1 +1,0 @@
-implementation-class=org.gradle.plugins.buildtypes.BuildTypesPlugin

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/pegdown.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/pegdown.properties
@@ -1,1 +1,0 @@
-implementation-class=org.gradle.plugins.pegdown.PegDownPlugin


### PR DESCRIPTION
### Context
In order to get task property validation
And let the `buildSrc` plugins descriptor be generated