### PR TITLE
Handle broken packaging types gracefully

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
+import com.google.common.base.Strings;
 import org.apache.ivy.core.IvyPatternHelper;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -22,25 +23,38 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactMetad
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.resource.ExternalResourceName;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
 abstract class AbstractResourcePattern implements ResourcePattern {
+    public static final String CLASSIFIER_KEY = "classifier";
     private final ExternalResourceName pattern;
     private final boolean revisionIsOptional;
     private final boolean organisationIsOptional;
+    private final boolean artifactIsOptional;
+    private final boolean classifierIsOptional;
+    private final boolean extensionIsOptional;
+    private final boolean typeIsOptional;
 
     public AbstractResourcePattern(String pattern) {
-        this.pattern = new ExternalResourceName(pattern);
-        this.revisionIsOptional = isOptionalToken(IvyPatternHelper.REVISION_KEY);
-        this.organisationIsOptional = isOptionalToken(IvyPatternHelper.ORGANISATION_KEY, IvyPatternHelper.ORGANISATION_KEY2);
+        this(new ExternalResourceName(pattern));
+
     }
 
     public AbstractResourcePattern(URI baseUri, String pattern) {
-        this.pattern = new ExternalResourceName(baseUri, pattern);
+        this(new ExternalResourceName(baseUri, pattern));
+    }
+
+    private AbstractResourcePattern(ExternalResourceName pattern) {
+        this.pattern = pattern;
         this.revisionIsOptional = isOptionalToken(IvyPatternHelper.REVISION_KEY);
         this.organisationIsOptional = isOptionalToken(IvyPatternHelper.ORGANISATION_KEY, IvyPatternHelper.ORGANISATION_KEY2);
+        this.artifactIsOptional = isOptionalToken(IvyPatternHelper.ARTIFACT_KEY);
+        this.classifierIsOptional = isOptionalToken(CLASSIFIER_KEY);
+        this.extensionIsOptional = isOptionalToken(IvyPatternHelper.EXT_KEY);
+        this.typeIsOptional = isOptionalToken(IvyPatternHelper.TYPE_KEY);
     }
 
     public String getPattern() {
@@ -72,7 +86,7 @@ abstract class AbstractResourcePattern implements ResourcePattern {
         attributes.put(IvyPatternHelper.ARTIFACT_KEY, ivyArtifact.getName());
         attributes.put(IvyPatternHelper.TYPE_KEY, ivyArtifact.getType());
         attributes.put(IvyPatternHelper.EXT_KEY, ivyArtifact.getExtension());
-        attributes.put("classifier", ivyArtifact.getClassifier());
+        attributes.put(CLASSIFIER_KEY, ivyArtifact.getClassifier());
         return attributes;
     }
 
@@ -93,15 +107,35 @@ abstract class AbstractResourcePattern implements ResourcePattern {
 
     @Override
     public boolean isComplete(ModuleIdentifier moduleIdentifier) {
-        return !moduleIdentifier.getName().isEmpty()
-            && (!moduleIdentifier.getGroup().isEmpty() || organisationIsOptional);
+        return isValidSubstitute(moduleIdentifier.getName(), false)
+            && isValidSubstitute(moduleIdentifier.getGroup(), organisationIsOptional);
     }
 
     @Override
     public boolean isComplete(ModuleComponentIdentifier componentIdentifier) {
-        return !componentIdentifier.getModule().isEmpty()
-            && (!componentIdentifier.getGroup().isEmpty() || organisationIsOptional)
-            && (!componentIdentifier.getVersion().isEmpty() || revisionIsOptional);
+        return isValidSubstitute(componentIdentifier.getModule(), false)
+            && isValidSubstitute(componentIdentifier.getGroup(), organisationIsOptional)
+            && isValidSubstitute(componentIdentifier.getVersion(), revisionIsOptional);
+    }
+
+    @Override
+    public boolean isComplete(ModuleComponentArtifactMetadata artifactIdentifier) {
+        IvyArtifactName artifactName = artifactIdentifier.getName();
+        ModuleComponentIdentifier componentIdentifier = artifactIdentifier.getId().getComponentIdentifier();
+        return isValidSubstitute(componentIdentifier.getModule(), false)
+            && isValidSubstitute(componentIdentifier.getGroup(), organisationIsOptional)
+            && isValidSubstitute(componentIdentifier.getVersion(), revisionIsOptional)
+            && isValidSubstitute(artifactName.getName(), artifactIsOptional)
+            && isValidSubstitute(artifactName.getClassifier(), classifierIsOptional)
+            && isValidSubstitute(artifactName.getExtension(), extensionIsOptional)
+            && isValidSubstitute(artifactName.getType(), typeIsOptional);
+    }
+
+    private boolean isValidSubstitute(@Nullable String candidate, boolean optional) {
+        if (Strings.isNullOrEmpty(candidate)) {
+            return optional;
+        }
+        return !candidate.startsWith("${");
     }
 
     private boolean isOptionalToken(String... tokenVariants) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceArtifactResolver.java
@@ -151,6 +151,6 @@ class DefaultExternalResourceArtifactResolver implements ExternalResourceArtifac
     }
 
     private boolean isIncomplete(ResourcePattern resourcePattern, ModuleComponentArtifactMetadata artifact) {
-        return !resourcePattern.isComplete(artifact.getId().getComponentIdentifier());
+        return !resourcePattern.isComplete(artifact);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenPattern.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenPattern.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 public class MavenPattern {
-    public static final String M2_PER_MODULE_VERSION_PATTERN = "[artifact]-[revision](-[classifier]).[ext]";
+    public static final String M2_PER_MODULE_VERSION_PATTERN = "[artifact]-[revision](-[classifier])(.[ext])";
     public static final String M2_PER_MODULE_PATTERN = "[revision]/" + M2_PER_MODULE_VERSION_PATTERN;
     public static final String M2_PATTERN = "[organisation]/[module]/" + M2_PER_MODULE_PATTERN;
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -197,7 +197,7 @@ public class MavenResolver extends GradleMetadataAwareExternalResourceResolver<M
     private MavenUniqueSnapshotModuleSource findUniqueSnapshotVersion(ModuleComponentIdentifier module, ResourceAwareResolveResult result) {
         M2ResourcePattern wholePattern = getWholePattern();
         if (!wholePattern.isComplete(module)) {
-            //do not attempt to download maven-metadata.xml fo incomplete identifiers
+            //do not attempt to download maven-metadata.xml for incomplete identifiers
             return null;
         }
         ExternalResourceName metadataLocation = wholePattern.toModuleVersionPath(module).resolve("maven-metadata.xml");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourcePattern.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourcePattern.java
@@ -50,12 +50,18 @@ public interface ResourcePattern {
     ExternalResourceName toModuleVersionPath(ModuleComponentIdentifier componentIdentifier);
 
     /**
-     * Checks if the given organisation and module values are sufficient to bind the [organisation] and [module] tokens in the pattern.
+     * Checks if the given identifier contains sufficient information to bind the tokens in this pattern.
      */
     boolean isComplete(ModuleIdentifier moduleIdentifier);
 
     /**
-     * Checks if the given organisation, module and revision values are sufficient to bind the [organisation], [module] and [revision] tokens in the pattern.
+     * Checks if the given identifier contains sufficient information to bind the tokens in this pattern.
      */
     boolean isComplete(ModuleComponentIdentifier componentIdentifier);
+
+    /**
+     * Checks if the given identifier contains sufficient information to bind the tokens in this pattern.
+     */
+    boolean isComplete(ModuleComponentArtifactMetadata id);
+
 }


### PR DESCRIPTION
Some POMs on Maven Central use profiles to determine
important information like their packaging type. The
result are unreplaced variables like ${packaging.type}.
Until now we would send requests with these unresolved
variables to remote repositories, which would in some
cases just slow down resolution and in other cases break
resolution.

Instead we now sanity check substitution variables and don't
even do a remote request if we find something that is definitely
not a valid name/type/extension/version. This makes resolution
fail faster in some cases and gracefully fall back in other cases.

See https://github.com/gradle/gradle/issues/3065 for a case that
now gracefully falls back to downloading the jar, which is what
Maven would also do in this case.
