### PR TITLE
Use "viewport" meta tag in docs

### DIFF
--- a/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
@@ -32,9 +32,9 @@
     <xsl:param name="css.decoration">0</xsl:param>
     <xsl:param name="highlight.source" select="1"/>
 
-    <!-- Use custom style sheet content -->
-    <xsl:param name="html.stylesheet">DUMMY</xsl:param>
-    <xsl:template name="output.html.stylesheets">
+    <!-- Customize the metadata and stylesheets to add to the <head> element -->
+    <xsl:template name="head.content">
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <link href="base.css" rel="stylesheet" type="text/css"/>
         <link href="docs.css" rel="stylesheet" type="text/css"/>
         <link href="userguide.css" rel="stylesheet" type="text/css"/>

--- a/subprojects/docs/src/transforms/release-notes.gradle
+++ b/subprojects/docs/src/transforms/release-notes.gradle
@@ -28,6 +28,7 @@ transformDocument {
 
     head().
             append("<meta charset='utf-8'>").
+            append("<meta name='viewport' content='width=device-width, initial-scale=1'>").
             append("<title>Gradle @version@ Release Notes</title>")
 
     head().append("<style>p{}</style>").children().last().childNode(0).attr("data", baseStyleFile.text + releaseNotesStyleFile.text)


### PR DESCRIPTION
As proposed by @eriwen in gradle/dotorg-docs#25, I used the ["viewport" meta tag](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag) in the `<head>` of the HTML pages for the release notes, user guide and DSL reference.

Two reasons for this change:

### 1. The release notes, user guide and DSL reference are now more readable on mobile devices

For example, here's a before-after of the release notes on an iPhone 6.

#### Before

![screenshot](https://user-images.githubusercontent.com/1498164/33224800-1307d728-d176-11e7-9373-67e3265658c0.png)

#### After

![screenshot](https://user-images.githubusercontent.com/1498164/33224841-7281470c-d176-11e7-8173-e6df4b76de0a.png)

### 2. These pages will become mobile-friendly on https://search.google.com/test/mobile-friendly

I can't test this now, but I think the following 4 issues will be resolved once this change makes it to https://docs.gradle.org.

![screenshot](https://user-images.githubusercontent.com/1498164/33224720-208c97ae-d175-11e7-866e-df2aaf875ac0.png)
