### PR TITLE
Fix typo in lazy configuration section of user guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/lazyConfiguration.adoc
+++ b/subprojects/docs/src/docs/userguide/lazyConfiguration.adoc
@@ -77,7 +77,7 @@ If provider types are not intended to be implemented directly by build script or
 [NOTE]
 ====
 
-api:org.gradle.api.Project[] does not provide a specific method signature for creating a provider from a `groovy.lang.Closure`. When writing a plugin with Groovy, you can use the method signature accepting a `java.util.concurrent.Callable` parameter. Groovy's http://docs.groovy-lang.org/next/html/documentation/core-semantics.html#_assigning_a_closure_to_a_sam_type[Closure to type coercion] will take of the rest.
+api:org.gradle.api.Project[] does not provide a specific method signature for creating a provider from a `groovy.lang.Closure`. When writing a plugin with Groovy, you can use the method signature accepting a `java.util.concurrent.Callable` parameter. Groovy's http://docs.groovy-lang.org/next/html/documentation/core-semantics.html#_assigning_a_closure_to_a_sam_type[Closure to type coercion] will take care of the rest.
 
 ====
 


### PR DESCRIPTION
### Context
The user guide should be spelling and grammar correct. 

### Contributor Checklist
- [y ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [y ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [y ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [na ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [na ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [y ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [na ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
