### PR TITLE
Fix buildSrc/AbstractProjectGeneratorTask task properties

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/DependencyGraph.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/DependencyGraph.groovy
@@ -16,11 +16,21 @@
 
 package org.gradle.testing.performance.generator
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+
 class DependencyGraph {
+
+    @Input
     int size = 0
+
+    @Input
     int depth = 1
+
+    @Input
     boolean useSnapshotVersions = false
 
+    @Internal
     boolean isEmpty() {
         size == 0
     }

--- a/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
@@ -57,11 +57,11 @@ abstract class AbstractProjectGeneratorTask extends ProjectGeneratorTask {
     @Input
     List<String> additionalProjectFiles = []
 
-    @Internal
+    @Internal("Represented as part of templateDirectories")
     String buildSrcTemplate
-    @Internal
+    @Internal("Represented as part of templateDirectories")
     List<String> rootProjectTemplates = ['root-project']
-    @Internal
+    @Internal("Represented as part of templateDirectories")
     List<String> subProjectTemplates = ['project-with-source']
 
     @Input

--- a/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/tasks/CppMultiProjectGeneratorTask.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/tasks/CppMultiProjectGeneratorTask.groovy
@@ -16,10 +16,12 @@
 
 package org.gradle.testing.performance.generator.tasks
 
+import org.gradle.api.tasks.Internal
 import org.gradle.testing.performance.generator.DependencyGenerator
 import org.gradle.testing.performance.generator.TestProject
 
 class CppMultiProjectGeneratorTask extends AbstractProjectGeneratorTask {
+    @Internal
     DependencyGenerator.DependencyInfo depInfo
 
     @Override

--- a/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/tasks/JvmProjectGeneratorTask.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/performance/generator/tasks/JvmProjectGeneratorTask.groovy
@@ -18,20 +18,26 @@ package org.gradle.testing.performance.generator.tasks
 
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.testing.performance.generator.*
 
 class JvmProjectGeneratorTask extends AbstractProjectGeneratorTask {
+
+    @Internal
     boolean groovyProject
+    @Internal
     boolean scalaProject
+    @Internal
     boolean createTestComponent = true
-    Closure createPackageName = { testProject, fileNumber ->
+
+    private final Closure createPackageName = { testProject, fileNumber ->
         "org.gradle.test.performance${testProject.subprojectNumber}_${(int) (fileNumber / filesPerPackage) + 1}"
     }
-    Closure createFileName = { testProject, prefix, fileNumber ->
+    private final Closure createFileName = { testProject, prefix, fileNumber ->
         "${prefix}${testProject.subprojectNumber}_${fileNumber + 1}"
     }
-    Closure createExtendsAndImplementsClause = { testProject, prefix, fileNumber -> '' }
-    Closure<List<Map<String, String>>> createExtraFields = { testProject, prefix, fileNumber -> [] }
+    private final Closure createExtendsAndImplementsClause = { testProject, prefix, fileNumber -> '' }
+    private final Closure<List<Map<String, String>>> createExtraFields = { testProject, prefix, fileNumber -> [] }
 
     @InputFiles
     FileCollection testDependencies


### PR DESCRIPTION
### Context
Follow up to #3574 and #3575

This PR reduces the number of warnings but leaves the`CacheableAsciidoctorTask` task untouched.

[CI Build](https://builds.gradle.org/viewLog.html?buildId=9523133) ✅ 