### PR TITLE
Include worker process in kill pattern on Windows

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/testing/LeakingProcessKillPattern.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testing/LeakingProcessKillPattern.groovy
@@ -16,12 +16,31 @@
 
 package org.gradle.testing
 
+import groovy.transform.CompileStatic
+
 import java.util.regex.Pattern
 
+@CompileStatic
 class LeakingProcessKillPattern {
     private LeakingProcessKillPattern() {}
 
-    static String generate(String rootProjectDir, String rootBuildDir) {
-        return "(?i)[/\\\\](java(?:\\.exe)?.+?(?:(?:-cp.+${Pattern.quote(rootProjectDir)}.+?(org\\.gradle\\.|[a-zA-Z]+))|(?:-classpath.+${Pattern.quote(rootBuildDir)}.+?(org\\.gradle\\.|[a-zA-Z]+))|(?:-classpath.+${Pattern.quote(rootProjectDir)}.+?(play\\.core\\.server\\.NettyServer))).+)"
+    static String generate(String agentDir, String rootProjectDir, String rootBuildDir) {
+        return "(?i)[/\\\\](java(?:\\.exe)?.+?(?:${toOrgGradleProcessInProjectDirectoryPattern(rootProjectDir)}|${toOrgGradleProcessInBuildDirectoryPattern(rootBuildDir)}|${toNettyServerPattern(rootProjectDir)}|${toWorkerProcessPattern(agentDir)}).+)"
+    }
+
+    private static String toNettyServerPattern(String rootProjectDir) {
+        return "(?:-classpath.+${Pattern.quote(rootProjectDir)}.+?(play\\.core\\.server\\.NettyServer))"
+    }
+
+    private static String toOrgGradleProcessInBuildDirectoryPattern(String rootBuildDir) {
+        return "(?:-classpath.+${Pattern.quote(rootBuildDir)}.+?(org\\.gradle\\.|[a-zA-Z]+))"
+    }
+
+    private static String toOrgGradleProcessInProjectDirectoryPattern(String rootProjectDir) {
+        return "(?:-cp.+${Pattern.quote(rootProjectDir)}.+?(org\\.gradle\\.|[a-zA-Z]+))"
+    }
+
+    private static String toWorkerProcessPattern(String agentDir) {
+        return "(?:-cp.+${Pattern.quote(agentDir)}[\\\\/]\\.gradle.+?(worker\\.org\\.gradle\\.process\\.internal\\.worker\\.GradleWorkerMain))"
     }
 }

--- a/buildSrc/src/test/groovy/org/gradle/testing/LeakingProcessKillPatternTest.groovy
+++ b/buildSrc/src/test/groovy/org/gradle/testing/LeakingProcessKillPatternTest.groovy
@@ -24,11 +24,22 @@ import spock.lang.Subject
 class LeakingProcessKillPatternTest extends Specification {
     @Issue("https://github.com/gradle/ci-health/issues/138")
     def "can match Play application process command-line on Windows"() {
-        def line = '"C:\\Program Files\\Java\\jdk1.7/bin/java.exe"    -Dhttp.port=0  -classpath "C:\\some\\ci\\workspace\\subprojects\\platform-play\\build\\tmp\\test files\\PlayDistributionAdvancedAppIntegrationTest\\can_run_play_distribution\\d3r0j\\build\\stage\\playBinary\\bin\\..\\lib\\advancedplayapp.jar" play.core.server.NettyServer '
-        def projectDir = 'C:\\some\\ci\\workspace'
-        def buildDir = 'C:\\some\\ci\\workspace\\build'
+        def line = '"C:\\Program Files\\Java\\jdk1.7/bin/java.exe"    -Dhttp.port=0  -classpath "C:\\some\\agent\\workspace\\subprojects\\platform-play\\build\\tmp\\test files\\PlayDistributionAdvancedAppIntegrationTest\\can_run_play_distribution\\d3r0j\\build\\stage\\playBinary\\bin\\..\\lib\\advancedplayapp.jar" play.core.server.NettyServer '
+        def agentDir = 'C:\\some\\agent'
+        def projectDir = 'C:\\some\\agent\\workspace'
+        def buildDir = 'C:\\some\\agent\\workspace\\build'
 
         expect:
-        (line =~ LeakingProcessKillPattern.generate(projectDir, buildDir)).find()
+        (line =~ LeakingProcessKillPattern.generate(agentDir, projectDir, buildDir)).find()
+    }
+
+    def "can match worker process command-line on Windows"() {
+        def line = '"C:\\Program Files\\Java\\jdk1.7\\bin\\java.exe" -Djava.security.manager=worker.org.gradle.process.internal.worker.child.BootstrapSecurityManager -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -cp C:\\some\\agent\\.gradle\\caches\\4.4-rc-1\\workerMain\\gradle-worker.jar worker.org.gradle.process.internal.worker.GradleWorkerMain "\'Gradle Worker Daemon 318\'"'
+        def agentDir = 'C:\\some\\agent'
+        def projectDir = 'C:\\some\\agent\\workspace'
+        def buildDir = 'C:\\some\\agent\\workspace\\build'
+
+        expect:
+        (line =~ LeakingProcessKillPattern.generate(agentDir, projectDir, buildDir)).find()
     }
 }

--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -243,7 +243,7 @@ project(":") {
 }
 
 def forEachJavaProcess(Closure action) {
-    String queryString = LeakingProcessKillPattern.generate(rootProject.projectDir.absolutePath, rootProject.buildDir.absolutePath)
+    String queryString = LeakingProcessKillPattern.generate(rootProject.projectDir.parentFile.absolutePath, rootProject.projectDir.absolutePath, rootProject.buildDir.absolutePath)
     def output = new ByteArrayOutputStream()
     def error = new ByteArrayOutputStream()
     def pidPattern


### PR DESCRIPTION
### Context
One solution to the `UnableToDeleteException` is to include worker process in the kill pattern ran during each CI job. This PR does exactly that and should only be merge once we agree that no other issue is present or that we set up some mechanizes to prevent this generalization from hiding valid bugs.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fcore%2Fworker-kill-pattern)
- [ ] Verify documentation
- [x] Recognize contributor in release notes
