### PR TITLE
Do not fail pom parsing if an optional dependency omits the version

### DIFF
--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
@@ -174,6 +174,45 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         dep.optional
     }
 
+    def "a bom can declare an optional dependency with excludes"() {
+        given:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group-a</groupId>
+    <artifactId>bom</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>group-b</groupId>
+                <artifactId>module-b</artifactId>
+                <version>1.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>group-c</groupId>
+                        <artifactId>module-c</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+"""
+
+        when:
+        parsePom()
+
+        then:
+        def dep = single(metadata.dependencies)
+        dep.excludes[0].moduleId.group == 'group-c'
+        dep.excludes[0].moduleId.name == 'module-c'
+        dep.excludes[0].artifact.name == '*'
+        dep.excludes[0].artifact.extension == '*'
+    }
+
     def "a bom version can be relocated"() {
         given:
         pomFile << """

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
@@ -142,6 +142,38 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         metadata.dependencies.empty
     }
 
+    def "an entry in the dependencyManagement block without version does not fail parsing"() {
+        given:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group-a</groupId>
+    <artifactId>bom</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>group-b</groupId>
+                <artifactId>module-b</artifactId>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+"""
+
+        when:
+        parsePom()
+
+        then:
+        def dep = single(metadata.dependencies)
+        dep.selector == moduleId('group-b', 'module-b', '')
+        dep.scope == MavenScope.Compile
+        hasDefaultDependencyArtifact(dep)
+        dep.optional
+    }
+
     def "a bom version can be relocated"() {
         given:
         pomFile << """


### PR DESCRIPTION
There are valid cases for this. For example when a parent POM declares
excludes for a dependency without explicitly stating its version:

```
<dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>org.springframework</groupId>
      <artifactId>spring-core</artifactId>
      <exclusions>
        <exclusion>
          <groupId>commons-logging</groupId>
          <artifactId>commons-logging</artifactId>
        </exclusion>
      </exclusions>
    </dependency>
  </dependencies>
</dependencyManagement>
```
(from: https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-build/1.2.1.RELEASE/spring-cloud-build-1.2.1.RELEASE.pom)

This fixes #3576 