### PR TITLE
Improve leaking process kill pattern to match Play app

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/testing/LeakingProcessKillPattern.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/LeakingProcessKillPattern.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import java.util.regex.Pattern
+
+class LeakingProcessKillPattern {
+    private LeakingProcessKillPattern() {}
+
+    static String generate(String rootProjectDir, String rootBuildDir) {
+        return "(?i)[/\\\\](java(?:\\.exe)?.+?(?:(?:-cp.+${Pattern.quote(rootProjectDir)}.+?(org\\.gradle\\.|[a-zA-Z]+))|(?:-classpath.+${Pattern.quote(rootBuildDir)}.+?(org\\.gradle\\.|[a-zA-Z]+))|(?:-classpath.+${Pattern.quote(rootProjectDir)}.+?(play\\.core\\.server\\.NettyServer))).+)"
+    }
+}

--- a/buildSrc/src/test/groovy/org/gradle/testing/LeakingProcessKillPatternTest.groovy
+++ b/buildSrc/src/test/groovy/org/gradle/testing/LeakingProcessKillPatternTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import spock.lang.Issue
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(LeakingProcessKillPattern)
+class LeakingProcessKillPatternTest extends Specification {
+    @Issue("https://github.com/gradle/ci-health/issues/138")
+    def "can match Play application process command-line on Windows"() {
+        def line = '"C:\\Program Files\\Java\\jdk1.7/bin/java.exe"    -Dhttp.port=0  -classpath "C:\\some\\ci\\workspace\\subprojects\\platform-play\\build\\tmp\\test files\\PlayDistributionAdvancedAppIntegrationTest\\can_run_play_distribution\\d3r0j\\build\\stage\\playBinary\\bin\\..\\lib\\advancedplayapp.jar" play.core.server.NettyServer '
+        def projectDir = 'C:\\some\\ci\\workspace'
+        def buildDir = 'C:\\some\\ci\\workspace\\build'
+
+        expect:
+        (line =~ LeakingProcessKillPattern.generate(projectDir, buildDir)).find()
+    }
+}

--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import java.util.regex.Pattern
 import org.gradle.testing.DistributionTest
+import org.gradle.testing.LeakingProcessKillPattern
 import org.gradle.util.GradleVersion
 
 ext.distributionTestTasks = tasks.withType(DistributionTest)
@@ -243,7 +243,7 @@ project(":") {
 }
 
 def forEachJavaProcess(Closure action) {
-    String queryString = "(?i)[/\\\\](java(?:\\.exe)?.+?(?:(?:-cp.+${Pattern.quote(rootProject.projectDir.absolutePath)}.+?(org\\.gradle\\.|[a-zA-Z]+))|(?:-classpath.+${Pattern.quote(rootProject.buildDir.absolutePath)}.+?(org\\.gradle\\.|[a-zA-Z]+))).+)"
+    String queryString = LeakingProcessKillPattern.generate(rootProject.projectDir.absolutePath, rootProject.buildDir.absolutePath)
     def output = new ByteArrayOutputStream()
     def error = new ByteArrayOutputStream()
     def pidPattern


### PR DESCRIPTION
### Context
Match leaked Play application during CI run cancellation.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fci-health%2Fwindows-failure)
- [x] Verify documentation
- [x] Recognize contributor in release notes
