### PR TITLE
Do not run `clean` for buildSrc

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -217,7 +217,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         then:
         output.contains(":buildSrc:compileJava") // executedTasks check fails with in process executer
         output.count(ConfigureProjectBuildOperationType.Details.name) == 2
-        output.count(ExecuteTaskBuildOperationType.Details.name) == 15 // including all buildSrc task execution events
+        output.count(ExecuteTaskBuildOperationType.Details.name) == 14 // including all buildSrc task execution events
     }
 
     void started(Class<?> type, Map<String, ?> payload = null) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/BuildableJavaComponent.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/BuildableJavaComponent.java
@@ -26,8 +26,6 @@ import java.util.Collection;
  * TODO - this is some legacy stuff, to be merged into other component interfaces
  */
 public interface BuildableJavaComponent {
-    Collection<String> getRebuildTasks();
-
     Collection<String> getBuildTasks();
 
     FileCollection getRuntimeClasspath();

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
@@ -106,7 +106,7 @@ public class BuildSourceBuilder {
         try {
             BuildController buildController = createBuildController(startParameter);
             try {
-                return buildSrcCache.useCache(new BuildSrcUpdateFactory(buildSrcCache, buildController, buildSrcBuildListenerFactory));
+                return buildSrcCache.useCache(new BuildSrcUpdateFactory(buildController, buildSrcBuildListenerFactory));
             } finally {
                 buildController.stop();
             }

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
@@ -42,17 +42,15 @@ public class BuildSrcBuildListenerFactory {
         this.buildSrcRootProjectConfiguration = buildSrcRootProjectConfiguration;
     }
 
-    Listener create(boolean rebuild) {
-        return new Listener(rebuild, buildSrcRootProjectConfiguration);
+    Listener create() {
+        return new Listener(buildSrcRootProjectConfiguration);
     }
 
     public static class Listener extends BuildAdapter implements ModelConfigurationListener {
         private Set<File> classpath;
-        private final boolean rebuild;
         private final Action<ProjectInternal> rootProjectConfiguration;
 
-        private Listener(boolean rebuild, Action<ProjectInternal> rootProjectConfiguration) {
-            this.rebuild = rebuild;
+        private Listener(Action<ProjectInternal> rootProjectConfiguration) {
             this.rootProjectConfiguration = rootProjectConfiguration;
         }
 
@@ -65,8 +63,7 @@ public class BuildSrcBuildListenerFactory {
         @Override
         public void onConfigure(GradleInternal gradle) {
             BuildableJavaComponent mainComponent = mainComponentOf(gradle);
-            gradle.getStartParameter().setTaskNames(
-                rebuild ? mainComponent.getRebuildTasks() : mainComponent.getBuildTasks());
+            gradle.getStartParameter().setTaskNames(mainComponent.getBuildTasks());
             classpath = mainComponent.getRuntimeClasspath().getFiles();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcUpdateFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcUpdateFactory.java
@@ -16,47 +16,34 @@
 
 package org.gradle.initialization.buildsrc;
 
-import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.cache.PersistentCache;
 import org.gradle.internal.Factory;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.invocation.BuildController;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Collection;
 
 public class BuildSrcUpdateFactory implements Factory<DefaultClassPath> {
-    private final PersistentCache cache;
     private final BuildController buildController;
     private BuildSrcBuildListenerFactory listenerFactory;
     private static final Logger LOGGER = Logging.getLogger(BuildSrcUpdateFactory.class);
 
-    public BuildSrcUpdateFactory(PersistentCache cache, BuildController buildController, BuildSrcBuildListenerFactory listenerFactory) {
-        this.cache = cache;
+    public BuildSrcUpdateFactory(BuildController buildController, BuildSrcBuildListenerFactory listenerFactory) {
         this.buildController = buildController;
         this.listenerFactory = listenerFactory;
     }
 
     public DefaultClassPath create() {
-        File markerFile = new File(cache.getBaseDir(), "built.bin");
-        final boolean rebuild = !markerFile.exists();
-
-        Collection<File> classpath = build(rebuild);
+        Collection<File> classpath = build();
         LOGGER.debug("Gradle source classpath is: {}", classpath);
-        try {
-            markerFile.createNewFile();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
         return new DefaultClassPath(classpath);
     }
 
-    private Collection<File> build(boolean rebuild) {
-        BuildSrcBuildListenerFactory.Listener listener = listenerFactory.create(rebuild);
+    private Collection<File> build() {
+        BuildSrcBuildListenerFactory.Listener listener = listenerFactory.create();
         GradleInternal gradle = buildController.getGradle();
         gradle.addListener(listener);
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -307,7 +307,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
     }
 
     protected SettingsLoaderFactory createSettingsLoaderFactory(SettingsProcessor settingsProcessor, BuildLayoutFactory buildLayoutFactory, NestedBuildFactory nestedBuildFactory,
-                                                                ClassLoaderScopeRegistry classLoaderScopeRegistry, CacheRepository cacheRepository,
+                                                                ClassLoaderScopeRegistry classLoaderScopeRegistry,
                                                                 BuildOperationExecutor buildOperationExecutor,
                                                                 CachedClasspathTransformer cachedClasspathTransformer,
                                                                 CachingServiceLocator cachingServiceLocator,
@@ -318,7 +318,6 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             new BuildSourceBuilder(
                 nestedBuildFactory,
                 classLoaderScopeRegistry.getCoreAndPluginsScope(),
-                cacheRepository,
                 buildOperationExecutor,
                 cachedClasspathTransformer,
                 new BuildSrcBuildListenerFactory(

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactoryTest.groovy
@@ -42,19 +42,8 @@ class BuildSrcBuildListenerFactoryTest extends Specification {
         getRootProject() >> project
     }
 
-    def "configures task names when rebuild on"() {
-        def listener = new BuildSrcBuildListenerFactory().create(true)
-        component.getRebuildTasks() >> ['fooBuild']
-
-        when:
-        listener.onConfigure(gradle)
-
-        then:
-        1 * startParameter.setTaskNames(['fooBuild'])
-    }
-
-    def "configures task names when rebuild off"() {
-        def listener = new BuildSrcBuildListenerFactory().create(false)
+    def "configures task names"() {
+        def listener = new BuildSrcBuildListenerFactory().create()
         component.getBuildTasks() >> ['barBuild']
 
         when:
@@ -66,7 +55,7 @@ class BuildSrcBuildListenerFactoryTest extends Specification {
 
     def "executes buildSrc configuration action after projects are loaded"() {
         def action = Mock(Action)
-        def listener = new BuildSrcBuildListenerFactory(action).create(true)
+        def listener = new BuildSrcBuildListenerFactory(action).create()
 
         when:
         listener.projectsLoaded(gradle)

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcUpdateFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcUpdateFactoryTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.initialization.buildsrc
 
-import org.gradle.cache.PersistentCache
 import org.gradle.internal.invocation.BuildController
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -26,14 +25,12 @@ class BuildSrcUpdateFactoryTest extends Specification {
 
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
 
-    def cache = Stub(PersistentCache)
     def launcher = Stub(BuildController)
     def listener = Stub(BuildSrcBuildListenerFactory.Listener)
     def listenerFactory = Mock(BuildSrcBuildListenerFactory)
     def factory = new BuildSrcUpdateFactory(launcher, listenerFactory)
 
     def "creates classpath"() {
-        cache.getBaseDir() >> temp.testDirectory
         listener.getRuntimeClasspath() >> [new File("dummy")]
 
         when:
@@ -41,27 +38,6 @@ class BuildSrcUpdateFactoryTest extends Specification {
 
         then:
         classpath.asFiles == [new File("dummy")]
-        1 * listenerFactory.create() >> listener
-    }
-
-    def "uses listener with rebuild off when marker file present"() {
-        temp.createFile("built.bin")
-        cache.getBaseDir() >> temp.testDirectory
-
-        when:
-        factory.create()
-
-        then:
-        1 * listenerFactory.create() >> listener
-    }
-
-    def "uses listener with rebuild on when marker file not present"() {
-        cache.getBaseDir() >> temp.createDir("empty")
-
-        when:
-        factory.create()
-
-        then:
         1 * listenerFactory.create() >> listener
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcUpdateFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcUpdateFactoryTest.groovy
@@ -30,7 +30,7 @@ class BuildSrcUpdateFactoryTest extends Specification {
     def launcher = Stub(BuildController)
     def listener = Stub(BuildSrcBuildListenerFactory.Listener)
     def listenerFactory = Mock(BuildSrcBuildListenerFactory)
-    def factory = new BuildSrcUpdateFactory(cache, launcher, listenerFactory)
+    def factory = new BuildSrcUpdateFactory(launcher, listenerFactory)
 
     def "creates classpath"() {
         cache.getBaseDir() >> temp.testDirectory
@@ -41,7 +41,7 @@ class BuildSrcUpdateFactoryTest extends Specification {
 
         then:
         classpath.asFiles == [new File("dummy")]
-        1 * listenerFactory.create(_) >> listener
+        1 * listenerFactory.create() >> listener
     }
 
     def "uses listener with rebuild off when marker file present"() {
@@ -52,7 +52,7 @@ class BuildSrcUpdateFactoryTest extends Specification {
         factory.create()
 
         then:
-        1 * listenerFactory.create(false) >> listener
+        1 * listenerFactory.create() >> listener
     }
 
     def "uses listener with rebuild on when marker file not present"() {
@@ -62,6 +62,6 @@ class BuildSrcUpdateFactoryTest extends Specification {
         factory.create()
 
         then:
-        1 * listenerFactory.create(true) >> listener
+        1 * listenerFactory.create() >> listener
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -31,7 +31,7 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec {
                     def component = project.services.get(${ComponentRegistry.canonicalName}).mainComponent
                     
                     assert component instanceof ${BuildableJavaComponent.canonicalName}
-                    assert component.buildTasks == [ JavaBasePlugin.BUILD_TASK_NAME ]
+                    assert component.buildTasks as List == [ JavaBasePlugin.BUILD_TASK_NAME ]
                     assert component.runtimeClasspath != null
                     assert component.compileDependencies == project.configurations.compileClasspath
                 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -31,7 +31,6 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec {
                     def component = project.services.get(${ComponentRegistry.canonicalName}).mainComponent
                     
                     assert component instanceof ${BuildableJavaComponent.canonicalName}
-                    assert component.rebuildTasks == [ BasePlugin.CLEAN_TASK_NAME, JavaBasePlugin.BUILD_TASK_NAME]
                     assert component.buildTasks == [ JavaBasePlugin.BUILD_TASK_NAME ]
                     assert component.runtimeClasspath != null
                     assert component.compileDependencies == project.configurations.compileClasspath

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -431,7 +431,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         }
 
         public Collection<String> getBuildTasks() {
-            return Collections.singletonList(JavaBasePlugin.BUILD_TASK_NAME);
+            return Collections.singleton(JavaBasePlugin.BUILD_TASK_NAME);
         }
 
         public FileCollection getRuntimeClasspath() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -50,8 +50,8 @@ import org.gradle.language.jvm.tasks.ProcessResources;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.Callable;
 
@@ -430,12 +430,8 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
             this.convention = convention;
         }
 
-        public Collection<String> getRebuildTasks() {
-            return Arrays.asList(BasePlugin.CLEAN_TASK_NAME, JavaBasePlugin.BUILD_TASK_NAME);
-        }
-
         public Collection<String> getBuildTasks() {
-            return Arrays.asList(JavaBasePlugin.BUILD_TASK_NAME);
+            return Collections.singletonList(JavaBasePlugin.BUILD_TASK_NAME);
         }
 
         public FileCollection getRuntimeClasspath() {


### PR DESCRIPTION
With better stale output file cleanup it should not be necessary anymore to run `clean` for `buildSrc` when changing Gradle versions.