### PR TITLE
Disable Maven2 legacy support for `maven-publish` plugin

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -62,6 +62,8 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 * Two overloaded `ValidateTaskProperties.setOutputFile()` methods were removed. They are replaced with auto-generated setters when the task is accessed from a build script.
 
+* The `maven-publish` plugin now produces more complete `maven-metadata.xml` files, including maintaining a list of `<snapshotVersion>` elements. Some older versions of Maven may not be able to consume this metadata.
+
 <!--
 ### Example breaking change
 -->

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -241,7 +241,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         if (hasModuleMetadata) {
             expectedArtifacts << "${artifactId}-${publishArtifactVersion}.module"
         }
-        assertArtifactsPublished(expectedArtifacts as String[])
+        assertArtifactsPublished(expectedArtifacts)
         assert parsedPom.packaging == packaging
     }
 
@@ -258,6 +258,13 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         for (name in names) {
             assertChecksumsPublishedFor(moduleDir.file(name))
         }
+    }
+
+    /**
+     * Asserts that exactly the given artifacts have been deployed, along with their checksum files
+     */
+    void assertArtifactsPublished(Iterable<String> names) {
+        assertArtifactsPublished(names as String[])
     }
 
     void assertChecksumsPublishedFor(TestFile testFile) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -285,6 +285,11 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     }
 
     @Override
+    DefaultSnapshotMavenMetaData getSnapshotMetaData() {
+        new DefaultSnapshotMavenMetaData("$path/${MAVEN_METADATA_FILE}", snapshotMetaDataFile)
+    }
+
+    @Override
     ModuleArtifact getArtifact() {
         return getArtifact([:])
     }
@@ -315,6 +320,10 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
 
     TestFile getRootMetaDataFile() {
         moduleDir.parentFile.file(MAVEN_METADATA_FILE)
+    }
+
+    TestFile getSnapshotMetaDataFile() {
+        moduleDir.file(MAVEN_METADATA_FILE)
     }
 
     TestFile artifactFile(Map<String, ?> options) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -280,8 +280,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     }
 
     @Override
-    DefaultMavenMetaData getRootMetaData() {
-        new DefaultMavenMetaData("$moduleRootPath/${MAVEN_METADATA_FILE}", rootMetaDataFile)
+    DefaultRootMavenMetaData getRootMetaData() {
+        new DefaultRootMavenMetaData("$moduleRootPath/${MAVEN_METADATA_FILE}", rootMetaDataFile)
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DefaultRootMavenMetaData.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DefaultRootMavenMetaData.groovy
@@ -21,20 +21,19 @@ import org.gradle.test.fixtures.file.TestFile
 /**
  * http://maven.apache.org/ref/3.0.1/maven-repository-metadata/repository-metadata.html
  */
-class DefaultMavenMetaData implements MavenMetaData {
+class DefaultRootMavenMetaData implements RootMavenMetaData {
 
     String text
 
     String groupId
     String artifactId
-    String version
 
     List<String> versions = []
     String lastUpdated
     final String path
     final TestFile file
 
-    DefaultMavenMetaData(String path, TestFile file) {
+    DefaultRootMavenMetaData(String path, TestFile file) {
         this.file = file
         this.path = path
         if (!file.exists()) {
@@ -46,7 +45,6 @@ class DefaultMavenMetaData implements MavenMetaData {
 
         groupId = xml.groupId[0]?.text()
         artifactId = xml.artifactId[0]?.text()
-        version = xml.version[0]?.text()
 
         def versioning = xml.versioning[0]
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DefaultSnapshotMavenMetaData.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DefaultSnapshotMavenMetaData.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,21 +21,22 @@ import org.gradle.test.fixtures.file.TestFile
 /**
  * http://maven.apache.org/ref/3.0.1/maven-repository-metadata/repository-metadata.html
  */
-class DefaultRootMavenMetaData implements RootMavenMetaData {
+class DefaultSnapshotMavenMetaData implements SnapshotMavenMetaData {
 
     String text
-
     String groupId
     String artifactId
+    String version
 
-    String releaseVersion
-
-    List<String> versions = []
+    String snapshotTimestamp
+    String snapshotBuildNumber
+    List<String> snapshotVersions = []
     String lastUpdated
+
     final String path
     final TestFile file
 
-    DefaultRootMavenMetaData(String path, TestFile file) {
+    DefaultSnapshotMavenMetaData(String path, TestFile file) {
         this.file = file
         this.path = path
         if (!file.exists()) {
@@ -47,14 +48,18 @@ class DefaultRootMavenMetaData implements RootMavenMetaData {
 
         groupId = xml.groupId[0]?.text()
         artifactId = xml.artifactId[0]?.text()
+        version = xml.version[0]?.text()
 
         def versioning = xml.versioning[0]
 
         lastUpdated = versioning.lastUpdated[0]?.text()
-        releaseVersion = versioning.release[0]?.text()
+        snapshotTimestamp =  versioning.snapshot.timestamp[0]?.text()
+        snapshotBuildNumber =  versioning.snapshot.buildNumber[0]?.text()
 
-        versioning.versions[0].version.each {
-            versions << it.text()
+        def snapshotVersionCollector = new LinkedHashSet<String>()
+        versioning.snapshotVersions.snapshotVersion.value.each {
+            snapshotVersionCollector << it.text()
         }
+        snapshotVersions = snapshotVersionCollector as List<String>
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -148,6 +148,10 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
         return backingModule.getRootMetaData();
     }
 
+    public ModuleArtifact getSnapshotMetaData() {
+        return backingModule.getSnapshotMetaData();
+    }
+
     @Override
     public MavenPom getParsedPom() {
         return backingModule.getParsedPom();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
@@ -45,7 +45,7 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
 
         List<String> expectedArtifacts = [artifact("module"), artifact("pom"), artifact("jar")]
         expectedArtifacts.addAll(additionalArtifacts)
-        module.assertArtifactsPublished(expectedArtifacts as String[])
+        module.assertArtifactsPublished(expectedArtifacts)
 
         // Verify Gradle metadata particulars
         assert module.parsedModuleMetadata.variants*.name as Set == ['api', 'runtime'] as Set

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -119,6 +119,8 @@ interface MavenModule extends Module {
 
     ModuleArtifact getRootMetaData()
 
+    ModuleArtifact getSnapshotMetaData()
+
     boolean getUniqueSnapshots()
 
     /**

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/RootMavenMetaData.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/RootMavenMetaData.groovy
@@ -18,6 +18,6 @@ package org.gradle.test.fixtures.maven
 
 import org.gradle.test.fixtures.ModuleArtifact
 
-interface MavenMetaData extends ModuleArtifact {
+interface RootMavenMetaData extends ModuleArtifact {
     List<String> getVersions();
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/SnapshotMavenMetaData.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/SnapshotMavenMetaData.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.maven
+
+import org.gradle.test.fixtures.ModuleArtifact
+
+interface SnapshotMavenMetaData extends ModuleArtifact {
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/MetaDataArtifact.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/MetaDataArtifact.groovy
@@ -18,9 +18,9 @@ package org.gradle.test.fixtures.server.http
 
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.maven.MavenFileModule
-import org.gradle.test.fixtures.maven.MavenMetaData
+import org.gradle.test.fixtures.maven.RootMavenMetaData
 
-class MetaDataArtifact extends HttpArtifact implements MavenMetaData {
+class MetaDataArtifact extends HttpArtifact implements RootMavenMetaData {
     MavenFileModule backingModule
 
     MetaDataArtifact(HttpServer httpServer, String path, MavenFileModule backingModule) {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -129,6 +129,12 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
         repoModule.assertPublished()
         localModule.assertNotPublished()
 
+        and:
+        repoModule.rootMetaData.groupId == "group"
+        repoModule.rootMetaData.artifactId == "root"
+        repoModule.rootMetaData.versions == ["1.0"]
+        repoModule.rootMetaData.releaseVersion == "1.0"
+
         when:
         succeeds 'publishToMavenLocal'
 
@@ -169,41 +175,6 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
         then:
         localM2Repo.module("group", "root", "1.0").assertNotPublished()
         javaLibrary(customLocalRepo.module("group", "root", "1.0")).assertPublished()
-    }
-
-    def "can publish a snapshot version"() {
-        settingsFile << 'rootProject.name = "snapshotPublish"'
-        buildFile << """
-    apply plugin: 'java'
-    apply plugin: 'maven-publish'
-
-    group = 'org.gradle'
-    version = '1.0-SNAPSHOT'
-
-    publishing {
-        repositories {
-            maven { url "${mavenRepo.uri}" }
-        }
-        publications {
-            pub(MavenPublication) {
-                from components.java
-            }
-        }
-    }
-"""
-
-        when:
-        succeeds 'publish'
-
-        then:
-        def module = mavenRepo.module('org.gradle', 'snapshotPublish', '1.0-SNAPSHOT')
-        module.assertArtifactsPublished("snapshotPublish-${module.publishArtifactVersion}.module", "snapshotPublish-${module.publishArtifactVersion}.jar", "snapshotPublish-${module.publishArtifactVersion}.pom", "maven-metadata.xml")
-
-        and:
-        resolveArtifacts(module) == ["snapshotPublish-${module.publishArtifactVersion}.jar"]
-
-        and:
-        module.parsedPom.version == '1.0-SNAPSHOT'
     }
 
     def "reports failure publishing when model validation fails"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
@@ -94,6 +94,10 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     def "can publish a snapshot version that was previously published with uploadArchives"() {
+        given:
+        using m2 // uploadArchives writes to .m2/repo
+
+        and:
         settingsFile << 'rootProject.name = "snapshotPublish"'
         buildFile << """
     apply plugin: 'java'

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
@@ -80,7 +80,7 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
             snapshotBuildNumber == '1'
             lastUpdated == snapshotTimestamp.replace('.', '')
 
-            snapshotVersions == []
+            snapshotVersions == ["1.0-${snapshotTimestamp}-${snapshotBuildNumber}"]
         }
 
         and:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven
+
+import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import org.gradle.test.fixtures.maven.MavenLocalRepository
+import org.gradle.util.SetSystemProperties
+import org.junit.Rule
+/**
+ * Tests “simple” maven publishing scenarios
+ */
+class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
+    @Rule
+    SetSystemProperties sysProp = new SetSystemProperties()
+
+    MavenLocalRepository localM2Repo
+
+    def "setup"() {
+        localM2Repo = m2.mavenRepo()
+    }
+
+    def "can publish a snapshot version"() {
+        settingsFile << 'rootProject.name = "snapshotPublish"'
+        buildFile << """
+    apply plugin: 'java'
+    apply plugin: 'maven-publish'
+
+    group = 'org.gradle'
+    version = '1.0-SNAPSHOT'
+
+    publishing {
+        repositories {
+            maven { url "${mavenRepo.uri}" }
+        }
+        publications {
+            pub(MavenPublication) {
+                from components.java
+            }
+        }
+    }
+"""
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = mavenRepo.module('org.gradle', 'snapshotPublish', '1.0-SNAPSHOT')
+        module.assertArtifactsPublished("snapshotPublish-${module.publishArtifactVersion}.module", "snapshotPublish-${module.publishArtifactVersion}.jar", "snapshotPublish-${module.publishArtifactVersion}.pom", "maven-metadata.xml")
+
+        and:
+        module.parsedPom.version == '1.0-SNAPSHOT'
+
+        with (module.rootMetaData) {
+            groupId == "org.gradle"
+            artifactId == "snapshotPublish"
+            releaseVersion == null
+            versions == ['1.0-SNAPSHOT']
+        }
+
+        with (module.snapshotMetaData) {
+            groupId == "org.gradle"
+            artifactId == "snapshotPublish"
+            version == "1.0-SNAPSHOT"
+
+            snapshotTimestamp != null
+            snapshotBuildNumber == '1'
+            lastUpdated == snapshotTimestamp.replace('.', '')
+
+            snapshotVersions == []
+        }
+
+        and:
+        resolveArtifacts(module) == ["snapshotPublish-${module.publishArtifactVersion}.jar"]
+    }
+}

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenPublishIntegrationTest.groovy
@@ -285,6 +285,26 @@ uploadArchives {
 
         and:
         module.parsedPom.version == '1.0-SNAPSHOT'
+
+        with (module.rootMetaData) {
+            groupId == "org.gradle"
+            artifactId == "test"
+            releaseVersion == null
+            versions == ['1.0-SNAPSHOT']
+        }
+
+        with (module.snapshotMetaData) {
+            groupId == "org.gradle"
+            artifactId == "test"
+            version == "1.0-SNAPSHOT"
+
+            snapshotTimestamp != null
+            snapshotBuildNumber == '1'
+            lastUpdated == snapshotTimestamp.replace('.', '')
+
+            // Snapshot versions are not published, due to Maven legacy support
+            snapshotVersions == []
+        }
     }
 
     def "can publish multiple deployments with attached artifacts"() {

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/AbstractMavenPublishAction.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/AbstractMavenPublishAction.java
@@ -63,7 +63,6 @@ abstract class AbstractMavenPublishAction implements MavenPublishAction {
         container = newPlexusContainer(wagonJars);
         session = new MavenRepositorySystemSession();
         session.setTransferListener(new LoggingMavenTransferListener());
-        session.getConfigProperties().put("maven.metadata.legacy", "true");
 
         Model pom = parsePom(pomFile);
         pomArtifact = new DefaultArtifact(pom.getGroupId(), pom.getArtifactId(), "pom", pom.getVersion()).setFile(pomFile);
@@ -81,6 +80,10 @@ abstract class AbstractMavenPublishAction implements MavenPublishAction {
 
     public void setLocalMavenRepositoryLocation(File localMavenRepository) {
         session.setLocalRepositoryManager(new SimpleLocalRepositoryManager(localMavenRepository));
+    }
+
+    public void produceLegacyMavenMetadata() {
+        session.getConfigProperties().put("maven.metadata.legacy", "true");
     }
 
     public void setMainArtifact(File file) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/BaseMavenDeployer.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/BaseMavenDeployer.java
@@ -51,6 +51,7 @@ public class BaseMavenDeployer extends AbstractMavenResolver implements MavenDep
     protected MavenPublishAction createPublishAction(File pomFile, File metadataFile, LocalMavenRepositoryLocator mavenRepositoryLocator) {
         MavenWagonDeployAction deployAction = new MavenWagonDeployAction(pomFile, metadataFile, getJars());
         deployAction.setLocalMavenRepositoryLocation(mavenRepositoryLocator.getLocalMavenRepository());
+        deployAction.produceLegacyMavenMetadata();
         deployAction.setUniqueVersion(isUniqueVersion());
         deployAction.setRepositories(remoteRepository, remoteSnapshotRepository);
         return deployAction;

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/BaseMavenInstaller.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/deployer/BaseMavenInstaller.java
@@ -34,6 +34,7 @@ public class BaseMavenInstaller extends AbstractMavenResolver {
     protected MavenPublishAction createPublishAction(File pomFile, File metadataFile, LocalMavenRepositoryLocator mavenRepositoryLocator) {
         MavenInstallAction installAction = new MavenInstallAction(pomFile, metadataFile);
         installAction.setLocalMavenRepositoryLocation(mavenRepositoryLocator.getLocalMavenRepository());
+        installAction.produceLegacyMavenMetadata();
         return installAction;
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
@@ -45,6 +45,9 @@ public class MavenRemotePublisher extends AbstractMavenPublisher {
 
     protected MavenPublishAction createDeployTask(File pomFile, File metadataFile, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
         GradleWagonMavenDeployAction deployTask = new GradleWagonMavenDeployAction(pomFile, metadataFile, artifactRepository, repositoryTransportFactory);
+
+        // This isn't right, since it seems like `org.sonatype.aether.impl.internal.DefaultDeployer` assumes that
+        // this will point to an existing `.m2` repository, so it can list previous snapshot versions to create maven-metadata.xml
         deployTask.setLocalMavenRepositoryLocation(temporaryDirFactory.create());
         deployTask.setRepositories(createMavenRemoteRepository(artifactRepository), null);
         return deployTask;


### PR DESCRIPTION
When publishing with `MavenDeployer` we set the `maven.metadata.legacy` flag to ensure compatibility with Maven2. Issue #2882 is about changing this default when using `MavenDeployer`.

This PR changes the default value for the `maven-publish` plugin, which provides less strong compatibility guarantees due to it's incubating status. (Granted, `maven-publish` has been around for a long time and we endeavour to maintain compatibility: we don't think this change will cause any breakages.)