### PR TITLE
Add dependency constraints DSL

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+
+/**
+ * Represents a constraints over all, including transitive, dependencies.
+ *
+ * @since 4.5
+ */
+@Incubating
+public interface DependencyConstraint extends Dependency {
+
+    /**
+     * Configures the version constraint for this dependency.
+     * @param configureAction the configuration action for the module version
+     */
+    void version(Action<? super MutableVersionConstraint> configureAction);
+
+    /**
+     * Returns the version constraint.
+     */
+    VersionConstraint getVersionConstraint();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependency.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+
+/**
+ * Implementations of this interface always describe direct dependencies and not
+ * constraints may optionally considered as dependency.
+ *
+ * @since 4.5
+ */
+public interface DirectDependency extends Dependency {
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependency.java
@@ -17,11 +17,14 @@
 package org.gradle.api.artifacts;
 
 
+import org.gradle.api.Incubating;
+
 /**
  * Implementations of this interface always describe direct dependencies and not
  * constraints may optionally considered as dependency.
  *
  * @since 4.5
  */
+@Incubating
 public interface DirectDependency extends Dependency {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -32,7 +32,7 @@ import static groovy.lang.Closure.DELEGATE_FIRST;
  * <p>
  * For examples on configuring the exclude rules please refer to {@link #exclude(java.util.Map)}.
  */
-public interface ModuleDependency extends Dependency {
+public interface ModuleDependency extends DirectDependency {
     /**
      * Adds an exclude rule to exclude transitive dependencies of this dependency.
      * <p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/SelfResolvingDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/SelfResolvingDependency.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * repository.
  */
 @HasInternalProtocol
-public interface SelfResolvingDependency extends Dependency, Buildable {
+public interface SelfResolvingDependency extends DirectDependency, Buildable {
     /**
      * Resolves this dependency. A {@link org.gradle.api.artifacts.ProjectDependency} is resolved with transitive equals true
      * by this method.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts.dsl;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.DependencyConstraint;
+
+/**
+ * <p>A {@code DependencyConstraintHandler} is used to declare dependency constraints.</p>
+ *
+ * @since 4.5
+ */
+@Incubating
+public interface DependencyConstraintHandler {
+    /**
+     * Adds a dependency constraint to the given configuration.
+     *
+     * @param configurationName The name of the configuration.
+     * @param dependencyConstraintNotation the constraint
+     */
+    DependencyConstraint add(String configurationName, Object dependencyConstraintNotation);
+
+    /**
+     * Adds a dependency constraint to the given configuration, and configures the dependency constraint using the given closure.
+     *
+     * @param configurationName The name of the configuration.
+     * @param dependencyNotation The dependency constraint notation
+     * @param configureAction The closure to use to configure the dependency constraint.
+     */
+    DependencyConstraint add(String configurationName, Object dependencyNotation, Action<? super DependencyConstraint> configureAction);
+
+    /**
+     * Creates a dependency constraint without adding it to a configuration.
+     *
+     * @param dependencyConstraintNotation The dependency constraint notation.
+     */
+    DependencyConstraint create(Object dependencyConstraintNotation);
+
+    /**
+     * Creates a dependency constraint without adding it to a configuration, and configures the dependency constraint using
+     * the given closure.
+     *
+     * @param dependencyConstraintNotation The dependency constraint notation.
+     * @param configureAction The closure to use to configure the dependency.
+     */
+    DependencyConstraint create(Object dependencyConstraintNotation, Action<? super DependencyConstraint> configureAction);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -338,6 +338,17 @@ public interface DependencyHandler {
     Dependency localGroovy();
 
     /**
+     * Configures dependency constraint for this project.
+     *
+     * <p>This method executes the given action against the {@link org.gradle.api.artifacts.dsl.DependencyConstraintHandler} for this project.
+     *
+     * @param configureAction the action to use to configure module metadata
+     * @since 4.5
+     */
+    @Incubating
+    void constraints(Action<? super DependencyConstraintHandler> configureAction);
+
+    /**
      * Returns the component metadata handler for this project. The returned handler can be used for adding rules
      * that modify the metadata of depended-on software components.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -338,9 +338,18 @@ public interface DependencyHandler {
     Dependency localGroovy();
 
     /**
+     * Returns the dependency constraint handler for this project.
+     *
+     * @return the dependency constraint handler for this project
+     * @since 4.5
+     */
+    @Incubating
+    DependencyConstraintHandler getConstraints();
+
+    /**
      * Configures dependency constraint for this project.
      *
-     * <p>This method executes the given action against the {@link org.gradle.api.artifacts.dsl.DependencyConstraintHandler} for this project.
+     * <p>This method executes the given action against the {@link org.gradle.api.artifacts.dsl.DependencyConstraintHandler} for this project.</p>
      *
      * @param configureAction the action to use to configure module metadata
      * @since 4.5
@@ -361,7 +370,7 @@ public interface DependencyHandler {
     /**
      * Configures component metadata for this project.
      *
-     * <p>This method executes the given action against the {@link org.gradle.api.artifacts.dsl.ComponentMetadataHandler} for this project.
+     * <p>This method executes the given action against the {@link org.gradle.api.artifacts.dsl.ComponentMetadataHandler} for this project.</p>
      *
      * @param configureAction the action to use to configure module metadata
      * @since 1.8

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractDependency.java
@@ -16,11 +16,11 @@
 
 package org.gradle.api.internal.artifacts.dependencies;
 
-import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DirectDependency;
 import org.gradle.api.internal.artifacts.DependencyResolveContext;
 import org.gradle.api.internal.artifacts.ResolvableDependency;
 
-public abstract class AbstractDependency implements ResolvableDependency, Dependency {
+public abstract class AbstractDependency implements ResolvableDependency, DirectDependency {
     protected void copyTo(AbstractDependency target) {
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyFactory.java
@@ -34,7 +34,7 @@ public interface DependencyFactory {
         }
     }
 
-    Dependency createDependency(Object dependencyNotation);
+    Dependency createDependency(Object dependencyNotation); //we should consider to change the return type to DirectDependency, which requires adjustment in Kotlin DSL
     ClientModule createModule(Object dependencyNotation, Closure configureClosure);
     ProjectDependency createProjectDependencyFromMap(ProjectFinder projectFinder, Map<? extends String, ? extends Object> map);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyFactory.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import groovy.lang.Closure;
 import org.gradle.api.artifacts.ClientModule;
+import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ProjectDependency;
 
@@ -35,6 +36,7 @@ public interface DependencyFactory {
     }
 
     Dependency createDependency(Object dependencyNotation); //we should consider to change the return type to DirectDependency, which requires adjustment in Kotlin DSL
+    DependencyConstraint createDependencyConstraint(Object dependencyNotation);
     ClientModule createModule(Object dependencyNotation, Closure configureClosure);
     ProjectDependency createProjectDependencyFromMap(ProjectFinder projectFinder, Map<? extends String, ? extends Object> map);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraintTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dependencies
+
+import org.gradle.api.artifacts.DependencyConstraint
+import spock.lang.Specification
+
+class DefaultDependencyConstraintTest extends Specification {
+
+    private DependencyConstraint dependencyConstraint = new DefaultDependencyConstraint("org.gradle", "gradle-core", "4.4-beta2")
+
+    void "has reasonable default values"() {
+        expect:
+        dependencyConstraint.group == "org.gradle"
+        dependencyConstraint.name == "gradle-core"
+        dependencyConstraint.version == "4.4-beta2"
+        dependencyConstraint.versionConstraint.preferredVersion == "4.4-beta2"
+        dependencyConstraint.versionConstraint.rejectedVersions == []
+    }
+
+
+    void "knows if is equal to"() {
+        expect:
+        new DefaultDependencyConstraint("group1", "name1", "version1") == new DefaultDependencyConstraint("group1", "name1", "version1")
+        new DefaultDependencyConstraint("group1", "name1", "version1").hashCode() == new DefaultDependencyConstraint("group1", "name1", "version1").hashCode()
+        new DefaultDependencyConstraint("group1", "name1", "version1") != new DefaultDependencyConstraint("group1", "name1", "version2")
+        new DefaultDependencyConstraint("group1", "name1", "version1") != new DefaultDependencyConstraint("group1", "name2", "version1")
+        new DefaultDependencyConstraint("group1", "name1", "version1") != new DefaultDependencyConstraint("group2", "name1", "version1")
+        new DefaultDependencyConstraint("group1", "name1", "version1") != new DefaultDependencyConstraint("group2", "name1", "version1")
+    }
+
+    def "creates deep copy"() {
+        when:
+        def copy = dependencyConstraint.copy() as DependencyConstraint
+
+        then:
+        assertDeepCopy(dependencyConstraint, copy)
+    }
+
+    static void assertDeepCopy(DependencyConstraint dependencyConstraint, DependencyConstraint copiedDependencyConstraint) {
+        assert copiedDependencyConstraint.group == dependencyConstraint.group
+        assert copiedDependencyConstraint.name == dependencyConstraint.name
+        assert copiedDependencyConstraint.version == dependencyConstraint.version
+        assert copiedDependencyConstraint.versionConstraint == copiedDependencyConstraint.versionConstraint
+        assert copiedDependencyConstraint.versionConstraint.preferredVersion == copiedDependencyConstraint.versionConstraint.preferredVersion
+        assert copiedDependencyConstraint.versionConstraint.rejectedVersions == copiedDependencyConstraint.versionConstraint.rejectedVersions
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -1,0 +1,247 @@
+
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+
+/**
+ * This is a variation of {@link OptionalDependenciesIntegrationTest} that tests dependency constraints
+ * declared in the build script (instead of published optional dependencies)
+ */
+class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        ExperimentalFeaturesFixture.enable(settingsFile)
+        settingsFile << "rootProject.name = 'test'"
+    }
+
+    void "dependency constraint is ignored when feature not enabled"() {
+        given:
+        mavenRepo.module("org", "foo", '1.0').publish()
+        mavenRepo.module("org", "foo", '1.1').publish()
+
+        // Do not enable feature
+        settingsFile.text = """
+            rootProject.name = 'test'
+"""
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf
+            }
+            dependencies {
+                conf 'org:foo:1.0'
+                constraints {
+                    conf 'org:foo:1.1'
+                }
+            }
+            task checkDeps {
+                doLast {
+                    def files = configurations.conf*.name.sort()
+                    assert files == ['foo-1.0.jar']
+                }
+            }
+        """
+
+        when:
+        run 'checkDeps'
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "dependency constraint is included into the result of resolution when a hard dependency is also added"() {
+        given:
+        mavenRepo.module("org", "foo", '1.1').publish()
+
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf
+            }
+            dependencies {
+                conf 'org:foo'
+                constraints {
+                    conf 'org:foo:1.1'
+                }
+            }
+            task checkDeps {
+                doLast {
+                    def files = configurations.conf*.name.sort()
+                    assert files == ['foo-1.1.jar']
+                }
+            }
+        """
+
+        when:
+        run 'checkDeps'
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "dependency constraint is included into the result of resolution when a hard dependency is also added transitively"() {
+        given:
+        mavenRepo.module("org", "foo", '1.0').publish()
+        mavenRepo.module("org", "foo", '1.1').publish()
+        mavenRepo.module("org", "bar", "1.0").dependsOn("org", "foo", "1.0").publish()
+
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf
+            }
+            dependencies {
+                conf 'org:bar:1.0'
+                constraints {
+                    conf 'org:foo:1.1'
+                }
+            }
+            task checkDeps {
+                doLast {
+                    def files = configurations.conf*.name.sort()
+                    assert files == ['bar-1.0.jar', 'foo-1.1.jar']
+                }
+            }
+        """
+
+        when:
+        run 'checkDeps'
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "range resolution kicks in with dependency constraints"() {
+        given:
+        mavenRepo.module("org", "foo", '1.0').publish()
+        mavenRepo.module("org", "foo", '1.1').publish()
+        mavenRepo.module("org", "foo", '1.2').publish()
+        mavenRepo.module("org", "bar", "1.0").dependsOn("org", "foo", "[1.0,1.2]").publish()
+
+
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf
+            }
+            dependencies {
+                conf 'org:bar:1.0'
+                constraints {
+                    conf 'org:foo:[1.0,1.1]'
+                }
+            }
+            task checkDeps {
+                doLast {
+                    def files = configurations.conf*.name.sort()
+                    assert files == ['bar-1.0.jar', 'foo-1.1.jar']
+                }
+            }
+        """
+
+        when:
+        run 'checkDeps'
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "transitive dependencies of an dependency constraint do not participate in conflict resolution if it is not included elsewhere"() {
+        given:
+        mavenRepo.module("org", "foo", '1.0').dependsOn('org', 'bar', '1.1').publish()
+        mavenRepo.module("org", "bar", '1.0').publish()
+        mavenRepo.module("org", "bar", '1.1').publish()
+
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf
+            }
+            dependencies {
+                conf 'org:bar:1.0'
+                constraints {
+                    conf 'org:foo:1.0'
+                }
+            }
+            task checkDeps {
+                doLast {
+                    def files = configurations.conf*.name.sort()
+                    assert files == ['bar-1.0.jar']
+                }
+            }
+        """
+
+        when:
+        run 'checkDeps'
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "dependency constraints on substituted module is recognized properly"() {
+        given:
+        mavenRepo.module("org", "foo", '1.0').publish()
+        mavenRepo.module("org", "foo", '1.1').publish()
+        mavenRepo.module("org", "bar", '1.1').publish()
+
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf {
+                   resolutionStrategy.dependencySubstitution {
+                      all { DependencySubstitution dependency ->
+                         if (dependency.requested.module == 'bar') {
+                            dependency.useTarget dependency.requested.group + ':foo:' + dependency.requested.version
+                         }
+                      }
+                   }
+                }
+            }
+            dependencies {
+                conf 'org:foo:1.0'
+                constraints {
+                    conf 'org:bar:1.1'
+                }
+            }
+            task checkDeps {
+                doLast {
+                    def files = configurations.conf*.name.sort()
+                    assert files == ['foo-1.1.jar']
+                }
+            }
+        """
+
+        when:
+        run 'checkDeps'
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
@@ -172,7 +172,7 @@ task checkDeps
 """
         then:
         fails 'checkDeps'
-        failure.assertThatCause(Matchers.startsWith("Cannot convert the provided notation to an object of type Dependency: 100."))
+        failure.assertThatCause(Matchers.startsWith("Cannot convert the provided notation to an object of type DirectDependency: 100."))
     }
 
     def "fails gracefully for single null notation"() {
@@ -190,7 +190,7 @@ task checkDeps
 """
         then:
         fails 'checkDeps'
-        failure.assertThatCause(Matchers.startsWith("Cannot convert a null value to an object of type Dependency"))
+        failure.assertThatCause(Matchers.startsWith("Cannot convert a null value to an object of type DirectDependency"))
     }
 
     def "fails gracefully for null notation in list"() {
@@ -208,7 +208,7 @@ task checkDeps
 """
         then:
         fails 'checkDeps'
-        failure.assertThatCause(Matchers.startsWith("Cannot convert a null value to an object of type Dependency"))
+        failure.assertThatCause(Matchers.startsWith("Cannot convert a null value to an object of type DirectDependency"))
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3271")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
@@ -18,7 +18,8 @@ package org.gradle.api.internal.artifacts;
 
 import groovy.lang.Closure;
 import org.gradle.api.artifacts.ClientModule;
-import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.DirectDependency;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ModuleFactoryDelegate;
@@ -29,20 +30,28 @@ import org.gradle.internal.typeconversion.NotationParser;
 import java.util.Map;
 
 public class DefaultDependencyFactory implements DependencyFactory {
-    private final NotationParser<Object, Dependency> dependencyNotationParser;
+    private final NotationParser<Object, DirectDependency> dependencyNotationParser;
+    private final NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser;
     private final NotationParser<Object, ClientModule> clientModuleNotationParser;
     private final ProjectDependencyFactory projectDependencyFactory;
 
-    public DefaultDependencyFactory(NotationParser<Object, Dependency> dependencyNotationParser,
+    public DefaultDependencyFactory(NotationParser<Object, DirectDependency> dependencyNotationParser,
+                                    NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser,
                                     NotationParser<Object, ClientModule> clientModuleNotationParser,
                                     ProjectDependencyFactory projectDependencyFactory) {
         this.dependencyNotationParser = dependencyNotationParser;
+        this.dependencyConstraintNotationParser = dependencyConstraintNotationParser;
         this.clientModuleNotationParser = clientModuleNotationParser;
         this.projectDependencyFactory = projectDependencyFactory;
     }
 
-    public Dependency createDependency(Object dependencyNotation) {
+    public DirectDependency createDependency(Object dependencyNotation) {
         return dependencyNotationParser.parseNotation(dependencyNotation);
+    }
+
+    @Override
+    public DependencyConstraint createDependencyConstraint(Object dependencyNotation) {
+        return dependencyConstraintNotationParser.parseNotation(dependencyNotation);
     }
 
     public ClientModule createModule(Object dependencyNotation, Closure configureClosure) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.AttributesSchema;
@@ -35,6 +36,7 @@ import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler;
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory;
+import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConstraintHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
@@ -201,17 +203,22 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         DependencyHandler createDependencyHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory,
-                                                  ProjectFinder projectFinder, ComponentMetadataHandler componentMetadataHandler, ComponentModuleMetadataHandler componentModuleMetadataHandler, ArtifactResolutionQueryFactory resolutionQueryFactory, AttributesSchema attributesSchema, VariantTransformRegistry artifactTransformRegistrations, ArtifactTypeRegistry artifactTypeRegistry) {
+                                                  ProjectFinder projectFinder, DependencyConstraintHandler dependencyConstraintHandler, ComponentMetadataHandler componentMetadataHandler, ComponentModuleMetadataHandler componentModuleMetadataHandler, ArtifactResolutionQueryFactory resolutionQueryFactory, AttributesSchema attributesSchema, VariantTransformRegistry artifactTransformRegistrations, ArtifactTypeRegistry artifactTypeRegistry) {
             return instantiator.newInstance(DefaultDependencyHandler.class,
                     configurationContainer,
                     dependencyFactory,
                     projectFinder,
+                    dependencyConstraintHandler,
                     componentMetadataHandler,
                     componentModuleMetadataHandler,
                     resolutionQueryFactory,
                     attributesSchema,
                     artifactTransformRegistrations,
                     artifactTypeRegistry);
+        }
+
+        DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory) {
+            return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory);
         }
 
         DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -72,6 +72,7 @@ import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.notations.ClientModuleNotationParserFactory;
+import org.gradle.api.internal.notations.DependencyConstraintNotationParser;
 import org.gradle.api.internal.notations.DependencyNotationParser;
 import org.gradle.api.internal.notations.ProjectDependencyFactory;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -152,6 +153,7 @@ class DependencyManagementBuildScopeServices {
 
         return new DefaultDependencyFactory(
             DependencyNotationParser.parser(instantiator, factory, classPathRegistry, fileLookup, runtimeShadedJarFactory, currentGradleInstallation),
+            DependencyConstraintNotationParser.parser(instantiator),
             new ClientModuleNotationParserFactory(instantiator).create(),
             projectDependencyFactory);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dependencies;
+
+import org.apache.commons.lang.StringUtils;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.MutableVersionConstraint;
+import org.gradle.api.artifacts.VersionConstraint;
+
+import javax.annotation.Nullable;
+
+public class DefaultDependencyConstraint implements DependencyConstraint {
+    private final String group;
+    private final String name;
+    private final MutableVersionConstraint versionConstraint;
+
+    public DefaultDependencyConstraint(String group, String name, String version) {
+        this.group = group;
+        this.name = name;
+        this.versionConstraint = new DefaultMutableVersionConstraint(version);
+    }
+
+    private DefaultDependencyConstraint(String group, String name, MutableVersionConstraint versionConstraint) {
+        this.group = group;
+        this.name = name;
+        this.versionConstraint = versionConstraint;
+    }
+
+    @Nullable
+    @Override
+    public String getGroup() {
+        return group;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Nullable
+    @Override
+    public String getVersion() {
+        return versionConstraint.getPreferredVersion();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = group != null ? group.hashCode() : 0;
+        result = 31 * result + name.hashCode();
+        result = 31 * result + versionConstraint.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DependencyConstraint that = (DependencyConstraint) o;
+        return contentEquals(that);
+    }
+
+    @Override
+    public boolean contentEquals(Dependency dependency) {
+        if (this == dependency) {
+            return true;
+        }
+        if (dependency == null || getClass() != dependency.getClass()) {
+            return false;
+        }
+        DefaultDependencyConstraint that = (DefaultDependencyConstraint) dependency;
+        return StringUtils.equals(group, that.getGroup()) && StringUtils.equals(name, that.getName()) && versionConstraint.equals(that.versionConstraint);
+    }
+
+    @Override
+    public Dependency copy() {
+        return new DefaultDependencyConstraint(group, name, versionConstraint);
+    }
+
+    @Override
+    public void version(Action<? super MutableVersionConstraint> configureAction) {
+        configureAction.execute(versionConstraint);
+    }
+
+    @Override
+    public VersionConstraint getVersionConstraint() {
+        return versionConstraint;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -92,7 +92,7 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     }
 
     @Override
-    public Dependency copy() {
+    public DependencyConstraint copy() {
         return new DefaultDependencyConstraint(group, name, versionConstraint);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
+import org.gradle.internal.metaobject.MethodAccess;
+import org.gradle.internal.metaobject.MethodMixIn;
+import org.gradle.util.ConfigureUtil;
+
+import javax.annotation.Nullable;
+
+public class DefaultDependencyConstraintHandler implements DependencyConstraintHandler, MethodMixIn {
+    private final ConfigurationContainer configurationContainer;
+    private final DependencyFactory dependencyFactory;
+    private final DynamicAddDependencyMethods dynamicMethods;
+
+    public DefaultDependencyConstraintHandler(ConfigurationContainer configurationContainer,
+                                              DependencyFactory dependencyFactory) {
+        this.configurationContainer = configurationContainer;
+        this.dependencyFactory = dependencyFactory;
+        this.dynamicMethods = new DynamicAddDependencyMethods(configurationContainer, new DependencyConstraintAdder());
+    }
+
+    @Override
+    public DependencyConstraint add(String configurationName, Object dependencyNotation) {
+        return doAdd(configurationContainer.getByName(configurationName), dependencyNotation, null);
+    }
+
+    @Override
+    public DependencyConstraint add(String configurationName, Object dependencyNotation, Action<? super DependencyConstraint> configureAction) {
+        return doAdd(configurationContainer.getByName(configurationName), dependencyNotation, configureAction);
+    }
+
+    @Override
+    public DependencyConstraint create(Object dependencyNotation) {
+        return doCreate(dependencyNotation, null);
+    }
+
+    @Override
+    public DependencyConstraint create(Object dependencyNotation, Action<? super DependencyConstraint> configureAction) {
+        return doCreate(dependencyNotation, configureAction);
+    }
+
+    private DependencyConstraint doCreate(Object dependencyNotation, @Nullable Action<? super DependencyConstraint> configureAction) {
+        DependencyConstraint dependencyConstraint = dependencyFactory.createDependencyConstraint(dependencyNotation);
+        if (configureAction != null) {
+            configureAction.execute(dependencyConstraint);
+        }
+        return dependencyConstraint;
+    }
+
+    private DependencyConstraint doAdd(Configuration configuration, Object dependencyNotation, @Nullable Action<? super DependencyConstraint> configureAction) {
+        DependencyConstraint dependency = doCreate(dependencyNotation, configureAction);
+        configuration.getDependencies().add(dependency);
+        return dependency;
+    }
+
+    @Override
+    public MethodAccess getAdditionalMethods() {
+        return dynamicMethods;
+    }
+
+    private class DependencyConstraintAdder implements DynamicAddDependencyMethods.DependencyAdder {
+        @Override
+        public Dependency add(Configuration configuration, Object dependencyNotation, Closure configureClosure) {
+            DependencyConstraint dependencyConstraint = ConfigureUtil.configure(configureClosure, dependencyFactory.createDependencyConstraint(dependencyNotation));
+            configuration.getDependencies().add(dependencyConstraint);
+            return dependencyConstraint;
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -154,6 +154,11 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
         configureAction.execute(dependencyConstraintHandler);
     }
 
+    @Override
+    public DependencyConstraintHandler getConstraints() {
+        return dependencyConstraintHandler;
+    }
+
     public void components(Action<? super ComponentMetadataHandler> configureAction) {
         configureAction.execute(getComponents());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import groovy.lang.Closure;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.internal.metaobject.DynamicInvokeResult;
+import org.gradle.internal.metaobject.MethodAccess;
+import org.gradle.util.CollectionUtils;
+
+import java.util.List;
+
+class DynamicAddDependencyMethods implements MethodAccess {
+    private ConfigurationContainer configurationContainer;
+    private DependencyAdder dependencyAdder;
+
+    DynamicAddDependencyMethods(ConfigurationContainer configurationContainer, DependencyAdder dependencyAdder) {
+        this.configurationContainer = configurationContainer;
+        this.dependencyAdder = dependencyAdder;
+    }
+
+    @Override
+    public boolean hasMethod(String name, Object... arguments) {
+        return arguments.length != 0 && configurationContainer.findByName(name) != null;
+    }
+
+    @Override
+    public DynamicInvokeResult tryInvokeMethod(String name, Object... arguments) {
+        if (arguments.length == 0) {
+            return DynamicInvokeResult.notFound();
+        }
+        Configuration configuration = configurationContainer.findByName(name);
+        if (configuration == null) {
+            return DynamicInvokeResult.notFound();
+        }
+
+        List<?> normalizedArgs = CollectionUtils.flattenCollections(arguments);
+        if (normalizedArgs.size() == 2 && normalizedArgs.get(1) instanceof Closure) {
+            return DynamicInvokeResult.found(dependencyAdder.add(configuration, normalizedArgs.get(0), (Closure) normalizedArgs.get(1)));
+        } else if (normalizedArgs.size() == 1) {
+            return DynamicInvokeResult.found(dependencyAdder.add(configuration, normalizedArgs.get(0), null));
+        } else {
+            for (Object arg : normalizedArgs) {
+                dependencyAdder.add(configuration, arg, null);
+            }
+            return DynamicInvokeResult.found();
+        }
+    }
+
+    interface DependencyAdder {
+        Dependency add(Configuration configuration, Object dependencyNotation, Closure configureAction);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.LenientConfiguration;
-import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
@@ -172,7 +171,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     private Set<DependencyGraphNodeResult> getFirstLevelNodes(Spec<? super Dependency> dependencySpec) {
         Set<DependencyGraphNodeResult> matches = new LinkedHashSet<DependencyGraphNodeResult>();
         TransientConfigurationResults graphResults = loadTransientGraphResults(getSelectedArtifacts());
-        for (Map.Entry<ModuleDependency, DependencyGraphNodeResult> entry : graphResults.getFirstLevelDependencies().entrySet()) {
+        for (Map.Entry<Dependency, DependencyGraphNodeResult> entry : graphResults.getFirstLevelDependencies().entrySet()) {
             if (dependencySpec.isSatisfiedBy(entry.getKey())) {
                 matches.add(entry.getValue());
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.clientmodule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ClientModule;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -185,7 +186,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         }
 
         @Override
-        public ModuleDependency getSource() {
+        public Dependency getSource() {
             return delegate.getSource();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependenciesToModuleDescriptorConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependenciesToModuleDescriptorConverter.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies;
 
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.ModuleDependency;
@@ -54,6 +55,9 @@ public class DefaultDependenciesToModuleDescriptorConverter implements Dependenc
             } else if (dependency instanceof FileCollectionDependency) {
                 final FileCollectionDependency fileDependency = (FileCollectionDependency) dependency;
                 metaData.addFiles(configuration.getName(), new DefaultLocalFileDependencyMetadata(fileDependency));
+            } else if (dependency instanceof DependencyConstraint) {
+                DependencyConstraint dependencyConstraint = (DependencyConstraint) dependency;
+                metaData.addDependency(dependencyDescriptorFactory.createDependencyConstraintDescriptor(metaData.getComponentId(), configuration.getName(), attributes, dependencyConstraint));
             } else {
                 throw new IllegalArgumentException("Cannot convert dependency " + dependency + " to local component dependency metadata.");
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
-import org.gradle.internal.component.model.Exclude;
+import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
@@ -48,7 +48,7 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
             nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName()), dependencyConstraint.getVersionConstraint());
         return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, null,
-            Collections.<IvyArtifactName>emptySet(), Collections.<Exclude>emptyList(), false, false, true, true);
+            Collections.<IvyArtifactName>emptySet(), Collections.<ExcludeMetadata>emptyList(), false, false, true, true);
     }
 
     private IvyDependencyDescriptorFactory findFactoryForDependency(ModuleDependency dependency) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+import org.gradle.internal.component.local.model.DslOriginDependencyMetadataWrapper;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
@@ -47,8 +48,9 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
     public LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
             nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName()), dependencyConstraint.getVersionConstraint());
-        return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, null,
-            Collections.<IvyArtifactName>emptySet(), Collections.<ExcludeMetadata>emptyList(), false, false, true, true);
+        LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, null,
+            Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, true);
+        return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependencyConstraint);
     }
 
     private IvyDependencyDescriptorFactory findFactoryForDependency(ModuleDependency dependency) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -17,12 +17,19 @@
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies;
 
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+import org.gradle.internal.component.model.Exclude;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.util.WrapUtil;
 
+import java.util.Collections;
 import java.util.List;
 
 public class DefaultDependencyDescriptorFactory implements DependencyDescriptorFactory {
@@ -37,6 +44,13 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
         return factoryInternal.createDependencyDescriptor(componentId, clientConfiguration, attributes, dependency);
     }
 
+    public LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
+        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
+            nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName()), dependencyConstraint.getVersionConstraint());
+        return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, null,
+            Collections.<IvyArtifactName>emptySet(), Collections.<Exclude>emptyList(), false, false, true, true);
+    }
+
     private IvyDependencyDescriptorFactory findFactoryForDependency(ModuleDependency dependency) {
         for (IvyDependencyDescriptorFactory ivyDependencyDescriptorFactory : dependencyDescriptorFactories) {
             if (ivyDependencyDescriptorFactory.canConvert(dependency)) {
@@ -44,5 +58,9 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
             }
         }
         throw new InvalidUserDataException("Can't map dependency of type: " + dependency.getClass());
+    }
+
+    private String nullToEmpty(String input) {
+        return input == null ? "" : input;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyDescriptorFactory.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies;
 
+import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
@@ -22,4 +23,5 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
 public interface DependencyDescriptorFactory {
     LocalOriginDependencyMetadata createDependencyDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, ModuleDependency dependency);
+    LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
@@ -46,7 +46,7 @@ public class ExternalModuleIvyDependencyDescriptorFactory extends AbstractIvyDep
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(
                 componentId, selector, clientConfiguration, clientAttributes, dependency.getTargetConfiguration(),
                 convertArtifacts(dependency.getArtifacts()),
-                excludes, force, changing, transitive);
+                excludes, force, changing, transitive, false);
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
@@ -49,7 +49,7 @@ public class ProjectIvyDependencyDescriptorFactory extends AbstractIvyDependency
             projectDependency.getTargetConfiguration(),
             convertArtifacts(dependency.getArtifacts()),
             excludes,
-            false, false, dependency.isTransitive());
+            false, false, dependency.isTransitive(), false);
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -42,6 +42,6 @@ public interface DependencyGraphEdge extends DependencyResult {
      * The original dependency instance declared in the build script, if any.
      */
     @Nullable
-    ModuleDependency getModuleDependency();
+    Dependency getOriginalDependency();
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.Transformer;
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
@@ -188,7 +188,7 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     @Override
-    public ModuleDependency getModuleDependency() {
+    public Dependency getOriginalDependency() {
         if (dependencyMetadata instanceof DslOriginDependencyMetadata) {
             return ((DslOriginDependencyMetadata) dependencyMetadata).getSource();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedConfigurationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedConfigurationBuilder.java
@@ -16,14 +16,14 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class DefaultResolvedConfigurationBuilder implements ResolvedConfigurationBuilder {
-    private final Map<Long, ModuleDependency> modulesMap = new HashMap<Long, ModuleDependency>();
+    private final Map<Long, Dependency> modulesMap = new HashMap<Long, Dependency>();
     private final TransientConfigurationResultsBuilder builder;
 
     public DefaultResolvedConfigurationBuilder(TransientConfigurationResultsBuilder builder) {
@@ -31,7 +31,7 @@ public class DefaultResolvedConfigurationBuilder implements ResolvedConfiguratio
     }
 
     @Override
-    public void addFirstLevelDependency(ModuleDependency moduleDependency, DependencyGraphNode dependency) {
+    public void addFirstLevelDependency(Dependency moduleDependency, DependencyGraphNode dependency) {
         builder.firstLevelDependency(dependency.getNodeId());
         //we don't serialise the module dependencies at this stage so we need to keep track
         //of the mapping module dependency <-> resolved dependency

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedGraphResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultResolvedGraphResults.java
@@ -16,20 +16,20 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 
 import java.util.Map;
 
 public class DefaultResolvedGraphResults implements ResolvedGraphResults {
-    private final Map<Long, ModuleDependency> modulesMap;
+    private final Map<Long, Dependency> modulesMap;
 
-    public DefaultResolvedGraphResults(Map<Long, ModuleDependency> modulesMap) {
+    public DefaultResolvedGraphResults(Map<Long, Dependency> modulesMap) {
         this.modulesMap = modulesMap;
     }
 
     @Override
-    public ModuleDependency getModuleDependency(long nodeId) {
-        ModuleDependency m = modulesMap.get(nodeId);
+    public Dependency getModuleDependency(long nodeId) {
+        Dependency m = modulesMap.get(nodeId);
         if (m == null) {
             throw new IllegalArgumentException("Unable to find module dependency for id: " + nodeId);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultTransientConfigurationResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/DefaultTransientConfigurationResults.java
@@ -16,22 +16,22 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult;
 
 import java.util.Map;
 
 public class DefaultTransientConfigurationResults implements TransientConfigurationResults {
-    private final Map<ModuleDependency, DependencyGraphNodeResult> firstLevelDependencies;
+    private final Map<Dependency, DependencyGraphNodeResult> firstLevelDependencies;
     private final DependencyGraphNodeResult root;
 
-    public DefaultTransientConfigurationResults(DependencyGraphNodeResult root, Map<ModuleDependency, DependencyGraphNodeResult> firstLevelDependencies) {
+    public DefaultTransientConfigurationResults(DependencyGraphNodeResult root, Map<Dependency, DependencyGraphNodeResult> firstLevelDependencies) {
         this.firstLevelDependencies = firstLevelDependencies;
         this.root = root;
     }
 
     @Override
-    public Map<ModuleDependency, DependencyGraphNodeResult> getFirstLevelDependencies() {
+    public Map<Dependency, DependencyGraphNodeResult> getFirstLevelDependencies() {
         return firstLevelDependencies;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationBuilder.java
@@ -15,13 +15,13 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 
 //builds old model of resolved dependency graph based on the result events
 public interface ResolvedConfigurationBuilder {
 
-    void addFirstLevelDependency(ModuleDependency moduleDependency, DependencyGraphNode dependency);
+    void addFirstLevelDependency(Dependency moduleDependency, DependencyGraphNode dependency);
 
     void addChild(DependencyGraphNode parent, DependencyGraphNode child, int artifactsId);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationDependencyGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationDependencyGraphVisitor.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
@@ -41,7 +41,7 @@ public class ResolvedConfigurationDependencyGraphVisitor implements DependencyAr
         builder.newResolvedDependency(node);
         for (DependencyGraphEdge dependency : node.getIncomingEdges()) {
             if (dependency.getFrom() == root) {
-                ModuleDependency moduleDependency = dependency.getModuleDependency();
+                Dependency moduleDependency = dependency.getOriginalDependency();
                 builder.addFirstLevelDependency(moduleDependency, node);
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedGraphResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedGraphResults.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 
 public interface ResolvedGraphResults {
-    ModuleDependency getModuleDependency(long nodeId);
+    Dependency getModuleDependency(long nodeId);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResults.java
@@ -16,14 +16,14 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult;
 
 import java.util.Map;
 
 public interface TransientConfigurationResults {
 
-    Map<ModuleDependency, DependencyGraphNodeResult> getFirstLevelDependencies();
+    Map<Dependency, DependencyGraphNodeResult> getFirstLevelDependencies();
 
     DependencyGraphNodeResult getRootNode();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResultsBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResultsBuilder.java
@@ -17,7 +17,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.artifacts.DefaultResolvedDependency;
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -150,7 +150,7 @@ public class TransientConfigurationResultsBuilder {
     private TransientConfigurationResults deserialize(Decoder decoder, ResolvedGraphResults graphResults, SelectedArtifactResults artifactResults, BuildOperationExecutor buildOperationProcessor) {
         Timer clock = Time.startTimer();
         Map<Long, DefaultResolvedDependency> allDependencies = new HashMap<Long, DefaultResolvedDependency>();
-        Map<ModuleDependency, DependencyGraphNodeResult> firstLevelDependencies = new LinkedHashMap<ModuleDependency, DependencyGraphNodeResult>();
+        Map<Dependency, DependencyGraphNodeResult> firstLevelDependencies = new LinkedHashMap<Dependency, DependencyGraphNodeResult>();
         DependencyGraphNodeResult root;
         int valuesRead = 0;
         byte type = -1;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintNotationParser.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.notations;
+
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.internal.typeconversion.NotationParserBuilder;
+
+public class DependencyConstraintNotationParser {
+    public static NotationParser<Object, DependencyConstraint> parser(Instantiator instantiator) {
+        return NotationParserBuilder
+            .toType(DependencyConstraint.class)
+            .fromCharSequence(new DependencyStringNotationConverter<DefaultDependencyConstraint>(instantiator, DefaultDependencyConstraint.class))
+            .converter(new DependencyMapNotationConverter<DefaultDependencyConstraint>(instantiator, DefaultDependencyConstraint.class))
+            .invalidNotationMessage("Comprehensive documentation on dependency notations is available in DSL reference for DependencyHandler type.")
+            .toComposite();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.notations;
 
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DirectDependency;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
@@ -31,9 +31,9 @@ import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 
 public class DependencyNotationParser {
-    public static NotationParser<Object, Dependency> parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, ClassPathRegistry classPathRegistry, FileLookup fileLookup, RuntimeShadedJarFactory runtimeShadedJarFactory, CurrentGradleInstallation currentGradleInstallation) {
+    public static NotationParser<Object, DirectDependency> parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, ClassPathRegistry classPathRegistry, FileLookup fileLookup, RuntimeShadedJarFactory runtimeShadedJarFactory, CurrentGradleInstallation currentGradleInstallation) {
         return NotationParserBuilder
-            .toType(Dependency.class)
+            .toType(DirectDependency.class)
             .fromCharSequence(new DependencyStringNotationConverter<DefaultExternalModuleDependency>(instantiator, DefaultExternalModuleDependency.class))
             .converter(new DependencyMapNotationConverter<DefaultExternalModuleDependency>(instantiator, DefaultExternalModuleDependency.class))
             .fromType(FileCollection.class, new DependencyFilesNotationConverter(instantiator))

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadata.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.component.local.model;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.internal.component.model.DependencyMetadata;
 
 /**
@@ -32,5 +32,5 @@ public interface DslOriginDependencyMetadata extends DependencyMetadata {
      *
      * The goal is to eventually replace these uses, and remove this type.
      */
-    ModuleDependency getSource();
+    Dependency getSource();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.component.local.model;
 
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -30,9 +30,9 @@ import java.util.List;
 
 public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMetadata, LocalOriginDependencyMetadata {
     private final LocalOriginDependencyMetadata delegate;
-    private final ModuleDependency source;
+    private final Dependency source;
 
-    public DslOriginDependencyMetadataWrapper(LocalOriginDependencyMetadata delegate, ModuleDependency source) {
+    public DslOriginDependencyMetadataWrapper(LocalOriginDependencyMetadata delegate, Dependency source) {
         this.delegate = delegate;
         this.source = source;
     }
@@ -43,7 +43,7 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
-    public ModuleDependency getSource() {
+    public Dependency getSource() {
         return source;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
@@ -18,7 +18,7 @@ package org.gradle.internal.component.model;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ClientModule;
-import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadata;
 
 import java.util.Collections;
@@ -45,7 +45,7 @@ public class DefaultComponentOverrideMetadata implements ComponentOverrideMetada
 
     private static ClientModule extractClientModule(DependencyMetadata dependencyMetadata) {
         if (dependencyMetadata instanceof DslOriginDependencyMetadata) {
-            ModuleDependency source = ((DslOriginDependencyMetadata) dependencyMetadata).getSource();
+            Dependency source = ((DslOriginDependencyMetadata) dependencyMetadata).getSource();
             if (source instanceof ClientModule) {
                 return (ClientModule) source;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -39,6 +39,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     private final boolean force;
     private final boolean changing;
     private final boolean transitive;
+    private final boolean optional;
 
     private final AttributeContainer moduleAttributes;
 
@@ -48,7 +49,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
                                             AttributeContainer moduleAttributes,
                                             String dependencyConfiguration,
                                             List<IvyArtifactName> artifactNames, List<ExcludeMetadata> excludes,
-                                            boolean force, boolean changing, boolean transitive) {
+                                            boolean force, boolean changing, boolean transitive, boolean optional) {
         this.componentId = componentId;
         this.selector = selector;
         this.moduleConfiguration = moduleConfiguration;
@@ -59,6 +60,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         this.force = force;
         this.changing = changing;
         this.transitive = transitive;
+        this.optional = optional;
     }
 
     @Override
@@ -134,7 +136,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
 
     @Override
     public boolean isOptional() {
-        return false;
+        return optional;
     }
 
     @Override
@@ -151,6 +153,6 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     private LocalOriginDependencyMetadata copyWithTarget(ComponentSelector selector) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, optional);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dsl.dependencies
+
+import org.gradle.api.Action
+import org.gradle.api.UnknownDomainObjectException
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.DependencyConstraint
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.internal.AsmBackedClassGenerator
+import spock.lang.Specification
+
+class DefaultDependencyConstraintHandlerTest extends Specification {
+
+    private static final String TEST_CONF_NAME = "someConf"
+    private static final String UNKNOWN_TEST_CONF_NAME = "unknown"
+
+    private def configurationContainer = Mock(ConfigurationContainer)
+    private def dependencyFactory = Mock(DependencyFactory)
+    private def configuration = Mock(Configuration)
+    private def dependencySet = Mock(DependencySet)
+
+    private DefaultDependencyConstraintHandler dependencyConstraintHandler = new AsmBackedClassGenerator().newInstance(DefaultDependencyConstraintHandler, configurationContainer, dependencyFactory)
+
+    void setup() {
+        _ * configurationContainer.findByName(TEST_CONF_NAME) >> configuration
+        _ * configurationContainer.getByName(TEST_CONF_NAME) >> configuration
+        _ * configurationContainer.getByName(UNKNOWN_TEST_CONF_NAME) >> { throw new UnknownDomainObjectException("") }
+        _ * configuration.dependencies >> dependencySet
+    }
+
+    void "creates and adds a dependency constraint from some notation"() {
+        def dependencyConstraint = Mock(DependencyConstraint)
+
+        when:
+        def result = dependencyConstraintHandler.add(TEST_CONF_NAME, "someNotation")
+
+        then:
+        result == dependencyConstraint
+
+        and:
+        1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
+        1 * dependencySet.add(dependencyConstraint)
+    }
+
+    void "creates, configures and adds a dependency constraint from some notation"() {
+        def dependencyConstraint = Mock(DependencyConstraint)
+
+        when:
+        def result = dependencyConstraintHandler.add(TEST_CONF_NAME, "someNotation") {
+            version { }
+        }
+
+        then:
+        result == dependencyConstraint
+
+        and:
+        1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
+        1 * dependencyConstraint.version(_ as Action<VersionConstraint>)
+        1 * dependencySet.add(dependencyConstraint)
+    }
+
+    void "creates a dependency constraint from some notation"() {
+        def dependencyConstraint = Mock(DependencyConstraint)
+
+        when:
+        def result = dependencyConstraintHandler.create("someNotation")
+
+        then:
+        result == dependencyConstraint
+
+        and:
+        1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
+    }
+
+    void "creates and configures a dependency constraint from some notation"() {
+        def dependencyConstraint = Mock(DependencyConstraint)
+
+        when:
+        def result = dependencyConstraintHandler.add(TEST_CONF_NAME, "someNotation") {
+            version { }
+        }
+
+        then:
+        result == dependencyConstraint
+
+        and:
+        1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
+        1 * dependencyConstraint.version(_ as Action<VersionConstraint>)
+    }
+
+    void "can use dynamic method to add dependency constraint"() {
+        def dependencyConstraint = Mock(DependencyConstraint)
+
+        when:
+        def result = dependencyConstraintHandler.someConf("someNotation")
+
+        then:
+        result == dependencyConstraint
+
+        and:
+        1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
+        1 * dependencySet.add(dependencyConstraint)
+
+    }
+
+    void "can use dynamic method to add and configure dependency constraint"() {
+        def dependencyConstraint = Mock(DependencyConstraint)
+
+        when:
+        def result = dependencyConstraintHandler.someConf("someNotation") { version { } }
+
+        then:
+        result == dependencyConstraint
+
+        and:
+        1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
+        1 * dependencySet.add(dependencyConstraint)
+        1 * dependencyConstraint.version(_ as Action<VersionConstraint>)
+    }
+
+    void "can use dynamic method to add multiple dependency constraint"() {
+        def constraint1 = Mock(DependencyConstraint)
+        def constraint2 = Mock(DependencyConstraint)
+
+        when:
+        def result = dependencyConstraintHandler.someConf("someNotation", "someOther")
+
+        then:
+        result == null
+
+        and:
+        1 * dependencyFactory.createDependencyConstraint("someNotation") >> constraint1
+        1 * dependencyFactory.createDependencyConstraint("someOther") >> constraint2
+        1 * dependencySet.add(constraint1)
+        1 * dependencySet.add(constraint2)
+    }
+
+    void "can use dynamic method to add multiple dependency constraint from nested lists"() {
+        def constraint1 = Mock(DependencyConstraint)
+        def constraint2 = Mock(DependencyConstraint)
+
+        when:
+        def result = dependencyConstraintHandler.someConf([["someNotation"], ["someOther"]])
+
+        then:
+        result == null
+
+        and:
+        1 * dependencyFactory.createDependencyConstraint("someNotation") >> constraint1
+        1 * dependencyFactory.createDependencyConstraint("someOther") >> constraint2
+        1 * dependencySet.add(constraint1)
+        1 * dependencySet.add(constraint2)
+    }
+
+    void "dynamic method fails for unknown configuration"() {
+        when:
+        dependencyConstraintHandler.unknown("someDep")
+
+        then:
+        def e = thrown(MissingMethodException)
+        e.message.startsWith('Could not find method unknown() for arguments [someDep] on ')
+    }
+
+    void "dynamic method fails for no args"() {
+        when:
+        dependencyConstraintHandler.someConf()
+
+        then:
+        def e = thrown(MissingMethodException)
+        e.message.startsWith('Could not find method someConf() for arguments [] on ')
+    }
+
+    void "cannot add dependency constraint to unknown configuration"() {
+        when:
+        dependencyConstraintHandler.add(UNKNOWN_TEST_CONF_NAME, "someNotation")
+
+        then:
+        thrown(UnknownDomainObjectException)
+    }
+
+    void "reasonable error when supplying null as a dependency notation"() {
+        when:
+        dependencyConstraintHandler."$TEST_CONF_NAME"(null)
+
+        then:
+        1 * dependencyFactory.createDependencyConstraint(null)
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.artifacts.VariantTransformRegistry
@@ -46,7 +47,7 @@ class DefaultDependencyHandlerTest extends Specification {
     private DependencySet dependencySet = Mock()
 
     private DefaultDependencyHandler dependencyHandler = new AsmBackedClassGenerator().newInstance(DefaultDependencyHandler,
-        configurationContainer, dependencyFactory, projectFinder, Stub(ComponentMetadataHandler), Stub(ComponentModuleMetadataHandler), Stub(ArtifactResolutionQueryFactory),
+        configurationContainer, dependencyFactory, projectFinder, Stub(DependencyConstraintHandler), Stub(ComponentMetadataHandler), Stub(ComponentModuleMetadataHandler), Stub(ArtifactResolutionQueryFactory),
         Stub(AttributesSchema), Stub(VariantTransformRegistry), Stub(Factory))
 
     void setup() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -20,11 +20,11 @@ import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.ClientModule
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.DirectDependency
 import org.gradle.api.artifacts.ExternalDependency
-import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
 import org.gradle.api.attributes.AttributesSchema
@@ -57,7 +57,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates and adds a dependency from some notation"() {
-        Dependency dependency = Mock()
+        DirectDependency dependency = Mock()
 
         when:
         def result = dependencyHandler.add(TEST_CONF_NAME, "someNotation")
@@ -88,7 +88,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates a dependency from some notation"() {
-        Dependency dependency = Mock()
+        DirectDependency dependency = Mock()
 
         when:
         def result = dependencyHandler.create("someNotation")
@@ -121,7 +121,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "can use dynamic method to add dependency"() {
-        Dependency dependency = Mock()
+        DirectDependency dependency = Mock()
 
         when:
         def result = dependencyHandler.someConf("someNotation")
@@ -151,8 +151,8 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "can use dynamic method to add multiple dependencies"() {
-        Dependency dependency1 = Mock()
-        Dependency dependency2 = Mock()
+        DirectDependency dependency1 = Mock()
+        DirectDependency dependency2 = Mock()
 
         when:
         def result = dependencyHandler.someConf("someNotation", "someOther")
@@ -168,8 +168,8 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "can use dynamic method to add multiple dependencies from nested lists"() {
-        Dependency dependency1 = Mock()
-        Dependency dependency2 = Mock()
+        DirectDependency dependency1 = Mock()
+        DirectDependency dependency2 = Mock()
 
         when:
         def result = dependencyHandler.someConf([["someNotation"], ["someOther"]])
@@ -273,7 +273,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates gradle api dependency"() {
-        Dependency dependency = Mock()
+        DirectDependency dependency = Mock()
 
         when:
         def result = dependencyHandler.gradleApi()
@@ -286,7 +286,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates Gradle test-kit dependency"() {
-        Dependency dependency = Mock()
+        DirectDependency dependency = Mock()
 
         when:
         def result = dependencyHandler.gradleTestKit()
@@ -299,7 +299,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates local groovy dependency"() {
-        Dependency dependency = Mock()
+        DirectDependency dependency = Mock()
 
         when:
         def result = dependencyHandler.localGroovy()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/IvyXmlModuleDescriptorWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/IvyXmlModuleDescriptorWriterTest.groovy
@@ -77,7 +77,7 @@ class IvyXmlModuleDescriptorWriterTest extends Specification {
     def addDependencyDescriptor(BuildableIvyModulePublishMetadata metadata, String organisation = "org.test", String moduleName, String revision = "1.0") {
         def dep = new LocalComponentDependencyMetadata(metadata.getComponentId(),
             DefaultModuleComponentSelector.newSelector(organisation, moduleName, new DefaultMutableVersionConstraint(revision)),
-            "default", null, "default", [] as List, [], false, false, true)
+            "default", null, "default", [] as List, [], false, false, true, false)
         metadata.addDependency(dep)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactoryTest.groovy
@@ -17,11 +17,13 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata
 import spock.lang.Specification
 
-public class DefaultDependencyDescriptorFactoryTest extends Specification {
+class DefaultDependencyDescriptorFactoryTest extends Specification {
     def configurationName = "conf"
     def projectDependency = Stub(ProjectDependency)
     def componentId = new OpaqueComponentIdentifier("foo")
@@ -35,7 +37,7 @@ public class DefaultDependencyDescriptorFactoryTest extends Specification {
         when:
         def dependencyDescriptorFactory = new DefaultDependencyDescriptorFactory(
                 ivyDependencyDescriptorFactory1, ivyDependencyDescriptorFactory2
-        );
+        )
         def created = dependencyDescriptorFactory.createDependencyDescriptor(componentId, configurationName, null, projectDependency)
 
         then:
@@ -56,10 +58,34 @@ public class DefaultDependencyDescriptorFactoryTest extends Specification {
         and:
         def dependencyDescriptorFactory = new DefaultDependencyDescriptorFactory(
                 ivyDependencyDescriptorFactory1
-        );
+        )
         dependencyDescriptorFactory.createDependencyDescriptor(componentId, configurationName, null, projectDependency)
 
         then:
         thrown InvalidUserDataException
+    }
+
+    def "creates descriptor for dependency constraints"() {
+        given:
+        def dependencyConstraint = new DefaultDependencyConstraint("g", "m", "1")
+
+        when:
+        def dependencyDescriptorFactory = new DefaultDependencyDescriptorFactory()
+        def created = dependencyDescriptorFactory.createDependencyConstraintDescriptor(componentId, configurationName, null, dependencyConstraint)
+        def selector = created.selector as ModuleComponentSelector
+
+        then:
+        created.optional
+        selector.group == "g"
+        selector.module == "m"
+        selector.version == "1"
+
+        and:
+        created.moduleConfiguration == configurationName
+        created.artifacts.empty
+        created.excludes.empty
+        !created.force
+        created.transitive
+        !created.changing
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -1081,7 +1081,7 @@ class DependencyGraphBuilderTest extends Specification {
         }
         def dependencyMetaData = new LocalComponentDependencyMetadata(from.componentId, componentSelector,
             "default", null, "default", [] as List<IvyArtifactName>,
-            excludeRules, force, false, transitive)
+            excludeRules, force, false, transitive, false)
         dependencyMetaData = new DslOriginDependencyMetadataWrapper(dependencyMetaData, Stub(ModuleDependency))
         from.getDependencies().add(dependencyMetaData)
         return dependencyMetaData

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyMetadataRulesTest.groovy
@@ -215,7 +215,7 @@ class DependencyMetadataRulesTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId("org.test", "consumer", "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(consumerIdentifier.group, consumerIdentifier.name, new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, null, [] as List, [], false, false, true)
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, null, [] as List, [], false, false, true, false)
 
         consumer.selectConfigurations(attributes, immutable, schema)[0]
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -63,14 +63,14 @@ class LocalComponentDependencyMetadataTest extends Specification {
 
     def "returns this when same target requested"() {
         def selector = Stub(ProjectComponentSelector)
-        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, "to", [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, "to", [] as List, [], false, false, true, false)
 
         expect:
         dep.withTarget(selector).is(dep)
     }
 
     def "selects the target configuration from target component"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true, false)
         def toComponent = Stub(ComponentResolveMetadata)
         def toConfig = Stub(LocalConfigurationMetadata) {
             isCanBeConsumed() >> true
@@ -86,7 +86,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
 
     @Unroll("selects configuration '#expected' from target component (#scenario)")
     def "selects the target configuration from target component which matches the attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -121,7 +121,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
     }
 
     def "revalidates default configuration if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, Dependency.DEFAULT_CONFIGURATION, [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, Dependency.DEFAULT_CONFIGURATION, [] as List, [], false, false, true, false)
         def defaultConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'default'
             isCanBeResolved() >> true
@@ -150,7 +150,7 @@ Configuration 'default': Required key 'other' and found incompatible value 'noth
     }
 
     def "revalidates explicit configuration selection if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, 'bar', [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, 'bar', [] as List, [], false, false, true, false)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -188,7 +188,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -258,7 +258,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy using short-hand notation (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy using short-hand notation"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -328,7 +328,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     def "fails to select target configuration when not present in the target component"() {
         def fromId = Stub(ComponentIdentifier) { getDisplayName() >> "thing a" }
-        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true, false)
         def toComponent = Stub(ComponentResolveMetadata)
         toComponent.componentId >> Stub(ComponentIdentifier) { getDisplayName() >> "thing b" }
 
@@ -345,7 +345,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     def "excludes nothing when no exclude rules provided"() {
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true, false)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -357,7 +357,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
         def exclude1 = new DefaultExclude(DefaultModuleIdentifier.newId("group1", "*"))
         def exclude2 = new DefaultExclude(DefaultModuleIdentifier.newId("group2", "*"))
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [exclude1, exclude2], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [exclude1, exclude2], false, false, true, false)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -388,7 +388,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     @Unroll("can select a compatible attribute value (#scenario)")
     def "can select a compatible attribute value"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -9,6 +9,14 @@
             "type": "org.gradle.api.tasks.testing.AbstractTestTask",
             "member": "Method org.gradle.api.tasks.testing.AbstractTestTask.setTestNameIncludePatterns(java.util.List)",
             "acceptation": "Method was pulled up from Test class"
+        },
+        {
+            "type": "org.gradle.api.artifacts.DirectDependency",
+            "member": "Class org.gradle.api.artifacts.DirectDependency",
+            "acceptation": "This new interface, which does not contain any additional methods at this point, is inserted into an existing stable interface hierarchy.",
+            "changes": [
+                "Interface has been added"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -11,11 +11,19 @@
             "acceptation": "Method was pulled up from Test class"
         },
         {
-            "type": "org.gradle.api.artifacts.DirectDependency",
-            "member": "Class org.gradle.api.artifacts.DirectDependency",
-            "acceptation": "This new interface, which does not contain any additional methods at this point, is inserted into an existing stable interface hierarchy.",
+            "type": "org.gradle.api.artifacts.ModuleDependency",
+            "member": "Class org.gradle.api.artifacts.ModuleDependency",
+            "acceptation": "Inserted new interface in hierarchy to distinguish direct dependencies and dependency constraints",
             "changes": [
-                "Interface has been added"
+                "org.gradle.api.artifacts.DirectDependency"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.SelfResolvingDependency",
+            "member": "Class org.gradle.api.artifacts.SelfResolvingDependency",
+            "acceptation": "Inserted new interface in hierarchy to distinguish direct dependencies and dependency constraints",
+            "changes": [
+                "org.gradle.api.artifacts.DirectDependency"
             ]
         }
     ]

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -157,7 +157,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
             selector, usageConfigurationName, null, mappedUsageConfiguration,
             ImmutableList.<IvyArtifactName>of(),
             EXCLUDE_RULES,
-            false, false, true);
+            false, false, true, false);
     }
 
 }


### PR DESCRIPTION
See #3550 and #3461 (design).

This PR contains a sequence of changes, each done as a separate commit. It might be simpler to review each commit separately:

1. Introduce new interface DirectDependency
  - This turns `Dependency` into a new super interface for "normal" dependencies (`DirectDependency`) and `DependencyConstraint`s. Renaming it to something else would be a breaking change. And we want constraints to be handled as all other dependencies in the context of configurations. The best way to achieve that is to make them subtypes of `Dependency`. Which is the interface the `Configuration` API works with. 
2. Add dependency constraints DSL
3. Make 'optional' configurable in LocalComponentDependencyMetadata
4. Pass dependency constraints into dependency resolution

In addition there are two commits that add integration tests.