### PR TITLE
Replace hash sets with linked lists in dependency graph

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphComponent.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphComponent.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 
-import java.util.Set;
+import java.util.Collection;
 
 /**
  * A component in the dependency graph.
@@ -26,5 +26,5 @@ import java.util.Set;
 public interface DependencyGraphComponent extends ComponentResult {
     ComponentResolveMetadata getMetadata();
 
-    Set<? extends DependencyGraphComponent> getDependents();
+    Collection<? extends DependencyGraphComponent> getDependents();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphNode.java
@@ -39,7 +39,7 @@ public interface DependencyGraphNode {
 
     DependencyGraphComponent getOwner();
 
-    Set<? extends DependencyGraphEdge> getIncomingEdges();
+    Collection<? extends DependencyGraphEdge> getIncomingEdges();
 
     Collection<? extends DependencyGraphEdge> getOutgoingEdges();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
@@ -32,8 +32,8 @@ import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 import org.gradle.internal.resolve.result.DefaultBuildableComponentResolveResult;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Resolution state for a given component
@@ -41,7 +41,7 @@ import java.util.Set;
 public class ComponentState implements ComponentResolutionState, ComponentResult, DependencyGraphComponent {
     private final ModuleVersionIdentifier id;
     private final ComponentMetaDataResolver resolver;
-    private final Set<NodeState> nodes = new LinkedHashSet<NodeState>();
+    private final List<NodeState> nodes = Lists.newLinkedList();
     private final Long resultId;
     private final ModuleResolveState module;
     private volatile ComponentResolveMetadata metaData;
@@ -51,7 +51,7 @@ public class ComponentState implements ComponentResolutionState, ComponentResult
     private ModuleVersionResolveException failure;
     private SelectorState selectedBy;
     private DependencyGraphBuilder.VisitState visitState = DependencyGraphBuilder.VisitState.NotSeen;
-    Set<SelectorState> allResolvers;
+    List<SelectorState> allResolvers;
 
     ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentMetaDataResolver resolver) {
         this.resultId = resultId;
@@ -97,7 +97,7 @@ public class ComponentState implements ComponentResolutionState, ComponentResult
         this.visitState = visitState;
     }
 
-    public Set<NodeState> getNodes() {
+    public List<NodeState> getNodes() {
         return nodes;
     }
 
@@ -119,7 +119,7 @@ public class ComponentState implements ComponentResolutionState, ComponentResult
     public void selectedBy(SelectorState resolver) {
         if (selectedBy == null) {
             selectedBy = resolver;
-            allResolvers = Sets.newLinkedHashSet();
+            allResolvers = Lists.newLinkedList();
         }
         allResolvers.add(resolver);
     }
@@ -204,8 +204,8 @@ public class ComponentState implements ComponentResolutionState, ComponentResult
     }
 
     @Override
-    public Set<ComponentState> getDependents() {
-        Set<ComponentState> incoming = new LinkedHashSet<ComponentState>();
+    public Collection<ComponentState> getDependents() {
+        List<ComponentState> incoming = Lists.newArrayListWithCapacity(nodes.size());
         for (NodeState configuration : nodes) {
             for (EdgeState dependencyEdge : configuration.getIncomingEdges()) {
                 incoming.add(dependencyEdge.getFrom().getComponent());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -57,7 +57,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class DependencyGraphBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(DependencyGraphBuilder.class);
@@ -185,7 +184,7 @@ public class DependencyGraphBuilder {
                                                   String version,
                                                   final ModuleResolveState module) {
         final ComponentState selected = module.getSelected();
-        Set<SelectorState> moduleSelectors = module.getSelectors();
+        List<SelectorState> moduleSelectors = module.getSelectors();
         if (selected == null && !resolveState.getModuleReplacementsData().participatesInReplacements(moduleId)) {
             if (allSelectorsAgreeWith(moduleSelectors, version, ALL_SELECTORS)) {
                 module.select(moduleRevision);
@@ -193,7 +192,7 @@ public class DependencyGraphBuilder {
             }
         }
 
-        final Set<SelectorState> selectedBy = moduleRevision.allResolvers;
+        final Collection<SelectorState> selectedBy = moduleRevision.allResolvers;
         if (selected != null && selected != moduleRevision) {
             if (allSelectorsAgreeWith(moduleRevision.allResolvers, selected.getVersion(), ALL_SELECTORS)) {
                 // if this selector agrees with the already selected version, don't bother and pick it

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
@@ -34,7 +35,6 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -47,7 +47,7 @@ class EdgeState implements DependencyGraphEdge {
     private final SelectorState selector;
     private final ResolveState resolveState;
     private final ModuleExclusion moduleExclusion;
-    private final Set<NodeState> targetNodes = new LinkedHashSet<NodeState>();
+    private final List<NodeState> targetNodes = Lists.newLinkedList();
 
     private ComponentState targetModuleRevision;
     private ModuleVersionResolveException targetNodeSelectionFailure;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -26,12 +26,10 @@ import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Resolution state for a given module.
@@ -42,7 +40,7 @@ class ModuleResolveState implements CandidateModule {
     private final ModuleIdentifier id;
     private final List<EdgeState> unattachedDependencies = new LinkedList<EdgeState>();
     private final Map<ModuleVersionIdentifier, ComponentState> versions = new LinkedHashMap<ModuleVersionIdentifier, ComponentState>();
-    private final Set<SelectorState> selectors = new HashSet<SelectorState>();
+    private final List<SelectorState> selectors = Lists.newLinkedList();
     private ComponentState selected;
 
     ModuleResolveState(IdGenerator<Long> idGenerator, ModuleIdentifier id, ComponentMetaDataResolver metaDataResolver) {
@@ -175,7 +173,7 @@ class ModuleResolveState implements CandidateModule {
         selectors.add(selector);
     }
 
-    public Set<SelectorState> getSelectors() {
+    public List<SelectorState> getSelectors() {
         return selectors;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -44,7 +43,7 @@ class NodeState implements DependencyGraphNode {
 
     private final Long resultId;
     private final ComponentState component;
-    private final Set<EdgeState> incomingEdges = new LinkedHashSet<EdgeState>();
+    private final List<EdgeState> incomingEdges = Lists.newLinkedList();
     private final List<EdgeState> outgoingEdges = Lists.newLinkedList();
     private final ResolvedConfigurationIdentifier id;
 
@@ -90,7 +89,7 @@ class NodeState implements DependencyGraphNode {
     }
 
     @Override
-    public Set<EdgeState> getIncomingEdges() {
+    public List<EdgeState> getIncomingEdges() {
         return incomingEdges;
     }
 


### PR DESCRIPTION
It doesn't seem that we actually need Set semantics here
and linked hash sets are pretty memory inefficient. Instead
we now use linked lists for these append-only collections.

This slightly reduces memory pressure (by 3%) in the large
Android build.