### PR TITLE
Add test coverage around XCTest filtering

### DIFF
--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/XCTestSelection.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/XCTestSelection.java
@@ -58,11 +58,6 @@ public class XCTestSelection {
                 }
             }
         }
-
-        if (includedTests.contains(INCLUDE_ALL_TESTS)) {
-            includedTests.clear();
-            includedTests.add(INCLUDE_ALL_TESTS);
-        }
     }
 
     private static boolean isIncludedTestCase(String includedTest) {
@@ -81,8 +76,15 @@ public class XCTestSelection {
 
     private void prepareIncludedTestList(Collection<String> testFilters, Set<String> testSuiteCache) {
         for (String testFilter : testFilters) {
-            includedTests.add(prepareIncludedTest(testFilter, testSuiteCache));
+            includedTests.add(prepareIncludedTest(disallowForwardSlash(testFilter), testSuiteCache));
         }
+    }
+
+    private String disallowForwardSlash(String testFilter) {
+        if (testFilter.contains("/")) {
+            throw new IllegalArgumentException(String.format("'%s' is an invalid pattern. Patterns cannot contain forward slash.", testFilter));
+        }
+        return testFilter;
     }
 
     private String prepareIncludedTest(String testFilter, Set<String> testSuiteCache) {

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/XCTestSelection.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/XCTestSelection.java
@@ -96,6 +96,8 @@ public class XCTestSelection {
                 String filter = tokens[0] + "." + tokens[1];
                 testSuiteCache.add(filter);
                 return filter;
+            } else if (tokens[2].isEmpty()) {
+                return testFilter;
             }
             return tokens[0] + "." + tokens[1] + "/" + tokens[2];
         } else if (tokens.length == 2 && !WILDCARD.equals(tokens[1])) {

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/XCTestSelectionTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/XCTestSelectionTest.groovy
@@ -90,6 +90,11 @@ class XCTestSelectionTest extends Specification {
         testFilter << ['/abc', 'a/bc', 'ab/c', 'a/b/c', 'a/bc', 'a.b/c']
     }
 
+    def "leaves filter as-is when filter has tailing dot"() {
+        expect:
+        select('a.b.').includedTests == ['a.b.']
+    }
+
     private static XCTestSelection select(String... commandLinePattern) {
         new XCTestSelection([], Arrays.asList(commandLinePattern))
     }

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/XCTestSelectionTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/XCTestSelectionTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.test.xctest.internal
 
 import org.gradle.testing.internal.util.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 @Subject(XCTestSelection)
 class XCTestSelectionTest extends Specification {
@@ -74,6 +75,19 @@ class XCTestSelectionTest extends Specification {
     def "conserve order of filters"() {
         expect:
         select('a.1', 'a.2', 'a.3', 'a.4').includedTests == ['a.1', 'a.2', 'a.3', 'a.4']
+    }
+
+    @Unroll
+    def "throws IllegalArgumentException when filter contains forward slash [#testFilter]"() {
+        when:
+        select(testFilter)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == "'$testFilter' is an invalid pattern. Patterns cannot contain forward slash."
+
+        where:
+        testFilter << ['/abc', 'a/bc', 'ab/c', 'a/b/c', 'a/bc', 'a.b/c']
     }
 
     private static XCTestSelection select(String... commandLinePattern) {


### PR DESCRIPTION
### Context
Following comments on PR https://github.com/gradle/gradle/pull/3506#pullrequestreview-79044170

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fxctest-filtering-test-coverage)
- [ ] Verify documentation
- [x] Recognize contributor in release notes
