### PR TITLE
Fix some buildSrc tasks properties

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/build/GradleStartScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/GradleStartScriptGenerator.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.TaskAction
 @CacheableTask
 @CompileStatic
 class GradleStartScriptGenerator extends DefaultTask {
+    @Internal
     File startScriptsDir
 
     @Internal

--- a/buildSrc/src/main/groovy/org/gradle/build/Install.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/Install.groovy
@@ -15,12 +15,15 @@
  */
 package org.gradle.build
 
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Sync
 
 class Install extends Sync {
 
+    @Internal
     String installDirPropertyName
-    File installDir
+
+    private File installDir
 
     def Install() {
         addPropertyCheck()

--- a/buildSrc/src/main/groovy/org/gradle/build/docs/UserGuideTransformTask.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/UserGuideTransformTask.groovy
@@ -81,8 +81,6 @@ class UserGuideTransformTask extends DefaultTask {
     @Input
     Set<String> tags = new LinkedHashSet()
 
-    final SampleElementValidator validator = new SampleElementValidator()
-
     @Input String getJavadocUrl() {
         javadocUrl
     }
@@ -94,6 +92,8 @@ class UserGuideTransformTask extends DefaultTask {
     @Input String getWebsiteUrl() {
         websiteUrl
     }
+
+    private final SampleElementValidator validator = new SampleElementValidator()
 
     @TaskAction
     def transform() {

--- a/buildSrc/src/main/groovy/org/gradle/cleanup/EmptyDirectoryCheck.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/cleanup/EmptyDirectoryCheck.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -28,7 +29,7 @@ import org.gradle.api.tasks.TaskAction
  * the directory to a report file.
  */
 class EmptyDirectoryCheck extends DefaultTask {
-    @Input
+    @InputFiles
     FileTree targetDir
 
     @OutputFile

--- a/buildSrc/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -26,6 +26,7 @@ import groovyx.net.http.ContentType
 import groovyx.net.http.RESTClient
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -65,6 +66,7 @@ class DistributedPerformanceTest extends PerformanceTest {
     @Input
     String teamCityUsername
 
+    @Internal
     String teamCityPassword
 
     @OutputFile
@@ -73,13 +75,13 @@ class DistributedPerformanceTest extends PerformanceTest {
     @OutputFile
     File scenarioReport
 
-    RESTClient client
+    private RESTClient client
 
-    List<String> scheduledBuilds = Lists.newArrayList()
+    private List<String> scheduledBuilds = Lists.newArrayList()
 
-    List<Object> finishedBuilds = Lists.newArrayList()
+    private List<Object> finishedBuilds = Lists.newArrayList()
 
-    Map<String, List<File>> testResultFilesForBuild = [:]
+    private Map<String, List<File>> testResultFilesForBuild = [:]
     private File workerTestResultsTempDir
 
     private final JUnitXmlTestEventsGenerator testEventsGenerator


### PR DESCRIPTION
### Context
Follow up to #3574 

This PR reduces the number of warnings but leaves the following tasks untouched:
- `AbstractProjectGeneratorTask` descendants
- `CacheableAsciidoctorTask` properties inherited from upstream `AsciidoctorTask`
