### PR TITLE
Use ConcurrentHashMap to fix flaky test 1031

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.event;
 
-import com.google.common.collect.Lists;
 import org.gradle.internal.dispatch.Dispatch;
 import org.gradle.internal.dispatch.MethodInvocation;
 import org.gradle.internal.dispatch.ProxyDispatchAdapter;
@@ -24,13 +23,13 @@ import org.gradle.internal.dispatch.ReflectionDispatch;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -38,7 +37,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public class DefaultListenerManager implements ListenerManager {
     private final Map<Object, ListenerDetails> allListeners = new LinkedHashMap<Object, ListenerDetails>();
     private final Map<Object, ListenerDetails> allLoggers = new LinkedHashMap<Object, ListenerDetails>();
-    private final Map<Class<?>, EventBroadcast> broadcasters = new HashMap<Class<?>, EventBroadcast>();
+    private final Map<Class<?>, EventBroadcast> broadcasters = new ConcurrentHashMap<Class<?>, EventBroadcast>();
     private final Object lock = new Object();
     private final DefaultListenerManager parent;
 
@@ -384,7 +383,7 @@ public class DefaultListenerManager implements ListenerManager {
             // block until the listener has finished notifying.
             notifyingLock.lock();
             try {
-                for (EventBroadcast<?> broadcaster : Lists.newArrayList(broadcasters.values())) {
+                for (EventBroadcast<?> broadcaster : broadcasters.values()) {
                     broadcaster.maybeRemove(this);
                 }
             } finally {


### PR DESCRIPTION
Fix https://github.com/gradle/gradle-private/issues/1031

This PR replace original Map in DefaultListenerManager with ConcurrentHashMap
to avoid concurrent access issue. A test is added to reproduce the issue.

@eskatos Since you're familiar with the context, could you take a look at it?
