### PR TITLE
Optimize IndexNormalizedFileSnapshot

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractNormalizedFileSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractNormalizedFileSnapshot.java
@@ -26,18 +26,18 @@ public abstract class AbstractNormalizedFileSnapshot implements NormalizedFileSn
     }
 
     @Override
-    public FileContentSnapshot getSnapshot() {
+    public final FileContentSnapshot getSnapshot() {
         return snapshot;
     }
 
     @Override
-    public void appendToHasher(BuildCacheHasher hasher) {
+    public final void appendToHasher(BuildCacheHasher hasher) {
         hasher.putString(getNormalizedPath());
         hasher.putHash(getSnapshot().getContentMd5());
     }
 
     @Override
-    public int compareTo(NormalizedFileSnapshot o) {
+    public final int compareTo(NormalizedFileSnapshot o) {
         int result = getNormalizedPath().compareTo(o.getNormalizedPath());
         if (result == 0) {
             result = getSnapshot().getContentMd5().compareTo(o.getSnapshot().getContentMd5());
@@ -46,7 +46,7 @@ public abstract class AbstractNormalizedFileSnapshot implements NormalizedFileSn
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
@@ -55,18 +55,27 @@ public abstract class AbstractNormalizedFileSnapshot implements NormalizedFileSn
         }
         AbstractNormalizedFileSnapshot that = (AbstractNormalizedFileSnapshot) o;
         return snapshot.equals(that.snapshot)
-            && getNormalizedPath().equals(that.getNormalizedPath());
+            && getNormalizedPathSequence().equals(that.getNormalizedPathSequence());
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = snapshot.hashCode();
-        result = 31 * result + getNormalizedPath().hashCode();
+        result = 31 * result + getNormalizedPathSequence().hashCode();
         return result;
     }
 
     @Override
-    public String toString() {
+    public final String toString() {
         return String.format("'%s' / %s", getNormalizedPath(), snapshot);
+    }
+
+    /**
+     * This is a performance optimization for subclasses that
+     * can return the normalized path as a {@link CharSequence}
+     * more efficiently than as a {@link String}.
+     */
+    protected CharSequence getNormalizedPathSequence() {
+        return getNormalizedPath();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IndexedNormalizedFileSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IndexedNormalizedFileSnapshot.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import java.nio.CharBuffer;
+
 public class IndexedNormalizedFileSnapshot extends AbstractNormalizedFileSnapshot {
     private final String absolutePath;
     private final int index;
@@ -37,5 +39,10 @@ public class IndexedNormalizedFileSnapshot extends AbstractNormalizedFileSnapsho
 
     public int getIndex() {
         return index;
+    }
+
+    @Override
+    protected CharSequence getNormalizedPathSequence() {
+        return CharBuffer.wrap(absolutePath, index, absolutePath.length());
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/NormalizedFileSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/NormalizedFileSnapshot.java
@@ -20,6 +20,9 @@ package org.gradle.api.internal.changedetection.state;
  * An immutable snapshot of some aspects of a file's metadata and content.
  *
  * Should implement {@link #equals(Object)} and {@link #hashCode()} to compare these aspects.
+ * Comparisons are very frequent, so these methods need to be fast.
+ *
+ * File snapshots are cached between builds, so their memory footprint should be kept to a minimum.
  */
 public interface NormalizedFileSnapshot extends Comparable<NormalizedFileSnapshot>, Snapshot {
     String getNormalizedPath();


### PR DESCRIPTION
This avoids actually allocating the normalized path when all we want is to hash it or test it for equality to another one.