### PR TITLE
Fix XCTest filtering

### DIFF
--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/XCTestSelection.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/XCTestSelection.java
@@ -96,8 +96,8 @@ public class XCTestSelection {
                 return filter;
             }
             return tokens[0] + "." + tokens[1] + "/" + tokens[2];
-        } else if (tokens.length == 2 && WILDCARD.equals(tokens[1])) {
-            return INCLUDE_ALL_TESTS;
+        } else if (tokens.length == 2 && !WILDCARD.equals(tokens[1])) {
+            testSuiteCache.add(testFilter);
         }
 
         return testFilter;

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/XCTestSelectionTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/XCTestSelectionTest.groovy
@@ -48,9 +48,9 @@ class XCTestSelectionTest extends Specification {
         select('one.dot', 'has.two.dots').includedTests == ['one.dot', 'has.two/dots']
     }
 
-    def "can use wildcard to select all tests from module"() {
+    def "ignores wildcard to select all tests from module"() {
         expect:
-        select('ModuleName.*').includedTests == ['All']
+        select('ModuleName.*').includedTests == ['ModuleName.*']
     }
 
     def "can use wildcard to select all test case from suite"() {
@@ -65,9 +65,10 @@ class XCTestSelectionTest extends Specification {
 
     def "ignores conceptual duplicate filters"() {
         expect:
-        select('a.*', 'a.b.c').includedTests == ['All']
         select('a.b.*', 'a.b.c', 'a.d.e').includedTests == ['a.b', 'a.d/e']
         select('a.b.c', 'a.d.e', 'a.b.*').includedTests == ['a.d/e', 'a.b']
+        select('a.b', 'a.b.c', 'a.d.e').includedTests == ['a.b', 'a.d/e']
+        select('a.b.c', 'a.d.e', 'a.b').includedTests == ['a.d/e', 'a.b']
     }
 
     def "conserve order of filters"() {


### PR DESCRIPTION
### Context
 * Don't translate `ModuleName.*` to `All` filter. `ModuleName` could
   be something else then the compiled module name which would result in
   wrongly assuming all test were selected.
 * Fix the duplication case where filter `ModuleName.testSuite` and
   `ModuleName.testSuite.testCase` were used at the same time.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fissue-with-xctest-filtering)
- [x] Verify documentation
- [x] Recognize contributor in release notes
