### PR TITLE
Close System.in after build

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/CancellableOperationManager.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/CancellableOperationManager.java
@@ -26,4 +26,8 @@ public interface CancellableOperationManager {
      */
     void monitorInput(Action<? super BuildCancellationToken> operation);
 
+    /**
+     * Perform clean-up work after build
+     */
+    void closeInput();
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultCancellableOperationManager.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultCancellableOperationManager.java
@@ -75,6 +75,15 @@ public class DefaultCancellableOperationManager implements CancellableOperationM
         }
     }
 
+    @Override
+    public void closeInput() {
+        try {
+            input.close();
+        } catch (IOException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
     private static boolean isCancellation(int c) {
         return c == KEY_CODE_CTRL_D || c == EOF;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/PassThruCancellableOperationManager.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/PassThruCancellableOperationManager.java
@@ -30,4 +30,8 @@ public class PassThruCancellableOperationManager implements CancellableOperation
     public void monitorInput(Action<? super BuildCancellationToken> operation) {
         operation.execute(cancellationToken);
     }
+
+    @Override
+    public void closeInput() {
+    }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ForwardClientInput.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ForwardClientInput.java
@@ -40,7 +40,7 @@ public class ForwardClientInput implements DaemonCommandAction {
         final PipedOutputStream inputSource = new PipedOutputStream();
         final PipedInputStream replacementStdin;
         try {
-            replacementStdin = new EndOnClosedInputStream(inputSource);
+            replacementStdin = new PipedInputStream(inputSource);
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
@@ -83,38 +83,5 @@ public class ForwardClientInput implements DaemonCommandAction {
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
-    }
-
-    private static class EndOnClosedInputStream extends PipedInputStream {
-        private volatile boolean closed;
-
-        private EndOnClosedInputStream(PipedOutputStream src) throws IOException {
-            super(src);
-        }
-
-        @Override
-        public void close() throws IOException {
-            this.closed = true;
-            super.close();
-        }
-
-        @Override
-        public synchronized int read(byte b[], int off, int len) throws IOException {
-            if (closed) {
-                return -1;
-            } else {
-                return super.read(b, off, len);
-            }
-        }
-
-        @Override
-        public synchronized int read() throws IOException {
-            if (closed) {
-                return -1;
-            } else {
-                return super.read();
-            }
-        }
-
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuter.java
@@ -30,7 +30,6 @@ import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.ContinuousExecutionGate;
 import org.gradle.initialization.DefaultContinuousExecutionGate;
 import org.gradle.initialization.ReportedException;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
@@ -50,8 +49,6 @@ import org.gradle.launcher.exec.BuildActionExecuter;
 import org.gradle.launcher.exec.BuildActionParameters;
 import org.gradle.util.DisconnectableInputStream;
 import org.gradle.util.SingleMessageLogger;
-
-import java.io.IOException;
 
 public class ContinuousBuildActionExecuter implements BuildActionExecuter<BuildActionParameters> {
     private final BuildActionExecuter<BuildActionParameters> delegate;
@@ -113,13 +110,7 @@ public class ContinuousBuildActionExecuter implements BuildActionExecuter<BuildA
             ContinuousExecutionGate deploymentRequestExecutionGate = deploymentRegistry.getExecutionGate();
             executeMultipleBuilds(action, requestContext, actionParameters, buildSessionScopeServices, cancellableOperationManager, deploymentRequestExecutionGate);
         }
-        if (System.in instanceof DisconnectableInputStream) {
-            try {
-                System.in.close();
-            } catch (IOException e) {
-                throw UncheckedException.throwAsUncheckedException(e);
-            }
-        }
+        cancellableOperationManager.closeInput();
     }
 
     private Object executeMultipleBuilds(BuildAction action, BuildRequestContext requestContext, final BuildActionParameters actionParameters, final ServiceRegistry buildSessionScopeServices,

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuter.java
@@ -30,6 +30,7 @@ import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.ContinuousExecutionGate;
 import org.gradle.initialization.DefaultContinuousExecutionGate;
 import org.gradle.initialization.ReportedException;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
@@ -49,6 +50,8 @@ import org.gradle.launcher.exec.BuildActionExecuter;
 import org.gradle.launcher.exec.BuildActionParameters;
 import org.gradle.util.DisconnectableInputStream;
 import org.gradle.util.SingleMessageLogger;
+
+import java.io.IOException;
 
 public class ContinuousBuildActionExecuter implements BuildActionExecuter<BuildActionParameters> {
     private final BuildActionExecuter<BuildActionParameters> delegate;
@@ -109,6 +112,13 @@ public class ContinuousBuildActionExecuter implements BuildActionExecuter<BuildA
             logger.println().println("Reloadable deployment detected. Entering continuous build.");
             ContinuousExecutionGate deploymentRequestExecutionGate = deploymentRegistry.getExecutionGate();
             executeMultipleBuilds(action, requestContext, actionParameters, buildSessionScopeServices, cancellableOperationManager, deploymentRequestExecutionGate);
+        }
+        if (System.in instanceof DisconnectableInputStream) {
+            try {
+                System.in.close();
+            } catch (IOException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
         }
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuterTest.groovy
@@ -38,10 +38,14 @@ import org.gradle.internal.time.Clock
 import org.gradle.internal.time.Time
 import org.gradle.launcher.exec.BuildActionExecuter
 import org.gradle.launcher.exec.BuildActionParameters
+import org.gradle.util.DisconnectableInputStream
 import org.gradle.util.RedirectStdIn
 import org.junit.Rule
 import spock.lang.AutoCleanup
 import spock.lang.Specification
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
 
 class ContinuousBuildActionExecuterTest extends Specification {
 
@@ -99,6 +103,21 @@ class ContinuousBuildActionExecuterTest extends Specification {
 
         then:
         thrown(RuntimeException)
+    }
+
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    def "close System.in after build"() {
+        when:
+        singleBuild()
+        interactiveBuild()
+        executeBuild()
+
+        then:
+        1 * delegate.execute(action, requestContext, actionParameters, _)
+        1 * deploymentRegistry.runningDeployments >> []
+        0 * waiterFactory._
+        System.in instanceof DisconnectableInputStream
+        System.in.read() == -1
     }
 
     def "waits for waiter"() {
@@ -177,6 +196,10 @@ class ContinuousBuildActionExecuterTest extends Specification {
 
     private void singleBuild() {
         actionParameters.continuous >> false
+    }
+
+    private void interactiveBuild() {
+        actionParameters.interactive >> true
     }
 
     private void continuousBuild() {


### PR DESCRIPTION
### Context

See #3534 for more details.

In brief, after build finishes, a `DisconnectableInputStream` [will be created](https://github.com/gradle/gradle/blob/e7e9502dbcf5bf8e4ca5e0c1763a301372a9ed83/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecuter.java#L90) in interactive mode, and it never gets closed so it would keep reading in background thread, which might cause https://github.com/gradle/gradle-private/issues/975.

This PR close it after the build finishes. @big-guy I'm not sure it's appropriate so I'd like you to take a review for it.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
