### PR TITLE
Prime build cache for Java 7

### DIFF
--- a/.teamcity/Gradle_BuildCacheDeactivated/settings.kts
+++ b/.teamcity/Gradle_BuildCacheDeactivated/settings.kts
@@ -43,8 +43,11 @@ val buildModel = CIBuildModel(
                                 TestCoverage(TestType.quick, OS.linux, JvmVersion.java8))),
                 Stage("Quick Feedback", "Run checks and functional tests (embedded executer)",
                         trigger = Trigger.eachCommit,
+                        specificBuilds = listOf(
+                                SpecificBuild.CompileAllJava7),
                         functionalTests = listOf(
-                                TestCoverage(TestType.quick, OS.windows, JvmVersion.java7)))
+                                TestCoverage(TestType.quick, OS.windows, JvmVersion.java7)),
+                        functionalTestsDependOnSpecificBuilds = true)
         )
 )
 project(RootProject(buildModel))

--- a/.teamcity/Gradle_Check/configurations/CompileAllJava7.kt
+++ b/.teamcity/Gradle_Check/configurations/CompileAllJava7.kt
@@ -1,0 +1,22 @@
+package configurations
+
+import model.CIBuildModel
+
+class CompileAllJava7(model: CIBuildModel) : BaseGradleBuildType(model, {
+    uuid = "${model.projectPrefix}CompileAllJava7"
+    extId = uuid
+    name = "Compile All Java 7"
+    description = "Compiles all sources on Java 7 to populate the build cache"
+
+    params {
+        param("env.JAVA_HOME", "%windows.java7.oracle.64bit%")
+    }
+
+    if (model.publishStatusToGitHub) {
+        features {
+            publishBuildStatusToGithub()
+        }
+    }
+
+    applyDefaults(model, this, "compileAll", extraParameters = "-DenableCodeQuality=true --parallel")
+}, usesParentBuildCache = true)

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -1,6 +1,7 @@
 package model
 
 import configurations.BuildDistributions
+import configurations.CompileAllJava7
 import configurations.Gradleception
 import configurations.SanityCheck
 import configurations.SmokeTests
@@ -22,8 +23,11 @@ data class CIBuildModel (
                     functionalTests = listOf(
                             TestCoverage(TestType.quick, OS.linux, JvmVersion.java8))),
             Stage("Quick Feedback", "Run checks and functional tests (embedded executer)",
+                    specificBuilds = listOf(
+                            SpecificBuild.CompileAllJava7),
                     functionalTests = listOf(
-                            TestCoverage(TestType.quick, OS.windows, JvmVersion.java7))),
+                            TestCoverage(TestType.quick, OS.windows, JvmVersion.java7)),
+                    functionalTestsDependOnSpecificBuilds = true),
             Stage("Branch Build Accept", "Run performance and functional tests (against distribution)",
                     specificBuilds = listOf(
                             SpecificBuild.BuildDistributions,
@@ -167,7 +171,7 @@ object NoBuildCache : BuildCache {
     }
 }
 
-data class Stage(val name: String, val description: String, val specificBuilds: List<SpecificBuild> = emptyList(), val performanceTests: List<PerformanceTestType> = emptyList(), val functionalTests: List<TestCoverage> = emptyList(), val trigger: Trigger = Trigger.never)
+data class Stage(val name: String, val description: String, val specificBuilds: List<SpecificBuild> = emptyList(), val performanceTests: List<PerformanceTestType> = emptyList(), val functionalTests: List<TestCoverage> = emptyList(), val trigger: Trigger = Trigger.never, val functionalTestsDependOnSpecificBuilds: Boolean = false)
 
 data class TestCoverage(val testType: TestType, val os: OS, val version: JvmVersion, val vendor: JvmVendor = JvmVendor.oracle) {
     fun asId(model : CIBuildModel): String {
@@ -221,6 +225,11 @@ enum class SpecificBuild {
     SanityCheck {
         override fun create(model: CIBuildModel): BuildType {
             return SanityCheck(model)
+        }
+    },
+    CompileAllJava7 {
+        override fun create(model: CIBuildModel): BuildType {
+            return CompileAllJava7(model)
         }
     },
     BuildDistributions {

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -7,6 +7,7 @@ import projects.RootProject
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class CIConfigIntegrationTests {
@@ -71,6 +72,18 @@ class CIConfigIntegrationTests {
             } else {
                 assertEquals(2, it.dependencies.items.size) //Individual Performance Worker
             }
+        }
+    }
+
+    @Test
+    fun functionalTestsCanDependOnSpecificBuilds() {
+        val m = CIBuildModel()
+        val p = RootProject(m)
+        val quickFeedbackProject = p.subProjects.find { it.name == "Quick Feedback" }!!
+        val quickFeedbackFunctionalTests = quickFeedbackProject.subProjects.find { it.name == TestCoverage(TestType.quick, OS.windows, JvmVersion.java7).asName() }!!.buildTypes
+        assertTrue(quickFeedbackFunctionalTests.isNotEmpty())
+        quickFeedbackFunctionalTests.forEach {
+            assertNotNull(it.dependencies.items.find { it.extId == "${m.projectPrefix}CompileAllJava7" }, "No dependency on CompileAllJava7 found")
         }
     }
 


### PR DESCRIPTION
Groovy compilation is not cached between a Java 7 and a Java 8 build.
This causes some race conditions on CI since it seems that Groovy
compilation is not reproducible completely.
By adding a build to compile all the sources on Java 7, too, we avoid
this problem.
